### PR TITLE
Order mismatch between styleTypes[] array and StyleIdx enum.

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -46,6 +46,7 @@ StyleType styleTypes[] = {
       StyleType("lyricsDistance",          ST_SPATIUM),
       StyleType("lyricsMinBottomDistance", ST_SPATIUM),
       StyleType("lyricsLineHeight",        ST_DOUBLE),      // in % of normal height (default: 1.0)
+
       StyleType("figuredBassFontFamily",   ST_STRING),
       StyleType("figuredBassFontSize",     ST_DOUBLE),      // in pt
       StyleType("figuredBassYOffset",      ST_DOUBLE),      // in sp
@@ -64,6 +65,7 @@ StyleType styleTypes[] = {
       StyleType("repeatBarTips",           ST_BOOL),
       StyleType("startBarlineSingle",      ST_BOOL),
       StyleType("startBarlineMultiple",    ST_BOOL),
+
       StyleType("bracketWidth",            ST_SPATIUM),     // system bracket line width
       StyleType("bracketDistance",         ST_SPATIUM),     // system bracket distance
       StyleType("akkoladeWidth",           ST_SPATIUM),
@@ -91,8 +93,8 @@ StyleType styleTypes[] = {
       StyleType("accidentalDistance",      ST_SPATIUM),
       StyleType("accidentalNoteDistance",  ST_SPATIUM),
       StyleType("multiMeasureRestMargin",  ST_SPATIUM),
-      StyleType("beamWidth",               ST_SPATIUM),
 
+      StyleType("beamWidth",               ST_SPATIUM),
       StyleType("beamDistance",            ST_DOUBLE),      // in beamWidth units
       StyleType("beamMinLen",              ST_SPATIUM),     // len for broken beams
       StyleType("beamMinSlope",            ST_DOUBLE),
@@ -104,7 +106,6 @@ StyleType styleTypes[] = {
       StyleType("dotDotDistance",          ST_SPATIUM),
       StyleType("propertyDistanceHead",    ST_SPATIUM),     // note property to note head
       StyleType("propertyDistanceStem",    ST_SPATIUM),     // note property to note stem
-
       StyleType("propertyDistance",        ST_SPATIUM),     // note property to note property
 //      StyleType("pageFillLimit",           ST_DOUBLE),      // 0-1.0
       StyleType("lastSystemFillLimit",     ST_DOUBLE),
@@ -124,7 +125,6 @@ StyleType styleTypes[] = {
       StyleType("showPageNumberOne",       ST_BOOL),
       StyleType("pageNumberOddEven",       ST_BOOL),
       StyleType("showMeasureNumber",       ST_BOOL),
-
       StyleType("showMeasureNumberOne",    ST_BOOL),
       StyleType("measureNumberInterval",   ST_INT),
       StyleType("measureNumberSystem",     ST_BOOL),
@@ -135,11 +135,11 @@ StyleType styleTypes[] = {
       StyleType("smallClefMag",            ST_DOUBLE),
       StyleType("genClef",                 ST_BOOL),           // create clef for all systems, not only for first
       StyleType("genKeysig",               ST_BOOL),         // create key signature for all systems
-
       StyleType("genTimesig",              ST_BOOL),
       StyleType("genCourtesyTimesig",      ST_BOOL),
       StyleType("genCourtesyKeysig",       ST_BOOL),
       StyleType("genCourtesyClef",         ST_BOOL),
+
       StyleType("useStandardNoteNames",    ST_BOOL),
       StyleType("useGermanNoteNames",      ST_BOOL),
       StyleType("useSolfeggioNoteNames",   ST_BOOL),
@@ -178,8 +178,8 @@ StyleType styleTypes[] = {
       StyleType("slurMidWidth",            ST_SPATIUM),
       StyleType("slurDottedWidth",         ST_SPATIUM),
       StyleType("slurBow",                 ST_SPATIUM),
-      StyleType("sectionPause",            ST_DOUBLE),
 
+      StyleType("sectionPause",            ST_DOUBLE),
       StyleType("musicalSymbolFont",       ST_STRING),
 
       StyleType("showHeader",              ST_BOOL),

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -191,7 +191,6 @@ enum StyleIdx {
       ST_clefLeftMargin,
       ST_keysigLeftMargin,
       ST_timesigLeftMargin,
-
       ST_clefKeyRightMargin,
       ST_clefBarlineDistance,
       ST_stemWidth,
@@ -199,23 +198,23 @@ enum StyleIdx {
       ST_shortStemProgression,
       ST_shortestStem,
       ST_beginRepeatLeftMargin,
+
       ST_minNoteDistance,
       ST_barNoteDistance,
       ST_barAccidentalDistance,
-      ST_multiMeasureRestMargin,
       ST_noteBarDistance,
-
       ST_measureSpacing,
       ST_staffLineWidth,
       ST_ledgerLineWidth,
       ST_ledgerLineLength,
       ST_accidentalDistance,
       ST_accidentalNoteDistance,
+      ST_multiMeasureRestMargin,
+
       ST_beamWidth,
       ST_beamDistance,
       ST_beamMinLen,
       ST_beamMinSlope,
-
       ST_beamMaxSlope,
       ST_maxBeamTicks,
       ST_dotMag,
@@ -225,6 +224,7 @@ enum StyleIdx {
       ST_propertyDistanceHead,
       ST_propertyDistanceStem,
       ST_propertyDistance,
+
       ST_lastSystemFillLimit,
 
       ST_hairpinY,
@@ -245,7 +245,6 @@ enum StyleIdx {
       ST_showMeasureNumberOne,
       ST_measureNumberInterval,
       ST_measureNumberSystem,
-
       ST_measureNumberAllStaffs,
       ST_smallNoteMag,
       ST_graceNoteMag,
@@ -271,10 +270,16 @@ enum StyleIdx {
       ST_minMMRestWidth,
       ST_hideEmptyStaves,
       ST_dontHideStavesInFirstSystem,
+
       ST_stemDir1,
       ST_stemDir2,
       ST_stemDir3,
       ST_stemDir4,
+
+	//---------------------------------------------------------
+    //   PlayStyle
+    //---------------------------------------------------------
+
       ST_gateTime,
       ST_tenutoGateTime,
       ST_staccatoGateTime,


### PR DESCRIPTION
As, while reading scores, the index in styleTypes is used to access StylesData::values which are order by StyleIdx, styles between ST_noteBarDistance and ST_accidentalNoteDistance are read back into (and possibly written from) the wrong style.

Fixed by re-arranging the StyleIdx enum elements in style.h.

Incidentally, the StyleIdx enum and the styleTypes array have been re-formatted with the same spacing and comments to ease a side-by-side comparison.
