### PR TITLE
Replace html special characters in text import

### DIFF
--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2326,7 +2326,7 @@ QString Text::convertFromHtml(const QString& ss) const
                               s += "<i>";
                         if (font.underline())
                               s += "<u>";
-                        s += f.text();
+                        s += f.text().toHtmlEscaped();
                         if (font.underline())
                               s += "</u>";
                         if (font.italic())


### PR DESCRIPTION
so that "&" (and similar) is not lost when importing text from version 1.3.
