### PR TITLE
Fix ambitus layout

### DIFF
--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -441,7 +441,13 @@ void Ambitus::draw(QPainter* p) const
 
 Space Ambitus::space() const
       {
-      return Space(spatium() * 0.75 - bbox().x(), width() + bbox().x() + spatium() * 0.5);
+      qreal _spatium = spatium();
+      // reduce left space if there accidentals
+      qreal leftSpace = _spatium *
+            ((_topAccid.accidentalType() != Accidental::ACC_NONE
+                  || _bottomAccid.accidentalType() != Accidental::ACC_NONE)
+            ? 0.5 : 0.75);
+      return Space(leftSpace - bbox().x(), width() + bbox().x() + _spatium * 0.5);
       }
 
 //---------------------------------------------------------

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3517,7 +3517,9 @@ void Measure::layoutX(qreal stretch)
                               e->adjustReadPos();
                               }
                         }
-                  else if (t != AMBITUS) {
+                  else if (t == AMBITUS)
+                        e->adjustReadPos();
+                  else {
                         e->setPos(-e->bbox().x(), 0.0);
                         e->adjustReadPos();
                         }


### PR DESCRIPTION
 Fix layout of ambitus elements with accidentals.

Ambitus elements with and without accidental(s) are laid out misaligned: each element is left-aligned to its left-most part, note head or accidental indifferently.

The new algorithm aligns the leftmost note heads of each ambitus and places accidentals 'hanging' on the left accordingly.

Other small improvements:
- improved management of accidental collision by 'undercutting' flats;
- corrected detection of octave shifts and transpositions in updateRange();
- reduced left margin for ambitus with accidentals.
