### PR TITLE
commenting out omr shortcut

### DIFF
--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -724,10 +724,12 @@
     <key>inspector</key>
     <seq>F8</seq>
     </SC>
+<!--
   <SC>
     <key>omr</key>
     <seq>F5</seq>
     </SC>
+-->
   <SC>
     <key>figured-bass</key>
     <seq>Ctrl+G</seq>


### PR DESCRIPTION
to prevent an "Internal error: shortcut <omr> not found" message
