### PR TITLE
24339 slurs from one voice to another

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1933,7 +1933,7 @@ void Measure::read(XmlReader& e, int staffIdx)
                         // if (spanner->track2() == -1)
                               // the absence of a track tag [?] means the
                               // track is the same as the beginning of the slur
-                        spanner->setTrack2(spanner->track());
+                        spanner->setTrack2(spanner->track2() == -1 ? spanner->track() : spanner->track2());
                         if (spanner->type() == OTTAVA) {
                               Ottava* o = static_cast<Ottava*>(spanner);
                               o->staff()->updateOttava(o);

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -863,6 +863,8 @@ void Slur::slurPos(SlurPos* sp)
 void SlurTie::writeProperties(Xml& xml) const
       {
       Element::writeProperties(xml);
+      if(this->track() != this->track2() && this->track2() != -1)
+            xml.tag("track2", this->track2());
       int idx = 0;
       foreach(const SpannerSegment* ss, spannerSegments())
             ((SlurSegment*)ss)->write(xml, idx++);


### PR DESCRIPTION
Makes saving & restoring of cross-voice slurs work.
Hasn't updated the debugger to display this property.
