### PR TITLE
fix #25225: context menu for rehearsal mark & repeat text

### DIFF
--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -230,6 +230,9 @@ void ScoreView::createElementPropertyMenu(Element* e, QMenu* popup)
                   popup->addAction(tr("Staff Text Properties..."))->setData("st-props");
             }
       else if (e->type() == Element::TEXT
+               || e->type() == Element::REHEARSAL_MARK
+               || e->type() == Element::MARKER
+               || e->type() == Element::JUMP
                || e->type() == Element::FINGERING
                || e->type() == Element::LYRICS
                || e->type() == Element::FIGURED_BASS) {


### PR DESCRIPTION
Display "text" context menu instead of generic one for rehearsal mark & repeat text (marker & jump).
