### PR TITLE
Fix 19151: bar lines of 1-line-staves

### DIFF
--- a/libmscore/barline.h
+++ b/libmscore/barline.h
@@ -20,12 +20,18 @@ class MuseScoreView;
 class Segment;
 class QPainter;
 
-#define DEFAULT_BARLINE_TO          (4*2)
-#define MIN_BARLINE_FROMTO_DIST     2
-#define MIN_BARLINE_SPAN_FROMTO     (-2)
+#define DEFAULT_BARLINE_TO                (4*2)
+#define MIN_BARLINE_FROMTO_DIST           2
+#define MIN_BARLINE_SPAN_FROMTO           (-2)
+// bar line span for 1-line staves is special: goes from 2sp above the line to 2sp below the line;
+// for some reason, the single staff line counts as line -1 rather than as line 0
+// thus, 2sp above it is -2 rather than -4 and 2sp below it is 6 rather than 4
+// (see StaffLines::y1() function in element.cpp)
+#define BARLINE_SPAN_1LINESTAFF_FROM      (-2)
+#define BARLINE_SPAN_1LINESTAFF_TO        6
 // used while reading a score for a default spanTo (to last staff line) toward a staff not yet read;
 // fixed once all staves are read
-#define UNKNOWN_BARLINE_TO          (-4)
+#define UNKNOWN_BARLINE_TO                (-4)
 
 //---------------------------------------------------------
 //   @@ BarLine

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1025,8 +1025,9 @@ bool Score::read(const QDomElement& de)
                   st->setBarLineFrom(st->lines()*2);
             // check spanTo
             Staff* stTo = st->barLineSpan() <= 1 ? st : staff(idx + st->barLineSpan() - 1);
-            int maxBarLineTo        = stTo->lines()*2;
-            int defaultBarLineTo    = (stTo->lines() - 1) * 2;
+            // 1-line staves have special bar line spans
+            int maxBarLineTo        = stTo->lines() == 1 ? BARLINE_SPAN_1LINESTAFF_TO : stTo->lines()*2;
+            int defaultBarLineTo    = stTo->lines() == 1 ? BARLINE_SPAN_1LINESTAFF_TO : (stTo->lines() - 1) * 2;
             if(st->barLineTo() == UNKNOWN_BARLINE_TO)
                   st->setBarLineTo(defaultBarLineTo);
             if(st->barLineTo() < MIN_BARLINE_SPAN_FROMTO)


### PR DESCRIPTION
1-line staves were created with 0-lenght bar lines.
Fixed: 1-line staves now have default bar lines from 2sp above the staff line to 2sp below it.

See: http://musescore.org/en/node/19151

I will merge soon if no concerns pop up.
