### PR TITLE
A proposal for aligning note heads to SMUFL conventions.

### DIFF
--- a/fonts/mscore/glyphnames.json
+++ b/fonts/mscore/glyphnames.json
@@ -206,10 +206,40 @@
     "keyboardPedalUp": {
         "codepoint": "U+e1a6"
     },
+    "mensuralBrevis": {
+        "codepoint": "U+e1c6"
+    },
+    "noteDoBlack": {
+        "codepoint": "U+e140"
+    },
+    "noteDoHalf": {
+        "codepoint": "U+e13e"
+    },
+    "noteDoWhole": {
+        "codepoint": "U+e13d"
+    },
+    "noteFaBlack": {
+        "codepoint": "U+e14e"
+    },
+    "noteFaHalf": {
+        "codepoint": "U+e14c"
+    },
+    "noteFaWhole": {
+        "codepoint": "U+e14a"
+    },
     "noteheadBlack": {
         "codepoint": "U+e12d"
     },
     "noteheadCircleX": {
+        "codepoint": "U+e13c"
+    },
+    "noteheadCircleXDoubleWhole": {
+        "codepoint": "U+e13c"
+    },
+    "noteheadCircleXHalf": {
+        "codepoint": "U+e13c"
+    },
+    "noteheadCircleXWhole": {
         "codepoint": "U+e13c"
     },
     "noteheadDiamondBlack": {
@@ -227,11 +257,26 @@
     "noteheadHalf": {
         "codepoint": "U+e12c"
     },
+    "noteheadSlashDiamondWhite": {
+        "codepoint": "U+e136"
+    },
     "noteheadSlashHorizontalEnds": {
         "codepoint": "U+e138"
     },
     "noteheadSlashWhite": {
         "codepoint": "U+e137"
+    },
+    "noteheadTriangleDownBlack": {
+        "codepoint": "U+e134"
+    },
+    "noteheadTriangleDownDoubleWhole": {
+        "codepoint": "U+e131"
+    },
+    "noteheadTriangleDownHalf": {
+        "codepoint": "U+e132"
+    },
+    "noteheadTriangleDownWhole": {
+        "codepoint": "U+e131"
     },
     "noteheadTriangleUpBlack": {
         "codepoint": "U+e134"
@@ -253,6 +298,51 @@
     },
     "noteheadXWhole": {
         "codepoint": "U+e139"
+    },
+    "noteLaBlack": {
+        "codepoint": "U+e152"
+    },
+    "noteLaHalf": {
+        "codepoint": "U+e151"
+    },
+    "noteLaWhole": {
+        "codepoint": "U+e150"
+    },
+    "noteMiBlack": {
+        "codepoint": "U+e149"
+    },
+    "noteMiHalf": {
+        "codepoint": "U+e148"
+    },
+    "noteMiWhole": {
+        "codepoint": "U+e147"
+    },
+    "noteReBlack": {
+        "codepoint": "U+e145"
+    },
+    "noteReHalf": {
+        "codepoint": "U+e143"
+    },
+    "noteReWhole": {
+        "codepoint": "U+e142"
+    },
+    "noteSoBlack": {
+        "codepoint": "U+e1ce"
+    },
+    "noteSoHalf": {
+        "codepoint": "U+e1cd"
+    },
+    "noteSoWhole": {
+        "codepoint": "U+e1cc"
+    },
+    "noteTiBlack": {
+        "codepoint": "U+e156"
+    },
+    "noteTiHalf": {
+        "codepoint": "U+e154"
+    },
+    "noteTiWhole": {
+        "codepoint": "U+e153"
     },
     "ornamentDownMordent": {
         "codepoint": "U+e18b"

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -64,41 +64,60 @@ namespace Ms {
 //---------------------------------------------------------
 
 const SymId noteHeads[2][Note::HEAD_GROUPS][HEAD_TYPES] = {
-      {     // down stem
-      { SymId::noteheadWhole,        SymId::noteheadHalf,        SymId::noteheadBlack,     SymId::noteheadDoubleWhole  },
-      { SymId::noteheadXWhole,       SymId::noteheadXHalf,       SymId::noteheadXBlack,    SymId::noteheadXWhole       },
-      { SymId::noteheadDiamondWhole, SymId::noteheadDiamondHalf, SymId::noteheadDiamondBlack, SymId::noteheadDiamondWhole  },
-#if 0
-      { SymId(s0triangleHeadSym),    SymId(d1triangleHeadSym),   SymId(d2triangleHeadSym), SymId(s0triangleHeadSym)    },
-      { SymId(s0miHeadSym),          SymId(s1miHeadSym),         SymId(s2miHeadSym),       SymId::noSym                },
-      { SymId(wholeslashheadSym),    SymId(halfslashheadSym),    SymId(quartslashheadSym), SymId(wholeslashheadSym)    },
-      { SymId(xcircledheadSym),      SymId(xcircledheadSym),     SymId(xcircledheadSym),   SymId(xcircledheadSym)      },
-      { SymId(s0doHeadSym),          SymId(d1doHeadSym),         SymId(d2doHeadSym),       SymId::noSym                },
-      { SymId(s0reHeadSym),          SymId(d1reHeadSym),         SymId(d2reHeadSym),       SymId::noSym                },
-      { SymId(d0faHeadSym),          SymId(d1faHeadSym),         SymId(d2faHeadSym),       SymId::noSym                },
-      { SymId(s0laHeadSym),          SymId(s1laHeadSym),         SymId(s2laHeadSym),       SymId::noSym                },
-      { SymId(s0tiHeadSym),          SymId(d1tiHeadSym),         SymId(d2tiHeadSym),       SymId::noSym                },
-      { SymId(s0solHeadSym),         SymId(s1solHeadSym),        SymId(s2solHeadSym),      SymId::noSym                },
-#endif
-      },
-      {     // up stem
-      { SymId::noteheadWhole,        SymId::noteheadHalf,        SymId::noteheadBlack,     SymId::noteheadDoubleWhole  },
-      { SymId::noteheadXWhole,       SymId::noteheadXHalf,       SymId::noteheadXBlack,    SymId::noteheadXWhole       },
-      { SymId::noteheadDiamondWhole, SymId::noteheadDiamondHalf, SymId::noteheadDiamondBlack, SymId::noteheadDiamondWhole  },
-#if 0 // TODO-smufl
-      { SymId(s0triangleHeadSym),    SymId(u1triangleHeadSym),   SymId(u2triangleHeadSym), SymId(s0triangleHeadSym)    },
-      { SymId(s0miHeadSym),          SymId(s1miHeadSym),         SymId(s2miHeadSym),       SymId::noSym                },
-      { SymId(wholeslashheadSym),    SymId(halfslashheadSym),    SymId(quartslashheadSym), SymId(wholeslashheadSym)    },
-      { SymId(xcircledheadSym),      SymId(xcircledheadSym),     SymId(xcircledheadSym),   SymId(xcircledheadSym)      },
-      { SymId(s0doHeadSym),          SymId(u1doHeadSym),         SymId(u2doHeadSym),       SymId::noSym                },
-      { SymId(s0reHeadSym),          SymId(u1reHeadSym),         SymId(u2reHeadSym),       SymId::noSym                },
-      { SymId(u0faHeadSym),          SymId(u1faHeadSym),         SymId(u2faHeadSym),       SymId::noSym                },
-      { SymId(s0laHeadSym),          SymId(s1laHeadSym),         SymId(s2laHeadSym),       SymId::noSym                },
-      { SymId(s0tiHeadSym),          SymId(u1tiHeadSym),         SymId(u2tiHeadSym),       SymId::noSym                },
-      { SymId(s0solHeadSym),         SymId(s1solHeadSym),        SymId(s2solHeadSym),      SymId::noSym                },
-#endif
-      }
-      };
+   // previous non-SMUFL data kept in comments for future reference
+   {     // down stem
+      { SymId::noteheadWhole,       SymId::noteheadHalf,          SymId::noteheadBlack,     SymId::noteheadDoubleWhole  },
+      { SymId::noteheadXWhole,      SymId::noteheadXHalf,         SymId::noteheadXBlack,    SymId::noteheadXWhole       },
+      { SymId::noteheadDiamondWhole,SymId::noteheadDiamondHalf,   SymId::noteheadDiamondBlack, SymId::noteheadDiamondWhole  },
+//    { SymId(s0triangleHeadSym),   SymId(d1triangleHeadSym),     SymId(d2triangleHeadSym), SymId(s0triangleHeadSym)    },
+      { SymId::noteheadTriangleDownWhole, SymId::noteheadTriangleDownHalf, SymId::noteheadTriangleDownBlack, SymId::noteheadTriangleDownDoubleWhole },
+//    { SymId(s0miHeadSym),         SymId(s1miHeadSym),           SymId(s2miHeadSym),           SymId::noSym            },
+      { SymId::noteMiWhole,         SymId::noteMiHalf,            SymId::noteMiBlack,           SymId::noSym            },
+//    { SymId(wholeslashheadSym),   SymId(halfslashheadSym),      SymId(quartslashheadSym),     SymId(wholeslashheadSym)},
+      { SymId::noteheadSlashDiamondWhite, SymId::noteheadSlashWhite, SymId::noteheadSlashHorizontalEnds, SymId::noteheadSlashDiamondWhite},
+//    { SymId(xcircledheadSym),     SymId(xcircledheadSym),       SymId(xcircledheadSym),       SymId(xcircledheadSym)  },
+      { SymId::noteheadCircleXWhole,SymId::noteheadCircleXHalf,   SymId::noteheadCircleX,       SymId::noteheadCircleXDoubleWhole},
+//    { SymId(s0doHeadSym),         SymId(d1doHeadSym),           SymId(d2doHeadSym),           SymId::noSym            },
+      { SymId::noteDoWhole,         SymId::noteDoHalf,            SymId::noteDoBlack,           SymId::noSym            },
+//    { SymId(s0reHeadSym),         SymId(d1reHeadSym),           SymId(d2reHeadSym),           SymId::noSym            },
+      { SymId::noteReWhole,         SymId::noteReHalf,            SymId::noteReBlack,           SymId::noSym            },
+//    { SymId(d0faHeadSym),         SymId(d1faHeadSym),           SymId(d2faHeadSym),           SymId::noSym            },
+      { SymId::noteFaWhole,         SymId::noteFaHalf,            SymId::noteFaBlack,           SymId::noSym            },
+//    { SymId(s0laHeadSym),         SymId(s1laHeadSym),           SymId(s2laHeadSym),           SymId::noSym            },
+      { SymId::noteLaWhole,         SymId::noteLaHalf,            SymId::noteLaBlack,           SymId::noSym            },
+//    { SymId(s0tiHeadSym),         SymId(d1tiHeadSym),           SymId(d2tiHeadSym),           SymId::noSym            },
+      { SymId::noteTiWhole,         SymId::noteTiHalf,            SymId::noteTiBlack,           SymId::noSym            },
+//    { SymId(s0solHeadSym),        SymId(s1solHeadSym),          SymId(s2solHeadSym),          SymId::noSym            },
+      { SymId::noteSoWhole,         SymId::noteSoHalf,            SymId::noteSoBlack,           SymId::noSym            },
+      { SymId::noteheadWhole,       SymId::noteheadHalf,          SymId::noteheadBlack,         SymId::mensuralBrevis   },
+   },
+   {     // up stem
+      { SymId::noteheadWhole,       SymId::noteheadHalf,          SymId::noteheadBlack,     SymId::noteheadDoubleWhole  },
+      { SymId::noteheadXWhole,      SymId::noteheadXHalf,         SymId::noteheadXBlack,    SymId::noteheadXWhole       },
+      { SymId::noteheadDiamondWhole,SymId::noteheadDiamondHalf,   SymId::noteheadDiamondBlack, SymId::noteheadDiamondWhole  },
+//    { SymId(s0triangleHeadSym),   SymId(d1triangleHeadSym),     SymId(d2triangleHeadSym), SymId(s0triangleHeadSym)    },
+      { SymId::noteheadTriangleDownWhole, SymId::noteheadTriangleDownHalf, SymId::noteheadTriangleDownBlack, SymId::noteheadTriangleDownDoubleWhole },
+//    { SymId(s0miHeadSym),         SymId(s1miHeadSym),           SymId(s2miHeadSym),           SymId::noSym            },
+      { SymId::noteMiWhole,         SymId::noteMiHalf,            SymId::noteMiBlack,           SymId::noSym            },
+//    { SymId(wholeslashheadSym),   SymId(halfslashheadSym),      SymId(quartslashheadSym),     SymId(wholeslashheadSym)},
+      { SymId::noteheadSlashDiamondWhite, SymId::noteheadSlashWhite, SymId::noteheadSlashHorizontalEnds, SymId::noteheadSlashDiamondWhite},
+//    { SymId(xcircledheadSym),     SymId(xcircledheadSym),       SymId(xcircledheadSym),       SymId(xcircledheadSym)  },
+      { SymId::noteheadCircleXWhole,SymId::noteheadCircleXHalf,   SymId::noteheadCircleX,       SymId::noteheadCircleXDoubleWhole},
+//    { SymId(s0doHeadSym),         SymId(d1doHeadSym),           SymId(d2doHeadSym),           SymId::noSym            },
+      { SymId::noteDoWhole,         SymId::noteDoHalf,            SymId::noteDoBlack,           SymId::noSym            },
+//    { SymId(s0reHeadSym),         SymId(d1reHeadSym),           SymId(d2reHeadSym),           SymId::noSym            },
+      { SymId::noteReWhole,         SymId::noteReHalf,            SymId::noteReBlack,           SymId::noSym            },
+//    { SymId(d0faHeadSym),         SymId(d1faHeadSym),           SymId(d2faHeadSym),           SymId::noSym            },
+      { SymId::noteFaWhole,         SymId::noteFaHalf,            SymId::noteFaBlack,           SymId::noSym            },
+//    { SymId(s0laHeadSym),         SymId(s1laHeadSym),           SymId(s2laHeadSym),           SymId::noSym            },
+      { SymId::noteLaWhole,         SymId::noteLaHalf,            SymId::noteLaBlack,           SymId::noSym            },
+//    { SymId(s0tiHeadSym),         SymId(d1tiHeadSym),           SymId(d2tiHeadSym),           SymId::noSym            },
+      { SymId::noteTiWhole,         SymId::noteTiHalf,            SymId::noteTiBlack,           SymId::noSym            },
+//    { SymId(s0solHeadSym),        SymId(s1solHeadSym),          SymId(s2solHeadSym),          SymId::noSym            },
+      { SymId::noteSoWhole,         SymId::noteSoHalf,            SymId::noteSoBlack,           SymId::noSym            },
+      { SymId::noteheadWhole,       SymId::noteheadHalf,          SymId::noteheadBlack,         SymId::mensuralBrevis   },
+   }
+};
 
 //---------------------------------------------------------
 //   noteHeadSym
@@ -296,22 +315,22 @@ void Note::undoSetTpc(int tpc)
 
 SymId Note::noteHead() const
       {
-      int hg, ht;
+      int up, ht;
       if (chord()) {
-            hg = chord()->up();
+            up = chord()->up();
             ht = chord()->durationType().headType();
             }
       else {
-            hg = 1;
+            up = 1;
             ht = HEAD_QUARTER;
             }
       if (_headType != HEAD_AUTO)
             ht = _headType;
 
-      SymId t = noteHeads[hg][int(_headGroup)][ht];
+      SymId t = noteHeads[up][int(_headGroup)][ht];
       if (t == SymId::noSym) {
             qDebug("invalid note head %d/%d", _headGroup, _headType);
-            t = noteHeads[hg][0][ht];
+            t = noteHeads[up][0][ht];
             }
       return t;
       }

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -106,6 +106,7 @@ class Note : public Element {
             HEAD_NORMAL = 0, HEAD_CROSS, HEAD_DIAMOND, HEAD_TRIANGLE, HEAD_MI,
             HEAD_SLASH, HEAD_XCIRCLE, HEAD_DO, HEAD_RE, HEAD_FA, HEAD_LA, HEAD_TI,
             HEAD_SOL,
+            HEAD_BREVIS_ALT,
             HEAD_GROUPS,
             HEAD_INVALID = -1
             };


### PR DESCRIPTION
It should re-enable all the note head functionality as per ver. 1.3 (and previous 2.0 releases), with most (all?) equal results.
- No new glyph added to font(s)
- Existing mscore glyphs have been matched to SMUFL note head symbols:
  - partly on similarity of shape
  - partly on similarity of semantics (in particular most of the _noteDo_..., _noteRe_..., ... heads)
- The dropped HEAD_BREVIS_ALT note head group have been re-instated (dropping it was a regression from 1.3)
- **fonts/mscore/glyphnames.json** has been updated
- **fonts/mscore/metadata.json** has NOT been updated (I have not understood its contents)

It may be improved incrementally, should the need arise.
