### PR TITLE
fix #18693 : Cut-n-paste of a measure containing a slur causes a crash

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -733,6 +733,65 @@ Segment* Measure::findSegment(Segment::SegmentType st, int t)
       return 0;
       }
 
+/**
+  Search for a grace segment at position \a tick and grace level \a gl.
+  See explantion for getGraceSement
+*/
+
+Segment* Measure::findGraceSegment(int tick, int gl)
+      {
+      Segment* s;
+
+      for (s = first(Segment::SegChordRest); s && s->tick() < tick; s = s->next(Segment::SegChordRest))
+            ;
+
+      if (!s || s->tick() != tick)
+            return 0;
+
+      int nGraces = 0;
+      // count SegGrace segments backwords
+      for (; s && s->tick() == tick; s = s->prev()) {
+            if (s->subtype() == Segment::SegGrace)
+                  nGraces++;
+
+            if (nGraces == gl)
+                  return s;
+            }
+
+      return 0;
+      }
+
+/**
+  Find the grace level for segment \a gs.
+  If the segment is not found or it is not a SegGrace, 0 is returned.
+*/
+
+int Measure::findGraceLevel(Segment* gs)
+{
+      if (gs->subtype() != Segment::SegGrace)
+            return 0;
+
+      Segment* s;
+      // find ChordRest with tick equal to the grace segment
+      for (s = first(Segment::SegChordRest); s && s->tick() < gs->tick(); s = s->next(Segment::SegChordRest))
+            ;
+
+      if (!s || s->tick() != gs->tick())
+            return 0;
+
+      // count grace levels
+      int graceLevel = 0;
+      for (; s && s->tick() == gs->tick(); s = s->prev()) {
+            if (s->subtype() == Segment::SegGrace)
+                  graceLevel++;
+
+            if (s == gs)
+                  return graceLevel;
+            }
+
+      return 0;
+}
+
 //---------------------------------------------------------
 //   undoGetSegment
 //---------------------------------------------------------

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -229,6 +229,9 @@ class Measure : public MeasureBase {
       Segment* getSegment(Segment::SegmentType st, int tick);
       Segment* getGraceSegment(int tick, int gl);
       Segment* findSegment(Segment::SegmentType st, int t);
+      Segment* findGraceSegment(int tick, int gl);
+
+      int findGraceLevel (Segment* gs);
 
       bool createEndBarLines();
       void setEndBarLineType(BarLineType val, bool g, bool visible = true, QColor color = Qt::black);

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -871,8 +871,25 @@ void Score::undoAddElement(Element* element)
                   Measure* m2    = s2->measure();
                   Measure* nm1   = score->tick2measure(m1->tick());
                   Measure* nm2   = score->tick2measure(m2->tick());
-                  Segment* ns1   = nm1->findSegment(s1->subtype(), s1->tick());
-                  Segment* ns2   = nm2->findSegment(s2->subtype(), s2->tick());
+                  Segment* ns1;
+                  Segment* ns2;
+
+                  if (s1->subtype() == Segment::SegGrace) {
+                        int gl = m1->findGraceLevel(s1);
+                        ns1 = nm1->findGraceSegment(s1->tick(), gl);
+                        }
+                  else {
+                        ns1 = nm1->findSegment(s1->subtype(), s1->tick());
+                        }
+
+                  if (s2->subtype() == Segment::SegGrace) {
+                        int gl = m2->findGraceLevel(s2);
+                        ns2 = nm2->findGraceSegment(s2->tick(), gl);
+                        }
+                  else {
+                        ns2 = nm2->findSegment(s2->subtype(), s2->tick());
+                        }
+
                   Chord* c1      = static_cast<Chord*>(ns1->element(staffIdx * VOICES + cr1->voice()));
                   Chord* c2      = static_cast<Chord*>(ns2->element(staffIdx * VOICES + cr2->voice()));
                   Slur* nslur    = static_cast<Slur*>(ne);


### PR DESCRIPTION
Added support for finding the nth grace note (or grace level as defined by getGraceSegment). Using this to test for grace notes in undo.cpp. This fixes the bug. The bug is not really related to cut and paste but the two grace notes in the beginning. findSegment() will always find the first grace note in a series of grace notes because of the tick of grace notes. Therefore we need an explicit check for grace notes.

This pull request only fixes the slur problem with several grace notes, but e.g. tie has the same problem, so I will fix that also if this is the right way to go.
