### PR TITLE
fix #24657: save correct mixer info for instrument change

### DIFF
--- a/libmscore/instrchange.cpp
+++ b/libmscore/instrchange.cpp
@@ -37,7 +37,10 @@ InstrumentChange::InstrumentChange(Score* s)
 void InstrumentChange::write(Xml& xml) const
       {
       xml.stag("InstrumentChange");
-      _instrument.write(xml);
+      if (segment())
+            staff()->part()->instr(segment()->tick())->write(xml); // _instrument may not reflect mixer changes
+      else
+            _instrument.write(xml);
       Text::writeProperties(xml);
       xml.etag();
       }

--- a/libmscore/instrchange.h
+++ b/libmscore/instrchange.h
@@ -36,7 +36,7 @@ class InstrumentChange : public Text  {
 
       Instrument instrument() const           { return _instrument; }
       void setInstrument(const Instrument& i) { _instrument = i;    }
-      Segment* segment()                      { return (Segment*)parent(); }
+      Segment* segment() const                { return (Segment*)parent(); }
       };
 
 

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1119,6 +1119,7 @@ void Score::undoAddElement(Element* element)
                   nis->setParent(ns1);
                   nis->setInstrument(*staff->part()->instr(s1->tick()));
                   undo(new AddElement(nis));
+                  undo(new ChangeInstrument(nis, nis->instrument()));
                   }
             else if (element->type() == Element::BREATH) {
                   Breath* breath   = static_cast<Breath*>(element);


### PR DESCRIPTION
My fix for InstrumentChange::write() ignores the copy of the Instrument object contained within the InstrumentChange element itself, because that copy does not reflect mixer changes.  Instead, I find the copy of the Instrument contained in the part itself, since this is what the mixer affects, and write that.  Appears to work, although I think at some point we should consider whether storing two copies of the instrument really makes sense, and if so, maybe find a way to keep them in sync.
