### PR TITLE
fix #25670: Stem direction on beamed notes not imported correctly in 1.3...

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -334,7 +334,9 @@ void Beam::layout1()
             else {
                   if (c1) {
                         Measure* m = c1->measure();
-                        if (m->hasVoices(c1->staffIdx()))
+                        if (c1->stemDirection() != Direction::AUTO)
+                              _up = c1->stemDirection() == Direction::UP;
+                        else if (m->hasVoices(c1->staffIdx()))
                               _up = !(c1->voice() % 2);
                         else if (!twoBeamedNotes()) {
                               // highest or lowest note determines stem direction


### PR DESCRIPTION
fix #25670: Stem direction on beamed notes not imported correctly in 1.3... score. Also, changing stem direction of first note of beam while entering is not ignored when entering more notes in the beam.

See discussion here http://musescore.org/en/node/25670
