### PR TITLE
Hide some styles in some contexts

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -226,9 +226,11 @@ static const QString ff("FreeSerifMscore");
 void initStyle(MStyle* s)
       {
       // this is an empty style, no offsets are allowed
-      // dont show this style in editor
+      // never show this style
       AS(TextStyle(
-         "", ff, 10, false, false, false, ALIGN_LEFT | ALIGN_BASELINE));
+         "", ff, 10, false, false, false, ALIGN_LEFT | ALIGN_BASELINE, QPointF(), OS, QPointF(), false,
+               Spatium(0.0), Spatium(0.0), 25, QColor(Qt::black), false, false, QColor(Qt::black),
+               QColor(255, 255, 255, 0), TextStyle::HIDE_ALWAYS));
 
       AS(TextStyle(
          TR("Title"), ff, 24, false, false, false,
@@ -279,7 +281,10 @@ void initStyle(MStyle* s)
 #if 0
       AS(TextStyle(           // internal style
          TR( "Dynamics2"), ff,  12, false, false, false,
-         ALIGN_LEFT | ALIGN_BASELINE, QPointF(0.0, 8.0), OS, QPointF(), true));
+         ALIGN_LEFT | ALIGN_BASELINE, QPointF(0.0, 8.0), OS, QPointF(), true,
+         Spatium(0.0), Spatium(0.0), 25, QColor(Qt::black), false, false,           // default params
+         QColor(Qt::black), QColor(255, 255, 255, 0),                               // default params
+         TextStyle::HIDE_ALWAYS));
 #endif
 
       AS(TextStyle(
@@ -325,7 +330,10 @@ void initStyle(MStyle* s)
 
       AS(TextStyle(
          TR( "Chordname"), ff,  12, false, false, false,
-         ALIGN_LEFT | ALIGN_BASELINE, QPointF(), OS, QPointF(), true));
+         ALIGN_LEFT | ALIGN_BASELINE, QPointF(), OS, QPointF(), true,
+         Spatium(0.0), Spatium(0.0), 25, QColor(Qt::black), false,      // default params
+         false, QColor(Qt::black), QColor(255, 255, 255, 0),            // default params
+         TextStyle::HIDE_IN_EDITOR));                                   // don't show in Style Editor
 
       AS(TextStyle(
          TR( "Rehearsal Mark"), ff,  14, true, false, false,
@@ -394,7 +402,10 @@ void initStyle(MStyle* s)
 
       AS(TextStyle(
       TR("Figured Bass"), "MScoreBC", 8, false, false, false,
-         ALIGN_LEFT | ALIGN_TOP, QPointF(0, 6), OS, QPointF(), true));
+         ALIGN_LEFT | ALIGN_TOP, QPointF(0, 6), OS, QPointF(), true,
+         Spatium(0.0), Spatium(0.0), 25, QColor(Qt::black), false,      // default params
+         false, QColor(Qt::black), QColor(255, 255, 255, 0),            // default params
+         TextStyle::HIDE_IN_EDITOR));                                   // don't show in Style Editor
 
 #undef MM
 #undef OA
@@ -662,25 +673,27 @@ StyleData::~StyleData()
 TextStyle::TextStyle()
       {
       d = new TextStyleData;
+      _hidden = HIDE_NEVER;
       }
 
