### PR TITLE
initial implementation of plop and scoop

### DIFF
--- a/libmscore/chordline.cpp
+++ b/libmscore/chordline.cpp
@@ -53,6 +53,14 @@ void ChordLine::setSubtype(ChordLineType st)
                   x2 = 2;
                   y2 = 2;
                   break;
+            case CHORDLINE_PLOP:
+                  x2 = -2;
+                  y2 = -2;
+                  break;
+            case CHORDLINE_SCOOP:
+                  x2 = -2;
+                  y2 = 2;
+                  break;
             default:
             case CHORDLINE_DOIT:
                   x2 = 2;
@@ -61,7 +69,12 @@ void ChordLine::setSubtype(ChordLineType st)
             }
       if (st) {
             path = QPainterPath();
-            path.cubicTo(x2/2, 0.0, x2, y2/2, x2, y2);
+            // chordlines to the right of the note
+            if (st == CHORDLINE_FALL || st == CHORDLINE_DOIT)
+                  path.cubicTo(x2/2, 0.0, x2, y2/2, x2, y2);
+            // chordlines to the left of the note
+            if (st == CHORDLINE_PLOP || st == CHORDLINE_SCOOP)
+                  path.cubicTo(0.0, y2/2, x2/2, y2, x2, y2);
             }
       _subtype = st;
       }
@@ -76,7 +89,14 @@ void ChordLine::layout()
       if (parent()) {
             Note* note = chord()->upNote();
             QPointF p(note->pos());
-            setPos(p.x() + note->headWidth() + _spatium * .2, p.y());
+            // chordlines to the right of the note
+            if (_subtype == CHORDLINE_FALL || _subtype == CHORDLINE_DOIT)
+                  setPos(p.x() + note->headWidth() + _spatium * .2, p.y());
+            // chordlines to the left of the note
+            if (_subtype == CHORDLINE_PLOP)
+                  setPos(p.x() + note->headWidth() * .25, p.y() - note->headHeight() * .75);
+            if (_subtype == CHORDLINE_SCOOP)
+                  setPos(p.x() + note->headWidth() * .25, p.y() + note->headHeight() * .75);
             }
       else
             setPos(0.0, 0.0);

--- a/libmscore/chordline.h
+++ b/libmscore/chordline.h
@@ -21,7 +21,8 @@ class QPainter;
 
 // subtypes:
 enum ChordLineType {
-      CHORDLINE_NOTYPE, CHORDLINE_FALL, CHORDLINE_DOIT
+      CHORDLINE_NOTYPE, CHORDLINE_FALL, CHORDLINE_DOIT,
+      CHORDLINE_PLOP, CHORDLINE_SCOOP
       };
 
 //---------------------------------------------------------

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1666,6 +1666,12 @@ static void chordAttributes(Chord* chord, Notations& notations, Technical& techn
                         case CHORDLINE_DOIT:
                               subtype = "doit";
                               break;
+                        case CHORDLINE_PLOP:
+                              subtype = "plop";
+                              break;
+                        case CHORDLINE_SCOOP:
+                              subtype = "scoop";
+                              break;
                         default:
                               qDebug("unknown ChordLine subtype %d", cl->subtype());
                         }

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -4440,7 +4440,9 @@ void MusicXml::xmlNotations(Note* note, ChordRest* cr, int trk, int ticks, QDomE
                         else if (eee.tagName() == "caesura")
                               breath = 3;
                         else if (eee.tagName() == "doit"
-                                 || eee.tagName() == "falloff")
+                                 || eee.tagName() == "falloff"
+                                 || eee.tagName() == "plop"
+                                 || eee.tagName() == "scoop")
                               chordLineType = eee.tagName();
                         else if (eee.tagName() == "strong-accent") {
                               QString strongAccentType = eee.attribute(QString("type"));
@@ -4649,6 +4651,10 @@ void MusicXml::xmlNotations(Note* note, ChordRest* cr, int trk, int ticks, QDomE
                   cl->setSubtype(CHORDLINE_FALL);
             if (chordLineType == "doit")
                   cl->setSubtype(CHORDLINE_DOIT);
+            if (chordLineType == "plop")
+                  cl->setSubtype(CHORDLINE_PLOP);
+            if (chordLineType == "scoop")
+                  cl->setSubtype(CHORDLINE_SCOOP);
             note->chord()->add(cl);
             }
 

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -395,6 +395,8 @@ Palette* MuseScore::newFallDoitPalette()
       const char* scorelineNames[] = {
             QT_TR_NOOP("fall"),
             QT_TR_NOOP("doit"),
+            QT_TR_NOOP("plop"),
+            QT_TR_NOOP("scoop"),
             };
 
       ChordLine* cl = new ChordLine(gscore);
@@ -404,6 +406,14 @@ Palette* MuseScore::newFallDoitPalette()
       cl = new ChordLine(gscore);
       cl->setSubtype(CHORDLINE_DOIT);
       sp->append(cl, tr(scorelineNames[1]));
+
+      cl = new ChordLine(gscore);
+      cl->setSubtype(CHORDLINE_PLOP);
+      sp->append(cl, tr(scorelineNames[2]));
+
+      cl = new ChordLine(gscore);
+      cl->setSubtype(CHORDLINE_SCOOP);
+      sp->append(cl, tr(scorelineNames[3]));
       return sp;
       }
 


### PR DESCRIPTION
Partial solution to issue #15077: plop and scoop are implemented and added to the fall/doit menu. They are exported/imported to and from MusicXML. Bend is still missing, as is the option to change the curved line to a straight one.
