### PR TITLE
fix #28401: transpose chords appropriately in parts

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -618,6 +618,18 @@ void Harmony::endEdit()
                         continue;
                   Harmony* h = static_cast<Harmony*>(e);
                   h->setHarmony(text());
+                  // transpose if necessary
+                  if (score()->styleB(StyleIdx::concertPitch) != h->score()->styleB(StyleIdx::concertPitch)) {
+                        Part* partDest = h->staff()->part();
+                        Interval interval = partDest->instr()->transpose();
+                        if (!interval.isZero()) {
+                              if (!h->score()->styleB(StyleIdx::concertPitch))
+                                    interval.flip();
+                              int rootTpc = transposeTpc(h->rootTpc(), interval, false);
+                              int baseTpc = transposeTpc(h->baseTpc(), interval, false);
+                              h->score()->undoTransposeHarmony(h, rootTpc, baseTpc);
+                              }
+                        }
                   }
             }
       score()->setLayoutAll(true);  // done in Text::endEdit() too, but no harm being sure

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -231,7 +231,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int staffIdx)
                               int tick = e.tick();
                               Measure* m = tick2measure(tick);
                               Segment* seg = m->undoGetSegment(Segment::Type::ChordRest, tick);
-                              if (seg->findAnnotationOrElement(Element::Type::HARMONY, dstStaffIdx * VOICES,dstStaffIdx * VOICES)) {
+                              if (seg->findAnnotationOrElement(Element::Type::HARMONY, dstStaffIdx * VOICES, dstStaffIdx * VOICES)) {
                                     QList<Element*> elements;
                                     foreach (Element* el, seg->annotations()) {
                                           if (el->type() == Element::Type::HARMONY

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1046,6 +1046,21 @@ void Score::undoAddElement(Element* element)
                   ne->setTrack(ntrack);
                   ne->setParent(seg);
                   undo(new AddElement(ne));
+                  // transpose harmony if necessary
+                  if (element->type() == Element::Type::HARMONY && ne != element) {
+                        Harmony* h = static_cast<Harmony*>(ne);
+                        if (score->styleB(StyleIdx::concertPitch) != element->score()->styleB(StyleIdx::concertPitch)) {
+                              Part* partDest = h->staff()->part();
+                              Interval interval = partDest->instr()->transpose();
+                              if (!interval.isZero()) {
+                                    if (!score->styleB(StyleIdx::concertPitch))
+                                          interval.flip();
+                                    int rootTpc = transposeTpc(h->rootTpc(), interval, false);
+                                    int baseTpc = transposeTpc(h->baseTpc(), interval, false);
+                                    score->undoTransposeHarmony(h, rootTpc, baseTpc);
+                                    }
+                              }
+                        }
                   }
             else if (element->type() == Element::Type::SLUR
                || element->type() == Element::Type::HAIRPIN


### PR DESCRIPTION
Implemented without introducing TPC1/TPC2 mechanism for harmony objects (that could always come later).  Instead, I am just making sure to transpose chords in linked staves when editing and when copying/pasting.
