### PR TITLE
Fix FiguredBass XML read

### DIFF
--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -396,6 +396,7 @@ void FiguredBassItem::read(XmlReader& e)
                   parenth[2] = (Parenthesis)e.intAttribute("b2");
                   parenth[3] = (Parenthesis)e.intAttribute("b3");
                   parenth[4] = (Parenthesis)e.intAttribute("b4");
+                  e.readNext();
                   }
             else if (tag == "prefix")
                   _prefix = (Modifier)(e.readInt());


### PR DESCRIPTION
Align reading FiguredBass XML from score with the new XML reader
