### PR TITLE
Modifying time signature input in setup wizard to prevent weird denominators.

### DIFF
--- a/mscore/timesigwizard.ui
+++ b/mscore/timesigwizard.ui
@@ -75,7 +75,7 @@
         </item>
         <item>
        <widget class="QComboBox" name="TimesigN">
-       <item>
+        <item>
          <property name="text">
           <string>1</string>
          </property>
@@ -95,7 +95,7 @@
           <string>8</string>
          </property>
         </item>
-	       <item>
+	<item>
          <property name="text">
           <string>16</string>
          </property>
@@ -192,7 +192,7 @@
       </item>
       <item>
        <widget class="QComboBox" name="pickupTimesigN">
- <item>
+        <item>
          <property name="text">
           <string>1</string>
          </property>
@@ -212,20 +212,18 @@
           <string>8</string>
          </property>
         </item>
-	       <item>
+	<item>
          <property name="text">
           <string>16</string>
          </property>
         </item>
-	       <item>
+	<item>
          <property name="text">
           <string>32</string>
          </property>
         </item>
        </widget>
       </item>
-       </widget>
-      </item> 
       <item>
        <spacer>
         <property name="orientation">


### PR DESCRIPTION
Following: http://musescore.org/en/node/7315

Modification of the time signature input in the startup wizard.
Now you can only input the expected denominators (1, 2, 4...).
Manually imputting others is impossible.

My programming knowledge is very limited, but I guess that could work... If not, sorry.

PS.1: It's the first time I modyfy something in GitHub.
PS.2: I don't know how to test the changes.
