### PR TITLE
Fix #20614 - Parts created from TAB staves have pitched staff.

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -117,6 +117,7 @@ Score* createExcerpt(const QList<Part*>& parts)
             int idx = 0;
             foreach(Staff* staff, *part->staves()) {
                   Staff* s = new Staff(score, p, idx);
+                  s->setStaffType(staff->staffType());
                   s->setUpdateKeymap(true);
                   s->linkTo(staff);
                   p->staves()->append(s);


### PR DESCRIPTION
Fix #20614 - Parts created from TAB staves have pitched staff.

Staff type was not set in createExcerpt() (file libmscore/excerpt.cpp).
