### PR TITLE
Fix #23521 : reading a workspace containing <file> tags crashes

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -609,8 +609,10 @@ QString readRootFile(MQZipReader* uz, QList<QString>& images)
                         const QStringRef& tag(e.name());
 
                         if (tag == "rootfile") {
-                              if (rootfile.isEmpty())
+                              if (rootfile.isEmpty()) {
                                     rootfile = e.attribute("full-path");
+                                    e.skipCurrentElement();
+                                    }
                               }
                         else if (tag == "file")
                               images.append(e.readElementText());


### PR DESCRIPTION
Fix #23521 : reading a workspace containing &lt;file&gt; tags crashes

The closing tag of the previous element was not read.
