### PR TITLE
fix #28301: text style assignment does not take effect

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3868,10 +3868,16 @@ bool Measure::setProperty(P_ID propertyId, const QVariant& value)
       {
       switch(propertyId) {
             case P_ID::TIMESIG_NOMINAL:
-                  _timesig = value.value<Fraction>();
+                  if (value.canConvert<Fraction>())
+                        _timesig = value.value<Fraction>();
+                  else
+                        qDebug("Measure::setProperty: unable to set _timesig");
                   break;
             case P_ID::TIMESIG_ACTUAL:
-                  _len = value.value<Fraction>();
+                  if (value.canConvert<Fraction>())
+                        _len = value.value<Fraction>();
+                  else
+                        qDebug("Measure::setProperty: unable to set _len");
                   break;
             case P_ID::REPEAT_FLAGS:
                   setRepeatFlags(Repeat(value.toInt()));

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2160,10 +2160,16 @@ bool Text::setProperty(P_ID propertyId, const QVariant& v)
       bool rv = true;
       switch (propertyId) {
             case P_ID::TEXT_STYLE:
-                  setTextStyle(v.value<TextStyle>());
+                  if (v.canConvert<TextStyle>())
+                        setTextStyle(v.value<TextStyle>());
+                  else
+                        qDebug("Text::setProperty: unable to set TextStyle");
                   break;
             case P_ID::TEXT_STYLE_TYPE:
-                  setTextStyleType(v.value<TextStyleType>());
+                  if (v.canConvert<TextStyleType>())
+                        setTextStyleType(v.value<TextStyleType>());     // won't happen currently
+                  else
+                        setTextStyleType(TextStyleType(v.toInt()));
                   setGenerated(false);
                   break;
             case P_ID::TEXT:

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -470,13 +470,22 @@ bool TimeSig::setProperty(P_ID propertyId, const QVariant& v)
                   setDenominatorString(v.toString());
                   break;
             case P_ID::GROUPS:
-                  setGroups(v.value<Groups>());
+                  if (v.canConvert<Groups>())
+                        setGroups(v.value<Groups>());
+                  else
+                        qDebug("TimeSig::setProperty: unable to set Groups");
                   break;
             case P_ID::TIMESIG:
-                  setSig(v.value<Fraction>());
+                  if (v.canConvert<Fraction>())
+                        setSig(v.value<Fraction>());
+                  else
+                        qDebug("TimeSig::setProperty: unable to set Sig");
                   break;
             case P_ID::TIMESIG_GLOBAL:
-                  setGlobalSig(v.value<Fraction>());
+                  if (v.canConvert<Fraction>())
+                        setGlobalSig(v.value<Fraction>());
+                  else
+                        qDebug("TimeSig::setProperty: unable to set GlobalSig");
                   break;
             case P_ID::TIMESIG_TYPE:
                   _timeSigType = (TimeSigType)(v.toInt());


### PR DESCRIPTION
We were using value<TextStyleType>() in setProperties, but I guess you can't do that for enum classes.

Even though it was only value<TextStyleType>() that was failing, I added canConvert() checks for TextStyle, Fraction, and Groups in their respective setProperties functions as well just to be safe.
