### PR TITLE
Selecting [undefined] TPC in Ambitus inspector causes crash.

### DIFF
--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -43,7 +43,7 @@ Ambitus::Ambitus(Score* s)
       _dir              = DIR_DEFAULT;
       _hasLine          = HASLINE_DEFAULT;
       _lineWidth        = LINEWIDTH_DEFAULT;
-      _topPitch = _bottomPitch = -1;
+      _topPitch = _bottomPitch = INVALID_PITCH;
       _topTpc = _bottomTpc = INVALID_TPC;
       _topAccid.setParent(this);
       _bottomAccid.setParent(this);
@@ -68,14 +68,16 @@ void Ambitus::setTrack(int t)
       // if not initialized and there is a segment and a staff,
       // initialize pitches and tpc's to first and last staff line
       // (for use in palettes)
-      if (_topTpc == INVALID_TPC || _bottomTpc == INVALID_TPC) {
+      if (_topPitch == INVALID_PITCH || _topTpc == INVALID_TPC
+            || _bottomPitch == INVALID_PITCH ||_bottomTpc == INVALID_TPC) {
             if (segm && stf) {
                   updateRange();
                   _topAccid.setTrack(t);
                   _bottomAccid.setTrack(t);
                   }
-            else
-                  _topPitch   = _bottomPitch = _topTpc = _bottomTpc = -1;
+//            else {
+//                  _topPitch = _bottomPitch = INVALID_PITCH;
+//                  _topTpc   = _bottomTpc   = INVALID_TPC;
             }
       }
 
@@ -260,7 +262,10 @@ void Ambitus::layout()
             }
 
       //
-      // NOTE HEADS Y POS (if pitch == -1, set to some default - for use in palettes)
+      // NOTE HEADS Y POS
+      //
+      // if pitch == INVALID_PITCH oor tpc == INALID_TPC, set to some default:
+      // for use in palettes and when actual range cannot be calculated (new ambitus or no notes in staff)
       //
       qreal xAccidOffTop    = 0;
       qreal xAccidOffBottom = 0;
@@ -270,7 +275,7 @@ void Ambitus::layout()
             key = KEY_C;
 
       // top note head
-      if (_topPitch == -1)
+      if (_topPitch == INVALID_PITCH || _topTpc == INVALID_TPC)
             _topPos.setY(0);                          // if uninitialized, set to top staff line
       else {
             topLine  = absStep(_topTpc, _topPitch);
@@ -296,7 +301,7 @@ void Ambitus::layout()
             }
 
       // bottom note head
-      if (_bottomPitch == -1)
+      if (_bottomPitch == INVALID_PITCH || _bottomTpc == INVALID_TPC)
             _bottomPos.setY( (numOfLines-1) * lineDist);          // if uninitialized, set to last staff line
       else {
             bottomLine  = absStep(_bottomTpc, _bottomPitch);

--- a/libmscore/pitchspelling.h
+++ b/libmscore/pitchspelling.h
@@ -21,6 +21,8 @@ class MidiNote;
 class Note;
 class Event;
 
+const int   INVALID_PITCH      = -1;
+
 // a list of tpc's, with legal ranges
 enum {
       INVALID_TPC = -2,

--- a/mscore/inspector/inspectorAmbitus.cpp
+++ b/mscore/inspector/inspectorAmbitus.cpp
@@ -72,10 +72,18 @@ InspectorAmbitus::InspectorAmbitus(QWidget* parent)
       // noteHeadType starts at -1
       for (int i = 0; i < 5; ++i)
             r.noteHeadType->setItemData(i, i-1);
+      // set proper itemdata for TPC combos
       for (int i = 0; i < TPC_MAX-TPC_MIN+2; ++i) {
             r.topTpc->   setItemData(i, tpcs[i]);
             r.bottomTpc->setItemData(i, tpcs[i]);
             }
+      // make first item of each TPC combo ("[undefined]") unselectable
+      const QStandardItemModel* model = qobject_cast<const QStandardItemModel*>(r.topTpc->model());
+      QStandardItem* item = model->item(0);
+      item->setFlags(item->flags() & ~(Qt::ItemIsSelectable|Qt::ItemIsEnabled));
+      model = qobject_cast<const QStandardItemModel*>(r.bottomTpc->model());
+      item = model->item(0);
+      item->setFlags(item->flags() & ~(Qt::ItemIsSelectable|Qt::ItemIsEnabled));
 
       iList = {
             { P_COLOR,          0, 0, b.color,         b.resetColor         },
@@ -134,7 +142,7 @@ void InspectorAmbitus::valueChanged(int idx)
 }
 
 //---------------------------------------------------------
-//   on updateRage clicked
+//   on updateRange clicked
 //---------------------------------------------------------
 
 void Ms::InspectorAmbitus::updateRange()


### PR DESCRIPTION
The [undefined] item is informational only (when the ambitus range cannot be calculated, for instance when there are no notes in the staff yet) and should not be selected.

Fixed at two levels:

1) The [undefined] item is disabled and cannot be selected any longer

2) The Ambitus::layout() method is more robust in dealing with undefined ranges.
