### PR TITLE
Simple courtesy accidentals

### DIFF
--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -319,6 +319,7 @@ enum class IconType : signed char {
       SBEAM, MBEAM, NBEAM, BEAM32, BEAM64, AUTOBEAM,
       FBEAM1, FBEAM2,
       VFRAME, HFRAME, TFRAME, FFRAME, MEASURE,
+      COURTESY,
       BRACKETS
       };
 

--- a/mscore/actions.cpp
+++ b/mscore/actions.cpp
@@ -1140,6 +1140,14 @@ Shortcut Shortcut::sc[] = {
           flatflat_ICON
          ),
       Shortcut(
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_NOTE_ENTRY_DRUM,
+         ShortcutFlags::A_CMD,
+         "courtesy",
+         QT_TRANSLATE_NOOP("action","Courtesy accidental"),
+          abeam_ICON
+         ),
+
+      Shortcut(
          STATE_NORMAL | STATE_NOTE_ENTRY,
          0,
          "acciaccatura",

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -252,6 +252,14 @@ Palette* MuseScore::newAccidentalsPalette(bool basic)
             }
       AccidentalBracket* ab = new AccidentalBracket(gscore);
       sp->append(ab, QT_TRANSLATE_NOOP("Palette", "round brackets"));
+
+      Icon* ik = new Icon(gscore);
+      ik->setIconType(IconType::COURTESY);
+      Shortcut* s = Shortcut::getShortcut("courtesy");
+      QAction* action = s->action();
+      QIcon icon(action->icon());
+      ik->setAction("courtesy", icon);
+      sp->append(ik, s->help());
       return sp;
       }
 


### PR DESCRIPTION
This patch allows you to insert parenthetical courtesy accidentals by just dragging the parentheses symbol onto the note, or double clicking it when the note is selected.

See: http://musescore.org/en/node/12496
