### PR TITLE
Fix #21162 - Remove ties to notes of a removed Chord

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1414,7 +1414,10 @@ RemoveElement::RemoveElement(Element* e)
                   Chord* chord = static_cast<Chord*>(e);
                   foreach(Note* note, chord->notes()) {
                         if (note->tieFor() && note->tieFor()->endNote())
-                              note->tieFor()->endNote()->setTieBack(0);
+//                              note->tieFor()->endNote()->setTieBack(0);
+                              score->undoRemoveElement(note->tieFor());
+                        if (note->tieBack())
+                              score->undoRemoveElement(note->tieBack());
                         }
                   }
             }


### PR DESCRIPTION
Fix #21162 - When a chord is removed, ties to it remain behind and attach to casual notes

Fixed in RemoveElement::RemoveElement() by handling Chord's Notes tieBack

Also removes tieFor in a cleaner way.
