### PR TITLE
Bugfix

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -688,7 +688,7 @@ Note* Chord::selectedNote() const
       {
       Note* note = 0;
       int n = _notes.size();
-      for (int i = 0; i < n; ++n) {
+      for (int i = 0; i < n; ++i) {
             Note* n = _notes.at(i);
             if (n->selected()) {
                   if (note)


### PR DESCRIPTION
This bug was driving me nuts, so I fixed it. :)

Bug description:
- The UI hanged every time I entered edit mode (clicking the "N" icon or pressing the "N" key).

The cause was an endless loop in the method "selectedNote()" in "libmscore/chord.cpp".
If you take a look at the patch the cause should be pretty clear.

Hope it helps!
