### PR TITLE
Issue #23298 - Stem lengths incorrect after a note in a chord is moved an octave

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1239,7 +1239,13 @@ void Score::upDown(bool up, UpDownMode mode)
                   // user added accidentals are removed here.
                   if (oNote->accidental())
                         undoRemoveElement(oNote->accidental());
-                  undoChangePitch(oNote, newPitch, newTpc, oNote->line());
+
+                  Staff* s = oNote->score()->staff(oNote->staffIdx() + oNote->chord()->staffMove());
+                  int tick = oNote->chord()->tick();
+                  ClefType clef = s->clef(tick);
+                  int newLine   = relStep(absStep(newTpc, newPitch), clef);
+
+                  undoChangePitch(oNote, newPitch, newTpc, newLine);
                   }
             // store fret change only if undoChangePitch has not been called,
             // as undoChangePitch() already manages fret changes, if necessary


### PR DESCRIPTION
Calculates new line of moved note at the beginning of the move process.

I'm not altogether happy with this patch as it simply duplicates code into the beginning of the move process without removing it from the end (ode currently exists in Note::updateAccidental()). The "problem" that this causes is mostly philosophical, and partly extended runtime, tho' I'm sure it's not noticeable.

The problem is solved in piano scores, without unwanted side effects.
