### PR TITLE
Deleted element in selection list

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -290,6 +290,8 @@ Element::~Element()
                   delete _links;
                   }
             }
+      if (_selected && _score && _score->selection().elements().contains(this))
+            _score->selection().remove(this);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR fixes issue 29471 which was caused by the stem to be deleted but not removed from the selection list.
