### PR TITLE
Added error checking to pa_context_connect for better debugging

### DIFF
--- a/mscore/pulseaudio.cpp
+++ b/mscore/pulseaudio.cpp
@@ -121,7 +121,7 @@ bool PulseAudio::init()
       pa_mainloop_api* pa_mlapi = pa_mainloop_get_api(pa_ml);
       pa_context* pa_ctx        = pa_context_new(pa_mlapi, "MuseScore");
       if (pa_context_connect(pa_ctx, NULL, pa_context_flags_t(0), NULL) != 0)
-            printf("PulseAudio Context Connect Failed with Error: %s", pa_strerror(pa_context_errno(pa_ctx)));
+            qDebug("PulseAudio Context Connect Failed with Error: %s", pa_strerror(pa_context_errno(pa_ctx)));
 
       int pa_ready = 0;
       pa_context_set_state_callback(pa_ctx, pa_state_cb, &pa_ready);


### PR DESCRIPTION
I was debugging an issue that turned out to be a problem with my environment, so no issue was created.  In the process, I had added some sanity checks in pulseaudio.cpp.  I think this one in particular should make it into master, as the error checking for that step didn't exist.
