### PR TITLE
Add include of stdint.h for int32_t

### DIFF
--- a/aeolus/aeolus/addsynth.h
+++ b/aeolus/aeolus/addsynth.h
@@ -20,6 +20,8 @@
 #ifndef __ADDSYNTH_H
 #define __ADDSYNTH_H
 
+#include <stdint.h>
+
 #define N_NOTE 11
 #define N_HARM 64
 #define NOTE_MIN 36

--- a/aeolus/aeolus/aeolus.h
+++ b/aeolus/aeolus/aeolus.h
@@ -24,7 +24,7 @@
 struct MidiPatch;
 class Event;
 
-#include "stdint.h"
+#include <stdint.h>
 #include "msynth/synti.h"
 #include "libmscore/midipatch.h"
 


### PR DESCRIPTION
File addsynth.h was missing an include of &lt;stdint.h&gt; before using int32_t,
and aeolus.h was incorrectly specifying "stdint.h" instead of &lt;stdint.h&gt;
(this was not evident in all build environments).
