### PR TITLE
TAB shortcut conflicts in French kbd

### DIFF
--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -825,7 +825,7 @@
     </SC>
   <SC>
     <key>rest-TAB</key>
-    <seq>'</seq>
+    <seq>;</seq>
     </SC>
   <SC>
     <key>string-above</key>


### PR DESCRIPTION
In French kbd, shortcut for adding a rest to TAB conflicts with shortcut for fret 4.

Fixed by changing the former to ';'
