### PR TITLE
Fix #21000 - Deleting the last annotation of a segment causes crash

### DIFF
--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -985,8 +985,10 @@ bool Segment::findAnnotationOrElement(ElementType type, int minTrack, int maxTra
 void Segment::removeAnnotation(Element* e)
       {
       for (auto i = _annotations.begin(); i != _annotations.end(); ++i) {
-            if (*i == e)
+            if (*i == e) {
                   _annotations.erase(i);
+                  break;
+                  }
             }
       }
 


### PR DESCRIPTION
Fix #21000 - Deleting the last annotation of a segment causes crash

In Segment::removeAnnotation(), deleting the last annotation fools the "i != _annotations.end()" look test.
Fixed by adding a break after the deletion.
