### PR TITLE
#13108 updates

### DIFF
--- a/libmscore/bagpembell.h
+++ b/libmscore/bagpembell.h
@@ -58,6 +58,7 @@ class BagpipeEmbellishment : public Element {
       void setEmbelType(int val)                  { _embelType = val;                       }
       virtual void write(Xml&) const;
       virtual void read(XmlReader&);
+      virtual void layout();
       virtual void draw(QPainter*) const;
       static BagpipeEmbellishmentInfo BagpipeEmbellishmentList[];
       static int nEmbellishments();


### PR DESCRIPTION
Replaced beam by flag for single grace note
Fixed "pixel dust" by setting bbox

Note that adding an embellishment of three or more grace notes results in a divide by zero in the beam layouter. This is not related to my changes, it also happens when using the regular grace note palette to add three grace notes to one normal note. Will submit an issue and (try to) investigate.
