### PR TITLE
Save number of lines for staff types

### DIFF
--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -134,7 +134,9 @@ void StaffType::write(Xml& xml, int idx) const
 void StaffType::writeProperties(Xml& xml) const
       {
       xml.tag("name", name());
-      if (lines() != 5)
+      // unconditionally save number of lines
+      // as different staff types have different default
+//      if (lines() != 5)
             xml.tag("lines", lines());
       if (lineDistance().val() != 1.0)
             xml.tag("lineDistance", lineDistance().val());


### PR DESCRIPTION
Number of lines in a staff type is written to score only when != 5. Different staff types have different defaults (tab has 6 lines as default). A TAB with 5 lines has its number of lines not saved.

This branch unconditionally saves the staff type number of lines to avoid this (bug report #17124)
