### PR TITLE
fix #26091: correct tick for staff text & symbol

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -761,7 +761,7 @@ bool Element::readProperties(XmlReader& e)
                   // - another bug allowed text items attached to notes or chords to also have invalid tick values (#25616)
                   //   the text might be of any type, but we are now converting any text elements within notes into FINGERING
                   // - at some point, a check for SYMBOL was included here, but it isn't clear what the issue was
-                  //   ignoring ticks for symbols menas they will be positioned incorrectly, and it is not safe in any case:
+                  //   ignoring ticks for symbols means they will be positioned incorrectly if not at start of measure, and it is not safe in any case:
                   //   it causes problems if there is also another item such as a STAFF_TEXT that was depending on the tick value of the symbol (http://musescore.org/en/node/25572)
                   //   when we re-discover the issue that caused the check for SYMBOL to be added,
                   //   we will need to find a different solution if possible


### PR DESCRIPTION
See discussion in issue - http://musescore.org/en/node/26091

This appears to fix the issue at hand as well as work for all the test cases in the referenced issues.  The only question is https://github.com/musescore/MuseScore/commit/a201385f13f0458df06e824f6f7b5e6da8ff6f47.  I still don't know what problem that commit was fixing, and this PR will probably break that again.  I am hoping we can write off any scores that break as "corrupt".
