### PR TITLE
Fix #20724 - Remove "Hide/show naturals" in keysig context menu

### DIFF
--- a/libmscore/keysig.h
+++ b/libmscore/keysig.h
@@ -40,16 +40,13 @@ struct KeySym {
 ///   The KeySig class represents a Key Signature on a staff
 //
 //    @P showCourtesy bool show courtesy key signature for this sig if appropriate
-//    @P showNaturals bool
 //---------------------------------------------------------------------------------------
 
 class KeySig : public Element {
       Q_OBJECT
       Q_PROPERTY(bool showCourtesy READ showCourtesy   WRITE undoSetShowCourtesy)
-      Q_PROPERTY(bool showNaturals READ showNaturals   WRITE undoSetShowNaturals)
 
       bool	_showCourtesy;
-      bool	_showNaturals;
       QList<KeySym*> keySymbols;
       KeySigEvent _sig;       // concertKeySig, transposingKeySig
       void addLayout(SymId sym, qreal x, int y);
@@ -69,7 +66,7 @@ class KeySig : public Element {
       void setOldSig(int oldSig);
 
       Segment* segment() const            { return (Segment*)parent(); }
-      Measure* measure() const            { return (Measure*)parent()->parent(); }
+      Measure* measure() const            { return parent() != nullptr ? (Measure*)parent()->parent() : nullptr; }
       Space space() const;
       void setCustom(const QList<KeySym*>& symbols);
       virtual void write(Xml&) const;
@@ -89,10 +86,6 @@ class KeySig : public Element {
       bool showCourtesy() const           { return _showCourtesy; }
       void setShowCourtesy(bool v)        { _showCourtesy = v;    }
       void undoSetShowCourtesy(bool v);
-
-      bool showNaturals() const           { return _showNaturals;    }
-      void setShowNaturals(bool v)        { _showNaturals = v;       }
-      void undoSetShowNaturals(bool v)    { _showNaturals = v;       }
 
       QVariant getProperty(P_ID propertyId) const;
       bool setProperty(P_ID propertyId, const QVariant&);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1517,7 +1517,7 @@ void Score::addSystemHeader(Measure* m, bool isFirstSystem)
             else if (!needKeysig && keysig)
                   undoRemoveElement(keysig);
             else if (keysig && keysig->keySigEvent() != keyIdx)
-                  undo(new ChangeKeySig(keysig, keyIdx, keysig->showCourtesy(), keysig->showNaturals()));
+                  undo(new ChangeKeySig(keysig, keyIdx, keysig->showCourtesy() /*, keysig->showNaturals()*/));
 
             bool needClef = isFirstSystem || styleB(ST_genClef);
             if (needClef) {
@@ -2606,7 +2606,7 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
                                           }
                                     else if (ks->keySigEvent() != ksv) {
                                           undo(new ChangeKeySig(ks, ksv,
-                                             ks->showCourtesy(), ks->showNaturals()));
+                                             ks->showCourtesy() /*, ks->showNaturals()*/));
                                           }
                                     // change bar line to qreal bar line
                                     // m->setEndBarLineType(DOUBLE_BAR, true); // this caused issue #12918

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -114,7 +114,7 @@ static const PropertyData propertyList[] = {
 
       { P_NUMERATOR_STRING,    false, "textN",         T_STRING },
       { P_DENOMINATOR_STRING,  false, "textD",         T_STRING },
-      { P_SHOW_NATURALS,       false, "showNaturals",  T_BOOL   },
+//      { P_SHOW_NATURALS,       false, "showNaturals",  T_BOOL   },
       { P_BREAK_HINT,          false, "",              T_BOOL   },
       { P_FBPREFIX,            false, "prefix",        T_INT    },
       { P_FBDIGIT,             false, "digit",         T_INT    },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -113,7 +113,7 @@ enum P_ID {
       P_NUMERATOR_STRING,
 
       P_DENOMINATOR_STRING,
-      P_SHOW_NATURALS,
+//      P_SHOW_NATURALS,
       P_BREAK_HINT,
       P_FBPREFIX,             // used for FiguredBassItem
       P_FBDIGIT,              //    "           "

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -338,8 +338,8 @@ void Score::transpose(int mode, TransposeDirection direction, int transposeKey,
                         KeySigEvent key  = km->key(ks->tick());
                         KeySigEvent okey = km->key(ks->tick() - 1);
                         key.setNaturalType(okey.accidentalType());
-                        undo(new ChangeKeySig(ks, key, ks->showCourtesy(),
-                           ks->showNaturals()));
+                        undo(new ChangeKeySig(ks, key, ks->showCourtesy() /*,
+                           ks->showNaturals()*/));
                         }
                   }
             return;
@@ -434,7 +434,8 @@ void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickE
                         KeySigEvent key  = km->key(s->tick());
                         KeySigEvent okey = km->key(s->tick() - 1);
                         key.setNaturalType(okey.accidentalType());
-                        undo(new ChangeKeySig(ks, key, ks->showCourtesy(), ks->showNaturals()));
+                        undo(new ChangeKeySig(ks, key, ks->showCourtesy() /*,
+                           ks->showNaturals()*/));
                         }
                   }
             }

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -472,7 +472,7 @@ void Score::undoChangeKeySig(Staff* ostaff, int tick, KeySigEvent st)
                   if (ks && !ks->generated())
                         break;
                   if (ks->keySigEvent() != st)
