### PR TITLE
TAB: augm. dot position when stems through staff

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1461,7 +1461,7 @@ void Chord::layout()
                   // centre fret string on stem
                   qreal x = stemX - fretWidth*0.5;
                   note->setPos(x, _spatium * tab->physStringToVisual(note->string()) * lineDist);
-                  note->layout2();              // needed? it is repeated later right before computing bbox
+//                  note->layout2();              // needed? it is repeated later right before computing bbox
 
                   }
             // horiz. spacing: leave half width at each side of the (potential) stem


### PR DESCRIPTION
TAB: fix cases of wrong positions of augm. dots with "Stems through staves" option
