### PR TITLE
Fix #20931 - Remember state of Inspector widget

### DIFF
--- a/mscore/inspector.cpp
+++ b/mscore/inspector.cpp
@@ -53,12 +53,12 @@
 void MuseScore::showInspector(bool visible)
       {
       QAction* a = getAction("inspector");
+      if (!inspector) {
+            inspector = new Inspector();
+            connect(inspector, SIGNAL(inspectorVisible(bool)), a, SLOT(setChecked(bool)));
+            addDockWidget(Qt::RightDockWidgetArea, inspector);
+            }
       if (visible) {
-            if (!inspector) {
-                  inspector = new Inspector();
-                  connect(inspector, SIGNAL(inspectorVisible(bool)), a, SLOT(setChecked(bool)));
-                  addDockWidget(Qt::RightDockWidgetArea, inspector);
-                  }
             updateInspector();
             }
       if (inspector)

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2881,6 +2881,7 @@ void MuseScore::writeSettings()
       settings.setValue("pos", pos());
       settings.setValue("maximized", isMaximized());
       settings.setValue("showPanel", paletteBox && paletteBox->isVisible());
+      settings.setValue("showInspector", inspector && inspector->isVisible());
       settings.setValue("state", saveState());
       settings.setValue("splitScreen", _splitScreen);
       settings.setValue("debuggerSplitter", mainWindow->saveState());
@@ -2947,6 +2948,7 @@ void MuseScore::readSettings()
       if (settings.value("maximized", false).toBool())
             showMaximized();
       mscore->showPalette(settings.value("showPanel", "1").toBool());
+      mscore->showInspector(settings.value("showInspector", "0").toBool());
 
       restoreState(settings.value("state").toByteArray());
       _horizontalSplit = settings.value("split", true).toBool();


### PR DESCRIPTION
State of Inspector widget was not remembered across MuseScore sessions

Fixed by:
*) Unconditionally creating the Inspector widget at start up before settings is read (as for the F9 palette widget)
*) Restoring the Inspector state from settings at start up
*) Storing in the settings the state of the Inspector widget (dock state, position, size) at close down
