### PR TITLE
Default style, base style, saving and reading score file styles.

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -1081,8 +1081,8 @@ bool StyleData::isDefault(StyleIdx idx) const
 
 //---------------------------------------------------------
 //   save
-//    if optimize is true, save only if different to default
-//    style
+//    if optimize is true, save only data which are different
+//    from built-in style ( MScore::baseStyle() )
 //---------------------------------------------------------
 
 void StyleData::save(Xml& xml, bool optimize) const
@@ -1103,7 +1103,7 @@ void StyleData::save(Xml& xml, bool optimize) const
                   }
             }
       for (int i = 0; i < TEXT_STYLES; ++i) {
-            if (!optimize || _textStyles[i] != MScore::defaultStyle()->textStyle(i))
+            if (!optimize || _textStyles[i] != MScore::baseStyle()->textStyle(i))
                   _textStyles[i].write(xml);
             }
       for (int i = TEXT_STYLES; i < _textStyles.size(); ++i)
@@ -1114,7 +1114,7 @@ void StyleData::save(Xml& xml, bool optimize) const
             xml.etag();
             }
       for (int i = 0; i < ARTICULATIONS; ++i) {
-            if (optimize && _articulationAnchor[i] == MScore::defaultStyle()->articulationAnchor(i))
+            if (optimize && _articulationAnchor[i] == MScore::baseStyle()->articulationAnchor(i))
                   continue;
             const ArticulationInfo& ai = Articulation::articulationList[i];
             xml.tag(ai.name + "Anchor", int(_articulationAnchor[i]));

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -308,7 +308,7 @@ Score* MuseScore::readScore(const QString& name)
       if (name.isEmpty())
             return 0;
 
-      Score* score = new Score(MScore::defaultStyle());
+      Score* score = new Score(MScore::baseStyle());  // start with built-in style
       setMidiPrefOperations(name);
       Score::FileError rv = Ms::readScore(score, name, false);
       if (rv == Score::FILE_TOO_OLD || rv == Score::FILE_TOO_NEW) {


### PR DESCRIPTION
**Background**: the MScore objects has two reference styles:
- _baseStyle, which is inited to the built-in default style (common to all MuseScore copies)
- _defaultStyle which is inited to the user-defined default style

They are equal in a default installation but become different as soon as the user chooses a custom default style in the Preferences.

**Issues**:
- score styles are saved as delta from the user-default style for texts and for articulations and as delta from the built-in default for the rest
- when the score is read back from file, it is inited to the user-default style and styles are read as a delta from it.

This makes:
- different parts of the saved style inconsistent among themselves
- styles saved in the score non-portable across different MuseScore copies (with potentially different user-default styles)

**Fix**:
- all style parts are saved as delta from the built-in default (to be portable)
- score is inited to built-in default style before being read from file.

**Note**: it is expected that users with custom default styles notice style differences when reading scores saved with previous 2.0 commits, as they were saved as delta from their respective user default styles.
