### PR TITLE
Improve spacing of "/" in renderBase

### DIFF
--- a/share/styles/stdchords.xml
+++ b/share/styles/stdchords.xml
@@ -59,7 +59,7 @@
 -->
 
   <renderRoot>:n m:0:-1 :a m:.5:1</renderRoot>
-  <renderBase>m:0:2 / :n :a</renderBase>
+  <renderBase>m:-0.2:1 / m:0.2:1 :n :a m:0:-2</renderBase>
 
   <chord id="1">
     <render></render>


### PR DESCRIPTION
Position the "/" halfway between root and bass, and move slightly left.
Also restore original y position after rendering bass note, for correct positioning of subsequent text, such as a capo chord.
