### PR TITLE
Instrument Wizard: filter staff presets according to instr. data

### DIFF
--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -758,8 +758,8 @@ void Staff::init(const InstrumentTemplate* t, const StaffType* staffType, int ci
 
       // use selected staff type
       setStaffType(st);
-      if (st->group() != TAB_STAFF)             // if not TAB (where num of staff lines is determined by TAB style)
-            setLines(t->staffLines[cidx]);      // use number of lines from instr. template
+//      if (st->group() == PITCHED_STAFF)         // if PITCHED (in other staff groups num of lines is determined by style)
+//            setLines(t->staffLines[cidx]);      // use number of lines from instr. template
       }
 
 //---------------------------------------------------------

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -79,15 +79,18 @@ void EditStaff::fillStaffTypeCombo()
       Score* score   = staff->score();
       int curIdx     = 0;
       int n          = score->staffTypes().size();
-      // can this instrument accept tabs?
-      bool acceptTab = instrument.tablature() && instrument.tablature()->strings() != 0;
+      // can this instrument accept tabs or drum set?
+      bool canUseTabs = instrument.tablature() && instrument.tablature()->strings() > 0;
+      bool canUsePerc = instrument.useDrumset();
       staffType->clear();
       for (int idx = 0; idx < n; ++idx) {
             StaffType* st = score->staffType(idx);
-            if (acceptTab || st->group() != TAB_STAFF) {
+            if ( (canUseTabs && st->group() == TAB_STAFF)
+                        || ( canUsePerc && st->group() == PERCUSSION_STAFF)
+                        || (!canUsePerc && st->group() == PITCHED_STAFF) ) {
                   staffType->addItem(st->name(), idx);
                   if (st == staff->staffType())
-                        curIdx = idx;
+                        curIdx = staffType->count() - 1;
                   }
             }
       staffType->setCurrentIndex(curIdx);
@@ -213,7 +216,8 @@ void EditStaff::apply()
       bool s            = small->isChecked();
       bool inv          = invisible->isChecked();
       qreal userDist    = spinExtraDistance->value();
-      StaffType* st     = score->staffType(staffType->currentIndex());
+      int staffIdx      = staffType->itemData(staffType->currentIndex()).toInt();
+      StaffType* st     = score->staffType(staffIdx);
 
 
       // before changing instrument, check if notes need to be updated

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -40,6 +40,7 @@
 #include "libmscore/stafftype.h"
 #include "libmscore/style.h"
 #include "libmscore/system.h"
+#include "libmscore/tablature.h"
 #include "libmscore/undo.h"
 
 void filterInstruments(QTreeWidget *instrumentList, const QString &searchPhrase = QString(""));
@@ -87,10 +88,20 @@ void StaffListItem::initStaffTypeCombo(bool forceRecreate)
       // Call initStaffTypeCombo(true) ONLY if the item has been repositioned
       // or a memory leak may result
 
+      bool canUseTabs = true;                   // assume all staff type are applicable
+      bool canUsePerc = true;
+      PartListItem* part = static_cast<PartListItem*>(QTreeWidgetItem::parent());
+      if (part) {
+            canUseTabs = part->it->tablature && part->it->tablature->strings() > 0;
+            canUsePerc = part->it->useDrumset;
+      }
       _staffTypeCombo = new QComboBox();
       _staffTypeCombo->setAutoFillBackground(true);
       foreach (STAFF_LIST_STAFF_TYPE staffTypeData, staffTypeList)
-            _staffTypeCombo->addItem(staffTypeData.displayName, staffTypeData.idx);
+            if ( (canUseTabs && staffTypeData.staffType->group() == TAB_STAFF)
+                        || ( canUsePerc && staffTypeData.staffType->group() == PERCUSSION_STAFF)
+                        || (!canUsePerc && staffTypeData.staffType->group() == PITCHED_STAFF) )
+                  _staffTypeCombo->addItem(staffTypeData.displayName, staffTypeData.idx);
       treeWidget()->setItemWidget(this, 4, _staffTypeCombo);
       connect(_staffTypeCombo, SIGNAL(currentIndexChanged(int)), SLOT(staffTypeChanged(int)) );
       }


### PR DESCRIPTION
Instrument Wizard (incl. New score Wizard):

Staff type presets listed in the preset combo boxes are filtered out according to instrument data:
- if has string data, allow normal and tab presets
- if has drum set, allow percussion presets only
- if has neither, allow normal preset(s) only

Also:

Staff Props dlg box: completes filtering out of perc. staff types (and fixes two bugs!)
