### PR TITLE
Fix #23508 : A custom style set as default style in Prefs. is not used

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4783,10 +4783,10 @@ int main(int argc, char* av[])
             qDebug() << "  Virtual size:" << screen->virtualSize().width() << "x" << screen->virtualSize().height();
             }
 
-      preferences.readDefaultStyle();
-
       if (!useFactorySettings)
             preferences.read();
+
+      preferences.readDefaultStyle();
 
       if (converterDpi == 0)
             converterDpi = preferences.pngResolution;

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -1450,7 +1450,7 @@ bool Preferences::readDefaultStyle()
       {
       if (defaultStyleFile.isEmpty())
             return false;
-      MStyle* style = new MStyle;
+      MStyle* style = new MStyle(*MScore::defaultStyle());
       QFile f(defaultStyleFile);
       if (!f.open(QIODevice::ReadOnly))
             return false;


### PR DESCRIPTION
Fix #23508 : A custom style set as default style in Prefs. is not used

Fixed by loading the preferences before loading the custom style. Also makes sure the custom style is complete, by initializing it with the built-in default style before loading.
