### PR TITLE
Set Mscore::DPI from logical DPI not physical

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4761,7 +4761,8 @@ int main(int argc, char* av[])
 
       QScreen* screen = QGuiApplication::primaryScreen();
       MScore::PDPI = screen->physicalDotsPerInch();        // physical resolution
-      MScore::DPI  = MScore::PDPI;             // logical drawing resolution
+      //MScore::DPI  = MScore::PDPI;                       // logical drawing resolution
+      MScore::DPI  = screen->logicalDotsPerInch();         // logical drawing resolution
       MScore::init();                          // initialize libmscore
 
       if (MScore::debugMode)


### PR DESCRIPTION
Currently, when editing chord names, they appear larger than when not in edit mode. This appears to be due to Mscore::DPI having been set to the physical DPI of the screen, but the QTextDocument uses the logical DPI.
Setting MScore::DPI to the logical DPI fixes the change of size when editing chord names. It also appears to make MuseScore correctly obey the user's display scaling set in the Windows control panel.

This change hasn't been tested on Mac or Linux, but it seems from the comment that DPI should be set from the logical DPI anyway.
