### PR TITLE
Fix 21190 - misplaced ledger lines for whole notes

### DIFF
--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -78,8 +78,8 @@ class Chord : public ChordRest {
       virtual qreal upPos()   const;
       virtual qreal downPos() const;
       virtual qreal centerX() const;
-      void addLedgerLine(qreal x, int staffIdx, int line, int extend, bool visible, qreal hw);
-      void addLedgerLines(qreal x, int move);
+      void addLedgerLine(int staffIdx, int line, bool visible, qreal x, Spatium len);
+      void addLedgerLines(int move);
       void processSiblings(std::function<void(Element*)> func);
       void layoutPitched();
       void layoutTablature();


### PR DESCRIPTION
Fix 21190 - misplaced ledger lines for whole notes

Fixed by computing a stem x-position in Chord::layoutPitched() which corresponds to the actual chord note widths and positions, rather than relying on a global, fixed value (score()->noteHeadWidth() ).

For details, see http://musescore.org/en/node/21190
