### PR TITLE
Add file exists function for plugins

### DIFF
--- a/mscore/plugins.cpp
+++ b/mscore/plugins.cpp
@@ -490,6 +490,12 @@ bool FileIO::remove()
       return file.remove();
       }
 
+bool FileIO::exists()
+      {
+      QFile file(mSource);
+      return file.exists();
+      }
+
 //---------------------------------------------------------
 //   setScore
 //---------------------------------------------------------

--- a/mscore/plugins.h
+++ b/mscore/plugins.h
@@ -37,6 +37,7 @@ class FileIO : public QObject {
       explicit FileIO(QObject *parent = 0);
 
       Q_INVOKABLE QString read();
+      Q_INVOKABLE bool exists();
       Q_INVOKABLE bool write(const QString& data);
       Q_INVOKABLE bool remove();
       Q_INVOKABLE QString tempPath() {QDir dir; return dir.tempPath();};


### PR DESCRIPTION
This function is needed in plugins (ie. ABC import) to avoid overwriting a previously imported tune.
