### PR TITLE
Remove symbols from status bar text and screen-reader info.

### DIFF
--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2558,7 +2558,7 @@ QString Text::accessibleInfo()
                   rez = Element::accessibleInfo();
                   break;
             }
-      return  QString("%1: %2").arg(rez).arg(plainText());
+      return  QString("%1: %2").arg(rez).arg(plainText(true));
       }
 }
 


### PR DESCRIPTION
This change should not be done to tempo text also. There the symbols are needed for the tempos in the palette.
https://github.com/musescore/MuseScore/blob/master/libmscore/tempotext.cpp#L259
