### PR TITLE
Proposal with larger icons for note values.

### DIFF
--- a/mscore/data/icons-dark/note-1.svg
+++ b/mscore/data/icons-dark/note-1.svg
@@ -1,23 +1,96 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='note-1.svg' height='24' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' inkscape:version='0.48.4 r9939' version='1.1' width='24' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="note-1.svg"
+   height="24"
+   id="svg7384"
+   inkscape:version="0.48.3.1 r9886"
+   version="1.1"
+   width="24">
+  <metadata
+     id="metadata90">
     <rdf:RDF>
-      <cc:Work rdf:about=''>
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>MuseScore Icon Theme</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='actions' inkscape:cx='106.00118' inkscape:cy='-41.12962' fit-margin-bottom='6' fit-margin-left='6' fit-margin-right='6' fit-margin-top='6' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#24201f' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='false' inkscape:snap-grids='true' inkscape:snap-nodes='false' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1021' inkscape:window-maximized='1' inkscape:window-width='1920' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
-    <inkscape:grid empspacing='2' enabled='true' id='grid4866' originx='-328.9994px' originy='-77.999999px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  <sodipodi:namedview
+     inkscape:bbox-nodes="false"
+     inkscape:bbox-paths="true"
+     bordercolor="#666666"
+     borderopacity="1"
+     inkscape:current-layer="actions"
+     inkscape:cx="11.525269"
+     inkscape:cy="7.6959386"
+     fit-margin-bottom="6"
+     fit-margin-left="6"
+     fit-margin-right="6"
+     fit-margin-top="6"
+     gridtolerance="10"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     id="namedview88"
+     inkscape:object-nodes="false"
+     inkscape:object-paths="false"
+     objecttolerance="10"
+     pagecolor="#24201f"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     showborder="true"
+     showgrid="true"
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-others="false"
+     inkscape:snap-to-guides="true"
+     inkscape:window-height="974"
+     inkscape:window-maximized="1"
+     inkscape:window-width="1280"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:zoom="45.254834"
+     borderlayer="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4350"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       spacingx="0.5px"
+       spacingy="0.5px" />
   </sodipodi:namedview>
-  <title id='title9167'>MuseScore Icon Theme</title>
-  <defs id='defs7386'/>
-  <g inkscape:groupmode='layer' id='actions' inkscape:label='actions' style='display:inline' transform='translate(-363.9994,-267)'>
-    
-    <path inkscape:connector-curvature='0' d='m 375.26344,284.33877 c -0.51329,0 -0.9058,0.18116 -1.17754,0.54347 -0.25664,0.36233 -0.38496,0.84542 -0.38496,1.44928 0,0.69445 0.18116,1.29076 0.54348,1.78895 0.37741,0.48309 0.78502,0.82277 1.22282,1.01902 0.4378,0.18116 0.8605,0.27174 1.26812,0.27174 0.51328,0 0.89824,-0.18116 1.15489,-0.54348 0.27173,-0.36232 0.4076,-0.84541 0.40761,-1.44927 -1e-5,-0.69444 -0.18872,-1.28321 -0.56612,-1.76631 -0.36233,-0.49818 -0.76239,-0.83786 -1.20018,-1.01902 -0.43781,-0.19625 -0.86052,-0.29438 -1.26812,-0.29438 m 0.74728,-0.58877 c 1.58514,0 2.91364,0.30948 3.98551,0.92844 1.07185,0.61897 1.60778,1.35115 1.60779,2.19656 -10e-6,0.8907 -0.55859,1.63798 -1.67573,2.24185 -1.10206,0.58876 -2.40791,0.88315 -3.91757,0.88315 -1.57005,0 -2.89855,-0.30948 -3.98551,-0.92844 -1.08695,-0.61896 -1.63043,-1.35115 -1.63043,-2.19656 0,-0.8907 0.55857,-1.63043 1.67572,-2.2192 1.11715,-0.60386 2.43056,-0.9058 3.94022,-0.9058' id='path2814-7-1' style='font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;font-family:MScore1;-inkscape-font-specification:MScore1'/>
+  <title
+     id="title9167">MuseScore Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     id="actions"
+     inkscape:label="actions"
+     style="display:inline"
+     transform="translate(-363.9994,-267)">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 371.9994,283 c 0,2 2.5,4.5 5.5,4.5 1.5,0 2.5,-1 2.5,-2.5 0,-2 -2.5,-4.5 -5.5,-4.5 -1.5,0 -2.5,1 -2.5,2.5 z m 4.01414,-4 c 1.9798,0 3.63904,0.49516 4.97777,1.4855 1.33871,0.99035 2.00808,2.16185 2.00809,3.5145 -10e-6,1.42512 -0.69767,2.62076 -2.09293,3.58696 -1.37644,0.94201 -3.00741,1.41304 -4.89293,1.41304 -1.96095,0 -3.62021,-0.49516 -4.97779,-1.4855 -1.35757,-0.99034 -2.03635,-2.16185 -2.03635,-3.5145 0,-1.42512 0.69763,-2.60869 2.09292,-3.55072 C 372.48761,279.4831 374.12802,279 376.01354,279"
+       id="path2814-7-1"
+       style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;font-family:MScore1;-inkscape-font-specification:MScore1"
+       sodipodi:nodetypes="ssssscsccssscc" />
   </g>
 </svg>

