### PR TITLE
fix 23038: make tooltip translatable

### DIFF
--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -601,6 +601,7 @@ void Page::doRebuildBspTree()
 
 //---------------------------------------------------------
 //   replaceTextMacros
+//   (keep in sync with toolTipHeaderFooter in EditStyle::EditStyle())
 //    $p          - page number, except on first page
 //    $P          - page number, on all pages
 //    $n          - number of pages
@@ -612,13 +613,17 @@ void Page::doRebuildBspTree()
 //    $c          - copyright, on all pages
 //    $$          - the $ sign itself
 //    $:tag:      - meta data tag
-//       already defined tags:
+//
+//       tags already defined:
+//       (see Score::init()))
+//       copyright
+//       creationDate
 //       movementNumber
 //       movementTitle
+//       platform
+//       source
 //       workNumber
 //       workTitle
-//       source
-//       copyright
 //---------------------------------------------------------
 
 QString Page::replaceTextMacros(const QString& s) const

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -35,43 +35,6 @@
 
 namespace Ms {
 
-// keep in sync with implementation in Page::replaceTextMacros (page.cpp)
-// jumping thru hoops here to make the job of translators easier, yet have a nice display
-static QString toolTipHeaderFooter
-        = QString("<html><head></head><body><p><b>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "Special symbols in header/footer")
-        + QString("</b></p>")
-        + QString("<table><tr><td>$p</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "page number, except on first page")
-        + QString("</i></td></tr><tr><td>$P</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "page number, on all pages")
-        + QString("</i></td></tr><tr><td>$n</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "number of pages")
-        + QString("</i></td></tr><tr><td>$f</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "file name")
-        + QString("</i></td></tr><tr><td>$F</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "file path+name")
-        + QString("</i></td></tr><tr><td>$d</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "current date")
-        + QString("</i></td></tr><tr><td>$D</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "creation date")
-        + QString("</i></td></tr><tr><td>$C</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "copyright, on first page only")
-        + QString("</i></td></tr><tr><td>$c</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "copyright, on all pages")
-        + QString("</i></td></tr><tr><td>$$</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "the $ sign itself")
-        + QString("</i></td></tr><tr><td>$:tag:</td><td>-</td><td><i>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "meta data tag")
-        + QString("</i></td></tr></table><p>")
-        + QT_TRANSLATE_NOOP("toolTipHeaderFooter", "already defined tags:")
-        + QString("</p><table><tr><td>movementNumber</td></tr>")
-        + QString("<tr><td>movementTitle</td></tr>")
-        + QString("<tr><td>workNumber</td></tr>")
-        + QString("<tr><td>workTitle</td></tr>")
-        + QString("<tr><td>source</td></tr>")
-        + QString("<tr><td>copyright</td></tr></table></body></html>");
-
 //---------------------------------------------------------
 //   EditStyle
 //---------------------------------------------------------
@@ -148,6 +111,45 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       connect(comboFBFont, SIGNAL(currentIndexChanged(int)), SLOT(on_comboFBFont_currentIndexChanged(int)));
 
       setValues();
+
+      // keep in sync with implementation in Page::replaceTextMacros (page.cpp)
+      // jumping thru hoops here to make the job of translators easier, yet have a nice display
+      QString toolTipHeaderFooter
+            = QString("<html><head></head><body><p><b>")
+            + tr("Special symbols in header/footer")
+            + QString("</b></p>")
+            + QString("<table><tr><td>$p</td><td>-</td><td><i>")
+            + tr("page number, except on first page")
+            + QString("</i></td></tr><tr><td>$P</td><td>-</td><td><i>")
+            + tr("page number, on all pages")
+            + QString("</i></td></tr><tr><td>$n</td><td>-</td><td><i>")
+            + tr("number of pages")
+            + QString("</i></td></tr><tr><td>$f</td><td>-</td><td><i>")
+            + tr("file name")
+            + QString("</i></td></tr><tr><td>$F</td><td>-</td><td><i>")
+            + tr("file path+name")
+            + QString("</i></td></tr><tr><td>$d</td><td>-</td><td><i>")
+            + tr("current date")
+            + QString("</i></td></tr><tr><td>$D</td><td>-</td><td><i>")
+            + tr("creation date")
+            + QString("</i></td></tr><tr><td>$C</td><td>-</td><td><i>")
+            + tr("copyright, on first page only")
+            + QString("</i></td></tr><tr><td>$c</td><td>-</td><td><i>")
+            + tr("copyright, on all pages")
+            + QString("</i></td></tr><tr><td>$$</td><td>-</td><td><i>")
+            + tr("the $ sign itself")
+            + QString("</i></td></tr><tr><td>$:tag:</td><td>-</td><td><i>")
+            + tr("meta data tag")
+            + QString("</i></td></tr></table><p>")
+            + tr("Available tags and their current values:")
+            + QString("</p><table>");
+      // shown all tags for curent score, see also Score::init()
+      QMapIterator<QString, QString> i(cs->metaTags());
+      while (i.hasNext()) {
+            i.next();
+            toolTipHeaderFooter += QString("<tr><td>%1</td><td>-</td><td>%2</td></tr>").arg(i.key()).arg(i.value());
+      }
+      toolTipHeaderFooter += QString("</table></body></html>");
       showHeader->setToolTip(toolTipHeaderFooter);
       showFooter->setToolTip(toolTipHeaderFooter);
       connect(buttonBox, SIGNAL(clicked(QAbstractButton*)), SLOT(buttonClicked(QAbstractButton*)));


### PR DESCRIPTION
and also generate the list of meta tags on the fly and from the current
score. Show their current values too.
