### PR TITLE
fix 1.x tremolo between 2 notes import

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1846,6 +1846,10 @@ void Measure::read(XmlReader& e, int staffIdx)
                                           tremolo->setParent(pch);
                                           pch->setTremolo(tremolo);
                                           chord->setTremolo(0);
+                                          Fraction pts(timeStretch * pch->globalDuration());
+                                          int pcrticks = pts.ticks();
+                                          pch->setDuration(pcrticks / 2);
+                                          chord->setDuration(crticks / 2);
                                           }
                                     else {
                                           qDebug("tremolo: first note not found");


### PR DESCRIPTION
Trying again after another git rebase:
This should fix import of tremolo between 2 notes from 1.x files (when the notes are not grace notes).
Partial fix for http://musescore.org/en/node/14840
