### PR TITLE
Turning empty segments in Guitar Pro 5 and below into rests

### DIFF
--- a/mscore/importgtp.h
+++ b/mscore/importgtp.h
@@ -24,6 +24,7 @@
 #include "libmscore/mscore.h"
 #include "libmscore/fraction.h"
 #include "libmscore/fret.h"
+#include "libmscore/chordrest.h"
 
 namespace Ms {
 
@@ -113,6 +114,7 @@ class GuitarPro {
       void applyBeatEffects(Chord*, int beatEffects);
       void readTremoloBar(int track, Segment*);
       void readChord(Segment* seg, int track, int numStrings, QString name, bool gpHeader);
+      void restsForEmptyBeats(Segment* seg, Measure* measure, ChordRest* cr, Fraction& l, int track, int tick);
 
    public:
       QString title, subtitle, artist, album, composer;


### PR DESCRIPTION
Fixes the issue of empty segments being created from Guitar Pro 5 files that specify them and instead creates invisible rests. If empty segments are detected past the end of the score, they will be removed from the score to avoid placing rests after the double bar line.
