### PR TITLE
add MSCORE_OUTPUT_NAME, to be used like cmake .. -DMSCORE_OUTPUT_NAME=mscore-nightly

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -298,6 +298,15 @@ target_link_libraries(mscore
       effects
       vorbisfile
       )
+
+if (MSCORE_OUTPUT_NAME)
+      set_target_properties(
+            ${ExecutableName}
+            PROPERTIES
+            OUTPUT_NAME ${MSCORE_OUTPUT_NAME}
+            )
+endif (MSCORE_OUTPUT_NAME)
+
 if (ZERBERUS)
       target_link_libraries(mscore zerberus synthesizer)
 endif ()


### PR DESCRIPTION
this allows easy changing of the executable name. My principle use-case is on the way to creating nightly packages that can be installed alongside musescore 1.3. (I'm aware other changes are needed for this.)
