### PR TITLE
'untranslate' debugger

### DIFF
--- a/mscore/debugger/accidental.ui
+++ b/mscore/debugger/accidental.ui
@@ -62,7 +62,7 @@
       <item row="1" column="1">
        <widget class="QCheckBox" name="small">
         <property name="text">
-         <string>small</string>
+         <string notr="true">small</string>
         </property>
        </widget>
       </item>

--- a/mscore/debugger/chord.ui
+++ b/mscore/debugger/chord.ui
@@ -43,14 +43,14 @@
       <item row="1" column="0">
        <widget class="QPushButton" name="arpeggioButton">
         <property name="text">
-         <string>Arpeggio</string>
+         <string notr="true">Arpeggio</string>
         </property>
        </widget>
       </item>
       <item row="1" column="4" colspan="2">
        <widget class="QPushButton" name="glissandoButton">
         <property name="text">
-         <string>Glissando</string>
+         <string notr="true">Glissando</string>
         </property>
        </widget>
       </item>
@@ -77,7 +77,7 @@
       <item row="1" column="1">
        <widget class="QPushButton" name="tremoloButton">
         <property name="text">
-         <string>Tremolo</string>
+         <string notr="true">Tremolo</string>
         </property>
        </widget>
       </item>

--- a/mscore/debugger/chordrest.ui
+++ b/mscore/debugger/chordrest.ui
@@ -109,7 +109,7 @@
         <item row="0" column="4">
          <widget class="QLabel" name="label_13">
           <property name="text">
-           <string>Lyrics:</string>
+           <string notr="true">Lyrics:</string>
           </property>
           <property name="indent">
            <number>5</number>
@@ -372,7 +372,7 @@
         </item>
        </layout>
       </item>
-      <item row="0" column="3" rowspan="2">
+      <item>
        <widget class="QLabel" name="label_131">
         <property name="text">
          <string notr="true">Lyrics:</string>
@@ -385,7 +385,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1" rowspan="2">
+      <item>
        <widget class="QLabel" name="label_21">
         <property name="toolTip">
          <string notr="true"/>

--- a/mscore/debugger/element.ui
+++ b/mscore/debugger/element.ui
@@ -424,12 +424,12 @@
           </property>
           <item>
            <property name="text">
-            <string>above</string>
+            <string notr="true">above</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>below</string>
+            <string notr="true">below</string>
            </property>
           </item>
          </widget>

--- a/mscore/debugger/linesegment.ui
+++ b/mscore/debugger/linesegment.ui
@@ -182,7 +182,7 @@
         <item>
          <widget class="QPushButton" name="line">
           <property name="text">
-           <string>Line</string>
+           <string notr="true">Line</string>
           </property>
          </widget>
         </item>

--- a/mscore/debugger/slursegment.ui
+++ b/mscore/debugger/slursegment.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>0</string>
+   <string notr="true">0</string>
   </property>
   <layout class="QVBoxLayout">
    <property name="spacing">
@@ -359,7 +359,7 @@
       <item row="5" column="0">
        <widget class="QPushButton" name="slurTie">
         <property name="text">
-         <string>SlurTie</string>
+         <string notr="true">SlurTie</string>
         </property>
        </widget>
       </item>

--- a/mscore/inspector/inspector_slur.ui
+++ b/mscore/inspector/inspector_slur.ui
@@ -38,7 +38,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Slur/Tie</string>
+      <string notr="true">Slur/Tie</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>


### PR DESCRIPTION
The vast majority of the debugger interface is in English and not translated, but a few sprinkles here and there are. It should be all English, esp. as it also should be hidden to normal users anyway.
