### PR TITLE
fix #30361

### DIFF
--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -321,6 +321,11 @@ void SynthControl::updateGui()
       idx = synti->indexOfEffect(1);
       effectB->setCurrentIndex(idx);
       effectStackB->setCurrentIndex(idx);
+      for (Synthesizer* s : synti->synthesizer()) {
+            if (strcmp(s->name(), "Aeolus") == 0)    // no gui for aeolus
+                  continue;
+            s->gui()->synthesizerChanged();
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
With this PR the updateGui() instruction also rebuilds the sounfont GUI list for the synthesizers (Fluid and Zerberus). Indeed, issue #30361 could have been solved by putting these lines only inside the loadButtonClicked() function so that this list rebuilding would have happened only when the sounfont list is loaded from the score. I will let Nicolas and Werner decide which of the two implementations is preferable.
