### PR TITLE
Fix #22235 : some ledger lines are too wide in chords with seconds.

### DIFF
--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include "chordrest.h"
 #include "noteevent.h"
+#include <vector>
 
 class QPainter;
 
@@ -52,6 +53,13 @@ enum TremoloChordType { TremoloSingle, TremoloFirstNote, TremoloSecondNote };
 class Chord : public ChordRest {
       Q_OBJECT
 
+      struct LedgerLineData {
+            int   line;
+            qreal minX, maxX;
+            bool  visible;
+            bool  accidental;
+            };
+
       Q_PROPERTY(QQmlListProperty<Ms::Note> notes READ qmlNotes)
       Q_PROPERTY(QQmlListProperty<Ms::Lyrics> lyrics READ qmlLyrics)
 
@@ -78,7 +86,8 @@ class Chord : public ChordRest {
       virtual qreal upPos()   const;
       virtual qreal downPos() const;
       virtual qreal centerX() const;
-      void addLedgerLine(int staffIdx, int line, bool visible, qreal x, Spatium len);
+//      void addLedgerLine(int staffIdx, int line, bool visible, qreal x, Spatium len);
+      void createLedgerLines(int track, std::vector<LedgerLineData> &vecLines, bool visible);
       void addLedgerLines(int move);
       void processSiblings(std::function<void(Element*)> func);
       void layoutPitched();


### PR DESCRIPTION
Fix #22235 : some ledger lines are too wide in chords with seconds.

If a chord contains an interval of a second (i.e. with flipped note heads) but the flipped note head(s) require no ledger lines OR topmost/bottommost note(s) only need short lines, lines wide as the entire chord are generated.

Fixed by constructing ledger lines in two passes each from the 'outside' of the chord toward the staff, once for lines below and once for lines above the staff

See http://musescore.org/en/node/22235 for details and a sample. The commit should fix both issues in the post.

NOTE: I had to remove the 'experimental' feature of avoiding collision between ledger lines and accidentals: the relevant test is there, but it is not clear to me what to do in this case.
