### PR TITLE
fix #30586: bad layout at beginning of some systems in parts

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3454,7 +3454,7 @@ qreal Score::computeMinWidth(Segment* fs)
                                     }
                               else {
                                     // if (pt & (Segment::Type::KeySig | Segment::Type::Clef))
-                                    bool firstClef = (segmentIdx == 1) && (pt == Segment::Type::Clef);
+                                    bool firstClef = (pt == Segment::Type::Clef) && (pSeg && pSeg->rtick() == 0);
                                     if ((pt & Segment::Type::KeySig) || firstClef)
                                           minDistance = qMax(minDistance, clefKeyRightMargin);
                                     }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3142,7 +3142,7 @@ void Measure::layoutX(qreal stretch)
                                     minDistance = qMax(minDistance, minNoteDistance);
                                     }
                               else {
-                                    bool firstClef = (segmentIdx == 1) && (pt == Segment::Type::Clef);
+                                    bool firstClef = (pt == Segment::Type::Clef) && (pSeg && pSeg->rtick() == 0);
                                     if ((pt & Segment::Type::KeySig) || firstClef)
                                           minDistance = qMax(minDistance, clefKeyRightMargin);
                                     }


### PR DESCRIPTION
See issue http://musescore.org/en/node/30586

Parts currently have empty key signature segments in measures for which there happened to be key signature segments in the score (ie, at the beginning of each system in the score).  As a result, when these measures occurred at the beginning of a system, the code that was supposed to add space between the first clef and first chordrest was failing, because the empty key signature in between was tripping it up.

The original code checked to see that the previous segment pSeg (which already was smart enough to skip the empty key sig segment) was a clef, and then that current chordrest segmentIdx was 1.  Thus, a system starting with clef + chordrest, nothing else before the clef or in between.  Aside from the fact that it didn't work in this particular case, the approach seems inherently unsafe to me, so I changed it.  I kept the check to see if pSeg is a clef, but instead of checking the chordrest segmentIdx, I check the rtick of the clef.  If it's zero that means this is an initial clef, and the fact that the clef is the pSeg means this is the first chordrest after the initial clef (again, pSeg skips empty segments).  So segments before the clef (should these ever happen), or _empty_ segments between the clef and chordrest, will no longer through off the calculation.

Another possible fix might have been to keep the check for segmentIdx == 1, but make sure we don't count empty segments.  We already skip empty segments in setting pSeg, so that is totally doable.  but I see segmentIdx is also used in some calculation involving end bar lines and I didn't want to risk interfering with that.  It's probably safe, but I'm not sure under what circumstances we'd ever have an end baline but segmentIdx of 0, so I don't know what we're really testing for there.
