### PR TITLE
Single lyrics paste

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1071,8 +1071,8 @@ Element* Note::drop(const DropData& data)
                   return 0;
 
             case LYRICS:
-                  e->setParent(ch->segment());
-                  e->setTrack(trackZeroVoice(track()));
+                  e->setParent(ch);
+                  e->setTrack(track());
                   score()->undoAddElement(e);
                   return e;
 


### PR DESCRIPTION
Fix the crash when (copying/cutting and) pasting a single lyrics to a single note.
