### PR TITLE
fix #19129 : Small note in chord is detached from stem

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -336,8 +336,6 @@ qreal Note::headWidth() const
       {
       int head = noteHead();
       qreal val = symbols[score()->symIdx()][head].width(magS());
-      if (_small)
-            val *= score()->styleD(ST_smallNoteMag);
       return val;
       }
 


### PR DESCRIPTION
It seems that the size of the small note head is reduced twice. qreal val gets the correct value before these two deleted lines, therefore I removed them. Based on my tests it works, and the mag setting in style also works.