--- a/mscore/data/icons-dark/note-2.svg
+++ b/mscore/data/icons-dark/note-2.svg
@@ -1,25 +1,102 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='note-2.svg' height='24' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' inkscape:version='0.48.4 r9939' version='1.1' width='24' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="note-2.svg"
+   height="24"
+   id="svg7384"
+   inkscape:version="0.48.3.1 r9886"
+   version="1.1"
+   width="24">
+  <metadata
+     id="metadata90">
     <rdf:RDF>
-      <cc:Work rdf:about=''>
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>MuseScore Icon Theme</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='actions' inkscape:cx='142.00118' inkscape:cy='-41.12962' fit-margin-bottom='6' fit-margin-left='6' fit-margin-right='6' fit-margin-top='6' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#24201f' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='false' inkscape:snap-grids='true' inkscape:snap-nodes='false' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1021' inkscape:window-maximized='1' inkscape:window-width='1920' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
-    <inkscape:grid empspacing='2' enabled='true' id='grid4866' originx='-292.9994px' originy='-77.999999px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  <sodipodi:namedview
+     inkscape:bbox-nodes="false"
+     inkscape:bbox-paths="true"
+     bordercolor="#666666"
+     borderopacity="1"
+     inkscape:current-layer="actions"
+     inkscape:cx="8.5197164"
+     inkscape:cy="12.24708"
+     fit-margin-bottom="6"
+     fit-margin-left="6"
+     fit-margin-right="6"
+     fit-margin-top="6"
+     gridtolerance="10"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     id="namedview88"
+     inkscape:object-nodes="false"
+     inkscape:object-paths="false"
+     objecttolerance="10"
+     pagecolor="#24201f"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     showborder="true"
+     showgrid="true"
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-nodes="false"
+     inkscape:snap-others="false"
+     inkscape:snap-to-guides="true"
+     inkscape:window-height="974"
+     inkscape:window-maximized="1"
+     inkscape:window-width="1280"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:zoom="20.48"
+     borderlayer="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3800"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       dotted="false" />
   </sodipodi:namedview>
