### PR TITLE
fix #23999: instrument change produces incorrect mixer details

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1117,6 +1117,7 @@ void Score::undoAddElement(Element* element)
                   Segment* ns1   = nm1->findSegment(s1->segmentType(), s1->tick());
                   InstrumentChange* nis = static_cast<InstrumentChange*>(ne);
                   nis->setParent(ns1);
+                  nis->setInstrument(*staff->part()->instr(s1->tick()));
                   undo(new AddElement(nis));
                   }
             else if (element->type() == Element::BREATH) {


### PR DESCRIPTION
Upon creation / addition of a new INSTRUMENT_CHANGE element, the "instrument" itself was left uninitialized until you actually did a Change Instrument, leading to non-deterministic results if you tried to view the Mixer.  I initially thought that was an odd thing to do until it was pointed out that this is how one would likely use instrument change for patch changes on synthesizer or organ parts.  So I've added an explicit initialization of the instrument - copied from the current instrument for that staff at that tick.
