### PR TITLE
Fix #20703 - Key sig changes lack naturals (1st solution)

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -407,6 +407,7 @@ void Score::undoChangeKeySig(Staff* ostaff, int tick, KeySigEvent st)
                   qDebug("measure for tick %d not found!", tick);
                   continue;
                   }
+            KeySigEvent oldKey = staff->key(tick-1);
             Segment* s   = measure->undoGetSegment(Segment::SegKeySig, tick);
             int staffIdx = score->staffIdx(staff);
             int track    = staffIdx * VOICES;
@@ -415,6 +416,7 @@ void Score::undoChangeKeySig(Staff* ostaff, int tick, KeySigEvent st)
             KeySig* nks  = new KeySig(score);
             nks->setTrack(track);
             nks->changeKeySigEvent(st);
+            nks->setOldSig(oldKey.accidentalType());
             nks->setParent(s);
             if (links == 0)
                   links = new LinkedElements(score);


### PR DESCRIPTION
Fix #20703 - Key sig changes lack naturals

When a key sig changes, no natural is ever displayed, regardless of the "Hide naturals" property of the key sig.

Corrected in undo.cpp (Score::undoChangeKeySig() ) by looking at the previous key sig and setting the accidental delta, when adding a new key sig.

Note: this fix does not cover updating naturals in following key sigs, if a previous key changes. This should probably dealt with during re-layout, rather than when adding/deleting key sigs.
