### PR TITLE
Add a STATE_HARMONY_FIGBASS_EDIT state

### DIFF
--- a/mscore/actions.cpp
+++ b/mscore/actions.cpp
@@ -758,7 +758,7 @@ Shortcut Shortcut::sc[] = {
          ),
       Shortcut(
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT | STATE_LYRICS_EDIT
-            | STATE_PLAY | STATE_SEARCH | STATE_FOTO,
+            | STATE_HARMONY_FIGBASS_EDIT | STATE_PLAY | STATE_SEARCH | STATE_FOTO,
          0,
          "escape",
          QT_TRANSLATE_NOOP("action","Escape")
@@ -1671,7 +1671,7 @@ Shortcut Shortcut::sc[] = {
          QT_TRANSLATE_NOOP("action","Show Page Margins")
          ),
       Shortcut(
-         STATE_TEXT_EDIT | STATE_LYRICS_EDIT,
+         STATE_TEXT_EDIT | STATE_LYRICS_EDIT | STATE_HARMONY_FIGBASS_EDIT,
          0,
          "show-keys",
          QT_TRANSLATE_NOOP("action","Insert Special Characters..."),
@@ -2174,91 +2174,91 @@ Shortcut Shortcut::sc[] = {
          QT_TRANSLATE_NOOP("action","Add fret 9 of current string (TAB only)")
          ),
 
-      // TEXT-specific actions (Harmony and/or FiguredBass)
+      // HARMONY / FIGURED BASS specific actions
 
       Shortcut(
-         STATE_TEXT_EDIT,
+         STATE_HARMONY_FIGBASS_EDIT,
          0,
          "advance-longa",
          QT_TRANSLATE_NOOP("action","Longa advance (F.B./Harm.)"),
          QT_TRANSLATE_NOOP("action","Advance of a longa (F.B./Harm. only)")
          ),
       Shortcut(
-         STATE_TEXT_EDIT,
+         STATE_HARMONY_FIGBASS_EDIT,
          0,
          "advance-breve",
          QT_TRANSLATE_NOOP("action","Breve advance (F.B./Harm.)"),
          QT_TRANSLATE_NOOP("action","Advance of a double whole note (F.B./Harm. only)")
          ),
       Shortcut(
-         STATE_TEXT_EDIT,
+         STATE_HARMONY_FIGBASS_EDIT,
          0,
          "advance-1",
          QT_TRANSLATE_NOOP("action","Whole note advance (F.B./Harm.)"),
          QT_TRANSLATE_NOOP("action","Advance of a whole note (F.B./Harm. only)")
          ),
       Shortcut(
-         STATE_TEXT_EDIT,
+         STATE_HARMONY_FIGBASS_EDIT,
          0,
          "advance-2",
          QT_TRANSLATE_NOOP("action","Half note advance (F.B./Harm.)"),
          QT_TRANSLATE_NOOP("action","Advance of a half note (F.B./Harm. only)")
          ),
       Shortcut(
-         STATE_TEXT_EDIT,
+         STATE_HARMONY_FIGBASS_EDIT,
          0,
          "advance-4",
          QT_TRANSLATE_NOOP("action","Quarter note advance (F.B./Harm.)"),
          QT_TRANSLATE_NOOP("action","Advance of a quarter note (F.B./Harm. only)")
         ),
       Shortcut(
-         STATE_TEXT_EDIT,
+         STATE_HARMONY_FIGBASS_EDIT,
          0,
          "advance-8",
          QT_TRANSLATE_NOOP("action","1/8 note advance (F.B./Harm.)"),
          QT_TRANSLATE_NOOP("action","Advance of a 1/8 note (F.B./Harm. only)")
          ),
       Shortcut(
-         STATE_TEXT_EDIT,
+         STATE_HARMONY_FIGBASS_EDIT,
          0,
          "advance-16",
          QT_TRANSLATE_NOOP("action","1/16 note advance (F.B./Harm.)"),
          QT_TRANSLATE_NOOP("action","Advance of a 1/16 note (F.B./Harm. only)")
          ),
       Shortcut(
-         STATE_TEXT_EDIT,
+         STATE_HARMONY_FIGBASS_EDIT,
          0,
          "advance-32",
          QT_TRANSLATE_NOOP("action","1/32 note advance (F.B./Harm.)"),
          QT_TRANSLATE_NOOP("action","Advance of a 1/32 note (F.B./Harm. only)")
          ),
       Shortcut(
-         STATE_TEXT_EDIT,
+         STATE_HARMONY_FIGBASS_EDIT,
          0,
          "advance-64",
          QT_TRANSLATE_NOOP("action","1/64 note advance (F.B./Harm.)"),
          QT_TRANSLATE_NOOP("action","Advance of a 1/64 note (F.B./Harm. only)")
          ),
       Shortcut(
-      STATE_TEXT_EDIT,
+      STATE_HARMONY_FIGBASS_EDIT,
          0,
          "prev-measure-TEXT",
          QT_TRANSLATE_NOOP("action","Previous measure (F.B./Harm.)")
          ),
       Shortcut(
-      STATE_TEXT_EDIT,
+      STATE_HARMONY_FIGBASS_EDIT,
          0,
          "next-measure-TEXT",
          QT_TRANSLATE_NOOP("action","Next measure (F.B./Harm.)")
          ),
       Shortcut(
-      STATE_TEXT_EDIT,
+      STATE_HARMONY_FIGBASS_EDIT,
          0,
          "prev-beat-TEXT",
          QT_TRANSLATE_NOOP("action","Previous beat (Harmony)")
          ),
       Shortcut(
-      STATE_TEXT_EDIT,
+      STATE_HARMONY_FIGBASS_EDIT,
          0,
          "next-beat-TEXT",
          QT_TRANSLATE_NOOP("action","Next beat (Harmony)")

--- a/mscore/globals.h
+++ b/mscore/globals.h
@@ -47,13 +47,15 @@ enum ScoreState {
       STATE_EDIT               = 1 <<  5,
       STATE_TEXT_EDIT          = 1 <<  6,
       STATE_LYRICS_EDIT        = 1 <<  7,
-      STATE_PLAY               = 1 <<  8,
-      STATE_SEARCH             = 1 <<  9,
-      STATE_FOTO               = 1 << 10,
-      STATE_LOCK               = 1 << 11,
+      STATE_HARMONY_FIGBASS_EDIT = 1 << 8,
+      STATE_PLAY               = 1 <<  9,
+      STATE_SEARCH             = 1 << 10,
+      STATE_FOTO               = 1 << 11,
+      STATE_LOCK               = 1 << 12,
 
-      STATE_NOTE_ENTRY = STATE_NOTE_ENTRY_PITCHED | STATE_NOTE_ENTRY_DRUM | STATE_NOTE_ENTRY_TAB,
-      STATE_ALL        = -1
+      STATE_NOTE_ENTRY      = STATE_NOTE_ENTRY_PITCHED | STATE_NOTE_ENTRY_DRUM | STATE_NOTE_ENTRY_TAB,
+      STATE_ALLTEXTUAL_EDIT = STATE_TEXT_EDIT | STATE_LYRICS_EDIT | STATE_HARMONY_FIGBASS_EDIT,
+      STATE_ALL             = -1
       };
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2790,6 +2790,9 @@ void MuseScore::changeState(ScoreState val)
             case STATE_LYRICS_EDIT:
                   showModeText(tr("lyrics edit mode"));
                   break;
+            case STATE_HARMONY_FIGBASS_EDIT:
+                  showModeText(tr("chords/fig.bass edit mode"));
+                  break;
             case STATE_PLAY:
                   showModeText(tr("play"));
                   break;
@@ -2844,7 +2847,7 @@ void MuseScore::changeState(ScoreState val)
       _sstate = val;
 
       Element* e = 0;
-      if (_sstate == STATE_LYRICS_EDIT || _sstate == STATE_TEXT_EDIT
+      if (_sstate == STATE_LYRICS_EDIT || _sstate == STATE_TEXT_EDIT || _sstate == STATE_HARMONY_FIGBASS_EDIT
          || _sstate == STATE_EDIT) {
             if (cv)
                   e = cv->getEditObject();
@@ -3177,6 +3180,7 @@ void MuseScore::undo()
       {
       if (_sstate == STATE_EDIT
          || _sstate == STATE_LYRICS_EDIT
+         || _sstate == STATE_HARMONY_FIGBASS_EDIT
          || _sstate == STATE_TEXT_EDIT) {
             cv->postCmd("escape");
             qApp->processEvents();
@@ -3210,6 +3214,7 @@ void MuseScore::redo()
       {
       if (_sstate == STATE_EDIT
          || _sstate == STATE_TEXT_EDIT
+         || _sstate == STATE_HARMONY_FIGBASS_EDIT
          || _sstate == STATE_LYRICS_EDIT) {
             cv->postCmd("escape");
             qApp->processEvents();
@@ -3646,6 +3651,7 @@ const char* stateName(ScoreState s)
             case STATE_EDIT:               return "STATE_EDIT";
             case STATE_TEXT_EDIT:          return "STATE_TEXT_EDIT";
             case STATE_LYRICS_EDIT:        return "STATE_LYRICS_EDIT";
+            case STATE_HARMONY_FIGBASS_EDIT: return "STATE_HARMONY_FIGBASS_EDIT";
             case STATE_PLAY:               return "STATE_PLAY";
             case STATE_SEARCH:             return "STATE_SEARCH";
             case STATE_FOTO:               return "STATE_FOTO";

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -280,6 +280,7 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
 
       if (viewer->mscoreState() != STATE_EDIT
          && viewer->mscoreState() != STATE_LYRICS_EDIT
+         && viewer->mscoreState() != STATE_HARMONY_FIGBASS_EDIT
          && viewer->mscoreState() != STATE_TEXT_EDIT) { // Already in startCmd in this case
             score->startCmd();
             }
@@ -319,6 +320,7 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
             qDebug("unknown selection state\n");
       if (viewer->mscoreState() != STATE_EDIT
          && viewer->mscoreState() != STATE_LYRICS_EDIT
+         && viewer->mscoreState() != STATE_HARMONY_FIGBASS_EDIT
          && viewer->mscoreState() != STATE_TEXT_EDIT) { //Already in startCmd mode in this case
             score->endCmd();
             }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2766,7 +2766,7 @@ void ScoreView::cmd(const QAction* a)
             mscore->endCmd();
             }
 
-      // STATE_TEXT_EDIT actions
+      // STATE_HARMONY_FIGBASS_EDIT actions
 
       else if (cmd == "advance-longa") {
             if (editObject->type() == Element::HARMONY)
@@ -3740,6 +3740,9 @@ ScoreState ScoreView::mscoreState() const
       if (sm->configuration().contains(states[EDIT])) {
             if (editObject && (editObject->type() == Element::LYRICS))
                   return STATE_LYRICS_EDIT;
+            else if (editObject &&
+                  ( (editObject->type() == Element::HARMONY) || editObject->type() == Element::FIGURED_BASS) )
+                  return STATE_HARMONY_FIGBASS_EDIT;
             else if (editObject && editObject->isText())
                   return STATE_TEXT_EDIT;
             return STATE_EDIT;


### PR DESCRIPTION
HARMONY and FIGURED_BASS editing shares the generic STATE_TEXT_EDIT state. This causes shortcuts for HARMONY and FIG_BASS which are characters to be 'eaten' while editing other types of Text.

The branch adds a STATE_HARMONY_FIGBASS_EDIT, for actions specific to them, making any character used their shortcuts available while editing other types of textual elements.
