### PR TITLE
TAB: improvements to fonts and presets

### DIFF
--- a/fonts/fonts_tablature.xml
+++ b/fonts/fonts_tablature.xml
@@ -2,58 +2,110 @@
 <museScore version="1.0">
 
    <fretFont>
-      <family>MScoreTabulature</family>
-      <displayName>MuseScore Tab Modern</displayName>
-      <defaultPitch>10</defaultPitch>
-      <fret value="0"  letter="0">ª</fret>
-      <fret value="1"  letter="0">¡</fret>
-      <fret value="2"  letter="0">¢</fret>
-      <fret value="3"  letter="0">£</fret>
-      <fret value="4"  letter="0">¤</fret>
-      <fret value="5"  letter="0">¥</fret>
-      <fret value="6"  letter="0">¦</fret>
-      <fret value="7"  letter="0">§</fret>
-      <fret value="8"  letter="0">¨</fret>
-      <fret value="9"  letter="0">©</fret>
-      <fret value="10" letter="0">¡ª</fret>
-      <fret value="11" letter="0">¡¡</fret>
-      <fret value="12" letter="0">¡¢</fret>
-      <fret value="13" letter="0">¡£</fret>
-      <fret value="14" letter="0">¡¤</fret>
-      <fret value="15" letter="0">¡¥</fret>
-      <fret value="16" letter="0">¡¦</fret>
-      <fret value="17" letter="0">¡§</fret>
-      <fret value="18" letter="0">¡¨</fret>
-      <fret value="19" letter="0">¡©</fret>
-      <fret value="20" letter="0">¢ª</fret>
-      <fret value="21" letter="0">¢¡</fret>
-      <fret value="22" letter="0">¢¢</fret>
-      <fret value="23" letter="0">¢£</fret>
-      <fret value="24" letter="0">¢¤</fret>
-      <fret value="0"  letter="1">ā</fret>
-      <fret value="1"  letter="1">Ă</fret>
-      <fret value="2"  letter="1">ă</fret>
-      <fret value="3"  letter="1">Ą</fret>
-      <fret value="4"  letter="1">ą</fret>
-      <fret value="5"  letter="1">Ć</fret>
-      <fret value="6"  letter="1">ć</fret>
-      <fret value="7"  letter="1">Ĉ</fret>
-      <fret value="8"  letter="1">ĉ</fret>
-      <fret value="9"  letter="1">ċ</fret>
-      <fret value="10" letter="1">Č</fret>
-      <fret value="11" letter="1">č</fret>
-      <fret value="12" letter="1">Ď</fret>
-      <fret value="13" letter="1">ď</fret>
-      <fret value="14" letter="1">Đ</fret>
-      <fret value="15" letter="1">đ</fret>
-      <fret value="16" letter="1">Ē</fret>
-      <mark value="x">Ę</mark>
-      <mark value="ghost">Ā</mark>
+      <family>FreeSans</family>
+      <displayName>MuseScore Tab Sans</displayName>
+      <defaultPitch>9</defaultPitch>
+      <defaultYOffset>0.0</defaultYOffset>
+      <fret value="0"  letter="0">0</fret>
+      <fret value="1"  letter="0">1</fret>
+      <fret value="2"  letter="0">2</fret>
+      <fret value="3"  letter="0">3</fret>
+      <fret value="4"  letter="0">4</fret>
+      <fret value="5"  letter="0">5</fret>
+      <fret value="6"  letter="0">6</fret>
+      <fret value="7"  letter="0">7</fret>
+      <fret value="8"  letter="0">8</fret>
+      <fret value="9"  letter="0">9</fret>
+      <fret value="10" letter="0">10</fret>
+      <fret value="11" letter="0">11</fret>
+      <fret value="12" letter="0">12</fret>
+      <fret value="13" letter="0">13</fret>
+      <fret value="14" letter="0">14</fret>
+      <fret value="15" letter="0">15</fret>
+      <fret value="16" letter="0">16</fret>
+      <fret value="17" letter="0">17</fret>
+      <fret value="18" letter="0">18</fret>
+      <fret value="19" letter="0">19</fret>
+      <fret value="20" letter="0">20</fret>
+      <fret value="21" letter="0">21</fret>
+      <fret value="22" letter="0">22</fret>
+      <fret value="23" letter="0">23</fret>
+      <fret value="24" letter="0">24</fret>
+      <fret value="0"  letter="1">a</fret>
+      <fret value="1"  letter="1">b</fret>
+      <fret value="2"  letter="1">c</fret>
+      <fret value="3"  letter="1">d</fret>
+      <fret value="4"  letter="1">e</fret>
+      <fret value="5"  letter="1">f</fret>
+      <fret value="6"  letter="1">g</fret>
+      <fret value="7"  letter="1">h</fret>
+      <fret value="8"  letter="1">i</fret>
+      <fret value="9"  letter="1">k</fret>
+      <fret value="10" letter="1">l</fret>
+      <fret value="11" letter="1">m</fret>
+      <fret value="12" letter="1">n</fret>
+      <fret value="13" letter="1">o</fret>
+      <fret value="14" letter="1">p</fret>
+      <fret value="15" letter="1">q</fret>
+      <fret value="16" letter="1">r</fret>
+      <mark value="x">x</mark>
+      <mark value="ghost">×</mark>
+   </fretFont>
+   <fretFont>
+      <family>FreeSerifMscore</family>
+      <displayName>MuseScore Tab Serif</displayName>
+      <defaultPitch>9</defaultPitch>
+      <defaultYOffset>0.0</defaultYOffset>
+      <fret value="0"  letter="0">0</fret>
+      <fret value="1"  letter="0">1</fret>
+      <fret value="2"  letter="0">2</fret>
+      <fret value="3"  letter="0">3</fret>
+      <fret value="4"  letter="0">4</fret>
+      <fret value="5"  letter="0">5</fret>
+      <fret value="6"  letter="0">6</fret>
+      <fret value="7"  letter="0">7</fret>
+      <fret value="8"  letter="0">8</fret>
+      <fret value="9"  letter="0">9</fret>
+      <fret value="10" letter="0">10</fret>
+      <fret value="11" letter="0">11</fret>
+      <fret value="12" letter="0">12</fret>
+      <fret value="13" letter="0">13</fret>
+      <fret value="14" letter="0">14</fret>
+      <fret value="15" letter="0">15</fret>
+      <fret value="16" letter="0">16</fret>
+      <fret value="17" letter="0">17</fret>
+      <fret value="18" letter="0">18</fret>
+      <fret value="19" letter="0">19</fret>
+      <fret value="20" letter="0">20</fret>
+      <fret value="21" letter="0">21</fret>
+      <fret value="22" letter="0">22</fret>
+      <fret value="23" letter="0">23</fret>
+      <fret value="24" letter="0">24</fret>
+      <fret value="0"  letter="1">a</fret>
+      <fret value="1"  letter="1">b</fret>
+      <fret value="2"  letter="1">c</fret>
+      <fret value="3"  letter="1">d</fret>
+      <fret value="4"  letter="1">e</fret>
+      <fret value="5"  letter="1">f</fret>
+      <fret value="6"  letter="1">g</fret>
+      <fret value="7"  letter="1">h</fret>
+      <fret value="8"  letter="1">i</fret>
+      <fret value="9"  letter="1">k</fret>
+      <fret value="10" letter="1">l</fret>
+      <fret value="11" letter="1">m</fret>
+      <fret value="12" letter="1">n</fret>
+      <fret value="13" letter="1">o</fret>
+      <fret value="14" letter="1">p</fret>
+      <fret value="15" letter="1">q</fret>
+      <fret value="16" letter="1">r</fret>
+      <mark value="x">x</mark>
+      <mark value="ghost">×</mark>
    </fretFont>
    <fretFont>
       <family>MScoreTabulature</family>
       <displayName>MuseScore Tab Renaiss</displayName>
       <defaultPitch>10</defaultPitch>