-  <title id='title9167'>MuseScore Icon Theme</title>
-  <defs id='defs7386'/>
-  <g inkscape:groupmode='layer' id='actions' inkscape:label='actions' style='display:inline' transform='translate(-327.9994,-267)'>
-    
-    <path inkscape:connector-curvature='0' d='m 342.25881,285.33406 c -0.0152,-0.24216 -0.11355,-0.43892 -0.29514,-0.59029 -0.18165,-0.16649 -0.40112,-0.24974 -0.65843,-0.24975 -0.42381,1e-5 -1.31682,0.44652 -2.67904,1.33953 -1.36223,0.87789 -2.20985,1.51359 -2.54283,1.90711 -0.16649,0.19677 -0.24974,0.40868 -0.24974,0.63572 0,0.25731 0.0908,0.47678 0.27245,0.65841 0.19677,0.18163 0.42379,0.27244 0.68111,0.27244 0.42381,0 1.31682,-0.43894 2.67906,-1.31682 1.37736,-0.89301 2.23253,-1.53628 2.56552,-1.92982 0.15135,-0.16649 0.22704,-0.37839 0.22704,-0.63572 l 0,-0.0907 m -5.24459,4.67698 c -1.27141,0 -1.90711,-0.54489 -1.90711,-1.63467 0,-0.52975 0.15136,-1.14276 0.45408,-1.83901 0.30271,-0.71138 0.71895,-1.24871 1.2487,-1.61196 1.12005,-0.7568 2.55039,-1.13519 4.29102,-1.1352 0.48435,10e-6 0.87032,0.0757 1.1579,0.22704 0.11655,0.0792 0.74059,0.28269 0.74059,0.28269 0,0 -0.001,0.63288 -0.0135,1.10224 -1e-5,0.52976 -0.15136,1.15034 -0.45408,1.86171 -0.30273,0.71139 -0.71896,1.24871 -1.2487,1.61198 -1.12007,0.75679 -2.54285,1.13518 -4.26833,1.13518' id='path8816-4' sodipodi:nodetypes='ccccsscscccccsccccccccc' style='font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;font-family:MScore1;-inkscape-font-specification:MScore1'/>
-    <rect height='16.302036' id='use4354-4-5-2' style='color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new' width='2' x='340.99942' y='268.0105'/>
-    <path inkscape:connector-curvature='0' d='m 341.28145,284.26005 c -0.52437,0.0309 -0.96741,0.3519 -1.43379,0.5603 -1.07515,0.53277 -2.06901,1.21452 -3.02983,1.92916 -0.45581,0.37443 -0.98208,0.74049 -1.19834,1.31325 -0.24237,0.67597 0.33672,1.45875 1.04466,1.47408 0.73422,0.0371 1.37693,-0.39063 1.98587,-0.74275 1.05843,-0.66676 2.12592,-1.32905 3.10104,-2.11549 0.33925,-0.2851 0.7122,-0.61702 0.73986,-1.09189 0.0556,-0.37274 -0.0799,-0.78783 -0.38109,-1.0147 -0.23772,-0.17204 -0.52149,-0.31733 -0.82838,-0.31196 z m 0,0.50001 c 0.29553,-0.0233 0.57651,0.11955 0.68967,0.39269 0.0734,0.29098 0.0255,0.63718 -0.22244,0.83473 -0.74123,0.68105 -1.60057,1.21652 -2.43597,1.77252 -0.79125,0.48864 -1.54742,1.10217 -2.474,1.30779 -0.42561,0.05 -0.83658,-0.37686 -0.73456,-0.80344 0.0983,-0.396 0.47194,-0.62709 0.75835,-0.88503 0.98561,-0.78 2.0439,-1.46606 3.12842,-2.09961 0.40687,-0.21659 0.82285,-0.47213 1.29054,-0.51965 z' id='path7287' style='font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:125%;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.33333334;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:MScore1;-inkscape-font-specification:MScore1'/>
+  <title
+     id="title9167">MuseScore Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     id="actions"
+     inkscape:label="actions"
+     style="display:inline"
+     transform="translate(-327.9994,-267)">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 344.87336,282.48157 c -0.0231,-0.38926 -0.17265,-0.70556 -0.44876,-0.94888 -0.27619,-0.26763 -0.60989,-0.40146 -1.00112,-0.40147 -0.64439,1e-5 -2.00219,0.71778 -4.0734,2.15329 -2.07124,1.4112 -3.36001,2.43309 -3.86631,3.06568 -0.25314,0.31631 -0.37972,0.65696 -0.37972,1.02192 0,0.41362 0.13806,0.76643 0.41426,1.05839 0.29918,0.29196 0.64436,0.43795 1.0356,0.43795 0.6444,0 2.0022,-0.70559 4.07344,-2.11679 2.09424,-1.43552 3.39449,-2.46956 3.9008,-3.10219 0.23012,-0.26763 0.34521,-0.60826 0.34521,-1.02192 l 0,-0.14574 M 336.89911,290 c -1.93315,0 -2.89971,-0.87591 -2.89971,-2.62773 0,-0.85157 0.23013,-1.83699 0.69041,-2.9562 0.46027,-1.14356 1.09315,-2.00732 1.89862,-2.59123 1.703,-1.21656 3.8778,-1.82482 6.52437,-1.82484 0.73644,2e-5 1.32329,0.12175 1.76056,0.36496 0.1772,0.12738 1.12604,0.45444 1.12604,0.45444 0,0 -10e-4,1.01734 -0.0205,1.77184 -3e-5,0.85159 -0.23015,1.84917 -0.69043,2.99269 -0.46029,1.14357 -1.09315,2.00732 -1.89861,2.59126 C 341.6868,289.39174 339.52351,290 336.89996,290"
+       id="path8816-4"
+       sodipodi:nodetypes="ccccsscscccccsccccccccc"
+       style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;font-family:MScore1;-inkscape-font-specification:MScore1" />
+    <rect
+       height="14"
+       id="use4354-4-5-2"
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new"
+       width="2.0000002"
+       x="343.99939"
+       y="267" />
   </g>
 </svg>

