### PR TITLE
fix #24245: slurs in voice > 1 attach to wrong voice on load

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -1069,7 +1069,6 @@ void Slur::write(Xml& xml) const
 void Slur::read(XmlReader& e)
       {
       setTrack(e.track());      // set staff
-      setTrack2(e.track());     // default to single voice slurs
       setId(e.intAttribute("id"));
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());


### PR DESCRIPTION
The end track was being set based on the start track at a time when the start track had not actually been read, so it kept defaulting to voice 0.  The code to copy the start track to end track _after_ the read was already present, so I just removed the premature copy and all seems well.  Tested to work for single-voice slurs (voice > 1) as well as cross voice slurs, both in 2.0 and 1.3 scores.
