### PR TITLE
Adjusts several points to changes in Score::_staffTypes

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -209,7 +209,7 @@ Score::FileError Score::read114(const QDomElement& de)
                   StaffType* ost = staffType(idx);
                   StaffType* st;
                   if (ost)
-                        st = ost;
+                        st = ost->clone();
                   else {
                         QString group  = ee.attribute("group", "pitched");
                         if (group == "percussion")
@@ -220,6 +220,7 @@ Score::FileError Score::read114(const QDomElement& de)
                               st  = new StaffTypePitched();
                         }
                   st->read(ee);
+                  st->setBuildin(false);
                   addStaffType(idx, st);
                   }
             else if (tag == "siglist")

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1910,15 +1910,25 @@ void Score::addStaffType(StaffType* st)
 
 void Score::addStaffType(int idx, StaffType* st)
       {
+      // if the modified staff type is NOT replacing an existing type
       if (idx < 0 || idx >= _staffTypes.size()) {
+            // store new pointer to pointer to type data
             StaffType** stp = new StaffType*;
             *stp = st;
             _staffTypes.append(stp);
             }
+      // if the modified staff type IS replacing an existing type
       else {
-            if (!(*(_staffTypes[idx]))->buildin())
-                  delete *(_staffTypes[idx]);
+            StaffType* oldStaffType = *(_staffTypes[idx]);
+            // update the type of each score staff which uses the old type
+            for(int staffIdx = 0; staffIdx < staves().size(); staffIdx++)
+                  if(staff(staffIdx)->staffType() == oldStaffType)
+                        staff(staffIdx)->setStaffType(st);
+            // store the updated staff type
             *(_staffTypes[idx]) = st;
+            // delete old staff type if not built-in
+            if (!oldStaffType->buildin())
+                  delete oldStaffType;
             }
       }
 

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -816,7 +816,7 @@ bool Score::read(const QDomElement& de)
                   StaffType* ost = staffType(idx);
                   StaffType* st;
                   if (ost)
-                        st = ost;
+                        st = ost->clone();
                   else {
                         QString group  = ee.attribute("group", "pitched");
                         if (group == "percussion")
@@ -827,6 +827,7 @@ bool Score::read(const QDomElement& de)
                               st  = new StaffTypePitched();
                         }
                   st->read(ee);
+                  st->setBuildin(false);
                   addStaffType(idx, st);
                   }
             else if (tag == "siglist")

--- a/mscore/stafftype.ui
+++ b/mscore/stafftype.ui
@@ -182,7 +182,7 @@
           <number>2</number>
          </property>
          <property name="currentIndex">
-          <number>1</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="page">
           <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,0,0,0,0,0">
@@ -1290,8 +1290,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>732</x>
+     <y>759</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -1306,8 +1306,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>789</x>
+     <y>759</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>

--- a/share/templates/tab_sample.mscx
+++ b/share/templates/tab_sample.mscx
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="1.24">
   <programVersion>2.0.0</programVersion>
-  <programRevision>da1358d</programRevision>
+  <programRevision>bbb35cb</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
     <SyntiSettings>
-      <s name="soundfont" val="/home/mmg/Documents/soundfonts/FluidR3_GM.sf2"/>
+      <s name="soundfont" val="C:/Program Files/MusicSW/soundfonts/FluidR3_GM.sf2"/>
       <f name="RevRoomsize" val="0.84"/>
       <f name="RevDamp" val="0.2"/>
       <f name="RevWidth" val="1"/>
@@ -49,26 +49,6 @@
         </page-layout>
       <Spatium>1.7</Spatium>
       </Style>
-    <StaffType idx="1" group="tablature">
-      <name>Tab</name>
-      <lines>6</lines>
-      <lineDistance>1.5</lineDistance>
-      <clef>0</clef>
-      <slashStyle>1</slashStyle>
-      <barlines>1</barlines>
-      <timesig>1</timesig>
-      <durations>1</durations>
-      <durationFontName>MuseScore Tab French</durationFontName>
-      <durationFontSize>15</durationFontSize>
-      <durationFontY>0</durationFontY>
-      <fretFontName>MuseScore Tab Renaiss</fretFontName>
-      <fretFontSize>10</fretFontSize>
-      <fretFontY>0</fretFontY>
-      <linesThrough>1</linesThrough>
-      <onLines>0</onLines>
-      <upsideDown>0</upsideDown>
-      <useNumbers>0</useNumbers>
-      </StaffType>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>
     <showFrames>1</showFrames>
@@ -83,12 +63,17 @@
     <metaTag name="workTitle">Lachrimae Antiquae</metaTag>
     <PageList>
       <Page>
+        <System>
+          </System>
+        <System>
+          </System>
         </Page>
       </PageList>
     <Part>
       <Staff id="1">
         <type>1</type>
         <bracket type="-1" span="1"/>
+        <barLineSpan from="0" to="8">1</barLineSpan>
         </Staff>
       <trackName>Renaissance Tenor Lute (6 course)</trackName>
       <Instrument>


### PR DESCRIPTION
*) Custom styles read from scores are clones (rather than shared pointers) and set to non-built-in
*) Score::addStaffType() updates pointers to type in staves which use a modified type
*) EditStaffType clones its staff styles and sets as non-built-in
*) Update of EditStaffType preview adapted to new Score::addStaffType()
*) TAB sample score for EditStaffType preview updated to latest version
