### PR TITLE
fix #23038: reduce height of dialogs to 560 pixels

### DIFF
--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>892</width>
-    <height>644</height>
+    <height>573</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/mscore/pluginCreator.ui
+++ b/mscore/pluginCreator.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>600</height>
+    <height>560</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>880</width>
-    <height>648</height>
+    <height>560</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/mscore/stafftext.ui
+++ b/mscore/stafftext.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>954</width>
-    <height>563</height>
+    <height>560</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/mscore/textproperties.ui
+++ b/mscore/textproperties.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>647</width>
-    <height>662</height>
+    <height>560</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/mscore/timedialog.ui
+++ b/mscore/timedialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>892</width>
-    <height>577</height>
+    <height>560</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/mscore/timesigproperties.ui
+++ b/mscore/timesigproperties.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>779</width>
-    <height>644</height>
+    <height>560</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
so they easily fit a 1024x600 screen on e.g. a Netbook, without losing
anything
