### PR TITLE
Remove guitar as default string set

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -133,7 +133,7 @@ InstrumentData::~InstrumentData()
 
 Tablature* InstrumentData::tablature() const
       {
-      return _tablature ? _tablature : &guitarTablature;
+      return _tablature ? _tablature : &emptyStringData;
       }
 
 //---------------------------------------------------------

--- a/libmscore/tablature.cpp
+++ b/libmscore/tablature.cpp
@@ -16,15 +16,21 @@
 #include "score.h"
 #include "undo.h"
 
-static int guitarStrings[6] = { 40, 45, 50, 55, 59, 64 };
+//static int guitarStrings[6] = { 40, 45, 50, 55, 59, 64 };
 
-Tablature guitarTablature(23, 6, guitarStrings);
+Tablature emptyStringData(0, 0, 0);
 
 //---------------------------------------------------------
 //   Tablature
 //---------------------------------------------------------
 
 bool Tablature::bFretting = false;
+
+Tablature::Tablature()
+      {
+      _frets = 0;
+      stringTable = QList<int>();
+      }
 
 Tablature::Tablature(int numFrets, int numStrings, int strings[])
       {

--- a/libmscore/tablature.h
+++ b/libmscore/tablature.h
@@ -28,7 +28,7 @@ class Tablature {
       static bool bFretting;
 
 public:
-      Tablature() {}
+      Tablature();
       Tablature(int numFrets, int numStrings, int strings[]);
       Tablature(int numFrets, QList<int>& strings);
       bool        convertPitch(int pitch, int* string, int* fret) const;
@@ -46,6 +46,6 @@ public:
       void        writeMusicXML(Xml& xml) const;
       };
 
-extern Tablature guitarTablature;
+extern Tablature emptyStringData;
 #endif
 

--- a/mscore/editstaff.h
+++ b/mscore/editstaff.h
@@ -41,6 +41,7 @@ class EditStaff : public QDialog, private Ui::EditStaffBase {
       int         _minPitchA, _maxPitchA, _minPitchP, _maxPitchP;
 
       void apply();
+      void fillStaffTypeCombo();
       void setInterval(const Interval&);
       void updateInstrument();
 

--- a/mscore/editstringdata.cpp
+++ b/mscore/editstringdata.cpp
@@ -35,17 +35,6 @@ EditStringData::EditStringData(QWidget *parent, QList<int> * strings, int * fret
       // if any string, insert into string list control and select the first one
       if(_strings->size()) {
             int   i, j;
-            // insert into local working copy sorting by decreasing MIDI code value
-/*            foreach(i, *_strings) {
-                  for(j=_stringsLoc.size()-1; j >= 0 && i > _stringsLoc[j]; j--)
-                        ;
-                  _stringsLoc.insert(j+1, i);
-                  }
-            // add to string list dlg control
-            foreach(i, _stringsLoc)
-                  stringList->addItem(midiCodeToStr(i));
-            stringList->setCurrentRow(0);
-*/
             // insert into local working copy and into string list dlg control
             // IN REVERSED ORDER
             for(i=_strings->size()-1; i >= 0; i--) {
@@ -73,21 +62,8 @@ EditStringData::EditStringData(QWidget *parent, QList<int> * strings, int * fret
 
 EditStringData::~EditStringData()
 {
-//    delete ui;
 }
-/*
-void EditStringData::changeEvent(QEvent *e)
-{
-      QDialog::changeEvent(e);
-      switch (e->type()) {
-            case QEvent::LanguageChange:
-                  retranslateUi(this);
-                  break;
-            default:
-                  break;
-      }
-}
-*/
+
 //---------------------------------------------------------
 //   deleteStringClicked
 //---------------------------------------------------------
@@ -136,15 +112,6 @@ void EditStringData::newStringClicked()
 
       EditPitch* ep = new EditPitch(this);
       if ( (newCode=ep->exec()) != -1) {
-            // find sorted postion for new string tuning value
-/*            for(i=_stringsLoc.size()-1; i >= 0 && newCode > _stringsLoc[i]; i--)
-                  ;
-            // insert in local string list and in dlg list control
-            _stringsLoc.insert(i+1, newCode);
-            stringList->insertItem(i+1, midiCodeToStr(newCode));
-            // select last added item and ensure buttons are active
-            stringList->setCurrentRow(i+1);
-*/
             // add below selected string o at the end if no selected string
             i = stringList->currentRow();
             if(i < 0)

--- a/mscore/editstringdata.h
+++ b/mscore/editstringdata.h
@@ -21,13 +21,8 @@
 #ifndef EDITSTRINGDATA_H
 #define EDITSTRINGDATA_H
 
-//#include <QDialog>
 #include "ui_editstringdata.h"
-/*
-namespace Ui {
-    class EditStringData;
-}
-*/
+
 class EditStringData : public QDialog, private Ui::EditStringDataBase {
       Q_OBJECT
 
@@ -41,11 +36,7 @@ class EditStringData : public QDialog, private Ui::EditStringDataBase {
       ~EditStringData();
 
    protected:
-//      void changeEvent(QEvent *e);
       QString midiCodeToStr(int midiCode);
-
-//private:
-//    Ui::EditStringData *ui;
 
 private slots:
       void accept();

--- a/mscore/editstringdata.ui
+++ b/mscore/editstringdata.ui
@@ -118,7 +118,10 @@
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
          <property name="minimum">
-          <number>1</number>
+          <number>0</number>
+         </property>
+         <property name="value">
+          <number>0</number>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Any instrument which does not have string data is given a default guitar-like string set.

Changed to a default empty string set.

This also allows to filter out TAB staff types in staff props dlg box for an instrument without strings defined.

Next step: similarly filter out tab presets in Instrument Wizard.
