### PR TITLE
Fix parenthesized accidental drawing

### DIFF
--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -301,22 +301,20 @@ void Accidental::layout()
       setMag(m);
 
       m = magS();
-      QPointF pos;
       if (_hasBracket) {
             SymElement e(SymId::noteheadParenthesisLeft, 0.0);
             el.append(e);
             r |= symBbox(SymId::noteheadParenthesisLeft);
-            pos = symAttach(SymId::noteheadParenthesisRight);
             }
 
       SymId s = symbol();
-      SymElement e(s, pos.x());
+      qreal x = r.x()+r.width();
+      SymElement e(s, x);
       el.append(e);
-      r |= symBbox(s);
-//      pos += symAttach(s);   ???
+      r |= symBbox(s).translated(x, 0.0);
 
       if (_hasBracket) {
-            qreal x = pos.x();     // symbols[s].width(m) + symbols[s].bbox(m).x();
+            x = r.x()+r.width();
             SymElement e(SymId::noteheadParenthesisRight, x);
             el.append(e);
             r |= symBbox(SymId::noteheadParenthesisRight).translated(x, 0.0);


### PR DESCRIPTION
Parenthesized accidentals are drawn with the closing parenthesis right after the left parenthesis rather than after the accidental.

Fixed by positioning the three elements according to their actual width in Accidental::layout().
