### PR TITLE
Fix #18865: Instrument wizard and bar line spans

### DIFF
--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -553,8 +553,10 @@ void Staff::setLines(int val)
       // create new staff type
       //
       StaffType* st = _staffType->clone();
+      if(part())
+            st->setName(partName());
       st->setLines(val);
-      _staffType = st;
+      setStaffType(st);
       score()->addStaffType(st);
       }
 


### PR DESCRIPTION
For Instrument-wizard-created staves with other than 5 lines, bar lines were wrong.

Fixed.
Also, cloned staff type has now a name of its own from the name of the part it was created for, rather than re-using the same default name.
