### PR TITLE
Fix broken build when USE_ALSA is not defined

### DIFF
--- a/mscore/mididriver.cpp
+++ b/mscore/mididriver.cpp
@@ -533,7 +533,8 @@ bool AlsaMidiDriver::putEvent(snd_seq_event_t* event)
             } while (error == -12);
       return true;
       }
+}
 
 #endif /* USE_ALSA */
-}
+
 


### PR DESCRIPTION
The bracket is not matched when USE_ALSA is not defined.
