### PR TITLE
Following: http://musescore.org/en/node/7315

### DIFF
--- a/mscore/timesigwizard.ui
+++ b/mscore/timesigwizard.ui
@@ -74,10 +74,41 @@
          </widget>
         </item>
         <item>
-         <widget class="Awl::DenominatorSpinBox" name="timesigN">
-          <property name="maximum">
-           <number>32</number>
-          </property>
+         <widget class="QComboBox" name="timesigN">
+          <item>
+         <property name="text">
+          <string>1</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>4</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>8</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>16</string>
+         </property>
+        </item>
+	       <item>
+         <property name="text">
+          <string>32</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+       </widget>
+      </item> 
          </widget>
         </item>
         <item>
@@ -164,10 +195,37 @@
        </widget>
       </item>
       <item>
-       <widget class="Awl::DenominatorSpinBox" name="pickupTimesigN">
-        <property name="maximum">
-         <number>32</number>
-        </property>
+       <widget class="QComboBox" name="pickupTimesigN">
+        <item>
+         <property name="text">
+          <string>1</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>4</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>8</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>16</string>
+         </property>
+        </item>
+	       <item>
+         <property name="text">
+          <string>32</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item>


### PR DESCRIPTION
Modification of the time signature input in the startup wizard.
Now you can only input the expected denominators (1, 2, 4...).
Manually imputting others is impossible.

My programming knowledge is very limited, but I guess that could work... If not, sorry.

PS.1: It's the first time I modyfy something in GitHub.
PS.2: I don't know how to test the changes.