-                        undo(new ChangeKeySig(ks, st, ks->showCourtesy(), ks->showNaturals()));
+                        undo(new ChangeKeySig(ks, st, ks->showCourtesy() /*, ks->showNaturals()*/));
                   }
             }
       }
@@ -1808,12 +1808,11 @@ void RemoveStaves::redo()
 //   ChangeKeySig
 //---------------------------------------------------------
 
-ChangeKeySig::ChangeKeySig(KeySig* _keysig, KeySigEvent _ks, bool sc, bool sn)
+ChangeKeySig::ChangeKeySig(KeySig* _keysig, KeySigEvent _ks, bool sc /*, bool sn*/)
       {
       keysig = _keysig;
       ks     = _ks;
       showCourtesy = sc;
-      showNaturals = sn;
       }
 
 //---------------------------------------------------------
@@ -1824,11 +1823,9 @@ void ChangeKeySig::flip()
       {
       KeySigEvent oe = keysig->keySigEvent();
       bool sc        = keysig->showCourtesy();
-      bool sn        = keysig->showNaturals();
 
       keysig->setKeySigEvent(ks);
       keysig->setShowCourtesy(showCourtesy);
-      keysig->setShowNaturals(showNaturals);
 
       // update keymap if keysig was not generated
       // this is needed during undo
@@ -1836,7 +1833,6 @@ void ChangeKeySig::flip()
             keysig->staff()->setKey(keysig->segment()->tick(), ks);
 
       showCourtesy = sc;
-      showNaturals = sn;
       ks           = oe;
 
       keysig->score()->setLayoutAll(true);

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -335,13 +335,12 @@ class ChangeKeySig : public UndoCommand {
       KeySig* keysig;
       KeySigEvent ks;
       bool showCourtesy;
-      bool showNaturals;
 
       void flip();
 
    public:
-      ChangeKeySig(KeySig*, KeySigEvent newKeySig, bool sc, bool sn);
-      UNDO_NAME("ChangeKeySig");
+      ChangeKeySig(KeySig*, KeySigEvent newKeySig, bool sc /*, bool sn*/);
+      UNDO_NAME("ChangeKeySig")
       };
 
 //---------------------------------------------------------

--- a/mscore/debugger/debugger.cpp
+++ b/mscore/debugger/debugger.cpp
@@ -2438,7 +2438,6 @@ void KeySigView::setElement(Element* e)
       ShowElementBase::setElement(e);
 
       keysig.showCourtesySig->setChecked(ks->showCourtesy());
-      keysig.showNaturals->setChecked(ks->showNaturals());
       keysig.accidentalType->setValue(ks->keySigEvent().accidentalType());
       keysig.naturalType->setValue(ks->keySigEvent().naturalType());
       keysig.customType->setValue(ks->keySigEvent().customType());

--- a/mscore/debugger/keysig.ui
+++ b/mscore/debugger/keysig.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>8</number>
+   </property>
+   <property name="topMargin">
+    <number>8</number>
+   </property>
+   <property name="rightMargin">
+    <number>8</number>
+   </property>
+   <property name="bottomMargin">
     <number>8</number>
    </property>
    <item>
@@ -98,13 +107,6 @@
        <widget class="QCheckBox" name="showCourtesySig">
         <property name="text">
          <string notr="true">showCourtesySig</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2" colspan="2">
-       <widget class="QCheckBox" name="showNaturals">
-        <property name="text">
-         <string notr="true">showNaturals</string>
         </property>
        </widget>
       </item>

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -733,10 +733,10 @@ void EditStyle::setValues()
       clefTab2->setChecked(lstyle.value(ST_tabClef).toInt() == int(ClefType::TAB2));
 
       crossMeasureValues->setChecked(lstyle.value(ST_crossMeasureValues).toBool());
-      // bool ??:
-      radioKeySigNatNone->setChecked  (lstyle.value(ST_keySigNaturals).toBool() == NAT_NONE);
-      radioKeySigNatBefore->setChecked(lstyle.value(ST_keySigNaturals).toBool() == NAT_BEFORE);
-      radioKeySigNatAfter->setChecked (lstyle.value(ST_keySigNaturals).toBool() == NAT_AFTER);
+
+      radioKeySigNatNone->setChecked  (lstyle.value(ST_keySigNaturals).toInt() == NAT_NONE);
+      radioKeySigNatBefore->setChecked(lstyle.value(ST_keySigNaturals).toInt() == NAT_BEFORE);
+      radioKeySigNatAfter->setChecked (lstyle.value(ST_keySigNaturals).toInt() == NAT_AFTER);
 
       tupletMaxSlope->setValue(lstyle.value(ST_tupletMaxSlope).toDouble());
       tupletOutOfStaff->setChecked(lstyle.value(ST_tupletOufOfStaff).toBool());

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -423,7 +423,7 @@ InspectorKeySig::InspectorKeySig(QWidget* parent)
             { P_LEADING_SPACE,  0, 1, s.leadingSpace,  s.resetLeadingSpace  },
             { P_TRAILING_SPACE, 0, 1, s.trailingSpace, s.resetTrailingSpace },
             { P_SHOW_COURTESY,  0, 0, k.showCourtesy,  k.resetShowCourtesy  },
-            { P_SHOW_NATURALS,  0, 0, k.showNaturals,  k.resetShowNaturals  }
+//            { P_SHOW_NATURALS,  0, 0, k.showNaturals,  k.resetShowNaturals  }
             };
       mapSignals();
       }

