### PR TITLE
Re-factor presets and staff types.

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -348,7 +348,7 @@ void Articulation::draw(QPainter* painter) const
       SymId sym = _up ? articulationList[articulationType()].upSym : articulationList[articulationType()].downSym;
       int flags = articulationList[articulationType()].flags;
       if (staff()) {
-            if (staff()->staffGroup() == TAB_STAFF) {
+            if (staff()->staffGroup() == TAB_STAFF_GROUP) {
                   if (!(flags & ARTICULATION_SHOW_IN_TABLATURE))
                         return;
                   }

--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -31,27 +31,27 @@ namespace Ms {
 // table must be in sync with enum ClefType
 const ClefInfo clefTable[] = {
 // tag    xmlName    line oCh pOff|-lines for sharps---||---lines for flats--|   name
-{ "G",    "G",         2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Treble clef"),            PITCHED_STAFF },
-{ "G8va", "G",         2,  1, 52, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Treble clef 8va"),        PITCHED_STAFF },
-{ "G15ma","G",         2,  2, 59, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Treble clef 15ma"),       PITCHED_STAFF },
-{ "G8vb", "G",         2, -1, 38, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Treble clef 8vb"),        PITCHED_STAFF },
-{ "F",    "F",         4,  0, 33, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef"),              PITCHED_STAFF },
-{ "F8vb", "F",         4, -1, 26, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef 8vb"),          PITCHED_STAFF },
-{ "F15mb","F",         4, -2, 19, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef 15mb"),         PITCHED_STAFF },
-{ "F3",   "F",         3,  0, 35, { 4, 0, 3,-1, 2, 5, 1, 1, 5, 2, 6, 3, 7, 4 }, TR("Baritone clef (F clef)"), PITCHED_STAFF },
-{ "F5",   "F",         5,  0, 31, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Subbass clef"),           PITCHED_STAFF },
-{ "C1",   "C",         1,  0, 43, { 5, 1, 4, 0, 3,-1, 2, 2,-1, 3, 0, 4, 1, 5 }, TR("Soprano clef"),           PITCHED_STAFF }, // CLEF_C1
-{ "C2",   "C",         2,  0, 41, { 3, 6, 2, 5, 1, 4, 0, 0, 4, 1, 5, 2, 6, 3 }, TR("Mezzo-soprano clef"),     PITCHED_STAFF }, // CLEF_C2
-{ "C3",   "C",         3,  0, 39, { 1, 4, 0, 3, 6, 2, 5, 5, 2, 6, 3, 7, 4, 8 }, TR("Alto clef"),              PITCHED_STAFF }, // CLEF_C3
-{ "C4",   "C",         4,  0, 37, { 6, 2, 5, 1, 4, 0, 3, 3, 0, 4, 1, 5, 2, 6 }, TR("Tenor clef"),             PITCHED_STAFF }, // CLEF_C4
-{ "TAB",  "TAB",       5,  0,  0, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Tablature"),              TAB_STAFF     },
-{ "PERC", "percussion",2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Percussion"),             PERCUSSION_STAFF },
-{ "C5",   "C",         5,  0, 35, { 4, 0, 3,-1, 2, 5, 1, 1, 5, 2, 6, 3, 7, 4 }, TR("Baritone clef (C clef)"), PITCHED_STAFF }, // CLEF_C5
-{ "G1",   "G",         1,  0, 47, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("French violin clef"),     PITCHED_STAFF }, // CLEF_G4
-{ "F8va", "F",         4,  1, 40, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef 8va"),          PITCHED_STAFF }, // CLEF_F_8VA
-{ "F15ma","F",         4,  2, 47, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef 15ma"),         PITCHED_STAFF }, // CLEF_F_15MA
-{ "PERC2","percussion",2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Percussion"),             PERCUSSION_STAFF }, // CLEF_PERC2 placeholder
-{ "TAB2", "TAB",       5,  0,  0, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Tablature2"),             TAB_STAFF     },
+{ "G",    "G",         2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Treble clef"),            STANDARD_STAFF_GROUP  },
+{ "G8va", "G",         2,  1, 52, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Treble clef 8va"),        STANDARD_STAFF_GROUP  },
+{ "G15ma","G",         2,  2, 59, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Treble clef 15ma"),       STANDARD_STAFF_GROUP  },
+{ "G8vb", "G",         2, -1, 38, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Treble clef 8vb"),        STANDARD_STAFF_GROUP  },
+{ "F",    "F",         4,  0, 33, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef"),              STANDARD_STAFF_GROUP  },
+{ "F8vb", "F",         4, -1, 26, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef 8vb"),          STANDARD_STAFF_GROUP  },
+{ "F15mb","F",         4, -2, 19, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef 15mb"),         STANDARD_STAFF_GROUP  },
+{ "F3",   "F",         3,  0, 35, { 4, 0, 3,-1, 2, 5, 1, 1, 5, 2, 6, 3, 7, 4 }, TR("Baritone clef (F clef)"), STANDARD_STAFF_GROUP  },
+{ "F5",   "F",         5,  0, 31, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Subbass clef"),           STANDARD_STAFF_GROUP  },
+{ "C1",   "C",         1,  0, 43, { 5, 1, 4, 0, 3,-1, 2, 2,-1, 3, 0, 4, 1, 5 }, TR("Soprano clef"),           STANDARD_STAFF_GROUP  }, // CLEF_C1
+{ "C2",   "C",         2,  0, 41, { 3, 6, 2, 5, 1, 4, 0, 0, 4, 1, 5, 2, 6, 3 }, TR("Mezzo-soprano clef"),     STANDARD_STAFF_GROUP  }, // CLEF_C2
+{ "C3",   "C",         3,  0, 39, { 1, 4, 0, 3, 6, 2, 5, 5, 2, 6, 3, 7, 4, 8 }, TR("Alto clef"),              STANDARD_STAFF_GROUP  }, // CLEF_C3
+{ "C4",   "C",         4,  0, 37, { 6, 2, 5, 1, 4, 0, 3, 3, 0, 4, 1, 5, 2, 6 }, TR("Tenor clef"),             STANDARD_STAFF_GROUP  }, // CLEF_C4
+{ "TAB",  "TAB",       5,  0,  0, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Tablature"),              TAB_STAFF_GROUP       },
+{ "PERC", "percussion",2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Percussion"),             PERCUSSION_STAFF_GROUP},
+{ "C5",   "C",         5,  0, 35, { 4, 0, 3,-1, 2, 5, 1, 1, 5, 2, 6, 3, 7, 4 }, TR("Baritone clef (C clef)"), STANDARD_STAFF_GROUP  }, // CLEF_C5
+{ "G1",   "G",         1,  0, 47, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("French violin clef"),     STANDARD_STAFF_GROUP  }, // CLEF_G4
+{ "F8va", "F",         4,  1, 40, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef 8va"),          STANDARD_STAFF_GROUP  }, // CLEF_F_8VA
+{ "F15ma","F",         4,  2, 47, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef 15ma"),         STANDARD_STAFF_GROUP  }, // CLEF_F_15MA
+{ "PERC2","percussion",2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Percussion"),             PERCUSSION_STAFF_GROUP}, // CLEF_PERC2 placeholder
+{ "TAB2", "TAB",       5,  0,  0, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Tablature2"),             TAB_STAFF_GROUP       },
       };
 #undef TR
 
@@ -141,10 +141,10 @@ void Clef::layout()
                   }
 
             // tablatures:
-            if (staffType->group() == TAB_STAFF) {
+            if (staffType->group() == TAB_STAFF_GROUP) {
                   // if current clef type not compatible with tablature,
                   // set tab clef according to score style
-                  if (clefTable[clefType()].staffGroup != TAB_STAFF)
+                  if (clefTable[clefType()].staffGroup != TAB_STAFF_GROUP)
                         setClefType( ClefType(score()->styleI(ST_tabClef)) );
                   }
             // all staff types: init values from staff type

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1082,14 +1082,14 @@ void Score::upDown(bool up, UpDownMode mode)
             Tablature* tab;
 
             switch(oNote->staff()->staffType()->group()) {
-                  case PERCUSSION_STAFF:
+                  case PERCUSSION_STAFF_GROUP:
                         {
                         Drumset* ds = part->instr()->drumset();
                         newPitch    = up ? ds->prevPitch(pitch) : ds->nextPitch(pitch);
                         newTpc      = oNote->tpc();
                         }
                         break;
-                  case TAB_STAFF:
+                  case TAB_STAFF_GROUP:
                         {
                         tab = part->instr()->tablature();
                         switch(mode) {
@@ -1149,7 +1149,7 @@ void Score::upDown(bool up, UpDownMode mode)
                               }
                         }
                         break;
-                  case PITCHED_STAFF:
+                  case STANDARD_STAFF_GROUP:
                         switch(mode) {
                               case UP_DOWN_OCTAVE:
                                     if (up) {
@@ -1230,7 +1230,7 @@ void Score::upDown(bool up, UpDownMode mode)
                   }
             // store fret change only if undoChangePitch has not been called,
             // as undoChangePitch() already manages fret changes, if necessary
-            else if( oNote->staff()->staffType()->group() == TAB_STAFF) {
+            else if( oNote->staff()->staffType()->group() == TAB_STAFF_GROUP) {
                   bool refret = false;
                   if (oNote->string() != string) {
                         undoChangeProperty(oNote, P_STRING, string);

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -685,7 +685,7 @@ void Score::putNote(const Position& p, bool replace)
       StaffTypeTablature * tab = 0;
 
       switch(st->staffType()->group()) {
-            case PERCUSSION_STAFF: {
+            case PERCUSSION_STAFF_GROUP: {
                   if (_is.rest)
                         break;
                   Drumset* ds   = instr->drumset();
@@ -698,7 +698,7 @@ void Score::putNote(const Position& p, bool replace)
                   stemDirection = ds->stemDirection(nval.pitch);
                   break;
                   }
-            case TAB_STAFF: {
+            case TAB_STAFF_GROUP: {
                   if (_is.rest)
                         return;
                   neck = instr->tablature();
@@ -718,7 +718,7 @@ void Score::putNote(const Position& p, bool replace)
                   break;
                   }
 
-            case PITCHED_STAFF: {
+            case STANDARD_STAFF_GROUP: {
                   AccidentalVal acci = s->measure()->findAccidental(s, staffIdx, line);
                   int step   = absStep(line, clef);
                   int octave = step/7;

--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -60,7 +60,7 @@ Drumset* InputState::drumset() const
 StaffGroup InputState::staffGroup() const
       {
       if (_segment == 0 || _track == -1)
-            return PITCHED_STAFF;
+            return STANDARD_STAFF_GROUP;
       return _segment->score()->staff(_track/VOICES)->staffType()->group();
       }
 

--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -105,7 +105,7 @@ InstrumentTemplate::InstrumentTemplate()
       maxPitchA          = 127;
       minPitchP          = 0;
       maxPitchP          = 127;
-      staffGroup        = PITCHED_STAFF;
+      staffGroup        = STANDARD_STAFF_GROUP;
       staffTypePreset   = 0;
       useDrumset         = false;
       drumset            = 0;
@@ -454,11 +454,11 @@ void InstrumentTemplate::read(XmlReader& e)
                   QString xmlPresetName = e.attribute("staffTypePreset", "");
                   QString stfGroup = e.readElementText();
                   if (stfGroup == "percussion")
-                        staffGroup = PERCUSSION_STAFF;
+                        staffGroup = PERCUSSION_STAFF_GROUP;
                   else if (stfGroup == "tablature")
-                        staffGroup = TAB_STAFF;
+                        staffGroup = TAB_STAFF_GROUP;
                   else
-                        staffGroup = PITCHED_STAFF;
+                        staffGroup = STANDARD_STAFF_GROUP;
                   int staffTypeIdx;
                   const StaffType* stfType = 0;
                   if (!xmlPresetName.isEmpty())

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3402,7 +3402,7 @@ void Measure::updateAccidentals(Segment* segment, int staffIdx, AccidentalState*
             // TAB_STAFF is different, as each note has to be fretted
             // in the context of the all of the chords of the whole segment
 
-            if (staffGroup == TAB_STAFF) {
+            if (staffGroup == TAB_STAFF_GROUP) {
                   instrument->tablature()->fretChords(chord);
                   continue;               // skip other staff type cases
                   }
@@ -3413,7 +3413,7 @@ void Measure::updateAccidentals(Segment* segment, int staffIdx, AccidentalState*
             for (int i = 0; i < n; ++i) {
                   Note* note = chord->notes().at(i);
                   switch(staffGroup) {
-                        case PITCHED_STAFF:
+                        case STANDARD_STAFF_GROUP:
                               if (note->tieBack()) {
                                     if (note->accidental() && note->tpc() == note->tieBack()->startNote()->tpc()) {
                                           // TODO: remove accidental only if note is not
@@ -3423,7 +3423,7 @@ void Measure::updateAccidentals(Segment* segment, int staffIdx, AccidentalState*
                                     }
                               note->updateAccidental(tversatz);
                               break;
-                        case PERCUSSION_STAFF:
+                        case PERCUSSION_STAFF_GROUP:
                               {
                               Drumset* drumset = instrument->drumset();
                               int pitch = note->pitch();
@@ -3437,7 +3437,7 @@ void Measure::updateAccidentals(Segment* segment, int staffIdx, AccidentalState*
                                     }
                               }
                               break;
-                        case TAB_STAFF:   // to avoid compiler warning
+                        case TAB_STAFF_GROUP:   // to avoid compiler warning
                               break;
                         }
                   }

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -242,9 +242,9 @@ enum UpDownMode {
 //---------------------------------------------------------
 
 enum StaffGroup {
-      PITCHED_STAFF, PERCUSSION_STAFF, TAB_STAFF
+      STANDARD_STAFF_GROUP, PERCUSSION_STAFF_GROUP, TAB_STAFF_GROUP
       };
-const int STAFF_GROUP_MAX = TAB_STAFF + 1;      // out of enum to avoid compiler complains about not handled switch cases
+const int STAFF_GROUP_MAX = TAB_STAFF_GROUP + 1;      // out of enum to avoid compiler complains about not handled switch cases
 
 //---------------------------------------------------------
 //   ClefType

--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -255,7 +255,7 @@ void Part::setInstrument(const Instrument& i, int tick)
 
       if (!_score->styleB(ST_concertPitch) && i.transpose().chromatic) {
             foreach(Staff* staff, _staves) {
-                  if (staff->staffType()->group() != PERCUSSION_STAFF)
+                  if (staff->staffType()->group() != PERCUSSION_STAFF_GROUP)
                         _score->cmdTransposeStaff(staff->idx(), i.transpose(), false);
                   }
             }
@@ -263,7 +263,7 @@ void Part::setInstrument(const Instrument& i, int tick)
             foreach(Staff* staff, _staves) {
                   Interval iv(i.transpose());
                   iv.flip();
-                  if (staff->staffType()->group() != PERCUSSION_STAFF)
+                  if (staff->staffType()->group() != PERCUSSION_STAFF_GROUP)
                         _score->cmdTransposeStaff(staff->idx(), iv, false);
                   }
             }

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -242,7 +242,7 @@ void Part::read114(XmlReader& e)
       if (instr(0)->useDrumset()) {
             foreach(Staff* staff, _staves) {
                   int lines = staff->lines();
-                  staff->setStaffType(score()->staffType(PERCUSSION_STAFF_TYPE));
+                  staff->setStaffType(score()->staffType(PERC_DEFAULT_STAFF_TYPE));
                   staff->setLines(lines);
                   }
             }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -279,8 +279,11 @@ void Score::init()
       _revisions      = new Revisions;
       _symIdx         = 0;
       _pageNumberOffset = 0;
-      foreach (StaffType* st, Ms::staffTypes)
-             addStaffType(st);
+      int numOfPresets = StaffType::numOfPresets();
+      for (int idx = 0; idx < numOfPresets; idx++) {
+            StaffType * st = StaffType::preset(idx)->clone();
+            addStaffType(st);
+            }
 
       _mscVersion     = MSCVERSION;
       _created        = false;
@@ -2542,7 +2545,7 @@ void Score::cmdConcertPitchChanged(bool flag, bool useDoubleSharpsFlats)
       undo(new ChangeConcertPitch(this, flag));
 
       foreach(Staff* staff, _staves) {
-            if (staff->staffType()->group() == PERCUSSION_STAFF)
+            if (staff->staffType()->group() == PERCUSSION_STAFF_GROUP)
                   continue;
             Instrument* instr = staff->part()->instr();
             Interval interval = instr->transpose();

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -163,7 +163,7 @@ Staff::Staff(Score* s)
       _rstaff         = 0;
       _part           = 0;
       _keymap[0]      = KeySigEvent(0);                  // default to C major
-      _staffType      = _score->staffType(PITCHED_STAFF_TYPE);
+      _staffType      = _score->staffType(STANDARD_STAFF_TYPE);
       _small          = false;
       _invisible      = false;
       _userDist       = .0;
@@ -181,7 +181,7 @@ Staff::Staff(Score* s, Part* p, int rs)
       _rstaff         = rs;
       _part           = p;
       _keymap[0]      = KeySigEvent(0);                  // default to C major
-      _staffType      = _score->staffType(PITCHED_STAFF_TYPE);
+      _staffType      = _score->staffType(STANDARD_STAFF_TYPE);
       _small          = false;
       _invisible      = false;
       _userDist       = .0;
@@ -714,9 +714,9 @@ void Staff::setStaffType(StaffType* st)
 
       if (_staffType->group() != csg) {
             switch(_staffType->group()) {
-                  case TAB_STAFF:        ct = ClefType(score()->styleI(ST_tabClef)); break;
-                  case PITCHED_STAFF:    ct = CLEF_G; break;      // TODO: use preferred clef for instrument
-                  case PERCUSSION_STAFF: ct = CLEF_PERC; break;
+                  case TAB_STAFF_GROUP:        ct = ClefType(score()->styleI(ST_tabClef)); break;
+                  case STANDARD_STAFF_GROUP:   ct = CLEF_G; break;      // TODO: use preferred clef for instrument
+                  case PERCUSSION_STAFF_GROUP: ct = CLEF_PERC; break;
                   }
             setInitialClef(ct);
             }
@@ -780,7 +780,7 @@ void Staff::initFromStaffType(const StaffType* staffType)
       // get staff type if given (if none, get default preset for default staff group)
       const StaffType* presetStaffType = staffType;
       if (!presetStaffType)
-            presetStaffType = StaffType::getDefaultPreset(PITCHED_STAFF, 0);
+            presetStaffType = StaffType::getDefaultPreset(STANDARD_STAFF_GROUP, 0);
 
       // look for a staff type with same structure among staff types already defined in the score
       StaffType* st = 0;
@@ -839,11 +839,11 @@ void Staff::setInitialClef(ClefType ct)
 bool Staff::genKeySig()
       {
       switch(_staffType->group()) {
-            case TAB_STAFF:
+            case TAB_STAFF_GROUP:
                   return false;
-            case PITCHED_STAFF:
+            case STANDARD_STAFF_GROUP:
                   return static_cast<StaffTypePitched*>(_staffType)->genKeysig();
-            case PERCUSSION_STAFF:
+            case PERCUSSION_STAFF_GROUP:
                   return static_cast<StaffTypePercussion*>(_staffType)->genKeysig();
             default:
                   return true;
@@ -857,11 +857,11 @@ bool Staff::genKeySig()
 bool Staff::showLedgerLines()
       {
       switch(_staffType->group()) {
-            case TAB_STAFF:
+            case TAB_STAFF_GROUP:
                   return false;
-            case PITCHED_STAFF:
+            case STANDARD_STAFF_GROUP:
                   return static_cast<StaffTypePitched*>(_staffType)->showLedgerLines();
-            case PERCUSSION_STAFF:
+            case PERCUSSION_STAFF_GROUP:
                   return static_cast<StaffTypePercussion*>(_staffType)->showLedgerLines();
             default:
                   return true;

--- a/libmscore/staff.h
+++ b/libmscore/staff.h
@@ -191,9 +191,9 @@ class Staff : public QObject {
       StaffType* staffType() const     { return _staffType;      }
       void setStaffType(StaffType* st);
       StaffGroup staffGroup() const    { return _staffType->group(); }
-      bool isPitchedStaff() const      { return staffGroup() == PITCHED_STAFF; }
-      bool isTabStaff() const          { return staffGroup() == TAB_STAFF; }
-      bool isDrumStaff() const         { return staffGroup() == PERCUSSION_STAFF; }
+      bool isPitchedStaff() const      { return staffGroup() == STANDARD_STAFF_GROUP; }
+      bool isTabStaff() const          { return staffGroup() == TAB_STAFF_GROUP; }
+      bool isDrumStaff() const         { return staffGroup() == PERCUSSION_STAFF_GROUP; }
 
       bool updateKeymap() const        { return _updateKeymap;   }
       void setUpdateKeymap(bool v)     { _updateKeymap = v;      }

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -1082,7 +1082,7 @@ struct StaffTypePreset {
       StaffType * staffType;                    // the actual StaffType settings
 };
 
-std::array<StaffTypePreset, 14> _presets;
+std::array<StaffTypePreset, STAFF_TYPES> _presets;
 
 static const int _defaultPreset[STAFF_GROUP_MAX] =
       { 0,              // default pitched preset is "stdNormal"
@@ -1104,7 +1104,7 @@ size_t StaffType::numOfPresets()
 const StaffType* StaffType::preset(int idx)
       {
       if (idx < 0 || idx >= (int)_presets.size())
-            return 0;
+            return _presets[0].staffType;
       return _presets[idx].staffType;
       }
 
@@ -1159,53 +1159,39 @@ const StaffType* StaffType::getDefaultPreset(StaffGroup grp, int *idx)
 void initStaffTypes()
       {
       // init staff type presets
-      //                                                       human readable name    lin dst clef  bars stmless time  key  ledger
-      StaffTypePitched*    st00 = new StaffTypePitched   (QObject::tr("normal"),        5, 1, true, true, false, true, true, true);
-      StaffTypePercussion* st01 = new StaffTypePercussion(QObject::tr("Perc. 1 lines"), 1, 1, true, true, false, true, true, true);
-      StaffTypePercussion* st02 = new StaffTypePercussion(QObject::tr("Perc. 3 lines"), 3, 1, true, true, false, true, true, true);
-      StaffTypePercussion* st03 = new StaffTypePercussion(QObject::tr("Perc. 5 lines"), 5, 1, true, true, false, true, true, true);
-      //                                                     human-readable name        lin dist  clef   bars stemless time  duration font                  size off genDur fret font                       size off  thru  minim style       onLin  rests  stmDn  stmThr upsDn  nums
-      StaffTypeTablature* st04 = new StaffTypeTablature(QObject::tr("Tab. 6-str simple"), 6, 1.5, true,  true, true,  false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Sans"),     9, 0, false, TAB_MINIM_NONE,   true,  false, true,  false, false, true);
-      StaffTypeTablature* st05 = new StaffTypeTablature(QObject::tr("Tab. 6-str common"), 6, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SHORTER,true,  false, true,  false, false, true);
-      StaffTypeTablature* st06 = new StaffTypeTablature(QObject::tr("Tab. 6-str full"),   6, 1.5, true,  true, false, true,  QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SLASHED,true,  true,  true,  true,  false, true);
-      StaffTypeTablature* st07 = new StaffTypeTablature(QObject::tr("Tab. 4-str simple"), 4, 1.5, true,  true, true,  false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Sans"),     9, 0, false, TAB_MINIM_NONE,   true,  false, true,  false, false, true);
-      StaffTypeTablature* st08 = new StaffTypeTablature(QObject::tr("Tab. 4-str common"), 4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SHORTER,true,  false, true,  false, false, true);
-      StaffTypeTablature* st09 = new StaffTypeTablature(QObject::tr("Tab. 4-str full"),   4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SLASHED,true,  true,  true,  true,  false, true);
-      StaffTypeTablature* st10 = new StaffTypeTablature(QObject::tr("Tab. ukulele"),      4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SHORTER,true,  true,  true,  false, false, true);
-      StaffTypeTablature* st11 = new StaffTypeTablature(QObject::tr("Tab. balalajka"),    3, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SHORTER,true,  true,  true,  false, false, true);
-      //                                               (QObject::tr("Tab. bandurria"),    6, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),   10, 0, false, TAB_MINIM_SLASHED,true,  true,  true,  true,  false, true);
-      StaffTypeTablature* st12 = new StaffTypeTablature(QObject::tr("Tab. 6-str Italian"),6, 1.5, false, true, true,  true,  QString("MuseScore Tab Italian"),15, 0, true,  QString("MuseScore Tab Renaiss"), 10, 0, true,  TAB_MINIM_NONE,   true,  true,  false, false, true,  true);
-      StaffTypeTablature* st13 = new StaffTypeTablature(QObject::tr("Tab. 6-str French"), 6, 1.5, false, true, true,  true,  QString("MuseScore Tab French"), 15, 0, true,  QString("MuseScore Tab Renaiss"), 10, 0, true,  TAB_MINIM_NONE,   false, false, false, false, false, false);
-      _presets[0].xmlName  = QString("stdNormal");          _presets[0].staffType  = st00;
-      _presets[1].xmlName  = QString("perc1Line");          _presets[1].staffType  = st01;
-      _presets[2].xmlName  = QString("perc3Line");          _presets[2].staffType  = st02;
-      _presets[3].xmlName  = QString("perc5Line");          _presets[3].staffType  = st03;
-      _presets[4].xmlName  = QString("tab6StrSimple");      _presets[4].staffType  = st04;
-      _presets[5].xmlName  = QString("tab6StrCommon");      _presets[5].staffType  = st05;
-      _presets[6].xmlName  = QString("tab6StrFull");        _presets[6].staffType  = st06;
-      _presets[7].xmlName  = QString("tab4StrSimple");      _presets[7].staffType  = st07;
-      _presets[8].xmlName  = QString("tab4StrCommon");      _presets[8].staffType  = st08;
-      _presets[9].xmlName  = QString("tab4StrFull");        _presets[9].staffType  = st09;
-      _presets[10].xmlName = QString("tabUkulele");         _presets[10].staffType = st10;
-      _presets[11].xmlName = QString("tabBalajka");         _presets[11].staffType = st11;
-      _presets[12].xmlName = QString("tab6StrItalian");     _presets[12].staffType = st12;
-      _presets[13].xmlName = QString("tab6StrFrench");      _presets[13].staffType = st13;
+//                                                                                 human readable name  lin dst clef  bars stmless time  key  ledger
+      _presets[STANDARD_STAFF_TYPE].staffType     = new StaffTypePitched   (QObject::tr("Standard"),      5, 1, true, true, false, true, true, true);
+      _presets[PERC_1LINE_STAFF_TYPE].staffType   = new StaffTypePercussion(QObject::tr("Perc. 1 lines"), 1, 1, true, true, false, true, true, true);
+      _presets[PERC_3LINE_STAFF_TYPE].staffType   = new StaffTypePercussion(QObject::tr("Perc. 3 lines"), 3, 1, true, true, false, true, true, true);
+      _presets[PERC_5LINE_STAFF_TYPE].staffType   = new StaffTypePercussion(QObject::tr("Perc. 5 lines"), 5, 1, true, true, false, true, true, true);
+//                                                                                     human-readable name  lin dist  clef   bars stemless time  duration font                 size off genDur fret font                       size off  thru  minim style       onLin  rests  stmDn  stmThr upsDn  nums
+      _presets[TAB_6SIMPLE_STAFF_TYPE].staffType  = new StaffTypeTablature(QObject::tr("Tab. 6-str simple"), 6, 1.5, true,  true, true,  false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Sans"),     9, 0, false, TAB_MINIM_NONE,   true,  false, true,  false, false, true);
+      _presets[TAB_6COMMON_STAFF_TYPE].staffType  = new StaffTypeTablature(QObject::tr("Tab. 6-str common"), 6, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SHORTER,true,  false, true,  false, false, true);
+      _presets[TAB_6FULL_STAFF_TYPE].staffType    = new StaffTypeTablature(QObject::tr("Tab. 6-str full"),   6, 1.5, true,  true, false, true,  QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SLASHED,true,  true,  true,  true,  false, true);
+      _presets[TAB_4SIMPLE_STAFF_TYPE].staffType  = new StaffTypeTablature(QObject::tr("Tab. 4-str simple"), 4, 1.5, true,  true, true,  false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Sans"),     9, 0, false, TAB_MINIM_NONE,   true,  false, true,  false, false, true);
+      _presets[TAB_4COMMON_STAFF_TYPE].staffType  = new StaffTypeTablature(QObject::tr("Tab. 4-str common"), 4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SHORTER,true,  false, true,  false, false, true);
+      _presets[TAB_4FULL_STAFF_TYPE].staffType    = new StaffTypeTablature(QObject::tr("Tab. 4-str full"),   4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SLASHED,true,  true,  true,  true,  false, true);
+      _presets[TAB_UKULELE_STAFF_TYPE].staffType  = new StaffTypeTablature(QObject::tr("Tab. ukulele"),      4, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SHORTER,true,  true,  true,  false, false, true);
+      _presets[TAB_BALALAJKA_STAFF_TYPE].staffType= new StaffTypeTablature(QObject::tr("Tab. balalajka"),    3, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),    9, 0, false, TAB_MINIM_SHORTER,true,  true,  true,  false, false, true);
+//                                                                        (QObject::tr("Tab. bandurria"),    6, 1.5, true,  true, false, false, QString("MuseScore Tab Modern"), 15, 0, false, QString("MuseScore Tab Serif"),   10, 0, false, TAB_MINIM_SLASHED,true,  true,  true,  true,  false, true);
+      _presets[TAB_ITALIAN_STAFF_TYPE].staffType  = new StaffTypeTablature(QObject::tr("Tab. 6-str Italian"),6, 1.5, false, true, true,  true,  QString("MuseScore Tab Italian"),15, 0, true,  QString("MuseScore Tab Renaiss"), 10, 0, true,  TAB_MINIM_NONE,   true,  true,  false, false, true,  true);
+      _presets[TAB_FRENCH_STAFF_TYPE].staffType   = new StaffTypeTablature(QObject::tr("Tab. 6-str French"), 6, 1.5, false, true, true,  true,  QString("MuseScore Tab French"), 15, 0, true,  QString("MuseScore Tab Renaiss"), 10, 0, true,  TAB_MINIM_NONE,   false, false, false, false, false, false);
 
-      // init built-in staff types
-
-      StaffTypePitched*    st0 = static_cast<StaffTypePitched*>(_presets[_defaultPreset[PITCHED_STAFF]].staffType)->clone();
-      StaffTypeTablature*  st1 = static_cast<StaffTypeTablature*>(_presets[_defaultPreset[TAB_STAFF]].staffType)->clone();
-      StaffTypePercussion* st2 = static_cast<StaffTypePercussion*>(_presets[_defaultPreset[PERCUSSION_STAFF]].staffType)->clone();
-      st0->setName(QObject::tr("Standard (built-in)"));
-      st1->setName(QObject::tr("Tablature (built-in)"));
-      st2->setName(QObject::tr("Percussion (built-in)"));
-      st0->setBuiltin(true);
-      st1->setBuiltin(true);
-      st2->setBuiltin(true);
-      staffTypes.append(st0);
-      staffTypes.append(st1);
-      staffTypes.append(st2);
+      _presets[STANDARD_STAFF_TYPE].xmlName     = QString("stdNormal");
+      _presets[PERC_1LINE_STAFF_TYPE].xmlName   = QString("perc1Line");
+      _presets[PERC_3LINE_STAFF_TYPE].xmlName   = QString("perc3Line");
+      _presets[PERC_5LINE_STAFF_TYPE].xmlName   = QString("perc5Line");
+      _presets[TAB_6SIMPLE_STAFF_TYPE].xmlName  = QString("tab6StrSimple");
+      _presets[TAB_6COMMON_STAFF_TYPE].xmlName  = QString("tab6StrCommon");
+      _presets[TAB_6FULL_STAFF_TYPE].xmlName    = QString("tab6StrFull");
+      _presets[TAB_4SIMPLE_STAFF_TYPE].xmlName  = QString("tab4StrSimple");
+      _presets[TAB_4COMMON_STAFF_TYPE].xmlName  = QString("tab4StrCommon");
+      _presets[TAB_4FULL_STAFF_TYPE].xmlName    = QString("tab4StrFull");
+      _presets[TAB_UKULELE_STAFF_TYPE].xmlName  = QString("tabUkulele");
+      _presets[TAB_BALALAJKA_STAFF_TYPE].xmlName= QString("tabBalajka");
+      _presets[TAB_ITALIAN_STAFF_TYPE].xmlName  = QString("tab6StrItalian");
+      _presets[TAB_FRENCH_STAFF_TYPE].xmlName   = QString("tab6StrFrench");
       }
 
-}
+}                 // namespace Ms
 

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -130,11 +130,18 @@ class StaffType {
       static const QString& presetName(int idx);
       };
 
-// first three staff types in staffTypes[] are built-in:
+// ready-made staff types:
 
 enum {
-      PITCHED_STAFF_TYPE, TAB_STAFF_TYPE, PERCUSSION_STAFF_TYPE,
-      STAFF_TYPES
+      STANDARD_STAFF_TYPE,
+      PERC_1LINE_STAFF_TYPE, PERC_3LINE_STAFF_TYPE, PERC_5LINE_STAFF_TYPE,
+      TAB_6SIMPLE_STAFF_TYPE, TAB_6COMMON_STAFF_TYPE, TAB_6FULL_STAFF_TYPE,
+            TAB_4SIMPLE_STAFF_TYPE, TAB_4COMMON_STAFF_TYPE, TAB_4FULL_STAFF_TYPE,
+            TAB_UKULELE_STAFF_TYPE, TAB_BALALAJKA_STAFF_TYPE, TAB_ITALIAN_STAFF_TYPE, TAB_FRENCH_STAFF_TYPE,
+      STAFF_TYPES,
+      // some usefull shorthands:
+            PERC_DEFAULT_STAFF_TYPE = PERC_5LINE_STAFF_TYPE,
+            TAB_DEFAULT_STAFF_TYPE = TAB_6COMMON_STAFF_TYPE
       };
 
 //---------------------------------------------------------
@@ -153,7 +160,7 @@ class StaffTypePitched : public StaffType {
             _genKeysig(genKeySig), _showLedgerLines(showLedgerLines)
             {
             }
-      virtual StaffGroup group() const        { return PITCHED_STAFF; }
+      virtual StaffGroup group() const        { return STANDARD_STAFF_GROUP; }
       virtual StaffTypePitched* clone() const { return new StaffTypePitched(*this); }
       virtual const char* groupName() const   { return "pitched"; }
       virtual bool isEqual(const StaffType&) const;
@@ -184,7 +191,7 @@ class StaffTypePercussion : public StaffType {
             _genKeysig(genKeySig), _showLedgerLines(showLedgerLines)
             {
             }
-      virtual StaffGroup group() const           { return PERCUSSION_STAFF; }
+      virtual StaffGroup group() const           { return PERCUSSION_STAFF_GROUP; }
       virtual StaffTypePercussion* clone() const { return new StaffTypePercussion(*this); }
       virtual const char* groupName() const      { return "percussion"; }
       virtual bool isEqual(const StaffType&) const;
@@ -335,7 +342,7 @@ class StaffTypeTablature : public StaffType {
             }
 
       // re-implemented virtual functions
-      virtual StaffGroup group() const          { return TAB_STAFF; }
+      virtual StaffGroup group() const          { return TAB_STAFF_GROUP; }
       virtual StaffTypeTablature* clone() const { return new StaffTypeTablature(*this); }
       virtual const char* groupName() const     { return "tablature"; }
       virtual void read(XmlReader& e);
@@ -415,7 +422,7 @@ class StaffTypeTablature : public StaffType {
 
 
 extern void initStaffTypes();
-extern QList<StaffType*> staffTypes;
+//extern QList<StaffType*> staffTypes;
 
 //---------------------------------------------------------
 //   TabDurationSymbol

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -211,7 +211,7 @@ int transposeTpcDiatonicByKey(int tpc, int steps, int key, bool keepAlteredDegre
 
 void Score::cmdTransposeStaff(int staffIdx, Interval interval, bool useDoubleSharpsFlats)
       {
-      if (staff(staffIdx)->staffType()->group() == PERCUSSION_STAFF)
+      if (staff(staffIdx)->staffType()->group() == PERCUSSION_STAFF_GROUP)
             return;
       int startTrack = staffIdx * VOICES;
       int endTrack   = startTrack + VOICES;
@@ -299,7 +299,7 @@ void Score::transpose(int mode, TransposeDirection direction, int transposeKey,
 
       if (_selection.state() == SEL_LIST) {
             foreach(Element* e, _selection.elements()) {
-                  if (e->staff()->staffType()->group() == PERCUSSION_STAFF)
+                  if (e->staff()->staffType()->group() == PERCUSSION_STAFF_GROUP)
                         continue;
                   if (e->type() == Element::NOTE) {
                         Note* note = static_cast<Note*>(e);
@@ -348,7 +348,7 @@ void Score::transpose(int mode, TransposeDirection direction, int transposeKey,
 
       for (Segment* segment = _selection.startSegment(); segment && segment != _selection.endSegment(); segment = segment->next1()) {
             for (int st = startTrack; st < endTrack; ++st) {
-                  if (staff(st/VOICES)->staffType()->group() == PERCUSSION_STAFF)
+                  if (staff(st/VOICES)->staffType()->group() == PERCUSSION_STAFF_GROUP)
                         continue;
                   Element* e = segment->element(st);
                   if (!e || e->type() != Element::CHORD)
@@ -399,7 +399,7 @@ void Score::transpose(int mode, TransposeDirection direction, int transposeKey,
 void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickEnd, const Interval& interval)
       {
       for (int staffIdx = staffStart; staffIdx < staffEnd; ++staffIdx) {
-            if (staff(staffIdx)->staffType()->group() == PERCUSSION_STAFF)
+            if (staff(staffIdx)->staffType()->group() == PERCUSSION_STAFF_GROUP)
                   continue;
 
             KeyList* km = staff(staffIdx)->keymap();

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -90,9 +90,9 @@ void EditStaff::fillStaffTypeCombo()
       staffType->clear();
       for (int idx = 0; idx < n; ++idx) {
             StaffType* st = score->staffType(idx);
-            if ( (canUseTabs && st->group() == TAB_STAFF)
-                        || ( canUsePerc && st->group() == PERCUSSION_STAFF)
-                        || (!canUsePerc && st->group() == PITCHED_STAFF) ) {
+            if ( (canUseTabs && st->group() == TAB_STAFF_GROUP)
+                        || ( canUsePerc && st->group() == PERCUSSION_STAFF_GROUP)
+                        || (!canUsePerc && st->group() == STANDARD_STAFF_GROUP) ) {
                   staffType->addItem(st->name(), idx);
                   if (st == staff->staffType())
                         curIdx = staffType->count() - 1;
@@ -234,9 +234,9 @@ void EditStaff::apply()
       StaffGroup ng = st->group();                          // new staff group
       StaffGroup og = staff->staffType()->group();          // old staff group
 
-      bool updateNeeded = (ng == TAB_STAFF && og != TAB_STAFF) ||
-                          (ng != TAB_STAFF && og == TAB_STAFF) ||
-                          (ng == TAB_STAFF && og == TAB_STAFF
+      bool updateNeeded = (ng == TAB_STAFF_GROUP && og != TAB_STAFF_GROUP) ||
+                          (ng != TAB_STAFF_GROUP && og == TAB_STAFF_GROUP) ||
+                          (ng == TAB_STAFF_GROUP && og == TAB_STAFF_GROUP
                              && instrument.tablature() != part->instr()->tablature());
 
       if (!(instrument == *part->instr()) || part->partName() != partName->text()) {

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -793,7 +793,7 @@ qDebug("BeginRepeat=============================================\n");
             if (midiChannel == GP_DEFAULT_PERCUSSION_CHANNEL) {
                   clefId = CLEF_PERC;
                   instr->setUseDrumset(true);
-                  staff->setStaffType(score->staffType(PERCUSSION_STAFF_TYPE));
+                  staff->setStaffType(score->staffType(PERC_DEFAULT_STAFF_TYPE));
                   }
             else if (patch >= 24 && patch < 32)
                   clefId = CLEF_G3;
@@ -808,7 +808,7 @@ qDebug("BeginRepeat=============================================\n");
 
 
             Channel& ch = instr->channel(0);
-            if (midiChannel == GP_DEFAULT_PERCUSSION_CHANNEL) {
+            if (midiChannel == PERC_DEFAULT_STAFF_TYPE) {
                   ch.program = 0;
                   ch.bank    = 128;
                   }
@@ -1273,7 +1273,7 @@ qDebug("BeginRepeat=============================================\n");
             if (midiChannel == GP_DEFAULT_PERCUSSION_CHANNEL) {
                   clefId = CLEF_PERC;
                   instr->setUseDrumset(true);
-                  staff->setStaffType(score->staffType(PERCUSSION_STAFF_TYPE));
+                  staff->setStaffType(score->staffType(PERC_DEFAULT_STAFF_TYPE));
                   }
             else if (patch >= 24 && patch < 32)
                   clefId = CLEF_G3;
@@ -1791,7 +1791,7 @@ void GuitarPro4::read(QFile* fp)
             if (midiChannel == GP_DEFAULT_PERCUSSION_CHANNEL) {
                   clefId = CLEF_PERC;
                   instr->setUseDrumset(true);
-                  staff->setStaffType(score->staffType(PERCUSSION_STAFF_TYPE));
+                  staff->setStaffType(score->staffType(PERC_DEFAULT_STAFF_TYPE));
                   }
             else if (patch >= 24 && patch < 32)
                   clefId = CLEF_G3;
@@ -2481,7 +2481,7 @@ void GuitarPro5::readTracks()
             if (midiChannel == GP_DEFAULT_PERCUSSION_CHANNEL) {
                   clefId = CLEF_PERC;
                   instr->setUseDrumset(true);
-                  staff->setStaffType(score->staffType(PERCUSSION_STAFF_TYPE));
+                  staff->setStaffType(score->staffType(PERC_DEFAULT_STAFF_TYPE));
                   }
             else if (patch >= 24 && patch < 32)
                   clefId = CLEF_G3;
@@ -2769,11 +2769,11 @@ Score::FileError importGTP(Score* score, const QString& name)
             stavesMap.append(score->staffIdx(staff));
             cloneStaves(score, pscore, stavesMap);
 
-            if (part->staves()->front()->staffType()->group() == PITCHED_STAFF) {
+            if (part->staves()->front()->staffType()->group() == STANDARD_STAFF_GROUP) {
                   p->setStaves(2);
                   Staff* s1 = p->staff(1);
                   s1->setUpdateKeymap(true);
-                  StaffTypeTablature* st = static_cast<StaffTypeTablature*>(pscore->staffType(TAB_STAFF_TYPE));
+                  StaffTypeTablature* st = static_cast<StaffTypeTablature*>(pscore->staffType(TAB_DEFAULT_STAFF_TYPE));
                   st->setSlashStyle(true);
                   s1->setStaffType(st);
                   s1->linkTo(s);
@@ -2788,9 +2788,9 @@ Score::FileError importGTP(Score* score, const QString& name)
             excerpt->parts().append(part);
             score->excerpts().append(excerpt);
 
-            if (part->staves()->front()->staffType()->group() == PITCHED_STAFF) {
+            if (part->staves()->front()->staffType()->group() == STANDARD_STAFF_GROUP) {
                   Staff* staff2 = pscore->staff(1);
-                  staff2->setStaffType(pscore->staffType(TAB_STAFF_TYPE));
+                  staff2->setStaffType(pscore->staffType(TAB_DEFAULT_STAFF_TYPE));
                   }
 
             //

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -1699,7 +1699,7 @@ void MusicXml::xmlPart(QDomElement e, QString id)
             // but may be incorrect for a percussion staff that does not use a percussion clef
             for (int j = 0; j < part->nstaves(); ++j)
                   if (part->staff(j)->lines() == 5 && !part->staff(j)->isDrumStaff())
-                        part->staff(j)->setStaffType(score->staffType(PERCUSSION_STAFF_TYPE));
+                        part->staff(j)->setStaffType(score->staffType(PERC_DEFAULT_STAFF_TYPE));
             // set drumset for instrument
             part->instr()->setUseDrumset(true);
             part->instr()->setDrumset(drumset);
@@ -3168,7 +3168,7 @@ void MusicXml::xmlAttributes(Measure* measure, int staff, QDomElement e)
                         staffIdx += number - 1;
                   // qDebug("xmlAttributes clef score->staff(0) %p staffIdx %d score->staff(%d) %p",
                   //       score->staff(0), staffIdx, staffIdx, score->staff(staffIdx));
-                  if (st != PITCHED_STAFF_TYPE)
+                  if (st != STANDARD_STAFF_TYPE)
                         score->staff(staffIdx)->setStaffType(score->staffType(st));
                   }
             else if (e.tagName() == "staves")
@@ -5186,7 +5186,7 @@ void MusicXml::xmlHarmony(QDomElement e, int tick, Measure* measure, int staff)
 int MusicXml::xmlClef(QDomElement e, int staffIdx, Measure* measure)
       {
       ClefType clef   = CLEF_G;
-      int res = PITCHED_STAFF_TYPE;
+      int res = STANDARD_STAFF_TYPE;
       int clefno = e.attribute(QString("number"), "1").toInt() - 1;
       QString c;
       int i = 0;
@@ -5254,11 +5254,11 @@ int MusicXml::xmlClef(QDomElement e, int staffIdx, Measure* measure)
             }
       else if (c == "percussion") {
             clef = CLEF_PERC2;
-            res = PERCUSSION_STAFF_TYPE;
+            res = PERC_DEFAULT_STAFF_TYPE;
             }
       else if (c == "TAB") {
             clef = CLEF_TAB2;
-            res = TAB_STAFF_TYPE;
+            res = TAB_DEFAULT_STAFF_TYPE;
             }
       else
             qDebug("ImportMusicXML: unknown clef <sign=%s line=%d oct ch=%d>", qPrintable(c), line, i);

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -292,13 +292,13 @@ void MuseScore::updateInputState(Score* score)
       if (is.noteEntryMode) {
             Staff* staff = score->staff(is.track() / VOICES);
             switch (staff->staffType()->group()) {
-                  case PITCHED_STAFF:
+                  case STANDARD_STAFF_GROUP:
                         changeState(STATE_NOTE_ENTRY_PITCHED);
                         break;
-                  case TAB_STAFF:
+                  case TAB_STAFF_GROUP:
                         changeState(STATE_NOTE_ENTRY_TAB);
                         break;
-                  case PERCUSSION_STAFF:
+                  case PERCUSSION_STAFF_GROUP:
                         changeState(STATE_NOTE_ENTRY_DRUM);
                         break;
                   }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2927,9 +2927,9 @@ void ScoreView::startNoteEntry()
       const InputState is = _score->inputState();
       Staff* staff = _score->staff(is.track() / VOICES);
       switch (staff->staffType()->group()) {
-            case PITCHED_STAFF:
+            case STANDARD_STAFF_GROUP:
                   break;
-            case TAB_STAFF: {
+            case TAB_STAFF_GROUP: {
                   int strg = 0;                 // assume topmost string as current string
                   // if entering note entry with a note selected and the note has a string
                   // set InputState::_string to note visual string
@@ -2940,7 +2940,7 @@ void ScoreView::startNoteEntry()
                   _score->inputState().setString(strg);
                   break;
                   }
-            case PERCUSSION_STAFF:
+            case PERCUSSION_STAFF_GROUP:
                   break;
             }
 
@@ -3714,11 +3714,11 @@ ScoreState ScoreView::mscoreState() const
             const InputState is = _score->inputState();
             Staff* staff = _score->staff(is.track() / VOICES);
             switch( staff->staffType()->group()) {
-                  case PITCHED_STAFF:
+                  case STANDARD_STAFF_GROUP:
                         return STATE_NOTE_ENTRY_PITCHED;
-                  case TAB_STAFF:
+                  case TAB_STAFF_GROUP:
                         return STATE_NOTE_ENTRY_TAB;
-                  case PERCUSSION_STAFF:
+                  case PERCUSSION_STAFF_GROUP:
                         return STATE_NOTE_ENTRY_DRUM;
                   }
             }

--- a/mscore/stafftype.ui
+++ b/mscore/stafftype.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
+    <width>855</width>
     <height>770</height>
    </rect>
   </property>
@@ -198,7 +198,7 @@
               </font>
              </property>
              <property name="text">
-              <string>PITCHED STAFF</string>
+              <string>STANDARD STAFF</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>
@@ -247,7 +247,7 @@
                 <string>Create a new staff type of current group.</string>
                </property>
                <property name="text">
-                <string>Create new pitched type</string>
+                <string>Create new standard type</string>
                </property>
               </widget>
              </item>
@@ -463,7 +463,16 @@
                     <enum>QFrame::Plain</enum>
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_6">
-                    <property name="margin">
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
                      <number>0</number>
                     </property>
                     <item>
@@ -524,7 +533,16 @@
                     <enum>QFrame::Plain</enum>
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_8">
-                    <property name="margin">
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
                      <number>0</number>
                     </property>
                     <item>
@@ -585,7 +603,16 @@
                     <enum>QFrame::Plain</enum>
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_9">
-                    <property name="margin">
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
                      <number>0</number>
                     </property>
                     <item>
@@ -658,7 +685,16 @@
                     <enum>QFrame::Plain</enum>
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_5">
-                    <property name="margin">
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
                      <number>0</number>
                     </property>
                     <item>
@@ -732,7 +768,16 @@
                     <enum>QFrame::Plain</enum>
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_17">
-                    <property name="margin">
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
                      <number>0</number>
                     </property>
                     <item>
@@ -793,7 +838,16 @@
                     <enum>QFrame::Plain</enum>
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_15">
-                    <property name="margin">
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
                      <number>0</number>
                     </property>
                     <item>
@@ -854,7 +908,16 @@
                     <enum>QFrame::Plain</enum>
                    </property>
                    <layout class="QHBoxLayout" name="horizontalLayout_18">
-                    <property name="margin">
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
                      <number>0</number>
                     </property>
                     <item>
@@ -1278,13 +1341,14 @@
   <tabstop>durY</tabstop>
   <tabstop>pushQuickConfig</tabstop>
   <tabstop>newTypeTablature</tabstop>
+  <tabstop>presetPercCombo</tabstop>
   <tabstop>showLedgerLinesPercussion</tabstop>
   <tabstop>genKeysigPercussion</tabstop>
   <tabstop>stemlessPercussion</tabstop>
   <tabstop>newTypePercussion</tabstop>
-  <tabstop>buttonBox</tabstop>
   <tabstop>save</tabstop>
   <tabstop>load</tabstop>
+  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/share/templates/tab_sample.mscx
+++ b/share/templates/tab_sample.mscx
@@ -1,22 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="1.24">
   <programVersion>2.0.0</programVersion>
-  <programRevision>bbb35cb</programRevision>
+  <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
-    <SyntiSettings>
-      <s name="soundfont" val="C:/Program Files/MusicSW/soundfonts/FluidR3_GM.sf2"/>
-      <f name="RevRoomsize" val="0.84"/>
-      <f name="RevDamp" val="0.2"/>
-      <f name="RevWidth" val="1"/>
-      <f name="RevGain" val="0.3"/>
-      <f name="ChoType" val="0"/>
-      <f name="ChoSpeed" val="0.002"/>
-      <f name="ChoDepth" val="0.8"/>
-      <f name="ChoBlocks" val="0.03"/>
-      <f name="ChoGain" val="2"/>
-      </SyntiSettings>
+    <Synthesizer>
+      <s>
+        </s>
+      <f>
+        </f>
+      <f>
+        </f>
+      <f>
+        </f>
+      <f>
+        </f>
+      <f>
+        </f>
+      <f>
+        </f>
+      <f>
+        </f>
+      <f>
+        </f>
+      <f>
+        </f>
+      </Synthesizer>
     <Division>480</Division>
     <Style>
       <staffLowerBorder>0</staffLowerBorder>
@@ -55,6 +65,7 @@
     <showMargins>0</showMargins>
     <metaTag name="Platform">WIN</metaTag>
     <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2013-08-18</metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
     <metaTag name="platform">X11</metaTag>
@@ -71,24 +82,12 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <type>1</type>
+        <type>5</type>
         <bracket type="-1" span="1"/>
-        <barLineSpan from="0" to="8">1</barLineSpan>
+        <barLineSpan from="0" to="14">1</barLineSpan>
         </Staff>
       <trackName>Renaissance Tenor Lute (6 course)</trackName>
       <Instrument>
-        <longName pos="0">
-<html><head><meta name="qrichtext" content="1" /><style type="text/css">
-p, li { white-space: pre-wrap; }
-</style></head><body>
-<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /><!--EndFragment--></p></body></html>
-          </longName>
-        <shortName pos="0">
-<html><head><meta name="qrichtext" content="1" /><style type="text/css">
-p, li { white-space: pre-wrap; }
-</style></head><body>
-<p style="-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><br /><!--EndFragment--></p></body></html>
-          </shortName>
         <trackName>Renaissance Tenor Lute (6 course)</trackName>
         <minPitchP>43</minPitchP>
         <maxPitchP>79</maxPitchP>
@@ -105,6 +104,7 @@ p, li { white-space: pre-wrap; }
           </Tablature>
         <Channel>
           <program value="25"/>
+          <synti>Fluid</synti>
           </Channel>
         </Instrument>
       </Part>
@@ -305,6 +305,9 @@ p, li { white-space: pre-wrap; }
             <string>1</string>
             </Note>
           <Note>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
             <pitch>68</pitch>
             <tpc>22</tpc>
             <fret>1</fret>
@@ -413,6 +416,9 @@ p, li { white-space: pre-wrap; }
         <Chord>
           <durationType>quarter</durationType>
           <Note>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
             <pitch>56</pitch>
             <tpc>22</tpc>
             <fret>3</fret>
@@ -452,6 +458,9 @@ p, li { white-space: pre-wrap; }
             <string>3</string>
             </Note>
           <Note>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
             <pitch>61</pitch>
             <tpc>21</tpc>
             <fret>4</fret>


### PR DESCRIPTION
#### Summary:
1. Built-in staff types have been removed.
2. Presets are internally used as source for the staff types of a new score, to match data in Instruments.xml and as reference to check for modifications.
3. Each new score is given by default one staff type for each preset; they use the same names as the presets.
4. The Instrument page of the New Score Wizard lists (under the name of "Staff types") the default staff types applicable to the instrument (actually it lists the preset, as the score does not have any staff type yet).
5. The "Add | Instruments" dlg box lists all the staff types applicable to the instrument: = the list of 4) + any user-created staff type.
6. The Staff Properties dlg box lists all the staff types applicable to the instrument: = list in 5)
7. The Staff Type Editor lists all the staff types: = lists in 5) and 6), but not filtered by applicability to a given instrument.

This should ensure consistency among the several lists of staff types and avoid duplication of similar items:
#### Terminology:
1. A new staff type created in the editor is named by default with the group name ("Standard-", "Perc-", "Tab-") + the index of the new type in its group + the suffix "[_]" marking a user customisation (ex.: "Tab-10 [_]"). The user is anyway able to rename it, if he want.
2. The pitched staff type has been renamed everywhere (hopefully!) to "Standard".
3. The term 'preset' have been removed from the UI, except from the Staff Type Editor where it keeps its usual meaning of ready-made collection of parameters.
#### Notes:
1. The commit affects many files, but a fair number of them have only changes in names of literals. The files with significant code changes are:
   *) libmscore/score.cpp
   *) libmscore/stafftype.cpp/.h
   *) mscore/editstafftype.cpp (code for naming a new staff type)
   *) mscore/instrdialog.cpp (building type list)
2. As score files store staff type indications as integer indices and the number and order of new default staff types is different from the old built-in types, there is a compatibility issue with old 2.0 scores using percussion and tab staves. In Score::read() (libmscore/scorefile.cpp), there is a rudimentary attempt to at least avoid crashes! Old scores will need manual fix anyway.
3. There should not be any (new) compatibility issue with 1.x scores, as they did not use staff types.
