### PR TITLE
fix #15373

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -37,7 +37,7 @@
 
 #include <math.h>
 #include "config.h"
-//#include "musescore.h"
+#include "musescore.h"
 #include "file.h"
 #include "libmscore/score.h"
 #include "libmscore/rest.h"
@@ -3896,6 +3896,14 @@ static void identification(Xml& xml, Score const* const score)
 
 void ExportMusicXml::write(QIODevice* dev)
       {
+      // must export in transposed pitch to prevent
+      // losing the transposition information
+      // if necessary, switch concert pitch mode off
+      // before export and restore it after export
+      bool concertPitch = getAction("concert-pitch")->isChecked();
+      if (concertPitch) {
+            score()->cmdConcertPitchChanged(false, false);
+            }
 
       calcDivisions();
 
@@ -4408,6 +4416,13 @@ void ExportMusicXml::write(QIODevice* dev)
             }
 
       xml.etag();
+
+      if (concertPitch) {
+            // restore concert pitch
+            // note: can't use score()->undo()->pop() as this fails
+            // with message "UndoStack:pop(): no active command"
+            score()->cmdConcertPitchChanged(true, false);
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Force transposed pitch on MusicXML export by calling score()->cmdConcertPitchChanged() before and after export. Works OK as far as I can tell, please review. I am not completely sure there is no unforeseen interaction with the undo system, as I am not familiar with that.
