### PR TITLE
Fixes to EditStyle dlg box

### DIFF
--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>892</width>
-    <height>668</height>
+    <height>573</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
   Fixes to EditStyle dlg box:

```
- Better tab clef names than "Tab1" Tab2", i.e.: "Standard TAB clef" and "Serif TAB clef"
- Corrected dlg tab order
- Added all buddy links.
```
