### PR TITLE
Fix ticks immediately when changing measure length

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1762,8 +1762,8 @@ void ChangeMeasureLen::flip()
             segment->setTick(endTick);
             }
       measure->setLen(len);
-      measure->score()->addLayoutFlags(LAYOUT_FIX_TICKS);
-//      measure->score()->fixTicks();
+//      measure->score()->addLayoutFlags(LAYOUT_FIX_TICKS); // we need to fix tick immediately!
+      measure->score()->fixTicks();
       len = oLen;
       }
 


### PR DESCRIPTION
Calls Score::fixTicks() from within undo's ChangeMeasureLen::flip() instead of simply adding LAYOUT_FIX_TICKS to layout flags.

Test:
1) Open or create any score
2) Reduce the actual duration of measure
3) Press OK
=> SIGFAULT

This is because any operation on measures after ChangeMeasureLen::flip() -- and before re-layout -- finds the score in an inconsistent state (with a 'time hole' between the reduced measure and the next).

Calling fixTicks() from within ChangeMeasureLen::flip() itself fix this.
