### PR TITLE
Add "Staff types..." item to "Edit" menu.

### DIFF
--- a/mscore/actions.cpp
+++ b/mscore/actions.cpp
@@ -2051,6 +2051,14 @@ Shortcut Shortcut::sc[] = {
          "unset-visible",
          QT_TRANSLATE_NOOP("action","set unvisible")
          ),
+      Shortcut(
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         0,
+         "staff-types",
+         QT_TRANSLATE_NOOP("action","Staff Types..."),
+         QT_TRANSLATE_NOOP("action","Staff type editor"),
+         QT_TRANSLATE_NOOP("action","Show staff type editor")
+         ),
       // xml==0  marks end of list
       Shortcut(0, 0, 0, 0)
       };

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -79,6 +79,7 @@
 #include "plugins.h"
 #include "helpBrowser.h"
 #include "drumtools.h"
+#include "editstafftype.h"
 
 #include "libmscore/mscore.h"
 #include "libmscore/system.h"
@@ -748,8 +749,11 @@ MuseScore::MuseScore()
       menuVoices->addAction(getAction("voice-x24"));
       menuVoices->addAction(getAction("voice-x34"));
       menuEdit->addMenu(menuVoices);
-
       menuEdit->addSeparator();
+
+      menuEdit->addAction(getAction("staff-types"));
+      menuEdit->addSeparator();
+
       menuEdit->addAction(getAction("debugger"));
       menuEdit->addSeparator();
 
@@ -2447,6 +2451,7 @@ int main(int argc, char* av[])
       mscore->setUnifiedTitleAndToolBarOnMac(false);
 #endif
 
+      mscore->changeState(mscore->noScore() ? STATE_DISABLED : STATE_NORMAL);
       mscore->show();
 
       if (sc)
@@ -4391,6 +4396,18 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                         cs->setLayoutMode(LayoutPage);
                         viewModeCombo->setCurrentIndex(0);
                         }
+                  }
+            }
+      else if(cmd == "staff-types") {
+            Staff * staff = cs->staff(0);
+            EditStaffType* est = new EditStaffType(this, staff);
+            if (est->exec() && est->isModified()) {
+                  Score* score = cs;
+                  score->startCmd();
+                  QList<StaffType*> tl = est->getStaffTypes();
+                  score->replaceStaffTypes(tl);
+                  score->setLayoutAll(true);
+                  score->endCmd();
                   }
             }
       else {


### PR DESCRIPTION
Also set initial mscore state in MuseScore constructor right before showing the window to initially enable/disable menu items which depend upon the presence of  a score.

Please review the new code for the added menu item (file mscore/musescore.cpp, MuseScore::cmd(), lines 4401-4412).
