### PR TITLE
Fix #29451 - No augm. dots in TAB styles which use them

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1567,14 +1567,20 @@ void Note::layout2()
 
             // if TAB and stems through staff
             if (staff()->isTabStaff()) {
+                  StaffType* tab = staff()->staffType();
+                  if (!tab->stemThrough())            // if !stemThrough, there are no dots at all:
+                        return;                       // stop here
+
+                  // with TAB's, dot Y is not calculated during layoutChords3(),
+                  // as layoutChords3() is not even called for TAB's;
+                  // setDotY() actually also manages creation/deletion of NoteDot's
+                  setDotY(MScore::Direction::AUTO);
+
                   // with TAB's, dotPosX is not set:
                   // get dot X from width of fret text and use TAB default spacing
                   x = width();
                   dd = STAFFTYPE_TAB_DEFAULTDOTDIST_X * spatium();
                   d = dd * 0.5;
-                  StaffType* tab = staff()->staffType();
-                  if (!tab->stemThrough())
-                        return;
                   }
 
             // apply to dots


### PR DESCRIPTION
Fix #29451 - No augm. dots in TAB styles which use them

In a TAB with the "Stem through staff" style, augmentation dots are not shown.

Fixed, by invoking the function which creates dots for standard staff (`setDotY()`); this function is in a workflow which is not executed for TAB's (as a number of layout steps, like those for accidentals, are not needed for TAB's).
