### PR TITLE
Fix #21040: "View | Synth" menu item check not synched with synth window visibility

### DIFF
--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -110,8 +110,9 @@ void SynthControl::setGain(float val)
 
 void SynthControl::closeEvent(QCloseEvent* ev)
       {
-      QAction* a = getAction("toggle-mixer");
-      a->setChecked(false);
+//      QAction* a = getAction("toggle-mixer");
+//      a->setChecked(false);
+      emit synthVisible(false);
       QWidget::closeEvent(ev);
       }
 
@@ -121,11 +122,13 @@ void SynthControl::closeEvent(QCloseEvent* ev)
 
 void MuseScore::showSynthControl(bool val)
       {
+      QAction* a = getAction("synth-control");
       if (synthControl == 0) {
             synthControl = new SynthControl(this);
             synthControl->setScore(cs);
             connect(synti, SIGNAL(gainChanged(float)), synthControl, SLOT(setGain(float)));
             connect(synthControl, SIGNAL(gainChanged(float)), synti, SLOT(setGain(float)));
+            connect(synthControl, SIGNAL(synthVisible(bool)), a,     SLOT(setChecked(bool)));
             if (mixer)
                   connect(synthControl, SIGNAL(soundFontChanged()), mixer, SLOT(patchListChanged()));
             }

--- a/mscore/synthcontrol.h
+++ b/mscore/synthcontrol.h
@@ -52,6 +52,7 @@ class SynthControl : public QWidget, Ui::SynthControl {
    signals:
       void gainChanged(float);
       void soundFontChanged();
+      void synthVisible(bool);
 
    public slots:
       void setGain(float);


### PR DESCRIPTION
Fix #21040: closing the Synth Control window with its own close button leaves the "View | Synth" menu item checked.

Fixed by connecting SynthControl::closeEvent() with the relevant action's setChecked()
