### PR TITLE
Fix loop out position and loop layout updates

### DIFF
--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -94,6 +94,7 @@ void ScoreView::doDragElement(QMouseEvent* ev)
             _score->doLayoutSystems();
             _score->layoutSpanner();
             update();
+            loopUpdate(getAction("loop")->isChecked());
             return;
             }
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4437,6 +4437,7 @@ void MuseScore::switchLayoutMode(int val)
             cs->doLayout();
             cs->setUpdateAll(true);
             cv->update();
+            cv->loopUpdate(getAction("loop")->isChecked());
             }
       }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5577,7 +5577,7 @@ void ScoreView::loopToggled(bool val)
       if (_score->lastMeasure() == 0)
             return;
       if (_score->pos(POS::LEFT) == 0 && _score->pos(POS::RIGHT) == 0)
-            _score->setPos(POS::RIGHT, _score->lastMeasure()->endTick());
+            _score->setPos(POS::RIGHT, _score->lastMeasure()->endTick()-1);
       _curLoopIn->move(_score->loopInTick());
       _curLoopOut->move(_score->loopOutTick());
       _curLoopIn->setVisible(val);

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -412,6 +412,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       virtual void adjustCanvasPosition(const Element* el, bool playBack);
       virtual void setCursor(const QCursor& c) { QWidget::setCursor(c); }
       virtual QCursor cursor() const { return QWidget::cursor(); }
+      void loopUpdate(bool val)   {  loopToggled(val); }
 
       OmrView* omrView() const    { return _omrView; }
       void setOmrView(OmrView* v) { _omrView = v;    }


### PR DESCRIPTION
Fix the loop out position when toggling the loop button for the first time (set the loop out position correctly to the end of the score).

Force an update of the loop cursors when changing view mode or dragging a staff.
