### PR TITLE
Jumps and markers loose custom styles and texts

### DIFF
--- a/libmscore/jump.cpp
+++ b/libmscore/jump.cpp
@@ -94,7 +94,7 @@ void Jump::read(XmlReader& e)
             else if (!Text::readProperties(e))
                   e.unknown();
             }
-      setTextStyleType(TEXT_STYLE_REPEAT_RIGHT);
+//      setTextStyleType(TEXT_STYLE_REPEAT_RIGHT);    // do not reset text style!
       }
 
 //---------------------------------------------------------

--- a/libmscore/marker.cpp
+++ b/libmscore/marker.cpp
@@ -153,25 +153,7 @@ void Marker::read(XmlReader& e)
             else if (!Text::readProperties(e))
                   e.unknown();
             }
-      switch (mt) {
-            case MarkerType::SEGNO:
-            case MarkerType::VARSEGNO:
-            case MarkerType::CODA:
-            case MarkerType::VARCODA:
-            case MarkerType::CODETTA:
-                  setTextStyleType(TEXT_STYLE_REPEAT_LEFT);
-                  break;
-
-            case MarkerType::FINE:
-            case MarkerType::TOCODA:
-                  setTextStyleType(TEXT_STYLE_REPEAT_RIGHT);
-                  break;
-
-            case MarkerType::USER:
-                  setTextStyleType(TEXT_STYLE_REPEAT);
-                  break;
-            }
-      setMarkerType(mt);
+      _markerType = mt;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
When a score is saved and reloaded, jumps loose any custom text style and markers loose any custom text style and text.

This is because Jump::read() and Marker::read() reset values read from the score with default values.

Fixed by commenting out those resets.
