### PR TITLE
fix: null pointer check in layout.cpp

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -919,7 +919,7 @@ qreal Score::cautionaryWidth(Measure* m)
                   }
             Segment* s = m->findSegment(Segment::SegKeySigAnnounce, tick);
 
-            if (showCourtesy && !s)
+            if (showCourtesy && !s && ks)
                   wwMax = qMax(wwMax, ks->space().width());
             else if (!showCourtesy && s && s->element(track))
                   wwMin = qMin(wwMin, -static_cast<KeySig*>(s->element(track))->space().width());


### PR DESCRIPTION
proposed fix for 18097:
Check if pointer ks is valid since a key signature doesn't need to be present in all staves.
