### PR TITLE
fix #23369

### DIFF
--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -467,9 +467,9 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
       {
       QString tok1, tok1L, tok2, tok2L;
       QString extensionDigits = "123456789";
-      QString special = "()[], ";
+      QString special = "()[],/\\ ";
       QString leading = "([ ";
-      QString trailing = ")], ";
+      QString trailing = ")],/\\ ";
       QString initial;
       bool take6 = false, take7 = false, take9 = false, take11 = false, take13 = false;
 #if 0

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -517,12 +517,15 @@ const ChordDescription* Harmony::parseHarmony(const QString& ss, int* root, int*
       else
             preferMinor = false;
       *base = INVALID_TPC;
-      int slash = s.indexOf('/');
+      int slash = s.lastIndexOf('/');
       if (slash != -1) {
             QString bs = s.mid(slash+1);
-            s = s.mid(idx, slash - idx);
+            s = s.mid(idx, slash - idx).simplified();
             int dummy;
             *base = convertRoot(bs, _baseSpelling, dummy);
+            if (*base == INVALID_TPC)
+                  // if no TPC after slash, reassemble chord
+                  s = s + "/" + bs;
             }
       else
             s = s.mid(idx).simplified();

--- a/share/styles/chords_jazz.xml
+++ b/share/styles/chords_jazz.xml
@@ -140,6 +140,7 @@
     <sym value="(" name="s("/>
     <sym value=")" name="s)"/>
     <sym value="," name="s,"/>
+    <sym value="/" name="s/"/>
 
     <sym code="0xe18a" name="striangle"/>
 
@@ -247,6 +248,16 @@
     <render>m:0:-&ext; m:0:-2 ) m:0:2 m:0:&ext;</render>
     </token>
 
+  <token class="extension">
+    <name>,</name>
+    <render>m:0:-&ext; m:0:-1 , m:0:1 m:0:&ext;</render>
+    </token>
+
+  <token class="extension">
+    <name>/</name>
+    <render>m:0:-&ext; m:0:-1 / m:0:1 m:0:&ext;</render>
+    </token>
+
   <token class="modifier">
     <name>(</name>
     <render>m:1:-&mod; s( m:0:&mod;</render>
@@ -260,6 +271,11 @@
   <token class="modifier">
     <name>,</name>
     <render>m:0:-&mod; s, m:0:&mod;</render>
+    </token>
+
+  <token class="modifier">
+    <name>/</name>
+    <render>m:0:-&mod; s/ m:0:&mod;</render>
     </token>
 
   <token class="modifier">
@@ -361,9 +377,10 @@
     <name>3</name>
     <render>m:0:-&modn; s3 m:0:&modn;</render>
     </token>
-<!-- kludge: 4 used with sus mostly, so lower it accordingly -->
+
   <token class="modifier">
     <name>4</name>
+    <!-- kludge: 4 used with sus mostly, so lower it accordingly -->
     <render>m:0:0 s4 m:0:0</render>
     </token>
 
@@ -444,5 +461,15 @@
                   so you can get all major seventh chords to render as "ma7" by creating a chord definition
                   with no id or render tag, and just the single name "ma7"
 -->
+
+  <chord>
+    <name>6/9</name>
+    <render>m:1:-2 s6 m:-2.5:0 s/ m:-2:7 s9 m:0:-5</render>
+    </chord>
+
+  <chord>
+    <name>6,9</name>
+    <render>s6 m:0:-&mod; s, m:0:&mod; s9</render>
+    </chord>
 
   </museScore>


### PR DESCRIPTION
Adds support for "/" within chordnames if the portion after the "/" is
not convertible to tpc and hence not a valid bass note.  This allows for
C6/9 to be rendered as such.  I look at the _last_ slash when deciding
how to proceed, so C6/9/E is handled correctly.
