### PR TITLE
Added layout and bbox to TabDurationSymbol; included its bbox in Chord box

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1268,7 +1268,6 @@ void Chord::layout()
             qreal lineDist = tab->lineDistance().val();
             foreach(Note* note, _notes) {
                   note->layout();
-//                  note->setPos(0.0, _spatium * (tab->upsideDown() ? tab->lines()-note->string()-1 : note->string()) * lineDist);
                   note->setPos(0.0, _spatium * tab->physStringToVisual(note->string()) * lineDist);
                   note->layout2();
                   }
@@ -1311,6 +1310,7 @@ void Chord::layout()
                               _tabDur->setDuration(durationType().type(), dots());
                         _tabDur->setParent(this);
                         // needed?        _tabDur->setTrack(track());
+                        _tabDur->layout();
                         }
                   else {                    // symbol not needed: if exists, delete
                         delete _tabDur;
@@ -1491,6 +1491,8 @@ const QRectF& Chord::bbox() const
             bb |= _stemSlash->bbox().translated(_stemSlash->pos());
       if (_tremolo)
             bb |= _tremolo->bbox().translated(_tremolo->pos());
+      if(staff()->isTabStaff() && _tabDur)
+            bb |= _tabDur->bbox().translated(_tabDur->pos());
       setbbox(bb);
       return Element::bbox();
       }

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -113,6 +113,8 @@ ChordRest::~ChordRest()
             delete a;
       foreach(Lyrics* l, _lyricsList)
             delete l;
+      if(_tabDur)
+            delete _tabDur;
       }
 
 //---------------------------------------------------------

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -706,15 +706,15 @@ TabDurationSymbol::TabDurationSymbol(const TabDurationSymbol& e)
 //---------------------------------------------------------
 //   layout
 //---------------------------------------------------------
-/*
+
 void TabDurationSymbol::layout()
       {
       QFontMetricsF fm(_tab->durationFont());
       qreal mags = magS();
       qreal w = fm.width(_text);
-      _bbox = QRectF(0.0, _tab->durationBoxY() * mags, w * mags, _tab->durationBoxH() * mags);
+      setbbox(QRectF(0.0, _tab->durationBoxY() * mags, w * mags, _tab->durationBoxH() * mags) );
       }
-*/
+
 //---------------------------------------------------------
 //   draw
 //---------------------------------------------------------

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -312,6 +312,7 @@ class TabDurationSymbol : public Element {
       virtual TabDurationSymbol* clone() const  { return new TabDurationSymbol(*this); }
       virtual void draw(QPainter*) const;
       virtual bool isEditable() const           { return false; }
+      virtual void layout();
       virtual ElementType type() const          { return TAB_DURATION_SYMBOL; }
 
       void  setDuration(TDuration::DurationType type, int dots) { buildText(type, dots); }


### PR DESCRIPTION
Sometime, duration symbols above TAB staves were not drawn or not drawn completely.

Computing their bbox and including it in Chord bbox is supposed to fix this.

I'll merge soon if no problem surfaces.
