### PR TITLE
Automatic control of JACK/ALSA MIDI Out ports

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -322,6 +322,7 @@ void Score::init()
       _tempomap               = 0;
       _layoutMode             = LayoutMode::PAGE;
       _noteHeadWidth          = 0.0;      // set in doLayout()
+      _midiPortCount          = 0;
       }
 
 //---------------------------------------------------------
@@ -402,6 +403,7 @@ Score::Score(Score* parent, const MStyle* s)
 
 Score::~Score()
       {
+      _midiPortCount = 0;
       foreach(MuseScoreView* v, viewer)
             v->removeScore();
       // deselectAll();
@@ -894,6 +896,7 @@ void Score::rebuildMidiMapping()
       int port    = 0;
       int channel = 0;
       int idx     = 0;
+      int maxport = 0;
       foreach(Part* part, _parts) {
             InstrumentList* il = part->instrList();
             for (auto i = il->begin(); i != il->end(); ++i) {
@@ -901,6 +904,8 @@ void Score::rebuildMidiMapping()
                   for (int k = 0; k < i->second.channel().size(); ++k) {
                         Channel* a = &(i->second.channel(k));
                         MidiMapping mm;
+                        if (port > maxport)
+                              maxport = port;
                         if (drum != DrumsetKind::NONE) {
                               mm.port    = port;
                               mm.channel = 9;
@@ -926,6 +931,31 @@ void Score::rebuildMidiMapping()
                         }
                   }
             }
+      setMidiPortCount(maxport);
+      }
+
+//---------------------------------------------------------
+//   midiPortCount
+//---------------------------------------------------------
+
+int Score::midiPortCount() const {
+      const Score* root = rootScore();
+      if (this == root)
+            return _midiPortCount;
+      else
+            return root->midiPortCount();
+      }
+
+//---------------------------------------------------------
+//   setMidiPortCount
+//---------------------------------------------------------
+
+void Score::setMidiPortCount(int maxport) {
+      Score* root = rootScore();
+      if (this == root)
+            _midiPortCount = maxport;
+      else
+            root->setMidiPortCount(maxport);
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -378,6 +378,7 @@ class Score : public QObject {
 
       qreal _noteHeadWidth;
       QString accInfo;             ///< information used by the screen-reader
+      int _midiPortCount;          // A count of JACK/ALSA midi out ports. Stored in a root score
 
       //------------------
 
@@ -756,6 +757,9 @@ class Score : public QObject {
       void updateChannel();
       void updateSwing();
       void createPlayEvents();
+
+      int midiPortCount() const;
+      void setMidiPortCount(int);
 
       void cmdConcertPitchChanged(bool, bool /*useSharpsFlats*/);
 

--- a/mscore/alsa.cpp
+++ b/mscore/alsa.cpp
@@ -764,6 +764,16 @@ void AlsaAudio::midiRead()
       {
       midiDriver->read();
       }
+
+//---------------------------------------------------------
+//   updateOutPortCount
+//   Add/remove ALSA MIDI Out ports
+//---------------------------------------------------------
+
+void AlsaAudio::updateOutPortCount(int maxport)
+      {
+      static_cast<AlsaMidiDriver*>(midiDriver)->updateInPortCount(maxport);
+      }
 }
 
 #endif

--- a/mscore/alsa.h
+++ b/mscore/alsa.h
@@ -136,6 +136,7 @@ class AlsaAudio : public Driver {
       void write(int n, void* l);
 
       virtual void midiRead();
+      virtual void updateOutPortCount(int maxport);
       };
 
 }

--- a/mscore/alsamidi.h
+++ b/mscore/alsamidi.h
@@ -56,6 +56,7 @@ class AlsaMidiDriver : public MidiDriver {
       virtual void getOutputPollFd(struct pollfd**, int* n);
       virtual void read();
       virtual void write(const Event&);
+      virtual void updateInPortCount(int);
       };
 
 }

--- a/mscore/driver.h
+++ b/mscore/driver.h
@@ -53,6 +53,7 @@ class Driver {
       virtual void handleTimeSigTempoChanged() {}
       virtual void checkTransportSeek(int, int, bool) {}
       virtual int bufferSize() {return 0;}
+      virtual void updateOutPortCount(int) {}
       };
 
 

--- a/mscore/jackaudio.cpp
+++ b/mscore/jackaudio.cpp
@@ -60,6 +60,36 @@ JackAudio::~JackAudio()
       }
 
 //---------------------------------------------------------
