### PR TITLE
Fix #25811 #25867 - Incomplete layout when adding linked staff

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -468,15 +468,26 @@ void cloneStaff(Staff* srcStaff, Staff* dstStaff)
                               continue;
                         if (oe->type() == ElementType::TIMESIG)
                               continue;
-                        Element* ne;
-                        if (oe->type() == ElementType::CLEF)
-                              ne = oe->clone();
+                        Element* ne = nullptr;
+                        if (oe->type() == ElementType::CLEF) {
+                              // only clone clef if it matches staff group and does not exists yet
+                              Clef* clef = static_cast<Clef*>(oe);
+                              int   tick = seg->tick();
+                              if (ClefInfo::staffGroup(clef->concertClef()) == dstStaff->staffGroup()
+                                          && dstStaff->clefTypeList(tick) != clef->clefTypeList()) {
+                                    ne = oe->clone();
+                                    // add to staff clef map too
+                                    dstStaff->setClef(tick, clef->clefTypeList());
+                                    }
+                              }
                         else
                               ne = oe->linkedClone();
-                        ne->setTrack(dstTrack);
-                        ne->setParent(seg);
-                        ne->setScore(score);
-                        score->undoAddElement(ne);
+                        if (ne) {
+                              ne->setTrack(dstTrack);
+                              ne->setParent(seg);
+                              ne->setScore(score);
+                              score->undoAddElement(ne);
+                              }
                         if (oe->isChordRest()) {
                               ChordRest* ocr = static_cast<ChordRest*>(oe);
                               ChordRest* ncr = static_cast<ChordRest*>(ne);

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -789,6 +789,7 @@ void InstrumentsDialog::on_editButton_clicked()
 
 //---------------------------------------------------------
 //   on_belowButton_clicked
+//    (actually "Add Staff" button)
 //---------------------------------------------------------
 
 void InstrumentsDialog::on_belowButton_clicked()
@@ -805,7 +806,7 @@ void InstrumentsDialog::on_belowButton_clicked()
       PartListItem* pli   = (PartListItem*)sli->QTreeWidgetItem::parent();
       StaffListItem* nsli = new StaffListItem();
       nsli->staff         = staff;
-      nsli->setDefaultClef(sli->clef());
+      nsli->setDefaultClef(sli->defaultClef());
       if (staff)
             nsli->op = ITEM_ADD;
       pli->insertChild(pli->indexOfChild(sli)+1, nsli);
@@ -833,7 +834,7 @@ void InstrumentsDialog::on_linkedButton_clicked()
       PartListItem* pli   = (PartListItem*)sli->QTreeWidgetItem::parent();
       StaffListItem* nsli = new StaffListItem();
       nsli->staff         = staff;
-      nsli->setDefaultClef(sli->clef());
+      nsli->setDefaultClef(sli->defaultClef());
       nsli->setLinked(true);
       if (staff)
             nsli->op = ITEM_ADD;
@@ -1128,9 +1129,10 @@ void MuseScore::editInstrList()
             rootScore->undo(new RemoveExcerpt(s));
 
       rootScore->setLayoutAll(true);
-      rootScore->endCmd();
+      rootScore->cmdUpdateNotes();  // do it before global layout or layout of chords will not
+      rootScore->endCmd();          // find notes in right positions for stems, ledger lines, etc
       rootScore->rebuildMidiMapping();
-      rootScore->updateNotes(); // need to compute frets for tabs
+//      rootScore->updateNotes();
       seq->initInstruments();
       }
 

--- a/mscore/instrdialog.h
+++ b/mscore/instrdialog.h
@@ -78,21 +78,22 @@ class StaffListItem : public QObject, public QTreeWidgetItem {
 
       int op;
       Staff* staff;
-      int partIdx() const      { return _partIdx; }
+      int partIdx() const                       { return _partIdx; }
       void setPartIdx(int val);
       int staffIdx;
 
       void setClef(const ClefTypeList& val);
-      const ClefTypeList& clef() const { return _clef;    }
+      const ClefTypeList& clef() const          { return _clef;    }
       void setDefaultClef(const ClefTypeList& val);
+      const ClefTypeList& defaultClef() const   { return _defaultClef;  }
       void setLinked(bool val);
-      bool linked() const              { return _linked;  }
+      bool linked() const                       { return _linked;  }
       void setStaffType(const StaffType*);
       void setStaffType(int);
       const StaffType* staffType() const;
       int staffTypeIdx() const;
       void initStaffTypeCombo(bool forceRecreate = false);
-      QComboBox* staffTypeCombo() { return _staffTypeCombo; }
+      QComboBox* staffTypeCombo()               { return _staffTypeCombo; }
       };
 
 //---------------------------------------------------------

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -388,7 +388,7 @@ void InstrumentWizard::on_linkedButton_clicked()
       pli->setVisible(true);
       StaffListItem* nsli = new StaffListItem();
       nsli->staff         = staff;
-      nsli->setDefaultClef(sli->clef());
+      nsli->setDefaultClef(sli->defaultClef());
       nsli->setLinked(true);
       if (staff)
             nsli->op = ITEM_ADD;
@@ -417,7 +417,7 @@ void InstrumentWizard::on_belowButton_clicked()
       PartListItem* pli   = (PartListItem*)sli->QTreeWidgetItem::parent();
       StaffListItem* nsli = new StaffListItem();
       nsli->staff         = staff;
-      nsli->setDefaultClef(sli->clef());
+      nsli->setDefaultClef(sli->defaultClef());
       if (staff)
             nsli->op = ITEM_ADD;
       pli->insertChild(pli->indexOfChild(sli)+1, nsli);


### PR DESCRIPTION
Fix #25811 #25867 - Incomplete layout when adding linked staff.

If a linked staff of a different type/group is added to the score, the new staff is not completely laid out.

Fixes:
- Default clef of new staff is copied from default clef of original staff, rather than from its actual clef.
- When score instruments are updated, notes are updated before laying out chords, as chords need to have notes in correct position to compute correct stems, ledger lines, etc.
- Notes are updated via `Score::cmdUpdateNotes()` rather `Score::updateNotes()`, as the former does create undo steps and the latter does not deals with the specifics of staff groups.
- `cloneStaff()` only clones clefs which are compatible with the staff group AND do not already exist.
- `cloneStaff()` also updates the staff clef map when cloning a clef.

Note: `Chord::updateNotes()` is much simpler than `Chord:cmdUpdateNotes()` and does not deal with a number of specific cases (https://github.com/musescore/MuseScore/blob/master/libmscore/chord.cpp#L1588 and following). Is this on purpose?
