### PR TITLE
fix #23223: Count in for xml files is now correct

### DIFF
--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -3296,9 +3296,8 @@ void MusicXml::xmlAttributes(Measure* measure, int staff, QDomElement e)
             int btp = 0; // beat-type as integer
             if (determineTimeSig(beats, beatType, timeSymbol, st, bts, btp)) {
                   fractionTSig = Fraction(bts, btp);
-                  // add timesig to all staves
-                  //ws score->sigmap()->add(tick, TimeSig::getSig(st));
-                  Part* part = score->staff(staff)->part();
+                  score->sigmap()->add(tick, fractionTSig);
+		  Part* part = score->staff(staff)->part();
                   int staves = part->nstaves();
                   for (int i = 0; i < staves; ++i) {
                         TimeSig* timesig = new TimeSig(score);


### PR DESCRIPTION
Count In for xml files now works as desired. 
