### PR TITLE
Fixed ScoreView searchPage function.

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5249,7 +5249,15 @@ void ScoreView::search(const QString& s)
 void ScoreView::searchPage(int n)
       {
       if (n >= _score->npages())
-            n = _score->npages() - 1;
+            n = _score->npages();
+
+      if(n != 0){
+          /* _score->pages() vector starts from 0
+           * so page N ( pN ) will actually be N-1.
+           */
+          n--;
+      }
+
       const Page* page = _score->pages()[n];
       foreach (System* s, *page->systems()) {
             if (s->firstMeasure()) {


### PR DESCRIPTION
As it is right now, when writing pN (N being a number) in the GoTo dialog, it would take you to page p(N+1). With  his fix the number inserted in the GoTo dialog will take you to the right page, as numbered below the workspace.

Note: I tried to make a pull request for the last commit only. I'm a bit new to working on large projects on GitHub. I've followed the git workflow from MuseScore.org. If I've done something wrong please let me know. Thank you! :)
