### PR TITLE
Fix bar line management for mensurstrich special case

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -494,7 +494,14 @@ void BarLine::endEdit()
                   int idx2 = idx1 + _span;
                   // set span 0 to all additional staves
                   for (int idx = idx1 + 1; idx < idx2; ++idx)
-                        score()->undoChangeBarLineSpan(score()->staff(idx), 0, 0, (score()->staff(idx)->lines()-1)*2);
+                        // mensurstrich special case:
+                        // if line spans to top line of a stave AND current staff is
+                        //    the last spanned staff BUT NOT the last score staff
+                        //          keep its bar lines
+                        // otherwise remove them
+                        if(_spanTo > 0 || !(idx == idx2-1 && idx != score()->nstaves()-1) )
+                              score()->undoChangeBarLineSpan(score()->staff(idx), 0, 0,
+                                          (score()->staff(idx)->lines()-1)*2);
                   }
             // if now bar lines span fewer staves
             else {

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2544,8 +2544,17 @@ bool Measure::createEndBarLines()
                         // we are extending down the bar line of a staff above (bl)
                         // and the bar line for this staff (cbl) is not needed: delete it
                         if (cbl && cbl != bl) {
-                              score()->undoRemoveElement(cbl);
-                              changed = true;
+                              // mensurstrich special case:
+                              // if line spans to top line of a stave AND current staff is
+                              //    the last spanned staff (span==1) BUT NOT the last score staff
+                              //          keep its bar line and scan this staff again!
+                              // otherwise remove them
+                              if(spanTo <= 0 && spanTot > 1 && (span == 1 && staffIdx != nstaves-1) )
+                                    staffIdx--;
+                              else {
+                                    score()->undoRemoveElement(cbl);
+                                    changed = true;
+                                    }
                               }
                         }
                   }


### PR DESCRIPTION
In mensurstrich bar lines, lines span 2 staves, but the 2nd staff needs its own bar lines kept, in order to allow mensurstrich bars from it to the following staff, if any.

Previous code deleted them unconditionally. This fix keeps the bar lines of a spanned staff, if they stop at the top staff line, without entering <b>into</b> the staff proper.
