### PR TITLE
Fix a bug in bsp

### DIFF
--- a/libmscore/bsp.cpp
+++ b/libmscore/bsp.cpp
@@ -138,9 +138,13 @@ QList<Element*> BspTree::items(const QRectF& rect)
       {
       FindItemBspTreeVisitor findVisitor;
       climbTree(&findVisitor, rect);
-      for (Element * e : findVisitor.foundItems)
-            e->itemDiscovered = false;
-      return findVisitor.foundItems;
+      QList<Element*> l;
+      for (Element * e : findVisitor.foundItems) {
+          e->itemDiscovered = 0;
+          if (e->pageBoundingRect().intersects(rect))
+                l.append(e);
+          }
+          return l;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Item() sometimes returns elements not intersected with input rect.
