### PR TITLE
Fix post 23402: note dragging in TAB

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -945,11 +945,13 @@ void Note::endDrag()
                         -_lineOffset : _lineOffset);
             _lineOffset = 0;
             // get a fret number for same pitch on new string
-            nFret       = staff->part()->instr()->stringData()->fret(_pitch, nString);
+            StringData* strData = staff->part()->instr()->stringData();
+            nFret       = strData->fret(_pitch, nString);
             if (nFret < 0)                      // no fret?
                   return;                       // no party!
             score()->undoChangeProperty(this, P_FRET, nFret);
             score()->undoChangeProperty(this, P_STRING, nString);
+            strData->fretChords(chord());
             }
       else {
             // on PITCHED / PERCUSSION staves, dragging a note changes the note pitch


### PR DESCRIPTION
In TAB's, when notes are dragged, for instance, above an already occupied string, other notes were not re-fretted.

See http://musescore.org/en/node/23402 for an example.
