### PR TITLE
23680 import accidentals

### DIFF
--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -1722,9 +1722,9 @@ void MusicXml::xmlPart(QDomElement e, QString id)
       lastMeasureLen        = 0;
       multiMeasureRestCount = -1;
       startMultiMeasureRest = false;
-      KeySigEvent ev;                  // ise court
-      KeySig currKeySig;              // ise court
-      currKeySig.setKeySigEvent(ev);  // ise court
+      KeySigEvent ev;
+      KeySig currKeySig;
+      currKeySig.setKeySigEvent(ev);
 
       // initVoiceMapperAndMapVoices(e);
       voicelist = pass1.getVoiceList(id);
@@ -1745,14 +1745,14 @@ void MusicXml::xmlPart(QDomElement e, QString id)
             if (e.tagName() == "measure") {
                   // set the correct start tick for the measure
                   tick = measureStart.at(measureNr);
-       // ise court
+
                   QList<bool> accTmp;
                   int i = 0;
                   while(i < 74){
                       accTmp.append(false);
                       i++;
                   }
-                  Measure* measure = xmlMeasure(part, e, e.attribute(QString("number")).toInt()-1, measureLength.at(measureNr), &currKeySig, &accTmp);  // ise court
+                  Measure* measure = xmlMeasure(part, e, e.attribute(QString("number")).toInt()-1, measureLength.at(measureNr), &currKeySig, &accTmp);
             // end ise
                   if (measure)
                         fillGapsInFirstVoices(measure, part);
@@ -1982,7 +1982,7 @@ static void handleBeamAndStemDir(ChordRest* cr, const BeamMode bm, const MScore:
  Read the MusicXML measure element.
  */
 
-Measure* MusicXml::xmlMeasure(Part* part, QDomElement e, int number, int measureLen, KeySig* currKeySig, QList<bool>* accTmp)   // ise court
+Measure* MusicXml::xmlMeasure(Part* part, QDomElement e, int number, int measureLen, KeySig* currKeySig, QList<bool>* accTmp)
       {
 #ifdef DEBUG_TICK
       qDebug("xmlMeasure %d begin", number);
@@ -2043,9 +2043,9 @@ Measure* MusicXml::xmlMeasure(Part* part, QDomElement e, int number, int measure
       QList<GraceNoteInfo> graceNotesInfos;
       for (e = e.firstChildElement(); !e.isNull(); e = e.nextSiblingElement()) {
             if (e.tagName() == "attributes")
-                  xmlAttributes(measure, staff, e.firstChildElement(), currKeySig);     // ise court
+                  xmlAttributes(measure, staff, e.firstChildElement(), currKeySig);
             else if (e.tagName() == "note") {
-                  xmlNote(measure, staff, part->id(), beam, cv, e, graceNotesInfos, currKeySig, accTmp);  // ise court
+                  xmlNote(measure, staff, part->id(), beam, cv, e, graceNotesInfos, currKeySig, accTmp);
                   moveTick(measure->tick(), tick, maxtick, noteTypeTickFr, divisions, e);
 #ifdef DEBUG_TICK
                   qDebug(" after inserting note tick=%d", tick);
@@ -3156,7 +3156,7 @@ static void xmlStaffDetails(Score* score, int staff, StringData* t, QDomElement 
 // staves must be read first, as it determines how many key and time signatures
 // must be inserted.
 
-void MusicXml::xmlAttributes(Measure* measure, int staff, QDomElement e, KeySig* currKeySig) // ise court
+void MusicXml::xmlAttributes(Measure* measure, int staff, QDomElement e, KeySig* currKeySig)
       {
       QString beats = "";
       QString beatType = "";
@@ -3215,12 +3215,7 @@ void MusicXml::xmlAttributes(Measure* measure, int staff, QDomElement e, KeySig*
                                     keysig->setVisible(printObject == "yes");
                                     Segment* s = measure->getSegment(keysig, tick);
                                     s->add(keysig);
-                                    currKeySig->setKeySigEvent(key);  // ise court
-                                    AccidentalState acc;    // ise test
-                                    acc.init(currKeySig->keySigEvent());   // ise test
-                                    acc.init(currKeySig->keySigEvent());   // ise test
-
-
+                                    currKeySig->setKeySigEvent(key);
                                     }
                               }
                         }
@@ -3237,7 +3232,7 @@ void MusicXml::xmlAttributes(Measure* measure, int staff, QDomElement e, KeySig*
                               keysig->setVisible(printObject == "yes");
                               Segment* s = measure->getSegment(keysig, tick);
                               s->add(keysig);
-                              currKeySig->setKeySigEvent(key);  // ise court
+                              currKeySig->setKeySigEvent(key);
                               }
                         }
                   }
@@ -4500,7 +4495,7 @@ static FiguredBass* findLastFiguredBass(int track, Segment* seg)
  \a Staff is the number of first staff of the part this note belongs to.
  */
 
-void MusicXml::xmlNote(Measure* measure, int staff, const QString& partId, Beam*& beam, QString& currentVoice, QDomElement e, QList<GraceNoteInfo>& gni, KeySig* currKeySig, QList<bool>* accTmp) // ise court
+void MusicXml::xmlNote(Measure* measure, int staff, const QString& partId, Beam*& beam, QString& currentVoice, QDomElement e, QList<GraceNoteInfo>& gni, KeySig* currKeySig, QList<bool>* accTmp)
       {
       int ticks = 0;
 #ifdef DEBUG_TICK
@@ -4914,7 +4909,7 @@ void MusicXml::xmlNote(Measure* measure, int staff, const QString& partId, Beam*
 
             // qDebug("staff for new note: %p (staff=%d, relStaff=%d)",
             //        score->staff(staff + relStaff), staff, relStaff);
-// ise court
+
             AccidentalState currAcc;
             currAcc.init(currKeySig->keySigEvent());
             int ln = absStep(note->tpc(), note->pitch());
@@ -4934,7 +4929,7 @@ void MusicXml::xmlNote(Measure* measure, int staff, const QString& partId, Beam*
                     else
                           accTmp->replace(ln, true);
                     }
-// end ise
+
             // LVIFIX: quarter tone accidentals support is "drawing only"
             //WS-TODO if (accidental == 18
             // || accidental == 19

--- a/mscore/musicxml.h
+++ b/mscore/musicxml.h
@@ -208,14 +208,14 @@ class MusicXml {
       void xmlPartList(QDomElement);
       void xmlPart(QDomElement, QString id);
       void xmlScorePart(QDomElement node, QString id, int& parts);
-      Measure* xmlMeasure(Part*, QDomElement, int, int measureLen, KeySig*, QList<bool>*);  // ise court
-      void xmlAttributes(Measure*, int stave, QDomElement node, KeySig*);   // ise court
+      Measure* xmlMeasure(Part*, QDomElement, int, int measureLen, KeySig*, QList<bool>*);
+      void xmlAttributes(Measure*, int stave, QDomElement node, KeySig*);
       void xmlLyric(int trk, QDomElement e,
                     QMap<int, Lyrics*>& numbrdLyrics,
                     QMap<int, Lyrics*>& defyLyrics,
                     QList<Lyrics*>& unNumbrdLyrics);
       void xmlNotations(Note* note, ChordRest* cr, int trk, int ticks, QDomElement node);
-      void xmlNote(Measure*, int stave, const QString& partId, Beam*& beam, QString& currentVoice, QDomElement node, QList<GraceNoteInfo>&, KeySig*, QList<bool>*); // ise court
+      void xmlNote(Measure*, int stave, const QString& partId, Beam*& beam, QString& currentVoice, QDomElement node, QList<GraceNoteInfo>&, KeySig*, QList<bool>*);
       void xmlHarmony(QDomElement node, int tick, Measure* m, int staff);
       int xmlClef(QDomElement, int staffIdx, Measure*);
       void readPageFormat(PageFormat* pf, QDomElement de, qreal conversion);


### PR DESCRIPTION
"Necessary" accidentals and accidentals with special xml attributes are handled as before. "Unnecessary" accidentals, as may occur in xml scores (like most courtesy accidentals in real written or printed scores), are identified and marked as user accidentals to prevent them from automatically elimination.
