### PR TITLE
Fix the tab order of text line properties dlg box.

### DIFF
--- a/mscore/lineproperties.ui
+++ b/mscore/lineproperties.ui
@@ -376,6 +376,26 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>beginText</tabstop>
+  <tabstop>beginTextTb</tabstop>
+  <tabstop>beginTextPlace</tabstop>
+  <tabstop>beginHook</tabstop>
+  <tabstop>beginHookHeight</tabstop>
+  <tabstop>beginHookType90</tabstop>
+  <tabstop>beginHookType45</tabstop>
+  <tabstop>continueText</tabstop>
+  <tabstop>continueTextTb</tabstop>
+  <tabstop>continueTextPlace</tabstop>
+  <tabstop>endText</tabstop>
+  <tabstop>endTextTb</tabstop>
+  <tabstop>endTextPlace</tabstop>
+  <tabstop>endHook</tabstop>
+  <tabstop>endHookHeight</tabstop>
+  <tabstop>endHookType90</tabstop>
+  <tabstop>endHookType45</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Fix the tab order of text line properties dlg box.

The dialogue box for Text Line Properties has an inconsistent tab order across its widgets.

Fixed to normal tab order flow from left to right and from top to bottom.
