### PR TITLE
fix #21838 fix #21910 change filename encoding in zip files

### DIFF
--- a/libmscore/qzip.cpp
+++ b/libmscore/qzip.cpp
@@ -362,21 +362,21 @@ struct FileHeader
     QByteArray file_comment;
 };
 
-QZipReader::FileInfo::FileInfo()
+MQZipReader::FileInfo::FileInfo()
     : isDir(false), isFile(false), isSymLink(false), crc32(0), size(0)
 {
 }
 
-QZipReader::FileInfo::~FileInfo()
+MQZipReader::FileInfo::~FileInfo()
 {
 }
 
-QZipReader::FileInfo::FileInfo(const FileInfo &other)
+MQZipReader::FileInfo::FileInfo(const FileInfo &other)
 {
     operator=(other);
 }
 
-QZipReader::FileInfo& QZipReader::FileInfo::operator=(const FileInfo &other)
+MQZipReader::FileInfo& MQZipReader::FileInfo::operator=(const FileInfo &other)
 {
     filePath = other.filePath;
     isDir = other.isDir;
@@ -389,26 +389,26 @@ QZipReader::FileInfo& QZipReader::FileInfo::operator=(const FileInfo &other)
     return *this;
 }
 
-bool QZipReader::FileInfo::isValid() const
+bool MQZipReader::FileInfo::isValid() const
 {
     return isDir || isFile || isSymLink;
 }
 
-class QZipPrivate
+class MQZipPrivate
 {
 public:
-    QZipPrivate(QIODevice *device, bool ownDev)
+    MQZipPrivate(QIODevice *device, bool ownDev)
         : device(device), ownDevice(ownDev), dirtyFileTree(true), start_of_directory(0)
     {
     }
 
-    ~QZipPrivate()
+    ~MQZipPrivate()
     {
         if (ownDevice)
             delete device;
     }
 
-    void fillFileInfo(int index, QZipReader::FileInfo &fileInfo) const;
+    void fillFileInfo(int index, MQZipReader::FileInfo &fileInfo) const;
 
     QIODevice *device;
     bool ownDevice;
@@ -418,7 +418,7 @@ public:
     uint start_of_directory;
 };
 
-void QZipPrivate::fillFileInfo(int index, QZipReader::FileInfo &fileInfo) const
+void MQZipPrivate::fillFileInfo(int index, MQZipReader::FileInfo &fileInfo) const
 {
     FileHeader header = fileHeaders.at(index);
     fileInfo.filePath = QString::fromLocal8Bit(header.file_name);
@@ -432,33 +432,33 @@ void QZipPrivate::fillFileInfo(int index, QZipReader::FileInfo &fileInfo) const
     fileInfo.lastModified = readMSDosDate(header.h.last_mod_file);
 }
 
-class QZipReaderPrivate : public QZipPrivate
+class MQZipReaderPrivate : public MQZipPrivate
 {
 public:
-    QZipReaderPrivate(QIODevice *device, bool ownDev)
-        : QZipPrivate(device, ownDev), status(QZipReader::NoError)
+    MQZipReaderPrivate(QIODevice *device, bool ownDev)
+        : MQZipPrivate(device, ownDev), status(MQZipReader::NoError)
     {
     }
 
     void scanFiles();
 
-    QZipReader::Status status;
+    MQZipReader::Status status;
 };
 
-class QZipWriterPrivate : public QZipPrivate
+class MQZipWriterPrivate : public MQZipPrivate
 {
 public:
-    QZipWriterPrivate(QIODevice *device, bool ownDev)
-        : QZipPrivate(device, ownDev),
-        status(QZipWriter::NoError),
+    MQZipWriterPrivate(QIODevice *device, bool ownDev)
+        : MQZipPrivate(device, ownDev),
+        status(MQZipWriter::NoError),
         permissions(QFile::ReadOwner | QFile::WriteOwner),
-        compressionPolicy(QZipWriter::AlwaysCompress)
+        compressionPolicy(MQZipWriter::AlwaysCompress)
     {
     }
 
-    QZipWriter::Status status;
+    MQZipWriter::Status status;
     QFile::Permissions permissions;
-    QZipWriter::CompressionPolicy compressionPolicy;
+    MQZipWriter::CompressionPolicy compressionPolicy;
 
     enum EntryType { Directory, File, Symlink };
 
@@ -481,18 +481,18 @@ LocalFileHeader CentralFileHeader::toLocalHeader() const
     return h;
 }
 
