### PR TITLE
Fix regression on header/footer vertical position.

### DIFF
--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -278,7 +278,9 @@ void Page::drawHeaderFooter(QPainter* p, int area, const QString& ss) const
       text.textStyle().setAlign(flags);
       text.setText(s);
       text.layout();
+      p->translate(text.pos());
       text.draw(p);
+      p->translate(-text.pos());
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
The Y offset parameter in header/footer textual styles no longer has any effect. As a consequence, header is always positioned at page top margin and footer at page bottom margin.

Fixed in `Page::drawHeaderFooter()` function.
