### PR TITLE
Fix #19331

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2759,6 +2759,7 @@ void Score::updateBarLineSpans(int idx, int linesOld, int linesNew)
       // in practice, a barLineFrom/To from/to the top half of the staff is linked to the staff top line,
       // a barLineFrom/To from/to the bottom half of the staff is linked to staff bottom line;
       // this ensures plainchant and mensurstrich special bar lines keep their relationships to the staff lines.
+      // 1-line staves are traited as a special case.
       for(int sIdx = 0; sIdx < nStaves; sIdx++) {
             _staff = staff(sIdx);
             // if this is the modified staff
@@ -2766,16 +2767,23 @@ void Score::updateBarLineSpans(int idx, int linesOld, int linesNew)
                   // if it has no bar line, set barLineTo to a default value
                   if(_staff->barLineSpan() == 0)
                         _staff->setBarLineTo( (linesNew-1) * 2);
+                  // if new line number is 1, set default From for 1-line staves
+                  else if(linesNew == 1)
+                        _staff->setBarLineFrom(BARLINE_SPAN_1LINESTAFF_FROM);
                   // if barLineFrom was below the staff middle position
                   // raise or lower it to account for new number of lines
                   else if(_staff->barLineFrom() > linesOld - 1)
                         _staff->setBarLineFrom(_staff->barLineFrom() + (linesNew - linesOld)*2);
             }
 
-            // if the modified staff is the destination of the current staff bar span AND
-            // barLineTo was below its middle position, raise or lower it
-            if(sIdx + _staff->barLineSpan() - 1 == idx
-                        &&_staff->barLineTo() > linesOld - 1)
-                  _staff->setBarLineTo(_staff->barLineTo() + (linesNew - linesOld)*2);
+            // if the modified staff is the destination of the current staff bar span:
+            if(sIdx + _staff->barLineSpan() - 1 == idx) {
+                  // if new line number is 1, set default To for 1-line staves
+                  if(linesNew == 1)
+                        _staff->setBarLineTo(BARLINE_SPAN_1LINESTAFF_TO);
+                  // if barLineTo was below its middle position, raise or lower it
+                  else if(_staff->barLineTo() > linesOld - 1)
+                        _staff->setBarLineTo(_staff->barLineTo() + (linesNew - linesOld)*2);
+                  }
             }
       }

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -565,7 +565,7 @@ void Staff::setLines(int val)
       // create new staff type
       //
       StaffType* st = _staffType->clone();
-      if(part())
+      if(part() && !partName().isEmpty())
             st->setName(partName());
       st->setLines(val);
       setStaffType(st);


### PR DESCRIPTION
1-line staves from ver 1.2 scores had no bar lines.
