### PR TITLE
TAB: letter shortcut for "fret-8" action changed from 'I' to 'J'

### DIFF
--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -874,7 +874,7 @@
   <SC>
     <key>fret-8</key>
     <seq>8</seq>
-    <seq>I</seq>
+    <seq>J</seq>
     </SC>
   <SC>
     <key>fret-9</key>


### PR DESCRIPTION
The letter shortcut for the "fret-8" action was 'I' and this created a conflict with the "instruments" action.

It has been changed to 'J' as:

*) J is not used by TAB and is then free
*) there is no conflict with "enharmonic-up", as enharmony makes no sense in TAB's and its actions are disabled in TAB note entry.

(Background: TAB note entry has double shortcuts for fret marks: a letter series and a digit series. TAB's can use both letters and numbers and having both shortcuts makes user life MUCH simpler)
