### PR TITLE
fix oversized noteheads in bagpipe palette

### DIFF
--- a/libmscore/bagpembell.h
+++ b/libmscore/bagpembell.h
@@ -61,6 +61,7 @@ class BagpipeEmbellishment : public Element {
       virtual ElementType type() const            { return BAGPIPE_EMBELLISHMENT;           }
       int embelType() const                       { return _embelType;                      }
       void setEmbelType(int val)                  { _embelType = val;                       }
+      virtual qreal mag() const;
       virtual void write(Xml&) const;
       virtual void read(XmlReader&);
       virtual void layout();


### PR DESCRIPTION
Notehead size issue fixed. One minor issue remaining: when dragging a single grace note, the flag is too low.
