### PR TITLE
better performance of clef handling

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1444,7 +1444,8 @@ void Score::addElement(Element* element)
             case Element::CLEF:
                   {
                   Clef* clef = static_cast<Clef*>(element);
-                  updateNoteLines(clef->segment(), clef->track());
+                  if (!clef->generated())
+                        updateNoteLines(clef->segment(), clef->track());
                   }
                   break;
             case Element::KEYSIG:
@@ -1602,7 +1603,8 @@ void Score::removeElement(Element* element)
             case Element::CLEF:
                   {
                   Clef* clef = static_cast<Clef*>(element);
-                  updateNoteLines(clef->segment(), clef->track());
+                  if (!clef->generated())
+                        updateNoteLines(clef->segment(), clef->track());
                   }
                   break;
             case Element::KEYSIG:


### PR DESCRIPTION
It is not necessary to call updateNoteLines() after adding or removing a generated clef, since (just as generated key signatures) these are only repeated and don't mean any (real) change.

On my machine this speeds up tst_concertpitchbenchmark by about 60%.