+//   updateOutPortCount
+//   Add/remove JACK MIDI Out ports
+//---------------------------------------------------------
+
+void JackAudio::updateOutPortCount(int maxport)
+      {
+      if (!preferences.useJackMidi || maxport == midiOutputPorts.size())
+            return;
+      if (MScore::debugMode)
+            qDebug()<<"JACK number of ports:"<<midiOutputPorts.size()<<", change to:"<<maxport;
+
+      bool oldremember = preferences.rememberLastConnections;
+      preferences.rememberLastConnections = true;
+
+      if (maxport > midiOutputPorts.size()) {
+            for (int i = midiOutputPorts.size(); i < maxport; ++i)
+                  registerPort(QString("mscore-midi-%1").arg(i+1), false, true);
+            restoreMidiConnections();
+            }
+      else if (maxport < midiOutputPorts.size()) {
+            rememberMidiConnections();
+            for(int i = midiOutputPorts.size() - 1; i >= maxport; --i) {
+                  unregisterPort(midiOutputPorts[i]);
+                  midiOutputPorts.removeAt(i);
+                  }
+            }
+      preferences.rememberLastConnections = oldremember;
+      }
+
+//---------------------------------------------------------
 //   registerPort
 //---------------------------------------------------------
 
@@ -442,8 +472,7 @@ bool JackAudio::init(bool hot)
             }
 
       if (preferences.useJackMidi) {
-            for (int i = 0; i < preferences.midiPorts; ++i)
-                  registerPort(QString("mscore-midi-%1").arg(i+1), false, true);
+            registerPort(QString("mscore-midi-1"), false, true);
             registerPort(QString("mscore-midiin-1"), true, true);
             }
       return true;
@@ -908,25 +937,11 @@ void JackAudio::hotPlug()
 
       // Midi connections
       if (preferences.useJackMidi) {
-            if (midiOutputPorts.size()<preferences.midiPorts) {
-                  for (int i = midiOutputPorts.size(); i < preferences.midiPorts; ++i)
-                        registerPort(QString("mscore-midi-%1").arg(i+1), false, true);
-                  }
-            else if (midiOutputPorts.size()>preferences.midiPorts) {
-                  for(int i = midiOutputPorts.size()-1; i>=preferences.midiPorts; --i) {
-                        unregisterPort(midiOutputPorts[i]);
-                        midiOutputPorts.removeAt(i);
-                        }
-                  }
-
             if (midiInputPorts.size() == 0)
                   registerPort(QString("mscore-midiin-1"), true, true);
             }
       else { // No midi
-            foreach(jack_port_t* mp, midiOutputPorts) {
-                  unregisterPort(mp);
-                  midiOutputPorts.removeOne(mp);
-                  }
+            updateOutPortCount(0);
             if (midiInputPorts.size() != 0) {
                   unregisterPort(midiInputPorts[0]);
                   midiInputPorts.removeOne(midiInputPorts[0]);

--- a/mscore/jackaudio.h
+++ b/mscore/jackaudio.h
@@ -86,6 +86,7 @@ class JackAudio : public Driver {
       virtual void checkTransportSeek(int, int, bool);
       virtual int bufferSize() {return _segmentSize;}
       void setBufferSize(int nframes) { _segmentSize = nframes;}
+      void updateOutPortCount(int);
       };
 
 

--- a/mscore/mididriver.cpp
+++ b/mscore/mididriver.cpp
@@ -160,10 +160,8 @@ bool AlsaMidiDriver::init()
             qDebug("Alsa: Subscribe System failed: %s", snd_strerror(error));
             return false;
             }
-      midiOutPorts = new Port[preferences.midiPorts];
       midiInPort   = registerOutPort("MuseScore Port-0");
-      for (int i = 0; i < preferences.midiPorts; ++i)
-            midiOutPorts[i] = registerInPort(QString("MuseScore Port-%1").arg(i));
+      midiOutPorts.append(registerInPort("MuseScore Port-0"));
 
       struct pollfd* pfd;
       int npfd;
@@ -322,6 +320,31 @@ Port AlsaMidiDriver::registerInPort(const QString& name)
       }
 
 //---------------------------------------------------------
