### PR TITLE
SpannerMap key fix

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3433,8 +3433,11 @@ void Score::undoInsertTime(int tick, int len)
                         }
                   }
             }
-            // insert time in (key, clef) maps
-            undo(new InsertTime(this, tick, len));
+      // fix spanner map to correctly map key to value->tick()
+      _spanner.fixKeys();
+
+      // insert time in (key, clef) maps
+      undo(new InsertTime(this, tick, len));
       }
 
 

--- a/libmscore/spannermap.cpp
+++ b/libmscore/spannermap.cpp
@@ -91,5 +91,18 @@ bool SpannerMap::removeSpanner(Spanner* s)
       return false;
       }
 
+void SpannerMap::fixKeys()
+      {
+      std::vector<std::pair<int,Spanner*>> values;
+      for (auto i = begin(); i != end(); ++i) {
+            values.push_back(*i);
+            }
+      clear();
+      for (auto i : values) {
+            i.first = i.second->tick();
+            insert(i);
+            }
+      }
+
 }     // namespace Ms
 

--- a/libmscore/spannermap.h
+++ b/libmscore/spannermap.h
@@ -42,6 +42,7 @@ class SpannerMap : std::multimap<int, Spanner*> {
       std::multimap<int,Spanner*>::const_iterator cend() const  { return std::multimap<int, Spanner*>::cend(); }
       void addSpanner(Spanner* s);
       bool removeSpanner(Spanner* s);
+      void fixKeys();
       };
 
 }     // namespace Ms


### PR DESCRIPTION
I found this bug in my selection-window branch, where I shortened the loop by going from, map.begin() to map.upper_bound(endTick).

When undoInsertTime is called, it loops through all spanners that are going to be affected, and corrects their start and end ticks. The keys in the map were not updated.

Undo does not work in this case yet.
