### PR TITLE
Open strings in StringData.

### DIFF
--- a/libmscore/stringdata.h
+++ b/libmscore/stringdata.h
@@ -24,10 +24,18 @@ class Note;
 //   StringData
 //---------------------------------------------------------
 
+// defines the string of an instrument
+struct instrString {
+      int   pitch;      // the pitch of the string
+      bool  open;       // true: string is open | false: string is fretted
+
+      bool operator==(const instrString& d) const { return d.pitch == pitch && d.open == open; }
+      };
+
 class StringData {
 //      QList<int>  stringTable { 40, 45, 50, 55, 59, 64 };   // guitar is default
 //      int         _frets = 19;
-      QList<int>  stringTable {  };                         // no strings by default
+      QList<instrString>  stringTable {  };                   // no strings by default
       int         _frets = 0;
 
       static bool bFretting;
@@ -37,16 +45,16 @@ class StringData {
 public:
       StringData() {}
       StringData(int numFrets, int numStrings, int strings[]);
-      StringData(int numFrets, QList<int>& strings);
+      StringData(int numFrets, QList<instrString>& strings);
       bool        convertPitch(int pitch, int* string, int* fret) const;
       int         fret(int pitch, int string) const;
       void        fretChords(Chord * chord) const;
       int         getPitch(int string, int fret) const;
-      int         strings() const         { return stringTable.size(); }
-      QList<int>  stringList() const      { return stringTable; }
-      QList<int>&  stringList()           { return stringTable; }
-      int         frets() const           { return _frets; }
-      void        setFrets(int val)       { _frets = val; }
+      int         strings() const               { return stringTable.size(); }
+      QList<instrString>  stringList() const    { return stringTable; }
+      QList<instrString>&  stringList()         { return stringTable; }
+      int         frets() const                 { return _frets; }
+      void        setFrets(int val)             { _frets = val; }
       void        read(XmlReader&);
       void        write(Xml&) const;
 //      void        readMusicXML(XmlReader& de);

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -386,8 +386,8 @@ void EditStaff::showInstrumentDialog()
 
 void EditStaff::editStringDataClicked()
       {
-      int         frets = instrument.stringData()->frets();
-      QList<int>  stringList = instrument.stringData()->stringList();
+      int                     frets = instrument.stringData()->frets();
+      QList<instrString>      stringList = instrument.stringData()->stringList();
 
       EditStringData* esd = new EditStringData(this, &stringList, &frets);
       esd->setWindowModality(Qt::WindowModal);

--- a/mscore/editstringdata.cpp
+++ b/mscore/editstringdata.cpp
@@ -28,34 +28,35 @@ namespace Ms {
 //    To edit the string data (tuning and number of frets) for an instrument
 //---------------------------------------------------------
 
-EditStringData::EditStringData(QWidget *parent, QList<int> * strings, int * frets)
+EditStringData::EditStringData(QWidget *parent, QList<instrString> * strings, int * frets)
    : QDialog(parent)
       {
       setupUi(this);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       _strings = strings;
+      QStringList hdrLabels;
+      int         numOfStrings = _strings->size();
+      hdrLabels << tr("Open", "string data") << tr("Pitch", "string data");
+      stringList->setHorizontalHeaderLabels(hdrLabels);
+      stringList->setRowCount(numOfStrings);
       // if any string, insert into string list control and select the first one
-      if(_strings->size()) {
-            int   i, j;
-            // insert into local working copy sorting by decreasing MIDI code value
-/*            foreach(i, *_strings) {
-                  for(j=_stringsLoc.size()-1; j >= 0 && i > _stringsLoc[j]; j--)
-                        ;
-                  _stringsLoc.insert(j+1, i);
-                  }
-            // add to string list dlg control
-            foreach(i, _stringsLoc)
-                  stringList->addItem(midiCodeToStr(i));
-            stringList->setCurrentRow(0);
-*/
+
+      if(numOfStrings > 0) {
+            int   i;
+            instrString strg;
             // insert into local working copy and into string list dlg control
             // IN REVERSED ORDER
-            for(i=_strings->size()-1; i >= 0; i--) {
-                  j = (*_strings)[i];
-                  _stringsLoc.append(j);
-                  stringList->addItem(midiCodeToStr(j));
+            for(i=0; i < numOfStrings; i++) {
+                  strg = (*_strings)[numOfStrings - i - 1];
+                  _stringsLoc.append(strg);
+                  QTableWidgetItem *newCheck = new QTableWidgetItem();
+                  newCheck->setFlags(Qt::ItemFlag(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled));
+                  newCheck->setCheckState(strg.open ? Qt::Checked : Qt::Unchecked);
+                  stringList->setItem(i, 0, newCheck);
+                  QTableWidgetItem *newPitch = new QTableWidgetItem(midiCodeToStr(strg.pitch));
+                  stringList->setItem(i, 1, newPitch);
                   }
-            stringList->setCurrentRow(0);
+            stringList->setCurrentCell(0, 1);
             }
       // if no string yet, disable buttons acting on individual string
       else {
@@ -69,27 +70,15 @@ EditStringData::EditStringData(QWidget *parent, QList<int> * strings, int * fret
       connect(deleteString, SIGNAL(clicked()), SLOT(deleteStringClicked()));
       connect(editString,   SIGNAL(clicked()), SLOT(editStringClicked()));
       connect(newString,    SIGNAL(clicked()), SLOT(newStringClicked()));
-      connect(stringList,   SIGNAL(doubleClicked(QModelIndex)), SLOT(editStringClicked()));
+      connect(stringList,   SIGNAL(doubleClicked(QModelIndex)),     SLOT(editStringClicked()));
+      connect(stringList,   SIGNAL(itemClicked(QTableWidgetItem*)), SLOT(listItemClicked(QTableWidgetItem *)));
       _modified = false;
       }
 
 EditStringData::~EditStringData()
 {
-//    delete ui;
 }
-/*
-void EditStringData::changeEvent(QEvent *e)
-{
-      QDialog::changeEvent(e);
-      switch (e->type()) {
-            case QEvent::LanguageChange:
-                  retranslateUi(this);
-                  break;
-            default:
-                  break;
-      }
-}
-*/
+
 //---------------------------------------------------------
 //   deleteStringClicked
 //---------------------------------------------------------
@@ -102,7 +91,7 @@ void EditStringData::deleteStringClicked()
       _stringsLoc.removeAt(i);
       stringList->model()->removeRow(i);
       // if no more items, disable buttons acting on individual string
-      if (stringList->count() == 0) {
+      if (stringList->rowCount() == 0) {
             editString->setEnabled(false);
             deleteString->setEnabled(false);
             }
@@ -118,14 +107,32 @@ void EditStringData::editStringClicked()
       int         i = stringList->currentRow();
       int         newCode;
 
-      EditPitch* ep = new EditPitch(this, _stringsLoc[i]);
+      EditPitch* ep = new EditPitch(this, _stringsLoc[i].pitch);
       if ( (newCode=ep->exec()) != -1) {
             // update item value in local string list and item text in dlg list control
-            _stringsLoc[i] = newCode;
-            QListWidgetItem * item = stringList->item(i);
+            _stringsLoc[i].pitch = newCode;
+            QTableWidgetItem * item = stringList->item(i, 1);
             item->setText(midiCodeToStr(newCode));
             _modified = true;
             }
+      }
+
+//---------------------------------------------------------
+//   listItemClicked
+//---------------------------------------------------------
+
+void EditStringData::listItemClicked(QTableWidgetItem * item)
+      {
+      int col = item->column();
+      if (col != 0)                 // ignore clicks not on check boxes
+            return;
+      int row = item->row();
+
+      // flip openness in local string list, then sync dlg list ctrl
+      bool open = !_stringsLoc[row].open;
+      _stringsLoc[row].open = open;
+      stringList->item(row, col)->setCheckState(open ? Qt::Checked : Qt::Unchecked);
+      _modified = true;
       }
 
 //---------------------------------------------------------
@@ -138,24 +145,22 @@ void EditStringData::newStringClicked()
 
       EditPitch* ep = new EditPitch(this);
       if ( (newCode=ep->exec()) != -1) {
-            // find sorted postion for new string tuning value
-/*            for(i=_stringsLoc.size()-1; i >= 0 && newCode > _stringsLoc[i]; i--)
-                  ;
+            // add below selected string or at the end if no selected string
+            i = stringList->currentRow() + 1;
+            if(i <= 0)
+                  i = stringList->rowCount();
             // insert in local string list and in dlg list control
-            _stringsLoc.insert(i+1, newCode);
-            stringList->insertItem(i+1, midiCodeToStr(newCode));
+            instrString strg = {newCode, 0};
+            _stringsLoc.insert(i, strg);
+            stringList->insertRow(i);
+            QTableWidgetItem *newCheck = new QTableWidgetItem();
+            newCheck->setFlags(Qt::ItemFlag(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled));
+            newCheck->setCheckState(strg.open ? Qt::Checked : Qt::Unchecked);
+            stringList->setItem(i, 0, newCheck);
+            QTableWidgetItem *newPitch = new QTableWidgetItem(midiCodeToStr(strg.pitch));
+            stringList->setItem(i, 1, newPitch);
             // select last added item and ensure buttons are active
-            stringList->setCurrentRow(i+1);
-*/
-            // add below selected string o at the end if no selected string
-            i = stringList->currentRow();
-            if(i < 0)
-                  i = stringList->count() - 1;
-            // insert in local string list and in dlg list control
-            _stringsLoc.insert(i+1, newCode);
-            stringList->insertItem(i+1, midiCodeToStr(newCode));
-            // select last added item and ensure buttons are active
-            stringList->setCurrentRow(i+1);
+            stringList->setCurrentCell(i, 1);
             editString->setEnabled(true);
             deleteString->setEnabled(true);
             _modified = true;

--- a/mscore/editstringdata.h
+++ b/mscore/editstringdata.h
@@ -21,6 +21,7 @@
 #define EDITSTRINGDATA_H
 
 #include "ui_editstringdata.h"
+#include "libmscore/stringdata.h"
 
 namespace Ms {
 
@@ -33,11 +34,11 @@ class EditStringData : public QDialog, private Ui::EditStringDataBase {
 
       int*              _frets;
       bool              _modified;
-      QList<int> *      _strings;         // pointer to original string list
-      QList<int>        _stringsLoc;      // local working copy of string list
+      QList<instrString>* _strings;         // pointer to original string list
+      QList<instrString>  _stringsLoc;      // local working copy of string list
 
    public:
-      EditStringData(QWidget *parent, QList<int> * strings, int * frets);
+      EditStringData(QWidget *parent, QList<instrString> * strings, int * frets);
       ~EditStringData();
 
    protected:
@@ -47,6 +48,7 @@ class EditStringData : public QDialog, private Ui::EditStringDataBase {
       void accept();
       void deleteStringClicked();
       void editStringClicked();
+      void listItemClicked(QTableWidgetItem * item);
       void newStringClicked();
       };
 

--- a/mscore/editstringdata.ui
+++ b/mscore/editstringdata.ui
@@ -26,7 +26,24 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
        <item>
-        <widget class="QListWidget" name="stringList"/>
+        <widget class="QTableWidget" name="stringList">
+         <attribute name="horizontalHeaderDefaultSectionSize">
+          <number>50</number>
+         </attribute>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Open</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Pitch</string>
+          </property>
+         </column>
+        </widget>
        </item>
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -88,6 +105,9 @@
          <property name="text">
           <string>Number of frets:</string>
          </property>
+         <property name="buddy">
+          <cstring>numOfFrets</cstring>
+         </property>
         </widget>
        </item>
        <item>
@@ -132,9 +152,14 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="musescore.qrc"/>
- </resources>
+ <tabstops>
+  <tabstop>stringList</tabstop>
+  <tabstop>newString</tabstop>
+  <tabstop>editString</tabstop>
+  <tabstop>deleteString</tabstop>
+  <tabstop>numOfFrets</tabstop>
+ </tabstops>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -4319,12 +4319,12 @@ void ExportMusicXml::write(QIODevice* dev)
                                           xml.stag("staff-details");
                                     xml.tag("staff-lines", st->lines());
                                     if (st->isTabStaff() && instrument->stringData()) {
-                                          QList<int> l = instrument->stringData()->stringList();
+                                          QList<instrString> l = instrument->stringData()->stringList();
                                           for (int i = 0; i < l.size(); i++) {
                                                 char step  = ' ';
                                                 int alter  = 0;
                                                 int octave = 0;
-                                                midipitch2xml(l.at(i), step, alter, octave);
+                                                midipitch2xml(l.at(i).pitch, step, alter, octave);
                                                 xml.stag(QString("staff-tuning line=\"%1\"").arg(i+1));
                                                 xml.tag("tuning-step", QString("%1").arg(step));
                                                 if (alter)

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -3095,7 +3095,7 @@ static void readStringData(StringData* t, QDomElement de)
             if (tag == "staff-lines") {
                   if (val > 0) {
                         // resize the string table and init with zeroes
-                        t->stringList() = QVector<int>(val).toList();
+                        t->stringList() = QVector<instrString>(val).toList();
                         }
                   else
                         qDebug("Tablature::readMusicXML: illegal staff-lines %d", val);
@@ -3120,7 +3120,7 @@ static void readStringData(StringData* t, QDomElement de)
                   if (0 < line && line <= t->stringList().size()) {
                         int pitch = MusicXMLStepAltOct2Pitch(step[0].toLatin1(), alter, octave);
                         if (pitch >= 0)
-                              t->stringList()[line - 1] = pitch;
+                              t->stringList()[line - 1].pitch = pitch;
                         else
                               qDebug("Tablature::readMusicXML invalid string %d tuning step/alter/oct %s/%d/%d",
                                      line, qPrintable(step), alter, octave);


### PR DESCRIPTION
Allows to mark strings as open (non-fretted).
Defaults to fretted, keeping backward-compatibility with existing scores.
Adds an attribute `open="1"` in score (and instruments.xml) string data (defaults to "0").

Benefits:
- allows future support (also in TAB's) for string instruments with non-fretted strings (mainly but, I think, not only the lute family)
- gives correct fretting for non-fretted strings
- instrument range can be more easily and automatically linked to actual string tuning
- as this will be eventually needed for better TAB support, the score reading/writing will be already able to manage it.