-TextStyle::TextStyle(
-   QString _name, QString _family, qreal _size,
+TextStyle::TextStyle(QString _name, QString _family, qreal _size,
    bool _bold, bool _italic, bool _underline,
    Align _align,
    const QPointF& _off, OffsetType _ot, const QPointF& _roff,
    bool sd,
    Spatium fw, Spatium pw, int fr, QColor co, bool _circle, bool _systemFlag,
-   QColor fg, QColor bg)
+   QColor fg, QColor bg, Hidden hidden)
       {
       d = new TextStyleData(_name, _family, _size,
          _bold, _italic, _underline, _align, _off, _ot, _roff,
          sd, fw, pw, fr, co, _circle, _systemFlag, fg, bg);
+      _hidden = hidden;
       }
 
 TextStyle::TextStyle(const TextStyle& s)
    : d(s.d)
       {
+      _hidden = s._hidden;
       }
 TextStyle::~TextStyle()
       {
@@ -693,6 +706,7 @@ TextStyle::~TextStyle()
 TextStyle& TextStyle::operator=(const TextStyle& s)
       {
       d = s.d;
+//      _hidden = s._hidden;
       return *this;
       }
 

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -31,7 +31,17 @@ class TextStyleData;
 //---------------------------------------------------------
 
 class TextStyle {
+   public:
+      enum Hidden {
+            HIDE_NEVER     = 0,
+            HIDE_IN_EDITOR = 1,
+            HIDE_IN_LISTS  = 2,
+            HIDE_ALWAYS    = 0xFFFF
+            };
+
+   private:
       QSharedDataPointer<TextStyleData> d;
+      Hidden _hidden;               // read-only parameter for text style visibility in various program places
 
    public:
       TextStyle();
@@ -44,11 +54,13 @@ class TextStyle {
          bool sd = false,
          Spatium fw = Spatium(0.0), Spatium pw = Spatium(0.0), int fr = 25,
          QColor co = QColor(Qt::black), bool circle = false, bool systemFlag = false,
-         QColor fg = QColor(Qt::black), QColor bg = QColor(255, 255, 255, 0));
+         QColor fg = QColor(Qt::black), QColor bg = QColor(255, 255, 255, 0), Hidden hidden = HIDE_NEVER);
 
       TextStyle(const TextStyle&);
       ~TextStyle();
       TextStyle& operator=(const TextStyle&);
+
+      friend class TextStyleDialog;             // allow TextStyleDialog to access _hidden without making it globally writeable
 
       QString name() const;
       QString family() const;
@@ -98,6 +110,7 @@ class TextStyle {
       void setSystemFlag(bool v);
       void setForegroundColor(const QColor& v);
       void setBackgroundColor(const QColor& v);
+      Hidden hidden() const   { return _hidden; }
       void write(Xml& xml) const;
       void writeProperties(Xml& xml) const;
       void read(XmlReader& v);

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -252,7 +252,10 @@ void ScoreView::createElementPropertyMenu(Element* e, QMenu* popup)
             genPropertyMenuText(e, popup);
             popup->addAction(tr("Staff Text Properties..."))->setData("st-props");
             }
-      else if (e->type() == Element::TEXT || e->type() == Element::FINGERING || e->type() == Element::LYRICS) {
+      else if (e->type() == Element::TEXT
+               || e->type() == Element::FINGERING
+               || e->type() == Element::LYRICS
+               || e->type() == Element::FIGURED_BASS) {
             genPropertyMenuText(e, popup);
             }
       else if (e->type() == Element::TEMPO_TEXT) {

--- a/mscore/textprop.cpp
+++ b/mscore/textprop.cpp
@@ -67,8 +67,14 @@ void TextProp::setScore(bool os, Score* score)
       else {
             textGroup->setVisible(false);
             styles->clear();
-            foreach(const TextStyle& st, score->style()->textStyles())
-                  styles->addItem(st.name());
+
+            const QList<TextStyle>& scoreStyles = score->style()->textStyles();
+            int n = scoreStyles.size();
+            for (int i = 0; i < n; ++i) {
+                  // if style not hidden in this context, add to combo with index in score style list as userData
+                  if ( !(scoreStyles.at(i).hidden() & TextStyle::HIDE_IN_LISTS) )
+                        styles->addItem(scoreStyles.at(i).name(), i);
+                  }
             }
       }
 
@@ -101,7 +107,10 @@ void TextProp::setTextStyleType(int st)
       {
       if (st == TEXT_STYLE_UNKNOWN || st == TEXT_STYLE_UNSTYLED)
             st = TEXT_STYLE_TITLE;
-      styles->setCurrentIndex(st);
+      st = styles->findData(st);          // find a combo item with that style idx
+      if (st < 0)                         // if none found...
+            st = 0;                       // ...=> first combo item
+      styles->setCurrentIndex(st);        // set current combo item
       }
 
 //---------------------------------------------------------
@@ -110,7 +119,7 @@ void TextProp::setTextStyleType(int st)
 
 int TextProp::textStyleType() const
       {
-      return styles->currentIndex();
+      return styles->itemData(styles->currentIndex()).toInt();
       }
 
 //---------------------------------------------------------
@@ -152,7 +161,7 @@ void TextProp::setTextStyle(const TextStyle& s)
       else
             alignTop->setChecked(true);
 
-      QString str;
+//      QString str;
       if (s.offsetType() == OFFSET_ABS) {
             xOffset->setValue(s.offset().x() * INCH);
             yOffset->setValue(s.offset().y() * INCH);


### PR DESCRIPTION
Allows to hide some styles in:
*) the Text Style editor left-side list
*) in style drop lists / combo boxes as the EditTools widget or the "Text Properties" dlg box

Currently,
*) DEFAULT style is hidden everywhere
*) FIGUREDBASS and CHORDNAME styles are hidden in the Text Style editor.

See dev-list thead http://dev-list.musescore.org/Finalizing-FiguredBass-text-styles-tp7577857.html for a discussion.
