### PR TITLE
Convert Poet TextStyle to Lyricist for 1.2 scores

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -1312,6 +1312,12 @@ void StyleData::setTextStyle(const TextStyle& ts)
                   _textStyles[i] = ts;
                   return;
                   }
+            // convert 1.2 Poet to Lyricist
+            if (_textStyles[i].name() == "Lyricist" && ts.name() == "Poet") {
+                  _textStyles[i] = ts;
+                  _textStyles[i].setName("Lyricist");
+                  return;
+                  }
             }
       _textStyles.append(ts);
       }


### PR DESCRIPTION
When reading a 1.2 score or template with text styles set,
the "Poet" TextStyle was not getting converted to "Lyricist".
This change performs that conversion for backward compatibility.
