### PR TITLE
fix #18618 : File suffix has to be entered when saving snapshot

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1131,14 +1131,8 @@ QString MuseScore::getAudioFile(const QString& d)
 //   getFotoFilename
 //---------------------------------------------------------
 
-QString MuseScore::getFotoFilename()
+QString MuseScore::getFotoFilename(QString& filter, QString* selectedFilter)
       {
-      QString filter =
-         tr("PNG Bitmap Graphic (*.png);;")+
-         tr("PDF File (*.pdf);;")+
-         tr("Encapsulated PostScript File (*.eps);;")+
-         tr("Scalable Vector Graphic (*.svg);;");
-
       QString title       = tr("MuseScore: Save Image");
 
       QFileInfo myImages(preferences.myImagesPath);
@@ -1152,7 +1146,8 @@ QString MuseScore::getFotoFilename()
                this,
                title,
                defaultPath,
-               filter
+               filter,
+               selectedFilter
                );
             return fn;
             }
@@ -1183,6 +1178,7 @@ QString MuseScore::getFotoFilename()
 
       if (saveImageDialog->exec()) {
             QStringList result = saveImageDialog->selectedFiles();
+            *selectedFilter = saveImageDialog->selectedNameFilter();
             return result.front();
             }
       return QString();

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -649,7 +649,15 @@ bool ScoreView::fotoRectHit(const QPoint& pos)
 
 bool ScoreView::saveFotoAs(bool printMode, const QRectF& r)
       {
-      QString fn = mscore->getFotoFilename();
+      QStringList fl;
+      fl.append(tr("PNG Bitmap Graphic (*.png)"));
+      fl.append(tr("PDF File (*.pdf)"));
+      fl.append(tr("Encapsulated PostScript File (*.eps)"));
+      fl.append(tr("Scalable Vector Graphic (*.svg)"));
+
+      QString selectedFilter;
+      QString filter = fl.join(";;");
+      QString fn = mscore->getFotoFilename(filter, &selectedFilter);
 
       if (fn.isEmpty())
             return false;
@@ -657,11 +665,28 @@ bool ScoreView::saveFotoAs(bool printMode, const QRectF& r)
       QFileInfo fi(fn);
       mscore->lastSaveDirectory = fi.absolutePath();
 
-      QString ext = fi.suffix();
+      QString ext;
+      if (selectedFilter.isEmpty()) {
+            ext = fi.suffix();
+            }
+      else {
+            int idx = fl.indexOf(selectedFilter);
+            if (idx != -1) {
+                  static const char* extensions[] = {
+                        "png", "pdf", "eps", "svg"
+                        };
+                  ext = extensions[idx];
+                  }
+            }
+
       if (ext.isEmpty()) {
             QMessageBox::critical(mscore, tr("MuseScore: Save As"), tr("cannot determine file type"));
             return false;
             }
+
+      if (fi.suffix() != ext)
+            fn += "." + ext;
+
       bool transparent = preferences.pngTransparent;
       double convDpi   = preferences.pngResolution;
       double mag       = convDpi / MScore::DPI;

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -548,7 +548,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QString getSaveScoreName(const QString& title,
          QString& name, const QString& filter, QString* selectedFilter, bool selectFolder);
       QString getStyleFilename(bool open, const QString& title = QString());
-      QString getFotoFilename();
+      QString getFotoFilename(QString& filter, QString *selectedFilter);
       QString getChordStyleFilename(bool open);
       QStringList getSoundFont(const QString&);
       QString getScanFile(const QString&);


### PR DESCRIPTION
The solution is the same as the one used in MuseScore::saveAs()
