### PR TITLE
Accidentals xml

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -2206,6 +2206,7 @@ void ExportMusicXml::chord(Chord* chord, int staff, const QList<Lyrics*>* ll, Dr
                   xml.tag("alter", alter);
             if (!alter && alter2)
                   xml.tag("alter", alter2);
+            // TODO what if both alter and alter2 are present? For Example: playing with transposing instruments
             xml.tag(useDrumset != DrumsetKind::NONE ? "display-octave" : "octave", octave);
             xml.etag();
 
@@ -2255,10 +2256,14 @@ void ExportMusicXml::chord(Chord* chord, int staff, const QList<Lyrics*>* ll, Dr
             // accidental
             if (acc) {
                   /*
-                        MusicXML accidental names include:
+                        MusicXML 2.0 accidental names include:
                         sharp,natural, flat, double-sharp, sharp-sharp, flat-flat,
                         natural-sharp, natural-flat, quarter-flat, quarter-sharp,
-                        three-quarters-flat, and three-quarters-sharp
+                        three-quarters-flat, and three-quarters-sharp.
+                        Added in MusicXml 3.0: sharp-down, sharp-up, natural-down, natural-up,
+                        flat-down, flat-up, triple-sharp, triple-flat, slash-quarter-sharp,
+                        slash-sharp, slash-flat, double-slash-flat, sharp-1, sharp-2,
+                        sharp-3, sharp-5, flat-1, flat-2, flat-3, flat-4, sori, and koron.
                     */
                   QString s;
                   switch (acc->accidentalType()) {

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -4809,11 +4809,11 @@ Note* MusicXml::xmlNote(Measure* measure, int staff, const QString& partId, Beam
                               if (!ok || alter < -2 || alter > 2) {
                                     qDebug("ImportXml: bad 'alter' value: %s at line %d col %d",
                                            qPrintable(altertext), ee.lineNumber(), ee.columnNumber());
-                                    if (qAbs(alter)<2) { // try to see if a microtonal accidental is needed
-                                          bool ok2;
-                                          double altervalue = altertext.toDouble(&ok2);
-                                          if (ok2 && (accidental == Accidental::Type::NONE))
-                                                accidental = microtonalGuess(altervalue);
+                                    bool ok2;
+                                    double altervalue = altertext.toDouble(&ok2);
+                                    if (ok2 && (qAbs(altervalue) < 2.0) && (accidental == Accidental::Type::NONE)) {
+                                          // try to see if a microtonal accidental is needed
+                                          accidental = microtonalGuess(altervalue);
                                           }
                                     alter = 0;
                                     }


### PR DESCRIPTION
This should fix #17508 and it should take care of software compatibility. I tested the export/import against a demo version of Sibelius 7.5.
Because of the way Sibelius exports microtonal accidentals to MusicXml, I had to partially rewrite my previous PR (which in the meantime got merged): sorry for the previous almost superfluous PR. It seems that Sibelius rounds the "alter" value to integer, determining (in the previous PR) a wrong import in MuseScore of 3/4 tone accidentals. Now it should work as expected.
I couldn't install the Dolet plugin (it does not seem to work with a demo), so I don't know if it exports better MusicXml files.
If someone owns a copy of Finale and/or Sibelius with Dolet, could she/he please test the import/export? (Actually, in the Sibelius Demo I could only enter 1/4 and 3/4 tone accidentals; these are now properly handled)
