### PR TITLE
allow dot flip for notes on spaces

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1428,7 +1428,10 @@ bool Note::dotIsUp() const
       {
       if (_dots[0] == 0)
             return true;
-      return _dots[0]->y() < spatium() * .1;
+      if (_userDotPosition == MScore::AUTO)
+            return _dots[0]->y() < spatium() * .1;
+      else
+            return (_userDotPosition == MScore::UP);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Now that notes on spaces can have two dot positions, allow "X" to flip between them (rather than requiring Inspector).  The code is already in place, but the new "dotIsUp" function is always returning "true" for a note on a space when the dot is in the normal default position (on the same space as note).  I changed it to use userDotPosition when not set to AUTO.  It could instead be fixed by actually figuring out whether default position counts as "UP" or "DOWN" depending on voice.  Probably other solutions as well.
