### PR TITLE
fix slur issue #24929

### DIFF
--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -355,9 +355,11 @@ ChordRest* Score::findCR(int tick, int track) const
       Segment* s = m->first(Segment::SegChordRest);
       for (;;) {
             Segment* ns = s->next(Segment::SegChordRest);
-            if (ns == 0 || ns->tick() >= tick)
+            if (ns == 0 || ns->tick() > tick)
                   break;
             s = ns;
+            if (ns->tick() == tick)
+                  break;
             }
       if (s)
             return static_cast<ChordRest*>(s->element(track));


### PR DESCRIPTION
Issue when you try to move first grip of slur to previous chord using shift+left.
