### PR TITLE
FiguredBassItem properties

### DIFF
--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -558,6 +558,16 @@ QVariant FiguredBassItem::getProperty(P_ID propertyId) const
                   return _suffix;
             case P_FBCONTINUATIONLINE:
                   return _contLine;
+            case P_FBPARENTHESIS1:
+                  return parenth[0];
+            case P_FBPARENTHESIS2:
+                  return parenth[1];
+            case P_FBPARENTHESIS3:
+                  return parenth[2];
+            case P_FBPARENTHESIS4:
+                  return parenth[3];
+            case P_FBPARENTHESIS5:
+                  return parenth[4];
             default:
                   return Element::getProperty(propertyId);
             }
@@ -585,6 +595,31 @@ bool FiguredBassItem::setProperty(P_ID propertyId, const QVariant& v)
                   break;
             case P_FBCONTINUATIONLINE:
                   _contLine = v.toBool();
+                  break;
+            case P_FBPARENTHESIS1:
+                  if(val < ParenthesisNone || val > ParenthesisSquaredClosed)
+                        return false;
+                  parenth[0] = (Parenthesis)val;
+                  break;
+            case P_FBPARENTHESIS2:
+                  if(val < ParenthesisNone || val > ParenthesisSquaredClosed)
+                        return false;
+                  parenth[1] = (Parenthesis)val;
+                  break;
+            case P_FBPARENTHESIS3:
+                  if(val < ParenthesisNone || val > ParenthesisSquaredClosed)
+                        return false;
+                  parenth[2] = (Parenthesis)val;
+                  break;
+            case P_FBPARENTHESIS4:
+                  if(val < ParenthesisNone || val > ParenthesisSquaredClosed)
+                        return false;
+                  parenth[3] = (Parenthesis)val;
+                  break;
+            case P_FBPARENTHESIS5:
+                  if(val < ParenthesisNone || val > ParenthesisSquaredClosed)
+                        return false;
+                  parenth[4] = (Parenthesis)val;
                   break;
             default:
                   return Element::setProperty(propertyId, v);
@@ -619,13 +654,16 @@ void FiguredBassItem::undoSetPrefix(Modifier pref)
             // if setting some prefix and there is a suffix already, clear suffix
             if(pref != ModifierNone && _suffix != ModifierNone)
                   score()->undoChangeProperty(this, P_FBSUFFIX, ModifierNone);
+            layout();                     // re-generate displayText
             }
       }
 
 void FiguredBassItem::undoSetDigit(int digit)
       {
-      if(digit >= 0 && digit <= 9)
+      if(digit >= 0 && digit <= 9) {
             score()->undoChangeProperty(this, P_FBDIGIT, digit);
+            layout();                     // re-generate displayText
+            }
       }
 
 void FiguredBassItem::undoSetSuffix(Modifier suff)
@@ -634,11 +672,39 @@ void FiguredBassItem::undoSetSuffix(Modifier suff)
       // if setting some suffix and there is a prefix already, clear prefix
       if(suff != ModifierNone && _prefix != ModifierNone)
             score()->undoChangeProperty(this, P_FBPREFIX, ModifierNone);
+      layout();                     // re-generate displayText
       }
 
 void FiguredBassItem::undoSetContLine(bool val)
       {
       score()->undoChangeProperty(this, P_FBCONTINUATIONLINE, val);
+      layout();                     // re-generate displayText
+      }
+
+void FiguredBassItem::undoSetParenth1(Parenthesis par)
+      {
+      score()->undoChangeProperty(this, P_FBPARENTHESIS1, par);
+      layout();                     // re-generate displayText
+      }
+void FiguredBassItem::undoSetParenth2(Parenthesis par)
+      {
+      score()->undoChangeProperty(this, P_FBPARENTHESIS2, par);
+      layout();                     // re-generate displayText
+      }
+void FiguredBassItem::undoSetParenth3(Parenthesis par)
+      {
+      score()->undoChangeProperty(this, P_FBPARENTHESIS3, par);
+      layout();                     // re-generate displayText
+      }
+void FiguredBassItem::undoSetParenth4(Parenthesis par)
+      {
+      score()->undoChangeProperty(this, P_FBPARENTHESIS4, par);
+      layout();                     // re-generate displayText
+      }
+void FiguredBassItem::undoSetParenth5(Parenthesis par)
+      {
+      score()->undoChangeProperty(this, P_FBPARENTHESIS5, par);
+      layout();                     // re-generate displayText
       }
 
 //---------------------------------------------------------

