### PR TITLE
TAB: edit staff type dlg box.

### DIFF
--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -109,10 +109,10 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
       connect(genTimesig,     SIGNAL(toggled(bool)),              SLOT(updateTabPreview()));
       connect(noteValuesSymb, SIGNAL(toggled(bool)),              SLOT(updateTabPreview()));
       connect(noteValuesStems,SIGNAL(toggled(bool)),              SLOT(on_tabStemsToggled(bool)));
-      connect(stemAboveRadio, SIGNAL(toggled(bool)),              SLOT(updateTabPreview()));
-      connect(stemBelowRadio, SIGNAL(toggled(bool)),              SLOT(updateTabPreview()));
       connect(stemBesideRadio,SIGNAL(toggled(bool)),              SLOT(updateTabPreview()));
       connect(stemThroughRadio,SIGNAL(toggled(bool)),             SLOT(on_tabStemThroughToggled(bool)));
+      connect(stemAboveRadio, SIGNAL(toggled(bool)),              SLOT(updateTabPreview()));
+      connect(stemBelowRadio, SIGNAL(toggled(bool)),              SLOT(updateTabPreview()));
 //    connect(minimNoneRadio, SIGNAL(toggled(bool)),              SLOT(updateTabPreview()));
       connect(minimShortRadio,SIGNAL(toggled(bool)),              SLOT(on_tabMinimShortToggled(bool)));
       connect(minimSlashedRadio,SIGNAL(toggled(bool)),            SLOT(updateTabPreview()));
@@ -569,8 +569,8 @@ void EditStaffType::blockTabPreviewSignals(bool block)
 
 void EditStaffType::tabStemsCompatibility(bool checked)
       {
-      stemAboveRadio->setEnabled(checked);
-      stemBelowRadio->setEnabled(checked);
+      stemAboveRadio->setEnabled(checked && !stemThroughRadio->isChecked());
+      stemBelowRadio->setEnabled(checked && !stemThroughRadio->isChecked());
       stemBesideRadio->setEnabled(checked);
       stemThroughRadio->setEnabled(checked && !minimShortRadio->isChecked());
       minimNoneRadio->setEnabled(checked);
@@ -602,6 +602,7 @@ void EditStaffType::tabMinimShortCompatibility(bool checked)
 //
 //    Setting "stems through" is incompatible with "minim short":
 //    if checking and "minim short" is checked, move check to "minim slashed"
+//    It also make "Stems above" and "Stems below" meaningless: disable them
 //---------------------------------------------------------
 
 void EditStaffType::tabStemThroughCompatibility(bool checked)
@@ -612,8 +613,11 @@ void EditStaffType::tabStemThroughCompatibility(bool checked)
                   minimSlashedRadio->setChecked(true);
                   }
             }
-      // disable / enable "minim short" according "stems through" is checked / unchecked
-      minimShortRadio->setEnabled(!checked && noteValuesStems->isChecked());
+      // disable / enable "minim short" and "stems above/below" according "stems through" is checked / unchecked
+      bool enab = !checked && noteValuesStems->isChecked();
+      minimShortRadio->setEnabled(enab);
+      stemAboveRadio->setEnabled(enab);
+      stemBelowRadio->setEnabled(enab);
       }
 
 //---------------------------------------------------------

--- a/mscore/stafftype.ui
+++ b/mscore/stafftype.ui
@@ -756,67 +756,6 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QFrame" name="frame_5">
-                   <property name="frameShape">
-                    <enum>QFrame::NoFrame</enum>
-                   </property>
-                   <property name="frameShadow">
-                    <enum>QFrame::Plain</enum>
-                   </property>
-                   <layout class="QHBoxLayout" name="horizontalLayout_15">
-                    <property name="margin">
-                     <number>0</number>
-                    </property>
-                    <item>
-                     <widget class="QLabel" name="stemPosLabel">
-                      <property name="minimumSize">
-                       <size>
-                        <width>120</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>Stem position:</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QRadioButton" name="stemAboveRadio">
-                      <property name="minimumSize">
-                       <size>
-                        <width>110</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>Above</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QRadioButton" name="stemBelowRadio">
-                      <property name="text">
-                       <string>Below</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_10">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item>
                   <widget class="QFrame" name="frame_6">
                    <property name="frameShape">
                     <enum>QFrame::NoFrame</enum>
@@ -863,6 +802,67 @@
                     </item>
                     <item>
                      <spacer name="horizontalSpacer_11">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QFrame" name="frame_5">
+                   <property name="frameShape">
+                    <enum>QFrame::NoFrame</enum>
+                   </property>
+                   <property name="frameShadow">
+                    <enum>QFrame::Plain</enum>
+                   </property>
+                   <layout class="QHBoxLayout" name="horizontalLayout_15">
+                    <property name="margin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <widget class="QLabel" name="stemPosLabel">
+                      <property name="minimumSize">
+                       <size>
+                        <width>120</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>Stem position:</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QRadioButton" name="stemAboveRadio">
+                      <property name="minimumSize">
+                       <size>
+                        <width>110</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>Above</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QRadioButton" name="stemBelowRadio">
+                      <property name="text">
+                       <string>Below</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_10">
                       <property name="orientation">
                        <enum>Qt::Horizontal</enum>
                       </property>
@@ -1248,7 +1248,6 @@
   <tabstop>presetTablatureCombo</tabstop>
   <tabstop>pushFullConfig</tabstop>
   <tabstop>upsideDown</tabstop>
-  <tabstop>pushQuickConfig</tabstop>
   <tabstop>fretFontName</tabstop>
   <tabstop>fretFontSize</tabstop>
   <tabstop>fretY</tabstop>
@@ -1261,10 +1260,10 @@
   <tabstop>noteValuesNone</tabstop>
   <tabstop>noteValuesSymb</tabstop>
   <tabstop>noteValuesStems</tabstop>
-  <tabstop>stemAboveRadio</tabstop>
-  <tabstop>stemBelowRadio</tabstop>
   <tabstop>stemBesideRadio</tabstop>
   <tabstop>stemThroughRadio</tabstop>
+  <tabstop>stemAboveRadio</tabstop>
+  <tabstop>stemBelowRadio</tabstop>
   <tabstop>minimNoneRadio</tabstop>
   <tabstop>minimShortRadio</tabstop>
   <tabstop>minimSlashedRadio</tabstop>
@@ -1272,6 +1271,7 @@
   <tabstop>durFontName</tabstop>
   <tabstop>durFontSize</tabstop>
   <tabstop>durY</tabstop>
+  <tabstop>pushQuickConfig</tabstop>
   <tabstop>newTypeTablature</tabstop>
   <tabstop>showLedgerLinesPercussion</tabstop>
   <tabstop>genKeysigPercussion</tabstop>


### PR DESCRIPTION
Re-order controls.
Correct enabled/disabled dependencies of "Stems above/below" from "Stems through"
