### PR TITLE
Fix #19902: TAB - vertical collision of fret marks

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -588,7 +588,7 @@ void Note::draw(QPainter* painter) const
             // draw background, if required
             if (!tab->linesThrough() || fretConflict()) {
                   qreal d  = spatium() * .1;
-                  QRectF bb = bbox().adjusted(-d, -d, d, d);
+                  QRectF bb = QRectF(bbox().x()-d, tab->fretMaskY(), bbox().width() + 2*d, tab->fretMaskH());
                   // we do not know which viewer did this draw() call
                   // so update all:
                   foreach(MuseScoreView* view, score()->getViewer())

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -582,7 +582,7 @@ void StaffTypeTablature::setFretMetrics()
       if(!_onLines)
             _fretYOffset -= lineDistance().val()*MScore::DPI*SPATIUM20 / 2.0;
 
-      // from _fretYOffset, compute _charBoxH and _charBoxY
+      // from _fretYOffset, compute _fretBoxH and _fretBoxY
       _fretBoxH = bb.height();
       _fretBoxY = bb.y()  + _fretYOffset;
 

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -312,6 +312,9 @@ class StaffTypeTablature : public StaffType {
       qreal durationFontYOffset()         { setDurationMetrics(); return _durationYOffset + _durationFontUserY * MScore::DPI*SPATIUM20; }
       qreal fretBoxH()                    { setFretMetrics(); return _fretBoxH; }
       qreal fretBoxY()                    { setFretMetrics(); return _fretBoxY + _fretFontUserY * MScore::DPI*SPATIUM20; }
+      // 2 methods to return the size of a box masking lines under a fret mark
+      qreal fretMaskH()                   { return _lineDistance.val() * MScore::DPI*SPATIUM20; }
+      qreal fretMaskY()                   { return (_onLines ? -0.5 : -1.0) * _lineDistance.val() * MScore::DPI*SPATIUM20; }
       const QFont&  fretFont()            { return _fretFont;           }
       const QString fretFontName() const  { return _fretFonts[_fretFontIdx].displayName; }
       qreal fretFontSize() const          { return _fretFontSize;       }


### PR DESCRIPTION
Fix #19902: in TAB's with the 'broken lines' flags, removing lines under a fret mark obliterated parts of other marks already drawn.
