### PR TITLE
Fix #21110 - text on glissando wavy line

### DIFF
--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -88,7 +88,7 @@ void Glissando::layout()
       LedgerLine * ledLin = static_cast<Chord*>(cr)->ledgerLines();
       // if dots, from right of last dot (assume a standard dot with of 1/4 sp)
       // if no dots, from right of ledger line, if any; from right of note head, if no ledger line
-      qreal x1 = (dots ? anchor1->dot(dots-1)->pos().x() + 0.25 * _spatium
+      qreal x1 = (dots ? anchor1->dot(dots-1)->pos().x() + anchor1->dot(dots-1)->width()
                   : (ledLin ? ledLin->pos().x() + ledLin->width() : anchor1->headWidth()) )
             - (cp2.x() - cp1.x());              // make relative to end note
       qreal y1 = anchor1->pos().y();


### PR DESCRIPTION
Fix #21110 - position the text of glissando according to its physical height and no longer by a hard-coded vert. offset; this takes into account changes to text style font size changes

It should also fix #20970: collision of glissando with ledger lines and dots.
