### PR TITLE
Fix transpose key

### DIFF
--- a/libmscore/key.cpp
+++ b/libmscore/key.cpp
@@ -224,14 +224,14 @@ void KeyList::read(const QDomElement& de, Score* cs)
 //---------------------------------------------------------
 
 int transposeKey(int key, const Interval& interval)
-{
+      {
       int tpc = key+14;
       tpc = transposeTpc(tpc, interval, false);
       // check for valid key sigs
       if (tpc > 21) tpc-=12; // no more than 7 sharps in keysig
       if (tpc < 7) tpc+=12; // no more than 7 flats in keysig
       return (tpc-14);
-}
+      }
 
 //---------------------------------------------------------
 //   initFromSubtype


### PR DESCRIPTION
transposeKey() in libmscore/key.cpp did return illegal key signatures such as (D# major) because D# itself doesn't use a double sharp. The key of D# major however does.
This was a problem when transposing scores.
