### PR TITLE
Init _cursor.line and _cursor.column before layout

### DIFF
--- a/libmscore/simpletext.cpp
+++ b/libmscore/simpletext.cpp
@@ -355,10 +355,10 @@ qreal SimpleText::baseLine() const
 
 void SimpleText::startEdit(MuseScoreView*, const QPointF& pt)
       {
-      if (_layout.isEmpty())
-            layout();
       _cursor.line   = 0;
       _cursor.column = 0;
+      if (_layout.isEmpty())
+            layout();
       setCursor(pt);
       undoPushProperty(P_TEXT);
       }


### PR DESCRIPTION
SimpleText::layout in edit mode calls cursorRect(), which uses
the value of _cursor.line to index an array. If _cursor.line
is not set to zero before calling layout(), it can be out of range,
causing a crash.
