### PR TITLE
Fix non-permanent mm/sp text style setting.

### DIFF
--- a/mscore/textprop.cpp
+++ b/mscore/textprop.cpp
@@ -101,6 +101,7 @@ void TextProp::mmToggled(bool val)
       QString unit(val ? tr("mm", "millimeter unit") : tr("sp", "spatium unit"));
       xOffset->setSuffix(unit);
       yOffset->setSuffix(unit);
+      curUnit = val ? 0 : 1;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
A change from "mm" to "sp" of a test style was not retained.

The error was in the code managing the dlg box UI, which omitted to update the relevant local variable.
