### PR TITLE
Fix #17727

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4849,7 +4849,7 @@ void ScoreView::cmdAddPitch(int note, bool addFlag)
       InputState& is = _score->inputState();
       if (is.track() == -1)          // invalid state
             return;
-      if (is.segment() == 0 || is.cr() == 0) {
+      if (is.segment() == 0 /*|| is.cr() == 0*/) {
             qDebug("cannot enter notes here (no chord rest at current position)");
             return;
             }


### PR DESCRIPTION
Removes a test ( is.cr() == 0 ) at the beginning of ScoreView::cmdAddPitch().

The test seems reasonable, but it prevents adding a note to a segment track if a ChordRest is not already there, which is precisely what happens with voices 2 to 4.

The InputState's ChrdRest is not used anywhere else in the function and the test seems redundant. The final call to score()->putNote() will add the needed segment ChordRest(s), if lacking (via expandVoice() ).

Some local tests with multi-voice scores did not exposed any side effect.