-void QZipReaderPrivate::scanFiles()
+void MQZipReaderPrivate::scanFiles()
 {
     if (!dirtyFileTree)
         return;
 
     if (! (device->isOpen() || device->open(QIODevice::ReadOnly))) {
-        status = QZipReader::FileOpenError;
+        status = MQZipReader::FileOpenError;
         return;
     }
 
     if ((device->openMode() & QIODevice::ReadOnly) == 0) { // only read the index from readable files.
-        status = QZipReader::FileReadError;
+        status = MQZipReader::FileReadError;
         return;
     }
 
@@ -570,7 +570,7 @@ void QZipReaderPrivate::scanFiles()
     }
 }
 
-void QZipWriterPrivate::addEntry(EntryType type, const QString &fileName, const QByteArray &contents/*, QFile::Permissions permissions, QZip::Method m*/)
+void MQZipWriterPrivate::addEntry(EntryType type, const QString &fileName, const QByteArray &contents/*, QFile::Permissions permissions, QZip::Method m*/)
 {
 #ifndef NDEBUG
     static const char *entryTypes[] = {
@@ -581,18 +581,18 @@ void QZipWriterPrivate::addEntry(EntryType type, const QString &fileName, const 
 #endif
 
     if (! (device->isOpen() || device->open(QIODevice::WriteOnly))) {
-        status = QZipWriter::FileOpenError;
+        status = MQZipWriter::FileOpenError;
         return;
     }
     device->seek(start_of_directory);
 
     // don't compress small files
-    QZipWriter::CompressionPolicy compression = compressionPolicy;
-    if (compressionPolicy == QZipWriter::AutoCompress) {
+    MQZipWriter::CompressionPolicy compression = compressionPolicy;
+    if (compressionPolicy == MQZipWriter::AutoCompress) {
         if (contents.length() < 64)
-            compression = QZipWriter::NeverCompress;
+            compression = MQZipWriter::NeverCompress;
         else
-            compression = QZipWriter::AlwaysCompress;
+            compression = MQZipWriter::AlwaysCompress;
     }
 
     FileHeader header;
@@ -603,7 +603,7 @@ void QZipWriterPrivate::addEntry(EntryType type, const QString &fileName, const 
     writeUInt(header.h.uncompressed_size, contents.length());
     writeMSDosDate(header.h.last_mod_file, QDateTime::currentDateTime());
     QByteArray data = contents;
-    if (compression == QZipWriter::AlwaysCompress) {
+    if (compression == MQZipWriter::AlwaysCompress) {
         writeUShort(header.h.compression_method, 8);
 
        ulong len = contents.length();
@@ -634,7 +634,7 @@ void QZipWriterPrivate::addEntry(EntryType type, const QString &fileName, const 
     crc_32 = ::crc32(crc_32, (const uchar *)contents.constData(), contents.length());
     writeUInt(header.h.crc_32, crc_32);
 
-    header.file_name = fileName.toLocal8Bit();
+    header.file_name = fileName.toUtf8();
     if (header.file_name.size() > 0xffff) {
         qWarning("QZip: Filename too long, chopping it to 65535 characters");
         header.file_name = header.file_name.left(0xffff);
@@ -733,11 +733,11 @@ void QZipWriterPrivate::addEntry(EntryType type, const QString &fileName, const 
     Create a new zip archive that operates on the \a fileName.  The file will be
     opened with the \a mode.
 */
-QZipReader::QZipReader(const QString &archive, QIODevice::OpenMode mode)
+MQZipReader::MQZipReader(const QString &archive, QIODevice::OpenMode mode)
 {
     QScopedPointer<QFile> f(new QFile(archive));
     f->open(mode);
-    QZipReader::Status status;
+    MQZipReader::Status status;
     if (f->error() == QFile::NoError)
         status = NoError;
     else {
@@ -751,7 +751,7 @@ QZipReader::QZipReader(const QString &archive, QIODevice::OpenMode mode)
             status = FileError;
     }
 
-    d = new QZipReaderPrivate(f.data(), /*ownDevice=*/true);
+    d = new MQZipReaderPrivate(f.data(), /*ownDevice=*/true);
     f.take();
     d->status = status;
 }
@@ -761,8 +761,8 @@ QZipReader::QZipReader(const QString &archive, QIODevice::OpenMode mode)
     You have to open the device previous to calling the constructor and only a
     device that is readable will be scanned for zip filecontent.
  */
-QZipReader::QZipReader(QIODevice *device)
-    : d(new QZipReaderPrivate(device, /*ownDevice=*/false))
+MQZipReader::MQZipReader(QIODevice *device)
+    : d(new MQZipReaderPrivate(device, /*ownDevice=*/false))
 {
     Q_ASSERT(device);
 }
@@ -770,7 +770,7 @@ QZipReader::QZipReader(QIODevice *device)
 /*!
     Desctructor
 */
-QZipReader::~QZipReader()
+MQZipReader::~MQZipReader()
 {
     close();
     delete d;
@@ -779,7 +779,7 @@ QZipReader::~QZipReader()
 /*!
     Returns device used for reading zip archive.
 */
-QIODevice* QZipReader::device() const
+QIODevice* MQZipReader::device() const
 {
     return d->device;
 }
@@ -787,7 +787,7 @@ QIODevice* QZipReader::device() const
 /*!
     Returns true if the user can read the file; otherwise returns false.
 */
-bool QZipReader::isReadable() const
+bool MQZipReader::isReadable() const
 {
     return d->device->isReadable();
 }
@@ -795,7 +795,7 @@ bool QZipReader::isReadable() const
 /*!
     Returns true if the file exists; otherwise returns false.
 */
-bool QZipReader::exists() const
+bool MQZipReader::exists() const
 {
     QFile *f = qobject_cast<QFile*> (d->device);
     if (f == 0)
@@ -806,12 +806,12 @@ bool QZipReader::exists() const
 /*!
     Returns the list of files the archive contains.
 */
-QList<QZipReader::FileInfo> QZipReader::fileInfoList() const
+QList<MQZipReader::FileInfo> MQZipReader::fileInfoList() const
 {
     d->scanFiles();
-    QList<QZipReader::FileInfo> files;
+    QList<MQZipReader::FileInfo> files;
     for (int i = 0; i < d->fileHeaders.size(); ++i) {
-        QZipReader::FileInfo fi;
+        MQZipReader::FileInfo fi;
         d->fillFileInfo(i, fi);
         files.append(fi);
     }
@@ -822,7 +822,7 @@ QList<QZipReader::FileInfo> QZipReader::fileInfoList() const
 /*!
     Return the number of items in the zip archive.
 */
-int QZipReader::count() const
+int MQZipReader::count() const
 {
     d->scanFiles();
     return d->fileHeaders.count();
@@ -835,10 +835,10 @@ int QZipReader::count() const
 
     \sa fileInfoList()
 */
-QZipReader::FileInfo QZipReader::entryInfoAt(int index) const
+MQZipReader::FileInfo MQZipReader::entryInfoAt(int index) const
 {
     d->scanFiles();
-    QZipReader::FileInfo fi;
+    MQZipReader::FileInfo fi;
     if (index >= 0 && index < d->fileHeaders.count())
         d->fillFileInfo(index, fi);
     return fi;
@@ -847,12 +847,12 @@ QZipReader::FileInfo QZipReader::entryInfoAt(int index) const
 /*!
     Fetch the file contents from the zip archive and return the uncompressed bytes.
 */
-QByteArray QZipReader::fileData(const QString &fileName) const
+QByteArray MQZipReader::fileData(const QString &fileName) const
 {
     d->scanFiles();
     int i;
     for (i = 0; i < d->fileHeaders.size(); ++i) {
-        if (QString::fromLocal8Bit(d->fileHeaders.at(i).file_name) == fileName)
+        if (QString::fromUtf8(d->fileHeaders.at(i).file_name) == fileName)
             break;
     }
     if (i == d->fileHeaders.size())
@@ -919,7 +919,7 @@ QByteArray QZipReader::fileData(const QString &fileName) const
     the local filesystem.
     In case writing or linking a file fails, the extraction will be aborted.
 */
-bool QZipReader::extractAll(const QString &destinationDir) const
+bool MQZipReader::extractAll(const QString &destinationDir) const
 {
     QDir baseDir(destinationDir);
 
@@ -985,7 +985,7 @@ bool QZipReader::extractAll(const QString &destinationDir) const
     Returns a status code indicating the first error that was met by QZipReader,
     or QZipReader::NoError if no error occurred.
 */
-QZipReader::Status QZipReader::status() const
+MQZipReader::Status MQZipReader::status() const
 {
     return d->status;
 }
@@ -993,7 +993,7 @@ QZipReader::Status QZipReader::status() const
 /*!
     Close the zip file.
 */
-void QZipReader::close()
+void MQZipReader::close()
 {
     d->device->close();
 }
@@ -1018,25 +1018,25 @@ void QZipReader::close()
     be opened with the \a mode.
     \sa isValid()
 */
-QZipWriter::QZipWriter(const QString &fileName, QIODevice::OpenMode mode)
+MQZipWriter::MQZipWriter(const QString &fileName, QIODevice::OpenMode mode)
 {
     QScopedPointer<QFile> f(new QFile(fileName));
     f->open(mode);
-    QZipWriter::Status status;
+    MQZipWriter::Status status;
     if (f->error() == QFile::NoError)
-        status = QZipWriter::NoError;
+        status = MQZipWriter::NoError;
     else {
         if (f->error() == QFile::WriteError)
-            status = QZipWriter::FileWriteError;
+            status = MQZipWriter::FileWriteError;
         else if (f->error() == QFile::OpenError)
-            status = QZipWriter::FileOpenError;
+            status = MQZipWriter::FileOpenError;
         else if (f->error() == QFile::PermissionsError)
-            status = QZipWriter::FilePermissionsError;
+            status = MQZipWriter::FilePermissionsError;
         else
-            status = QZipWriter::FileError;
+            status = MQZipWriter::FileError;
     }
 
-    d = new QZipWriterPrivate(f.data(), /*ownDevice=*/true);
+    d = new MQZipWriterPrivate(f.data(), /*ownDevice=*/true);
     f.take();
     d->status = status;
 }
@@ -1046,13 +1046,13 @@ QZipWriter::QZipWriter(const QString &fileName, QIODevice::OpenMode mode)
     You have to open the device previous to calling the constructor and
     only a device that is readable will be scanned for zip filecontent.
  */
-QZipWriter::QZipWriter(QIODevice *device)
-    : d(new QZipWriterPrivate(device, /*ownDevice=*/false))
+MQZipWriter::MQZipWriter(QIODevice *device)
+    : d(new MQZipWriterPrivate(device, /*ownDevice=*/false))
 {
     Q_ASSERT(device);
 }
 
-QZipWriter::~QZipWriter()
+MQZipWriter::~MQZipWriter()
 {
     close();
     delete d;
@@ -1061,7 +1061,7 @@ QZipWriter::~QZipWriter()
 /*!
     Returns device used for writing zip archive.
 */
-QIODevice* QZipWriter::device() const
+QIODevice* MQZipWriter::device() const
 {
     return d->device;
 }
@@ -1069,7 +1069,7 @@ QIODevice* QZipWriter::device() const
 /*!
     Returns true if the user can write to the archive; otherwise returns false.
 */
-bool QZipWriter::isWritable() const
+bool MQZipWriter::isWritable() const
 {
     return d->device->isWritable();
 }
@@ -1077,7 +1077,7 @@ bool QZipWriter::isWritable() const
 /*!
     Returns true if the file exists; otherwise returns false.
 */
-bool QZipWriter::exists() const
+bool MQZipWriter::exists() const
 {
     QFile *f = qobject_cast<QFile*> (d->device);
     if (f == 0)
@@ -1101,7 +1101,7 @@ bool QZipWriter::exists() const
     Returns a status code indicating the first error that was met by QZipWriter,
     or QZipWriter::NoError if no error occurred.
 */
-QZipWriter::Status QZipWriter::status() const
+MQZipWriter::Status MQZipWriter::status() const
 {
     return d->status;
 }
@@ -1122,7 +1122,7 @@ QZipWriter::Status QZipWriter::status() const
     \sa compressionPolicy()
     \sa addFile()
 */
-void QZipWriter::setCompressionPolicy(CompressionPolicy policy)
+void MQZipWriter::setCompressionPolicy(CompressionPolicy policy)
 {
     d->compressionPolicy = policy;
 }
@@ -1132,7 +1132,7 @@ void QZipWriter::setCompressionPolicy(CompressionPolicy policy)
     \sa setCompressionPolicy()
     \sa addFile()
 */
-QZipWriter::CompressionPolicy QZipWriter::compressionPolicy() const
+MQZipWriter::CompressionPolicy MQZipWriter::compressionPolicy() const
 {
     return d->compressionPolicy;
 }
@@ -1145,7 +1145,7 @@ QZipWriter::CompressionPolicy QZipWriter::compressionPolicy() const
     \sa creationPermissions()
     \sa addFile()
 */
-void QZipWriter::setCreationPermissions(QFile::Permissions permissions)
+void MQZipWriter::setCreationPermissions(QFile::Permissions permissions)
 {
     d->permissions = permissions;
 }
@@ -1156,7 +1156,7 @@ void QZipWriter::setCreationPermissions(QFile::Permissions permissions)
     \sa setCreationPermissions()
     \sa addFile()
 */
-QFile::Permissions QZipWriter::creationPermissions() const
+QFile::Permissions MQZipWriter::creationPermissions() const
 {
     return d->permissions;
 }
@@ -1173,9 +1173,9 @@ QFile::Permissions QZipWriter::creationPermissions() const
     \sa setCreationPermissions()
     \sa setCompressionPolicy()
 */
-void QZipWriter::addFile(const QString &fileName, const QByteArray &data)
+void MQZipWriter::addFile(const QString &fileName, const QByteArray &data)
 {
-    d->addEntry(QZipWriterPrivate::File, fileName, data);
+    d->addEntry(MQZipWriterPrivate::File, fileName, data);
 }
 
 /*!
@@ -1185,7 +1185,7 @@ void QZipWriter::addFile(const QString &fileName, const QByteArray &data)
     The file will be stored in the archive using the \a fileName which
     includes the full path in the archive.
 */
-void QZipWriter::addFile(const QString &fileName, QIODevice *device)
+void MQZipWriter::addFile(const QString &fileName, QIODevice *device)
 {
     Q_ASSERT(device);
     QIODevice::OpenMode mode = device->openMode();
@@ -1197,7 +1197,7 @@ void QZipWriter::addFile(const QString &fileName, QIODevice *device)
             return;
         }
     }
-    d->addEntry(QZipWriterPrivate::File, fileName, device->readAll());
+    d->addEntry(MQZipWriterPrivate::File, fileName, device->readAll());
     if (opened)
         device->close();
 }
@@ -1206,13 +1206,13 @@ void QZipWriter::addFile(const QString &fileName, QIODevice *device)
     Create a new directory in the archive with the specified \a dirName and
     the \a permissions;
 */
-void QZipWriter::addDirectory(const QString &dirName)
+void MQZipWriter::addDirectory(const QString &dirName)
 {
     QString name = dirName;
     // separator is mandatory
     if (!name.endsWith(QDir::separator()))
         name.append(QDir::separator());
-    d->addEntry(QZipWriterPrivate::Directory, name, QByteArray());
+    d->addEntry(MQZipWriterPrivate::Directory, name, QByteArray());
 }
 
 /*!
@@ -1220,15 +1220,15 @@ void QZipWriter::addDirectory(const QString &dirName)
     and the \a permissions;
     A symbolic link contains the destination (relative) path and name.
 */
-void QZipWriter::addSymLink(const QString &fileName, const QString &destination)
+void MQZipWriter::addSymLink(const QString &fileName, const QString &destination)
 {
-    d->addEntry(QZipWriterPrivate::Symlink, fileName, QFile::encodeName(destination));
+    d->addEntry(MQZipWriterPrivate::Symlink, fileName, QFile::encodeName(destination));
 }
 
 /*!
    Closes the zip file.
 */
-void QZipWriter::close()
+void MQZipWriter::close()
 {
     if (!(d->device->openMode() & QIODevice::WriteOnly)) {
         d->device->close();

--- a/libmscore/qzipreader_p.h
+++ b/libmscore/qzipreader_p.h
@@ -61,22 +61,22 @@
 
 QT_BEGIN_NAMESPACE
 
-class QZipReaderPrivate;
+class MQZipReaderPrivate;
 
-class Q_GUI_EXPORT QZipReader
+class MQZipReader
 {
 public:
-    QZipReader(const QString &fileName, QIODevice::OpenMode mode = QIODevice::ReadOnly );
+    MQZipReader(const QString &fileName, QIODevice::OpenMode mode = QIODevice::ReadOnly );
 
-    explicit QZipReader(QIODevice *device);
-    ~QZipReader();
+    explicit MQZipReader(QIODevice *device);
+    ~MQZipReader();
 
     QIODevice* device() const;
 
     bool isReadable() const;
     bool exists() const;
 
-    struct Q_GUI_EXPORT FileInfo
+    struct FileInfo
     {
         FileInfo();
         FileInfo(const FileInfo &other);
@@ -114,8 +114,8 @@ public:
     void close();
 
 private:
-    QZipReaderPrivate *d;
-    Q_DISABLE_COPY(QZipReader)
+    MQZipReaderPrivate *d;
+    Q_DISABLE_COPY(MQZipReader)
 };
 
 QT_END_NAMESPACE

--- a/libmscore/qzipwriter_p.h
+++ b/libmscore/qzipwriter_p.h
@@ -58,16 +58,16 @@
 
 QT_BEGIN_NAMESPACE
 
-class QZipWriterPrivate;
+class MQZipWriterPrivate;
 
 
-class Q_GUI_EXPORT QZipWriter
+class MQZipWriter
 {
 public:
-    QZipWriter(const QString &fileName, QIODevice::OpenMode mode = (QIODevice::WriteOnly | QIODevice::Truncate) );
+    MQZipWriter(const QString &fileName, QIODevice::OpenMode mode = (QIODevice::WriteOnly | QIODevice::Truncate) );
 
-    explicit QZipWriter(QIODevice *device);
-    ~QZipWriter();
+    explicit MQZipWriter(QIODevice *device);
+    ~MQZipWriter();
 
     QIODevice* device() const;
 
@@ -106,8 +106,8 @@ public:
 
     void close();
 private:
-    QZipWriterPrivate *d;
-    Q_DISABLE_COPY(QZipWriter)
+    MQZipWriterPrivate *d;
+    Q_DISABLE_COPY(MQZipWriter)
 };
 
 QT_END_NAMESPACE

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -385,7 +385,7 @@ void Score::saveCompressedFile(QFileInfo& info, bool onlySelection)
 
 void Score::saveCompressedFile(QIODevice* f, QFileInfo& info, bool onlySelection)
       {
-      QZipWriter uz(f);
+      MQZipWriter uz(f);
 
       QString fn = info.completeBaseName() + ".mscx";
       QBuffer cbuf;
@@ -558,7 +558,7 @@ void Score::saveFile(QIODevice* f, bool msczFormat, bool onlySelection)
 
 Score::FileError Score::loadCompressedMsc(QString name, bool ignoreVersionError)
       {
-      QZipReader uz(name);
+      MQZipReader uz(name);
       if (!uz.exists()) {
             qDebug("loadCompressedMsc: <%s> not found\n", qPrintable(name));
             MScore::lastError = QT_TRANSLATE_NOOP("file", "file not found");
@@ -587,8 +587,8 @@ Score::FileError Score::loadCompressedMsc(QString name, bool ignoreVersionError)
       QByteArray dbuf = uz.fileData(rootfile);
       if (dbuf.isEmpty()) {
 //            qDebug("root file <%s> is empty", qPrintable(rootfile));
-            QList<QZipReader::FileInfo> fil = uz.fileInfoList();
-            foreach(const QZipReader::FileInfo& fi, fil) {
+            QList<MQZipReader::FileInfo> fil = uz.fileInfoList();
+            foreach(const MQZipReader::FileInfo& fi, fil) {
                   if (fi.filePath.endsWith(".mscx")) {
                         dbuf = uz.fileData(fi.filePath);
                         break;
@@ -1042,7 +1042,7 @@ void Score::print(QPainter* painter, int pageNo)
 
 QByteArray Score::readCompressedToBuffer()
       {
-      QZipReader uz(filePath());
+      MQZipReader uz(filePath());
 
       QByteArray cbuf = uz.fileData("META-INF/container.xml");
 

--- a/libmscore/xml.cpp
+++ b/libmscore/xml.cpp
@@ -274,6 +274,7 @@ bool compareProperty(void* val, void* defaultVal)
 
 Xml::Xml()
       {
+      setCodec("UTF-8");
       stack.clear();
       curTick       = 0;
       curTrack      = -1;

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -351,6 +351,7 @@ if (MINGW)
       portaudio
       portmidi
       winmm
+      z
       )
 
    if (OMR)

--- a/mscore/capxml.cpp
+++ b/mscore/capxml.cpp
@@ -1100,7 +1100,7 @@ void convertCapella(Score* score, Capella* cap, bool capxMode);
 Score::FileError importCapXml(Score* score, const QString& name)
       {
       qDebug("importCapXml(score %p, name %s)", score, qPrintable(name));
-      QZipReader uz(name);
+      MQZipReader uz(name);
       if (!uz.exists()) {
             qDebug("importCapXml: <%s> not found", qPrintable(name));
             MScore::lastError = QT_TRANSLATE_NOOP("file", "file not found");

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -3863,7 +3863,7 @@ void ExportMusicXml::write(QIODevice* dev)
             bracket[i] = 0;
 
       xml.setDevice(dev);
-      xml.setCodec("utf8");
+      xml.setCodec("UTF-8");
       xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
       xml << "<!DOCTYPE score-partwise PUBLIC \"-//Recordare//DTD MusicXML 3.0 Partwise//EN\" \"http://www.musicxml.org/dtds/partwise.dtd\">\n";
       xml.stag("score-partwise");
@@ -4446,7 +4446,7 @@ bool saveXml(Score* score, const QString& name)
 
 bool saveMxl(Score* score, const QString& name)
       {
-      QZipWriter uz(name);
+      MQZipWriter uz(name);
 
       QFileInfo fi(name);
 #if 0
@@ -4462,6 +4462,7 @@ bool saveMxl(Score* score, const QString& name)
       cbuf.open(QIODevice::ReadWrite);
       Xml xml;
       xml.setDevice(&cbuf);
+      xml.setCodec("UTF-8");
       xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
       xml.stag("container");
       xml.stag("rootfiles");

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -492,7 +492,7 @@ Extract rootfile from compressed MusicXML file \a qf, return true if OK and fals
 
 static bool extractRootfile(QFile* qf, QByteArray& data)
       {
-      QZipReader f(qf->fileName());
+      MQZipReader f(qf->fileName());
       data = f.fileData("META-INF/container.xml");
 
       QDomDocument container;

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -945,7 +945,7 @@ bool Palette::read(const QString& p)
       if (!path.endsWith(".mpal"))
             path += ".mpal";
 
-      QZipReader f(path);
+      MQZipReader f(path);
       if (!f.exists())
             return false;
       clear();
@@ -1049,7 +1049,7 @@ void Palette::write(const QString& p)
       if (!path.endsWith(".mpal"))
             path += ".mpal";
 
-      QZipWriter f(path);
+      MQZipWriter f(path);
       // f.setCompressionPolicy(QZipWriter::NeverCompress);
       f.setCreationPermissions(
          QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner
@@ -1057,7 +1057,7 @@ void Palette::write(const QString& p)
          | QFile::ReadGroup | QFile::WriteGroup | QFile::ExeGroup
          | QFile::ReadOther | QFile::WriteOther | QFile::ExeOther);
 
-      if (f.status() != QZipWriter::NoError) {
+      if (f.status() != MQZipWriter::NoError) {
             writeFailed(path);
             return;
             }
@@ -1097,7 +1097,7 @@ void Palette::write(const QString& p)
       f.addFile("palette.xml", cbuf.data());
       }
       f.close();
-      if (f.status() != QZipWriter::NoError)
+      if (f.status() != MQZipWriter::NoError)
             writeFailed(path);
       }
 

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -234,14 +234,14 @@ void Workspace::write()
             dir.mkpath(_path);
             _path += "/" + _name + ext;
             }
-      QZipWriter f(_path);
+      MQZipWriter f(_path);
       f.setCreationPermissions(
          QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner
          | QFile::ReadUser | QFile::WriteUser | QFile::ExeUser
          | QFile::ReadGroup | QFile::WriteGroup | QFile::ExeGroup
          | QFile::ReadOther | QFile::WriteOther | QFile::ExeOther);
 
-      if (f.status() != QZipWriter::NoError) {
+      if (f.status() != MQZipWriter::NoError) {
             writeFailed(_path);
             return;
             }
@@ -291,7 +291,7 @@ void Workspace::write()
       cbuf.close();
       }
 
-      if (f.status() != QZipWriter::NoError)
+      if (f.status() != MQZipWriter::NoError)
             writeFailed(_path);
       }
 
@@ -310,7 +310,7 @@ void Workspace::read()
       QFileInfo fi(_path);
       _readOnly = !fi.isWritable();
 
-      QZipReader f(_path);
+      MQZipReader f(_path);
       QByteArray ba = f.fileData("META-INF/container.xml");
 
       XmlReader e(ba);

--- a/zerberus/instrument.cpp
+++ b/zerberus/instrument.cpp
@@ -40,10 +40,10 @@ Sample::~Sample()
 //   readSample
 //---------------------------------------------------------
 
-Sample* ZInstrument::readSample(const QString& s, QZipReader* uz)
+Sample* ZInstrument::readSample(const QString& s, MQZipReader* uz)
       {
       if (uz) {
-            QList<QZipReader::FileInfo> fi = uz->fileInfoList();
+            QList<MQZipReader::FileInfo> fi = uz->fileInfoList();
 
             buf = uz->fileData(s);
             if (buf.isEmpty()) {
@@ -156,7 +156,7 @@ bool ZInstrument::loadFromFile(const QString& path)
             printf("<%s> not a orchestra file\n", qPrintable(path));
             return false;
             }
-      QZipReader uz(path);
+      MQZipReader uz(path);
       if (!uz.exists()) {
             printf("Instrument::load: %s not found\n", qPrintable(path));
             return false;
@@ -174,7 +174,7 @@ bool ZInstrument::loadFromFile(const QString& path)
 //    read orchestra
 //---------------------------------------------------------
 
-bool ZInstrument::read(const QByteArray& buf, QZipReader* /*uz*/, const QString& /*path*/)
+bool ZInstrument::read(const QByteArray& buf, MQZipReader* /*uz*/, const QString& /*path*/)
       {
       Ms::XmlReader e(buf);
       while (e.readNextStartElement()) {

--- a/zerberus/instrument.h
+++ b/zerberus/instrument.h
@@ -18,7 +18,7 @@
 
 class Zerberus;
 class XmlReader;
-class QZipReader;
+class MQZipReader;
 struct Zone;
 struct SfzRegion;
 class Sample;
@@ -38,7 +38,7 @@ class ZInstrument {
       bool loadFromFile(const QString&);
       bool loadSfz(const QString&);
       bool loadFromDir(const QString&);
-      bool read(const QByteArray&, QZipReader*, const QString& path);
+      bool read(const QByteArray&, MQZipReader*, const QString& path);
 
    public:
       ZInstrument(Zerberus*);
@@ -52,7 +52,7 @@ class ZInstrument {
       QString path() const                  { return instrumentPath; }
       const std::list<Zone*>& zones() const { return _zones;  }
       std::list<Zone*>& zones()             { return _zones;  }
-      Sample* readSample(const QString& s, QZipReader* uz);
+      Sample* readSample(const QString& s, MQZipReader* uz);
       void addZone(Zone* z)                 { _zones.push_back(z); }
       void addRegion(SfzRegion&);
 


### PR DESCRIPTION
This is a proposed fix for http://musescore.org/en/node/21910 and http://musescore.org/en/node/21838 it's a bit invasive and I would like some feedback before merging. In particular, does it work as expected on Mac and Linux?

Basically, I rename all the zip classes to make sure that we are using them at runtime. 
I changed the encoding of the filename in the zip file to UTF-8.
Apparently, TextStream doesn't care about the codec if it's set before the device. I added setCodec after each setDevice in exportxml.cpp
