### PR TITLE
Take into account _small flag for accidental layout

### DIFF
--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -288,6 +288,8 @@ void Accidental::layout()
             }
 
       qreal m = magS();
+      if (_small)
+            m *= score()->styleD(ST_smallNoteMag);
       QPointF pos;
       if (_hasBracket) {
             SymElement e(leftparenSym, 0.0);


### PR DESCRIPTION
Necessary to compute the right bbox and the right position of parentheses, if present (currently parentheses are positioned as if the accidental inside be large rather than small).
