### PR TITLE
TAB: Stems through staves option

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -57,11 +57,11 @@ ArticulationInfo Articulation::articulationList[ARTICULATIONS] = {
             },
       { staccatoSym, staccatoSym,
             "staccato", QT_TRANSLATE_NOOP("articulation", "staccato"),
-            0., ARTICULATION_SHOW_IN_PITCHED_STAFF
+            0., ARTICULATION_SHOW_IN_PITCHED_STAFF | ARTICULATION_SHOW_IN_TABLATURE
             },
       { ustaccatissimoSym,   dstaccatissimoSym,
             "staccatissimo", QT_TRANSLATE_NOOP("articulation", "staccatissimo"),
-            0., ARTICULATION_SHOW_IN_PITCHED_STAFF
+            0., ARTICULATION_SHOW_IN_PITCHED_STAFF | ARTICULATION_SHOW_IN_TABLATURE
             },
       { tenutoSym, tenutoSym,
             "tenuto", QT_TRANSLATE_NOOP("articulation", "tenuto"),

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -386,6 +386,7 @@ void ChordRest::layoutArticulations()
       if (parent() == 0 || _articulations.isEmpty())
             return;
       qreal _spatium  = spatium();
+      qreal _spStaff  = _spatium * staff()->lineDistance(); // scaled to staff line distance for vert. pos. within a staff
       if (type() == CHORD) {
             if (_articulations.size() == 1) {
                   static_cast<Chord*>(this)->layoutArticulation(_articulations[0]);
@@ -408,7 +409,7 @@ void ChordRest::layoutArticulations()
                   if ((st1 == Articulation_Tenuto || st1 == Articulation_Staccato)
                      && (st2 == Articulation_Marcato)) {
                         QPointF pt = static_cast<Chord*>(this)->layoutArticulation(a1);
-                        pt.ry() += a1->up() ? -_spatium * .5 : _spatium * .5;
+                        pt.ry() += a1->up() ? -_spStaff * .5 : _spStaff * .5;
                         a2->layout();
                         a2->setUp(a1->up());
                         a2->setPos(pt);
@@ -426,7 +427,7 @@ void ChordRest::layoutArticulations()
                   if ((st1 == Articulation_Tenuto || st1 == Articulation_Staccato)
                      && (st2 == Articulation_Sforzatoaccent)) {
                         QPointF pt = static_cast<Chord*>(this)->layoutArticulation(a1);
-                        pt.ry() += a1->up() ? -_spatium * .7 : _spatium * .7;
+                        pt.ry() += a1->up() ? -_spStaff * .7 : _spStaff * .7;
                         a2->layout();
                         a2->setUp(a1->up());
                         a2->setPos(pt);

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1268,6 +1268,9 @@ void Note::layout()
             setbbox(symbols[score()->symIdx()][noteHead()].bbox(magS()));
             if (parent() == 0)
                   return;
+            }
+      // if not TAB or TAB with stems through
+      if (!useTablature || ((StaffTypeTablature*)staff()->staffType())->stemThrough()) {
             int dots = chord()->dots();
             for (int i = 0; i < 3; ++i) {
                   if (i < dots) {

--- a/libmscore/notedot.cpp
+++ b/libmscore/notedot.cpp
@@ -42,7 +42,7 @@ void NoteDot::layout()
 
 void NoteDot::draw(QPainter* p) const
       {
-      if (!staff()->isTabStaff()) {
+      if (!staff()->isTabStaff() || ((StaffTypeTablature*)staff()->staffType())->stemThrough()) {
             p->setPen(curColor());
             symbols[score()->symIdx()][dotSym].draw(p, magS());
             }

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -681,13 +681,13 @@ QPointF StaffTypeTablature::chordStemPos(const Chord *chord) const
 
       // if stems are through staff, stem goes from fartest note string
       if (stemThrough())
-            y = (stemsDown() ? chord->upString() : chord->downString()) * _lineDistance.val();
+            y = (chord->up() ? chord->downString() : chord->upString()) * _lineDistance.val();
       else
       // if stems beside staff, position are fixed, but take into account delta
             y = (stemsDown() ? (_lines-1)*_lineDistance.val() + STAFFTYPE_TAB_DEFAULTSTEMPOSY_DN :
                   STAFFTYPE_TAB_DEFAULTSTEMPOSY_UP) + delta;
 
-      return QPointF(STAFFTYPE_TAB_DEFAULTSTEMPOSX, y);
+      return QPointF(chordStemPosX(chord), y);
       }
 
 //---------------------------------------------------------
@@ -699,7 +699,7 @@ QPointF StaffTypeTablature::chordStemPosBeam(const Chord *chord) const
       {
       qreal y = ( stemsDown() ? chord->downString() : chord->upString() ) * _lineDistance.val();
 
-      return QPointF(STAFFTYPE_TAB_DEFAULTSTEMPOSX, y);
+      return QPointF(chordStemPosX(chord), y);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Make the "Stem through staves" option for TABs more similar to regular pitch layout.

See http://musescore.org/en/node/20342 for discussion and examples.
