### PR TITLE
Allow both Control and Shift while dragging.

### DIFF
--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -69,9 +69,9 @@ void ScoreView::doDragElement(QMouseEvent* ev)
       QPointF delta = toLogical(ev->pos()) - startMove;
 
       QPointF pt(delta);
-      if (qApp->keyboardModifiers() == Qt::ShiftModifier)
+      if (qApp->keyboardModifiers() & Qt::ShiftModifier)
             pt.setX(0.0);
-      else if (qApp->keyboardModifiers() == Qt::ControlModifier)
+      if (qApp->keyboardModifiers() & Qt::ControlModifier)
             pt.setY(0.0);
       EditData data;
       data.hRaster = mscore->hRaster();


### PR DESCRIPTION
Control resets vertical position, shift resets horizontal position.
Now Control-Shift can be used to reset both horizontal and vertical position.
Previously only one or the other could be done.
