### PR TITLE
One new member not initialized in Image copy contructor

### DIFF
--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -54,6 +54,7 @@ Image::Image(const Image& img)
       _storeItem       = img._storeItem;
       _sizeIsSpatium   = img._sizeIsSpatium;
       _storeItem->reference(this);
+      _linkPath        = img._linkPath;
       _linkIsValid     = img._linkIsValid;
       }
 


### PR DESCRIPTION
In previous commit, Image::_linkPath member was not carried over in Image copy constructor; this resulted in empty path after editing an image. Fixed.
