### PR TITLE
Increased support for GP4 and GP5 file formats (trils, accents, heavy accents, tremolos)

### DIFF
--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -1606,6 +1606,11 @@ void GuitarPro4::readNote(int string, Note* note, GpNote* gpNote)
             if (modMask2 & 0x20) {
                   readUChar();      // trill fret
                   readUChar();      // trill length
+
+                  Articulation* art = new Articulation(note->score());
+                  art->setArticulationType(Articulation_Trill);
+                  note->score()->addArticulation(note, art);
+
                   }
             }
       if (fretNumber == -1) {
@@ -2055,6 +2060,11 @@ void GuitarPro5::readNoteEffects(Note* note)
       if (modMask2 & 0x20) {
             readUChar();      // trill fret
             int period = readUChar();      // trill length
+
+            Articulation* art = new Articulation(note->score());
+            art->setArticulationType(Articulation_Trill);
+            note->score()->addArticulation(note, art);
+
             switch(period) {
                   case 1:           // 16
                         break;


### PR DESCRIPTION
These four commits add support to musescore to import  trills, accents, heavy accents, and tremolos  in GP4 and GP5 file formats.
