### PR TITLE
Play notes being added to a chord.

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -362,6 +362,7 @@ Note* Score::addNote(Chord* chord, int pitch)
       note->setPitch(pitch);
       note->setTpcFromPitch();
       undoAddElement(note);
+      _playNote = true;
       select(note, SELECT_SINGLE, 0);
       return note;
       }
@@ -379,6 +380,7 @@ Note* Score::addNote(Chord* chord, NoteVal& noteVal)
       if (note->tpc() == INVALID_TPC)
             note->setTpcFromPitch();
       undoAddElement(note);
+      _playNote = true;
       select(note, SELECT_SINGLE, 0);
       return note;
       }


### PR DESCRIPTION
When entering notes via midi, if the first note is held down while
more notes are played, to enter a chord of notes, only the first
note sounds. This patch allows the subsequent notes to be heard.

NB. If two notes are pressed at exactly the same time so that they
are both processed in a single call to Score::processMidiInput(),
then still only one of them will be heard.
