### PR TITLE
Fix #20782 - Section break and measure renumbering

### DIFF
--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -128,6 +128,8 @@ void MeasureBase::add(Element* e)
                   case LAYOUT_BREAK_SECTION:
                         _sectionBreak = b;
 //does not work with repeats: score()->tempomap()->setPause(endTick(), b->pause());
+                        if(b->startWithMeasureOne())
+                              score()->renumberMeasures();
                         break;
                   }
             }
@@ -156,6 +158,8 @@ void MeasureBase::remove(Element* el)
                   case LAYOUT_BREAK_SECTION:
                         _sectionBreak = 0;
                         score()->tempomap()->setPause(endTick(), 0);
+                        if(lb->startWithMeasureOne())
+                              score()->renumberMeasures();
                         break;
                   }
             }


### PR DESCRIPTION
Fix #20782 - Adding or removing a section break (with a "Restart from meas. 1" default) does not immediately renumber measures.

Added calls to Score::renumberMeasures into relevant cases of MeasureBase::add() and MeasureBase::remove(). This also ensures that measures are renumbered when the property of the section break is changed.
