### PR TITLE
Fix a bug in Measure::createEndBarLines().

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2529,8 +2529,8 @@ bool Measure::setStartRepeatBarLine(bool val)
 
 //---------------------------------------------------------
 //   createEndBarLines
-//    actually create or modify barlines
-//    return true if layout changes
+//    actually creates or modifies barlines
+//    returns true if layout changes
 //---------------------------------------------------------
 
 bool Measure::createEndBarLines()
@@ -2542,6 +2542,7 @@ bool Measure::createEndBarLines()
       BarLine* bl = 0;
       int span    = 0;        // span counter
       int aspan   = 0;        // actual span
+      bool mensur = false;    // keep note of mensurstrich case
       int spanTot;            // to keep track of the target span
       int spanFrom;
       int spanTo;
@@ -2565,9 +2566,11 @@ bool Measure::createEndBarLines()
                         }
                   else {                              // otherwise, get from staff
                         span        = staff->barLineSpan();
-                        if (span) {
+                        // if some span OR last staff (span=0) of a mensurstrich case, get From/To from staff
+                        if (span || mensur) {
                               spanFrom    = staff->barLineFrom();
                               spanTo      = staff->barLineTo();
+                              mensur      = false;
                               }
                         // but if staff is set to no span, a multi-staff spanning bar line
                         // has been shortened to span less staves and following staves left without bars;
@@ -2575,7 +2578,7 @@ bool Measure::createEndBarLines()
                         else {
                               span        = 1;
                               spanFrom    = 0;
-                              spanTot     = (staff->lines()-1)*2;
+                              spanTo      = (staff->lines()-1)*2;
                               }
                         }
                   if ((staffIdx + span) > nstaves)
@@ -2669,8 +2672,10 @@ bool Measure::createEndBarLines()
                   }
             // if just finished (span==0) a multi-staff span (spanTot>1) ending at the top of a staff (spanTo<=0)
             // scan this staff again, as it may have its own bar lines (mensurstich(-like) span)
-            if (spanTot > 1 && spanTo <= 0 && span == 0)
+            if (spanTot > 1 && spanTo <= 0 && span == 0) {
+                  mensur = true;
                   staffIdx--;
+                  }
             }
       return changed;
       }


### PR DESCRIPTION
Fix a bug in Measure::createEndBarLines().

A typo in function Measure::createEndBarLines() was creating a problem (additional bar lines not created when a mensurstrich span style was reduced at a normal span style).
At the same time, the typo was hiding another, perhaps more serious, bug: in some cases, extra bar lines were created for staves spanned by multi-staff bar lines.

Corrected.