--- a/mscore/data/icons-dark/note-4.svg
+++ b/mscore/data/icons-dark/note-4.svg
@@ -1,24 +1,101 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='note-4.svg' height='24' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' inkscape:version='0.48.4 r9939' version='1.1' width='24' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="note-4.svg"
+   height="24"
+   id="svg7384"
+   inkscape:version="0.48.3.1 r9886"
+   version="1.1"
+   width="24">
+  <metadata
+     id="metadata90">
     <rdf:RDF>
-      <cc:Work rdf:about=''>
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>MuseScore Icon Theme</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='actions' inkscape:cx='178.00078' inkscape:cy='-41.12962' fit-margin-bottom='6' fit-margin-left='6' fit-margin-right='6' fit-margin-top='6' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#24201f' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='false' inkscape:snap-grids='true' inkscape:snap-nodes='false' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1021' inkscape:window-maximized='1' inkscape:window-width='1920' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
-    <inkscape:grid empspacing='2' enabled='true' id='grid4866' originx='-256.9998px' originy='-77.999999px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  <sodipodi:namedview
+     inkscape:bbox-nodes="false"
+     inkscape:bbox-paths="true"
+     bordercolor="#666666"
+     borderopacity="1"
+     inkscape:current-layer="actions"
+     inkscape:cx="8.9678003"
+     inkscape:cy="14.168639"
+     fit-margin-bottom="6"
+     fit-margin-left="6"
+     fit-margin-right="6"
+     fit-margin-top="6"
+     gridtolerance="10"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     id="namedview88"
+     inkscape:object-nodes="false"
+     inkscape:object-paths="false"
+     objecttolerance="10"
+     pagecolor="#24201f"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     showborder="true"
+     showgrid="true"
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-nodes="false"
+     inkscape:snap-others="false"
+     inkscape:snap-to-guides="true"
+     inkscape:window-height="974"
+     inkscape:window-maximized="1"
+     inkscape:window-width="1280"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:zoom="20.48"
+     borderlayer="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2986"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
   </sodipodi:namedview>
-  <title id='title9167'>MuseScore Icon Theme</title>
-  <defs id='defs7386'/>
-  <g inkscape:groupmode='layer' id='actions' inkscape:label='actions' style='display:inline' transform='translate(-291.9998,-267)'>
-    
-    <path inkscape:connector-curvature='0' d='m 304.54607,283.85913 c -1.21704,0 -2.35613,0.44556 -3.41731,1.33666 -1.06118,0.8911 -1.59177,1.84904 -1.59176,2.87381 0,0.62377 0.23004,1.12501 0.69013,1.50373 0.4601,0.37872 1.06118,0.56809 1.80327,0.56809 1.21702,0 2.35609,-0.44556 3.41728,-1.33666 1.06119,-0.8911 1.59178,-1.84904 1.59178,-2.87381 0,-0.62377 -0.23004,-1.12502 -0.69014,-1.50373 -0.46009,-0.37873 -1.06119,-0.56809 -1.80325,-0.56809' id='path3488' style='font-size:83.33329773px;font-style:normal;font-weight:400;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;font-family:MScore' vector-effect='non-scaling-stroke'/>
-    <rect height='17.775534' id='use4354-4-3-2' style='color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new' width='2' x='305' y='268.0105'/>
+  <title
+     id="title9167">MuseScore Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     id="actions"
+     inkscape:label="actions"
+     style="display:inline"
+     transform="translate(-291.9998,-267)">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 306.01161,280 c -1.94665,0 -3.76863,0.70924 -5.46598,2.12766 -1.69736,1.41843 -2.54604,2.94326 -2.54603,4.57447 0,0.9929 0.36795,1.79076 1.10387,2.3936 0.73593,0.60283 1.69736,0.90427 2.88434,0.90427 1.94661,0 3.76856,-0.70924 5.46593,-2.12766 1.69738,-1.41843 2.54606,-2.94326 2.54606,-4.57447 0,-0.9929 -0.36795,-1.79077 -1.10388,-2.3936 C 308.16,280.30142 307.19854,280 306.01161,280"
+       id="path3488"
+       style="font-size:83.33329773px;font-style:normal;font-weight:400;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;font-family:MScore"
+       vector-effect="non-scaling-stroke" />
+    <rect
+       height="16"
+       id="use4354-4-3-2"
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new"
+       width="2"
+       x="307.99979"
+       y="267" />
   </g>
 </svg>

