### PR TITLE
Fix #9083

### DIFF
--- a/mscore/synthcontrol.ui
+++ b/mscore/synthcontrol.ui
@@ -19,7 +19,7 @@
      <item row="0" column="3">
       <widget class="QPushButton" name="storeButton">
        <property name="text">
-        <string>Store</string>
+        <string>Set as Default</string>
        </property>
       </widget>
      </item>
@@ -29,7 +29,7 @@
         <string>Save to Score</string>
        </property>
        <property name="text">
-        <string>Save</string>
+        <string>Save to Score</string>
        </property>
       </widget>
      </item>
@@ -52,14 +52,14 @@
         <string>Load from Score</string>
        </property>
        <property name="text">
-        <string>Load</string>
+        <string>Load from Score</string>
        </property>
       </widget>
      </item>
      <item row="0" column="4">
       <widget class="QPushButton" name="recallButton">
        <property name="text">
-        <string>Recall</string>
+        <string>Load Default</string>
        </property>
       </widget>
      </item>
@@ -255,8 +255,6 @@
    <header>awl/mslider.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="musescore.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
http://musescore.org/en/node/9083

As stated in the discussion, the issue is no longer relevant as Musescore 2 works in a different way and already solves the problem.
However some button labels on the Synthetizer dialog should be improved to make their function more explict. This patch changes the button labels.
