### PR TITLE
fix #30661: last note of tuplet shortened on paste

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -183,7 +183,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int staffIdx)
                                           graceNotes.clear();
                                           }
                                     //shorten last cr to fit in the space made by makeGap
-                                    if ((tick - dstTick) + cr->durationTicks() > tickLen) {
+                                    if ((tick - dstTick) + cr->actualTicks() > tickLen) {
                                           int newLength = tickLen - (tick - dstTick);
                                           cr->setDuration(newLength);
                                           cr->setDurationType(newLength);


### PR DESCRIPTION
The issue I am fixing is:

http://musescore.org/en/node/30661

The issue was introduced with the following commit:

https://github.com/musescore/MuseScore/commit/107bbc9f2225cc76ff506a2c3225f3a0a8ee850d

which was created to fix the following issue:

http://musescore.org/en/node/11889

I have verified that my fix here does in fact fix the current issue 30661 while still fixing 11889 with the given steps (both the original and the ones in comment #2.  What I am less certain of is whether there might remain some cases where problems might still remain.  But I think not.  If I'm not msitaken, actualTicks() and durationTicks() differ only for tuplets.  And since we don't allow copying of partial tuplets, the only way for this difference to matter is if the last selected note is the _last_ chordrest of a tuplet.  And as best as I can think right now, preserving that last note of the tuplet should always make sense.
