### PR TITLE
fix warnings due to -Wunused-parameters

### DIFF
--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -2295,7 +2295,7 @@ Measure* MusicXml::xmlMeasure(Part* part, QDomElement e, int number, int measure
 // SLine placement is modified by changing the first segments user offset
 // As the SLine has just been created, it does not have any segment yet
       
-static void setSLinePlacement(SLine* sli, float spatium, const QString placement, bool hasYoff, qreal yoff)
+static void setSLinePlacement(SLine* sli, float spatium, const QString placement, bool /*hasYoff*/, qreal /*yoff*/)
       {
       /*
       qDebug("setSLinePlacement sli %p type %d s=%g pl='%s' hasy=%d yoff=%g",
@@ -2338,8 +2338,8 @@ static void setSLinePlacement(SLine* sli, float spatium, const QString placement
 //   addElem
 //---------------------------------------------------------
       
-static void addElem(Element* el, bool hasYoffset, int staff, int rstaff, Score* score, QString& placement,
-                    qreal rx, qreal ry, int /* offset */, Measure* measure, int tick)
+static void addElem(Element* el, bool /*hasYoffset*/, int staff, int rstaff, Score* score, QString& placement,
+                    qreal /*rx*/, qreal /*ry*/, int /* offset */, Measure* measure, int tick)
       {
       /*
       qDebug("addElem el %p hasYoff %d staff %d rstaff %d placement %s rx %g ry %g tick %d",

--- a/mscore/texttools.cpp
+++ b/mscore/texttools.cpp
@@ -374,7 +374,7 @@ void TextTools::italicClicked(bool val)
 //   setHalign
 //---------------------------------------------------------
 
-void TextTools::setHalign(QAction* a)
+void TextTools::setHalign(QAction* /*a*/)
       {
 //TODO      _textElement->setCurHalign(a->data().toInt());
       updateTools();
@@ -385,7 +385,7 @@ void TextTools::setHalign(QAction* a)
 //   setValign
 //---------------------------------------------------------
 
-void TextTools::setValign(QAction* a)
+void TextTools::setValign(QAction* /*a*/)
       {
 //TODO      _textElement->setAlign((_textElement->align() & ~ALIGN_VMASK) | Align(a->data().toInt()));
       updateTools();


### PR DESCRIPTION
all happening because the qDebug() calls inside that uses these are
commented out.
