### PR TITLE
fix #19890 On restart auto-loaded score has wrong zoom

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1455,7 +1455,7 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
       if (view->magIdx() == MAG_FREE)
             mag->setMag(view->mag());
       else
-            mag->setMagIdx(view->magIdx());
+            mag->setCurrentIndex(view->magIdx());
 
       setWindowTitle("MuseScore: " + cs->name());
 


### PR DESCRIPTION
last zoom is saved in session file.
blockSignals(true) in setMag prevents events, so the zoom was not used to layout the score.
