### PR TITLE
fix #23543-update_accidentals

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1286,15 +1286,18 @@ void Score::addArticulation(ArticulationType attr)
 
 void Score::changeAccidental(Accidental::Type idx)
       {
-      foreach(Note* note, selection().noteList())
-            changeAccidental(note, idx);
+       bool altPressed = property("AltModifier").toBool();
+       foreach(Note* note, selection().noteList()) {
+             setProperty("AltModifier", altPressed);
+             changeAccidental(note, idx);
+             }
       }
 
 //---------------------------------------------------------
 //   changeAccidental2
 //---------------------------------------------------------
 
-static void changeAccidental2(Note* n, int pitch, int tpc)
+static void changeAccidental2(Note* n, int pitch, int tpc, Accidental::Type accidental = Accidental::Type::NONE)
       {
       Score* score  = n->score();
       Chord* chord  = n->chord();
@@ -1322,6 +1325,13 @@ static void changeAccidental2(Note* n, int pitch, int tpc)
             tpc1 = tpc2;
             tpc2 = tpc;
             }
+
+      // change pitches and tpc's for
+      // whole measure
+      if(score->property("AltModifier").toBool())
+            score->updatePitches(chord->segment(), staffIdx, pitch, tpc1, tpc2, n->line(), accidental);
+      score->setProperty("AltModifier", false);
+
       score->undoChangePitch(n, pitch, tpc1, tpc2);
       if (!st->isTabStaff()) {
             //

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -72,7 +72,6 @@
 #include "stringdata.h"
 #include "tiemap.h"
 #include "tupletmap.h"
-#include "accidental.h"
 #include "layout.h"
 #include "icon.h"
 #include "ambitus.h"
@@ -3683,6 +3682,67 @@ void Measure::cmdUpdateNotes(int staffIdx)
                   chord->cmdUpdateNotes(&as);
                   }
             }
+      }
+
+//---------------------------------------------------------
+//   updatePitches
+//---------------------------------------------------------
+
+bool Measure::updatePitches(Segment* segment, int staffIdx, int pitch, int tpc1, int tpc2, int line, Accidental::Type newAccType)
+      {
+      Staff* staff            = score()->staff(staffIdx);
+      int startTrack          = staffIdx * VOICES;
+      int endTrack            = startTrack + VOICES;
+      StaffGroup staffGroup   = staff->staffType()->group();
+      const Instrument* instrument = staff->part()->instr();
+
+      for (int track = startTrack; track < endTrack; ++track) {
+            Chord* chord = static_cast<Chord*>(segment->element(track));
+            if (!chord || chord->type() != Element::Type::CHORD)
+                 continue;
+
+            // TAB_STAFF is different, as each note has to be fretted
+            // in the context of the whole chord
+
+            if (staffGroup == StaffGroup::TAB) {
+                  for (Chord* ch : chord->graceNotes())
+                        instrument->stringData()->fretChords(ch);
+                  instrument->stringData()->fretChords(chord);
+                  continue;               // skip other staff type cases
+                  }
+            // PITCHED_ and PERCUSSION_STAFF can go note by note
+            int n = chord->notes().size();
+            for (int i = 0; i < n; ++i) {
+                  Note* note = chord->notes().at(i);
+                  if(note->staffIdx() == staffIdx && note->line() == line){
+                        if (staffGroup == StaffGroup::STANDARD){
+                              if (note->tieBack()) {
+                                    int line = note->tieBack()->startNote()->line();
+                                    note->setLine(line);
+                                    if (note->accidental()) {
+                                          // TODO: remove accidental only if note is not
+                                          // on new system
+                                          score()->undoRemoveElement(note->accidental());
+                                          }
+                                    }
+                              else {
+                                    if(note->accidental()) {
+                                          if(note->accidental()->accidentalType() == newAccType)
+                                                score()->undoRemoveElement(note->accidental());
+                                          else
+                                                return false;
+                                          }
+                                    else {
+                                          note->undoSetPitch(pitch);
+                                          note->undoSetTpc1(tpc1);
+                                          note->undoSetTpc2(tpc2);
+                                          }
+                                    }
+                              }
+                        }
+                  }
+            }
+      return true;
       }
 
 //---------------------------------------------------------

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -21,6 +21,7 @@
 #include "measurebase.h"
 #include "fraction.h"
 #include "segmentlist.h"
+#include "accidental.h"
 
 namespace Ms {
 
@@ -301,6 +302,7 @@ class Measure : public MeasureBase {
 
       void updateNotes(int staffIdx);
       void cmdUpdateNotes(int staffIdx);
+      bool updatePitches(Segment* segment, int staffIdx, int pitch, int tcp1, int tcp2, int line, Accidental::Type newAccType);
 
       void layoutStage1();
       int playbackCount() const      { return _playbackCount; }

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1901,6 +1901,19 @@ void Note::endEdit()
             }
       }
 
+
+//---------------------------------------------------------
+//   updatePitch
+//---------------------------------------------------------
+
+void Note::updatePitch(int pitch, int tcp)
+      {
+//      undoSetPitch(pitch);
+//      undoSetTpc(tcp);
+      setPitch(pitch);
+      setTpc(tcp);
+      }
+
 //---------------------------------------------------------
 //   updateAccidental
 //    set _accidental and _line depending on tpc
