### PR TITLE
fix #29046: make text easier to select after adding/editing

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -618,7 +618,7 @@ void Harmony::endEdit()
                   h->setHarmony(text());
                   }
             }
-      score()->setLayoutAll(true);
+      score()->setLayoutAll(true);  // done in Text::endEdit() too, but no harm being sure
       }
 
 //---------------------------------------------------------

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -1484,6 +1484,7 @@ void Text::endEdit()
                   }
             }
       textChanged();
+      score()->setLayoutAll(true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
We need to doLayout after an edit (or at least force the page to rebuildBsbTree) or else you can't select the text anywhere but near the beginning.
