### PR TITLE
fix #19500  Crash on deleting fermata

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1626,7 +1626,11 @@ void Score::removeElement(Element* element)
             case Element::TREMOLO:
             case Element::ARTICULATION:
             case Element::ARPEGGIO:
-                  ::createPlayEvents(static_cast<Chord*>(element->parent()));
+                  {
+                  Element* cr = element->parent();
+                  if (cr->type() == Element::CHORD)
+                         ::createPlayEvents(static_cast<Chord*>(cr));
+                  }
                   break;
 
             default:


### PR DESCRIPTION
fix #19500
Crash on deleting fermata
The problem was in Score::removeElement, which was calling createPlayEvents also when the parent element was a rest. If then a fermata was removed from a rest, this was causing a crash because of chord->notes() (called in createPlayEvents) not properly defined when "chord" is a rest.
Score::addElement was already correct. I just copied and pasted the correction to the removeElelment function.