+      <defaultYOffset>0</defaultYOffset>
       <fret value="0"  letter="0">0</fret>
       <fret value="1"  letter="0">1</fret>
       <fret value="2"  letter="0">2</fret>
@@ -103,6 +155,7 @@
       <family>MScoreTabulature</family>
       <displayName>MuseScore Tab Late Renaiss</displayName>
       <defaultPitch>10</defaultPitch>
+      <defaultYOffset>0</defaultYOffset>
       <fret value="0"  letter="0">0</fret>
       <fret value="1"  letter="0">1</fret>
       <fret value="2"  letter="0">2</fret>
@@ -153,6 +206,7 @@
       <family>MScoreTabulature</family>
       <displayName>MuseScore Tab Modern</displayName>
       <defaultPitch>15</defaultPitch>
+      <defaultYOffset>0</defaultYOffset>
       <duration value="longa">Ƞ</duration>
       <duration value="brevis">ȡ</duration>
       <duration value="semibrevis">Ȣ</duration>
@@ -170,6 +224,7 @@
       <family>MScoreTabulature</family>
       <displayName>MuseScore Tab Italian</displayName>
       <defaultPitch>15</defaultPitch>
+      <defaultYOffset>0</defaultYOffset>
       <duration value="longa">Ȁ</duration>
       <duration value="brevis">ȁ</duration>
       <duration value="semibrevis">Ȃ</duration>
