### PR TITLE
Fix #21990 - Dragging staves problems in continuous view

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3242,7 +3242,8 @@ void Score::doLayoutSystems()
       {
       foreach(System* system, _systems)
             system->layout2();
-      layoutPages();
+      if (layoutMode() != LayoutLine)
+            layoutPages();
       rebuildBspTree();
       _updateAll = true;
 


### PR DESCRIPTION
In continuous view, when dragging a staff, layoutPages() mustn't be executed. Many problems were linked to this : navigator showing pages while dragging, remnants elements appearing, the canvas moving down once we start dragging, etc.
