### PR TITLE
fix #30061: markup appear in textline properties for 1.3 scores

### DIFF
--- a/mscore/lineproperties.cpp
+++ b/mscore/lineproperties.cpp
@@ -54,9 +54,21 @@ LineProperties::LineProperties(TextLine* l, QWidget* parent)
       otl = l;
       tl  = l->clone();
 
-      beginText->setText(otl->beginText());
-      continueText->setText(otl->continueText());
-      endText->setText(otl->endText());
+      Text* t = otl->beginTextElement();
+      if (t) {
+            t->layout();
+            beginText->setText(t->plainText());
+            }
+      t = otl->continueTextElement();
+      if (t) {
+            t->layout();
+            continueText->setText(t->plainText());
+            }
+      t = otl->endTextElement();
+      if (t) {
+            t->layout();
+            endText->setText(t->plainText());
+            }
 
       setTextPlace(otl->beginTextPlace(),    beginTextPlace);
       setTextPlace(otl->continueTextPlace(), continueTextPlace);


### PR DESCRIPTION
The problem is the begin, continue, and end texts in the dialog are not laid out - only the copies made for the individual segments are.  A layout or equivalent has to happen at some point so we can get the plainText to put in the dialog.  I elected to do the layout right in the dialog initialization, then I take the plainText.  I'm sure there are other ways that would work - but I can tell you from experience there are a lot of ways that _don't_ work :-).
