### PR TITLE
fix #20018: MIDI note input

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2798,7 +2798,8 @@ void ScoreView::cmd(const QAction* a)
 
       else
             _score->cmd(a);
-      _score->processMidiInput();
+      if (_score->processMidiInput())
+            mscore->endCmd();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Add call to MuseScore::endCmd() after processing MIDI note input,
so that the note is played and the cursor box position is updated.
