### PR TITLE
Fix #18934

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2513,8 +2513,18 @@ bool Measure::createEndBarLines()
                         }
                   else {                              // otherwise, get from staff
                         span        = staff->barLineSpan();
-                        spanFrom    = staff->barLineFrom();
-                        spanTo      = staff->barLineTo();
+                        if (span) {
+                              spanFrom    = staff->barLineFrom();
+                              spanTo      = staff->barLineTo();
+                              }
+                        // but if staff is set to no span, a multi-staff spanning bar line
+                        // has been shortened to span less staves and following staves left without bars;
+                        // set bar line span values to default
+                        else {
+                              span        = 1;
+                              spanFrom    = 0;
+                              spanTot     = (staff->lines()-1)*2;
+                              }
                         }
                   if ((staffIdx + span) > nstaves)
                         span = nstaves - staffIdx;


### PR DESCRIPTION
When a single bar line spanning several staves was shortened to span fewer staves, bar lines for following staves were not created.

Corrected.

See: http://musescore.org/en/node/18934
