### PR TITLE
Fix #29946 - Input via mouse in TAB's disrupts input cursor position

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5563,7 +5563,10 @@ void ScoreView::posChanged(POS pos, unsigned tick)
       {
       switch (pos) {
             case POS::CURRENT:
-                  moveCursor(tick);
+                  if (noteEntryMode())
+                        moveCursor();     // update input cursor position
+                  else
+                        moveCursor(tick); // update play position
                   break;
             case POS::LEFT:
                   _curLoopIn->move(_score->pos(POS::LEFT));


### PR DESCRIPTION
See http://musescore.org/en/node/29946 for details.
