### PR TITLE
Fix for slurs and slur layout improvement

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -704,38 +704,35 @@ void Slur::slurPos(SlurPos* sp)
       SlurAnchor sa1 = SA_NONE;
       SlurAnchor sa2 = SA_NONE;
       if ((sc->up() == ec->up()) && !sc->beam() && !ec->beam() && (_up == sc->up())) {
-            sa1 = SA_STEM;
-            sa2 = SA_STEM;
-            printf("Stem-Stem\n");
+            if (stem1) sa1 = SA_STEM;
+            if (stem2) sa2 = SA_STEM;
+            //qDebug("Stem-Stem\n");
+            }
+      qreal __up = _up ? -1.0 : 1.0;
+      qreal hw   = note1->headWidth();
+      switch (sa1) {
+            case SA_STEM:
+                  sp->p1 += sc->stemPosBeam() - sc->pagePos() + stem1->p2();
+                  sp->p1 += QPointF(0.35 * _spatium, __up * 0.25 * _spatium);
+                  break;
+            case SA_NONE:
+                  break;
+            }
+      switch(sa2) {
+            case SA_STEM:
+                  sp->p2 += ec->stemPosBeam() - ec->pagePos() + stem2->p2();
+                  sp->p2 += QPointF(-0.35 * _spatium, __up * 0.25 * _spatium);
+                  break;
+            case SA_NONE:
+                  break;
             }
 
-      qreal hw   = note1->headWidth();
-      if (sa1 != SA_NONE && sa2 != SA_NONE) {
-            switch (sa1) {
-                  case SA_STEM:
-                        sp->p1 += sc->stemPosBeam() - sc->pagePos() + sc->stem()->p2();
-                        sp->p1 += QPointF(0.25 * _spatium, 0.75 * _spatium);
-                        break;
-                  case SA_NONE:
-                        break;
-                  }
-            switch(sa2) {
-                  case SA_STEM:
-                        sp->p2 += ec->stemPosBeam() - ec->pagePos() + ec->stem()->p2();
-                        sp->p2 += QPointF(-0.25 * _spatium, 0.75 * _spatium);
-                        break;
-                  case SA_NONE:
-                        break;
-                  }
-            return;
-            }
 
       //
       // default position:
       //    horizontal: middle of note head
       //    vertical:   _spatium * .4 above/below note head
       //
-      qreal __up = _up ? -1.0 : 1.0;
 
       //------p1
       bool stemPos = false;   // p1 starts at chord stem side
@@ -781,8 +778,8 @@ void Slur::slurPos(SlurPos* sp)
                         yo = fixArticulations(yo, sc, __up);
                   }
             }
-
-      sp->p1 += QPointF(xo, yo);
+      if(sa1 == SA_NONE)
+            sp->p1 += QPointF(xo, yo);
 
       //------p2
       xo = hw * .5;
@@ -834,8 +831,8 @@ void Slur::slurPos(SlurPos* sp)
             else if (ec->up() != _up)
                   yo = fixArticulations(yo, ec, __up);
             }
-
-      sp->p2 += QPointF(xo, yo);
+      if(sa2 == SA_NONE)
+            sp->p2 += QPointF(xo, yo);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
fix #17544: Inverting slur between whole note (no stem) and quarter note causes crash, improve slur default layout on stem-stem case.

The layout of Stem-Stem slurs has been changed. There are closer to the stems because it seems better and other scorewriters do it this way. Maybe Gould should be checked?

The code should also now handle whole to quarter and quarter to whole slurs correctly.

PDF made with this fix, nothing tweaked : https://dl.dropbox.com/u/497455/slurtest.pdf
The mscz file (will probably not open before the fix, because of #17544): https://dl.dropbox.com/u/497455/slurtest.mscz
