### PR TITLE
fix #24214: fixed previous chord command

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1121,7 +1121,7 @@ void Seq::prevChord()
       {
       int tick  = playPos->first;
       //find the chord just before playpos
-      EventMap::const_iterator i = events.upper_bound(cs->repeatList()->tick2utick(cs->playPos()));
+      EventMap::const_iterator i = events.upper_bound(cs->repeatList()->tick2utick(tick));
       for (;;) {
             if (i->second.type() == ME_NOTEON) {
                   const NPlayEvent& n = i->second;


### PR DESCRIPTION
It seems that the person writing the code mistakenly wrote cs-playPos(), which returns the tick of the place where the play button has been pressed. 

The variable playPos, stores the current position during playback, and after switching cs->playPos() to tick, I have verified that the feature works correctly.