@@ -1908,6 +1921,9 @@ void Note::endEdit()
 
 void Note::updateAccidental(AccidentalState* as)
       {
+      // avoid "in between" update in case of update acc. with alt key pressed
+      if(score()->property("AltModifier").toBool())
+            return;
       int relLine = absStep(tpc(), epitch());
 
       // don't touch accidentals that don't concern tpc such as

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -373,6 +373,7 @@ class Note : public Element {
       int customizeVelocity(int velo) const;
       NoteDot* dot(int n)                       { return _dots[n];           }
       QQmlListProperty<Ms::NoteDot> qmlDots();
+      void updatePitch(int pitch, int tcp);
       void updateAccidental(AccidentalState*);
       void updateLine();
       void setNval(const NoteVal&);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2048,6 +2048,9 @@ void Score::cmdUpdateNotes()
 
 void Score::cmdUpdateAccidentals(Measure* beginMeasure, int staffIdx)
       {
+      if(property("AltModifier").toBool())
+            return;
+
       for (Measure* m = beginMeasure; m; m = m->nextMeasureMM()) {
             m->cmdUpdateNotes(staffIdx);
             if (m == beginMeasure)
@@ -2059,6 +2062,23 @@ void Score::cmdUpdateAccidentals(Measure* beginMeasure, int staffIdx)
                   }
             }
       }
+
+
+//---------------------------------------------------------
+//   updatePitches
+//---------------------------------------------------------
+
+void Score::updatePitches(Segment* segment, int staffIdx, int pitch, int tpc1, int tpc2, int line, Accidental::Type accidental)
+       {
+       Measure* m = segment->measure();
+       for (Segment* seg = segment->next(); seg; seg = seg->next()) {           // alters the following notes on the same line
+             if(seg->measure() == m->nextMeasure())
+                   return;
+             if (seg->segmentType() & (Segment::Type::ChordRest))
+                    if(! m->updatePitches(seg, staffIdx, pitch, tpc1, tpc2, line, accidental))
+                          break;
+             }
+       }
 
 //---------------------------------------------------------
 //   clone

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -890,7 +890,7 @@ class Score : public QObject {
       QMap<QString, QString>& metaTags();
       Q_INVOKABLE QString metaTag(const QString& s) const;
       Q_INVOKABLE void setMetaTag(const QString& tag, const QString& val);
-
+      void updatePitches(Segment*, int, int, int, int, int, Accidental::Type);
       void updateNotes();
       void cmdUpdateNotes();
       void cmdUpdateAccidentals(Measure* m, int staffIdx);

--- a/mscore/actions.cpp
+++ b/mscore/actions.cpp
@@ -2199,6 +2199,14 @@ Shortcut Shortcut::sc[] = {
          ),
       Shortcut(
          STATE_NORMAL,
+         ShortcutFlags::A_CMD,
+         "alt-delete",
+         QT_TRANSLATE_NOOP("action","Alt-Del pressed"),
+         QT_TRANSLATE_NOOP("action","Alt-Del pressed"),
+         QT_TRANSLATE_NOOP("action","Alt-Del pressed")
+         ),
+      Shortcut(
+         STATE_NORMAL,
          0,
          "lock",
          QT_TRANSLATE_NOOP("action","Lock Score")

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -421,6 +421,10 @@
     <seq>Ctrl+Ins</seq>
     </SC>
   <SC>
+    <key>alt-delete</key>
+    <seq>Alt+Del</seq>
+    </SC>
+  <SC>
     <key>duplet</key>
     <seq>Ctrl+2</seq>
     </SC>

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -457,6 +457,7 @@ void ScoreView::dropEvent(QDropEvent* event)
                   case Element::Type::AMBITUS:
                         {
                         Element* el = 0;
+                        _score->setProperty("AltModifier", qApp->keyboardModifiers().testFlag(Qt::AltModifier));
                         for (const Element* e : elementsAt(pos)) {
                               if (e->acceptDrop(this, pos, dragElement)) {
                                     el = const_cast<Element*>(e);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4282,11 +4282,20 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             if (_textTools)
                   _textTools->toggleUnderline();
             }
-
+      else if (cmd == "alt-delete"){
+           cv->score()->setProperty("AltModifier", true);
+           foreach(Element* el, cv->score()->selection().elements()) {
+                 if(el->type() == Element::Type::ACCIDENTAL)
+                       cv->score()->changeAccidental(static_cast<Note*>(el->parent()), Accidental::Type::NONE);
+                 }
+            cv->score()->setProperty("AltModifier", false);
+            }
       else {
             if (cv) {
+                  cv->score()->setProperty("AltModifier", qApp->keyboardModifiers().testFlag(Qt::AltModifier));
                   cv->setFocus();
                   cv->cmd(a);
+                  cv->score()->setProperty("AltModifier", false);
                   }
             else
                   qDebug("2:unknown cmd <%s>", qPrintable(cmd));

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -291,6 +291,7 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
       Score* score   = mscore->currentScore();
       if (score == 0)
             return;
+      score->setProperty("AltModifier", qApp->keyboardModifiers().testFlag(Qt::AltModifier));
       const Selection& sel = score->selection();
 
       if (sel.isNone())
@@ -355,6 +356,7 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
          && viewer->mscoreState() != STATE_TEXT_EDIT) { //Already in startCmd mode in this case
             score->endCmd();
             }
+      score->setProperty("AltModifier", false);
       mscore->endCmd();
       }
 


### PR DESCRIPTION
This version actually is (once more again) at moment up to date. It replaces  #1026.

The feature enables, that changing the accidental of any note is automatically valid for the whole measure from this note on.

Usage: Press the ALT-Key while performing any change of accidenteal (clicking on the symbols within the action bar, or dragging and dropping from the accidental palette, double-clicking there, or pressing the delete key to remove an accidental).
