### PR TITLE
fix #28931: marker text lost on load

### DIFF
--- a/libmscore/marker.cpp
+++ b/libmscore/marker.cpp
@@ -38,37 +38,44 @@ void Marker::setMarkerType(Type t)
       _markerType = t;
       switch (t) {
             case Type::SEGNO:
-                  setText("<sym>segno</sym>");
+                  if (isEmpty())
+                      setText("<sym>segno</sym>");
                   setLabel("segno");
                   break;
 
             case Type::VARSEGNO:
-                  setText("<sym>segnoSerpent1</sym>");
+                  if (isEmpty())
+                        setText("<sym>segnoSerpent1</sym>");
                   setLabel("varsegno");
                   break;
 
             case Type::CODA:
-                  setText("<sym>coda</sym>");
+                  if (isEmpty())
+                        setText("<sym>coda</sym>");
                   setLabel("codab");
                   break;
 
             case Type::VARCODA:
-                  setText("<sym>codaSquare</sym>");
+                  if (isEmpty())
+                        setText("<sym>codaSquare</sym>");
                   setLabel("varcoda");
                   break;
 
             case Type::CODETTA:
-                  setText("<sym>coda</sym><sym>coda</sym>");
+                  if (isEmpty())
+                        setText("<sym>coda</sym><sym>coda</sym>");
                   setLabel("codetta");
                   break;
 
             case Type::FINE:
-                  setText("Fine");
+                  if (isEmpty())
+                        setText("Fine");
                   setLabel("fine");
                   break;
 
             case Type::TOCODA:
-                  setText("To Coda");
+                  if (isEmpty())
+                        setText("To Coda");
                   setLabel("coda");
                   break;
 


### PR DESCRIPTION
See issue report.  This fix allows custom text in markers to be saved/loaded.  A side effect is that if one uses the Inspector to change a coda into a segno, the appearance does not change.  I am considering that a feature.
