### PR TITLE
Brevis note heads vertical alignment

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -262,7 +262,8 @@ void Score::layoutChords1(QList<Note*>& notes, int voices, Staff* staff, Segment
                         x = stemX - hw + stemWidth5 * 2;
                   }
             else {
-                  if (chord->durationType().headType() == Note::HEAD_WHOLE) {
+                  int ht = chord->durationType().headType();
+                  if (ht == Note::HEAD_WHOLE || ht == Note::HEAD_BREVIS) {
                         // center whole note
                         qreal xd = (hw - noteHeadWidth() * chord->mag()) * .5;
                         if (_up)


### PR DESCRIPTION
Breves are vertically misaligned and in different horiz. positions when 'up-stemmed' and 'down-stemmed' (assuming they had a stem).

Fixed by adding the Note::HEAD_BREVIS case when centring note heads.
