### PR TITLE
fix #22572: clean up repeat text styles

### DIFF
--- a/libmscore/jump.cpp
+++ b/libmscore/jump.cpp
@@ -30,11 +30,11 @@ struct JumpTypeTable {
       };
 
 static const JumpTypeTable jumpTypeTable[] = {
-      { Jump::Type::DC,         TextStyleType::REPEAT,       "D.C.",         "start", "end",  "" },
-      { Jump::Type::DC_AL_FINE, TextStyleType::REPEAT,       "D.C. al Fine", "start", "fine", "" },
-      { Jump::Type::DC_AL_CODA, TextStyleType::REPEAT,       "D.C. al Coda", "start", "coda", "codab" },
-      { Jump::Type::DS_AL_CODA, TextStyleType::REPEAT,       "D.S. al Coda", "segno", "coda", "codab" },
-      { Jump::Type::DS_AL_FINE, TextStyleType::REPEAT,       "D.S. al Fine", "segno", "fine", "" },
+      { Jump::Type::DC,         TextStyleType::REPEAT_RIGHT, "D.C.",         "start", "end",  "" },
+      { Jump::Type::DC_AL_FINE, TextStyleType::REPEAT_RIGHT, "D.C. al Fine", "start", "fine", "" },
+      { Jump::Type::DC_AL_CODA, TextStyleType::REPEAT_RIGHT, "D.C. al Coda", "start", "coda", "codab" },
+      { Jump::Type::DS_AL_CODA, TextStyleType::REPEAT_RIGHT, "D.S. al Coda", "segno", "coda", "codab" },
+      { Jump::Type::DS_AL_FINE, TextStyleType::REPEAT_RIGHT, "D.S. al Fine", "segno", "fine", "" },
       { Jump::Type::DS,         TextStyleType::REPEAT_RIGHT, "D.S.",         "segno", "end",  "" }
       };
 
@@ -46,7 +46,7 @@ Jump::Jump(Score* s)
    : Text(s)
       {
       setFlags(ElementFlag::MOVABLE | ElementFlag::SELECTABLE);
-      setTextStyleType(TextStyleType::REPEAT);
+      setTextStyleType(TextStyleType::REPEAT_RIGHT);
       setLayoutToParentWidth(true);
       }
 

--- a/libmscore/marker.cpp
+++ b/libmscore/marker.cpp
@@ -26,7 +26,7 @@ Marker::Marker(Score* s)
       {
       _markerType = Type::FINE;
       setFlags(ElementFlag::MOVABLE | ElementFlag::SELECTABLE | ElementFlag::ON_STAFF);
-      setTextStyleType(TextStyleType::REPEAT);
+      setTextStyleType(TextStyleType::REPEAT_LEFT);
       setLayoutToParentWidth(true);
       }
 
@@ -66,6 +66,7 @@ void Marker::setMarkerType(Type t)
 
             case Type::FINE:
                   txt = "Fine";
+                  setTextStyleType(TextStyleType::REPEAT_RIGHT);
                   setLabel("fine");
                   break;
 
@@ -146,6 +147,21 @@ Marker::Type Marker::markerType(const QString& s) const
       }
 
 //---------------------------------------------------------
+//   layout
+//---------------------------------------------------------
+
+void Marker::layout()
+      {
+      setPos(textStyle().offset(spatium()));
+      Text::layout1();
+      // although markers are normally laid out to parent (measure) width,
+      // force them to center over barline if left-aligned
+      if (!(textStyle().align() & (AlignmentFlags::RIGHT|AlignmentFlags::HCENTER)))
+            rxpos() -= width() * 0.5;
+      adjustReadPos();
+      }
+
+//---------------------------------------------------------
 //   read
 //---------------------------------------------------------
 
@@ -164,6 +180,9 @@ void Marker::read(XmlReader& e)
             else if (!Text::readProperties(e))
                   e.unknown();
             }
+      // REPEAT is obsolete, but was previously used for both left and right aligned text
+      if (textStyleType() == TextStyleType::REPEAT)
+            setTextStyleType(TextStyleType::REPEAT_LEFT);
       setMarkerType(mt);
       }
 

--- a/libmscore/marker.h
+++ b/libmscore/marker.h
@@ -61,6 +61,7 @@ class Marker : public Text {
 
       Measure* measure() const         { return (Measure*)parent(); }
 
+      virtual void layout() override;
       virtual void read(XmlReader&) override;
       virtual void write(Xml& xml) const override;
 

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -299,7 +299,7 @@ void initStyle(MStyle* s)
          false, Spatium(0.2), Spatium(0.5), 25, Qt::black, false, true);
 
       AS("Repeat Text", ff,  12, false, false, false,          // for backward compatibility
-         AlignmentFlags::HCENTER | AlignmentFlags::BASELINE, QPointF(0, -2.0), OS, true,
+         AlignmentFlags::RIGHT | AlignmentFlags::BASELINE, QPointF(0, -2.0), OS, true,
          false, Spatium(0.2), Spatium(0.5), 25, Qt::black, false, true);
 
       // y offset may depend on voltaHook style element


### PR DESCRIPTION
This seems to do the job well for both new scores and imported 1.3 scores.
