### PR TITLE
Issue 24492 fixed - crash when add Volta in endBarLine

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -241,7 +241,7 @@ void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos)
             Measure* m = static_cast<Measure*>(mb);
             QRectF b(m->canvasBoundingRect());
 
-            if (pos.x() >= (b.x() + b.width() * .5) && m->endBarLineType() != BarLineType::END_BAR)
+            if (pos.x() >= (b.x() + b.width() * .5) && b != m->score()->lastMeasure()->canvasBoundingRect())
                   m = m->nextMeasure();
             spanner->setTick(m->tick());
             spanner->setTick2(m->endTick());

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -97,7 +97,7 @@ bool ScoreView::dragMeasureAnchorElement(const QPointF& pos)
             QRectF b(m->canvasBoundingRect());
 
             QPointF anchor;
-            if (pos.x() < (b.x() + b.width() * .5) || m->endBarLineType() == BarLineType::END_BAR)
+            if (pos.x() < (b.x() + b.width() * .5) || b == m->score()->lastMeasure()->canvasBoundingRect())
                   anchor = m->canvasBoundingRect().topLeft();
             else
                   anchor = m->canvasBoundingRect().topRight();


### PR DESCRIPTION
http://musescore.org/en/node/24492

MuseScore crash when volta_element is add in the end bar line.
