### PR TITLE
Some letters do not work in letter tablature entry mode

### DIFF
--- a/mscore/actions.cpp
+++ b/mscore/actions.cpp
@@ -2378,6 +2378,41 @@ Shortcut Shortcut::sc[] = {
          QT_TRANSLATE_NOOP("action","Fret 9 (TAB)"),
          QT_TRANSLATE_NOOP("action","Add fret 9 of current string (TAB only)")
          ),
+      Shortcut(
+         STATE_NOTE_ENTRY_TAB,
+         0,
+         "fret-10",
+         QT_TRANSLATE_NOOP("action","Fret 10 (TAB)"),
+         QT_TRANSLATE_NOOP("action","Add fret 10 of current string (TAB only)")
+         ),
+      Shortcut(
+         STATE_NOTE_ENTRY_TAB,
+         0,
+         "fret-11",
+         QT_TRANSLATE_NOOP("action","Fret 11 (TAB)"),
+         QT_TRANSLATE_NOOP("action","Add fret 11 of current string (TAB only)")
+         ),
+      Shortcut(
+         STATE_NOTE_ENTRY_TAB,
+         0,
+         "fret-12",
+         QT_TRANSLATE_NOOP("action","Fret 12 (TAB)"),
+         QT_TRANSLATE_NOOP("action","Add fret 12 of current string (TAB only)")
+         ),
+      Shortcut(
+         STATE_NOTE_ENTRY_TAB,
+         0,
+         "fret-13",
+         QT_TRANSLATE_NOOP("action","Fret 13 (TAB)"),
+         QT_TRANSLATE_NOOP("action","Add fret 13 of current string (TAB only)")
+         ),
+      Shortcut(
+         STATE_NOTE_ENTRY_TAB,
+         0,
+         "fret-14",
+         QT_TRANSLATE_NOOP("action","Fret 14 (TAB)"),
+         QT_TRANSLATE_NOOP("action","Add fret 14 of current string (TAB only)")
+         ),
 
       // HARMONY / FIGURED BASS specific actions
 

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -374,11 +374,11 @@
     </SC>
   <SC>
     <key>add-hairpin</key>
-    <seq>H</seq>
+    <seq>&lt;</seq>
     </SC>
   <SC>
     <key>add-hairpin-reverse</key>
-    <seq>Shift+H</seq>
+    <seq>&gt;</seq>
     </SC>
   <SC>
     <key>add-8va</key>
@@ -880,6 +880,21 @@
     <key>fret-9</key>
     <seq>9</seq>
     <seq>K</seq>
+    </SC>
+  <SC>
+    <key>fret-10</key>
+    </SC>
+  <SC>
+    <key>fret-11</key>
+    </SC>
+  <SC>
+    <key>fret-12</key>
+    </SC>
+  <SC>
+    <key>fret-13</key>
+    </SC>
+  <SC>
+    <key>fret-14</key>
     </SC>
 <!-- HARMONY / FIGURED BASS specific shortcuts -->
   <SC>

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2993,6 +2993,16 @@ void ScoreView::cmd(const QAction* a)
             cmdAddFret(8);
       else if(cmd == "fret-9")
             cmdAddFret(9);
+      else if(cmd == "fret-10")
+            cmdAddFret(10);
+      else if(cmd == "fret-11")
+            cmdAddFret(11);
+      else if(cmd == "fret-12")
+            cmdAddFret(12);
+      else if(cmd == "fret-13")
+            cmdAddFret(13);
+      else if(cmd == "fret-14")
+            cmdAddFret(14);
       else
             _score->cmd(a);
       if (_score->processMidiInput())


### PR DESCRIPTION
Some letters do not work in letter tablature entry mode (opposed to number entry mode)
- The current default setup for shortcut keys has a conflict between the 'H' assigned to the hairpin and the 'H' assigned to the 8th fret in tablature letter mode.
- There are defined tablature note entry actions only up to the 9th fret.

Fixes:

According to the suggestions in forum post http://musescore.org/en/node/25244, this patch implements the following fixes:
- Default shortcut key for hairpin are changed into the more language-independent keys '>' and '<'.
- Actions for fret 10th - 14th are added, so they appear in the shortcut preference dlg box.
- No key is defined for these new actions (for analogy, they should be mapped to 'L' to 'P'), to avoid occupying several more letter keys in the general setup (note that 'N' and 'P' are already taken): the interested user has a known and simple way to define his own keys, if he has the need.
