### PR TITLE
Loading scores with layers

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -974,6 +974,7 @@ bool Score::read(XmlReader& e)
                   layer.name = e.attribute("name");
                   layer.tags = e.attribute("mask").toUInt();
                   _layer.append(layer);
+                  e.readNext();
                   }
             else if (tag == "currentLayer")
                   _currentLayer = e.readInt();


### PR DESCRIPTION
Fix #29286
Prevent crash on loading scores with more than just the default layer in
them.
