### PR TITLE
Figured bass navigation corrections

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4826,7 +4826,7 @@ void ScoreView::figuredBassTab(bool bMeas, bool bBack)
 
             while (nextSegm) {                   // look for a ChordRest in the compatible track range
                   foreach (const Element* e, nextSegm->annotations())
-                        if (e->type() == Element::FIGURED_BASS)
+                        if (e->type() == Element::FIGURED_BASS && e->track() >= minTrack && e->track() <= maxTrack)
                               goto Found;
                   for (currTrack = minTrack; currTrack <= maxTrack; currTrack++)
                         if (nextSegm->element(currTrack) )


### PR DESCRIPTION
Remove empty FB element correctly in end edit.
Prevent Space and shift-Space from skipping FB not attached to note/rest.
Correct behaviour of Ctrl-number when changing to a new measure.
Call changeState() in the correct place - after startEdit().
A few comment corrections.
