### PR TITLE
fix #24030: Styles and default styles for parts

### DIFF
--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -36,6 +36,7 @@ bool  MScore::debugMode;
 bool  MScore::testMode = false;
 
 MStyle* MScore::_defaultStyle;
+MStyle* MScore::_defaultStyleForParts;
 MStyle* MScore::_baseStyle;
 QString MScore::_globalShare;
 int     MScore::_vRaster;
@@ -55,7 +56,8 @@ qreal   MScore::nudgeStep;
 qreal   MScore::nudgeStep10;
 qreal   MScore::nudgeStep50;
 int     MScore::defaultPlayDuration;
-QString MScore::partStyle;
+QString MScore::defaultStyleFile;
+QString MScore::defaultStyleFileForParts;
 QString MScore::lastError;
 bool    MScore::layoutDebug = false;
 int     MScore::division    = 480;   // pulses per quarter note (PPQ) // ticks per beat
@@ -128,7 +130,8 @@ void MScore::init()
       replaceFractions    = true;
       playRepeats         = true;
       panPlayback         = true;
-      partStyle           = "";
+      defaultStyleFile    = "";
+      defaultStyleFileForParts = "";
 
       lastError           = "";
 
@@ -136,9 +139,11 @@ void MScore::init()
       frameMarginColor    = QColor("#6abed3");
       bgColor.setNamedColor("#dddddd");
 
-      _defaultStyle         = new MStyle();
+      _defaultStyle           = new MStyle();
+      _defaultStyleForParts   = new MStyle();
       Ms::initStyle(_defaultStyle);
-      _baseStyle            = new MStyle(*_defaultStyle);
+      Ms::initStyle(_defaultStyleForParts);
+      _baseStyle              = new MStyle(*_defaultStyle);
 
       //
       //  load internal fonts
@@ -183,6 +188,15 @@ MStyle* MScore::defaultStyle()
       }
 
 //---------------------------------------------------------
+//   defaultStyleForParts
+//---------------------------------------------------------
+
+MStyle* MScore::defaultStyleForParts()
+      {
+      return _defaultStyleForParts;
+      }
+
+//---------------------------------------------------------
 //   baseStyle
 //---------------------------------------------------------
 
@@ -195,10 +209,13 @@ MStyle* MScore::baseStyle()
 //   setDefaultStyle
 //---------------------------------------------------------
 
