### PR TITLE
Added changing of clef when switching to a different instrument

### DIFF
--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -62,6 +62,8 @@ EditStaff::EditStaff(Staff* s, QWidget* parent)
       staff->setStaffType(orgStaff->staffType());
       staff->setPart(part);
 
+      instrumentClefChanged.first = false;
+
       // hide string data controls if instrument has no strings
       stringDataFrame->setVisible(instrument.stringData() && instrument.stringData()->strings() > 0);
       // set dlg controls
@@ -228,6 +230,9 @@ void EditStaff::apply()
       instrument.setShortName(shortName->toPlainText());
       instrument.setLongName(longName->toPlainText());
 
+      if(instrumentClefChanged.first)
+            score->undoChangeClef(orgStaff,score->firstSegment(),instrumentClefChanged.second);
+
       bool s         = small->isChecked();
       bool inv       = invisible->isChecked();
       qreal userDist = spinExtraDistance->value();
@@ -358,6 +363,13 @@ void EditStaff::showInstrumentDialog()
       if (si.exec()) {
             instrument = Instrument::fromTemplate(si.instrTemplate());
             updateInstrument();
+            bool concertPitch = staff->score()->styleB(StyleIdx::concertPitch);
+            if (concertPitch)
+                  instrumentClefChanged.second = si.instrTemplate()->clefTypes[0]._concertClef;
+            else
+                  instrumentClefChanged.second = si.instrTemplate()->clefTypes[0]._transposingClef;
+
+            instrumentClefChanged.first = true;
             }
       }
 

--- a/mscore/editstaff.h
+++ b/mscore/editstaff.h
@@ -30,6 +30,7 @@ namespace Ms {
 
 class Staff;
 class InstrumentTemplate;
+enum class ClefType : signed char;
 
 //---------------------------------------------------------
 //   EditStaff
@@ -42,6 +43,7 @@ class EditStaff : public QDialog, private Ui::EditStaffBase {
       Staff*      staff;
       Staff*      orgStaff;
       Instrument  instrument;
+      std::pair<bool,ClefType>      instrumentClefChanged;
       int         _minPitchA, _maxPitchA, _minPitchP, _maxPitchP;
 
       void apply();


### PR DESCRIPTION
Added code that changes the clef, when an instrument has been changed in the staff properties.
Unfortunately, the optional template is not yet available, so I had to go with std::pair, where the first boolean is true when the instrument has been changed, and the second member is the actual clef.