### PR TITLE
Remove a left-over from removing guitar string data as default for each instrument

### DIFF
--- a/libmscore/tablature.h
+++ b/libmscore/tablature.h
@@ -49,7 +49,6 @@ public:
       };
 
 extern Tablature emptyStringData;
-extern Tablature guitarTablature;
 
 }     // namespace Ms
 #endif


### PR DESCRIPTION
Remove a left-over from removing guitar string data as default for each instrument.
