### PR TITLE
7713 reducing measure duration

### DIFF
--- a/mscore/measureproperties.cpp
+++ b/mscore/measureproperties.cpp
@@ -25,6 +25,7 @@
 #include "libmscore/repeat.h"
 #include "libmscore/undo.h"
 #include "libmscore/range.h"
+#include "globals.h"
 
 namespace Ms {
 
@@ -234,6 +235,13 @@ void MeasureProperties::apply()
                         m->adjustToLen(len());
                         score->select(m, SELECT_RANGE, 0);
                         }
+                  else
+                        if(!noGui)
+                              QMessageBox::warning(0,
+                                 QT_TRANSLATE_NOOP("MeasureProperties", "MuseScore"),
+                                 QT_TRANSLATE_NOOP("MeasureProperties", "cannot change measure length:\n"
+                                 "tuplet would cross measure")
+                                 );
                   }
             }
       score->select(0, SELECT_SINGLE, 0);


### PR DESCRIPTION
Fixes for issue #7713, Reducing actual duration corrupts tuplets.
Ms no longer crashes. User is prevented from shortening a measure beyond the requirements of any contained tuplets. User is informed if shortening is prevented.
