### PR TITLE
Fix #25958 - Crash when [Apply]ing and [OK]ing some prop changes

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -672,7 +672,8 @@ void InstrumentData::setDrumset(Drumset* ds)
 void InstrumentData::setLongName(const QString& f)
       {
       _longNames.clear();
-      _longNames.append(StaffName(f, 0));
+      if (f.length() > 0)
+            _longNames.append(StaffName(f, 0));
       }
 
 //---------------------------------------------------------
@@ -682,7 +683,8 @@ void InstrumentData::setLongName(const QString& f)
 void InstrumentData::setShortName(const QString& f)
       {
       _shortNames.clear();
-      _shortNames.append(StaffName(f, 0));
+      if (f.length() > 0)
+            _shortNames.append(StaffName(f, 0));
       }
 
 //---------------------------------------------------------

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2356,6 +2356,9 @@ void ChangeStaffType::redo()
       StaffType st = *staff->staffType();
       staff->setStaffType(&staffType);
       staffType = st;
+      Score* score = staff->score();
+      score->setLayoutAll(true);
+      score->scanElements(0, notifyTimeSigs);
       }
 
 void ChangeStaffType::undo()
@@ -2392,6 +2395,8 @@ void ChangeStaffType::undo()
             seg->add(clef);
             }
 //      cmdUpdateNotes();                         // needed?
+      score->setLayoutAll(true);
+      score->scanElements(0, notifyTimeSigs);
       }
 
 //---------------------------------------------------------

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -114,15 +114,15 @@ void EditStaff::updateInstrument()
       {
       updateInterval(instrument.transpose());
 
-      QList<StaffName>& nl = instrument.shortNames();
-      QString df = nl.isEmpty() ? "" : nl[0].name;
+      QList<StaffName>& snl = instrument.shortNames();
+      QString df = snl.isEmpty() ? "" : snl[0].name;
       shortName->setText(df);
 
-      nl = instrument.longNames();
-      df = nl.isEmpty() ? "" : nl[0].name;
+      QList<StaffName>& lnl = instrument.longNames();
+      df = lnl.isEmpty() ? "" : lnl[0].name;
       longName->setText(df);
 
-      if (partName->text() == instrumentName->text())    // Updates part name is no custom name has been set before
+      if (partName->text() == instrumentName->text())    // Updates part name if no custom name has been set before
             partName->setText(instrument.trackName());
 
       instrumentName->setText(instrument.trackName());
@@ -191,14 +191,14 @@ void EditStaff::bboxClicked(QAbstractButton* button)
 
             case QDialogButtonBox::RejectRole:
                   close();
+                  if (staff != nullptr)
+                        delete staff;
                   break;
 
             default:
                   qDebug("EditStaff: unknown button %d", int(br));
                   break;
             }
-      if (staff != nullptr)
-            delete staff;
       }
 
 //---------------------------------------------------------
@@ -245,7 +245,7 @@ void EditStaff::apply()
             }
 
       if (s != staff->small() || inv != staff->invisible() || userDist != staff->userDist() || col != staff->color())
-            score->undo(new ChangeStaff(staff, s, inv, userDist * score->spatium(), col));
+            score->undo(new ChangeStaff(orgStaff, s, inv, userDist * score->spatium(), col));
 
       if ( !(*orgStaff->staffType() == *staff->staffType()) ) {
             // updateNeeded |= (orgStaff->staffGroup() == StaffGroup::TAB || staff->staffGroup() == StaffGroup::TAB);


### PR DESCRIPTION
Fix #25958 - Crash when [Apply]ing and [OK]ing some prop changes

Additional fixes:
- Changes to staff own properties (small, invisible, user dist., colour) were not carried on.
- Changes to staff type were not visibly laid out into the score.
- Finally time sigs are re-laid out when staff type changes.
- If short and long names are empty strings, instrument relevant lists are no longer set to an empty string; rather the relevant list is left empty; this matches the situation when the dlg is initially open with either name not set and avoids unnecessary ChangePart operations.
