### PR TITLE
add support for selecting staff text by subtype (text style)

### DIFF
--- a/libmscore/stafftext.h
+++ b/libmscore/stafftext.h
@@ -46,6 +46,9 @@ class StaffText : public Text  {
       virtual void write(Xml& xml) const;
       virtual void read(XmlReader&);
 
+      virtual int subtype() const         { return (int) textStyleType(); }
+      virtual QString subtypeName() const { return textStyle().name(); }
+
       QString channelName(int voice) const                { return _channelNames[voice]; }
       void setChannelName(int v, const QString& s)        { _channelNames[v] = s;        }
       const QList<ChannelActions>* channelActions() const { return &_channelActions;    }


### PR DESCRIPTION
Very simple change, enables the "same subtype" button in the Select / More dialog for staff text, using text style as the subtype.  This should be become increasingly useful as we start overloading staff text for things like swing using different text styles to differentiate them.
