### PR TITLE
fix #25797: enharmonic spelling of Shift+note

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4832,8 +4832,8 @@ void ScoreView::cmdAddPitch(int note, bool addFlag)
             score()->repitchNote(pos, !addFlag);
       else
             score()->putNote(pos, !addFlag);
-      _score->endCmd();
 
+      _score->endCmd();
       adjustCanvasPosition(is.cr(), false);
       }
 


### PR DESCRIPTION
Borrowed the line to set tpc from putNote() which seems to get it right
