### PR TITLE
FiguredBass: Enables pasting FiguredBass elements.

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -312,9 +312,10 @@ qDebug("cannot make gap in staff %d at tick %d", staffIdx, dst->tick());
                            || tag == "Text"
                            || tag == "StaffText"
                            || tag == "TempoText"
+                           || tag == "FiguredBass"
                            ) {
                               Element* el = Element::name2Element(tag, this);
-                              el->setTrack(dstStaffIdx * VOICES);
+                              el->setTrack(dstStaffIdx * VOICES);             // a valid track might be necessary for el->read() to work
 
                               int tick = e.tick() - tickStart + dstTick;
                               Measure* m = tick2measure(tick);
@@ -322,6 +323,9 @@ qDebug("cannot make gap in staff %d at tick %d", staffIdx, dst->tick());
                               el->setParent(seg);
                               el->read(e);
 
+                              // be sure to paste the element in the destination track;
+                              // setting track needs to be repeated, as it might have been overwritten by el->read()
+                              el->setTrack(dstStaffIdx * VOICES);
                               undoAddElement(el);
                               }
                         else if (tag == "Clef") {


### PR DESCRIPTION
FiguredBass elements were not pasted, if copied.

To be sure the element is pasted into the right track, the track is set again after reading the element. This also affects Dynamic, Symbol, FretDiagram, Marker, Jump, Image, Text, StaffText, TempoText.
