### PR TITLE
fix #23785: chord symbol text style changes require reload

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1131,6 +1131,16 @@ void Harmony::spatiumChanged(qreal oldValue, qreal newValue)
       }
 
 //---------------------------------------------------------
+//   textStyleChanged
+//---------------------------------------------------------
+
+void Harmony::textStyleChanged()
+      {
+      Text::textStyleChanged();
+      render();
+      }
+
+//---------------------------------------------------------
 //   dragAnchor
 //---------------------------------------------------------
 

--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -167,6 +167,7 @@ class Harmony : public Text {
       const ChordDescription* fromXml(const QString& s, const QList<HDegree>&);
       const ChordDescription* fromXml(const QString& s);
       virtual void spatiumChanged(qreal oldValue, qreal newValue);
+      virtual void textStyleChanged();
       virtual QLineF dragAnchor() const;
       void setHarmony(const QString& s);
       virtual QPainterPath shape() const;

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -130,7 +130,7 @@ class Text : public SimpleText {
       void setModified(bool v);
       void clear();
       QRectF pageRectangle() const;
-      void textStyleChanged();
+      virtual void textStyleChanged();
       virtual void setScore(Score* s);
       friend class TextProperties;
 

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2409,7 +2409,7 @@ static void updateTextStyle(void* a, Element* e)
       QString s = *(QString*)a;
       if (e->isText()) {
             Text* text = static_cast<Text*>(e);
-            if (text->styled() && text->textStyle().name() == s) {
+            if ((text->styled() && text->textStyle().name() == s) || (text->type() == Element::HARMONY && s == "Chord Symbol")) {
                   text->setTextStyle(text->score()->textStyle(s));
                   text->textStyleChanged();
                   }


### PR DESCRIPTION
Changes to chord symbol text style were not taking effect until reload.
This change forces a render() call on all chord symbols if the text
style changes.
