### PR TITLE
fix #30106: note input cursor too close too barline

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1405,6 +1405,7 @@ void ScoreView::moveCursor()
       double x        = segment->canvasPos().x();
       double y        = system->staffYpage(staffIdx) + system->page()->pos().y();
       double _spatium = score()->spatium();
+      x              -= qMin(segment->pos().x() - score()->styleD(StyleIdx::barNoteDistance) * _spatium, 0.0);
 
       update(_matrix.mapRect(_cursor->rect()).toRect().adjusted(-1,-1,1,1));
 


### PR DESCRIPTION
A small tweak to note input cursor: make sure it's always positioned at least barNoteDistance (style parameter) from the barline.  This keeps the cursor from overlapping the barline when entering an empty measure (it's trying to center the box at x position 0.0).
