### PR TITLE
Fix #23447 and #21577 : Time sig addition and deletion and key sigs

### DIFF
--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -406,15 +406,17 @@ bool TrackList::write(int track, Measure* measure) const
                               }
                         }
                   }
-            else if (e->type() == Element::KEYSIG) {
-                  // keysig has to be at start of measure
-                  }
+//            else if (e->type() == Element::KEYSIG) {
+//                  // keysig has to be at start of measure
+//                  }
             else if (e->type() == Element::BAR_LINE)
                   ;
             else {
-                  if (m == 0)
+                  if (m == nullptr)
                         break;
-                  segment = m->getSegment(e, m->tick() + pos.ticks());
+                  // add the element in its own segment;
+                  // but KeySig has to be at start of (current) measure
+                  segment = m->getSegment(e, m->tick() + e->type() == Element::KEYSIG ? 0 : pos.ticks());
                   Element* ne = e->clone();
                   ne->setScore(score);
                   ne->setTrack(track);


### PR DESCRIPTION
Fix #23447 and #21577 : Adding or removing a time sig deletes key changes in the affected score span.

The function TrackList::write(), which restores a score span after reworking the measures affected by the time change, ignores key sig changes. Corrected.

As key sigs have to be placed at measure beginning, an existing key sig which, with the new measure boundaries, would be placed mid-measure is moved at the beginning of the (new) measure it falls into.

Note: this may be not round-trip safe; i.e. if a time signature which alters measure boundaries is added and then (manually) removed, key signatures may end up at different points than originally. Undo, however, works as expected.
