### PR TITLE
Fix #23371 : TAB - grace chords fretted incorrectly

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3459,20 +3459,22 @@ void Measure::updateAccidentals(Segment* segment, int staffIdx, AccidentalState*
             if (!chord || chord->type() != CHORD)
                  continue;
 
-            for (Chord* ch : chord->graceNotes()) {
-                  for (Note* note : ch->notes())
-                        note->updateAccidental(tversatz);
-                  }
-
             // TAB_STAFF is different, as each note has to be fretted
             // in the context of the all of the chords of the whole segment
 
             if (staffGroup == TAB_STAFF_GROUP) {
+                  for (Chord* ch : chord->graceNotes())
+                        instrument->stringData()->fretChords(ch);
                   instrument->stringData()->fretChords(chord);
                   continue;               // skip other staff type cases
                   }
 
             // PITCHED_ and PERCUSSION_STAFF can go note by note
+
+            for (Chord* ch : chord->graceNotes()) {
+                  for (Note* note : ch->notes())
+                        note->updateAccidental(tversatz);
+                  }
 
             for (Note* note : chord->notes()) {
                   switch(staffGroup) {

--- a/libmscore/tablature.h
+++ b/libmscore/tablature.h
@@ -18,6 +18,7 @@
 namespace Ms {
 
 class Chord;
+class Note;
 
 //---------------------------------------------------------
 //   StringData
@@ -28,6 +29,8 @@ class StringData {
       int         _frets;
 
       static bool bFretting;
+
+      void        sortChordNotes(QMap<int, Note *>& sortedNotes, const Chord* chord, int* count) const;
 
 public:
       StringData();


### PR DESCRIPTION
Fix #23371 : in TAB's grace chords are not fretted at all or fretted incorrectly.

Since the grace chords have been moved from a parent segment of their own to a parent chord, the fretting algorithm no longer 'sees' them correctly.

Fixed by extending the fretting algorithm to deal with chords not belonging to segments.
