### PR TITLE
Made extendSelection aware of activeSegment.

### DIFF
--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -991,10 +991,14 @@ void Selection::extendRangeSelection(Segment* seg, Segment* segAfter, int staffI
             _staffEnd = staffIdx + 1;
 
       if (tick < tickStart()) {
+            if (_activeSegment == _endSegment)
+                  _endSegment = _startSegment->next();
             _startSegment = seg;
             activeIsFirst = true;
             }
-      else if (etick >= tickEnd()) {
+      else if (_endSegment && etick >= tickEnd()) {
+            if (_activeSegment == _startSegment)
+                  _startSegment = _endSegment->prev();
             _endSegment = segAfter;
             }
       else {


### PR DESCRIPTION
This PR fixes the selection extend method.

It partly introduces the old behavior where a selection extended on the opposite of active element (usually left) changed to span from the new element to the start selection segment.

There was one problem with the previous code, when we created a selection of 2 elements from right to left. Only the first element was in the selection, when extending, the new end segment was the previous start segment.
Since the end segment should be a segment right after the last segment in the selection, the note was not selected.

The code below fixes this by ensuring that the swap is done correctly.
