### PR TITLE
Fix #20907 - Crash when starting a plugin with no score open

### DIFF
--- a/mscore/qmlplugin.cpp
+++ b/mscore/qmlplugin.cpp
@@ -39,7 +39,7 @@ QmlPlugin::~QmlPlugin()
 Score* QmlPlugin::curScore() const
       {
       printf("QmlPlugin::curScore(): %p %p %s\n", msc, msc->currentScore(),
-        qPrintable(msc->currentScore()->name()));
+            qPrintable(msc->currentScore() ? msc->currentScore()->name() : "(None)"));
       return msc->currentScore();
       }
 


### PR DESCRIPTION
Fix #20907 - Regardless of check code in a plugin, starting a plugin with no score open crashes the program.

A diagnostic "prinf" statement was unconditionally trying to access the score name, even with no score. Corrected by adding a condition.
