### PR TITLE
Fix #20905: Can't nudge frames with keyboard

### DIFF
--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -274,6 +274,8 @@ void ScoreView::editKey(QKeyEvent* ev)
       ed.curGrip = curGrip;
       ed.delta   = delta;
       ed.view    = this;
+      ed.hRaster = mscore->hRaster();
+      ed.vRaster = mscore->vRaster();
       if (curGrip >= 0)
             ed.pos = grip[curGrip].center() + delta;
       editObject->editDrag(ed);


### PR DESCRIPTION
Fix #20905: Can't nudge frames with keyboard

ScoreView::editKey() passed to Box::editDrag() bogus hRaster and vRaster values in the EditData struct.