--- a/mscore/data/icons-dark/note-breve.svg
+++ b/mscore/data/icons-dark/note-breve.svg
@@ -1,25 +1,110 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='note-breve.svg' height='24' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' inkscape:version='0.48.4 r9939' version='1.1' width='24' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="note-breve.svg"
+   height="24"
+   id="svg7384"
+   inkscape:version="0.48.3.1 r9886"
+   version="1.1"
+   width="24">
+  <metadata
+     id="metadata90">
     <rdf:RDF>
-      <cc:Work rdf:about=''>
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>MuseScore Icon Theme</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='actions' inkscape:cx='70.001163' inkscape:cy='-41.12962' fit-margin-bottom='6' fit-margin-left='6' fit-margin-right='6' fit-margin-top='6' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#24201f' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='false' inkscape:snap-grids='true' inkscape:snap-nodes='false' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1021' inkscape:window-maximized='1' inkscape:window-width='1920' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
-    <inkscape:grid empspacing='2' enabled='true' id='grid4866' originx='-364.99942px' originy='-77.999999px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  <sodipodi:namedview
+     inkscape:bbox-nodes="false"
+     inkscape:bbox-paths="true"
+     bordercolor="#666666"
+     borderopacity="1"
+     inkscape:current-layer="actions"
+     inkscape:cx="12.814703"
+     inkscape:cy="9.8114053"
+     fit-margin-bottom="6"
+     fit-margin-left="6"
+     fit-margin-right="6"
+     fit-margin-top="6"
+     gridtolerance="10"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     id="namedview88"
+     inkscape:object-nodes="false"
+     inkscape:object-paths="false"
+     objecttolerance="10"
+     pagecolor="#24201f"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     showborder="true"
+     showgrid="true"
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-nodes="false"
+     inkscape:snap-others="false"
+     inkscape:snap-to-guides="true"
+     inkscape:window-height="974"
+     inkscape:window-maximized="1"
+     inkscape:window-width="1280"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:zoom="32"
+     borderlayer="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4396"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       spacingx="0.5px"
+       spacingy="0.5px" />
   </sodipodi:namedview>
