### PR TITLE
Search box/filter added to the instrument list

### DIFF
--- a/mscore/instrdialog.h
+++ b/mscore/instrdialog.h
@@ -101,6 +101,9 @@ class InstrumentsDialog : public QDialog, public Ui::InstrumentDialogBase {
       void buildTemplateList();
       virtual void accept();
 
+      void on_search_textChanged(const QString &searchPhrase);
+      void on_clearSearch_clicked();
+
    public:
       InstrumentsDialog(QWidget* parent = 0);
       void setScore(Score* s) { cs = s; }

--- a/mscore/instrdialog.ui
+++ b/mscore/instrdialog.ui
@@ -46,6 +46,33 @@
         </widget>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="search">
+           <property name="focusPolicy">
+            <enum>Qt::StrongFocus</enum>
+           </property>
+           <property name="inputMask">
+            <string notr="true"/>
+           </property>
+           <property name="placeholderText">
+            <string>Search</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="clearSearch">
+           <property name="text">
+            <string>Clear</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QCheckBox" name="showMore">
          <property name="text">
           <string>show more</string>

--- a/mscore/instrwizard.ui
+++ b/mscore/instrwizard.ui
@@ -38,6 +38,27 @@
       </widget>
      </item>
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLineEdit" name="search">
+         <property name="placeholderText">
+          <string>Search</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="clearSearch">
+         <property name="text">
+          <string>Clear</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
       <widget class="QCheckBox" name="showMore">
        <property name="text">
         <string>show more</string>

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -38,6 +38,7 @@
 #include "libmscore/sym.h"
 
 extern Palette* newKeySigPalette();
+extern void filterInstruments(QTreeWidget *instrumentList, const QString &searchPhrase = QString(""));
 
 //---------------------------------------------------------
 //   InstrumentWizard
@@ -73,6 +74,10 @@ InstrumentWizard::InstrumentWizard(QWidget* parent)
 
 void InstrumentWizard::buildTemplateList()
       {
+      // clear search if instrument list is updated
+      search->clear();
+      filterInstruments(instrumentList);
+
       populateInstrumentList(instrumentList, showMore->isChecked());
       }
 
@@ -896,3 +901,21 @@ bool NewWizard::useTemplate() const
       return field("useTemplate").toBool();
       }
 
+//---------------------------------------------------------
+//   on_search_textChanged
+//---------------------------------------------------------
+
+void InstrumentWizard::on_search_textChanged(const QString &searchPhrase)
+      {
+      filterInstruments(instrumentList, searchPhrase);
+      }
+
+//---------------------------------------------------------
+//   on_clearSearch_clicked
+//---------------------------------------------------------
+
+void InstrumentWizard::on_clearSearch_clicked()
+      {
+      search->clear();
+      filterInstruments (instrumentList);
+      }

--- a/mscore/newwizard.h
+++ b/mscore/newwizard.h
@@ -51,6 +51,10 @@ class InstrumentWizard : public QWidget, private Ui::InstrumentWizard {
       void on_belowButton_clicked();
       void buildTemplateList();
 
+      void on_search_textChanged(const QString &searchPhrase);
+
+      void on_clearSearch_clicked();
+
    signals:
       void completeChanged(bool);
 


### PR DESCRIPTION
I've added a search box / filter to the instrument dialog and the new wizard. It is a simple linear search which gives good performance on my computer. This could be improved in the future if needed.

This feature is requested here http://musescore.org/en/node/18542

The filterInstruments() functions is placed in the instrdialog.cpp file, but probably it should be placed somewhere else.

I'm very open to suggestions, improvements, comments, etc.
