### PR TITLE
Ensure Bravura is the fallback font - Step 1

### DIFF
--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -25,10 +25,12 @@ namespace Ms {
 //---------------------------------------------------------
 
 QVector<ScoreFont> ScoreFont::_scoreFonts = {
+      ScoreFont("Bravura",    "Bravura",     ":/fonts/bravura/",  "Bravura.otf"),
       ScoreFont("Emmentaler", "MScore",      ":/fonts/mscore/",   "mscore.ttf"),
-//      ScoreFont("Goneville",  "Gonville-20", ":/fonts/gonville/", "gonville-20.ttf"),
-      ScoreFont("Bravura",    "Bravura",     ":/fonts/bravura/",  "Bravura.otf")
+//      ScoreFont("Goneville",  "Gonville-20", ":/fonts/gonville/", "gonville-20.ttf")
       };
+
+static const int FONTFACTORY_BRAVURA_INDEX = 0;
 
 //---------------------------------------------------------
 //   table of symbol names
@@ -3338,16 +3340,18 @@ QPixmap ScoreFont::sym2pixmap(SymId id, qreal mag)
 
 void ScoreFont::draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos) const
       {
+      Sym sm = sym(id);
       qreal imag = 1.0 / mag;
       painter->scale(mag, mag);
       painter->setFont(_font);
-      painter->drawText(pos * imag, toString(id));
+      painter->drawText(pos * imag, sm.string());
       painter->scale(imag, imag);
       }
 
 void ScoreFont::draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos, int n) const
       {
-      QString s = toString(id);
+      Sym sm = sym(id);
+      QString s = sm.string();
       QString d;
       for (int i = 0; i < n; ++i)
             d += s;
@@ -3644,8 +3648,8 @@ ScoreFont* ScoreFont::fontFactory(QString s)
 
 const Sym& ScoreFont::sym(SymId id) const
       {
-      if (!_symbols[int(id)].isValid() && (this != &_scoreFonts[0]))
-            return _scoreFonts[0]._symbols[int(id)];
+      if (!_symbols[int(id)].isValid() && (this != &_scoreFonts[FONTFACTORY_BRAVURA_INDEX]))
+            return _scoreFonts[FONTFACTORY_BRAVURA_INDEX]._symbols[int(id)];
       return _symbols[int(id)];
       }
 


### PR DESCRIPTION
1) _ScoreFont::sym()_ was looking for the wrong fallback font, as it was looking for font 0 and font 0 was Emmentaler. Corrected.

2) _ScoreFont::draw()_ was not falling back to Bravura at all, drawing the empty string (= nothing) for undefined glyphs of the current font. The first step is to have _ScoreFont::draw()_ to look for the 'right' string to draw: current font string if defined, Bravura string if not; this usually results in an hollow box (undefined character) being drawn and at least alerts the user that the font does not supply the intended glyph.

The next step will be to also use the right font. This can be done in several ways:
1. having _ScoreFont::sym()_ to also return a font (in an additional _ScoreFont*_ parameter);
2. adding a specific function _ScoreFont::font(SymId id)_, doing the same test _ScoreFont::sym()_ is doing and returning the chosen font.

Please advise how to proceed.
