### PR TITLE
Prevent adding beam properties to rests

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -331,6 +331,8 @@ void Beam::layout1()
                   _up = _direction == MScore::UP;
                   }
             else {
+                  if (!c1)
+                        return;
                   Measure* m = c1->measure();
                   if (m->hasVoices(c1->staffIdx()))
                         _up = !(c1->voice() % 2);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -686,10 +686,10 @@ void Score::doLayout()
                         continue;
                   if (e->isChordRest()) {
                         ChordRest* cr = static_cast<ChordRest*>(e);
-                        if (cr->beam() && cr->beam()->elements().front() == cr)
-                              cr->beam()->layout();
-
                         if (cr->type() == Element::CHORD) {
+                              if (cr->beam() && cr->beam()->elements().front() == cr)
+                                    cr->beam()->layout();
+
                               Chord* c = static_cast<Chord*>(cr);
                               for (Chord* cc : c->graceNotes()) {
                                     if (cc->beam() && cc->beam()->elements().front() == cc)


### PR DESCRIPTION
or trying to layout a rest with a beam property.
