### PR TITLE
partial fix for #25247: default height of hairpin

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -408,7 +408,7 @@ StyleData::StyleData()
             { StyleIdx::propertyDistance,            QVariant(1.0) },
             { StyleIdx::articulationMag,             QVariant(1.0) },
             { StyleIdx::lastSystemFillLimit,         QVariant(0.3) },
-            { StyleIdx::hairpinY,                    QVariant(8) },
+            { StyleIdx::hairpinY,                    QVariant(7.5) },
             { StyleIdx::hairpinHeight,               QVariant(1.2) },
             { StyleIdx::hairpinContHeight,           QVariant(0.5) },
             { StyleIdx::hairpinLineWidth,            QVariant(0.13) },


### PR DESCRIPTION
Aligns hairpin vertical position with dynamics as per Gould p. 103.  This works with current Dynamics text style.  I suppose we could consider calculating the hairpin height from Dynamics text style rather than managing two separate style parameters, but someone is bound to prefer having separate control.
