### PR TITLE
Fix the placements of flats in soprano clef

### DIFF
--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -42,7 +42,7 @@ const ClefInfo ClefInfo::clefTable[] = {
 { "F15mb","F",         4, -2, 19, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, TR("Bass clef 15mb"),         StaffGroup::STANDARD  },
 { "F3",   "F",         3,  0, 35, { 4, 0, 3,-1, 2, 5, 1, 1, 5, 2, 6, 3, 7, 4 }, TR("Baritone clef (F clef)"), StaffGroup::STANDARD  },
 { "F5",   "F",         5,  0, 31, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, TR("Subbass clef"),           StaffGroup::STANDARD  },
-{ "C1",   "C",         1,  0, 43, { 5, 1, 4, 0, 3,-1, 2, 2,-1, 3, 0, 4, 1, 5 }, TR("Soprano clef"),           StaffGroup::STANDARD  }, // C1
+{ "C1",   "C",         1,  0, 43, { 5, 1, 4, 0, 3,-1, 2, 2, 6, 3, 7, 4, 8, 5 }, TR("Soprano clef"),           StaffGroup::STANDARD  }, // C1
 { "C2",   "C",         2,  0, 41, { 3, 6, 2, 5, 1, 4, 0, 0, 4, 1, 5, 2, 6, 3 }, TR("Mezzo-soprano clef"),     StaffGroup::STANDARD  }, // C2
 { "C3",   "C",         3,  0, 39, { 1, 4, 0, 3, 6, 2, 5, 5, 2, 6, 3, 7, 4, 8 }, TR("Alto clef"),              StaffGroup::STANDARD  }, // C3
 { "C4",   "C",         4,  0, 37, { 6, 2, 5, 1, 4, 0, 3, 3, 0, 4, 1, 5, 2, 6 }, TR("Tenor clef"),             StaffGroup::STANDARD  }, // C4


### PR DESCRIPTION
Hi!

I've noticed that the placement of flats in the key signature in soprano clef is quite unusual. While I know there is a lack of standardization of the placement of flats/sharps in key signatures for some of the less used clefs (baritone, mezzo-soprano), there is a common way for the placement of flats in soprano clef, which is also used in other software (Finale, Lilypond) as well as music I've seen (Bach SATB chorales, Mozart keyboard works).

Current: ![alt text](http://seanyeh.com/tmp/musescore/soprano_old.png)

Proposed: ![alt text](http://seanyeh.com/tmp/musescore/soprano_new.png)

I'm not a(n) specialist/expert in the history of music notation, so please let me know what you think about this change.

Thanks!
Sean
