### PR TITLE
fix #30151: first ottava of 1.3 score can mess up playback of following notes

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -777,8 +777,11 @@ bool SLine::readProperties(XmlReader& e)
       {
       const QStringRef& tag(e.name());
 
-      if (tag == "tick2")                 // obsolete
+      if (tag == "tick2") {               // obsolete
+            if (tick() == -1) // not necessarily set (for first note of score?) #30151
+                  setTick(0);
             setTick2(e.readInt());
+            }
       else if (tag == "tick")             // obsolete
             setTick(e.readInt());
       else if (tag == "ticks")


### PR DESCRIPTION
Apparently an ottava on the first note of a score might be missing a "tick" tag, and the default of -1 means the length is too large by 1 now, which can affect playback of subsequent notes (and possibly layout in some cases).  This fixes that.
