### PR TITLE
12918 double bar key sig

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1818,7 +1818,7 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
                                              ks->showCourtesy(), ks->showNaturals()));
                                           }
                                     // change bar line to qreal bar line
-                                    // m->setEndBarLineType(DOUBLE_BAR, true); // this causes issue #12918
+                                    // m->setEndBarLineType(DOUBLE_BAR, true); // this caused issue #12918
                                     }
                               }
                         if (!showCourtesySig) {


### PR DESCRIPTION
(reposting since I deleted by mistake the branch in my github account)
This is a quick fix that avoids the creation of the double bar at a courtesy key sig. By doing so, the barline which was already present at the key sig change is preserved, and thus it is kept when the courtesy key sig is no more needed (i.e. when the key change no more happens at the beginning of a line). See http://musescore.org/en/node/12918
I just commented the code line instead of deleting it.
