### PR TITLE
Image from file fallback

### DIFF
--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -273,6 +273,8 @@ void Image::read(const QDomElement& de)
                   _storeItem = imageStore.getImage(_path);
                   if (_storeItem)
                         _storeItem->reference(this);
+                  else
+                        load(_path);
                   }
             else if (!Element::readProperties(e))
                   domError(e);


### PR DESCRIPTION
Adds two lines to Image::read() (libmscore/image.cpp) to load from file images not found in Storage (compat. with in older version(s) scores)