-void MScore::setDefaultStyle(MStyle* s)
+void MScore::setDefaultStyle(MStyle* s, bool forParts)
       {
-      delete _defaultStyle;
-      _defaultStyle = s;
+      delete (forParts ? _defaultStyleForParts : _defaultStyle);
+      if (forParts)
+            _defaultStyleForParts = s;
+      else
+            _defaultStyle = s;
       }
 
 }

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -332,6 +332,7 @@ class MScore : public QObject {
    private:
       static MStyle* _defaultStyle;       // default modified by preferences
       static MStyle* _baseStyle;          // buildin initial style
+      static MStyle* _defaultStyleForParts;       // default style for parts modified by preferences
       static QString _globalShare;
       static int _hRaster, _vRaster;
 
@@ -342,8 +343,9 @@ class MScore : public QObject {
 
       static void init();
       static MStyle* defaultStyle();
+      static MStyle* defaultStyleForParts();
       static MStyle* baseStyle();
-      static void setDefaultStyle(MStyle*);
+      static void setDefaultStyle(MStyle*, bool forParts = false);
       static const QString& globalShare()   { return _globalShare; }
       static qreal hRaster()                { return _hRaster;     }
       static qreal vRaster()                { return _vRaster;     }
@@ -368,7 +370,8 @@ class MScore : public QObject {
       static qreal nudgeStep10;
       static qreal nudgeStep50;
       static int defaultPlayDuration;
-      static QString partStyle;
+      static QString defaultStyleFile;
+      static QString defaultStyleFileForParts;
       static QString lastError;
       static bool layoutDebug;
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -377,12 +377,11 @@ Score::Score(Score* parent)
       {
       _parentScore = parent;
       init();
-
-      _style = *parent->style();
-      if (!MScore::partStyle.isEmpty()) {
-            QFile f(MScore::partStyle);
-            if (f.open(QIODevice::ReadOnly))
-                  _style.load(&f);
+      if (!MScore::defaultStyleFileForParts.isEmpty()){
+            _style = *MScore::defaultStyleForParts();
+            }
+      else {
+            _style = *parent->style();
             }
       _synthesizerState = parent->_synthesizerState;
       }

--- a/mscore/actions.cpp
+++ b/mscore/actions.cpp
@@ -1546,6 +1546,13 @@ Shortcut Shortcut::sc[] = {
          QT_TRANSLATE_NOOP("action","Save Style as Default..."),
           fileSave_ICON
          ),
+      Shortcut(
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
+         A_SCORE,
+         "save-default-style-for-parts",
+         QT_TRANSLATE_NOOP("action","Save Style as Default for Parts..."),
+          fileSave_ICON
+         ),
       Shortcut (
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
          A_CMD,

--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -318,3 +318,44 @@ void ExcerptsDialog::accept()
       }
 }
 
+//---------------------------------------------------------
+//   Load part style
+//---------------------------------------------------------
+
+void Ms::ExcerptsDialog::on_loadPartsStyleButton_clicked()
+{
+      QString name = mscore->getStyleFilename(true);
+      if (!name.isEmpty()) {
+            if(score->excerpts().count() == 0) {
+                  QMessageBox msgBox;
+                  msgBox.setText(QT_TRANSLATE_NOOP("ExcerptsDialog", "There are no parts."));
+                  msgBox.setInformativeText(QT_TRANSLATE_NOOP("ExcerptsDialog", "Do you want to generate them now?"));
+                  QPushButton* makePartsButton = msgBox.addButton(tr(QT_TRANSLATE_NOOP("ExcerptsDialog", "Generate Parts")), QMessageBox::ActionRole);
+                  QPushButton* abortButton = msgBox.addButton(QMessageBox::Abort);
+                  msgBox.exec();
+
+                  if (msgBox.clickedButton() == makePartsButton) {
+                        if(!excerptList->count())
+                              newAllClicked();
+                        accept();
+                        }
+                  else if (msgBox.clickedButton() == abortButton) {
+                        return;
+                        }
+                  }
+            foreach(Excerpt* excerpt, score->excerpts()){
+                  Score* sc = excerpt->score();
+                  sc->startCmd();
+                  if (!sc->loadStyle(name)) {
+                        QMessageBox::critical(this, tr("MuseScore: load style"), MScore::lastError);
+                        }
+                  else {
+                        score->setSaved(false);
+                        score->setDirty(true);
+                        }
+                   sc->endCmd();
+                   }
+            }
+      raise();
+}
+

--- a/mscore/excerptsdialog.h
+++ b/mscore/excerptsdialog.h
@@ -74,6 +74,7 @@ class ExcerptsDialog : public QDialog, private Ui::ExcerptsDialog {
       void partClicked(QListWidgetItem*);
       void createExcerptClicked(QListWidgetItem*);
       void titleChanged(const QString&);
+      void on_loadPartsStyleButton_clicked();
 
    public:
       ExcerptsDialog(Score*, QWidget* parent = 0);

--- a/mscore/excerptsdialog.ui
+++ b/mscore/excerptsdialog.ui
@@ -103,7 +103,20 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="3" column="0">
+    <widget class="QPushButton" name="loadPartsStyleButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Load Parts Style</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1032,6 +1032,7 @@ MuseScore::MuseScore()
       menuStyle->addAction(getAction("load-style"));
       menuStyle->addAction(getAction("save-style"));
       menuStyle->addAction(getAction("save-default-style"));
+      menuStyle->addAction(getAction("save-default-style-for-parts"));
 
       //---------------------
       //    Menu Plugins
@@ -4168,19 +4169,10 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   }
             }
       else if (cmd == "save-default-style") {
-            QString name = getStyleFilename(false);
-            if (!name.isEmpty()) {
-                  if (!cs->saveStyle(name)) {
-                        QMessageBox::critical(this,
-                           tr("MuseScore: save style"), MScore::lastError);
-                        }
-                  else {
-                        QFileInfo info(name);
-                        if (info.suffix().isEmpty())
-                              info.setFile(info.filePath() + ".mss");
-                        preferences.defaultStyleFile = info.filePath();
-                        }
-                  }
+            saveDefaultStyle(false);
+            }
+      else if (cmd == "save-default-style-for-parts") {
+            saveDefaultStyle(true);
             }
       else if (cmd == "load-style") {
             QString name = mscore->getStyleFilename(true);
@@ -4288,6 +4280,87 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             }
       if (debugger)
             debugger->reloadClicked();
+      }
+
+//---------------------------------------------------------
+//   saveDefaultStyle
+//---------------------------------------------------------
+
+void MuseScore::saveDefaultStyle(bool forParts)
+      {
+      QString name = getStyleFilename(false);
+      if (!name.isEmpty()) {
+            if (!cs->saveStyle(name)) {
+                  QMessageBox::critical(this,
+                                  tr("MuseScore: save style"), MScore::lastError);
+            }
+            else {
+                  QFileInfo info(name);
+                  if (info.suffix().isEmpty())
+                        info.setFile(info.filePath() + ".mss");
+                  if(forParts)
+                        preferences.defaultStyleFileForParts = info.filePath();
+                  else
+                        preferences.defaultStyleFile = info.filePath();
+                  }
+                  preferences.readDefaultStyle(forParts);
+            }
+      }
+
+//---------------------------------------------------------
+//   cmdAddChordName2
+//---------------------------------------------------------
+
+void MuseScore::cmdAddChordName2()
+      {
+      if (cs == 0 || !cs->checkHasMeasures())
+            return;
+      ChordRest* cr = cs->getSelectedChordRest();
+      if (!cr)
+            return;
+      int rootTpc = 14;
+      if (cr->type() == Element::CHORD) {
+            Chord* chord = static_cast<Chord*>(cr);
+            rootTpc = chord->downNote()->tpc();
+            }
+      Harmony* s = 0;
+      Segment* segment = cr->segment();
+
+      foreach(Element* e, segment->annotations()) {
+            if (e->type() == Element::HARMONY && (e->track() == cr->track())) {
+                  s = static_cast<Harmony*>(e);
+                  break;
+                  }
+            }
+
+      bool created = false;
+      if (s == 0) {
+            s = new Harmony(cs);
+            s->setTrack(cr->track());
+            s->setParent(segment);
+            s->setRootTpc(rootTpc);
+            created = true;
+            }
+      ChordEdit ce(cs);
+      ce.setHarmony(s);
+      int rv = ce.exec();
+      if (rv) {
+            const Harmony* h = ce.harmony();
+            s->setRootTpc(h->rootTpc());
+            s->setBaseTpc(h->baseTpc());
+            s->setId(h->id());
+            s->clearDegrees();
+            for (int i = 0; i < h->numberOfDegrees(); i++)
+                  s->addDegree(h->degree(i));
+            s->render();
+            cs->select(s, SELECT_SINGLE, 0);
+            cs->undoAddElement(s);
+            cs->setLayoutAll(true);
+            }
+      else {
+            if (created)
+                  delete s;
+            }
       }
 
 //---------------------------------------------------------
@@ -4720,11 +4793,19 @@ int main(int argc, char* av[])
             qDebug() << "  Virtual size:" << screen->virtualSize().width() << "x" << screen->virtualSize().height();
             }
 