+//   updateInPortCount
+//---------------------------------------------------------
+
+void AlsaMidiDriver::updateInPortCount(int maxport)
+      {
+      int ports = midiOutPorts.size();
+      if (maxport == ports)
+            return;
+      if (MScore::debugMode)
+            qDebug()<<"ALSA number of ports:"<<ports<<", change to:"<<maxport;
+      if (maxport > ports) {
+            for (int i = ports; i < maxport; ++i)
+                  midiOutPorts.append(registerInPort(QString("MuseScore Port-%1").arg(i)));
+            }
+      else if (maxport < ports) {
+            for(int i = ports - 1; i >= maxport; --i) {
+                  if (snd_seq_delete_simple_port(alsaSeq, midiOutPorts[i].alsaPort()) < 0)
+                        qDebug("Can not delete ALSA port");
+                  else
+                        midiOutPorts.removeAt(i);
+                  }
+            }
+      }
+
+//---------------------------------------------------------
 //   getInputPollFd
 //---------------------------------------------------------
 
@@ -446,7 +469,7 @@ void AlsaMidiDriver::write(const Event& e)
       snd_seq_event_t event;
       memset(&event, 0, sizeof(event));
       snd_seq_ev_set_direct(&event);
-      if (port >= preferences.midiPorts)
+      if (port >= midiOutPorts.size())
             port = 0;
       snd_seq_ev_set_source(&event, midiOutPorts[port].alsaPort());
       snd_seq_ev_set_dest(&event, SND_SEQ_ADDRESS_SUBSCRIBERS, 0);

