### PR TITLE
Correctly choosing the end segment when selecting only one or the last m...

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1212,7 +1212,13 @@ void Score::cmdDeleteSelectedMeasures()
       MeasureBase* is   = selection().startSegment()->measure();
       int startIdx      = measureIdx(is);
       Segment* seg      = selection().endSegment();
-      MeasureBase* ie   = seg ? seg->measure() : lastMeasure();
+      MeasureBase* ie;
+      // choose the correct last measure based on the end segment
+      // this depends on whether a whole measure is selected or only a few notes within it
+      if (seg)
+            ie = !seg->prev() ? seg->measure()->prev() : seg->measure();
+      else
+            ie = lastMeasure();
       int endIdx        = measureIdx(ie);
 
       // createEndBar if last measure is deleted

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2814,7 +2814,7 @@ void Score::select(Element* e, SelectType type, int staffIdx)
                   int etick = tick + m->ticks();
                   if (_selection.state() == SEL_NONE) {
                         _selection.setStartSegment(m->tick2segment(tick, true));
-                        _selection.setEndSegment(tick2segment(etick));
+                        _selection.setEndSegment(m == lastMeasure() ? 0 : tick2segment(etick));
                         }
                   else {
                         select(0, SELECT_SINGLE, 0);
@@ -2853,10 +2853,8 @@ void Score::select(Element* e, SelectType type, int staffIdx)
                   if (_selection.state() == SEL_NONE) {
                         _selection.setStaffStart(staffIdx);
                         _selection.setStaffEnd(staffIdx + 1);
-                        //_selection.setStartSegment(m->tick2segment(tick, true));
-                        _selection.setStartSegment(m->first());
-                        // _selection.setEndSegment(tick2segment(etick, true));
-                        _selection.setEndSegment(m->last());
+                        _selection.setStartSegment(m->tick2segment(tick, true));
+                        _selection.setEndSegment(m == lastMeasure() ? 0 : tick2segment(etick, true));
                         }
                   else if (_selection.state() == SEL_RANGE) {
                         if (staffIdx < _selection.staffStart())
@@ -2868,14 +2866,14 @@ void Score::select(Element* e, SelectType type, int staffIdx)
                               activeIsFirst = true;
                               }
                         else if (etick >= _selection.tickEnd())
-                              _selection.setEndSegment(tick2segment(etick, true));
+                              _selection.setEndSegment(m == lastMeasure() ? 0 : tick2segment(etick, true));
                         else {
                               if (_selection.activeSegment() == _selection.startSegment()) {
                                     _selection.setStartSegment(m->tick2segment(tick, true));
                                     activeIsFirst = true;
                                     }
                               else
-                                    _selection.setEndSegment(tick2segment(etick, true));
+                                    _selection.setEndSegment(m == lastMeasure() ? 0 : tick2segment(etick, true));
                               }
                         }
                   else if (_selection.isSingle()) {


### PR DESCRIPTION
...easure

When a single measure is selected by clicking it, the endSegment of the selection is now set to the next segment after the selection (as what is done in all other cases)

When selecting the last measure the endSegment is set to 0 to add consistency. This is what is done if you drag-select the last measure.
