### PR TITLE
Fix post 22235: ledger lines in chords with seconds

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -583,6 +583,8 @@ void Chord::addLedgerLines(int move)
                   visible = true;         // all lines are visible (WHICH IS NOT ALWAYS TRUE!)
 
             int l = note->line();         // check note line outside current range
+            if (l >= 0 && l < minLineBelow)     // if this note has no ledger lines
+                  continue;               // just ignore it
             if (l < minLine)  minLine = l;
             if (l > maxLine)  maxLine = l;
 


### PR DESCRIPTION
Fix uselessly wide ledger lines in chords with seconds.

If a chord contains an interval of a second (i.e. with flipped note heads) but the flipped note head(s) require no ledger lines, lines wide as the entire chords are generated.

Fixed by ignoring note heads within staff boundaries while computing ledger lines.

See http://musescore.org/en/node/22235 for details and a sample. Note that this fix corrects the second problem in that post, but (yet?) the first.
