### PR TITLE
Changing time signature input in setup wizard

### DIFF
--- a/mscore/timesigwizard.ui
+++ b/mscore/timesigwizard.ui
@@ -74,12 +74,41 @@
          </widget>
         </item>
         <item>
-         <widget class="Awl::DenominatorSpinBox" name="timesigN">
-          <property name="maximum">
-           <number>32</number>
-          </property>
-         </widget>
+       <widget class="QComboBox" name="TimesigN">
+       <item>
+         <property name="text">
+          <string>1</string>
+         </property>
         </item>
+        <item>
+         <property name="text">
+          <string>2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>4</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>8</string>
+         </property>
+        </item>
+	       <item>
+         <property name="text">
+          <string>16</string>
+         </property>
+        </item>
+	<item>
+         <property name="text">
+          <string>32</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+       </widget>
+      </item> 
         <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
@@ -164,12 +193,41 @@
        </widget>
       </item>
       <item>
-       <widget class="Awl::DenominatorSpinBox" name="pickupTimesigN">
-        <property name="maximum">
-         <number>32</number>
-        </property>
+       <widget class="QComboBox" name="pickupTimesigN">
+ <item>
+         <property name="text">
+          <string>1</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>4</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>8</string>
+         </property>
+        </item>
+	       <item>
+         <property name="text">
+          <string>16</string>
+         </property>
+        </item>
+	       <item>
+         <property name="text">
+          <string>32</string>
+         </property>
+        </item>
        </widget>
       </item>
+       </widget>
+      </item> 
       <item>
        <spacer>
         <property name="orientation">


### PR DESCRIPTION
This changes the setup wizard so that you now can't put a time signature denominator other that 1, 2, 4, 8, 16 or 32. Now it's impossible to type other values manually.

According to: http://musescore.org/en/node/7315

My programming knowledge is very limited, but I guess that could work... If not, sorry.

PS.1. I don't know how to test the changes... Sorry.
PS.2. That's the first time I modyfy something in GitHub.
