### PR TITLE
Fix #19923: TAB digits not centered on stem

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1368,7 +1368,9 @@ void Chord::layout()
             for (int i = 0; i < n; ++i) {
                   Note* note = _notes.at(i);
                   note->layout();
-                  note->setPos(0.0, _spatium * tab->physStringToVisual(note->string()) * lineDist);
+                  // centre fret string on stem
+                  qreal x = tab->chordStemPosX(this) * _spatium - note->bbox().width()*0.5;
+                  note->setPos(x, _spatium * tab->physStringToVisual(note->string()) * lineDist);
                   note->layout2();
                   }
             // if tab type is stemless or duration longer than half (if halves have stems) or duration longer than crochet

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1254,9 +1254,7 @@ void Note::layout()
             StaffTypeTablature* tab = (StaffTypeTablature*)staff()->staffType();
             qreal mags = magS();
             qreal w = tabHeadWidth(tab);
-            // centre fret string to note head
-            qreal xo = (headWidth() - w) * .5;
-            bbox().setRect(xo, tab->fretBoxY() * mags, w, tab->fretBoxH() * mags);
+            bbox().setRect(0.0, tab->fretBoxY() * mags, w, tab->fretBoxH() * mags);
             }
       else {
             setbbox(symbols[score()->symIdx()][noteHead()].bbox(magS()));

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -346,6 +346,7 @@ class StaffTypeTablature : public StaffType {
 
       // utility functions for tab specially managed elements
       QPointF     chordStemPos(const Chord * chord) const;
+      qreal       chordStemPosX(const Chord * /*chord*/) const    { return STAFFTYPE_TAB_DEFAULTSTEMPOSX; }
       QPointF     chordStemPosBeam(const  Chord * chord) const;
       qreal       chordStemLength(const Chord *chord) const;
 


### PR DESCRIPTION
Fix #19923: TAB digits were not centered on stem.
