### PR TITLE
fix crash when copying chordnames between scores

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -19,6 +19,9 @@
 #include "chordlist.h"
 #include "mscore.h"
 #include "fret.h"
+#include "staff.h"
+#include "part.h"
+#include "utils.h"
 
 namespace Ms {
 
@@ -164,13 +167,22 @@ void Harmony::write(Xml& xml) const
       if (_leftParen)
             xml.tagE("leftParen");
       if (_rootTpc != INVALID_TPC) {
-            xml.tag("root", _rootTpc);
+            int rRootTpc = _rootTpc;
+            int rBaseTpc = _baseTpc;
+            if (staff()) {
+                  const Interval& interval = staff()->part()->instr()->transpose();
+                  if (xml.clipboardmode && !score()->styleB(ST_concertPitch) && interval.chromatic) {
+                        rRootTpc = transposeTpc(_rootTpc, interval, false);
+                        rBaseTpc = transposeTpc(_baseTpc, interval, false);
+                        }
+                  }
+            xml.tag("root", rRootTpc);
             if (_id > 0)
                   xml.tag("extension", _id);
             if (_textName != "")
                   xml.tag("name", _textName);
-            if (_baseTpc != INVALID_TPC)
-                  xml.tag("base", _baseTpc);
+            if (rBaseTpc != INVALID_TPC)
+                  xml.tag("base", rBaseTpc);
             foreach(const HDegree& hd, _degreeList) {
                   int tp = hd.type();
                   if (tp == ADD || tp == ALTER || tp == SUBTRACT) {

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -286,13 +286,11 @@ qDebug("cannot make gap in staff %d at tick %d", staffIdx, dst->tick());
                               harmony->setTrack(e.track());
                               harmony->read(e);
                               harmony->setTrack(dstStaffIdx * VOICES);
-                              //transpose
+                              // transpose
                               Part* partDest = staff(dstStaffIdx)->part();
-                              Part* partSrc = staff(srcStaffIdx)->part();
-                              Interval intervalDest = partDest->instr()->transpose();
-                              Interval intervalSrc = partSrc->instr()->transpose();
-                              Interval interval = Interval(intervalSrc.diatonic - intervalDest.diatonic, intervalSrc.chromatic - intervalDest.chromatic);
-                              if (!styleB(ST_concertPitch)) {
+                              Interval interval = partDest->instr()->transpose();
+                              if (!styleB(ST_concertPitch) && !interval.isZero()) {
+                                    interval.flip();
                                     int rootTpc = transposeTpc(harmony->rootTpc(), interval, false);
                                     int baseTpc = transposeTpc(harmony->baseTpc(), interval, false);
                                     undoTransposeHarmony(harmony, rootTpc, baseTpc);


### PR DESCRIPTION
Problem had to do with determining correct transposition.  Fix is to
always represent Harmony objects as concert pitch in clipboard.  Convert
to on copy, convert from on paste.  This is the same strategy used for
Chord/Note objects.
