### PR TITLE
Fix tab order of Inspector dlgs.

### DIFF
--- a/mscore/inspector/inspector_articulation.ui
+++ b/mscore/inspector/inspector_articulation.ui
@@ -230,6 +230,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>direction</tabstop>
+  <tabstop>resetDirection</tabstop>
+  <tabstop>anchor</tabstop>
+  <tabstop>resetAnchor</tabstop>
+  <tabstop>timeStretch</tabstop>
+  <tabstop>resetTimeStretch</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_beam.ui
+++ b/mscore/inspector/inspector_beam.ui
@@ -376,6 +376,22 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>distribute</tabstop>
+  <tabstop>resetDistribute</tabstop>
+  <tabstop>direction</tabstop>
+  <tabstop>resetDirection</tabstop>
+  <tabstop>growLeft</tabstop>
+  <tabstop>resetGrowLeft</tabstop>
+  <tabstop>growRight</tabstop>
+  <tabstop>resetGrowRight</tabstop>
+  <tabstop>noSlope</tabstop>
+  <tabstop>resetNoSlope</tabstop>
+  <tabstop>userPosition</tabstop>
+  <tabstop>resetUserPosition</tabstop>
+  <tabstop>y1</tabstop>
+  <tabstop>y2</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_chord.ui
+++ b/mscore/inspector/inspector_chord.ui
@@ -295,6 +295,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>offsetX</tabstop>
+  <tabstop>resetX</tabstop>
+  <tabstop>offsetY</tabstop>
+  <tabstop>resetY</tabstop>
+  <tabstop>small</tabstop>
+  <tabstop>resetSmall</tabstop>
+  <tabstop>stemless</tabstop>
+  <tabstop>resetStemless</tabstop>
+  <tabstop>stemDirection</tabstop>
+  <tabstop>resetStemDirection</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_dynamic.ui
+++ b/mscore/inspector/inspector_dynamic.ui
@@ -143,6 +143,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>dynRange</tabstop>
+  <tabstop>resetDynRange</tabstop>
+  <tabstop>velocity</tabstop>
+  <tabstop>resetVelocity</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_element.ui
+++ b/mscore/inspector/inspector_element.ui
@@ -361,6 +361,17 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>visible</tabstop>
+  <tabstop>resetVisible</tabstop>
+  <tabstop>resetColor</tabstop>
+  <tabstop>offsetX</tabstop>
+  <tabstop>vRaster</tabstop>
+  <tabstop>resetX</tabstop>
+  <tabstop>offsetY</tabstop>
+  <tabstop>hRaster</tabstop>
+  <tabstop>resetY</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -162,6 +162,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>type</tabstop>
+  <tabstop>resetType</tabstop>
+  <tabstop>text</tabstop>
+  <tabstop>resetText</tabstop>
+  <tabstop>showText</tabstop>
+  <tabstop>resetShowText</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_hairpin.ui
+++ b/mscore/inspector/inspector_hairpin.ui
@@ -285,6 +285,20 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>hairpinCircledTip</tabstop>
+  <tabstop>resetHairpinCircledTip</tabstop>
+  <tabstop>hairpinType</tabstop>
+  <tabstop>resetHairpinType</tabstop>
+  <tabstop>dynRange</tabstop>
+  <tabstop>resetDynRange</tabstop>
+  <tabstop>veloChange</tabstop>
+  <tabstop>resetVeloChange</tabstop>
+  <tabstop>hairpinHeight</tabstop>
+  <tabstop>resetHairpinHeight</tabstop>
+  <tabstop>hairpinContHeight</tabstop>
+  <tabstop>resetHairpinContHeight</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_hbox.ui
+++ b/mscore/inspector/inspector_hbox.ui
@@ -194,6 +194,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>leftGap</tabstop>
+  <tabstop>resetLeftGap</tabstop>
+  <tabstop>rightGap</tabstop>
+  <tabstop>resetRightGap</tabstop>
+  <tabstop>width</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_image.ui
+++ b/mscore/inspector/inspector_image.ui
@@ -251,6 +251,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>autoscale</tabstop>
+  <tabstop>resetAutoscale</tabstop>
+  <tabstop>sizeWidth</tabstop>
+  <tabstop>sizeHeight</tabstop>
+  <tabstop>scaleWidth</tabstop>
+  <tabstop>scaleHeight</tabstop>
+  <tabstop>lockAspectRatio</tabstop>
+  <tabstop>resetLockAspectRatio</tabstop>
+  <tabstop>sizeIsSpatium</tabstop>
+  <tabstop>resetSizeIsSpatium</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_jump.ui
+++ b/mscore/inspector/inspector_jump.ui
@@ -133,6 +133,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>jumpTo</tabstop>
+  <tabstop>resetJumpTo</tabstop>
+  <tabstop>playUntil</tabstop>
+  <tabstop>resetPlayUntil</tabstop>
+  <tabstop>continueAt</tabstop>
+  <tabstop>resetContinueAt</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_keysig.ui
+++ b/mscore/inspector/inspector_keysig.ui
@@ -121,6 +121,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>showCourtesy</tabstop>
+  <tabstop>resetShowCourtesy</tabstop>
+  <tabstop>showNaturals</tabstop>
+  <tabstop>resetShowNaturals</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_lasso.ui
+++ b/mscore/inspector/inspector_lasso.ui
@@ -148,6 +148,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>posX</tabstop>
+  <tabstop>posY</tabstop>
+  <tabstop>sizeWidth</tabstop>
+  <tabstop>sizeHeight</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_line.ui
+++ b/mscore/inspector/inspector_line.ui
@@ -241,6 +241,15 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>diagonal</tabstop>
+  <tabstop>resetDiagonal</tabstop>
+  <tabstop>resetLineColor</tabstop>
+  <tabstop>lineWidth</tabstop>
+  <tabstop>resetLineWidth</tabstop>
+  <tabstop>lineStyle</tabstop>
+  <tabstop>resetLineStyle</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_marker.ui
+++ b/mscore/inspector/inspector_marker.ui
@@ -162,6 +162,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>markerType</tabstop>
+  <tabstop>resetMarkerType</tabstop>
+  <tabstop>jumpLabel</tabstop>
+  <tabstop>resetJumpLabel</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_note.ui
+++ b/mscore/inspector/inspector_note.ui
@@ -647,6 +647,26 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>small</tabstop>
+  <tabstop>resetSmall</tabstop>
+  <tabstop>noteHeadGroup</tabstop>
+  <tabstop>resetNoteHeadGroup</tabstop>
+  <tabstop>noteHeadType</tabstop>
+  <tabstop>resetNoteHeadType</tabstop>
+  <tabstop>mirrorHead</tabstop>
+  <tabstop>resetMirrorHead</tabstop>
+  <tabstop>dotPosition</tabstop>
+  <tabstop>resetDotPosition</tabstop>
+  <tabstop>tuning</tabstop>
+  <tabstop>resetTuning</tabstop>
+  <tabstop>play</tabstop>
+  <tabstop>resetPlay</tabstop>
+  <tabstop>velocityType</tabstop>
+  <tabstop>resetVelocityType</tabstop>
+  <tabstop>velocity</tabstop>
+  <tabstop>resetVelocity</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_ottava.ui
+++ b/mscore/inspector/inspector_ottava.ui
@@ -196,6 +196,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>ottavaType</tabstop>
+  <tabstop>resetOttavaType</tabstop>
+  <tabstop>placement</tabstop>
+  <tabstop>resetPlacement</tabstop>
+  <tabstop>numbersOnly</tabstop>
+  <tabstop>resetNumbersOnly</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_rest.ui
+++ b/mscore/inspector/inspector_rest.ui
@@ -94,6 +94,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>small</tabstop>
+  <tabstop>resetSmall</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_segment.ui
+++ b/mscore/inspector/inspector_segment.ui
@@ -180,6 +180,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>leadingSpace</tabstop>
+  <tabstop>resetLeadingSpace</tabstop>
+  <tabstop>trailingSpace</tabstop>
+  <tabstop>resetTrailingSpace</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_slur.ui
+++ b/mscore/inspector/inspector_slur.ui
@@ -131,6 +131,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>lineType</tabstop>
+  <tabstop>resetLineType</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_tempotext.ui
+++ b/mscore/inspector/inspector_tempotext.ui
@@ -140,6 +140,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>followText</tabstop>
+  <tabstop>resetFollowText</tabstop>
+  <tabstop>tempo</tabstop>
+  <tabstop>resetTempo</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_timesig.ui
+++ b/mscore/inspector/inspector_timesig.ui
@@ -106,6 +106,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>showCourtesy</tabstop>
+  <tabstop>resetShowCourtesy</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_tuplet.ui
+++ b/mscore/inspector/inspector_tuplet.ui
@@ -202,6 +202,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>direction</tabstop>
+  <tabstop>resetDirection</tabstop>
+  <tabstop>numberType</tabstop>
+  <tabstop>resetNumberType</tabstop>
+  <tabstop>bracketType</tabstop>
+  <tabstop>resetBracketType</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_vbox.ui
+++ b/mscore/inspector/inspector_vbox.ui
@@ -382,6 +382,21 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>topGap</tabstop>
+  <tabstop>resetTopGap</tabstop>
+  <tabstop>bottomGap</tabstop>
+  <tabstop>resetBottomGap</tabstop>
+  <tabstop>height</tabstop>
+  <tabstop>leftMargin</tabstop>
+  <tabstop>resetLeftMargin</tabstop>
+  <tabstop>rightMargin</tabstop>
+  <tabstop>resetRightMargin</tabstop>
+  <tabstop>topMargin</tabstop>
+  <tabstop>resetTopMargin</tabstop>
+  <tabstop>bottomMargin</tabstop>
+  <tabstop>resetBottomMargin</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>


### PR DESCRIPTION
Many (sub-)dlgs making up the Inspector have a seemingly random tab order. To improve navigation via keyboard, the tab oder of all dlgs has been corrected to the visual order of controls.

Care has been taken not to alter the dlg sizes or, in general, any other detail except tab order.
