### PR TITLE
fix #28321: remove chord symbol from text palette

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -971,9 +971,16 @@ Palette* MuseScore::newTextPalette()
       text->setText(tr("1."));
       sp->append(text, tr("Lyrics Verse Number"));
 
+#if 0
+      // creating a true Harmony object is more involved than this but would be a mistake
+      // as it would lock in a chord id unnecessarily
       Harmony* harmony = new Harmony(gscore);
       harmony->setText("C7");
+      int root, bass;
+      harmony->parseHarmony("C7", &root, &bass);
       sp->append(harmony, tr("Chord Symbol"));
+#endif
+
       return sp;
       }
 


### PR DESCRIPTION
The chord symbol does not work properly, and while it could be fixed, there is more to it than just getting it to display.  I don't think it is worth it - there really is no need to have a chord symbol on the palette anyhow.  So I am removing it.
