### PR TITLE
Grey out mixer chorus and reverb controls - Fix issue #30551

### DIFF
--- a/mscore/mixer.ui
+++ b/mscore/mixer.ui
@@ -160,6 +160,9 @@
         </item>
         <item row="0" column="2">
          <widget class="Awl::Knob" name="reverb" native="true">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Ignored">
             <horstretch>0</horstretch>
@@ -197,6 +200,9 @@
         </item>
         <item row="0" column="3">
          <widget class="Awl::Knob" name="chorus" native="true">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Ignored">
             <horstretch>0</horstretch>


### PR DESCRIPTION
Since the introduction of master effects, the mixer reverb and chorus controls are only active with Jack MIDI out. This sets the default state in the mixer as disabled. Code could be added to the preferences dialogue to enable them if Jack MIDI out is selected. This fixes issue http://musescore.org/en/node/22683
