### PR TITLE
Fixed range creating after cut and delete.

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1792,7 +1792,7 @@ void Score::cmdDeleteSelection()
                         }
                   }
             s1 = tick2segment(stick1);
-            s2 = tick2segment(stick2);
+            s2 = tick2segment(stick2,true);
             if (s1 == 0 || s2 == 0)
                   deselectAll();
             else {


### PR DESCRIPTION
Fixes range selection after deleting or cutting a chordrest in a following situation:
c - cut, q - quarter, b - breath
c
q q b 
