### PR TITLE
avoid dots for notes which may result in 256th notes/rests or shorter

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2603,13 +2603,13 @@ void Score::padToggle(Pad n)
                   _is.setRest(!_is.rest());
                   break;
             case Pad::DOT:
-                  if (_is.duration().dots() == 1)
+                  if ((_is.duration().dots() == 1) || (_is.duration() == TDuration::DurationType::V_128TH))
                         _is.setDots(0);
                   else
                         _is.setDots(1);
                   break;
             case Pad::DOTDOT:
-                  if (_is.duration().dots() == 2)
+                  if ((_is.duration().dots() == 2) || (_is.duration() == TDuration::DurationType::V_64TH) || (_is.duration() == TDuration::DurationType::V_128TH))
                         _is.setDots(0);
                   else
                         _is.setDots(2);

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -305,8 +305,21 @@ void MuseScore::updateInputState(Score* score)
             }
 
       getAction("pad-rest")->setChecked(is.rest());
+      getAction("pad-dot")->setEnabled(true);
+      getAction("pad-dotdot")->setEnabled(true);
       getAction("pad-dot")->setChecked(is.duration().dots() == 1);
       getAction("pad-dotdot")->setChecked(is.duration().dots() == 2);
+      switch (is.duration().type()) {
+            case TDuration::DurationType::V_128TH:
+                  getAction("pad-dot")->setChecked(false);
+                  getAction("pad-dot")->setEnabled(false);
+            case TDuration::DurationType::V_64TH:
+                  getAction("pad-dotdot")->setChecked(false);
+                  getAction("pad-dotdot")->setEnabled(false);
+                  break;
+            default:
+                  break;
+            }
 
       getAction("note-longa")->setChecked(is.duration()  == TDuration::DurationType::V_LONG);
       getAction("note-breve")->setChecked(is.duration()  == TDuration::DurationType::V_BREVE);


### PR DESCRIPTION
This is just a tentative implementation to avoid problems such as:
http://musescore.org/node/23473
http://musescore.org/en/node/9077
I don't know if there may be other possible extreme cases in which these short-notes-problems may arise.