### PR TITLE
fix #23653: add (back) tempo palette

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1034,6 +1034,7 @@ void MuseScore::setAdvancedPalette()
       paletteBox->addPalette(newNoteHeadsPalette());
       paletteBox->addPalette(newTremoloPalette());
       paletteBox->addPalette(newRepeatsPalette());
+      paletteBox->addPalette(newTempoPalette());
       paletteBox->addPalette(newTextPalette());
       paletteBox->addPalette(newBreaksPalette());
       paletteBox->addPalette(newBagpipeEmbellishmentPalette());
@@ -1126,6 +1127,7 @@ void MuseScore::setBasicPalette()
       paletteBox->addPalette(newNoteHeadsPalette());
       paletteBox->addPalette(newTremoloPalette());
       paletteBox->addPalette(newRepeatsPalette());
+      paletteBox->addPalette(newTempoPalette());
       paletteBox->addPalette(newTextPalette());
       paletteBox->addPalette(newBreaksPalette());
 //      paletteBox->addPalette(newBagpipeEmbellishmentPalette());


### PR DESCRIPTION
to both, the basic and the advanced workspace

This issue seemed the lowest hanging fruit from http://musescore.org/en/project/issues/musescore?tag=2.0 ;-)
