### PR TITLE
Fix for Mandola Clef and tone range

### DIFF
--- a/share/templates/instruments.xml
+++ b/share/templates/instruments.xml
@@ -5291,10 +5291,10 @@
         <string>62</string>
         <string>69</string>
         </Tablature>
-      <clef>C3</clef>
+      <clef>G8vb</clef>
       <barlineSpan>1</barlineSpan>
-      <aPitchRange>48-87</aPitchRange>
-      <pPitchRange>48-93</pPitchRange>
+      <aPitchRange>43-74</aPitchRange>
+      <pPitchRange>43-82</pPitchRange>
       <Channel>
         <program value="24"/>
         </Channel>


### PR DESCRIPTION
mandola scores are usually written in Treble clef 8vb,
so musescore should also use that as a default.

Tuning of a mandola is g-d-a-e one exactly the same as a
mandolin just one octave lower - not equivalent to a viola obviously
so the ranges also had to be fixed.
