### PR TITLE
Fix #18761

### DIFF
--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -234,6 +234,7 @@ void TextLineSegment::layout()
                   y1 = h;
             }
       setbbox(QRectF(.0, y1, pp2.x(), y2 - y1));
+      adjustReadPos();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
TextLineSegment does not keep user offset across saving and re-opening.

Fixed by adding adjustRedPos() to layout().
