### PR TITLE
make sure new scores get a chordList

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -536,6 +536,11 @@ void MuseScore::newFile()
             score->fileInfo()->setFile(createDefaultName());
             newWizard->createInstruments(score);
             }
+      if (!score->style()->chordList()->loaded()) {
+            if (score->style()->value(ST_chordsXmlFile).toBool())
+                  score->style()->chordList()->read("chords.xml");
+            score->style()->chordList()->read(score->style()->value(ST_chordDescriptionFile).toString());
+            }
       if (!newWizard->title().isEmpty())
             score->fileInfo()->setFile(newWizard->title());
       Measure* pm = score->firstMeasure();


### PR DESCRIPTION
New scores created from scratch inherit style from defaultStyle, which used to be populated during reading of the the Chordname palette item.  Change makes sure chordList is loaded in new score whether already present in defaultStyle or not.
