### PR TITLE
fix #23154: undo StaffTypes crash

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1988,9 +1988,6 @@ void Score::addStaffType(int idx, StaffType* st)
                         staff(staffIdx)->setStaffType(st);
             // store the updated staff type
             *(s->_staffTypes[idx]) = st;
-            // delete old staff type if not built-in
-            if (!oldStaffType->builtin())
-                  delete oldStaffType;
             }
       }
 


### PR DESCRIPTION
Undoing Staff Type no longer causes crash
