### PR TITLE
fix #20697 - enable Delete key on MacOS

### DIFF
--- a/mscore/actions.cpp
+++ b/mscore/actions.cpp
@@ -1735,8 +1735,8 @@ Shortcut Shortcut::sc[] = {
          QT_TRANSLATE_NOOP("action","Note entry: 8th rest")
          ),
       Shortcut(                     // mapped to undo in note entry mode
-         STATE_NOTE_ENTRY,
-         0,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         A_CMD,
          "backspace",
          QT_TRANSLATE_NOOP("action","Backspace")
          ),

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4065,8 +4065,14 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             showAlbumManager();
       else if (cmd == "layer")
             showLayerManager();
-      else if (cmd == "backspace")
-            undo();
+      else if (cmd == "backspace") {
+            if ( _sstate != STATE_NORMAL )
+                  undo();
+#ifdef Q_OS_MAC
+            else if ( cs )
+                  cs->cmdDeleteSelection();
+#endif
+            }
       else if (cmd == "zoomin")
             incMag();
       else if (cmd == "zoomout")


### PR DESCRIPTION
Enable the delete key on MacOS.  Preserves existing behavior of <DELETE> == UNDO while in note editing mode.
