### PR TITLE
Fix alignment of unstyled text.

### DIFF
--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -265,6 +265,7 @@ void Text::layout1()
                   o.rx() -= size.width();
             else if (align() & ALIGN_HCENTER)
                   o.rx() -= (size.width() * .5);
+            setPos(textStyle().offset(spatium()));
             bbox().setRect(o.x(), o.y(), size.width(), size.height());
             _doc->setModified(false);
             }
@@ -864,7 +865,7 @@ QPainterPath Text::shape() const
             int n = tl->lineCount();
             for (int i = 0; i < n; ++i) {
                   QTextLine l = tl->lineAt(i);
-                  QRectF r(l.naturalTextRect().translated(tl->position()));
+                  QRectF r(l.naturalTextRect().translated(tl->position()+bbox().topLeft()));
                   r.adjust(-l.position().x(), 0.0, 0.0, 0.0);
                   pp.addRect(r);
                   }


### PR DESCRIPTION
Separate out the offset from the text alignment, and use the
text alignment to set the bounding box.

This fixes alignment for chord symbols without breaking other unstyled text.