--- a/libmscore/figuredbass.h
+++ b/libmscore/figuredbass.h
@@ -26,8 +26,9 @@ FiguredBass is rather simple: it contains only _ticks, telling the duration of t
 and a list of FiguredBassItem elements which do most of the job. It also maintains a text with the
 normalized (made uniform) version of the text, which is used during editing.
 
-Normally, a FiguredBass element is assumed to be styled with the FIGURED_BASS style and it is set
-in this way upon creation.
+Normally, a FiguredBass element is assumed to be styled with an internally maintained text style
+(based on the parameters of the general style "Figured Bass") FIGURED_BASS style and it is set
+in this way upon creation and upon layout().
 - - - -
 FiguredBassItem contains the actually f.b. info; it is made of 4 parts (in this order):
 1) prefix: one of [nothing, doubleflat, flat, natural, sharp, doublesharp]
@@ -58,10 +59,15 @@ and it is edited (via the normalized text); so it is derived from Text.
 //   @@ FiguredBassItem
 ///   One line of a figured bass indication
 //
-//    @P prefix               the accidental before the digit; enum ModifierNone, ModifierDoubleFlat, ModifierFlat, ModifierNatural, ModifierSharp, ModifierDoubleSharp
+//    @P prefix               enum FiguredBassItem.ModifierNone, .ModifierDoubleFlat, .ModifierFlat, .ModifierNatural, .ModifierSharp, .ModifierDoubleSharp the accidental before the digit
 //    @P digit                int         the main digit (0 - 9)
-//    @P suffix               the accidental/diacritic after the digit; enum ModifierNone, ModifierDoubleFlat, ModifierFlat, ModifierNatural, ModifierSharp, ModifierDoubleSharp, ModifierPlus, ModifierBackslash, ModifierSlash
+//    @P suffix               enum FiguredBassItem.ModifierNone, .ModifierDoubleFlat, .ModifierFlat, .ModifierNatural, .ModifierSharp, .ModifierDoubleSharp, .ModifierPlus, .ModifierBackslash, .ModifierSlash    the accidental/diacritic after the digit
 //    @P continuationLine     bool        whether the item has a continuation line or not
+//    @P parenthesis1         enum FiguredBassItem.ParenthesisNone, .ParenthesisRoundOpen, ParenthesisRoundClosed, ParenthesisSquaredOpen, ParenthesisSquaredClosed     the parentesis before the prefix
+//    @P parenthesis2         enum FiguredBassItem.ParenthesisNone, .ParenthesisRoundOpen, ParenthesisRoundClosed, ParenthesisSquaredOpen, ParenthesisSquaredClosed     the parentesis after the prefix / before the digit
+//    @P parenthesis3         enum FiguredBassItem.ParenthesisNone, .ParenthesisRoundOpen, ParenthesisRoundClosed, ParenthesisSquaredOpen, ParenthesisSquaredClosed     the parentesis after the digit / before the suffix
+//    @P parenthesis4         enum FiguredBassItem.ParenthesisNone, .ParenthesisRoundOpen, ParenthesisRoundClosed, ParenthesisSquaredOpen, ParenthesisSquaredClosed     the parentesis after the suffix / before the cont. line
+//    @P parenthesis5         enum FiguredBassItem.ParenthesisNone, .ParenthesisRoundOpen, ParenthesisRoundClosed, ParenthesisSquaredOpen, ParenthesisSquaredClosed     the parentesis after the cont. line
 //    @P displayText          string      R/O the text displayed (depends on configured fonts)
 //    @P normalizedText       string      R/O conventional textual representation of item properties (= text used during input)
 //---------------------------------------------------------
