### PR TITLE
fix #17892

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -935,10 +935,10 @@ bool Score::layoutSystem(qreal& minWidth, qreal w, bool isFirstSystem, bool long
                   if (isFirstMeasure) {
                         firstMeasure = m;
                         addSystemHeader(m, !isFirstSystem);
-                        ww = m->minWidth2();
+                        ww = m->minWidthWSysHdr();
                         }
                   else
-                        ww = m->minWidth1();
+                        ww = m->minWidthNoSysHdr();
 
                   Segment* s = m->last();
                   if ((s->subtype() == Segment::SegEndBarLine) && s->element(0)) {
@@ -962,7 +962,7 @@ bool Score::layoutSystem(qreal& minWidth, qreal w, bool isFirstSystem, bool long
                               }
                         }
 
-// printf("%d) %f %f   %f\n", m->no()+1, m->minWidth1(), m->minWidth2(), ww);
+// printf("%d) %f %f   %f\n", m->no()+1, m->minWidthNoSysHdr(), m->minWidthWSysHdr(), ww);
 
                   ww *= m->userStretch() * styleD(ST_measureSpacing);
                   if (ww < minMeasureWidth)
@@ -1150,10 +1150,10 @@ bool Score::layoutSystem1(qreal& minWidth, bool isFirstSystem, bool longName)
                   m->createEndBarLines();       // TODO: type not set right here
                   if (isFirstMeasure) {
                         addSystemHeader(m, !isFirstSystem);
-                        ww = m->minWidth2();
+                        ww = m->minWidthWSysHdr();
                         }
                   else
-                        ww = m->minWidth1();
+                        ww = m->minWidthNoSysHdr();
 
 // printf("%d) %d %f\n", m->no()+1, m->systemHeader(), m->minWidth());
 
@@ -1880,7 +1880,7 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
                         Measure* m = (Measure*)mb;
                         if (needRelayout)
                               m->setDirty();
-                        minWidth    += m->minWidth2();
+                        minWidth    += m->minWidthWSysHdr();
                         totalWeight += m->ticks() * m->userStretch();
                         }
                   }
@@ -1922,7 +1922,7 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
                               }
                         else {
                               qreal weight = m->ticks() * m->userStretch();
-                              ww           = m->minWidth2() + rest * weight;
+                              ww           = m->minWidthWSysHdr() + rest * weight;
                               }
                         m->layout(ww);
                         }
@@ -2039,7 +2039,7 @@ void Score::layoutLinear()
             if (mb->type() == MEASURE) {
                   Measure* m = static_cast<Measure*>(mb);
                   m->createEndBarLines();       // TODO: not set here
-                  w = m->minWidth1() * 1.5;
+                  w = m->minWidthNoSysHdr() * 1.5;
                   m->layout(w);
                   }
             else

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -123,8 +123,8 @@ Measure::Measure(Score* s)
             staves.push_back(s);
             }
 
-      _minWidth1             = 0.0;
-      _minWidth2             = 0.0;
+      _minWidthNoSysHdr      = 0.0;
+      _minWidthWSysHdr       = 0.0;
 
       _no                    = 0;
       _noOffset              = 0;
@@ -157,8 +157,8 @@ Measure::Measure(const Measure& m)
       foreach(MStaff* ms, m.staves)
             staves.append(new MStaff(*ms));
 
-      _minWidth1             = m._minWidth1;
-      _minWidth2             = m._minWidth2;
+      _minWidthNoSysHdr      = m._minWidthNoSysHdr;
+      _minWidthWSysHdr       = m._minWidthWSysHdr;
 
       _no                    = m._no;
       _noOffset              = m._noOffset;
@@ -2809,8 +2809,8 @@ void Space::max(const Space& s)
 
 void Measure::setDirty()
       {
-      _minWidth1 = 0.0;
-      _minWidth2 = 0.0;
+      _minWidthNoSysHdr = 0.0;
+      _minWidthWSysHdr = 0.0;
       }
 
 //---------------------------------------------------------
@@ -2822,17 +2822,21 @@ void Measure::setDirty()
 
 bool Measure::systemHeader() const
       {
-      Segment* s = first();
-      return s && (s->subtype() == Segment::SegClef) && s->element(0) && s->element(0)->generated();
+//      Segment* s = first();
+//      return s && (s->subtype() == Segment::SegClef) && s->element(0) && s->element(0)->generated();
+      // relying on clef segment may be wrong if staves are all TAB's, as TAB's can be clef-less;
+      // trying another way:
+      System * sys = system();
+      return sys && (sys->measures().first() == this);
       }
 
 //---------------------------------------------------------