@@ -187,6 +242,7 @@
       <family>MScoreTabulature</family>
       <displayName>MuseScore Tab French</displayName>
       <defaultPitch>15</defaultPitch>
+      <defaultYOffset>0</defaultYOffset>
       <duration value="longa">Ȑ</duration>
       <duration value="brevis">ȑ</duration>
       <duration value="semibrevis">Ȓ</duration>

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -850,6 +850,8 @@ void TabDurationSymbol::draw(QPainter* painter) const
 
 bool TablatureFretFont::read(XmlReader& e)
       {
+      defPitch = 9.0;
+      defYOffset = 0.0;
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
 
@@ -861,6 +863,8 @@ bool TablatureFretFont::read(XmlReader& e)
                   displayName = e.readElementText();
             else if (tag == "defaultPitch")
                   defPitch = e.readDouble();
+            else if (tag == "defaultYOffset")
+                  defYOffset = e.readDouble();
             else if (tag == "mark") {
                   QString val = e.attribute("value");
                   QString txt(e.readElementText());
@@ -902,6 +906,8 @@ bool TablatureDurationFont::read(XmlReader& e)
                   displayName = e.readElementText();
             else if (tag == "defaultPitch")
                   defPitch = e.readDouble();
+            else if (tag == "defaultYOffset")
+                  defYOffset = e.readDouble();
             else if (tag == "duration") {
                   QString val = e.attribute("value");
                   QString txt(e.readElementText());
@@ -1034,23 +1040,25 @@ QList<QString> StaffTypeTablature::fontNames(bool bDuration)
 //---------------------------------------------------------
 
 bool StaffTypeTablature::fontData(bool bDuration, int nIdx, QString * pFamily, QString * pDisplayName,
-            qreal * pSize)
+            qreal * pSize, qreal* pYOff)
       {
-      if(bDuration) {
-            if(nIdx >= 0 && nIdx < _durationFonts.size()) {
+      if (bDuration) {
+            if (nIdx >= 0 && nIdx < _durationFonts.size()) {
                   TablatureDurationFont f = _durationFonts.at(nIdx);
-                  if(pFamily)       *pFamily          = f.family;
-                  if(pDisplayName)  *pDisplayName     = f.displayName;
-                  if(pSize)         *pSize            = f.defPitch;
+                  if (pFamily)      *pFamily          = f.family;
+                  if (pDisplayName) *pDisplayName     = f.displayName;
+                  if (pSize)        *pSize            = f.defPitch;
+                  if (pYOff)        *pYOff            = f.defYOffset;
                   return true;
                   }
             }
       else {
-            if(nIdx >= 0 && nIdx < _fretFonts.size()) {
+            if (nIdx >= 0 && nIdx < _fretFonts.size()) {
                   TablatureFretFont f = _fretFonts.at(nIdx);
-                  if(pFamily)       *pFamily          = f.family;
-                  if(pDisplayName)  *pDisplayName     = f.displayName;
-                  if(pSize)         *pSize            = f.defPitch;
+                  if (pFamily)      *pFamily          = f.family;
+                  if (pDisplayName) *pDisplayName     = f.displayName;
+                  if (pSize)        *pSize            = f.defPitch;
+                  if (pYOff)        *pYOff            = f.defYOffset;
                   return true;
                   }
             }

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -164,6 +164,7 @@ struct TablatureFretFont {
       QString           family;                 // the family of the physical font to use
       QString           displayName;            // the name to display to the user
       qreal             defPitch;               // the default size of the font
+      qreal             defYOffset;             // the default Y displacement
       QChar             xChar;                  // the char to use for 'x'
       QChar             ghostChar;              // the char to use for ghost notes
       QString           displayDigit[NUM_OF_DIGITFRETS];    // the string to draw for digit frets
@@ -197,6 +198,7 @@ struct TablatureDurationFont {
       QString           family;                 // the family of the physical font to use
       QString           displayName;            // the name to display to the user
       qreal             defPitch;               // the default size of the font
+      qreal             defYOffset;             // the default Y displacement
       QChar             displayDot;             // the char to use to draw a dot
       QChar             displayValue[NUM_OF_TAB_VALS];       // the char to use to draw a duration value
 
@@ -357,7 +359,7 @@ class StaffTypeTablature : public StaffType {
       static bool             readConfigFile(const QString& fileName);
       static QList<QString>   fontNames(bool bDuration);
       static bool             fontData(bool bDuration, int nIdx, QString *pFamily,
-                                    QString *pDisplayName, qreal * pSize);
+                                    QString *pDisplayName, qreal * pSize, qreal *pYOff);
 
    protected:
       void  setDurationMetrics();

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -57,13 +57,15 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
             }
 
       // init tab presets
-      //                                                                          clef   bars stemless time  durations                      size off genDur frets                            size off thru  minim style       onLin  rests  stmDn  stmThr upsDn  nums
-      _tabPresets[TAB_PRESET_GUITAR]  = new StaffTypeTablature(QString(), 6, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Modern"),  10, 0, false, TAB_MINIM_NONE,   true,  false, true,  true,  false, true);
-      _tabPresets[TAB_PRESET_BASS]    = new StaffTypeTablature(QString(), 4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Modern"),  10, 0, false, TAB_MINIM_NONE,   true,  false, true,  true,  false, true);
-      _tabPresets[TAB_PRESET_UKULELE] = new StaffTypeTablature(QString(), 4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Modern"),  10, 0, false, TAB_MINIM_SHORTER,true,  true,  true,  false, false, true);
-      _tabPresets[TAB_PRESET_BANDURRIA]=new StaffTypeTablature(QString(), 6, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Modern"),  10, 0, false, TAB_MINIM_SLASHED,true,  true,  true,  true,  false, true);
-      _tabPresets[TAB_PRESET_ITALIAN] = new StaffTypeTablature(QString(), 6, 1.5, false, true, true,  true,  QString("MuseScore Tab Italian"),15, 0, true,  QString("MuseScore Tab Renaiss"), 10, 0, true,  TAB_MINIM_NONE,   true,  true,  false, false, true,  true);
-      _tabPresets[TAB_PRESET_FRENCH]  = new StaffTypeTablature(QString(), 6, 1.5, false, true, true,  true,  QString("MuseScore Tab French"), 15, 0, true,  QString("MuseScore Tab Renaiss"), 10, 0, true,  TAB_MINIM_NONE,   false, false, false, false, false, false);
+      //                                                                               clef   bars stemless time  durations                      size off genDur frets                            size off thru  minim style       onLin  rests  stmDn  stmThr upsDn  nums
+      _tabPresets[TAB_PRESET_GUITAR_SIMPLE]= new StaffTypeTablature(QString(), 6, 1.5, true,  true, true,  false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Sans"),     9, 0, false, TAB_MINIM_NONE,   true,  false, true,  false, false, true);
+      _tabPresets[TAB_PRESET_GUITAR_FULL]  = new StaffTypeTablature(QString(), 6, 1.5, true,  true, false, true,  QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SLASHED,true,  true,  true,  true,  false, true);
+      _tabPresets[TAB_PRESET_BASS_SIMPLE]  = new StaffTypeTablature(QString(), 4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Sans"),     9, 0, false, TAB_MINIM_NONE,   true,  false, true,  false, false, true);
+      _tabPresets[TAB_PRESET_BASS_FULL]    = new StaffTypeTablature(QString(), 4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SLASHED,true,  true,  true,  true,  false, true);
+      _tabPresets[TAB_PRESET_UKULELE]      = new StaffTypeTablature(QString(), 4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SHORTER,true,  true,  true,  false, false, true);
+//    _tabPresets[TAB_PRESET_BANDURRIA]    = new StaffTypeTablature(QString(), 6, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Modern"),  10, 0, false, TAB_MINIM_SLASHED,true,  true,  true,  true,  false, true);
+      _tabPresets[TAB_PRESET_ITALIAN]      = new StaffTypeTablature(QString(), 6, 1.5, false, true, true,  true,  QString("MuseScore Tab Italian"),15, 0, true,  QString("MuseScore Tab Renaiss"), 10, 0, true,  TAB_MINIM_NONE,   true,  true,  false, false, true,  true);
+      _tabPresets[TAB_PRESET_FRENCH]       = new StaffTypeTablature(QString(), 6, 1.5, false, true, true,  true,  QString("MuseScore Tab French"), 15, 0, true,  QString("MuseScore Tab Renaiss"), 10, 0, true,  TAB_MINIM_NONE,   false, false, false, false, false, false);
 
       // tab page configuration
       tabDetails->hide();                       // start tabulature page in simple mode
@@ -117,10 +119,10 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
       connect(minimShortRadio,SIGNAL(toggled(bool)),              SLOT(on_tabMinimShortToggled(bool)));
       connect(minimSlashedRadio,SIGNAL(toggled(bool)),            SLOT(updateTabPreview()));
       connect(showRests,      SIGNAL(toggled(bool)),              SLOT(updateTabPreview()));
-      connect(durFontName,    SIGNAL(currentIndexChanged(int)),   SLOT(updateTabPreview()));
+      connect(durFontName,    SIGNAL(currentIndexChanged(int)),   SLOT(on_durFontNameChanged(int)));
       connect(durFontSize,    SIGNAL(valueChanged(double)),       SLOT(updateTabPreview()));
       connect(durY,           SIGNAL(valueChanged(double)),       SLOT(updateTabPreview()));
-      connect(fretFontName,   SIGNAL(currentIndexChanged(int)),   SLOT(updateTabPreview()));
+      connect(fretFontName,   SIGNAL(currentIndexChanged(int)),   SLOT(on_fretFontNameChanged(int)));
       connect(fretFontSize,   SIGNAL(valueChanged(double)),       SLOT(updateTabPreview()));
       connect(fretY,          SIGNAL(valueChanged(double)),       SLOT(updateTabPreview()));
       connect(linesThroughRadio, SIGNAL(toggled(bool)),           SLOT(updateTabPreview()));
@@ -135,10 +137,12 @@ EditStaffType::~EditStaffType()
       {
       foreach(StaffType* st, staffTypes)
             delete st;
-      delete _tabPresets[TAB_PRESET_GUITAR];
-      delete _tabPresets[TAB_PRESET_BASS];
+      delete _tabPresets[TAB_PRESET_GUITAR_SIMPLE];
+      delete _tabPresets[TAB_PRESET_GUITAR_FULL];
+      delete _tabPresets[TAB_PRESET_BASS_SIMPLE];
+      delete _tabPresets[TAB_PRESET_BASS_FULL];
       delete _tabPresets[TAB_PRESET_UKULELE];
-      delete _tabPresets[TAB_PRESET_BANDURRIA];
+//    delete _tabPresets[TAB_PRESET_BANDURRIA];
       delete _tabPresets[TAB_PRESET_ITALIAN];
       delete _tabPresets[TAB_PRESET_FRENCH];
       }
@@ -494,6 +498,32 @@ void EditStaffType::on_pushQuickConfig_clicked()
       {
       tabDetails->hide();
       tabPresets->show();
+      }
+
+//---------------------------------------------------------
+//   Tabulature duration / fret font name changed
+//
+//    set depending parameters
+//---------------------------------------------------------
+
+void EditStaffType::on_durFontNameChanged(int idx)
+      {
+      qreal size, yOff;
+      if (StaffTypeTablature::fontData(true, idx, 0, 0, &size, &yOff)) {
+            durFontSize->setValue(size);
+            durY->setValue(yOff);
+            }
+      updateTabPreview();
+      }
+
+void EditStaffType::on_fretFontNameChanged(int idx)
+      {
+      qreal size, yOff;
+      if (StaffTypeTablature::fontData(false, idx, 0, 0, &size, &yOff)) {
+            fretFontSize->setValue(size);
+            fretY->setValue(yOff);
+            }
+      updateTabPreview();
       }
 
 //---------------------------------------------------------

--- a/mscore/editstafftype.h
+++ b/mscore/editstafftype.h
@@ -48,10 +48,11 @@ class EditStaffType : public QDialog, private Ui::EditStaffType {
       ScoreView* tabPreview;
 #endif
       enum {
-            TAB_PRESET_GUITAR = 0,
-            TAB_PRESET_BASS,
+            TAB_PRESET_GUITAR_SIMPLE = 0,
+            TAB_PRESET_GUITAR_FULL,
+            TAB_PRESET_BASS_SIMPLE,
+            TAB_PRESET_BASS_FULL,
             TAB_PRESET_UKULELE,
-            TAB_PRESET_BANDURRIA,
             TAB_PRESET_ITALIAN,
             TAB_PRESET_FRENCH,
             TAB_PRESET_CUSTOM,                  // custom preset has no effect
@@ -72,6 +73,8 @@ class EditStaffType : public QDialog, private Ui::EditStaffType {
       void createNewType();
       void nameEdited(const QString&);
       void presetTablatureChanged(int idx);
+      void on_durFontNameChanged(int idx);
+      void on_fretFontNameChanged(int idx);
       void on_pushFullConfig_clicked();
       void on_pushQuickConfig_clicked();
       void on_tabStemThroughToggled(bool checked);

--- a/mscore/stafftype.ui
+++ b/mscore/stafftype.ui
@@ -306,22 +306,27 @@
                 </property>
                 <item>
                  <property name="text">
-                  <string comment="tablatture type">6 strings (generic guitar)</string>
+                  <string comment="tablatture type">6 strings (simple)</string>
                  </property>
                 </item>
                 <item>
                  <property name="text">
-                  <string comment="tablature type">4 strings (generic bass)</string>
+                  <string>6 string (full)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string comment="tablature type">4 strings (simple)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>4strings (full)</string>
                  </property>
                 </item>
                 <item>
                  <property name="text">
                   <string>ukulele</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>bandurria</string>
                  </property>
                 </item>
                 <item>


### PR DESCRIPTION
*) Add a serif font for fret marks (built-in FreeSerifMscore)
*) Use built-in FreeSans as fret mark sans font instead of special font
*) Split generic 6-str and 4-str presets into "simple" and "full" each
*) Remove "Bandurria" preset (now equal to 6-str full)
