### PR TITLE
Improve handling of mscore/revision.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PREFIX    = "/usr/local"
 VERSION   = "2.0b-${REVISION}"
 #VERSION   = 2.0
 
-release: revision
+release:
 	mkdir build.release;                       \
       cd build.release;                          \
       cmake -DCMAKE_BUILD_TYPE=RELEASE	       \
@@ -35,7 +35,7 @@ release: revision
       make -j ${CPUS};                           \
 
 
-debug: revision
+debug:
 	if test ! -d build.debug; then mkdir build.debug; fi; \
       cd build.debug;                                       \
       cmake -DCMAKE_BUILD_TYPE=DEBUG	                  \
@@ -94,13 +94,13 @@ clean:
 revision:
 	@git rev-parse --short HEAD > mscore/revision.h
 
-version: revision
+version:
 	@echo ${VERSION}
 
-install: release revision
+install: release
 	cd build.release; make install
 
-installdebug: debug revision
+installdebug: debug
 	cd build.debug; make install
 
 #

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -58,7 +58,7 @@ lrelease:
 revision:
 	@git rev-parse --short HEAD > mscore/revision.h
 
-version: revision
+version:
 	@echo ${VERSION}
 
 install:

--- a/build/git/hooks/README
+++ b/build/git/hooks/README
@@ -1,0 +1,10 @@
+Copy the post-checkout file from build/git/hooks/ into .git/hooks/ in order
+for git to update mscore/revision.h with the branch number automatically when
+checking out:
+
+$ cp -p build/git/hooks/post-checkout .git/hooks/
+
+This only needs doing once, and then removes the need to do "make revision"
+manually for setting the correct revision number after doing a checkout.
+
+This works for Linux, Windows (MinGW) and OSX.

--- a/build/git/hooks/post-checkout
+++ b/build/git/hooks/post-checkout
@@ -1,0 +1,2 @@
+#!/bin/sh
+git rev-parse --short HEAD >mscore/revision.h

--- a/mscore/revision.h
+++ b/mscore/revision.h
@@ -1,0 +1,1 @@
+Unknown


### PR DESCRIPTION
Added a default mscore/revision.h containing "Unknown" as the
revision number (mscore/revision.h remains in .gitignore).
Removed the dependency on "revision" in the Makefiles. Now
"make revision" must be done manually if required.
Added sample post-checkout git hook to allow git automatically
to update mscore/revision.h when doing a git checkout. If installed,
this removes the need to do "make revision" manually.
