### PR TITLE
Fix #23457 : Chord symbol copying

### DIFF
--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -655,20 +655,17 @@ Enabling copying of more element types requires enabling pasting in Score::paste
       xml.stag(QString("SymbolList version=\"" MSC_VERSION "\" fromtrack=\"%1\" totrack=\"%2\"")
                   .arg(topTrack).arg(bottomTrack));
       // scan the map, outputting elements each with a relative <track> tag on track change,
-      // a delta tick and the number of CR segments to skip
+      // a relative tick and the number of CR segments to skip
       int   currTrack = -1;
       for (auto iter = map.cbegin(); iter != map.cend(); ++iter) {
-//            int   currTick;
             int   numSegs;
             int   track = (int)(iter->first >> 32);
             if (currTrack != track) {
                   xml.tag("trackOffset", track - topTrack);
                   currTrack = track;
-//                  currTick  = firstTick;
                   seg       = firstSeg;
                   }
-//            xml.tag("tickDelta", (int)(iter->first & 0xFFFFFFFF) - currTick);
-//            currTick = (int)(iter->first & 0xFFFFFFFF);
+            xml.tag("tickOffset", (int)(iter->first & 0xFFFFFFFF) - firstTick);
             numSegs = 0;
             // with figured bass, we need to look for the proper segment
             // not only according to ChordRest elements, but also annotations

--- a/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames-ref.mscx
+++ b/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames-ref.mscx
@@ -270,9 +270,6 @@
             <tpc>18</tpc>
             </Note>
           </Chord>
-        <Harmony>
-          <root>16</root>
-          </Harmony>
         <Chord>
           <durationType>quarter</durationType>
           <Note>
@@ -286,6 +283,9 @@
           </BarLine>
         </Measure>
       <Measure number="6">
+        <Harmony>
+          <root>16</root>
+          </Harmony>
         <Beam id="3">
           <l1>11</l1>
           <l2>16</l2>
@@ -306,9 +306,6 @@
             <tpc>13</tpc>
             </Note>
           </Chord>
-        <Harmony>
-          <root>14</root>
-          </Harmony>
         <Chord>
           <durationType>eighth</durationType>
           <Beam>3</Beam>
@@ -345,9 +342,6 @@
             <tpc>16</tpc>
             </Note>
           </Chord>
-        <Harmony>
-          <root>15</root>
-          </Harmony>
         <Chord>
           <durationType>eighth</durationType>
           <Beam>4</Beam>
@@ -370,20 +364,21 @@
           </BarLine>
         </Measure>
       <Measure number="7">
+        <Harmony>
+          <root>14</root>
+          </Harmony>
         <Chord>
-          <durationType>half</durationType>
+          <durationType>whole</durationType>
           <Note>
             <pitch>76</pitch>
             <tpc>18</tpc>
             </Note>
           </Chord>
-        <Chord>
-          <durationType>half</durationType>
-          <Note>
-            <pitch>74</pitch>
-            <tpc>16</tpc>
-            </Note>
-          </Chord>
+        <tick>12480</tick>
+        <Harmony>
+          <root>15</root>
+          </Harmony>
+        <tick>13440</tick>
         <BarLine>
           <subtype>normal</subtype>
           <span>1</span>

--- a/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames.mscx
+++ b/mtest/libmscore/copypastesymbollist/copypastesymbollist-chordnames.mscx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="1.24">
   <programVersion>2.0.0</programVersion>
-  <programRevision>e5de291</programRevision>
+  <programRevision>fa034c3</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
@@ -358,17 +358,10 @@
         </Measure>
       <Measure number="7">
         <Chord>
-          <durationType>half</durationType>
+          <durationType>whole</durationType>
           <Note>
             <pitch>76</pitch>
             <tpc>18</tpc>
-            </Note>
-          </Chord>
-        <Chord>
-          <durationType>half</durationType>
-          <Note>
-            <pitch>74</pitch>
-            <tpc>16</tpc>
             </Note>
           </Chord>
         <BarLine>


### PR DESCRIPTION
Fix #23457

When multiple staff-collateral elements are selected, copied and pasted, they are pasted according to the note (chord) count of the original passage rather than according to the tick distances.

This makes sense for all the supported element kinds, except chord symbols.

Corrected to paste chord symbols according to source tick distances. If a chord symbol falls on a tick where there is no SegChordRest segment, such a segment is created.
