### PR TITLE
On a new installation, "Preferences" crashes

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1866,7 +1866,7 @@ void MuseScore::removeTab(int i)
 
       if (checkDirty(score))
             return;
-      if (seq->score() == score) {
+      if (seq && seq->score() == score) {
             seq->stopWait();
             seq->setScoreView(0);
             }

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -814,7 +814,7 @@ void PreferenceDialog::updateValues()
             }
       checkUpdateStartup->setCurrentIndex(curPeriodIdx);
 
-      if (seq->isRunning()) {
+      if (seq && seq->isRunning()) {
             QList<QString> sl = seq->inputPorts();
             int idx = 0;
             for (QList<QString>::iterator i = sl.begin(); i != sl.end(); ++i, ++idx) {
@@ -1280,7 +1280,8 @@ void PreferenceDialog::apply()
          || (prefs.alsaPeriodSize != alsaPeriodSize->currentText().toInt())
          || (prefs.alsaFragments != alsaFragments->value())
             ) {
-            seq->exit();
+            if (seq)
+                  seq->exit();
             prefs.useAlsaAudio       = alsaDriver->isChecked();
             prefs.useJackAudio       = jackDriver->isChecked();
             prefs.usePortaudioAudio  = portaudioDriver->isChecked();
@@ -1292,9 +1293,11 @@ void PreferenceDialog::apply()
             prefs.alsaFragments      = alsaFragments->value();
             preferences = prefs;
             Driver* driver = driverFactory(seq, "");
-            seq->setDriver(driver);
-            if (!seq->init()) {
-                  qDebug("sequencer init failed\n");
+            if (seq) {
+                  seq->setDriver(driver);
+                  if (!seq->init()) {
+                        qDebug("sequencer init failed\n");
+                        }
                   }
             }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3036,7 +3036,8 @@ bool ScoreView::mousePress(QMouseEvent* ev)
 
 void ScoreView::mouseReleaseEvent(QMouseEvent* event)
       {
-      seq->stopNoteTimer();
+      if (seq)
+            seq->stopNoteTimer();
       QWidget::mouseReleaseEvent(event);
       }
 


### PR DESCRIPTION
On a new (Linux?) installation, if no sound output is enabled, opening "Preferences" crashes.

In mscore/preferences.cpp, mscore/musescore.cpp, mscore/scoreview.cpp seq is accessed but set to 0.

Added some safeguard checks.

(Same for master as another recent patch for qt5)
