### PR TITLE
fix wrong icon for plugin reload

### DIFF
--- a/mscore/pluginCreator.cpp
+++ b/mscore/pluginCreator.cpp
@@ -56,7 +56,7 @@ PluginCreator::PluginCreator(QWidget* parent)
       actionOpen->setShortcut(QKeySequence(QKeySequence::Open));
       fileTools->addAction(actionOpen);
 
-      actionReload->setIcon(*icons[fileOpen_ICON]);
+      actionReload->setIcon(*icons[viewRefresh_ICON]);
       fileTools->addAction(actionReload);
 
       actionSave->setIcon(*icons[fileSave_ICON]);


### PR DESCRIPTION
There's no fileReload_ICON, but viewRefresh_ICON comes closest to the meaning or reloading the plugin code, much closer than fileOpen_ICON, which implies a file selector to show up.
