### PR TITLE
Fix ukulele instrument data

### DIFF
--- a/share/templates/instruments.xml
+++ b/share/templates/instruments.xml
@@ -8505,6 +8505,7 @@
             <Instrument id="ukulele-4-str-tab">
                   <longName>Ukulele (Tablature)</longName>
                   <shortName>Uk.</shortName>
+                  <trackName>Ukulele (Tablature)</trackName>
                   <init>ukulele</init>
                   <description>Ukulele (4-str. TAB)</description>
                   <musicXMLid>pluck.ukulele</musicXMLid>
@@ -8536,7 +8537,14 @@
                   <shortName>Bar. Uk.</shortName>
                   <description>Baritone Ukulele</description>
                   <musicXMLid>pluck.ukulele</musicXMLid>
-                  <clef>G</clef>
+                  <StringData>
+                        <frets>18</frets>
+                        <string>50</string>
+                        <string>55</string>
+                        <string>57</string>
+                        <string>64</string>
+                  </StringData>
+                  <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>50-76</aPitchRange>
                   <pPitchRange>50-76</pPitchRange>


### PR DESCRIPTION
- Show " (tablature)" for the ukulele tablature variant
- Add tuning data for the baritone ukulele

See http://musescore.org/en/node/24089 for more details.
Source of data: http://en.wikipedia.org/wiki/Ukulele
