### PR TITLE
Use user-friendly names for items in the note-head palette

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -474,7 +474,7 @@ Palette* MuseScore::newNoteHeadsPalette()
                   sym = noteHeads[0][i][3];
             NoteHead* nh = new NoteHead(gscore);
             nh->setSym(sym);
-            sp->append(nh, qApp->translate("symbol", Sym::id2name(sym)));
+            sp->append(nh, Sym::id2userName(sym));
             }
       Icon* ik = new Icon(gscore);
       ik->setIconType(ICON_BRACKETS);


### PR DESCRIPTION
Names shown in tooltips for items of the note-head palette are obscure glyph tags.

This patch uses symbol "user names" (SymbolNames::mname) instead of SymbolNames::name for the note-head palette items.

(Workspace re-generation may be needed in order to see the effects)
