### PR TITLE
Figured Bass: add top/bottom alignment parameter

### DIFF
--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -491,15 +491,20 @@ void FiguredBassItem::layout()
 
       // position the text so that [x1<-->x2] is centered below the note
       x = x - (x1+x2) * 0.5;
+      // vertical position
       h = fm.lineSpacing();
       h *= score()->styleD(ST_figuredBassLineHeight);
+      if (score()->styleI(ST_figuredBassAlignment) == 0)          // top alignment: stack down from first item
+            y = h * ord;
+      else                                                        // bottom alignment: stack up from last item
+            y = -h * (figuredBass()->numOfItems() - ord);
+      setPos(x, y);
+      // determine bbox from text width and from longest cont. line
       w = fm.width(str);
       textWidth = w;
       int lineLen;
       if(_contLine && (lineLen=figuredBass()->lineLength(0)) > w)
             w = lineLen;
-      y = h * ord;
-      setPos(x, y);
       bbox().setRect(0, 0, w, h);
       }
 

--- a/libmscore/figuredbass.h
+++ b/libmscore/figuredbass.h
@@ -302,6 +302,7 @@ Q_INVOKABLE FiguredBassItem* addItem();
                                                             return _lineLenghts.at(idx);
                                                           return 0;   }
       bool              onNote() const          { return _onNote; }