-  <title id='title9167'>MuseScore Icon Theme</title>
-  <defs id='defs7386'/>
-  <g inkscape:groupmode='layer' id='actions' inkscape:label='actions' style='display:inline' transform='translate(-399.99942,-267)'>
-    
-    <rect height='6.25' id='rect4341-0-1' style='color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new' width='2' x='416.99939' y='283.75'/>
-    <path inkscape:connector-curvature='0' d='m 411.26346,284.33885 c -0.51329,0 -0.9058,0.18116 -1.17754,0.54347 -0.25664,0.36233 -0.38496,0.84542 -0.38496,1.44928 0,0.69445 0.18116,1.29076 0.54348,1.78895 0.37741,0.48309 0.78502,0.82277 1.22282,1.01902 0.4378,0.18116 0.8605,0.27174 1.26812,0.27174 0.51328,0 0.89824,-0.18116 1.15489,-0.54348 0.27173,-0.36232 0.4076,-0.84541 0.40761,-1.44927 -1e-5,-0.69444 -0.18872,-1.28321 -0.56612,-1.76631 -0.36233,-0.49818 -0.76239,-0.83786 -1.20018,-1.01902 -0.43781,-0.19625 -0.86052,-0.29438 -1.26812,-0.29438 m 0.74728,-0.58877 c 1.58514,0 2.91364,0.30948 3.98551,0.92844 1.07185,0.61897 1.60778,1.35115 1.60779,2.19656 -10e-6,0.8907 -0.55859,1.63798 -1.67573,2.24185 -1.10206,0.58876 -2.40791,0.88315 -3.91757,0.88315 -1.57005,0 -2.89855,-0.30948 -3.98551,-0.92844 -1.08695,-0.61896 -1.63043,-1.35115 -1.63043,-2.19656 0,-0.8907 0.55857,-1.63043 1.67572,-2.2192 1.11715,-0.60386 2.43056,-0.9058 3.94022,-0.9058' id='path2814-7-0-1' style='font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;font-family:MScore1;-inkscape-font-specification:MScore1'/>
-    <rect height='6.25' id='rect8865-0' style='color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new' width='2' x='405.00021' y='283.75'/>
+  <title
+     id="title9167">MuseScore Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     id="actions"
+     inkscape:label="actions"
+     style="display:inline"
+     transform="translate(-399.99942,-267)">
+    <rect
+       height="10"
+       id="rect4341-0-1"
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new"
+       width="2"
+       x="417.99942"
+       y="279" />
+    <rect
+       height="10"
+       id="rect8865-0"
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new"
+       width="2"
+       x="403.99942"
+       y="279" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 407.99942,283 c 0,2 2.5,4.5 5.5,4.5 1.5,0 2.5,-1 2.5,-2.5 0,-2 -2.5,-4.5 -5.5,-4.5 -1.5,0 -2.5,1 -2.5,2.5 z m 4.01414,-4 c 1.9798,0 3.63904,0.49516 4.97777,1.4855 1.33871,0.99035 2.00808,2.16185 2.00809,3.5145 -10e-6,1.42512 -0.69767,2.62076 -2.09293,3.58696 -1.37644,0.94201 -3.00741,1.41304 -4.89293,1.41304 -1.96095,0 -3.62021,-0.49516 -4.97779,-1.4855 -1.35757,-0.99034 -2.03635,-2.16185 -2.03635,-3.5145 0,-1.42512 0.69763,-2.60869 2.09292,-3.55072 C 408.48763,279.4831 410.12804,279 412.01356,279"
+       id="path2814-7-1"
+       style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:MScore1;-inkscape-font-specification:MScore1"
+       sodipodi:nodetypes="ssssscsccssscc" />
   </g>
 </svg>

--- a/mscore/data/icons-dark/note-longa.svg
+++ b/mscore/data/icons-dark/note-longa.svg
@@ -1,25 +1,110 @@
-<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='note-longa.svg' height='24' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' inkscape:version='0.48.4 r9939' version='1.1' width='24' xmlns='http://www.w3.org/2000/svg'>
-  <metadata id='metadata90'>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="note-longa.svg"
+   height="24"
+   id="svg7384"
+   inkscape:version="0.48.3.1 r9886"
+   version="1.1"
+   width="24">
+  <metadata
+     id="metadata90">
     <rdf:RDF>
-      <cc:Work rdf:about=''>
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>MuseScore Icon Theme</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview inkscape:bbox-nodes='false' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='actions' inkscape:cx='34.000773' inkscape:cy='-41.12962' fit-margin-bottom='6' fit-margin-left='6' fit-margin-right='6' fit-margin-top='6' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#24201f' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='false' inkscape:snap-grids='true' inkscape:snap-nodes='false' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1021' inkscape:window-maximized='1' inkscape:window-width='1920' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
-    <inkscape:grid empspacing='2' enabled='true' id='grid4866' originx='-400.99981px' originy='-77.999999px' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+  <sodipodi:namedview
+     inkscape:bbox-nodes="false"
+     inkscape:bbox-paths="true"
+     bordercolor="#666666"
+     borderopacity="1"
+     inkscape:current-layer="actions"
+     inkscape:cx="8.9270349"
+     inkscape:cy="18.070292"
+     fit-margin-bottom="6"
+     fit-margin-left="6"
+     fit-margin-right="6"
+     fit-margin-top="6"
+     gridtolerance="10"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     id="namedview88"
+     inkscape:object-nodes="false"
+     inkscape:object-paths="false"
+     objecttolerance="10"
+     pagecolor="#24201f"
+     inkscape:pageopacity="1"
+     inkscape:pageshadow="2"
+     showborder="true"
+     showgrid="true"
+     showguides="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-nodes="false"
+     inkscape:snap-others="false"
+     inkscape:snap-to-guides="true"
+     inkscape:window-height="974"
+     inkscape:window-maximized="1"
+     inkscape:window-width="1280"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:zoom="32"
+     borderlayer="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4396"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       spacingx="0.5px"
+       spacingy="0.5px" />
   </sodipodi:namedview>
