### PR TITLE
Fix even-odd page contiguous-ness.

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2926,7 +2926,7 @@ Page* Score::getEmptyPage()
       page->setNo(curPage);
       page->layout();
       qreal x = (curPage == 0) ? 0.0 : _pages[curPage - 1]->pos().x()
-         + page->width() + ((curPage & 1) ? 50.0 : 1.0);
+         + page->width() + (((curPage+_pageNumberOffset) & 1) ? 50.0 : 1.0);
       ++curPage;
       page->setPos(x, 0.0);
       page->systems()->clear();


### PR DESCRIPTION
In page view, the pages are shown in contiguous pairs, unconditionally starting with the second page, regardless of page numbering.

This fix makes each even page contiguous with the odd page following it, according to page numbering, i.e. taking into account `_pageNumberOffset`.
