### PR TITLE
Crash on Staff Type dlg box Presets drop list

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1397,7 +1397,7 @@ void Chord::layout()
                         if (!_tabDur)
                               _tabDur = new TabDurationSymbol(score(), tab, durationType().type(), dots());
                         else
-                              _tabDur->setDuration(durationType().type(), dots());
+                              _tabDur->setDuration(durationType().type(), dots(), tab);
                         _tabDur->setParent(this);
                         _tabDur->layout();
                         }

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -319,7 +319,7 @@ void Rest::layout()
                   if (!_tabDur)
                         _tabDur = new TabDurationSymbol(score(), tab, durationType().type(), dots());
                   else
-                        _tabDur->setDuration(durationType().type(), dots());
+                        _tabDur->setDuration(durationType().type(), dots(), tab);
                   _tabDur->setParent(this);
 // needed?        _tabDur->setTrack(track());
                   _tabDur->layout();

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -801,8 +801,7 @@ TabDurationSymbol::TabDurationSymbol(Score* s, StaffTypeTablature * tab, TDurati
       {
       setFlags(ELEMENT_MOVABLE | ELEMENT_SELECTABLE);
       setGenerated(true);
-      _tab  = tab;
-      buildText(type, dots);
+      setDuration(type, dots, tab);
       }
 
 TabDurationSymbol::TabDurationSymbol(const TabDurationSymbol& e)
@@ -818,6 +817,10 @@ TabDurationSymbol::TabDurationSymbol(const TabDurationSymbol& e)
 
 void TabDurationSymbol::layout()
       {
+      if(!_tab) {
+            setbbox(QRectF());
+            return;
+            }
       QFontMetricsF fm(_tab->durationFont());
       qreal mags = magS();
       qreal w = fm.width(_text);
@@ -849,18 +852,6 @@ void TabDurationSymbol::draw(QPainter* painter) const
       painter->scale(imag, imag);
       }
 
-//---------------------------------------------------------
-//   buildText
-//---------------------------------------------------------
-/*
-void TabDurationSymbol::buildText(TDuration::DurationType type, int dots)
-      {
-      // text string is a main symbol plus as many dots as required by chord duration
-      _text = QString(g_cDurationChars[type]);
-      for(int count=0; count < dots; count++)
-            _text.append(g_cDurationChars[STAFFTYPETAB_IDXOFDOTCHAR]);
-      }
-*/
 //---------------------------------------------------------
 //   STATIC FUNCTIONS FOR FONT CONFIGURATION MANAGEMENT
 //---------------------------------------------------------

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -373,9 +373,6 @@ class TabDurationSymbol : public Element {
       StaffTypeTablature* _tab;
       QString             _text;
 
-      void buildText(TDuration::DurationType type, int dots)
-                                                { _text = _tab->durationString(type, dots); }
-
    public:
       TabDurationSymbol(Score* s);
       TabDurationSymbol(Score* s, StaffTypeTablature * tab, TDuration::DurationType type, int dots);
@@ -386,8 +383,10 @@ class TabDurationSymbol : public Element {
       virtual void layout();
       virtual ElementType type() const          { return TAB_DURATION_SYMBOL; }
 
-      void  setDuration(TDuration::DurationType type, int dots) { buildText(type, dots); }
-      void  setTablature(StaffTypeTablature * tab)              { _tab = tab; }
+      void  setDuration(TDuration::DurationType type, int dots, StaffTypeTablature* tab)
+                                                { _tab = tab;
+                                                  _text = tab->durationString(type, dots);
+                                                }
       };
 
 #endif


### PR DESCRIPTION
Using the Preset drop list in the Tab part of the Staff Type dlg box may lead to program crash.

Fixed.
