### PR TITLE
Fix #22694 - List of available staff type not updated on instr. change

### DIFF
--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -274,6 +274,7 @@ void EditStaff::showInstrumentDialog()
       if (si.exec()) {
             instrument = Instrument::fromTemplate(si.instrTemplate());
             updateInstrument();
+            fillStaffTypeCombo();
             }
       }
 

--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -589,7 +589,14 @@
        </widget>
       </item>
       <item row="0" column="5">
-       <widget class="QComboBox" name="staffType"/>
+       <widget class="QComboBox" name="staffType">
+        <property name="maxVisibleItems">
+         <number>16</number>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
       </item>
       <item row="0" column="4">
        <widget class="QLabel" name="label_12">
@@ -633,6 +640,9 @@
       </item>
       <item row="1" column="5">
        <widget class="QDoubleSpinBox" name="spinExtraDistance">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
         <property name="suffix">
          <string>sp</string>
         </property>


### PR DESCRIPTION
Fix #22694: In the Staff Properties dlg box, when the instrument is changed, the list of available staff types is not updated.

(Also made more room for longer staff type names and longer list in the drop list properties)