+<<<<<<< HEAD
       if (!useFactorySettings)
             preferences.read();
 
       preferences.readDefaultStyle();
 
+=======
+
+      if (!useFactorySettings)
+            preferences.read();
+      preferences.readDefaultStyle(false);
+      preferences.readDefaultStyle(true);
+>>>>>>> fix #24030: Styles and default styles for parts
       if (converterDpi == 0)
             converterDpi = preferences.pngResolution;
 

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -367,6 +367,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void showKeyEditor();
       bool saveFile();
       bool saveFile(Score* score);
+      void saveDefaultStyle(bool);
       void fingeringMenu();
       void registerPlugin(PluginDescription*);
       int  pluginIdxFromPath(QString pluginPath);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -136,11 +136,12 @@ void Preferences::init()
       portaudioDevice    = -1;
       portMidiInput      = "";
 
-      antialiasedDrawing       = true;
-      sessionStart             = SCORE_SESSION;
-      startScore               = ":/data/Promenade_Example.mscz";
-      defaultStyleFile         = "";
-      showSplashScreen         = true;
+      antialiasedDrawing        = true;
+      sessionStart              = SCORE_SESSION;
+      startScore                = ":/data/Promenade_Example.mscz";
+      defaultStyleFile          = "";
+      defaultStyleFileForParts  = "";
+      showSplashScreen          = true;
 
       useMidiRemote      = false;
       for (int i = 0; i < MIDI_REMOTES; ++i)