-  <title id='title9167'>MuseScore Icon Theme</title>
-  <defs id='defs7386'/>
-  <g inkscape:groupmode='layer' id='actions' inkscape:label='actions' style='display:inline' transform='translate(-435.99981,-267)'>
-    
-    <rect height='22' id='rect8873-7' style='color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new' width='2' x='452.99976' y='268'/>
-    <path inkscape:connector-curvature='0' d='m 447.26385,284.33885 c -0.51329,0 -0.9058,0.18116 -1.17754,0.54347 -0.25664,0.36233 -0.38496,0.84542 -0.38496,1.44928 0,0.69445 0.18116,1.29076 0.54348,1.78895 0.37741,0.48309 0.78502,0.82277 1.22282,1.01902 0.4378,0.18116 0.8605,0.27174 1.26812,0.27174 0.51328,0 0.89824,-0.18116 1.15489,-0.54348 0.27173,-0.36232 0.4076,-0.84541 0.40761,-1.44927 -10e-6,-0.69444 -0.18872,-1.28321 -0.56612,-1.76631 -0.36233,-0.49818 -0.76239,-0.83786 -1.20018,-1.01902 -0.43781,-0.19625 -0.86052,-0.29438 -1.26812,-0.29438 m 0.74728,-0.58877 c 1.58514,0 2.91364,0.30948 3.98551,0.92844 1.07185,0.61897 1.60778,1.35115 1.60779,2.19656 -10e-6,0.8907 -0.55859,1.63798 -1.67573,2.24185 -1.10206,0.58876 -2.40791,0.88315 -3.91757,0.88315 -1.57005,0 -2.89855,-0.30948 -3.98551,-0.92844 -1.08695,-0.61896 -1.63043,-1.35115 -1.63043,-2.19656 0,-0.8907 0.55857,-1.63043 1.67572,-2.2192 1.11715,-0.60386 2.43056,-0.9058 3.94022,-0.9058' id='path8877-3' style='font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;font-family:MScore1;-inkscape-font-specification:MScore1'/>
-    <rect height='6.25' id='rect8879-8' style='color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new' width='2' x='441.00021' y='283.75'/>
+  <title
+     id="title9167">MuseScore Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     inkscape:groupmode="layer"
+     id="actions"
+     inkscape:label="actions"
+     style="display:inline"
+     transform="translate(-399.99942,-267)">
+    <rect
+       height="23"
+       id="rect4341-0-1"
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new"
+       width="2"
+       x="417.99942"
+       y="267" />
+    <rect
+       height="10"
+       id="rect8865-0"
+       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50800002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new"
+       width="2"
+       x="403.99942"
+       y="280" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 407.99942,284 c 0,2 2.5,4.5 5.5,4.5 1.5,0 2.5,-1 2.5,-2.5 0,-2 -2.5,-4.5 -5.5,-4.5 -1.5,0 -2.5,1 -2.5,2.5 z m 4.01414,-4 c 1.9798,0 3.63904,0.49516 4.97777,1.4855 1.33871,0.99035 2.00808,2.16185 2.00809,3.5145 -10e-6,1.42512 -0.69767,2.62076 -2.09293,3.58696 -1.37644,0.94201 -3.00741,1.41304 -4.89293,1.41304 -1.96095,0 -3.62021,-0.49516 -4.97779,-1.4855 -1.35757,-0.99034 -2.03635,-2.16185 -2.03635,-3.5145 0,-1.42512 0.69763,-2.60869 2.09292,-3.55072 C 408.48763,280.4831 410.12804,280 412.01356,280"
+       id="path2814-7-1"
+       style="font-size:20px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:MScore1;-inkscape-font-specification:MScore1"
+       sodipodi:nodetypes="ssssscsccssscc" />
   </g>
 </svg>


### PR DESCRIPTION
Goals:
- have more 'white' in each icon (so that any highlighting or dimming is more evident)
- make features of each shape more evident.

Stems have been purposely shortened to give more evidence to the head.
