### PR TITLE
fix Double-clicking certain elements disables editing

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -195,7 +195,7 @@ class EditTransition : public QMouseEventTransition
 
    protected:
       virtual bool eventTest(QEvent* event) {
-            if (!QMouseEventTransition::eventTest(event) || canvas->getOrigEditObject())
+            if (!QMouseEventTransition::eventTest(event) ) // || canvas->getOrigEditObject()) // this caused issue: double click on certain elements disables editing
                   return false;
             QMouseEvent* me = static_cast<QMouseEvent*>(static_cast<QStateMachine::WrappedEvent*>(event)->event());
             QPointF p = canvas->toLogical(me->pos());


### PR DESCRIPTION
The code I removed seemed to allow double clicking on certain objects that
shouldn't allow for that. I just commented out the code because someone
must have put it there for a reason.
