### PR TITLE
Fix TAB and PERC clefs.

### DIFF
--- a/fonts/bravura/glyphnames.json
+++ b/fonts/bravura/glyphnames.json
@@ -3,19 +3,19 @@
         "codepoint": "U+E07B"
     }, 
     "4stringTabClefSerif": {
-        "codepoint": "U+E07B"
+        "codepoint": "U+F406"
     }, 
     "4stringTabClefTall": {
-        "codepoint": "U+E07B"
+        "codepoint": "U+F405"
     }, 
     "6stringTabClef": {
         "codepoint": "U+E07A"
     }, 
     "6stringTabClefSerif": {
-        "codepoint": "U+E07A"
+        "codepoint": "U+F404"
     }, 
     "6stringTabClefTall": {
-        "codepoint": "U+E07A"
+        "codepoint": "U+F403"
     }, 
     "accdnLH2Ranks16Round": {
         "codepoint": "U+E966"

--- a/fonts/mscore/glyphnames.json
+++ b/fonts/mscore/glyphnames.json
@@ -1,4 +1,7 @@
 {
+    "6stringTabClef": {
+        "codepoint": "U+e1cB"
+    },
     "6stringTabClefSerif": {
         "codepoint": "U+e1a2"
     },

--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -250,17 +250,17 @@ void Clef::layout1()
                   yoff = 0.0;
                   break;
             case ClefType::TAB:                            // TAB clef
-                  symbol->setSym(SymId::sixStringTabClefTall);
+                  symbol->setSym(SymId::sixStringTabClef);
                   // on tablature, position clef at half the number of spaces * line distance
                   yoff = curLineDist * (curLines - 1) * .5;
-                  break;                              // TAB clef alternate style
-            case ClefType::TAB2:
+                  break;
+            case ClefType::TAB2:                           // TAB clef alternate style
                   symbol->setSym(SymId::sixStringTabClefSerif);
                   // on tablature, position clef at half the number of spaces * line distance
                   yoff = curLineDist * (curLines - 1) * .5;
                   break;
             case ClefType::PERC:                           // percussion clefs
-            case ClefType::PERC2:
+            case ClefType::PERC2:         // no longer supported: fall back to same glyph as PERC
                   symbol->setSym(SymId::unpitchedPercussionClef1);
                   yoff = curLineDist * (curLines - 1) * 0.5;
                   break;

--- a/libmscore/clef.h
+++ b/libmscore/clef.h
@@ -56,7 +56,7 @@ enum class ClefType : signed char {
       G4,
       F_8VA,
       F_15MA,
-      PERC2,
+      PERC2,            // no longer supported, but kept for compat. with old scores; rendered as PERC
       TAB2,
       MAX
       };

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -628,13 +628,14 @@ Palette* MuseScore::newClefsPalette()
       sp->setMag(0.8);
       sp->setGrid(33, 60);
       sp->setYOffset(1.0);
-      static const ClefType clefs[21] = {
+      // Up to ClefType::MAX-1, because ClefType::PERC2 is no longer supported
+      static const ClefType clefs[(int)(ClefType::MAX)-1] = {
             ClefType::G, ClefType::G1, ClefType::G2, ClefType::G3, ClefType::G4,
             ClefType::C1, ClefType::C2, ClefType::C3, ClefType::C4, ClefType::C5,
             ClefType::F, ClefType::F_8VA, ClefType::F_15MA, ClefType::F8, ClefType::F15, ClefType::F_B, ClefType::F_C,
-            ClefType::PERC, ClefType::TAB, ClefType::TAB2, ClefType::PERC2
+            ClefType::PERC, ClefType::TAB, ClefType::TAB2
             };
-      for (int i = 0; i < 20; ++i) {
+      for (int i = 0; i < (int)(ClefType::MAX)-1; ++i) {
             ClefType j = clefs[i];
             Clef* k = new Ms::Clef(gscore);
             k->setClefType(ClefTypeList(j, j));


### PR DESCRIPTION
**TAB**: The two TAB clefs showed the same in the palette(s) and the 'flourished' one was displaying nothing in the score. Fixed by:
- adjusting TAB clef mapping in fonts/bravura/glyphnames.json,
- adding the proper mapping to fonts/mscore/glyphnames.json,
- correcting the symbol set for TAB in Clef::layout1()

**PERC**: The PERC2 clef has been dropped at some point in the past; it is no longer shown in the UI and silently rendered as PERC, if found in scores. Added some comments to:
- ClefType definition,
- Clef::layout1() function,
- to MuseScore::newClefPalette() function (with a reformulation of the _for_ instr.)

to make the situation more evident.

In practice, there almost no change in the code proper itself.
