### PR TITLE
Adjusting view positions after deleting measures

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1403,7 +1403,8 @@ void Score::cmdDeleteSelectedMeasures()
             else {
                   focusOn = this->firstMeasure();
                   }
-            foreach(MuseScoreView* v, viewer)
+
+            foreach(MuseScoreView* v, score->viewer)
                   v->adjustCanvasPosition(focusOn, false);
 
             if (createEndBar) {


### PR DESCRIPTION
Added view adjusting after deleting measures. Sometimes the view remained over a gray area, if a page has been removed. This moves the view to a measure right before the deleted ones.
