### PR TITLE
fix #29511: keep voltas when adding notes

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1451,7 +1451,7 @@ RemoveElement::RemoveElement(Element* e)
                         }
                   if (s->type() == Element::Type::SLUR && (s->startElement() == e || s->endElement() == e))
                         sl.append(s);
-                  else if ((s->tick() == tick) && (s->track() == element->track()))
+                  else if ((s->tick() == tick) && (s->track() == element->track()) && (s->anchor() != Spanner::Anchor::MEASURE))
                         sl.append(s);
                   }
             for (auto s : sl)       // actually remove scheduled spanners


### PR DESCRIPTION
I'm going with the cheap but hopefully safe fix: I keep spanners with MEASURE anchors, delete all others.  It's probably possible to be more clever and detect if we are replacing the anchor note with another and keep hairpins & pedals if so, but not important to me right now.
