### PR TITLE
fix #30571: crash on drum note entry

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1882,7 +1882,10 @@ void Note::setSmall(bool val)
 void Note::setLine(int n)
       {
       _line = n;
-      rypos() = (_line + staff()->staffType()->stepOffset()) * spatium() * .5;
+      int off = 0;
+      if (staff())
+            off = staff()->staffType()->stepOffset();
+      rypos() = (_line + off) * spatium() * .5;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Recent change to fix layout of 3-line drum staves broke drum note entry, but a simple fix.
