### PR TITLE
fix #19528: Font changed when editing a dynamic

### DIFF
--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -193,7 +193,7 @@ QString Dynamic::subtypeName() const
 
 void Dynamic::startEdit(MuseScoreView* v, const QPointF& p)
       {
-      setSubtype(0);
+      //setSubtype(0); commented s. Bug Report #19528
       Text::startEdit(v, p);
       }
 


### PR DESCRIPTION
when editing a Dynamic the subtype of the font was set to 0. This had changed the font from "Dynamics2" to "Dynamics".
