### PR TITLE
fix #24499: chord symbol edit mode layout issues

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -573,6 +573,7 @@ void Harmony::startEdit(MuseScoreView* view, const QPointF& p)
             Text::createLayout(); // create TextBlocks from text
             }
       Text::startEdit(view, p);
+      layout();
       }
 
 //---------------------------------------------------------

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -1998,6 +1998,19 @@ void Text::textStyleChanged()
       }
 
 //---------------------------------------------------------
+//   setTextStyle
+//---------------------------------------------------------
+
+void Text::setTextStyle(const TextStyle& st)
+      {
+      _textStyle = st;
+      if (editMode()) {
+            setText(plainText());
+            createLayout();
+            }
+      }
+
+//---------------------------------------------------------
 //   setTextStyleType
 //---------------------------------------------------------
 

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -222,7 +222,7 @@ class Text : public Element {
       bool editMode() const                   { return _editMode; }
       void setEditMode(bool val)              { _editMode = val;  }
 
-      virtual void setTextStyle(const TextStyle& st)  { _textStyle = st; }
+      virtual void setTextStyle(const TextStyle& st);
       const TextStyle& textStyle() const      { return _textStyle; }
       TextStyle& textStyle()                  { return _textStyle; }
       int textStyleType() const               { return _styleIndex; }


### PR DESCRIPTION
A few related issues for chord symbol edit mode fixed:
- edit box drawn at wrong size (the render size, not the text size)
- chord symbol jumps up and down while editing if using any vertical alignment but BASELINE
- change of text style while in edit mode can lead to markup appearing in chord symbol
