### PR TITLE
partial fix for #17508

### DIFF
--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -2312,6 +2312,10 @@ Measure* MusicXml::xmlMeasure(Part* part, QDomElement e, int number, Fraction me
                                      || (alter ==  1 && currAccVal == AccidentalVal::SHARP   && nt->accidental()->accidentalType() == Accidental::Type::SHARP   && !accTmp.value(ln))) {
                                      nt->accidental()->setRole(Accidental::Role::USER);
                                      }
+                               else if  (alter ==  0 && currAccVal == AccidentalVal::NATURAL && nt->accidental()->accidentalType() != Accidental::Type::NATURAL) {
+                                     nt->accidental()->setRole(Accidental::Role::USER);
+                                     accTmp.replace(ln, false);
+                                     }
                                else {
                                      accTmp.replace(ln, true);
                                      }


### PR DESCRIPTION
Microtonal accidentals are attached to natural notes and they are given the USER flag. 
