### PR TITLE
Fix #19809 Semibreve and breve vertical misalignment

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1455,7 +1455,9 @@ void Chord::layout()
             adjustReadPos();
 
             qreal stemWidth5;
-            qreal stemX = _up ? symbols[score()->symIdx()][quartheadSym].width(magS()) : 0.0;
+            qreal noteWidth = _notes.size() ? _notes.at(0)->headWidth() :
+                        symbols[score()->symIdx()][quartheadSym].width(magS());
+            qreal stemX = _up ? noteWidth : 0.0;
             if (stem()) {
                   stemWidth5 = stem()->lineWidth() * .5;
                   _stem->rxpos() = _up ? stemX - stemWidth5 : stemWidth5;
@@ -1472,12 +1474,12 @@ void Chord::layout()
                   qreal hw = note->headWidth();
 
                   if (note->mirror())
-                        if (stem() && _up)
+                        if (_up)
                               x = stemX - stemWidth5 * 2;
                         else
                               x = stemX - hw + stemWidth5 * 2;
                   else {
-                        if (stem() && _up)
+                        if (_up)
                               x = stemX - hw;
                         else
                               x = 0.0;


### PR DESCRIPTION
Fix #19809 correcting vertical alignment for stemless notes (semibreves and breves).

See http://musescore.org/en/node/19809 for details.
