### PR TITLE
fix #23366: notehead -> note head

### DIFF
--- a/mscore/actions.cpp
+++ b/mscore/actions.cpp
@@ -2463,7 +2463,7 @@ Shortcut Shortcut::sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY,
          A_CMD,
          "add-brackets",
-         QT_TRANSLATE_NOOP("action","Add brackets to notehead"),
+         QT_TRANSLATE_NOOP("action","Add brackets to note head"),
          brackets_ICON
          ),
       Shortcut(

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -4953,7 +4953,7 @@ p, li { white-space: pre-wrap; }
              <item row="2" column="0">
               <widget class="QLabel" name="label_50">
                <property name="text">
-                <string>Vertical distance from notehead:</string>
+                <string>Vertical distance from note head:</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
It is "note head" in 6 places, "notehead" in 2. Some consistency is needed, one way or the other.
