### PR TITLE
added score constructor for parts

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -639,7 +639,6 @@ Score::FileError Score::read114(XmlReader& e)
                   }
             Score* nscore = Ms::createExcerpt(excerpt->parts());
             if (nscore) {
-                  nscore->setParentScore(this);
                   nscore->setName(excerpt->title());
                   nscore->rebuildMidiMapping();
                   nscore->updateChannel();

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -393,6 +393,16 @@ Score::Score(Score* parent)
       _synthesizerState = parent->_synthesizerState;
       }
 
+Score::Score(Score* parent, const MStyle* s)
+   : _is(this), _selection(this)
+      {
+      _parentScore = parent;
+      init();
+      _tempomap = new TempoMap;
+      _sigmap   = new TimeSigMap();
+      _style    = *s;
+      }
+
 //---------------------------------------------------------
 //   ~Score
 //---------------------------------------------------------
@@ -2034,7 +2044,6 @@ void Score::replaceStaffTypes(const QList<StaffType*>& tl)
 
 void Score::addExcerpt(Score* score)
       {
-      score->setParentScore(this);
       Excerpt* ex = new Excerpt(score);
       excerpts().append(ex);
       ex->setTitle(score->name());

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -441,6 +441,7 @@ class Score : public QObject {
       Score();
       Score(const MStyle*);
       Score(Score*);                // used for excerpts
+      Score(Score*, const MStyle*);
       ~Score();
 
       Score* clone();

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1043,8 +1043,7 @@ bool Score::read(XmlReader& e)
                    if (MScore::noExcerpts)
                         e.skipCurrentElement();
                   else {
-                        Score* s = new Score(MScore::baseStyle());
-                        s->setParentScore(this);
+                        Score* s = new Score(this, MScore::baseStyle());
                         s->read(e);
                         addExcerpt(s);
                         }

--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -284,7 +284,6 @@ void ExcerptsDialog::createExcerptClicked(QListWidgetItem* cur)
       Score* nscore = Ms::createExcerpt(e->parts());
       if (nscore == 0)
             return;
-      nscore->setParentScore(score);
       e->setScore(nscore);
       nscore->setName(e->title());
       nscore->rebuildMidiMapping();


### PR DESCRIPTION
Added constructor that is used when creating part scores during loading of a score.

I also removed the redundant calls to setParentScore, since createExcerpt already calls the constructor that sets the parent score.
