### PR TITLE
#12398: Adds a dotted style to the bar line styles.

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -38,7 +38,7 @@ int  BarLine::_origSpan, BarLine::_origSpanFrom, BarLine::_origSpanTo;
 
 static const char* barLineNames[] = {
       "normal", "double", "start-repeat", "end-repeat", "dashed", "end",
-      "end-start-repeat"
+      "end-start-repeat", "dotted"
       };
 
 //---------------------------------------------------------
@@ -171,6 +171,12 @@ void BarLine::draw(QPainter* painter) const
       switch(subtype()) {
             case BROKEN_BAR:
                   pen.setStyle(Qt::DashLine);
+                  painter->setPen(pen);
+                  painter->drawLine(QLineF(lw * .5, y1, lw * .5, y2));
+                  break;
+
+            case DOTTED_BAR:
+                  pen.setStyle(Qt::DotLine);
                   painter->setPen(pen);
 
             case NORMAL_BAR:
@@ -340,6 +346,7 @@ void BarLine::read(const QDomElement& de)
                               case  4: ct = BROKEN_BAR; break;
                               case  5: ct = END_BAR; break;
                               case  6: ct = END_START_REPEAT; break;
+                              case  7: ct = DOTTED_BAR; break;
                               }
                         setSubtype(ct);
                         }
@@ -385,7 +392,7 @@ bool BarLine::acceptDrop(MuseScoreView*, const QPointF&, Element* e) const
               }
           if (parent() && parent()->type() == SYSTEM) {
               BarLine* b = static_cast<BarLine*>(e);
-              return (b->subtype() == BROKEN_BAR || b->subtype() == NORMAL_BAR || b->subtype() == DOUBLE_BAR);
+              return (b->subtype() == BROKEN_BAR || b->subtype() == DOTTED_BAR || b->subtype() == NORMAL_BAR || b->subtype() == DOUBLE_BAR);
               } 
       }else {
             return (type == ARTICULATION
@@ -686,6 +693,7 @@ qreal BarLine::layoutWidth(Score* score, BarLineType type, qreal mag)
                   break;
             case BROKEN_BAR:
             case NORMAL_BAR:
+            case DOTTED_BAR:
                   break;
             default:
                   qDebug("illegal bar line type\n");

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -348,7 +348,8 @@ void Score::layoutStage1()
             MeasureBase* mb = m->prev();
             if (mb && mb->type() == Element::MEASURE) {
                   Measure* pm = static_cast<Measure*>(mb);
-                  if (pm->endBarLineType() != NORMAL_BAR && pm->endBarLineType() != BROKEN_BAR)
+                  if (pm->endBarLineType() != NORMAL_BAR
+                              && pm->endBarLineType() != BROKEN_BAR && pm->endBarLineType() != DOTTED_BAR)
                         m->setBreakMMRest(true);
                   foreach(Spanner* spanner, pm->spannerBack()) {
                         if (spanner->type() == Element::VOLTA)

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -329,7 +329,7 @@ enum {
 
 enum BarLineType {
       NORMAL_BAR, DOUBLE_BAR, START_REPEAT, END_REPEAT,
-      BROKEN_BAR, END_BAR, END_START_REPEAT
+      BROKEN_BAR, END_BAR, END_START_REPEAT, DOTTED_BAR
       };
 
 // Icon() subtypes

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2772,6 +2772,7 @@ void Score::undoChangeBarLine(Measure* m, BarLineType barType)
                   case NORMAL_BAR:
                   case DOUBLE_BAR:
                   case BROKEN_BAR:
+                  case DOTTED_BAR:
                         {
                         s->undoChangeRepeatFlags(measure, measure->repeatFlags() & ~RepeatEnd);
                         if (nm)

--- a/mscore/exportly.cpp
+++ b/mscore/exportly.cpp
@@ -2123,6 +2123,7 @@ int ExportLy::voltaCheckBar(Measure* meas, int i)
       voltarray[i].barno=taktnr;
       break;
     case BROKEN_BAR:
+    case DOTTED_BAR:
       i++;
       voltarray[i].voltart=brokenbar;
       voltarray[i].barno=taktnr;

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1236,6 +1236,9 @@ void ExportMusicXml::barlineRight(Measure* m)
                               xml.tag("bar-style", QString("light-heavy"));
                               break;
                         case BROKEN_BAR:
+                              xml.tag("bar-style", QString("dashed"));
+                              break;
+                        case DOTTED_BAR:
                               xml.tag("bar-style", QString("dotted"));
                               break;
                         case END_BAR:

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -2400,8 +2400,10 @@ Measure* MusicXml::xmlMeasure(Part* part, QDomElement e, int number, int measure
                               barLine->setSubtype(END_BAR);
                         else if (barStyle == "regular")
                               barLine->setSubtype(NORMAL_BAR);
-                        else if (barStyle == "dotted")
+                        else if (barStyle == "dashed")
                               barLine->setSubtype(BROKEN_BAR);
+                        else if (barStyle == "dotted")
+                              barLine->setSubtype(DOTTED_BAR);
                         else if (barStyle == "light-light")
                               barLine->setSubtype(DOUBLE_BAR);
                         /*

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -231,6 +231,7 @@ Palette* MuseScore::newBarLinePalette()
             } t[] = {
             { NORMAL_BAR,       QT_TR_NOOP("Normal") },
             { BROKEN_BAR,       QT_TR_NOOP("Dashed") },
+            { DOTTED_BAR,       QT_TR_NOOP("Dotted") },
             { END_BAR,          QT_TR_NOOP("End Bar") },
             { DOUBLE_BAR,       QT_TR_NOOP("Double Bar") },
             { START_REPEAT,     QT_TR_NOOP("Start Repeat") },


### PR DESCRIPTION
More toward fixing #12398: adds a dotted bar line style.

Manages MusicXML import/export; does not manage Lilypond export or OVE import.

NOTE: if palettes have been customized, requires deleting the profile to get the new bar line style in the palette.