@@ -70,6 +76,19 @@ class FiguredBass;
 
 class FiguredBassItem : public Element {
       Q_OBJECT
+      Q_ENUMS(Modifier)
+      Q_ENUMS(Parenthesis)
+      Q_PROPERTY(Modifier     prefix            READ prefix       WRITE undoSetPrefix)
+      Q_PROPERTY(int          digit             READ digit        WRITE undoSetDigit)
+      Q_PROPERTY(Modifier     suffix            READ suffix       WRITE undoSetSuffix)
+      Q_PROPERTY(bool         continuationLine  READ contLine     WRITE undoSetContLine)
+      Q_PROPERTY(Parenthesis  parenthesis1      READ parenth1     WRITE undoSetParenth1)
+      Q_PROPERTY(Parenthesis  parenthesis2      READ parenth2     WRITE undoSetParenth2)
+      Q_PROPERTY(Parenthesis  parenthesis3      READ parenth3     WRITE undoSetParenth3)
+      Q_PROPERTY(Parenthesis  parenthesis4      READ parenth4     WRITE undoSetParenth4)
+      Q_PROPERTY(Parenthesis  parenthesis5      READ parenth5     WRITE undoSetParenth5)
+      Q_PROPERTY(QString      displayText       READ displayText)
+      Q_PROPERTY(QString      normalizedText    READ normalizedText)
 
    public:
       enum Modifier {
@@ -94,12 +113,6 @@ class FiguredBassItem : public Element {
       };
 
    private:
-      Q_PROPERTY(Modifier     prefix            READ prefix       WRITE undoSetPrefix)
-      Q_PROPERTY(int          digit             READ digit        WRITE undoSetDigit)
-      Q_PROPERTY(Modifier     suffix            READ suffix       WRITE undoSetSuffix)
-      Q_PROPERTY(bool         continuationLine  READ contLine     WRITE undoSetContLine)
-      Q_PROPERTY(QString      displayText       READ displayText)
-      Q_PROPERTY(QString      normalizedText    READ normalizedText)
 
       static const QChar normParenthToChar[NumOfParentheses];
 
@@ -156,6 +169,16 @@ class FiguredBassItem : public Element {
       void              undoSetSuffix(Modifier suff);
       bool              contLine() const              { return _contLine;     }
       void              undoSetContLine(bool val);
+      Parenthesis       parenth1()                    { return parenth[0];    }
+      Parenthesis       parenth2()                    { return parenth[1];    }
+      Parenthesis       parenth3()                    { return parenth[2];    }
+      Parenthesis       parenth4()                    { return parenth[3];    }
+      Parenthesis       parenth5()                    { return parenth[4];    }
+      void              undoSetParenth1(Parenthesis par);
+      void              undoSetParenth2(Parenthesis par);
+      void              undoSetParenth3(Parenthesis par);
+      void              undoSetParenth4(Parenthesis par);
+      void              undoSetParenth5(Parenthesis par);
       QString           normalizedText() const;
       QString           displayText() const           { return _displayText;  }
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -106,10 +106,15 @@ static const PropertyData propertyList[] = {
       { P_SHOW_NATURALS,       "showNaturals",  T_BOOL   },
       { P_BREAK_HINT,          "",              T_BOOL   },
 
-      { P_FBPREFIX,            "",              T_INT    },
-      { P_FBDIGIT,             "",              T_INT    },
-      { P_FBSUFFIX,            "",              T_INT    },
-      { P_FBCONTINUATIONLINE,  "",              T_BOOL   },
+      { P_FBPREFIX,            "prefix",        T_INT    },
+      { P_FBDIGIT,             "digit",         T_INT    },
+      { P_FBSUFFIX,            "suffix",        T_INT    },
+      { P_FBCONTINUATIONLINE,  "continuationLine", T_BOOL},
+      { P_FBPARENTHESIS1,      "",              T_INT    },
+      { P_FBPARENTHESIS2,      "",              T_INT    },
+      { P_FBPARENTHESIS3,      "",              T_INT    },
+      { P_FBPARENTHESIS4,      "",              T_INT    },
+      { P_FBPARENTHESIS5,      "",              T_INT    },
 
       { P_END,                 "",              T_INT    }
       };

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -96,6 +96,11 @@ enum P_ID {
       P_FBDIGIT,              //    "           "
       P_FBSUFFIX,             //    "           "
       P_FBCONTINUATIONLINE,   //    "           "
+      P_FBPARENTHESIS1,       //    "           "
+      P_FBPARENTHESIS2,       //    "           "
+      P_FBPARENTHESIS3,       //    "           "
+      P_FBPARENTHESIS4,       //    "           "
+      P_FBPARENTHESIS5,       //    "           "
 
       P_END
       };


### PR DESCRIPTION
This pull should complete the FiguredBassItem properties.

I am not really satisfied with parenthesis1 ... 5 implementation, but I did not find a way to bind a member variable of an array of non-pointers to a QML array property.
