### PR TITLE
Fix beam alignment in TABs

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1688,10 +1688,16 @@ void Beam::layout2(QList<ChordRest*>crl, SpannerSegmentType, int frag)
                               // create segment
                               x3 = cr2->stemPosX() - _pagePos.x();
 
-                              if (staff()->isTabStaff() || cr1->up())
-                                    x2 -= stemWidth;
-                              else
-                                    x3 += stemWidth;
+                              if (staff()->isTabStaff()) {
+                                    x2 -= stemWidth * 0.5;
+                                    x3 += stemWidth * 0.5;
+                                    }
+                              else {
+                                    if (cr1->up())
+                                          x2 -= stemWidth;
+                                    else
+                                          x3 += stemWidth;
+                                    }
                               }
                         else {
                               // create broken segment

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1381,7 +1381,8 @@ void Chord::layout()
                   _hook = 0;
                   }
             // if stem is required but missing, add it
-            else if(/*durationType().hasStem() &&*/ _stem == 0)
+            // stem position and length are set in Chord:layoutStem()
+            else if (_stem == 0)
                   setStem(new Stem(score()));
             // unconditionally delete grace slashes
             delete _stemSlash;


### PR DESCRIPTION
In TABs with stems and beams, beams were not aligned with stems.
