### PR TITLE
Fix #22870 - No shortcut available to enter rests in TAB's

### DIFF
--- a/mscore/actions.cpp
+++ b/mscore/actions.cpp
@@ -2264,6 +2264,14 @@ Shortcut Shortcut::sc[] = {
       Shortcut(
          STATE_NOTE_ENTRY_TAB,
          0,
+         "rest-TAB",
+         QT_TRANSLATE_NOOP("action","Rest (TAB)"),
+         QT_TRANSLATE_NOOP("action","Enter rest (TAB)"),
+         quartrest_ICON
+         ),
+      Shortcut(
+         STATE_NOTE_ENTRY_TAB,
+         0,
          "pad-rest-TAB",
          QT_TRANSLATE_NOOP("action","Rest (TAB)"),
          QT_TRANSLATE_NOOP("action","Note entry: rest (TAB)")

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -824,6 +824,10 @@
     <seq>Q</seq>
     </SC>
   <SC>
+    <key>rest-TAB</key>
+    <seq>'</seq>
+    </SC>
+  <SC>
     <key>string-above</key>
     <seq>Up</seq>
     </SC>
@@ -874,13 +878,14 @@
   <SC>
     <key>fret-8</key>
     <seq>8</seq>
-    <seq>J</seq>
+    <seq>I</seq>
     </SC>
   <SC>
     <key>fret-9</key>
     <seq>9</seq>
     <seq>K</seq>
     </SC>
+<!-- HARMONY / FIGURED BASS specific shortcuts -->
   <SC>
     <key>advance-longa</key>
     <seq>Ctrl+9</seq>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2409,10 +2409,10 @@ void MuseScore::changeState(ScoreState val)
 //            return;
       static const char* stdNames[] = {
             "note-longa", "note-breve", "pad-note-1", "pad-note-2", "pad-note-4",
-            "pad-note-8", "pad-note-16", "pad-note-32", "pad-note-64", "pad-note-128", "pad-rest"};
+      "pad-note-8", "pad-note-16", "pad-note-32", "pad-note-64", "pad-note-128", "pad-rest", "rest"};
       static const char* tabNames[] = {
             "note-longa-TAB", "note-breve-TAB", "pad-note-1-TAB", "pad-note-2-TAB", "pad-note-4-TAB",
-            "pad-note-8-TAB", "pad-note-16-TAB", "pad-note-32-TAB", "pad-note-64-TAB", "pad-note-128-TAB", "pad-rest-TAB"};
+      "pad-note-8-TAB", "pad-note-16-TAB", "pad-note-32-TAB", "pad-note-64-TAB", "pad-note-128-TAB", "pad-rest-TAB", "rest-TAB"};
       bool intoTAB = (_sstate != STATE_NOTE_ENTRY_TAB) && (val == STATE_NOTE_ENTRY_TAB);
       bool fromTAB = (_sstate == STATE_NOTE_ENTRY_TAB) && (val != STATE_NOTE_ENTRY_TAB);
       // if activating TAB note entry, swap "pad-note-...-TAB" shorctuts into "pad-note-..." actions

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2709,7 +2709,7 @@ void ScoreView::cmd(const QAction* a)
                   updateAll();
                   }
             }
-      else if (cmd == "rest")
+      else if (cmd == "rest" || cmd == "rest-TAB")
             cmdEnterRest();
       else if (cmd == "rest-1")
             cmdEnterRest(TDuration(TDuration::V_WHOLE));


### PR DESCRIPTION
Fix #22870 - No shortcut available to enter rests in TAB's

Fixed by adding a TAB-specific shortcut parallel to the "rest" shortcut available for other staff types (def. '0').

Its default shortcut has been tentatively assigned to ' (apostrophe)
