### PR TITLE
fix #24102 - pedal was always applied to top part of score

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -828,7 +828,8 @@ void Score::renderMidi(EventMap* events)
                   if (s->type() != Element::PEDAL)
                         continue;
 
-                  int channel = s->staff()->part()->midiChannel();
+                  int idx = s->staff()->channel(s->tick(), 0);
+                  int channel = s->staff()->part()->instr(s->tick())->channel(idx).channel;
                   if (s->tick() >= utick1 && s->tick() < utick2) {
                         NPlayEvent event(ME_CONTROLLER, channel, CTRL_SUSTAIN, 127);
                         events->insert(std::pair<int,NPlayEvent>(s->tick() + tickOffset, event));


### PR DESCRIPTION
Code was assigning the "local" channel (index within instrument) to the pedal events rather than the actual midi channel.  Fixed.

I notice that the loop through spanners here actually hits each pedal element twice.  I don't understand the structure of the spanner map and can't say if that's normal or not.  I might guess that it's once for the begin, once for the end of the spanner.  But the code here actually creates both the pedal on and pedal off event both time.  So we're actually getting two pedal ons and two pedal offs for each pedal marking (even if there is only a single staff).  Seems harmless, and unrelated to the issue at hand, so I didn't mess with it.  Someone might want to look at this, though.
