### PR TITLE
Fix #19611 and #19709 - TAB stems too long

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1785,6 +1785,8 @@ void Beam::layout2(QList<ChordRest*>crl, SpannerSegmentType, int frag)
                   y1 = by + _pagePos.y();
                   }
 
+            if (staff()->isTabStaff())          // for some reason, this is only need for TAB's
+                  stem->setPos(stemPos - c->pagePos());
             stem->setLen(y2 - y1);
 
             //

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -302,17 +302,17 @@ QPointF Chord::stemPos() const
 
 //---------------------------------------------------------
 //   stemPosX
-//    return chord coordinates
+//    return page coordinates
 //---------------------------------------------------------
 
 qreal Chord::stemPosX() const
       {
+      qreal x = pageX();
       if (staff() && staff()->isTabStaff()) {
             QPointF p = static_cast<StaffTypeTablature*>(staff()->staffType())->chordStemPos(this) * spatium();
-            return p.x();
+            x += p.x();
             }
-      qreal x = pageX();
-      if (_up)
+      else if (_up)
             x += symbols[score()->symIdx()][quartheadSym].width(magS());
       return x;
       }


### PR DESCRIPTION
TAB formatting re-aligned with changes on semantics for chord and stem function computing stem data.
