### PR TITLE
Do not delete key sigs in TABs, only hide them. Fix #17930

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -90,6 +90,13 @@ void KeySig::layout()
       qreal _spatium = spatium();
       setbbox(QRectF());
 
+      if(staff() && staff()->isTabStaff()) {     // no key sigs on TAB staves
+            foreach(KeySym* ks, keySymbols)
+                  delete ks;
+            keySymbols.clear();
+            return;
+            }
+
       if (isCustom()) {
             foreach(KeySym* ks, keySymbols) {
                   ks->pos = ks->spos * _spatium;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -747,8 +747,8 @@ void Score::addSystemHeader(Measure* m, bool isFirstSystem)
                               break;
                         }
                   }
-            bool needKeysig = !staff->isTabStaff()
-               && keyIdx.isValid()
+            bool needKeysig = /* !staff->isTabStaff()       // keep key sigs in TABs: TABs themselves should hide them
+               && */ keyIdx.isValid()
                && (isFirstSystem || styleB(ST_genKeysig));
 
             if (needKeysig && !keysig) {


### PR DESCRIPTION
Changed:
- Score::addSystemHeader() to not delete key sigs in TAB staves
- KeySig::layout() to hide itself if in TAB staff.
