### PR TITLE
Crash Fix - Rests at End of Score

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1461,6 +1461,16 @@ void Score::cmdEnterRest(const TDuration& d)
             if (cr)
                   nextInputPos(cr, false);
             }
+
+      // avoid out of bounds crash at end of score
+      Measure* measure = last()->system()->lastMeasure();
+      if (_is.cr() == 0 && measure && seg->measure()->no() == measure->no()) {
+  	    ChordRest* cr = selection().lastChordRest();
+	    Element* el = measure->last()->nextChordRest(cr->track(), true);
+	    cr = static_cast<ChordRest*>(el);
+	    moveInputPos(cr->segment());
+            }
+
       _is.rest = false;  // continue with normal note entry
       endCmd();
       }


### PR DESCRIPTION
If you hit rest (0) until you reach the end of the score, and then hit left or right arrow, it causes a segmentation fault, because filling up the final chordrest with a rest puts the cursor out of bounds.

This crash is present in trunk in Debian stable, and on 1.2 in Debian stable, Ubuntu 12.04, and Windows 7, and on 1.1 in Windows 7.

This commit adds a check to the end of Score::cmdEnterRest in edit.cpp to see if it's about to go out of bounds. If so, it reuses methodology from "select-end-score" and "prev-measure" to keep your cursor safely within bounds at the end of the score.
