### PR TITLE
Checks _imageStore is valid before accessing it.

### DIFF
--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -357,8 +357,7 @@ bool Image::load(const QString& ss)
       _linkIsValid = true;
       _linkPath = fi.canonicalFilePath();
       _storeItem = imageStore.add(_linkPath, ba);
-      if(_storeItem)
-            _storeItem->reference(this);
+      _storeItem->reference(this);
       return true;
       }
 


### PR DESCRIPTION
Occasionally, Image::_imageStore might be accessed without being valid. For instance, when cloning an image from the whole score to an excerpt, when the image is not available.

This fix adds the relevant checks in two places.
