### PR TITLE
End-Start-Repeat Bar line: span of separate Start not always correct

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2486,8 +2486,11 @@ bool Measure::setStartRepeatBarLine(bool val)
                   score()->undoRemoveElement(bl);
                   changed = true;
                   }
-            if (bl && val && span)
+            if (bl && val && span) {
                   bl->setSpan(span);
+                  bl->setSpanFrom(staff->barLineFrom());
+                  bl->setSpanTo(staff->barLineTo());
+                  }
 
             ++staffIdx;
             //


### PR DESCRIPTION
End-Start-Repeat Bar line: When at end of system, the From-To span of the separate Start bar line is not adjusted to staff From-To span
