### PR TITLE
TAB entry mode: Sync current note with string cursor.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1084,7 +1084,7 @@ void Score::upDown(bool up, UpDownMode mode)
                                     string += (up ? -1 : 1);
                                     if (string < 0 || string >= stringData->strings())
                                           return;           // no next string to move to
-                                    string = stt->VisualStringToPhys(string);
+                                    string = stt->visualStringToPhys(string);
                                     fret = stringData->fret(pitch, string);
                                     if (fret == -1)          // can't have that note on that string
                                           return;

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -894,7 +894,7 @@ void Score::putNote(const Position& p, bool replace)
                         return;
                   stringData = instr->stringData();
                   tab = st->staffType();
-                  int string = tab->VisualStringToPhys(line);
+                  int string = tab->visualStringToPhys(line);
                   if (string < 0 || string >= stringData->strings())
                       return;
                   // build a default NoteVal for that line

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -649,7 +649,7 @@ int StaffType::physStringToVisual(int strg) const
       return (_upsideDown ? _lines - 1 - strg : strg);
       }
 
-int StaffType::VisualStringToPhys(int strg) const
+int StaffType::visualStringToPhys(int strg) const
       {
       if(strg <= VISUAL_STRING_NONE || strg >= _lines)      // if no visual string, return topmost physical string
             return 0;

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -259,7 +259,7 @@ class StaffType {
 
       // functions to cope with tabulature visual order (top down or upside down)
       int physStringToVisual(int strg) const;       // return the string in visual order from physical string
-      int VisualStringToPhys(int strg) const;       // return the string in physical order from visual string
+      int visualStringToPhys(int strg) const;       // return the string in physical order from visual string
 
       // properties getters (some getters require updated metrics)
       qreal durationBoxH();


### PR DESCRIPTION
In TAB entry mode, while moving the string cursor up or down, the current (selected) note remains the last inserted note, with the following inconsistency:
- new notes are entered at the string cursor
- BUT cmds affecting a note (pitch up/down and like) change the selected note;

this is likely to lead to confusion and unexpected results.

With this fix, when the string cursor is moved up/down and a note is found at the new string, it is made current (selected). If there is no note, the selection remains unaffected.

Note: Also corrected a typo in the name of a StaffType method.
