### PR TITLE
fix import of 1.x tremolo between 2 notes

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1983,6 +1983,11 @@ void Measure::read(XmlReader& e, int staffIdx)
                                           tremolo->setParent(pch);
                                           pch->setTremolo(tremolo);
                                           chord->setTremolo(0);
+                                          Fraction pts(timeStretch * pch->globalDuration());
+                                          int pcrticks = pts.ticks();
+                                          pch->setDuration(pcrticks / 2);
+                                          chord->setDuration(crticks / 2);
+                                          segment->setTick(e.tick());
                                           }
                                     else {
                                           qDebug("tremolo: first note not found");


### PR DESCRIPTION
This should fix import of tremolo between 2 notes from 1.x files (when the notes are not grace notes).
This pull request is a partial fix for http://musescore.org/en/node/14840
