### PR TITLE
Fix crash in removeOverlappingNotes function (midi import)

### DIFF
--- a/mscore/importmidi_chord.cpp
+++ b/mscore/importmidi_chord.cpp
@@ -74,6 +74,7 @@ void removeOverlappingNotes(std::multimap<int, MTrack> &tracks)
                                            secondOnTime.ticks(), note2.len.ticks());
                                     note1.len = secondOnTime - firstOnTime;
                                     ii = chords.end();
+                                    --ii;
                                     break;
                                     }
                               }


### PR DESCRIPTION
Interesting that this logical bug was revealed on MacOS only.
