### PR TITLE
fix #21188

### DIFF
--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -577,6 +577,9 @@
             <property name="decimals">
              <number>1</number>
             </property>
+            <property name="minimum">
+             <double>-100.000000000000000</double>
+            </property>
             <property name="singleStep">
              <double>0.500000000000000</double>
             </property>
@@ -608,6 +611,9 @@
             </property>
             <property name="decimals">
              <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>-100.000000000000000</double>
             </property>
             <property name="singleStep">
              <double>0.500000000000000</double>


### PR DESCRIPTION
allow lyrics upper and lower margin to go negative, just like 1.x did.
