### PR TITLE
fix #25409: always at least 4sp below lyrics

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3165,6 +3165,7 @@ void Measure::layoutX(qreal stretch)
                               }
                         if (lyrics) {
                               qreal y = lyrics->ipos().y() + score()->styleS(StyleIdx::lyricsMinBottomDistance).val() * _spatium;
+                              y -= score()->staff(staffIdx)->height();
                               if (y > staves[staffIdx]->distanceDown)
                                  staves[staffIdx]->distanceDown = y;
                               space.max(Space(llw, rrw));


### PR DESCRIPTION
Correct calculation of distanceDown by subtracting off staff height.