-//   minWidth1
+//   minWidthNoSysHdr
 //---------------------------------------------------------
 
-qreal Measure::minWidth1() const
+qreal Measure::minWidthNoSysHdr() const
       {
-      if (_minWidth1 == 0.0) {
+      if (_minWidthNoSysHdr == 0.0) {
             Segment* s = first();
             if (s->subtype() == Segment::SegClef && s->element(0) && s->element(0)->generated() && s->next()) {
                   s = s->next();
@@ -2841,20 +2845,20 @@ qreal Measure::minWidth1() const
                   if (s->subtype() == Segment::SegStartRepeatBarLine && s->next())
                         s = s->next();
                   }
-            _minWidth1 = score()->computeMinWidth(s);
+            _minWidthNoSysHdr = score()->computeMinWidth(s);
             }
-      return _minWidth1;
+      return _minWidthNoSysHdr;
       }
 
 //---------------------------------------------------------
-//   minWidth2
+//   minWidthWSysHdr
 //---------------------------------------------------------
 
-qreal Measure::minWidth2() const
+qreal Measure::minWidthWSysHdr() const
       {
-      if (_minWidth2 == 0.0)
-            _minWidth2 = score()->computeMinWidth(first());
-      return _minWidth2;
+      if (_minWidthWSysHdr == 0.0)
+            _minWidthWSysHdr = score()->computeMinWidth(first());
+      return _minWidthWSysHdr;
       }
 
 //-----------------------------------------------------------------------------
@@ -3224,7 +3228,7 @@ void Measure::layoutX(qreal stretch)
 
 void Measure::layoutStage1()
       {
-      (systemHeader() ? _minWidth2 : _minWidth1) = 0.0;
+      (systemHeader() ? _minWidthWSysHdr : _minWidthNoSysHdr) = 0.0;
       for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
             setBreakMMRest(false);
             if (score()->styleB(ST_createMultiMeasureRests)) {
@@ -3376,8 +3380,8 @@ Measure* Measure::cloneMeasure(Score* sc, TieMap* tieMap, SpannerMap* spannerMap
       m->_playbackCount         = _playbackCount;
       m->_endBarLineColor       = _endBarLineColor;
 
-      m->_minWidth1             = _minWidth1;
-      m->_minWidth2             = _minWidth2;
+      m->_minWidthNoSysHdr      = _minWidthNoSysHdr;
+      m->_minWidthWSysHdr       = _minWidthWSysHdr;
 
       m->setTick(tick());
       m->setLineBreak(lineBreak());

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -101,8 +101,8 @@ class Measure : public MeasureBase {
 
       qreal _userStretch;
 
-      mutable qreal _minWidth1;     ///< minimal measure width without system header
-      mutable qreal _minWidth2;     ///< minimal measure width with system header
+      mutable qreal _minWidthNoSysHdr;     ///< minimal measure width without system header
+      mutable qreal _minWidthWSysHdr;     ///< minimal measure width with system header
 
       bool _irregular;              ///< Irregular measure, do not count
       bool _breakMultiMeasureRest;  ///< set by user
@@ -168,10 +168,10 @@ class Measure : public MeasureBase {
       virtual qreal userDistanceUp(int i) const;
       virtual qreal userDistanceDown(int i) const;
 
-      qreal minWidth1() const;
-      qreal minWidth2() const;
-      void setMinWidth1(qreal w)           { _minWidth1 = w;      }
-      void setMinWidth2(qreal w)           { _minWidth2 = w;      }
+      qreal minWidthNoSysHdr() const;
+      qreal minWidthWSysHdr() const;
+      void setminWidthNoSysHdr(qreal w)    { _minWidthNoSysHdr = w; }
+      void setminWidthWSysHdr(qreal w)     { _minWidthWSysHdr = w;  }
       bool systemHeader() const;
       void setDirty();
 


### PR DESCRIPTION
Make Measure::systemHeader() not to rely on clef segment but on position of measure in system() list.

Also rename minWith1, minWidth2 with...minWithNoSysHrd and minWithWSysHdr resp.
