### PR TITLE
Undo commit from muelleki/17906-chords that conflicts with watery/17906-...

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -385,12 +385,9 @@ qDebug("add pitch %d %d", pitch, addFlag);
             Note* n = addNote(chord, pitch);
             setLayoutAll(false);
             setLayout(chord->measure());
+            moveToNextInputPos();
             return n;
             }
-      if (_is.moveBeforeAdding())
-            moveToNextInputPos();
-      else
-          _is.setMoveBeforeAdding(true);
       expandVoice();
 
       // insert note
@@ -448,6 +445,7 @@ qDebug("add pitch %d %d", pitch, addFlag);
                   qDebug("addPitch: cannot find slur note");
             setLayoutAll(true);
             }
+      moveToNextInputPos();
       return note;
       }
 

--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -32,7 +32,6 @@ InputState::InputState() :
    _segment(0),
    _string(VISUAL_STRING_NONE),
    _repitchMode(false),
-   _moveBeforeAdding(false),
    rest(false),
    pitch(72),
    noteType(NOTE_NORMAL),

--- a/libmscore/input.h
+++ b/libmscore/input.h
@@ -34,7 +34,6 @@ class InputState {
       Segment*    _segment;         // current segment
       int         _string;          // visual string selected for input (TAB staves only)
       bool        _repitchMode;
-      bool        _moveBeforeAdding;
 
    public:
       bool rest;              // rest mode
@@ -70,9 +69,6 @@ class InputState {
 
       bool repitchMode() const            { return _repitchMode;    }
       void setRepitchMode(bool val)       { _repitchMode = val;     }
-
-      bool moveBeforeAdding() const       { return _moveBeforeAdding;    }
-      void setMoveBeforeAdding(bool val)  { _moveBeforeAdding = val;     }
 
       StaffGroup staffGroup() const;
       };

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2707,7 +2707,6 @@ void Score::setInputState(Element* e)
             e = static_cast<Chord*>(e)->upNote();
 
       _is.setDrumNote(-1);
-      _is.setMoveBeforeAdding(false);
 //      _is.setDrumset(0);
       if (e->type() == Element::NOTE) {
             Note* note    = static_cast<Note*>(e);


### PR DESCRIPTION
...midichordinput

See 0bc14e8694611c814cf754d43adaf112019c5d1f
