### PR TITLE
Fix for issue #25598 - Text spacing incorrect on load

### DIFF
--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -281,7 +281,7 @@ void TextBlock::layout(Text* t)
                   w = fm.width(f.text);
                   _bbox |= r;
                   x += w;
-                  _lineSpacing = qMax(_lineSpacing, fm.lineSpacing());
+                  _lineSpacing = _lineSpacing == 0 || fm.lineSpacing() == 0 ? qMax(_lineSpacing, fm.lineSpacing()) : qMin(_lineSpacing, fm.lineSpacing());
                   }
             }
       qreal rx;


### PR DESCRIPTION
Makes text space as per MS 1.3