@@ -276,7 +277,7 @@ void Preferences::write()
             }
       s.setValue("startScore",         startScore);
       s.setValue("defaultStyle",       defaultStyleFile);
-      s.setValue("partStyle",          MScore::partStyle);
+      s.setValue("defaultStyleForParts",       defaultStyleFileForParts);
       s.setValue("showSplashScreen",   showSplashScreen);
 
       s.setValue("midiExpandRepeats",  midiExpandRepeats);
@@ -421,8 +422,9 @@ void Preferences::read()
       antialiasedDrawing = s.value("antialiasedDrawing", antialiasedDrawing).toBool();
 
       defaultStyleFile         = s.value("defaultStyle", defaultStyleFile).toString();
-      MScore::partStyle        = s.value("partStyle", MScore::partStyle).toString();
-
+      defaultStyleFileForParts = s.value("defaultStyleForParts", defaultStyleFileForParts).toString();
+      MScore::defaultStyleFile = s.value("defaultStyle", MScore::defaultStyleFile).toString();
+      MScore::defaultStyleFileForParts = s.value("defaultStyleForParts", MScore::defaultStyleFileForParts).toString();
       showSplashScreen         = s.value("showSplashScreen", showSplashScreen).toBool();
       midiExpandRepeats        = s.value("midiExpandRepeats", midiExpandRepeats).toBool();
       MScore::playRepeats      = s.value("playRepeats", MScore::playRepeats).toBool();
@@ -990,6 +992,7 @@ void PreferenceDialog::updateValues()
       animations->setChecked(prefs.animations);
 
       defaultStyle->setText(prefs.defaultStyleFile);
+      partStyle->setText(prefs.defaultStyleFileForParts);
 
       myScores->setText(prefs.myScoresPath);
       myStyles->setText(prefs.myStylesPath);
@@ -1435,7 +1438,10 @@ void PreferenceDialog::apply()
             prefs.defaultStyleFile = defaultStyle->text();
             prefs.readDefaultStyle();
             }
-
+      if (partStyle->text() != prefs.defaultStyleFileForParts) {
+            prefs.defaultStyleFileForParts = partStyle->text();
+            prefs.readDefaultStyle(true);
+            }
       genIcons();
 
       mscore->setIconSize(QSize(prefs.iconWidth, prefs.iconHeight));
@@ -1443,6 +1449,7 @@ void PreferenceDialog::apply()
       preferences = prefs;
       emit preferencesChanged();
       preferences.write();
+      preferences.read();
       mscore->startAutoSave();
       }
 
