### PR TITLE
Fix #17227 - Wrong transpositions in scores from templates

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -547,7 +547,7 @@ void MuseScore::newFile()
                               // transpose key
                               //
                               KeySigEvent nKey = ks;
-                              if (part->instr()->transpose().chromatic && !newWizard->useTemplate()) {
+                              if (part->instr()->transpose().chromatic && !score->styleB(ST_concertPitch)) {
                                     int diff = -part->instr()->transpose().chromatic;
                                     nKey.setAccidentalType(transposeKey(nKey.accidentalType(), diff));
                                     }


### PR DESCRIPTION
Fix #17227 - When creating a score from a template not in Concert Pitch, transposing instruments had wrong key signatures.

Corrected in mscore/file.cpp, by repeating the same test used in ver. 1.3
