### PR TITLE
fix #22205: microtonal accidentals that change pitch display as naturals

### DIFF
--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -163,7 +163,7 @@ void Accidental::read(XmlReader& e)
                                      at = AccidentalType::MIRRORED_FLAT;
                                      break;
                                case 20:
-                                     at = AccidentalType::MIRRIRED_FLAT_SLASH;
+                                     at = AccidentalType::MIRRORED_FLAT_SLASH;
                                      break;
                                case 21:
                                      at = AccidentalType::FLAT_FLAT_SLASH;

--- a/libmscore/accidental.h
+++ b/libmscore/accidental.h
@@ -64,7 +64,7 @@ class Accidental : public Element {
             FLAT_SLASH2,
             MIRRORED_FLAT2,
             MIRRORED_FLAT,
-            MIRRIRED_FLAT_SLASH,
+            MIRRORED_FLAT_SLASH,
             FLAT_FLAT_SLASH,
 
             SHARP_SLASH,

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1445,18 +1445,16 @@ void Score::changeAccidental(Note* note, Accidental::AccidentalType accidental)
             if (a)
                   undoRemoveElement(note->accidental());
             }
-      else {
-            if (acc == acc2) {
-                  //
-                  // this is a precautionary accidental
-                  //
-
-                  Accidental* a = new Accidental(this);
-                  a->setParent(note);
-                  a->setAccidentalType(accidental);
-                  a->setRole(Accidental::AccidentalRole::USER);
-                  undoAddElement(a);
-                  }
+      else if (acc == acc2 || accidental > Accidental::AccidentalType::NATURAL) {
+            //
+            // precautionary or microtonal accidental
+            // either way, we display it unconditionally
+            //
+            Accidental* a = new Accidental(this);
+            a->setParent(note);
+            a->setAccidentalType(accidental);
+            a->setRole(Accidental::AccidentalRole::USER);
+            undoAddElement(a);
             }
 
       if (note->links()) {

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -905,8 +905,8 @@ void Note::read(XmlReader& e)
                         // only construct a new accidental, if the other tag has not been read yet
                         // (<userAccidental> tag is only used in older scores: no need to check the score mscVersion)
                         if (!hasAccidental) {
-                              _accidental = new Accidental(score());
-                              _accidental->setParent(this);
+                              Accidental* a = new Accidental(score());
+                              add(a);
                               }
                         // TODO: for backward compatibility
                         bool bracket = k & 0x8000;
@@ -924,7 +924,7 @@ void Note::read(XmlReader& e)
                               case 7: at = Accidental::AccidentalType::FLAT_SLASH2; break;
                               case 8: at = Accidental::AccidentalType::MIRRORED_FLAT2; break;
                               case 9: at = Accidental::AccidentalType::MIRRORED_FLAT; break;
-                              case 10: at = Accidental::AccidentalType::MIRRIRED_FLAT_SLASH; break;
+                              case 10: at = Accidental::AccidentalType::MIRRORED_FLAT_SLASH; break;
                               case 11: at = Accidental::AccidentalType::FLAT_FLAT_SLASH; break;
 
                               case 12: at = Accidental::AccidentalType::SHARP_SLASH; break;
@@ -1631,6 +1631,12 @@ void Note::layout10(AccidentalState* as)
                               relLine = absStep(tpc(), epitch());
                               }
                         }
+#if 0
+                  else if (acci > Accidental::AccidentalType::NATURAL) {
+                        // microtonal accidental - see comment in updateAccidental
+                        as->setAccidentalVal(relLine, AccidentalVal::NATURAL, _tieBack != 0);
+                        }
+#endif
                   }
             else  {
                   AccidentalVal accVal = tpc2alter(tpc());
@@ -1921,6 +1927,17 @@ void Note::updateAccidental(AccidentalState* as)
                         }
                   }
             }
+#if 0
+      else {
+            // currently, microtonal accidentals playback as naturals
+            // but have no effect on accidental state of measure
+            // ultimetely, they should probably get their own state
+            // or at least change state to natural, so subsequent notes playback as might be expected
+            // however, this would represent an incompatible change
+            // so hold off until playback of microtonal accidentals is fully implemented
+            as->setAccidentalVal(relLine, AccidentalVal::NATURAL, _tieBack != 0);
+            }
+#endif
       updateRelLine(relLine, true);
       }
 

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -3990,7 +3990,7 @@ static Accidental::AccidentalType convertAccidental(QString mxmlName)
       map["flat-down"] = Accidental::AccidentalType::FLAT_ARROW_DOWN;
       map["flat-up"] = Accidental::AccidentalType::FLAT_ARROW_UP;
 
-      map["slash-quarter-sharp"] = Accidental::AccidentalType::MIRRIRED_FLAT_SLASH;
+      map["slash-quarter-sharp"] = Accidental::AccidentalType::MIRRORED_FLAT_SLASH;
       map["slash-sharp"] = Accidental::AccidentalType::SHARP_SLASH;
       map["slash-flat"] = Accidental::AccidentalType::FLAT_SLASH;
       map["double-slash-flat"] = Accidental::AccidentalType::FLAT_SLASH2;


### PR DESCRIPTION
Microtonal accidentals are treated as naturals for playback purposes, but they were also _displaying_ as naturals as well in cases where an actual natural sign would not have been merely cautionary (eg, if the note was already flat or sharp because of the key signature or an earlier accidental).  This PR fixes that bug

I also added some commented-out code that would cause microtonal accidentals to also be treated as naturals rather than no-ops in terms of how they affect the "accidental state" - the pitch of subsequent notes in the measure.  We'll probably want to enable this code (or build on it) if we ever implement playback of microtonal accidentals.  But for now, it would represent an incompatible change and should probably remain disabled.