--- a/mscore/inspector/inspector_keysig.ui
+++ b/mscore/inspector/inspector_keysig.ui
@@ -63,42 +63,15 @@
      <property name="spacing">
       <number>0</number>
      </property>
-     <item row="1" column="1">
-      <widget class="QToolButton" name="resetShowCourtesy">
-       <property name="toolTip">
-        <string>reset value</string>
-       </property>
-       <property name="text">
-        <string>...</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../musescore.qrc">
-         <normaloff>:/data/icons/resetproperty.png</normaloff>:/data/icons/resetproperty.png</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>14</width>
-         <height>14</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
+     <item row="0" column="0">
       <widget class="QCheckBox" name="showCourtesy">
        <property name="text">
         <string>Show courtesy</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="showNaturals">
-       <property name="text">
-        <string>Show naturals</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QToolButton" name="resetShowNaturals">
+     <item row="0" column="1">
+      <widget class="QToolButton" name="resetShowCourtesy">
        <property name="toolTip">
         <string>reset value</string>
        </property>
@@ -124,8 +97,6 @@
  <tabstops>
   <tabstop>showCourtesy</tabstop>
   <tabstop>resetShowCourtesy</tabstop>
-  <tabstop>showNaturals</tabstop>
-  <tabstop>resetShowNaturals</tabstop>
  </tabstops>
  <resources>
   <include location="../musescore.qrc"/>

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -255,10 +255,6 @@ void ScoreView::createElementPropertyMenu(Element* e, QMenu* popup)
                      ? QT_TRANSLATE_NOOP("KeySig", "Hide Courtesy Key Signature")
                      : QT_TRANSLATE_NOOP("KeySig", "Show Courtesy Key Signature") );
                   a->setData("key-courtesy");
-                  a = popup->addAction(ks->showNaturals()
-                     ? QT_TRANSLATE_NOOP("KeySig", "Hide naturals")
-                     : QT_TRANSLATE_NOOP("KeySig", "Show naturals") );
-                  a->setData("key-naturals");
                   }
             }
       else if (e->type() == Element::STAFF_STATE && static_cast<StaffState*>(e)->staffStateType() == STAFF_STATE_INSTRUMENT) {
@@ -497,11 +493,7 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
             }
       else if (cmd == "key-courtesy") {
             KeySig* ks = static_cast<KeySig*>(e);
-            score()->undo(new ChangeKeySig(ks, ks->keySigEvent(), !ks->showCourtesy(), ks->showNaturals()));
-            }
-      else if (cmd == "key-naturals") {
-            KeySig* ks = static_cast<KeySig*>(e);
-            score()->undo(new ChangeKeySig(ks, ks->keySigEvent(), ks->showCourtesy(), !ks->showNaturals()));
+            score()->undo(new ChangeKeySig(ks, ks->keySigEvent(), !ks->showCourtesy() /*, ks->showNaturals()*/));
             }
       else if (cmd == "ss-props") {
             StaffState* ss = static_cast<StaffState*>(e);


### PR DESCRIPTION
Fix #20724 - In addition to the score-wide style (which is kept without changes), naturals for individual key sigs are controlled by a previous section break: if the previous measure has a section break, naturals are always hidden; otherwise they follow the score settings.

The KeySig::_showNaturals member var is removed, as well as all the code involving it. This should bring a substantial simplification of the matter, while keeping the possibility to control individual key sig instances.

A partial regression is introduced for 1.x scores, which did not have the concept of section break: they will show naturals originally hidden, until the proper section breaks are not added (which it likely to be done anyway, if the score contains several pieces).
