### PR TITLE
Measure alignment for tempo text and rehearsal marks

### DIFF
--- a/libmscore/marker.cpp
+++ b/libmscore/marker.cpp
@@ -177,9 +177,9 @@ void Marker::layout()
       {
       setPos(textStyle().offset(spatium()));
       Text::layout1();
-      // although markers are normally laid out to parent (measure) width,
-      // force them to center over barline if left-aligned
-      if (!(textStyle().align() & (AlignmentFlags::RIGHT|AlignmentFlags::HCENTER)))
+      // although normally laid out to parent (measure) width,
+      // force to center over barline if left-aligned
+      if (layoutToParentWidth() && !(textStyle().align() & (AlignmentFlags::RIGHT|AlignmentFlags::HCENTER)))
             rxpos() -= width() * 0.5;
       adjustReadPos();
       }

--- a/libmscore/rehearsalmark.cpp
+++ b/libmscore/rehearsalmark.cpp
@@ -25,5 +25,23 @@ RehearsalMark::RehearsalMark(Score* s)
       setTextStyleType(TextStyleType::REHEARSAL_MARK);
       }
 
+void RehearsalMark::layout()
+      {
+      setPos(textStyle().offset(spatium()));
+      Text::layout1();
+      Segment* s = segment();
+      if (s && !s->rtick()) {
+            // rehearsal mark on first chordrest of measure should align over barline
+            rxpos() -= s->x();
+#if 0
+            // if there is a clef, align right after that instead
+            Segment* p = segment()->prev(Segment::Type::Clef);
+            if (p)
+                  rxpos() += p->next()->x();
+#endif
+            }
+      adjustReadPos();
+      }
+
 }
 

--- a/libmscore/rehearsalmark.h
+++ b/libmscore/rehearsalmark.h
@@ -29,6 +29,7 @@ class RehearsalMark : public Text  {
       virtual RehearsalMark* clone() const { return new RehearsalMark(*this); }
       virtual Element::Type type() const   { return Element::Type::REHEARSAL_MARK; }
       Segment* segment() const             { return (Segment*)parent(); }
+      virtual void layout() override;
       };
 
 

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -280,7 +280,7 @@ void initStyle(MStyle* s)
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Technique"), ff, 12, false, true, false,
          AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0.0, -2.0), OffsetType::SPATIUM));
 
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Tempo"), ff, 12, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Tempo"), ff, 12, true, false, false,
          AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0, -4.0), OffsetType::SPATIUM,
          true, false, Spatium(.2), Spatium(.5), 0, Qt::black, false, true));
 

--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -244,12 +244,28 @@ QVariant TempoText::propertyDefault(P_ID id) const
 
 void TempoText::layout()
       {
-      Text::layout();
+      setPos(textStyle().offset(spatium()));
+      Text::layout1();
+      Segment* s = segment();
+      if (s && !s->rtick()) {
+            // tempo text on first chordrest of measure should align over time sig if present
+            Segment* p = segment()->prev(Segment::Type::TimeSig);
+            if (p) {
+                  rxpos() -= s->x() - p->x();
+                  Element* e = p->element(staffIdx() * VOICES);
+                  if (e)
+                        rxpos() += e->x();
+                  }
+            // correct user offset in older scores
+            if (score()->mscVersion() <= 114 && !userOff().isNull())
+                  rUserXoffset() += s->x() - p->x();
+            }
       if (placement() == Element::Placement::BELOW) {
             rypos() = -rypos() + 4 * spatium();
             // rUserYoffset() *= -1;
             // text height ?
             }
+      adjustReadPos();
       }
 
 QString TempoText::accessibleInfo()


### PR DESCRIPTION
This change affects both tempo texts and rehearsal marks, if attached to first chord/rest of measure.

For tempo text, the text is aligned normally unless there is a time signature earlier in the bar - in which case, it aligns with that.

For rehearsal marks, the text aligns with the start of the measure (over the barline).

In both cases, new and 1.3 scores will pick up up the change automatically.  For 1.3 scores, any user offset that had been applied is rebased on first layout.
