### PR TITLE
don't load shortcuts without GUI

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -334,7 +334,8 @@ void Shortcut::init()
                   break;
             _shortcuts[sc[i]._key] = &sc[i];
             }
-      load();
+      if (!MScore::noGui)
+            load();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
i.e. in converter- or plugin mode, as it doesn't make any sense then.

The initialization is needed though, else MuseScore crashes in converter mode
