### PR TITLE
Fix #18664

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1929,7 +1929,29 @@ void Score::addStaffTypes(const QList<StaffType*>& tl)
 
 void Score::replaceStaffTypes(const QList<StaffType*>& tl)
       {
-      rootScore()->_staffTypes = tl;
+      Score* score = rootScore();
+      int   numCommonTypes = qMin(_staffTypes.size(), tl.size());
+      int   idx;
+
+      // overwrite existing styles with styles in list
+      // re-use existing _stafftype objects, so that pointers to styles in staves remain valid
+      for(idx = 0; idx < numCommonTypes; idx++)
+            if(score->_staffTypes.at(idx)->group() == tl.at(idx)->group())
+                  switch (tl.at(idx)->group()) {
+                  case PITCHED_STAFF:
+                        *(StaffTypePitched*)(score->_staffTypes[idx]) = *(StaffTypePitched*)(tl.at(idx));
+                        break;
+                  case PERCUSSION_STAFF:
+                        *(StaffTypePercussion*)(score->_staffTypes[idx]) = *(StaffTypePercussion*)(tl.at(idx));
+                        break;
+                  case TAB_STAFF:
+                        *(StaffTypeTablature*)(score->_staffTypes[idx]) = *(StaffTypeTablature*)(tl.at(idx));
+                        break;
+                  }
+
+      // add new styles
+      for(; idx < tl.size(); idx++)
+            score->_staffTypes.append(tl.at(idx)->clone());
       }
 
 //---------------------------------------------------------

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -38,7 +38,8 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
       setupUi(this);
       staff = st;
       Score* score = staff->score();
-      staffTypes   = score->staffTypes();
+      foreach(StaffType* st, score->staffTypes())
+             staffTypes.append(st->clone());
       int idx = 0;
       QListWidgetItem* ci = 0;
       foreach(StaffType* st, staffTypes) {
@@ -71,7 +72,7 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
       // load a sample tabulature score in preview
       Score* sc = new Score(MScore::defaultStyle());
       tabPreview = 0;
-      if (readScore(sc, QString(":/data/tab_sample.mscx"), false) != Score::FILE_NO_ERROR) {
+      if (readScore(sc, QString(":/data/tab_sample.mscx"), false) == Score::FILE_NO_ERROR) {
             // add a preview widget to tabulature page
 #ifdef _USE_NAVIGATOR_PREVIEW_
             NScrollArea* sa = new NScrollArea;
@@ -125,6 +126,8 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
 
 EditStaffType::~EditStaffType()
 {
+      foreach(StaffType* st, staffTypes)
+            delete st;
       if(_tabPresets[TAB_PRESET_GUITAR])
             delete _tabPresets[TAB_PRESET_GUITAR];
       if(_tabPresets[TAB_PRESET_BASS])
@@ -294,6 +297,7 @@ void EditStaffType::typeChanged(QListWidgetItem* n, QListWidgetItem* o)
                   {
                   StaffTypeTablature* stt = static_cast<StaffTypeTablature*>(st);
                   setDlgFromTab(stt);
+                  name->setText(stt->name());   // setDlgFromTab() does not copy the name and it shouldn't
                   stack->setCurrentIndex(1);
                   }
                   break;
@@ -319,7 +323,7 @@ void EditStaffType::typeChanged(QListWidgetItem* n, QListWidgetItem* o)
 
 void EditStaffType::setDlgFromTab(const StaffTypeTablature * stt)
       {
-      name->setText(stt->name());
+//      name->setText(stt->name());             // keep existing name: presets should not overwrite type name
       lines->setValue(stt->lines());
       lineDistance->setValue(stt->lineDistance().val());
       genClef->setChecked(stt->genClef());
@@ -327,7 +331,7 @@ void EditStaffType::setDlgFromTab(const StaffTypeTablature * stt)
       genTimesig->setChecked(stt->genTimesig());
       upsideDown->setChecked(stt->upsideDown());
       int idx = fretFontName->findText(stt->fretFontName(), Qt::MatchFixedString);
-      if(idx == -1)     idx = 0;          // if name not found, use firstt name
+      if(idx == -1)     idx = 0;          // if name not found, use first name
       fretFontName->setCurrentIndex(idx);
       fretFontSize->setValue(stt->fretFontSize());
       fretY->setValue(stt->fretFontUserY());

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4374,6 +4374,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   score->setLayoutAll(true);
                   score->endCmd();
                   }
+            delete est;
             }
       else {
             if (cv) {


### PR DESCRIPTION
Edit Staff Types dlg box uses a separate copy of score styles
Edit Staff Types dlg box does not clear the type name when using presets
Edit Staff Types dlg box shows preview for TAB types
Score imports a list of staff types with a in-place deep copy (to keep valid pntrs to type in staves)

Issue: http://musescore.org/en/node/18664
Also needed to fix #18640 (http://musescore.org/en/node/18640)
