### PR TITLE
Fix #11073

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1546,8 +1546,6 @@ void Score::cmdDeleteSelection()
                   qDebug("...nothing selected");
             foreach(Element* e, el)
                   deleteItem(e);
-            if (!noteEntryMode())   // in entry mode deleting note or chord add rest selected
-                  deselectAll();
             }
       _layoutAll = true;
       }


### PR DESCRIPTION
http://musescore.org/en/node/11073

The Score::deleteItem() implementation already does that: after deleting a note from a chord, another note - specifically the chord->downNote() - should be automatically selected.

But later in the Score::cmdDeleteSelection() method all the selection was cleared, unless the user is in Note Entry mode. I don't know what was the intention of this block of code, but removing it solves the bug and (as far as I can tell) there is no negative side-effect.
