### PR TITLE
Fix #25165 - crash when changing measure with whole measure rest

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1662,7 +1662,7 @@ void Measure::adjustToLen(Fraction nf)
                         // set the existing rest to the first value of the duration list
                         score()->undo(new ChangeChordRestLen(rest, durList[0]));
                         // add rests for any other duration list value
-                        int tickOffset = durList[0].ticks();
+                        int tickOffset = tick() + durList[0].ticks();
                         for (int i = 1; i < durList.count(); i++) {
                               Rest* newRest = new Rest(score());
                               newRest->setDurationType(durList.at(i));


### PR DESCRIPTION
Fix #25165 - crash when changing the actual duration of measure with single whole-measure rest to or from irregular time.

When the actual duration of a measure is changed and either the starting or ending duration cannot be represented with a simple value (for instance 5/4) and the measure contains a single whole measure rest, a division by 0 results. See http://musescore.org/en/node/25165 for examples, discussion and analysis.

Fixed.

If the new measure value is different from the current time sig, rest(s) to represent the actual measure values are used instead of a single whole measure rest.
