### PR TITLE
Fix a potential crash in FiguredBass

### DIFF
--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -1089,7 +1089,7 @@ NoLen:
 
       // get length of printed lines from horiz. page position of lastCR
       // (enter a bit 'into' the ChordRest for clarity)
-      _printedLineLength = lastCR->pageX() - pageX() + 1.5*spatium();
+      _printedLineLength = lastCR ? lastCR->pageX() - pageX() + 1.5*spatium() : 3 * spatium();
 
       // get duration indicator line(s) from page position of nextSegm
       QList<System*>* systems = score()->systems();


### PR DESCRIPTION
In theory, `lastCR` may be null in line 1090. It should not happen in normal operations, but one never knows...
