### PR TITLE
fix #19897 and others

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1141,6 +1141,21 @@ void Score::deleteItem(Element* el)
                   }
                   break;
 
+            case Element::REPEAT_MEASURE:
+                  {
+                  ChordRest* cr = static_cast<ChordRest*>(el);
+                  Measure* m1 = cr->measure();
+                  Segment* seg = cr->segment();
+                  removeChordRest(cr, false);
+                  Rest* rest = new Rest(this, TDuration(TDuration::V_MEASURE));
+                  rest->setDuration(Fraction(m1->len()));
+                  rest->setTrack(el->track());
+                  rest->setParent(cr->parent());
+                  undoAddCR(rest, seg->measure(), seg->tick());
+                  select(rest, SELECT_SINGLE, 0);
+                  }
+                  break;
+
             case Element::MEASURE:
                   {
                   Measure* measure = static_cast<Measure*>(el);
@@ -1313,6 +1328,8 @@ void Score::cmdDeleteSelection()
                               f = cr->duration();
                               }
                         else {
+                              if (cr->type() == Element::REPEAT_MEASURE)
+                                    f += s1->measure()->len();
                               removeChordRest(cr, true);
                               f += cr->duration();
                               }

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -165,6 +165,8 @@ QRectF Rest::drag(const QPointF& s)
 bool Rest::acceptDrop(MuseScoreView*, const QPointF&, Element* e) const
       {
       int type = e->type();
+      if (type == ARTICULATION && this->type() == Element::REPEAT_MEASURE)
+            return false;
       if (
          (type == ICON && static_cast<Icon*>(e)->subtype() == ICON_SBEAM)
          || (type == ICON && static_cast<Icon*>(e)->subtype() == ICON_MBEAM)

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1124,7 +1124,7 @@ void Score::undoRemoveElement(Element* element)
             undo(new RemoveElement(e));
             if (e->type() == Element::KEYSIG)                  // TODO: should be done in undo()/redo()
                   e->score()->cmdUpdateNotes();
-            if (!e->isChordRest() && e->parent() && (e->parent()->type() == Element::SEGMENT)) {
+            if (!(e->isChordRest() || (e->type() == Element::REPEAT_MEASURE)) && e->parent() && (e->parent()->type() == Element::SEGMENT)) {
                   Segment* s = static_cast<Segment*>(e->parent());
                   if (!segments.contains(s))
                         segments.append(s);


### PR DESCRIPTION
fix #19897
I tried to fix a series of problems related to the repeat measure sign (%):
-1- the one explained in http://musescore.org/en/node/19897
-2- the fact that by selecting a repeat measure sign alone (not the whole measure as in point -1-) and deleting creates a corrupted empty measure
-3- the fact that trying to add a fermata to a repeat measure sign results into a crash.
For point -3-, in particular, the code I added to rest.cpp prevents a priori the possibility of adding a fermata onto a repeat measure sign.
