### PR TITLE
fix #18548: Feathered Beam broken

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1788,9 +1788,11 @@ void Beam::layout2(QList<ChordRest*>crl, SpannerSegmentType, int frag)
                                     x2 += stemWidth;
                               x3 = x2 + len;
                               }
+                        //feathered beams
                         qreal yo   = py1 + bl * _beamDist * _grow1;
+                        qreal yoo = py1 + bl * _beamDist * _grow2;
                         qreal ly1  = (x2 - x1) * slope + yo;
-                        qreal ly2  = (x3 - x1) * slope + yo;
+                        qreal ly2  = (x3 - x1) * slope + yoo;
                         if (!qIsFinite(x2) || !qIsFinite(ly1)
                            || !qIsFinite(x3) || !qIsFinite(ly2)) {
                               qDebug("bad beam segment: slope %f", slope);

--- a/mscore/inspector_beam.ui
+++ b/mscore/inspector_beam.ui
@@ -187,6 +187,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="singleStep">
+        <double>0.250000000000000</double>
+       </property>
        <property name="value">
         <double>1.000000000000000</double>
        </property>
@@ -199,6 +202,9 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="singleStep">
+        <double>0.250000000000000</double>
        </property>
        <property name="value">
         <double>1.000000000000000</double>


### PR DESCRIPTION
Fixed broken Feathered Beams. 
(Actually, lasconic did...)

Also reduced step from 1.00 to 0.25 in
inspector_beam.ui  (the up/down arrow controls for grow left and grow right values in inspector)
