### PR TITLE
fix #29516: note input cursor in drum entry mode

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -304,7 +304,6 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
             return;
       ScoreView* viewer = mscore->currentScoreView();
 
-
       if (viewer->mscoreState() != STATE_EDIT
          && viewer->mscoreState() != STATE_LYRICS_EDIT
          && viewer->mscoreState() != STATE_HARMONY_FIGBASS_EDIT
@@ -355,6 +354,8 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
          && viewer->mscoreState() != STATE_HARMONY_FIGBASS_EDIT
          && viewer->mscoreState() != STATE_TEXT_EDIT) { //Already in startCmd mode in this case
             score->endCmd();
+            if (viewer->mscoreState() == STATE_NOTE_ENTRY_DRUM)
+                  viewer->moveCursor();
             }
       mscore->endCmd();
       }


### PR DESCRIPTION
The problem is that the cursor was being moved too early - in Rest::drop(), for a rest that had been created by makeGap() but had not been laid out yet.

I added a call to moveCursor() at the end of Palette::mouseDoubleClickEvent(), only in the case of drum entry mode.  I left the old one where it was as it might be useful in other situations.  Seems harmless.
