### PR TITLE
Fix #15212 - Incorrect pan in continous view when zoomed

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3665,24 +3665,21 @@ void ScoreView::pageEnd()
 void ScoreView::adjustCanvasPosition(const Element* el, bool playBack)
       {
       if (score()->layoutMode() == LayoutLine) {
-            qreal x1 = el->canvasPos().x();
-            qreal x2 = x1 + el->width();
+            qreal xo;  // new x offset
+            qreal curPosR = _cursor->rect().right();
+            qreal curPosL = _cursor->rect().left();
+            qreal curPosMagR = curPosR * mag() + xoffset();
+            qreal curPosMagL = curPosL * mag() + xoffset();
 
-            int ix1 = (x1 + xoffset()) * mag();
-            int ix2 = (x2 + xoffset()) * mag();
-            qreal xo;
-            int dx = ix2 - ix1;
-            if (dx < width()) {
-                  if (ix2 >= width()) {
-                        xo = dx / mag() - x2;
-                        setOffset(xo, yoffset());
-                        update();
-                        }
-                  else if (ix1 < 0) {
-                        xo = (width() - dx) / mag() - x1;
-                        setOffset(xo, yoffset());
-                        update();
-                        }
+            if (curPosMagR >= width() * 0.90) {   // leaves 10% margin to the right
+                  xo = xoffset() - curPosMagL + width() * 0.05;
+                  setOffset(xo, yoffset());
+                  update();
+                  }
+            else if (curPosMagL < width() * 0.05) {  // leaves 5% margin to the left
+                  xo = -curPosL*mag() + width() * 0.05;
+                  setOffset(xo, yoffset());
+                  update();
                   }
             return;
             }


### PR DESCRIPTION
Here's a fix for the panning in continuous view.
I've changed it quite a bit to base the panning on the cursor position instead of the element.
I also based the panning on margins on each side (5% on the left and 10% on the right).
