### PR TITLE
Inspector for generic element: make ranges for X and Y offsets wider.

### DIFF
--- a/mscore/inspector/inspector_element.ui
+++ b/mscore/inspector/inspector_element.ui
@@ -124,7 +124,7 @@
         <double>-100.000000000000000</double>
        </property>
        <property name="maximum">
-        <double>100.000000000000000</double>
+        <double>200.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>0.500000000000000</double>
@@ -185,10 +185,10 @@
         <string extracomment="spatium unit">sp</string>
        </property>
        <property name="minimum">
-        <double>-10.000000000000000</double>
+        <double>-200.000000000000000</double>
        </property>
        <property name="maximum">
-        <double>10.000000000000000</double>
+        <double>300.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>0.500000000000000</double>


### PR DESCRIPTION
For instance, while placing a text element within a full page frame, the current ranges are too strict, as for instance Y offset is limited to 10 sp max.
