### PR TITLE
Make XCode generator add headers to project

### DIFF
--- a/aeolus/aeolus/CMakeLists.txt
+++ b/aeolus/aeolus/CMakeLists.txt
@@ -20,12 +20,19 @@
 
 include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
 
+if (APPLE)
+        file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+        set(INCS "")
+endif (APPLE)
+
 add_library (aeolus STATIC
       aeolus.cpp audio.cpp model.cpp addsynth.cpp scales.cpp
 	reverb.cpp asection.cpp division.cpp rankwave.cpp
       rngen.cpp exp2ap.cpp
       ${PROJECT_BINARY_DIR}/all.h
       ${PCH}
+      ${INCS}
       )
 
 set_target_properties (

--- a/awl/CMakeLists.txt
+++ b/awl/CMakeLists.txt
@@ -36,11 +36,18 @@ QT4_WRAP_CPP (mocs
       denomspinbox.h
       )
 
+if (APPLE)
+        file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+        set(INCS "")
+endif (APPLE)
+
 add_library (
       awl STATIC
       ${PROJECT_BINARY_DIR}/all.h
       ${PCH}
       ${mocs}
+      ${INCS}
       aslider.cpp
       knob.cpp
       panknob.cpp

--- a/bww2mxml/CMakeLists.txt
+++ b/bww2mxml/CMakeLists.txt
@@ -21,7 +21,14 @@
 
 include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
 
+if (APPLE)
+        file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+        set(INCS "")
+endif (APPLE)
+
 add_library(bww STATIC
+   ${INCS}
    lexer.cpp
    parser.cpp
    symbols.cpp
@@ -30,6 +37,7 @@ add_library(bww STATIC
 
 if (NOT MINGW)
 add_executable(bww2mxml
+   ${INCS}
    lexer.cpp
    main.cpp
    mxmlwriter.cpp

--- a/fluid/CMakeLists.txt
+++ b/fluid/CMakeLists.txt
@@ -25,6 +25,12 @@ set(SRC
   conv.cpp gen.cpp mod.cpp rev.cpp tuning.cpp
   )
 
+if (APPLE)
+	file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+        set(INCS "")
+endif (APPLE)
+
 if (SOUNDFONT3)
       set(SRC ${SRC} sfont3.cpp)
 endif (SOUNDFONT3)
@@ -33,6 +39,7 @@ add_library (fluid STATIC
       ${PROJECT_BINARY_DIR}/all.h
       ${PCH}
       ${SRC}
+      ${INCS}
       )
 set_target_properties (
       fluid

--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -34,10 +34,17 @@ add_custom_command(
    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
    )
 
+if (APPLE)
+        file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+        set(INCS "")
+endif (APPLE)
+
 add_library (
       libmscore STATIC
       ${PROJECT_BINARY_DIR}/all.h
       ${mocs}
+      ${INCS}
       segmentlist.cpp fingering.cpp accidental.cpp arpeggio.cpp
       articulation.cpp barline.cpp beam.cpp bend.cpp box.cpp
       bracket.cpp breath.cpp bsp.cpp chord.cpp chordline.cpp

--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -15,8 +15,16 @@ include_directories(
       ${PROJECT_BINARY_DIR}
       ${PROJECT_SOURCE_DIR}
       )
+
+if (APPLE)
+        file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+        set(INCS "")
+endif (APPLE)
+
 add_executable(
       genManual
+      ${INCS}
       genManual.cpp
       )
 target_link_libraries(

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -67,6 +67,7 @@ if (OMR)
       set(OMR_MOCS omrpanel.h)
 endif (OMR)
 
+
 QT4_WRAP_CPP (mocs
       scoreview.h editinstrument.h editstyle.h edittempo.h instrdialog.h debugger.h
       musescore.h navigator.h pagesettings.h palette.h mixer.h playpanel.h
@@ -144,6 +145,12 @@ if (OMR)
       set(OMR_FILES omrpanel.cpp)
 endif (OMR)
 
+if (APPLE)
+	file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+	set(INCS "")
+endif (APPLE)
+
 add_executable ( ${ExecutableName}
       ${qrc_files}
       ${ui_headers}
@@ -151,6 +158,7 @@ add_executable ( ${ExecutableName}
       ${PROJECT_BINARY_DIR}/all.h
       ${PCH}
       ${resource_file}
+      ${INCS}
 
       actions.cpp scoreview.cpp editinstrument.cpp editstyle.cpp
       edittempo.cpp exportxml.cpp icons.cpp importbww.cpp importxml.cpp

--- a/mstyle/CMakeLists.txt
+++ b/mstyle/CMakeLists.txt
@@ -35,11 +35,18 @@ QT4_WRAP_CPP (mocs
       windowmanager.h
       )
 
+if (APPLE)
+      file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+      set(INCS "")
+endif (APPLE)
+
 add_library (
       mstyle STATIC
       ${PROJECT_BINARY_DIR}/all.h
       ${PCH}
       ${mocs}
+      ${INCS}
       mstyle.cpp colorscheme.cpp colorutils.cpp tileset.cpp stylehelper.cpp frameshadow.cpp
       animations.cpp animationdata.cpp dockseparatordata.cpp
       dockseparatorengine.cpp enabledata.cpp genericdata.cpp headerviewdata.cpp

--- a/msynth/CMakeLists.txt
+++ b/msynth/CMakeLists.txt
@@ -25,10 +25,17 @@ include_directories(
       ${PROJECT_SOURCE_DIR}
       )
 
+if (APPLE)
+        file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+        set(INCS "")
+endif (APPLE)
+
 add_library (
       msynth STATIC
       ${PROJECT_BINARY_DIR}/all.h
       ${PCH}
+      ${INCS}
       synti.cpp
       )
 

--- a/thirdparty/diff/CMakeLists.txt
+++ b/thirdparty/diff/CMakeLists.txt
@@ -20,10 +20,17 @@
 
 include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
 
+if (APPLE)
+        file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+        set(INCS "")
+endif (APPLE)
+
 add_library(diff_match_patch STATIC
    diff_match_patch.cpp
    ${PROJECT_BINARY_DIR}/all.h
    ${PCH}
+   ${INCS}
    )
 
 set_target_properties (

--- a/thirdparty/ofqf/CMakeLists.txt
+++ b/thirdparty/ofqf/CMakeLists.txt
@@ -26,10 +26,17 @@ QT4_WRAP_CPP (mocs
       qosctypes.h
       )
 
+if (APPLE)
+        file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+        set(INCS "")
+endif (APPLE)
+
 add_library(ofqf STATIC
    ${PROJECT_BINARY_DIR}/all.h
    ${PCH}
    ${mocs}
+   ${INCS}
    qoscclient.cpp qoscserver.cpp qosctypes.cpp
    )
 

--- a/thirdparty/portmidi/CMakeLists.txt
+++ b/thirdparty/portmidi/CMakeLists.txt
@@ -21,9 +21,12 @@
 set(CMAKE_C_FLAGS "-DNEWBUFFER -DPMNULL")
 
 if (APPLE)
+  file(GLOB_RECURSE INCS "*.h")
+
   add_library (
     portmidi STATIC
-        pm_common/pmutil.c
+	${INCS}
+	pm_common/pmutil.c
 	pm_common/portmidi.c
 	pm_mac/finddefault.c
 	pm_mac/pmmac.c

--- a/thirdparty/rtf2html/CMakeLists.txt
+++ b/thirdparty/rtf2html/CMakeLists.txt
@@ -18,8 +18,15 @@
 #  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #=============================================================================
 
+if (APPLE)
+        file(GLOB_RECURSE INCS "*.h")
+else (APPLE)
+        set(INCS "")
+endif (APPLE)
+
 add_library (
   rtf2html STATIC
+  ${INCS}
   fmt_opts.cpp
   rtf2html.cpp
   rtf_keyword.cpp


### PR DESCRIPTION
On Xcode, certain things don't work if the headers
aren't also part of the project, namely .h/.cpp
flipping ("Jump to Next Counterpart" in the navigation
menu) and searching the entire workspace for symbols.

The header files are now collected from the directory
of the target and show up in the XCode project under
"Header files" (per target).

I limited this change to Mac since I cannot test anywhere
else, but it would probably not hurt to do the same thing
on other platforms.

According to forums, the add_executable and add_library
commands of CMake should just silently ignore these files,
but add them to the generated target in the project.
