### PR TITLE
fix #14353: lyrics and staff spacers don't work with hide empty staves

### DIFF
--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -304,6 +304,7 @@ void System::layout2()
       qreal y = 0.0;
       int lastStaffIdx  = 0;   // last visible staff
       int firstStaffIdx = -1;
+      qreal lastStaffDistanceDown = 0.0;
       for (int staffIdx = 0; staffIdx < nstaves; ++staffIdx) {
             Staff* staff = score()->staff(staffIdx);
             StyleIdx downDistance;
@@ -335,6 +336,7 @@ void System::layout2()
 
             SysStaff* s    = _staves[staffIdx];
             qreal distDown = score()->styleS(downDistance).val() * _spatium + userDist;
+            qreal nominalDistDown = distDown;
             qreal distUp   = 0.0;
             int n = ml.size();
             for (int i = 0; i < n; ++i) {
@@ -356,6 +358,7 @@ void System::layout2()
             s->bbox().setRect(_leftMargin, y + dup, width() - _leftMargin, sHeight);
             y += dup + sHeight + s->distanceDown();
             lastStaffIdx = staffIdx;
+            lastStaffDistanceDown = distDown - nominalDistDown;
             if (firstStaffIdx == -1)
                   firstStaffIdx = staffIdx;
             }
@@ -363,6 +366,8 @@ void System::layout2()
             firstStaffIdx = 0;
 
       qreal systemHeight = staff(lastStaffIdx)->bbox().bottom();
+      if (lastStaffIdx < nstaves - 1)
+            systemHeight += lastStaffDistanceDown;
       setHeight(systemHeight);
 
       int n = ml.size();


### PR DESCRIPTION
Fixes calculation of system height when there are spacers down or lyrics adding to distanceDown for a staff and the staves below are all hidden/empty.  I thought maybe spacers up and/or fret diagrams would have a similar issue, but they don't - the bbox() calculation already accounts for those.

I will say I don't totally understand all the interactions between the calculations involved, and I wouldn't mind if someone reviewed this a bit to be sure I am not doing something stupid.  But it does fix the problem cases, and should not change behavior if the bottom staff is not hidden.
