### PR TITLE
Dynamics: permanent text edit

### DIFF
--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -197,6 +197,13 @@ void Dynamic::startEdit(MuseScoreView* v, const QPointF& p)
       Text::startEdit(v, p);
       }
 
+void Dynamic::endEdit()
+      {
+      Text::endEdit();
+      if (!styled() || text() != QString::fromUtf8(dynList[_dynamicType].text))
+            _dynamicType = DYNAMIC_OTHER;
+      }
+
 //---------------------------------------------------------
 //   reset
 //---------------------------------------------------------

--- a/libmscore/dynamic.h
+++ b/libmscore/dynamic.h
@@ -91,6 +91,7 @@ class Dynamic : public Text {
 
       virtual bool isEditable() const { return true; }
       virtual void startEdit(MuseScoreView*, const QPointF&);
+      virtual void endEdit();
       virtual void reset();
 
       void setVelocity(int v);


### PR DESCRIPTION
Text of dynamics created via the palette cannot be permanently edited as the edited text is not saved to the score: the text is saved only for dynamics of type DYNAMIC_OTHER.

Fix: If the text of standard dynamic is changed, the type is also changed to DYNAMIC_OTHER, allowing storing the edited text.
