### PR TITLE
Add string data to 1.x scores.

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -219,7 +219,8 @@ void Part::read114(XmlReader& e)
                   instrument->read(e);
                   // add string data from MIDI program number, if possible
                   if (instrument->stringData()->strings() == 0
-                              && instrument->channel().count() > 0) {
+                              && instrument->channel().count() > 0
+                              && instrument->drumset() == nullptr) {
                         int program = instrument->channel(0).program;
                         if (program >= 24 && program <= 30)       // guitars
                               instrument->setStringData(StringData(19, 6, g_guitarStrings));


### PR DESCRIPTION
Based on the MIDI program of the instrument, the code tries to add string data to instruments read from 1.x scores.

It is not fool-proof and covers only the most common (and less likely to have been customized) cases. For other cases, the user will have to change the part instrument or to copy the part to a suitably created instrument.

It covers:
- guitar(s)
- bass(es), either bass guitars and double bass
- violin, viola and cello, as their MIDI programs are used for a number of other string instruments; in these cases, string number and/or tuning may need to be customized, but this at least provides a convenient start point.

Comments are welcome.
