### PR TITLE
fix #29901: cursor left in note input mode

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1686,12 +1686,12 @@ bool Score::processMidiInput()
 Element* Score::move(const QString& cmd)
       {
       ChordRest* cr;
-      if (selection().activeCR())
+      if (noteEntryMode())
+            cr = inputState().cr();
+      else if (selection().activeCR())
             cr = selection().activeCR();
       else
             cr = selection().lastChordRest();
-      if (cr == 0 && noteEntryMode())
-            cr = inputState().cr();
 
       // no chord/rest found? look for another type of element
       if (cr == 0) {


### PR DESCRIPTION
See issue report.  My expectations are simple: in note input mode, "C D" enters two notes and puts input cursor on the following rest (or whatever); I expect "left" to move it back to the note just entered, not back to the note _before_ the one just entered.  This has bugged me forever.  Hopefully i'm not the only one.  Try this out if you like; I think you'll like it.
