### PR TITLE
Fix #23538: update accidentals when tie is deleted

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -451,8 +451,13 @@ void Chord::remove(Element* e)
                   Note* note = static_cast<Note*>(e);
                   if (_notes.removeOne(note)) {
                         if (note->tieFor()) {
-                              if (note->tieFor()->endNote())
+                              if (note->tieFor()->endNote()) {
                                     note->tieFor()->endNote()->setTieBack(0);
+                                    // update accidentals for endNote
+                                    Chord* chord = note->tieFor()->endNote()->chord();
+                                    Measure* m = chord->segment()->measure();
+                                    note->score()->updateAccidentals(m,chord->staffIdx());
+                                    }
                               }
                         }
                   else

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -515,8 +515,13 @@ void Note::remove(Element* e)
                   {
                   Tie* tie = static_cast<Tie*>(e);
                   setTieFor(0);
-                  if (tie->endNote())
+                  if (tie->endNote()) {
                         tie->endNote()->setTieBack(0);
+                        // update accidentals for endNote
+                        Chord* chord = tie->endNote()->chord();
+                        Measure *m = chord->segment()->measure();
+                        score()->updateAccidentals(m,chord->staffIdx());
+                        }
                   int n = tie->spannerSegments().size();
                   for (int i = 0; i < n; ++i) {
                         SpannerSegment* ss = tie->spannerSegments().at(i);

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1396,6 +1396,8 @@ void RemoveElement::undo()
                   foreach(Note* note, chord->notes()) {
                         if (note->tieBack())
                               note->tieBack()->setEndNote(note);
+                        if (note->tieFor() && note->tieFor()->endNote()) 
+                              note->tieFor()->endNote()->setTieBack(note->tieFor());
                         }
                   }
             undoAddTuplet(static_cast<ChordRest*>(element));
@@ -1416,8 +1418,25 @@ void RemoveElement::undo()
 void RemoveElement::redo()
       {
       element->score()->removeElement(element);
-      if (element->isChordRest())
+      if (element->isChordRest()) {
             undoRemoveTuplet(static_cast<ChordRest*>(element));
+            if (element->type() == Element::CHORD) {
+                  Chord* chord = static_cast<Chord*>(element);
+                  Note* endNote = 0; // find one instance of endNote
+                  foreach(Note* note, chord->notes()) {
+                        if (note->tieFor() && note->tieFor()->endNote()) {
+                              endNote = note->tieFor()->endNote();
+                              note->tieFor()->endNote()->setTieBack(0);
+                              }
+                        }
+                  if (endNote) {
+                        // update accidentals in endNotes's measure
+                        Chord* eChord = endNote->chord();
+                        Measure* m = eChord->segment()->measure();
+                        endNote->score()->updateAccidentals(m,eChord->staffIdx());
+                        }
+                  }
+            }
       else if (element->type() == Element::KEYSIG) {
             KeySig* ks = static_cast<KeySig*>(element);
             if (!ks->generated())


### PR DESCRIPTION
UPDATED: This is to fix #23538 (formerly #12116):

Added call to updateAccidentals() in Chord::remove(Element_) and Note::remove(Element_) to make sure, notes which are no longer tied back get needed accidentals. This was the described issue #23538.

Let RemoveElement::undo() reset the tieBack property of the tie's endNote when restoring a removed tie, to avoid crashes.

Added a call to updateAccidentals() for the end measure of a tie being removed in RemoveElement::redo():
Example: Key signature of F major, a B nat is tied to the next measure which contains a second B nat.
This second B nat needs an accidental because the tied note doesn't have one. If the tie is removed, the first note gets a natural and now the second one does no longer need one. Therefore we need to check the measure of the last note of the tie.
