### PR TITLE
fix 18226: [MusicXML] Beamed multiple grace notes not beamed

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -782,11 +782,15 @@ Segment* Measure::getSegment(Segment::SegmentType st, int t)
 
 Segment* Measure::getGraceSegment(int t, int gl)
       {
-      Segment* s;
+      Segment* s = 0;
 
       // find the first segment at tick >= t
-      for (s = first(Segment::SegChordRest); s && s->tick() < t; s = s->next(Segment::SegChordRest))
-            ;
+          for (Segment* ss = first(Segment::SegChordRest); ss && ss->tick() <= t; ss = ss->next(Segment::SegChordRest)) {
+              if(ss->tick() == t) {
+                  s = ss;
+                  break;
+              }
+          }
       if (s == 0) {
             s = new Segment(this, Segment::SegChordRest, t);
             add(s);
@@ -798,13 +802,17 @@ Segment* Measure::getGraceSegment(int t, int gl)
       int nGraces  = 0;
       Segment* sCr = 0;
       for (Segment* ss = s; ss && ss->tick() == t; ss = ss->next()) {
-            if (ss->subtype() == Segment::SegGrace)
-                  nGraces++;
             if (ss->subtype() == Segment::SegChordRest) {
                   sCr = ss;
                   break;
                   }
             }
+          
+      for (Segment* ss = sCr; ss && ss->tick() == t; ss = ss->prev()) {
+          if ((ss->subtype() == Segment::SegGrace) && (ss->tick() == t))
+              nGraces++;
+      }
+          
       for (; nGraces < gl; ++nGraces) {
             Segment* ps = new Segment(this, Segment::SegGrace, t);
             _segments.insert(ps, s);


### PR DESCRIPTION
maybe fix:
http://musescore.org/en/node/18226
http://musescore.org/en/node/18288

When get grace segment, first get chordrest segment at tick, then search backwards for its graces. If there is already grace segment, do not create it.
