### PR TITLE
Fix make -f Makefile.osx revision on osx

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -66,7 +66,7 @@ lrelease:
 	cd build.release;xcodebuild -project mscore.xcodeproj -target lrelease;
 
 revision:
-	@svnversion -n | cut -c 1-4 > mscore/revision.h
+	@git rev-parse --short HEAD > mscore/revision.h
 
 version: revision
 	@echo ${VERSION}


### PR DESCRIPTION
Update the Makefile to create a valid revision tag using git
