### PR TITLE
fix #19985 - mark score dirty

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -697,6 +697,7 @@ void Score::setShowInvisible(bool v)
       {
       _showInvisible = v;
       _updateAll     = true;
+      _dirty         = true;
       end();
       }
 
@@ -708,6 +709,7 @@ void Score::setShowUnprintable(bool v)
       {
       _showUnprintable = v;
       _updateAll      = true;
+      _dirty          = true;
       end();
       }
 
@@ -719,6 +721,7 @@ void Score::setShowFrames(bool v)
       {
       _showFrames = v;
       _updateAll  = true;
+      _dirty      = true;
       end();
       }
 
@@ -730,6 +733,7 @@ void Score::setShowPageborders(bool v)
       {
       _showPageborders = v;
       _updateAll = true;
+      _dirty     = true;
       end();
       }
 


### PR DESCRIPTION
after changes to Menu -> Display -> Show
{Invisible|Unprintable|Frames|Page Margins}
