### PR TITLE
FiguredBass: align with changes to SimpleText

### DIFF
--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -969,12 +969,14 @@ void FiguredBass::layout()
       {
       qreal       y;
 
-//      if(items.size()) {
-            TextStyle st("local", g_FBFonts[0].family, score()->styleD(ST_figuredBassFontSize),
-                        false, false, false, ALIGN_LEFT | ALIGN_TOP);
-            st.setSizeIsSpatiumDependent(true);
-            setTextStyle(st);
-//            }
+      Text::layout();                     // Text and/or SimpleText may expect some internal data to be setup
+
+      // force 'our' style
+      TextStyle st("local", g_FBFonts[0].family, score()->styleD(ST_figuredBassFontSize),
+                  false, false, false, ALIGN_LEFT | ALIGN_TOP);
+      st.setSizeIsSpatiumDependent(true);
+      setTextStyle(st);
+
       layoutLines();
 
       // vertical position


### PR DESCRIPTION
SimpleText now requires its _layout list to be set before an edit operation is started (and possibly for other tasks too).

Changed FiguredBass::layout() to call Text::layout() to set anything required up.
