### PR TITLE
Fix #20703 - Key sig changes lack naturals (3rd solution)

### DIFF
--- a/libmscore/key.cpp
+++ b/libmscore/key.cpp
@@ -167,6 +167,8 @@ void AccidentalState::init(const KeySigEvent& ks)
 
 //---------------------------------------------------------
 //   key
+//
+//    locates the key sig currently in effect at tick
 //---------------------------------------------------------
 
 KeySigEvent KeyList::key(int tick) const
@@ -178,6 +180,23 @@ KeySigEvent KeyList::key(int tick) const
             return KeySigEvent();
       --i;
       return i->second;
+      }
+
+//---------------------------------------------------------
+//   nextKeyTick
+//
+//    return the tick at which the key sig after tick is located
+//    return 0, if no such a key sig
+//---------------------------------------------------------
+
+int KeyList::nextKeyTick(int tick) const
+      {
+      if (empty())
+            return 0;
+      auto i = upper_bound(tick+1);
+      if (i == end())
+            return 0;
+      return i->first;
       }
 
 //---------------------------------------------------------

--- a/libmscore/key.h
+++ b/libmscore/key.h
@@ -103,6 +103,7 @@ class KeyList : public std::map<const int, KeySigEvent> {
    public:
       KeyList() {}
       KeySigEvent key(int tick) const;
+      int nextKeyTick(int tick) const;
       void read(XmlReader&, Score*);
       void write(Xml&, const char* name) const;
       };

--- a/libmscore/keysig.h
+++ b/libmscore/keysig.h
@@ -44,8 +44,8 @@ class KeySig : public Element {
       Q_PROPERTY(bool showCourtesy READ showCourtesy   WRITE undoSetShowCourtesy)
       Q_PROPERTY(bool showNaturals READ showNaturals   WRITE undoSetShowNaturals)
 
-	bool	_showCourtesy;
-	bool	_showNaturals;
+      bool	_showCourtesy;
+      bool	_showNaturals;
       QList<KeySym*> keySymbols;
       KeySigEvent _sig;
       void addLayout(int sym, qreal x, int y);
@@ -78,19 +78,21 @@ class KeySig : public Element {
       void changeKeySigEvent(const KeySigEvent&);
       void setKeySigEvent(const KeySigEvent& e)      { _sig = e; }
       int tick() const;
+      void insertIntoKeySigChain();
+      void removeFromKeySigChain();
 
-      bool showCourtesy() const           { return _showCourtesy; };
-      void setShowCourtesy(bool v)        { _showCourtesy = v;    };
+      bool showCourtesy() const           { return _showCourtesy; }
+      void setShowCourtesy(bool v)        { _showCourtesy = v;    }
       void undoSetShowCourtesy(bool v);
 
-      bool showNaturals() const           { return _showNaturals;    };
-	void setShowNaturals(bool v)        { _showNaturals = v;       };
-	void undoSetShowNaturals(bool v)    { _showNaturals = v;       };
+      bool showNaturals() const           { return _showNaturals;    }
+      void setShowNaturals(bool v)        { _showNaturals = v;       }
+      void undoSetShowNaturals(bool v)    { _showNaturals = v;       }
 
       QVariant getProperty(P_ID propertyId) const;
       bool setProperty(P_ID propertyId, const QVariant&);
       QVariant propertyDefault(P_ID id) const;
-	};
+      };
 
 extern const char* keyNames[15];
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1451,8 +1451,10 @@ void Score::addElement(Element* element)
                   KeySig* ks = static_cast<KeySig*>(element);
                   Staff*  staff = element->staff();
                   KeySigEvent keySigEvent = ks->keySigEvent();
-                  if (!ks->generated())
+                  if (!ks->generated()) {
                         staff->setKey(ks->segment()->tick(), keySigEvent);
+                        ks->insertIntoKeySigChain();
+                        }
                   }
                   break;
             case Element::TEMPO_TEXT:
@@ -1609,8 +1611,10 @@ void Score::removeElement(Element* element)
                   {
                   KeySig* ks    = static_cast<KeySig*>(element);
                   Staff*  staff = element->staff();
-                  if (!ks->generated())
+                  if (!ks->generated()) {
+                        ks->removeFromKeySigChain();
                         staff->removeKey(ks->segment()->tick());
+                        }
                   }
                   break;
             case Element::TEMPO_TEXT:

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -361,11 +361,25 @@ void Staff::removeTimeSig(TimeSig* timesig)
 
 //---------------------------------------------------------
 //   Staff::key
+//
+//    locates the key sig currently in effect at tick
 //---------------------------------------------------------
 
 KeySigEvent Staff::key(int tick) const
       {
       return _keymap->key(tick);
+      }
+
+//---------------------------------------------------------
+//   Staff::nextKeyTick
+//
+//    return the tick at which the key sig after tick is located
+//    return 0, if no such a key sig
+//---------------------------------------------------------
+
+int Staff::nextKeyTick(int tick) const
+      {
+      return _keymap->nextKeyTick(tick);
       }
 
 //---------------------------------------------------------

--- a/libmscore/staff.h
+++ b/libmscore/staff.h
@@ -157,6 +157,7 @@ class Staff : public QObject {
 
       KeyList* keymap() const        { return _keymap;      }
       KeySigEvent key(int tick) const;
+      int nextKeyTick(int tick) const;
       void setKey(int tick, int st);
       void setKey(int tick, const KeySigEvent& st);
       void removeKey(int tick);

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1757,6 +1757,7 @@ void ChangeElement::flip()
             KeySig* ks = static_cast<KeySig*>(newElement);
             if (!ks->generated()) {
                   ks->staff()->setKey(ks->tick(),ks->keySigEvent());
+                  ks->insertIntoKeySigChain();
                   ks->score()->cmdUpdateAccidentals(ks->measure(), ks->staffIdx());
                   // newElement->staff()->setUpdateKeymap(true);
                   }


### PR DESCRIPTION
Fix #20703 - Key sig changes lack naturals (3rd solution)

When a key sig changes, no natural is ever displayed, regardless of the "Hide naturals" property of the key sig.

Corrected by:
- adding methods to KeySig to locate the prev and next key sigs and update naturals accordingly when a key sig is added or removed
- in Score::addElement(), Score::removeElement() and undo's ChangeElement::flip(), by calling the relevant KeySig method

Notes:
1) Covers updating naturals in following key sigs, if a previous key changes.
2) Fully integrated in undo
3) The fix is already predisposed to cope with a score style setting for natural display style: none, before, after accidentals. Until this style is implemented, the relevant code is commented out.