@@ -1450,17 +1457,20 @@ void PreferenceDialog::apply()
 //   readDefaultStyle
 //---------------------------------------------------------
 
-bool Preferences::readDefaultStyle()
+bool Preferences::readDefaultStyle(bool forParts)
       {
-      if (defaultStyleFile.isEmpty())
+      QString styleFile = forParts ? defaultStyleFileForParts : defaultStyleFile;
+      if (styleFile.isEmpty())
             return false;
-      MStyle* style = new MStyle(*MScore::defaultStyle());
-      QFile f(defaultStyleFile);
+      MStyle* style = new MStyle;
+      QFile f(styleFile);
+
       if (!f.open(QIODevice::ReadOnly))
             return false;
+
       bool rv = style->load(&f);
-      if (rv)
-            MScore::setDefaultStyle(style);     // transfer ownership
+            MScore::setDefaultStyle(style, forParts);  // transfer ownership
+
       f.close();
       return rv;
       }

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -115,6 +115,7 @@ struct Preferences {
       SessionStart sessionStart;
       QString startScore;
       QString defaultStyleFile;
+      QString defaultStyleFileForParts;
       bool showSplashScreen;
 
       bool useMidiRemote;
@@ -186,7 +187,7 @@ struct Preferences {
       void write();
       void read();
       void init();
-      bool readDefaultStyle();
+      bool readDefaultStyle(bool forParts = false);
       };
 
 //---------------------------------------------------------

--- a/share/locale/mscore_de.ts
+++ b/share/locale/mscore_de.ts
@@ -3162,6 +3162,22 @@ p, li { white-space: pre-wrap; }
         <source>New</source>
         <translation>Neu</translation>
     </message>
+    <message>
+        <source>Load Parts Style</source>
+        <translation>Formatvorlage für Einzelstimmen öffnen</translation>
+    </message>
+    <message>
+        <source>There are no parts.</source>
+        <translation>Es gibt noch keine Einzelstimmen.</translation>
+    </message>
+    <message>
+        <source>Do you want to generate them now?</source>
+        <translation>Wollen Sie sie jetzt erzeugen?</translation>
+    </message>
+    <message>
+        <source>Generate Parts</source>
+        <translation>Einzelstimmen erzeugen</translation>
+    </message>
 </context>
 <context>
     <name>FluidGui</name>
@@ -9370,6 +9386,14 @@ fehlgeschlagen: </translation>
         <translation>Verwendeter Zeichensatz beim Import von Binär-Dateien</translation>
     </message>
     <message>
+        <source>Style:</source>
+        <translation type="unfinished">Formatvorlage:</translation>
+    </message>
+    <message>
+        <source>Style for Part:</source>
+        <translation type="unfinished">Formatvorlage für Stimmen:</translation>
+    </message>
+    <message>
         <source>Overture import character set:</source>
         <translation>Verwendeter Zeichensatz beim Import von Overture Dateien</translation>
     </message>
@@ -11597,7 +11621,427 @@ fehlgeschlagen: </translation>
     </message>
     <message>
         <source>Add D</source>
-        <translation>D hinzufügen</translation>
+        <translation>D    zur markierten Note dazu</translation>
+    </message>
+    <message>
+        <source>Add note D to chord</source>
+        <translation>Note D zu Akkord hinzufügen</translation>
+    </message>
+    <message>
+        <source>Add E</source>
+        <translation>E    zur markierten Note dazu</translation>
+    </message>
+    <message>
+        <source>Add note E to chord</source>
+        <translation>Note E zu Akkord hinzufügen</translation>
+    </message>
+    <message>
+        <source>Add F</source>
+        <translation>F    zur markierten Note dazu</translation>
+    </message>
+    <message>
+        <source>Add note F to chord</source>
+        <translation>Note F zu Akkord hinzufügen</translation>
+    </message>
+    <message>
+        <source>Add G</source>
+        <translation>G    zur markierten Note dazu</translation>
+    </message>
+    <message>
+        <source>Add note G to chord</source>
+        <translation>Note G zu Akkord hinzufügen</translation>
+    </message>
+    <message>
+        <source>Add More Stretch</source>
+        <translation>D e h n e n</translation>
+    </message>
+    <message>
+        <source>Add more stretch to selected measure</source>
+        <translation>Markierten Takt dehnen</translation>
+    </message>
+    <message>
+        <source>Add Less Stretch</source>
+        <translation>Zusammenziehen</translation>
+    </message>
+    <message>
+        <source>Add less stretch to selected measure</source>
+        <translation>Markierten Takt zusammenziehen</translation>
+    </message>
+    <message>
+        <source>Reset Beam Mode</source>
+        <translation>Balkeneigenschaften zurücksetzen</translation>
+    </message>
+    <message>
+        <source>Delete Selected Measures</source>
+        <translation>Ausgewählte Takte löschen</translation>
+    </message>
+    <message>
+        <source>Append Measures...</source>
+        <translation>Takte anhängen...</translation>
+    </message>
+    <message>
+        <source>Insert Measures...</source>
+        <translation>Takte einfügen...</translation>
+    </message>
+    <message>
+        <source>Insert Horizontal Frame</source>
+        <translation>Horizontalen Rahmen einfügen</translation>
+    </message>
+    <message>
+        <source>Insert Vertical Frame</source>
+        <translation>Vertikalen Rahmen einfügen</translation>
+    </message>
+    <message>
+        <source>Append Horizontal Frame</source>
+        <translation>Horizontalen Rahmen anhängen</translation>
+    </message>
+    <message>
+        <source>Append Vertical Frame</source>
+        <translation>Vertikalen Rahmen anhängen</translation>
+    </message>
+    <message>
+        <source>Duplet</source>
+        <translation>Duole</translation>
+    </message>
+    <message>
+        <source>Triplet</source>
+        <translation>Triole</translation>
+    </message>
+    <message>
+        <source>Quadruplet</source>
+        <translation>Quartole</translation>
+    </message>
+    <message>
+        <source>Quintuplet</source>
+        <translation>Quintole</translation>
+    </message>
+    <message>
+        <source>Sextuplet</source>
+        <translation>Sextole</translation>
+    </message>
+    <message>
+        <source>Septuplet</source>
+        <translation>Septole</translation>
+    </message>
+    <message>
+        <source>Octuplet</source>
+        <translation>Oktole</translation>
+    </message>
+    <message>
+        <source>Nonuplet</source>
+        <translation>Nonole</translation>
+    </message>
+    <message>
+        <source>Other...</source>
+        <translation>Weitere...</translation>
+    </message>
+    <message>
+        <source>Longa</source>
+        <translation>Longa</translation>
+    </message>
+    <message>
+        <source>Palette</source>
+        <translation>Palette</translation>
+    </message>
+    <message>
+        <source>Play Panel</source>
+        <translation>Wiedergabepult</translation>
+    </message>
+    <message>
+        <source>Navigator</source>
+        <translation>Navigator</translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <translation>Mischpult</translation>
+    </message>
+    <message>
+        <source>Transport</source>
+        <translation>Wiedergabe</translation>
+    </message>
+    <message>
+        <source>Status Bar</source>
+        <translation>Statuszeile</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Beenden</translation>
+    </message>
+    <message>
+        <source>Lyrics</source>
+        <translation>Liedtext</translation>
+    </message>
+    <message>
+        <source>Metronome</source>
+        <translation>Metronom</translation>
+    </message>
+    <message>
+        <source>System Text</source>
+        <translation>Systemtext</translation>
+    </message>
+    <message>
+        <source>Staff Text</source>
+        <translation>Notenzeilentext</translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation>Titel</translation>
+    </message>
+    <message>
+        <source>Subtitle</source>
+        <translation>Untertitel</translation>
+    </message>
+    <message>
+        <source>Composer</source>
+        <translation>Komponist</translation>
+    </message>
+    <message>
+        <source>Chord Name</source>
+        <translation>Akkordbezeichnung</translation>
+    </message>
+    <message>
+        <source>Harmony Properties</source>
+        <translation>Harmonieeigenschaften</translation>
+    </message>
+    <message>
+        <source>Rehearsal Mark</source>
+        <translation>Übungszeichen</translation>
+    </message>
+    <message>
+        <source>Play</source>
+        <translation>Abspielen</translation>
+    </message>
+    <message>
+        <source>Start or stop playback</source>
+        <translation>Wiedergabe/Pause</translation>
+    </message>
+    <message>
+        <source>Rewind</source>
+        <translation>Zurückspulen</translation>
+    </message>
+    <message>
+        <source>Load Style...</source>
+        <translation>Formatvorlage öffnen...</translation>
+    </message>
+    <message>
+        <source>Save Style...</source>
+        <translation>Formatvorlage speichern...</translation>
+    </message>
+    <message>
+        <source>Save Style as Default...</source>
+        <translation>Formatvorlage als Vorgabe speichern...</translation>
+    </message>
+    <message>
+        <source>Save Style as Default for Parts...</source>
+        <translation>Formatvorlage als Vorgabe für Stimmen speichern...</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Alles auswählen</translation>
+    </message>
+    <message>
+        <source>Transpose</source>
+        <translation>Transponieren</translation>
+    </message>
+    <message>
+        <source>Exchange Voice 1-2</source>
+        <translation>Stimmen 1-2 austauschen</translation>
+    </message>
+    <message>
+        <source>Exchange Voice 1-3</source>
+        <translation>Stimmen 1-3 austauschen</translation>
+    </message>
+    <message>
+        <source>Exchange Voice 1-4</source>
+        <translation>Stimmen 1-4 austauschen</translation>
+    </message>
+    <message>
+        <source>Exchange Voice 2-3</source>
+        <translation>Stimmen 2-3 austauschen</translation>
+    </message>
+    <message>
+        <source>Exchange Voice 2-4</source>
+        <translation>Stimmen 2-4 austauschen</translation>
+    </message>
+    <message>
+        <source>Exchange Voice 3-4</source>
+        <translation>Stimmen 3-4 austauschen</translation>
+    </message>
+    <message>
+        <source>Concert Pitch</source>
+        <translation>Klingende Notation</translation>
+    </message>
+    <message>
+        <source>Repeat last command</source>
+        <translation>Letztes Kommando wiederholen</translation>
+    </message>
+    <message>
+        <source>Toggle System Break</source>
+        <translation>Manueller Zeilenumbruch</translation>
+    </message>
+    <message>
+        <source>Toggle Page Break</source>
+        <translation>Manueller Seitenumbruch</translation>
+    </message>
+    <message>
+        <source>Edit Element</source>
+        <translation>Element bearbeiten</translation>
+    </message>
+    <message>
+        <source>Inspector</source>
+        <translation>Objekt-Inspektor</translation>
+    </message>
+    <message>
+        <source>Reset Stretch</source>
+        <translation>Dehnung zurücksetzen</translation>
+    </message>
+    <message>
+        <source>Show Invisible</source>
+        <translation>Unsichtbares anzeigen</translation>
+    </message>
+    <message>
+        <source>Show Frames</source>
+        <translation>Rahmen anzeigen</translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation>Vergrößern</translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation>Verkleinern</translation>
+    </message>
+    <message>
+        <source>Select all similar elements</source>
+        <translation>Alle ähnlichen Elemente auswählen</translation>
+    </message>
+    <message>
+        <source>All Similar Elements</source>
+        <translation>Alle ähnlichen Elemente</translation>
+    </message>
+    <message>
+        <source>Select all similar elements in same staff</source>
+        <translation>Alle ähnlichen Elemente in der gleichen Notenzeile auswählen</translation>
+    </message>
+    <message>
+        <source>All Similar Elements in Same Staff</source>
+        <translation>Alle ähnlichen Elemente in der gleichen Notenzeile</translation>
+    </message>
+    <message>
+        <source>Synthesizer</source>
+        <translation>Synthesizer</translation>
+    </message>
+    <message>
+        <source>Repeat selection</source>
+        <translation>Auswahl wiederholen</translation>
+    </message>
+    <message>
+        <source>Local handbook</source>
+        <translation>Lokales Handbuch</translation>
+    </message>
+    <message>
+        <source>Show local handbook</source>
+        <translation>Lokales Handbuch anzeigen</translation>
+    </message>
+    <message>
+        <source>File open</source>
+        <translation>Datei öffnen</translation>
+    </message>
+    <message>
+        <source>Load score from file</source>
+        <translation>Partitur laden</translation>
+    </message>
+    <message>
+        <source>File save</source>
+        <translation>Datei speichern</translation>
+    </message>
+    <message>
+        <source>Save score to file</source>
+        <translation>Partitur speichern</translation>
+    </message>
+    <message>
+        <source>File save as</source>
+        <translation>Datei speichern unter</translation>
+    </message>
+    <message>
+        <source>Save score under a new file name</source>
+        <translation>Partitur unter einem neuen Dateinamen speichern</translation>
+    </message>
+    <message>
+        <source>File save a copy</source>
+        <translation>Kopie der Datei speichern</translation>
+    </message>
+    <message>
+        <source>Save a copy of the score in addition to the current file</source>
+        <translation>Kopie der Datei zusätzlich zur aktuellen Datei speichern</translation>
+    </message>
+    <message>
+        <source>File close</source>
+        <translation>Datei schließen</translation>
+    </message>
+    <message>
+        <source>Close current score</source>
+        <translation>Aktuelle Partitur schließen</translation>
+    </message>
+    <message>
+        <source>Print</source>
+        <translation>Drucken</translation>
+    </message>
+    <message>
+        <source>Print score</source>
+        <translation>Partitur drucken</translation>
+    </message>
+    <message>
+        <source>Undo last change</source>
+        <translation>Letzte Änderung rückgängig machen</translation>
+    </message>
+    <message>
+        <source>Redo last undo</source>
+        <translation>Letzte Änderung wiederherstellen</translation>
+    </message>
+    <message>
+        <source>Show instruments dialog</source>
+        <translation>Instrumentendialog anzeigen</translation>
+    </message>
+    <message>
+        <source>Note input mode</source>
+        <translation>Noteneingabemodus</translation>
+    </message>
+    <message>
+        <source>Enter note A</source>
+        <translation>Note A eingeben</translation>
+    </message>
+    <message>
+        <source>Enter note B</source>
+        <translation>Note H eingeben</translation>
+    </message>
+    <message>
+        <source>Enter note C</source>
+        <translation>Note C eingeben</translation>
+    </message>
+    <message>
+        <source>Enter note D</source>
+        <translation>Note D eingeben</translation>
+    </message>
+    <message>
+        <source>Enter note E</source>
+        <translation>Note E eingeben</translation>
+    </message>
+    <message>
+        <source>Enter note F</source>
+        <translation>Note F eingeben</translation>
+    </message>
+    <message>
+        <source>Enter note G</source>
+        <translation>Note G eingeben</translation>
+    </message>
+    <message>
+        <source>Enter rest</source>
+        <translation>Pause eingeben</translation>
+    </message>
+    <message>
+        <source>Rest</source>
+        <translation>Pause</translation>
     </message>
     <message>
         <source>Add note D to chord</source>


### PR DESCRIPTION
There is a new button in the parts window for loading a style that applies to parts of a given Score. A parts style stored in preferences affects now parts. A new command "Save Style as Default for Parts" was added to the menu. German translations for new text literals where added.
