### PR TITLE
add MSCORE_OUTPUT_NAME, to be used like cmake .. -DMSCORE_OUTPUT_NAME=mscore-nightly

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -299,6 +299,9 @@ target_link_libraries(mscore
       vorbisfile
       )
 
+#if MSCORE_OUTPUT_NAME is set (e.g, when cmake is called by ther user), the output executable will be
+#called MSCORE_OUTPUT_NAME instead of 'mscore'. This can be used to have MuseScore stable and unstable
+#both installed in the same prefix on a Linux system.
 if (MSCORE_OUTPUT_NAME)
       set_target_properties(
             ${ExecutableName}


### PR DESCRIPTION
this allows easy changing of the executable name. My principle use-case is on the way to creating nightly packages that can be installed alongside musescore 1.3. (I'm aware other changes are needed for this.)
