### PR TITLE
update to SMuFL 0.9 - glyphsWithAnchors

### DIFF
--- a/fonts/gonville/metadata.json
+++ b/fonts/gonville/metadata.json
@@ -32,7 +32,7 @@
         "tupletBracketThickness": 0.16
     }, 
 
-    "glyphs": {
+    "glyphsWithAnchors": {
         "flag1024thDown": {
             "stemDownSW": [
                 0.0,
@@ -1788,6 +1788,55 @@
                 0.988,
                 0.316
             ]
+        },
+        "accidentalFlat": {
+            "cutOutNE": [
+                0.19,
+                0.59
+            ],
+            "cutOutSE": [
+                0.5,
+                -0.36
+            ]
+        },
+        "accidentalDoubleFlat": {
+            "cutOutNE": [
+                0.84,
+                0.59
+            ],
+            "cutOutSE": [
+                1.13,
+                -0.36
+            ]
+        },
+        "accidentalNatural": {
+            "cutOutNE": [
+                0.18,
+                0.85
+            ],
+            "cutOutSW": [
+                0.49,
+                -0.84
+            ]
+        },
+        "accidentalSharp": {
+            "cutOutNE": [
+                0.87,
+                0.9
+            ],
+            "cutOutNW": [
+                0.23,
+                0.62
+            ],
+            "cutOutSE": [
+                0.87,
+                -0.65
+            ],
+            "cutOutSW": [
+                0.23,
+                -0.9
+            ]
         }
     }
+
 }

--- a/fonts/mscore/metadata.json
+++ b/fonts/mscore/metadata.json
@@ -7,7 +7,7 @@
         "tieMidpointThickness": 0.22
     },
 
