### PR TITLE
Fix #19463

### DIFF
--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -160,7 +160,7 @@ ChordRest* Selection::lastChordRest(int track) const
             Element* el = _el[0];
             if (el && el->type() == Element::NOTE)
                   return static_cast<ChordRest*>(el->parent());
-            else if (el->type() == Element::REST)
+            else if (el->type() == Element::CHORD || el->type() == Element::REST)
                   return static_cast<ChordRest*>(el);
             return 0;
             }


### PR DESCRIPTION
Fix #19463

After changing a note/chord value, arrow keys become ineffective.

See: http://musescore.org/en/node/19463
