### PR TITLE
fix 24377: crash on create parts if tbox present

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -16,6 +16,7 @@
 #include "xml.h"
 #include "staff.h"
 #include "box.h"
+#include "textframe.h"
 #include "style.h"
 #include "page.h"
 #include "text.h"
@@ -173,6 +174,8 @@ void cloneStaves(Score* oscore, Score* score, const QList<int>& map)
                   nmb = new HBox(score);
             else if (mb->type() == Element::VBOX)
                   nmb = new VBox(score);
+            else if (mb->type() == Element::TBOX)
+                  nmb = new TBox(score);
             else if (mb->type() == Element::MEASURE) {
                   Measure* m  = static_cast<Measure*>(mb);
                   Measure* nm = new Measure(score);


### PR DESCRIPTION
This fix is trivial and safe.  However, I note that adding a box - whether text, horizontal, or vertical - _after_ creating of parts does not link.  This appears to have been deliberately unlinked some time ago - see the following:

https://github.com/musescore/MuseScore/commit/a5d1ac231bfe3a44537e1cc0ea6b6c83092d651f#diff-1b7205502c863c4426ee75767ddb1ea4L1756

I think this needs to be revisited.  Assuming this is addressed, then I will create a series of tests in the "link" folder for frame handling.