-    "glyphs": {
+    "glyphsWithAnchors": {
         "flag128thDown": {
             "stemDownSW": [
                 0.0,
@@ -1751,56 +1751,53 @@
                 0.988,
                 0.316
             ]
-        }
-    },
-
-    "glyphsWithAnchors" : {
+        },
         "accidentalFlat": {
             "cutOutNE": [
-                0.25,
-                0.65
+                0.19,
+                0.59
             ],
             "cutOutSE": [
-                0.5,
-                -0.4
+                0.49,
+                -0.36
             ]
         },
         "accidentalDoubleFlat": {
             "cutOutNE": [
-                0.9,
-                0.65
+                0.84,
+                0.59
             ],
             "cutOutSE": [
-                1.15,
-                -0.4
+                1.13,
+                -0.36
             ]
         },
         "accidentalNatural": {
             "cutOutNE": [
-                0.22,
-                0.86
+                0.18,
+                0.85
             ],
             "cutOutSW": [
-                0.45,
-                -0.86
+                0.49,
+                -0.85
             ]
         },
         "accidentalSharp": {
             "cutOutNE": [
-                0.9,
-                1.0
+                0.87,
+                0.9
             ],
             "cutOutNW": [
-                0.2,
-                0.66
+                0.23,
+                0.62
             ],
             "cutOutSE": [
-                0.9,
-                -0.65
+                0.87,
+                -0.62
             ],
             "cutOutSW": [
-                0.2,
-                -0.95
+                0.23,
+                -0.9
             ]
         }
     }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -558,7 +558,7 @@ struct AcEl {
 //    lx = calculated position of rightmost edge of left accidental relative to origin
 //---------------------------------------------------------
 
-static bool resolveAccidentals(AcEl* left, AcEl* right, qreal& lx, qreal pnd, qreal pd, qreal sp)
+static bool resolveAccidentals(AcEl* left, AcEl* right, qreal& lx, qreal pd, qreal sp)
       {
       AcEl* upper;
       AcEl* lower;
@@ -594,7 +594,7 @@ static bool resolveAccidentals(AcEl* left, AcEl* right, qreal& lx, qreal pnd, qr
       // amount by which overlapping accidentals will be separated
       // for example, the vertical stems of two flat signs
       // these need more space than we would need between non-overlapping accidentals
-      qreal overlapShift = pd * 1.4;
+      qreal overlapShift = pd * 1.41;
 
       // accidentals with more significant overlap
       // acceptable if one accidental can subsume overlap
@@ -656,9 +656,9 @@ static qreal layoutAccidental(AcEl* me, AcEl* above, AcEl* below, qreal colOffse
       Accidental* acc = me->note->accidental();
 
       if (above)
-            conflictAbove = resolveAccidentals(me, above, lx, pnd, pd, sp);
+            conflictAbove = resolveAccidentals(me, above, lx, pd, sp);
       if (below)
-            conflictBelow = resolveAccidentals(me, below, lx, pnd, pd, sp);
+            conflictBelow = resolveAccidentals(me, below, lx, pd, sp);
       if (conflictAbove || conflictBelow)
             me->x = lx - acc->width() - acc->bbox().x();
       else if (colOffset != 0.0)
@@ -710,7 +710,6 @@ void Score::layoutChords3(QList<Note*>& notes, Staff* staff, Segment* segment)
                   acel.top    = line * 0.5 * sp + ac->bbox().top();
                   acel.bottom = line * 0.5 * sp + ac->bbox().bottom();
                   acel.width  = ac->width();
-#if 1
                   QPointF bboxNE = ac->symBbox(ac->symbol()).topRight();
                   QPointF bboxSW = ac->symBbox(ac->symbol()).bottomLeft();
                   QPointF cutOutNE = ac->symCutOutNE(ac->symbol());
@@ -731,40 +730,6 @@ void Score::layoutChords3(QList<Note*>& notes, Staff* staff, Segment* segment)
                         acel.descent   = 0.0;
                         acel.leftClear = 0.0;
                         }
-#else
-                  qreal scale = sp * ac->mag();
-                  switch (ac->accidentalType()) {
-                        case Accidental::ACC_FLAT:
-                              acel.ascent = 1.2 * scale;
-                              acel.descent = 0;
-                              acel.rightClear = 0.5 * scale;
-                              acel.leftClear = 0;
-                              break;
-                        case Accidental::ACC_FLAT2:
-                              acel.ascent = 1.2 * scale;
-                              acel.descent = 0;
-                              acel.rightClear = 0.25 * scale;
-                              acel.leftClear = 0;
-                              break;
-                        case Accidental::ACC_NATURAL:
-                              acel.ascent = 0.5 * scale;
-                              acel.descent = 0.7 * scale;
-                              acel.rightClear = 0.5 * scale;
-                              acel.leftClear = 0.5 * scale;
-                              break;
-                        case Accidental::ACC_SHARP:
-                              acel.ascent = 0.25 * scale;
-                              acel.descent = 0.25 * scale;
-                              acel.rightClear = 0;
-                              acel.leftClear = 0;
-                              break;
-                        default:
-                              acel.ascent = 0;
-                              acel.descent = 0;
-                              acel.rightClear = 0;
-                              acel.leftClear = 0;
-                        }
-#endif
                   int pitchClass = (line + 700) % 7;
                   acel.next = columnBottom[pitchClass];
                   columnBottom[pitchClass] = nAcc;

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -6114,27 +6114,7 @@ void ScoreFont::load()
             qDebug("Json parse error in <%s>(offset: %d): %s", qPrintable(fi.fileName()),
                error.offset, qPrintable(error.errorString()));
 
-      QJsonObject oo = o.value("glyphs").toObject();
-      for (auto i : oo.keys()) {
-            QJsonObject ooo = oo.value(i).toObject();
-            SymId symId = Sym::lnhash.value(i, SymId::noSym);
-            if (symId == SymId::noSym)
-                  qDebug("ScoreFont: symId not found <%s> in <%s>", qPrintable(i), qPrintable(fi.fileName()));
-            Sym* sym = &_symbols[int(symId)];
-            for (auto i : ooo.keys()) {
-                  if (i == "stemDownNW") {
-                        //qreal x = ooo.value(i).toArray().at(0).toDouble();
-                        //qreal y = ooo.value(i).toArray().at(1).toDouble();
-                        }
-                  else if (i == "stemUpSE") {
-                        qreal x = ooo.value(i).toArray().at(0).toDouble();
-                        qreal y = ooo.value(i).toArray().at(1).toDouble();
-                        sym->setAttach(QPointF(4.0 * x * MScore::DPI/PPI, 4.0 * -y * MScore::DPI/PPI));
-                        }
-                  }
-            }
-
-      oo = o.value("glyphsWithAnchors").toObject();
+      QJsonObject oo = o.value("glyphsWithAnchors").toObject();
       for (auto i : oo.keys()) {
             qreal scale = MScore::DPI * SPATIUM20;
             QJsonObject ooo = oo.value(i).toObject();
@@ -6147,7 +6127,16 @@ void ScoreFont::load()
                   }
             Sym* sym = &_symbols[int(symId)];
             for (auto i : ooo.keys()) {
-                  if (i == "cutOutNE") {
+                  if (i == "stemDownNW") {
+                        //qreal x = ooo.value(i).toArray().at(0).toDouble();
+                        //qreal y = ooo.value(i).toArray().at(1).toDouble();
+                        }
+                  else if (i == "stemUpSE") {
+                        qreal x = ooo.value(i).toArray().at(0).toDouble();
+                        qreal y = ooo.value(i).toArray().at(1).toDouble();
+                        sym->setAttach(QPointF(4.0 * x * MScore::DPI/PPI, 4.0 * -y * MScore::DPI/PPI));
+                        }
+                  else if (i == "cutOutNE") {
                         qreal x = ooo.value(i).toArray().at(0).toDouble() * scale;
                         qreal y = ooo.value(i).toArray().at(1).toDouble() * scale;
                         sym->setCutOutNE(QPointF(x, -y));


### PR DESCRIPTION
- Move the contents of the former "glyphs" structure to "glyphsWithAnchors", merging with the cutOut keys that were added recently.
- Add cutOut keys for Gonville
- Slight improvement to cutOut key values for Emmentaler
- Remove old/unused code
