### PR TITLE
Fix #29881 - Stopped left over slides from being applied to rests

### DIFF
--- a/mscore/importgtp-gp4.cpp
+++ b/mscore/importgtp-gp4.cpp
@@ -811,9 +811,8 @@ void GuitarPro4::read(QFile* fp)
                               }
                         else if (slurs[staffIdx] && hasSlur) {
                               }
-                        if (slide) {
+                        if (cr && (cr->type() == Element::Type::CHORD) && slide > 0)
                               createSlide(convertGP4SlideNum(slide), cr, staffIdx);
-                        }
                         restsForEmptyBeats(segment, measure, cr, l, track, tick);
                         createSlur(hasSlur, staffIdx, cr);
                         tick += cr->actualTicks();

--- a/mscore/importgtp-gp5.cpp
+++ b/mscore/importgtp-gp5.cpp
@@ -265,8 +265,8 @@ int GuitarPro5::readBeat(int tick, int voice, Measure* measure, int staffIdx, Tu
       if (r & 0x8) {
             int rrr = readChar();
 qDebug("  3beat read 0x%02x", rrr);
-            }
-      if (slide)
+           }
+      if (cr && (cr->type() == Element::Type::CHORD) && slide > 0)
             createSlide(slide, cr, staffIdx);
       restsForEmptyBeats(segment, measure, cr, l, track, tick);
       return cr ? cr->actualTicks() : measure->ticks();

--- a/mscore/importgtp-gp6.cpp
+++ b/mscore/importgtp-gp6.cpp
@@ -1236,7 +1236,7 @@ int GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* measure,
                                                             delete art;
                                                       }
 
-
+                                                if (cr && (cr->type() == Element::Type::CHORD) && slide > 0)
                                                 createSlide(slide, cr, staffIdx);
                                                 note->setTpcFromPitch();
 


### PR DESCRIPTION
Fixes a crash that can occur with slides in Guitar Pro files with slides which lap over bars.
