### PR TITLE
Prevent possible infinite loop in aeolus

### DIFF
--- a/aeolus/rankwave.cpp
+++ b/aeolus/rankwave.cpp
@@ -106,6 +106,8 @@ void Pipewave::play()
                     k2 = (int)(-y / dy);
 	        }
                 k1 -= k2;
+                if (k2<0)
+                  k2 = 0;
                 while (k2--)
        	        {
                     *q++ += g * (r [0] + y * (r [1] - r [0]));
@@ -160,6 +162,8 @@ void Pipewave::play()
                     k2 = (int)(-y / dy);
 	        }
                 k1 -= k2;
+                if (k2<0)
+                  k2 = 0;
                 while (k2--)
        	        {
                     *q++ += p [0] + y * (p [1] - p [0]);


### PR DESCRIPTION
In debug build playing an organ file with a Pedal marking through aeolus synthesizer leads to random crashes because of an infinite loop. This behavior is not observed in release build, but maybe it is better to prevent the possible infinite loop as well.
