### PR TITLE
Incomplete re-layout when the group of a staff is changed.

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2365,9 +2365,12 @@ void ChangeStaffType::redo()
       {
       initialClef = staff->clefTypeList(0);
       StaffType st = *staff->staffType();
+      bool updateNotesNeeded = st.group() != staffType.group();
       staff->setStaffType(&staffType);
       staffType = st;
       Score* score = staff->score();
+      if (updateNotesNeeded)
+            score->cmdUpdateNotes();
       score->setLayoutAll(true);
       score->scanElements(0, notifyTimeSigs);
       }
@@ -2375,6 +2378,7 @@ void ChangeStaffType::redo()
 void ChangeStaffType::undo()
       {
       StaffType st = *staff->staffType();
+      bool updateNotesNeeded = st.group() != staffType.group();
       staff->setStaffType(&staffType);
       staffType = st;
 
@@ -2405,7 +2409,8 @@ void ChangeStaffType::undo()
             clef->setParent(seg);
             seg->add(clef);
             }
-//      cmdUpdateNotes();                         // needed?
+      if (updateNotesNeeded)
+            score->cmdUpdateNotes();
       score->setLayoutAll(true);
       score->scanElements(0, notifyTimeSigs);
       }


### PR DESCRIPTION
If a staff type is changed from one group to another (like standard <=> TAB), lines or frets/strings for notes are not recalculated.

Fixed by adding a `Score::cmdUpdateNotes()` call to `ChangeStaffType::redo()` and `::undo()` when the group of the staff type changes.
