### PR TITLE
Allow pressing backspace in the shortcut dialog (#11645)

### DIFF
--- a/mscore/shortcutcapturedialog.cpp
+++ b/mscore/shortcutcapturedialog.cpp
@@ -42,7 +42,11 @@ ShortcutCaptureDialog::ShortcutCaptureDialog(Shortcut* _s, QMap<QString, Shortcu
       connect(replaceButton, SIGNAL(clicked()), SLOT(replaceClicked()));
       clearClicked();
       grabKeyboard();
+
+      oshrtLabel->installEventFilter(this);
+      nshrtLabel->installEventFilter(this);
       }
+
 
 //---------------------------------------------------------
 //   addClicked
@@ -68,8 +72,29 @@ void ShortcutCaptureDialog::replaceClicked()
 
 ShortcutCaptureDialog::~ShortcutCaptureDialog()
       {
+      nshrtLabel->removeEventFilter(this);
+      oshrtLabel->removeEventFilter(this);
       releaseKeyboard();
       }
+
+//---------------------------------------------------------
+//   eventFilter
+//---------------------------------------------------------
+
+bool ShortcutCaptureDialog::eventFilter(QObject* o, QEvent* e)
+{
+    // Grab the backspace key before one of the QLineEdit widgets
+    // gets them. Otherwise Qt swallows the Backspace even if
+    // the field is read-only.
+    if (e->type() == QEvent::KeyPress
+        && static_cast<QKeyEvent*>(e)->key() == Qt::Key_Backspace)
+    {
+        keyPressEvent(static_cast<QKeyEvent*>(e));
+        return true;
+    }
+    return false;
+}
+
 
 //---------------------------------------------------------
 //   keyPressEvent

--- a/mscore/shortcutcapturedialog.h
+++ b/mscore/shortcutcapturedialog.h
@@ -40,6 +40,7 @@ class ShortcutCaptureDialog : public QDialog, public Ui::ShortcutCaptureDialogBa
       private:
       Shortcut* s;
       void keyPressEvent(QKeyEvent* e);
+      virtual bool eventFilter(QObject* o, QEvent* e);
       QKeySequence key;
       QMap<QString, Shortcut*> localShortcuts;
 


### PR DESCRIPTION
At least on Mac, I wanted to be able to reconfigure
the delete action to work with backspace. It seemed
not to work at first, but it actually did - but only if the
focus was not on the edit fields in the dialog.

There seems to be a bug in Qt, in the implementation of
QLineEdit: it swallows the Backspace key even if the
edit field is in read-only mode. Looks like a forgotten
code path to me.

As a workaround, we grab the backspace keyboard events
before they are fed to any of the line edit fields and
handle them ourselves.
