### PR TITLE
fix #12557 untitled score doesn't save (review needed)

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -224,8 +224,9 @@ bool MuseScore::checkDirty(Score* s)
                QMessageBox::Save);
             if (n == QMessageBox::Save) {
                   if (s->isSavable()) {
-                        if (!s->saveFile())
-                              return true;
+                        saveFile();
+                        //if (!s->saveFile())
+                        //      return true;
                         }
                   else {
                         if (!saveAs(s, false))

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -225,6 +225,10 @@ void MuseScore::closeEvent(QCloseEvent* ev)
       unloadPlugins();
       QList<Score*> removeList;
       foreach(Score* score, scoreList) {
+            int idcur = scoreList.indexOf(score);
+            setCurrentView(0,idcur);
+            tab1->setExcerpt(0);
+            setCurrentView(0,idcur);
             if (score->created() && !score->dirty())
                   removeList.append(score);
             else {
@@ -1886,6 +1890,9 @@ void MuseScore::removeTab(int i)
 
       QString tmpName = score->tmpName();
 
+      setCurrentView(0,i);
+      tab1->setExcerpt(0);
+      setCurrentView(0,i);
       if (checkDirty(score))
             return;
       if (seq && seq->score() == score) {


### PR DESCRIPTION
This pull request tries to fix the fact that untitled scores are not saved (or, actually, saved in the folder where mscore starts, without mscz extension and without warnings for overwriting). It mimics the use of the GUI save button. For scores with parts, it first switches to the main score and then saves.