--- a/mscore/mididriver.h
+++ b/mscore/mididriver.h
@@ -68,7 +68,7 @@ class Port {
 class MidiDriver {
    protected:
       Port midiInPort;
-      Port* midiOutPorts;
+      QList<Port> midiOutPorts;
       Seq* seq;
 
    public:

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -130,7 +130,6 @@ void Preferences::init()
       usePortaudioAudio = true;
 #endif
 
-      midiPorts          = 2;
       rememberLastConnections = true;
 
       alsaDevice         = "default";
@@ -260,7 +259,6 @@ void Preferences::write()
       s.setValue("jackTimebaseMaster", jackTimebaseMaster);
       s.setValue("usePortaudioAudio",  usePortaudioAudio);
       s.setValue("usePulseAudio",      usePulseAudio);
-      s.setValue("midiPorts",          midiPorts);
       s.setValue("rememberLastMidiConnections", rememberLastConnections);
 
       s.setValue("alsaDevice",         alsaDevice);
@@ -429,7 +427,6 @@ void Preferences::read()
       MScore::playRepeats      = s.value("playRepeats", MScore::playRepeats).toBool();
       MScore::panPlayback      = s.value("panPlayback", MScore::panPlayback).toBool();
       alternateNoteEntryMethod = s.value("alternateNoteEntry", alternateNoteEntryMethod).toBool();
-      midiPorts                = s.value("midiPorts", midiPorts).toInt();
       rememberLastConnections  = s.value("rememberLastMidiConnections", rememberLastConnections).toBool();
       proximity                = s.value("proximity", proximity).toInt();
       autoSave                 = s.value("autoSave", autoSave).toBool();
@@ -857,7 +854,6 @@ void PreferenceDialog::updateValues()
             case MusicxmlExportBreaks::NO:      exportNoBreaks->setChecked(true); break;
             }
 
-      midiPorts->setValue(prefs.midiPorts);
       rememberLastMidiConnections->setChecked(prefs.rememberLastConnections);
       proximity->setValue(prefs.proximity);
       autoSave->setChecked(prefs.autoSave);
@@ -1282,7 +1278,6 @@ void PreferenceDialog::apply()
 
       prefs.useJackTransport   = jackDriver->isChecked() && useJackTransport->isChecked();
       prefs.jackTimebaseMaster = becomeTimebaseMaster->isChecked();
-      prefs.midiPorts          = midiPorts->value();
       prefs.rememberLastConnections = rememberLastMidiConnections->isChecked();
 
       bool wasJack = (prefs.useJackMidi || prefs.useJackAudio);

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -101,7 +101,6 @@ struct Preferences {
       bool useJackMidi;
       bool useJackTransport;
       bool jackTimebaseMaster;
-      int midiPorts;
       bool rememberLastConnections;
 
       QString alsaDevice;

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2285,8 +2285,11 @@
       <layout class="QVBoxLayout" name="verticalLayout_8">
        <item>
         <widget class="QGroupBox" name="pulseaudioDriver">
-         <property name="accessibleName">
-          <string>Pulse Audio</string>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="title">
           <string>PulseAudio</string>
@@ -2634,8 +2637,43 @@
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout71">
+          <item row="1" column="2">
+           <widget class="QCheckBox" name="becomeTimebaseMaster">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="accessibleName">
+             <string>Timebase Master</string>
+            </property>
+            <property name="text">
+             <string>Timebase Master</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="useJackTransport">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="accessibleName">
+             <string>Use JACK Transport</string>
+            </property>
+            <property name="text">
+             <string>Use JACK Transport</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0" colspan="2">
            <widget class="QCheckBox" name="useJackAudio">
+            <property name="accessibleName">
+             <string>Use JACK Audio</string>
+            </property>
             <property name="text">
              <string>Use JACK Audio</string>
             </property>
@@ -2644,87 +2682,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="useJackMidi">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="accessibleName">
-             <string>Use JACK MIDI</string>
-            </property>
-            <property name="text">
-             <string>Use JACK MIDI</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <spacer name="horizontalSpacer_20">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>5</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="label_22">
-            <property name="text">
-             <string>Ports:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QSpinBox" name="midiPorts">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="accessibleName">
-             <string>Ports</string>
-            </property>
-            <property name="accessibleDescription">
-             <string>Choose number of ports</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>8</number>
-            </property>
-            <property name="value">
-             <number>1</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="4" colspan="3">
-           <spacer name="horizontalSpacer_19">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Expanding</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>606</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="2" column="0" colspan="4">
+          <item row="0" column="3">
            <widget class="QCheckBox" name="rememberLastMidiConnections">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -2743,39 +2701,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="4">
-           <widget class="QCheckBox" name="useJackTransport">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="accessibleName">
-             <string>Use JACK Transport</string>
-            </property>
-            <property name="text">
-             <string>Use JACK Transport</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="5">
-           <widget class="QCheckBox" name="becomeTimebaseMaster">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="accessibleName">
-             <string>Timebase Master</string>
-            </property>
-            <property name="text">
-             <string>Timebase Master</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="6">
+          <item row="1" column="3">
            <spacer name="horizontalSpacer_8">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -2787,6 +2713,22 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="0" column="2">
+           <widget class="QCheckBox" name="useJackMidi">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="accessibleName">
+             <string>Use JACK MIDI</string>
+            </property>
+            <property name="text">
+             <string>Use JACK MIDI</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -3691,7 +3633,6 @@
   <tabstop>jackDriver</tabstop>
   <tabstop>useJackAudio</tabstop>
   <tabstop>useJackMidi</tabstop>
-  <tabstop>midiPorts</tabstop>
   <tabstop>rememberLastMidiConnections</tabstop>
   <tabstop>useJackTransport</tabstop>
   <tabstop>becomeTimebaseMaster</tabstop>

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -969,6 +969,8 @@ ScoreView::~ScoreView()
       delete bgPixmap;
       delete fgPixmap;
       delete shadowNote;
+      // Let's compute maximum count of ports in remaining scores
+      seq->recomputeMaxMidiOutPort();
       }
 
 //---------------------------------------------------------

--- a/mscore/seq.h
+++ b/mscore/seq.h
@@ -109,6 +109,7 @@ class Seq : public QObject, public Sequencer {
                                           // Also we save current preferences.useJackTransport value to useJackTransportSavedFlag
                                           // to restore it when count in ends. After this all applications start playing in sync.
       bool useJackTransportSavedFlag;
+      int maxMidiOutPort;                 // Maximum count of midi out ports in all opened scores
       Fraction prevTimeSig;
       double prevTempo;
 
@@ -229,6 +230,7 @@ class Seq : public QObject, public Sequencer {
       void startNote(int channel, int, int, double nt);
       void eventToGui(NPlayEvent);
       void stopNoteTimer();
+      void recomputeMaxMidiOutPort();
       };
 
 extern Seq* seq;


### PR DESCRIPTION
With this feature MuseScore users can deal with MIDI faster and more comfortable. Now they don't need to think about MIDI Out ports number ("-Why it doesn't sound? <...> Ah, I have to increase midi ports number...").

I used "lazy" approach to prevent flooding to JACK/ALSA with a lot of API calls: we add new ports only if we really need to do it (e.g. when opening a score with a lot of staves OR when adding a new instrument).

Example: If we have several scores opened with 1, 3 and 2 midi ports, we'll have 3 midi out ports even if we switch between scores (would not change from 1 to 3 and 2).

Recomputing number of midi ports is also optimized: we don't need to do an extra loop every second/tick/etc.

You can read about this new feature here:
http://igevorse.lited.net/p14.html
http://igevorse.lited.net/p18.html
