### PR TITLE
Fix editstyle.ui layout control names

### DIFF
--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -1703,7 +1703,7 @@ p, li { white-space: pre-wrap; }
          </property>
          <layout class="QGridLayout" name="gridLayout_9">
           <item row="0" column="0">
-           <layout class="QGridLayout" name="gridLayout_99">
+           <layout class="QGridLayout" name="gridLayout_17">
             <property name="horizontalSpacing">
              <number>10</number>
             </property>
@@ -3494,7 +3494,7 @@ p, li { white-space: pre-wrap; }
          <property name="title">
           <string>Volta</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout0">
+         <layout class="QGridLayout" name="gridLayout_18">
           <property name="verticalSpacing">
            <number>0</number>
           </property>
@@ -3992,7 +3992,7 @@ p, li { white-space: pre-wrap; }
          <property name="title">
           <string>Pedal Line</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout">
+         <layout class="QGridLayout" name="gridLayout_19">
           <item row="0" column="1" rowspan="2" colspan="2">
            <widget class="QDoubleSpinBox" name="pedalY">
             <property name="suffix">
@@ -4926,7 +4926,7 @@ p, li { white-space: pre-wrap; }
       </layout>
      </widget>
      <widget class="QWidget" name="Page19">
-      <layout class="QVBoxLayout" name="verticalLayout_30">
+      <layout class="QVBoxLayout" name="verticalLayout_39">
        <property name="spacing">
         <number>0</number>
        </property>


### PR DESCRIPTION
A few gridLayout's and one verticalLayout control have duplicated or out-of-sequence names which generate warnings while compiling.

Warning are harmless, but sequences have been fixed for tidiness.
