### PR TITLE
fix #24380: text frame in 1.3 files ignored if non-default width

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -328,6 +328,12 @@ Score::FileError Score::read114(XmlReader& e)
                   TextStyle s;
                   s.read(e);
 
+                  qreal spMM = _style.spatium() / MScore::DPMM;
+                  if (s.frameWidthMM() != 0.0)
+                        s.setFrameWidth(Spatium(s.frameWidthMM() / spMM));
+                  if (s.paddingWidthMM() != 0.0)
+                        s.setPaddingWidth(Spatium(s.paddingWidthMM() / spMM));
+\
                   // convert 1.2 text styles
                   if (s.name() == "Chordname")
                         s.setName("Chord Symbol");


### PR DESCRIPTION
The frame settings changed from being expressed in mm units to sp, with a corresponding change in tag names.  The style loading code handles this conversion for old standalone style files, but read114.cpp was not doing the conversion for styles embedded in scores.  End result was that if you changed frame width, no frame would be drawn at all. This PR fixes that - the conversion code from the style load is duplicated in read114.
