### PR TITLE
Starting playback while in entry mode should exit entry mode.

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2582,8 +2582,11 @@ void ScoreView::cmd(const QAction* a)
                   }
             }
       else if (cmd == "play") {
-            if (seq && seq->canStart())
+            if (seq && seq->canStart()) {
+                  if (noteEntryMode())          // force out of entry mode
+                        sm->postEvent(new CommandEvent("note-input"));
                   sm->postEvent(new CommandEvent(cmd));
+                  }
             else
                   getAction("play")->setChecked(false);
             }


### PR DESCRIPTION
Currently, starting playback while in entry mode leaves entry mode on, even if entry is actually impossible during playback.

In addition, when playback stops, entry mode (which is still on) is not stable and lacks an input cursor.

This fix shuts down entry mode altogether when starting playback.
