### PR TITLE
fix #30116: crash on crazy short tremolo

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -708,6 +708,8 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime)
                   }
             else if (chord->tremoloChordType() == TremoloChordType::TremoloSingle) {
                   int t = MScore::division / (1 << (tremolo->lines() + chord->durationType().hooks()));
+                  if (!t)
+                        t = 1;
                   int n = chord->durationTicks() / t;
                   int l = 1000 / n;
                   for (int k = 0; k < notes; ++k) {


### PR DESCRIPTION
I won't vouch that playback is "correct", but a four stroke tremolo on a 128th note?!  Be happy it doesn't crash :-)
