### PR TITLE
Fix part name when changing instrument

### DIFF
--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -117,6 +117,9 @@ void EditStaff::updateInstrument()
       df = nl.isEmpty() ? QTextDocumentFragment() : nl[0].name;
       longName->setHtml(df.toHtml());
 
+      if (partName->text() == instrumentName->text())    // Updates part name is no custom name has been set before
+            partName->setText(instrument.trackName());
+
       instrumentName->setText(instrument.trackName());
 
       _minPitchA = instrument.minPitchA();


### PR DESCRIPTION
This fix the issue http://musescore.org/en/node/22253

If the part name has never been changed (the part name = the instrument name), the new instrument name is assign to the part name.
