### PR TITLE
TAB Staff Type Editor: settings compatibility

### DIFF
--- a/mscore/editstafftype.h
+++ b/mscore/editstafftype.h
@@ -63,6 +63,9 @@ class EditStaffType : public QDialog, private Ui::EditStaffType {
       void saveCurrent(QListWidgetItem*);
       void setDlgFromTab(const StaffTypeTablature* stt);
       void setTabFromDlg(StaffTypeTablature* stt);
+      void tabStemsCompatibility(bool checked);
+      void tabMinimShortCompatibility(bool checked);
+      void tabStemThroughCompatibility(bool checked);
 
    private slots:
       void typeChanged(QListWidgetItem*, QListWidgetItem*);
@@ -71,6 +74,8 @@ class EditStaffType : public QDialog, private Ui::EditStaffType {
       void presetTablatureChanged(int idx);
       void on_pushFullConfig_clicked();
       void on_pushQuickConfig_clicked();
+      void on_tabStemThroughToggled(bool checked);
+      void on_tabMinimShortToggled(bool checked);
       void on_tabStemsToggled(bool checked);
       void updateTabPreview();
 

--- a/mscore/stafftype.ui
+++ b/mscore/stafftype.ui
@@ -707,7 +707,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QRadioButton" name="noteValues0">
+                     <widget class="QRadioButton" name="noteValuesNone">
                       <property name="minimumSize">
                        <size>
                         <width>110</width>
@@ -720,7 +720,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QRadioButton" name="noteValues1">
+                     <widget class="QRadioButton" name="noteValuesSymb">
                       <property name="minimumSize">
                        <size>
                         <width>120</width>
@@ -733,7 +733,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QRadioButton" name="noteValues2">
+                     <widget class="QRadioButton" name="noteValuesStems">
                       <property name="text">
                        <string>Stems and beams</string>
                       </property>
@@ -1258,9 +1258,9 @@
   <tabstop>aboveLinesRadio</tabstop>
   <tabstop>linesThroughRadio</tabstop>
   <tabstop>linesBrokenRadio</tabstop>
-  <tabstop>noteValues0</tabstop>
-  <tabstop>noteValues1</tabstop>
-  <tabstop>noteValues2</tabstop>
+  <tabstop>noteValuesNone</tabstop>
+  <tabstop>noteValuesSymb</tabstop>
+  <tabstop>noteValuesStems</tabstop>
   <tabstop>stemAboveRadio</tabstop>
   <tabstop>stemBelowRadio</tabstop>
   <tabstop>stemBesideRadio</tabstop>


### PR DESCRIPTION
Implemented compatibility across different TAB settings:

*) Values as Stems and Beams with stem settings
*) Minim Short with Stems Through
