### PR TITLE
Stafftext.ui update

### DIFF
--- a/mscore/stafftext.ui
+++ b/mscore/stafftext.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">


### PR DESCRIPTION
Finally managed to sort this out! Aeolus stop list buttons are now of a
uniform colour and Tremulants have green text and couplers have red.
Had to resort to hacking the file in Notepad++ to get the width and
height back to the original values -Qt Designer insists on increasing
the width to 1134 and then won't let you change it.