+      int               numOfItems() const      { return items.size(); }
       void              setOnNote(bool val)     { _onNote = val;  }
       Segment *         segment() const         { return static_cast<Segment*>(parent()); }
       int               ticks() const           { return _ticks;  }

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -49,6 +49,7 @@ StyleType styleTypes[] = {
       StyleType("figuredBassFontSize",     ST_DOUBLE),      // in pt
       StyleType("figuredBassYOffset",      ST_DOUBLE),      // in sp
       StyleType("figuredBassLineHeight",   ST_DOUBLE),      // in % of normal height
+      StyleType("figuredBassAlignment",    ST_INT),         // 0 = top, 1 = bottom
       StyleType("figuredBassStyle" ,       ST_INT),         // 0=modern, 1=historic
       StyleType("systemFrameDistance",     ST_SPATIUM),     // dist. between staff and vertical box
       StyleType("frameSystemDistance",     ST_SPATIUM),     // dist. between vertical box and next system
@@ -420,6 +421,7 @@ StyleData::StyleData()
             StyleVal(ST_figuredBassFontSize, qreal(8.0)),
             StyleVal(ST_figuredBassYOffset, Spatium(6.0)),
             StyleVal(ST_figuredBassLineHeight, qreal(1.0)),
+            StyleVal(ST_figuredBassAlignment, 0),
             StyleVal(ST_figuredBassStyle, 0),
             StyleVal(ST_systemFrameDistance, Spatium(7.0)),
             StyleVal(ST_frameSystemDistance, Spatium(7.0)),
@@ -454,7 +456,7 @@ StyleData::StyleData()
             StyleVal(ST_barNoteDistance,Spatium(1.2)),
             StyleVal(ST_noteBarDistance,Spatium(1.0)),
 
-            //38
+            //43
             StyleVal(ST_measureSpacing, qreal(1.2)),
             StyleVal(ST_staffLineWidth,Spatium(0.08)),      // 0.09375
             StyleVal(ST_ledgerLineWidth,Spatium(0.12)),     // 0.1875
@@ -494,7 +496,7 @@ StyleData::StyleData()
             StyleVal(ST_measureNumberInterval, 5),
             StyleVal(ST_measureNumberSystem, true),
 
-            //68
+            //77
             StyleVal(ST_measureNumberAllStaffs,false),
             StyleVal(ST_smallNoteMag, qreal(.7)),
             StyleVal(ST_graceNoteMag, qreal(0.7)),
@@ -531,7 +533,7 @@ StyleData::StyleData()
             StyleVal(ST_FixMeasureNumbers, 0),
             StyleVal(ST_FixMeasureWidth, false),
 
-            //100
+            //109
             StyleVal(ST_SlurEndWidth, Spatium(.07)),
             StyleVal(ST_SlurMidWidth, Spatium(.15)),
             StyleVal(ST_SlurDottedWidth, Spatium(.1)),

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -154,6 +154,7 @@ enum StyleIdx {
       ST_figuredBassFontSize,
       ST_figuredBassYOffset,
       ST_figuredBassLineHeight,
+      ST_figuredBassAlignment,
       ST_figuredBassStyle,
       ST_systemFrameDistance,
       ST_frameSystemDistance,

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -346,6 +346,7 @@ void EditStyle::getValues()
       lstyle.set(ST_figuredBassFontSize,   size);
       lstyle.set(ST_figuredBassYOffset,    vPos);
       lstyle.set(ST_figuredBassLineHeight, ((double)spinFBLineHeight->value()) / 100.0);
+      lstyle.set(ST_figuredBassAlignment,  radioFBTop->isChecked() ? 0 : 1);
       lstyle.set(ST_figuredBassStyle,      radioFBModern->isChecked() ? 0 : 1);
       // copy to text style data relevant to it (LineHeight and Style are not in text style);
       // offsetType is necessarily OFFSET_SPATIUM
@@ -511,6 +512,8 @@ void EditStyle::setValues()
       doubleSpinFBSize->setValue(lstyle.value(ST_figuredBassFontSize).toDouble());
       doubleSpinFBVertPos->setValue(lstyle.value(ST_figuredBassYOffset).toDouble());
       spinFBLineHeight->setValue(lstyle.valueS(ST_figuredBassLineHeight).val() * 100.0);
+      radioFBTop->setChecked(lstyle.valueI(ST_figuredBassAlignment) == 0);
+      radioFBBottom->setChecked(lstyle.valueI(ST_figuredBassAlignment) == 1);
       radioFBModern->setChecked(lstyle.valueI(ST_figuredBassStyle) == 0);
       radioFBHistoric->setChecked(lstyle.valueI(ST_figuredBassStyle) == 1);
 

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -157,7 +157,7 @@
    <item row="0" column="1">
     <widget class="QStackedWidget" name="pageStack">
      <property name="currentIndex">
-      <number>14</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="Seite1">
       <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -3665,14 +3665,33 @@ p, li { white-space: pre-wrap; }
          <property name="title">
           <string>Figured Bass</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_32" stretch="0,1,0,2">
+         <layout class="QVBoxLayout" name="verticalLayout_32">
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_5">
             <item>
-             <layout class="QFormLayout" name="formLayout_8">
-              <property name="fieldGrowthPolicy">
-               <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-              </property>
+             <layout class="QGridLayout" name="gridLayout_16">
+              <item row="3" column="1">
+               <widget class="QSpinBox" name="spinFBLineHeight">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="suffix">
+                 <string>%</string>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>500</number>
+                </property>
+                <property name="singleStep">
+                 <number>10</number>
+                </property>
+                <property name="value">
+                 <number>100</number>
+                </property>
+               </widget>
+              </item>
               <item row="0" column="0">
                <widget class="QLabel" name="labelFBFont">
                 <property name="text">
@@ -3686,10 +3705,25 @@ p, li { white-space: pre-wrap; }
                 </property>
                </widget>
               </item>
-              <item row="0" column="1">
-               <widget class="QComboBox" name="comboFBFont">
-                <property name="sizeAdjustPolicy">
-                 <enum>QComboBox::AdjustToContents</enum>
+              <item row="2" column="1">
+               <widget class="QDoubleSpinBox" name="doubleSpinFBVertPos">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="suffix">
+                 <string>sp</string>
+                </property>
+                <property name="minimum">
+                 <double>-25.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>25.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.500000000000000</double>
+                </property>
+                <property name="value">
+                 <double>6.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -3725,41 +3759,6 @@ p, li { white-space: pre-wrap; }
                 </property>
                </widget>
               </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="labelFBVertPos">
-                <property name="text">
-                 <string>Vertical position:</string>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::PlainText</enum>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QDoubleSpinBox" name="doubleSpinFBVertPos">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="suffix">
-                 <string>sp</string>
-                </property>
-                <property name="minimum">
-                 <double>-25.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>25.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.500000000000000</double>
-                </property>
-                <property name="value">
-                 <double>6.000000000000000</double>
-                </property>
-               </widget>
-              </item>
               <item row="3" column="0">
                <widget class="QLabel" name="labelFBLineHeight">
                 <property name="text">
@@ -3773,25 +3772,37 @@ p, li { white-space: pre-wrap; }
                 </property>
                </widget>
               </item>
-              <item row="3" column="1">
-               <widget class="QSpinBox" name="spinFBLineHeight">
+              <item row="2" column="0">
+               <widget class="QLabel" name="labelFBVertPos">
+                <property name="text">
+                 <string>Vertical position:</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::PlainText</enum>
+                </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-                <property name="suffix">
-                 <string>%</string>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="comboFBFont">
+                <property name="sizeAdjustPolicy">
+                 <enum>QComboBox::AdjustToContents</enum>
                 </property>
-                <property name="minimum">
-                 <number>1</number>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QLabel" name="label_98">
+                <property name="text">
+                 <string>from top of staff</string>
                 </property>
-                <property name="maximum">
-                 <number>500</number>
-                </property>
-                <property name="singleStep">
-                 <number>10</number>
-                </property>
-                <property name="value">
-                 <number>100</number>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QLabel" name="label_99">
+                <property name="text">
+                 <string>of font height</string>
                 </property>
                </widget>
               </item>
@@ -3811,6 +3822,29 @@ p, li { white-space: pre-wrap; }
              </spacer>
             </item>
            </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupFBAlign">
+            <property name="title">
+             <string>Alignment</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_11">
+             <item>
+              <widget class="QRadioButton" name="radioFBTop">
+               <property name="text">
+                <string>Top</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="radioFBBottom">
+               <property name="text">
+                <string>Bottom</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
           <item>
            <spacer name="verticalSpacer_17">
@@ -4160,11 +4194,13 @@ p, li { white-space: pre-wrap; }
   <tabstop>staffDistance</tabstop>
   <tabstop>akkoladeDistance</tabstop>
   <tabstop>minSystemDistance</tabstop>
+  <tabstop>maxSystemDistance</tabstop>
   <tabstop>lyricsDistance</tabstop>
   <tabstop>lyricsMinBottomDistance</tabstop>
   <tabstop>lyricsLineHeight</tabstop>
   <tabstop>systemFrameDistance</tabstop>
   <tabstop>frameSystemDistance</tabstop>
+  <tabstop>lastSystemFillThreshold</tabstop>
   <tabstop>genClef</tabstop>
   <tabstop>genTimesig</tabstop>
   <tabstop>genKeysig</tabstop>
@@ -4271,13 +4307,19 @@ p, li { white-space: pre-wrap; }
   <tabstop>ottavaY</tabstop>
   <tabstop>ottavaHook</tabstop>
   <tabstop>ottavaLineWidth</tabstop>
+  <tabstop>pedalY</tabstop>
+  <tabstop>trillY</tabstop>
   <tabstop>useGermanNoteNames</tabstop>
   <tabstop>chordDescriptionFile</tabstop>
   <tabstop>chordDescriptionFileButton</tabstop>
+  <tabstop>harmonyY</tabstop>
+  <tabstop>harmonyFretDist</tabstop>
   <tabstop>comboFBFont</tabstop>
   <tabstop>doubleSpinFBSize</tabstop>
   <tabstop>doubleSpinFBVertPos</tabstop>
   <tabstop>spinFBLineHeight</tabstop>
+  <tabstop>radioFBTop</tabstop>
+  <tabstop>radioFBBottom</tabstop>
   <tabstop>radioFBModern</tabstop>
   <tabstop>radioFBHistoric</tabstop>
   <tabstop>propertyDistanceHead</tabstop>
@@ -4286,12 +4328,12 @@ p, li { white-space: pre-wrap; }
   <tabstop>articulationTable</tabstop>
   <tabstop>tableWidget</tabstop>
   <tabstop>voice1Up</tabstop>
-  <tabstop>voice1Down</tabstop>
   <tabstop>voice2Up</tabstop>
-  <tabstop>voice2Down</tabstop>
   <tabstop>voice3Up</tabstop>
-  <tabstop>voice3Down</tabstop>
   <tabstop>voice4Up</tabstop>
+  <tabstop>voice1Down</tabstop>
+  <tabstop>voice2Down</tabstop>
+  <tabstop>voice3Down</tabstop>
   <tabstop>voice4Down</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
Add an alignment parameter to the Figured Bass page of General Style, to the Score style parameters and to the layout of the FiguredBass element.

With Top alignment, marks 'hang' from the staff; with Bottom alignment, marks 'sits' on an imaginary line.

The top alignment is normally used for continuo scores, while the bottom alignment is more used in harmony teaching material.
