### PR TITLE
fix guitarpro mtests

### DIFF
--- a/mtest/guitarpro/arpeggio.gpx-ref.mscx
+++ b/mtest/guitarpro/arpeggio.gpx-ref.mscx
@@ -153,36 +153,32 @@
           </Chord>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>12</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>13</lid>
+          <lid>12</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>14</lid>
+            <lid>13</lid>
             <pitch>48</pitch>
             <tpc>14</tpc>
             <fret>3</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>15</lid>
+            <lid>14</lid>
             <pitch>53</pitch>
             <tpc>13</tpc>
             <fret>3</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>16</lid>
+            <lid>15</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Arpeggio>
-            <lid>17</lid>
+            <lid>16</lid>
             <subtype>2</subtype>
             </Arpeggio>
           </Chord>
@@ -366,36 +362,32 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>12</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>13</lid>
+            <lid>12</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>3</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>3</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>16</lid>
+              <lid>15</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Arpeggio>
-              <lid>17</lid>
+              <lid>16</lid>
               <subtype>2</subtype>
               </Arpeggio>
             </Chord>
@@ -442,36 +434,32 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>12</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>13</lid>
+            <lid>12</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>3</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>3</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>16</lid>
+              <lid>15</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Arpeggio>
-              <lid>17</lid>
+              <lid>16</lid>
               <subtype>2</subtype>
               </Arpeggio>
             </Chord>

--- a/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
+++ b/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
@@ -239,24 +239,20 @@
           </Chord>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>23</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>24</lid>
+          <lid>23</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>27</lid>
+            <lid>26</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>25</lid>
+            <lid>24</lid>
             <Text>
-              <lid>26</lid>
+              <lid>25</lid>
               <style></style>
               <halign>center</halign>
               <valign>center</valign>
@@ -272,19 +268,19 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>28</lid>
+          <lid>27</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>31</lid>
+            <lid>30</lid>
             <pitch>55</pitch>
             <tpc>15</tpc>
             <fret>10</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>29</lid>
+            <lid>28</lid>
             <Text>
-              <lid>30</lid>
+              <lid>29</lid>
               <style></style>
               <halign>center</halign>
               <valign>center</valign>
@@ -300,19 +296,19 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>32</lid>
+          <lid>31</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>35</lid>
+            <lid>34</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>33</lid>
+            <lid>32</lid>
             <Text>
-              <lid>34</lid>
+              <lid>33</lid>
               <style></style>
               <halign>center</halign>
               <valign>center</valign>
@@ -328,19 +324,19 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>36</lid>
+          <lid>35</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>39</lid>
+            <lid>38</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>37</lid>
+            <lid>36</lid>
             <Text>
-              <lid>38</lid>
+              <lid>37</lid>
               <style></style>
               <halign>center</halign>
               <valign>center</valign>
@@ -621,24 +617,20 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>23</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>24</lid>
+            <lid>23</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>27</lid>
+              <lid>26</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>25</lid>
+              <lid>24</lid>
               <Text>
-                <lid>26</lid>
+                <lid>25</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>
@@ -654,19 +646,19 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>28</lid>
+            <lid>27</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>31</lid>
+              <lid>30</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>10</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>29</lid>
+              <lid>28</lid>
               <Text>
-                <lid>30</lid>
+                <lid>29</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>
@@ -682,19 +674,19 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>32</lid>
+            <lid>31</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>35</lid>
+              <lid>34</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>33</lid>
+              <lid>32</lid>
               <Text>
-                <lid>34</lid>
+                <lid>33</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>
@@ -710,19 +702,19 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>36</lid>
+            <lid>35</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>39</lid>
+              <lid>38</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>37</lid>
+              <lid>36</lid>
               <Text>
-                <lid>38</lid>
+                <lid>37</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>
@@ -863,24 +855,20 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>23</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>24</lid>
+            <lid>23</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>27</lid>
+              <lid>26</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>25</lid>
+              <lid>24</lid>
               <Text>
-                <lid>26</lid>
+                <lid>25</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>
@@ -896,19 +884,19 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>28</lid>
+            <lid>27</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>31</lid>
+              <lid>30</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>10</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>29</lid>
+              <lid>28</lid>
               <Text>
-                <lid>30</lid>
+                <lid>29</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>
@@ -924,19 +912,19 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>32</lid>
+            <lid>31</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>35</lid>
+              <lid>34</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>33</lid>
+              <lid>32</lid>
               <Text>
-                <lid>34</lid>
+                <lid>33</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>
@@ -952,19 +940,19 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>36</lid>
+            <lid>35</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>39</lid>
+              <lid>38</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>37</lid>
+              <lid>36</lid>
               <Text>
-                <lid>38</lid>
+                <lid>37</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>

--- a/mtest/guitarpro/brush.gpx-ref.mscx
+++ b/mtest/guitarpro/brush.gpx-ref.mscx
@@ -153,36 +153,32 @@
           </Chord>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>12</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>13</lid>
+          <lid>12</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>14</lid>
+            <lid>13</lid>
             <pitch>48</pitch>
             <tpc>14</tpc>
             <fret>3</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>15</lid>
+            <lid>14</lid>
             <pitch>53</pitch>
             <tpc>13</tpc>
             <fret>3</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>16</lid>
+            <lid>15</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Arpeggio>
-            <lid>17</lid>
+            <lid>16</lid>
             <subtype>5</subtype>
             </Arpeggio>
           </Chord>
@@ -366,36 +362,32 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>12</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>13</lid>
+            <lid>12</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>3</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>3</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>16</lid>
+              <lid>15</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Arpeggio>
-              <lid>17</lid>
+              <lid>16</lid>
               <subtype>5</subtype>
               </Arpeggio>
             </Chord>
@@ -442,36 +434,32 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>12</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>13</lid>
+            <lid>12</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>3</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>3</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>16</lid>
+              <lid>15</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Arpeggio>
-              <lid>17</lid>
+              <lid>16</lid>
               <subtype>5</subtype>
               </Arpeggio>
             </Chord>

--- a/mtest/guitarpro/crescendo-diminuendo.gpx-ref.mscx
+++ b/mtest/guitarpro/crescendo-diminuendo.gpx-ref.mscx
@@ -133,6 +133,11 @@
             <string>2</string>
             </Note>
           </Chord>
+        <HairPin id="2">
+          <subtype>0</subtype>
+          <veloChange>10</veloChange>
+          <lid>20</lid>
+          </HairPin>
         <Chord>
           <lid>8</lid>
           <durationType>half</durationType>
@@ -144,6 +149,7 @@
             <string>3</string>
             </Note>
           </Chord>
+        <endSpanner id="2"/>
         <Chord>
           <lid>10</lid>
           <durationType>quarter</durationType>
@@ -157,43 +163,39 @@
           </Chord>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>13</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>14</lid>
+          <lid>13</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>15</lid>
+            <lid>14</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
             <string>2</string>
             </Note>
           </Chord>
-        <HairPin id="2">
+        <HairPin id="3">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
-          <lid>22</lid>
+          <lid>21</lid>
           </HairPin>
         <Chord>
-          <lid>16</lid>
+          <lid>15</lid>
           <durationType>half</durationType>
           <Note>
-            <lid>17</lid>
+            <lid>16</lid>
             <pitch>52</pitch>
             <tpc>18</tpc>
             <fret>2</fret>
             <string>3</string>
             </Note>
           </Chord>
-        <endSpanner id="2"/>
+        <endSpanner id="3"/>
         <Chord>
-          <lid>18</lid>
+          <lid>17</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>19</lid>
+            <lid>18</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -360,6 +362,11 @@
               <string>2</string>
               </Note>
             </Chord>
+          <HairPin id="4">
+            <subtype>0</subtype>
+            <veloChange>10</veloChange>
+            <lid>20</lid>
+            </HairPin>
           <Chord>
             <lid>8</lid>
             <durationType>half</durationType>
@@ -371,6 +378,7 @@
               <string>3</string>
               </Note>
             </Chord>
+          <endSpanner id="4"/>
           <Chord>
             <lid>10</lid>
             <durationType>quarter</durationType>
@@ -382,45 +390,43 @@
               <string>4</string>
               </Note>
             </Chord>
+          <tick>1440</tick>
+          <endSpanner id="5"/>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>13</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>14</lid>
+            <lid>13</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
               <string>2</string>
               </Note>
             </Chord>
-          <HairPin id="3">
+          <HairPin id="6">
             <subtype>1</subtype>
             <veloChange>10</veloChange>
-            <lid>22</lid>
+            <lid>21</lid>
             </HairPin>
           <Chord>
-            <lid>16</lid>
+            <lid>15</lid>
             <durationType>half</durationType>
             <Note>
-              <lid>17</lid>
+              <lid>16</lid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <fret>2</fret>
               <string>3</string>
               </Note>
             </Chord>
-          <endSpanner id="3"/>
+          <endSpanner id="6"/>
           <Chord>
-            <lid>18</lid>
+            <lid>17</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>18</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -432,7 +438,7 @@
             <span>1</span>
             </BarLine>
           <tick>3360</tick>
-          <endSpanner id="4"/>
+          <endSpanner id="7"/>
           </Measure>
         </Staff>
       <Staff id="2">
@@ -452,6 +458,11 @@
               <string>2</string>
               </Note>
             </Chord>
+          <HairPin id="5">
+            <subtype>0</subtype>
+            <veloChange>10</veloChange>
+            <lid>20</lid>
+            </HairPin>
           <Chord>
             <lid>8</lid>
             <durationType>half</durationType>
@@ -476,31 +487,27 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>13</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>14</lid>
+            <lid>13</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
               <string>2</string>
               </Note>
             </Chord>
-          <HairPin id="4">
+          <HairPin id="7">
             <subtype>1</subtype>
             <veloChange>10</veloChange>
-            <lid>22</lid>
+            <lid>21</lid>
             </HairPin>
           <Chord>
-            <lid>16</lid>
+            <lid>15</lid>
             <durationType>half</durationType>
             <Note>
-              <lid>17</lid>
+              <lid>16</lid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <fret>2</fret>
@@ -508,10 +515,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>18</lid>
+            <lid>17</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>18</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>

--- a/mtest/guitarpro/directions.gpx-ref.mscx
+++ b/mtest/guitarpro/directions.gpx-ref.mscx
@@ -159,26 +159,18 @@
           <lid>13</lid>
           <text>Da Capo</text>
           </StaffText>
-        <KeySig>
-          <lid>14</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>15</lid>
+          <lid>14</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="3">
-        <KeySig>
-          <lid>17</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>18</lid>
+          <lid>16</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>19</lid>
+            <lid>17</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
@@ -186,43 +178,35 @@
             </Note>
           </Chord>
         <Rest>
+          <lid>18</lid>
+          <durationType>quarter</durationType>
+          </Rest>
+        <Rest>
+          <lid>19</lid>
+          <durationType>quarter</durationType>
+          </Rest>
+        <Rest>
           <lid>20</lid>
-          <durationType>quarter</durationType>
-          </Rest>
-        <Rest>
-          <lid>21</lid>
-          <durationType>quarter</durationType>
-          </Rest>
-        <Rest>
-          <lid>22</lid>
           <durationType>quarter</durationType>
           </Rest>
         </Measure>
       <Measure number="4">
         <StaffText>
-          <lid>24</lid>
+          <lid>22</lid>
           <text>D.C. al Coda</text>
           </StaffText>
-        <KeySig>
-          <lid>25</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>26</lid>
+          <lid>23</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="5">
-        <KeySig>
-          <lid>28</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>29</lid>
+          <lid>25</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>30</lid>
+            <lid>26</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
@@ -230,43 +214,35 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>31</lid>
+          <lid>27</lid>
           <durationType>quarter</durationType>
           </Rest>
         <Rest>
-          <lid>32</lid>
+          <lid>28</lid>
           <durationType>quarter</durationType>
           </Rest>
         <Rest>
-          <lid>33</lid>
+          <lid>29</lid>
           <durationType>quarter</durationType>
           </Rest>
         </Measure>
       <Measure number="6">
         <StaffText>
-          <lid>35</lid>
+          <lid>31</lid>
           <text>D.C. al Double Coda</text>
           </StaffText>
-        <KeySig>
-          <lid>36</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>37</lid>
+          <lid>32</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="7">
-        <KeySig>
-          <lid>39</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>40</lid>
+          <lid>34</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>41</lid>
+            <lid>35</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
@@ -274,394 +250,282 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>42</lid>
+          <lid>36</lid>
           <durationType>quarter</durationType>
           </Rest>
         <Rest>
-          <lid>43</lid>
+          <lid>37</lid>
           <durationType>quarter</durationType>
           </Rest>
         <Rest>
-          <lid>44</lid>
+          <lid>38</lid>
           <durationType>quarter</durationType>
           </Rest>
         </Measure>
       <Measure number="8">
         <StaffText>
-          <lid>46</lid>
+          <lid>40</lid>
           <text>D.C. al Fine</text>
           </StaffText>
-        <KeySig>
-          <lid>47</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>48</lid>
+          <lid>41</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="9">
-        <KeySig>
-          <lid>50</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>51</lid>
+          <lid>43</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="10">
         <StaffText>
-          <lid>53</lid>
+          <lid>45</lid>
           <text>D.S. al Coda</text>
           </StaffText>
-        <KeySig>
-          <lid>54</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>55</lid>
+          <lid>46</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="11">
-        <KeySig>
-          <lid>57</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>58</lid>
+          <lid>48</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="12">
         <StaffText>
-          <lid>60</lid>
+          <lid>50</lid>
           <text>D.S. al Double Coda</text>
           </StaffText>
-        <KeySig>
-          <lid>61</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>62</lid>
+          <lid>51</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="13">
-        <KeySig>
-          <lid>64</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>65</lid>
+          <lid>53</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="14">
         <StaffText>
-          <lid>67</lid>
+          <lid>55</lid>
           <text>D.S. al Fine</text>
           </StaffText>
-        <KeySig>
-          <lid>68</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>69</lid>
+          <lid>56</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="15">
-        <KeySig>
-          <lid>71</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>72</lid>
+          <lid>58</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="16">
         <StaffText>
-          <lid>74</lid>
+          <lid>60</lid>
           <text>Da Segno Segno</text>
           </StaffText>
-        <KeySig>
-          <lid>75</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>76</lid>
+          <lid>61</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="17">
-        <KeySig>
-          <lid>78</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>79</lid>
+          <lid>63</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="18">
-        <KeySig>
-          <lid>81</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>82</lid>
+          <lid>65</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="19">
         <StaffText>
-          <lid>84</lid>
+          <lid>67</lid>
           <text>D.S.S. al Coda</text>
           </StaffText>
-        <KeySig>
-          <lid>85</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>86</lid>
+          <lid>68</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="20">
-        <KeySig>
-          <lid>88</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>89</lid>
+          <lid>70</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="21">
-        <KeySig>
-          <lid>91</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>92</lid>
+          <lid>72</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="22">
         <StaffText>
-          <lid>94</lid>
+          <lid>74</lid>
           <text>D.S.S. al Double Coda</text>
           </StaffText>
-        <KeySig>
-          <lid>95</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>96</lid>
+          <lid>75</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="23">
-        <KeySig>
-          <lid>98</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>99</lid>
+          <lid>77</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="24">
-        <KeySig>
-          <lid>101</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>102</lid>
+          <lid>79</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="25">
         <StaffText>
-          <lid>104</lid>
+          <lid>81</lid>
           <text>D.S.S. al Fine</text>
           </StaffText>
-        <KeySig>
-          <lid>105</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>106</lid>
+          <lid>82</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="26">
-        <KeySig>
-          <lid>108</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>109</lid>
+          <lid>84</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="27">
         <StaffText>
-          <lid>111</lid>
+          <lid>86</lid>
           <text>Da Coda</text>
           </StaffText>
-        <KeySig>
-          <lid>112</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>113</lid>
+          <lid>87</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="28">
-        <KeySig>
-          <lid>115</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>116</lid>
+          <lid>89</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="29">
         <StaffText>
-          <lid>118</lid>
+          <lid>91</lid>
           <text>Da Double Coda</text>
           </StaffText>
-        <KeySig>
-          <lid>119</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>120</lid>
+          <lid>92</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="30">
-        <KeySig>
-          <lid>122</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>123</lid>
+          <lid>94</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="31">
-        <KeySig>
-          <lid>125</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Symbol>
           <name>segno</name>
-          <lid>126</lid>
+          <lid>96</lid>
           </Symbol>
         <Rest>
-          <lid>127</lid>
+          <lid>97</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="32">
-        <KeySig>
-          <lid>129</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>130</lid>
+          <lid>99</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="33">
-        <KeySig>
-          <lid>132</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Symbol>
           <name>segno</name>
-          <lid>133</lid>
+          <lid>101</lid>
           </Symbol>
         <Symbol>
           <name>segno</name>
-          <lid>134</lid>
+          <lid>102</lid>
           </Symbol>
         <Symbol>
           <name>segno</name>
-          <lid>146</lid>
+          <lid>112</lid>
           </Symbol>
         <Rest>
-          <lid>135</lid>
+          <lid>103</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="34">
-        <KeySig>
-          <lid>137</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Symbol>
           <name>coda</name>
-          <lid>138</lid>
+          <lid>105</lid>
           </Symbol>
         <Rest>
-          <lid>139</lid>
+          <lid>106</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="35">
-        <KeySig>
-          <lid>141</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Symbol>
           <name>coda</name>
-          <lid>142</lid>
+          <lid>108</lid>
           </Symbol>
         <Symbol>
           <name>coda</name>
-          <lid>143</lid>
+          <lid>109</lid>
           </Symbol>
         <Symbol>
           <name>coda</name>
-          <lid>147</lid>
+          <lid>113</lid>
           </Symbol>
         <Rest>
-          <lid>144</lid>
+          <lid>110</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
@@ -701,8 +565,6 @@
       <showMargins>0</showMargins>
       <PageList>
         <Page>
-          <System>
-            </System>
           <System>
             </System>
           <System>
@@ -851,26 +713,18 @@
             <lid>13</lid>
             <text>Da Capo</text>
             </StaffText>
-          <KeySig>
-            <lid>14</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>15</lid>
+            <lid>14</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>17</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>18</lid>
+            <lid>16</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>17</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -878,43 +732,35 @@
               </Note>
             </Chord>
           <Rest>
+            <lid>18</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <lid>19</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
             <lid>20</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <Rest>
-            <lid>21</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <Rest>
-            <lid>22</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="4">
           <StaffText>
-            <lid>24</lid>
+            <lid>22</lid>
             <text>D.C. al Coda</text>
             </StaffText>
-          <KeySig>
-            <lid>25</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>26</lid>
+            <lid>23</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="5">
-          <KeySig>
-            <lid>28</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>29</lid>
+            <lid>25</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>30</lid>
+              <lid>26</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -922,43 +768,35 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>31</lid>
+            <lid>27</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>32</lid>
+            <lid>28</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>33</lid>
+            <lid>29</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="6">
           <StaffText>
-            <lid>35</lid>
+            <lid>31</lid>
             <text>D.C. al Double Coda</text>
             </StaffText>
-          <KeySig>
-            <lid>36</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>37</lid>
+            <lid>32</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="7">
-          <KeySig>
-            <lid>39</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>40</lid>
+            <lid>34</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>41</lid>
+              <lid>35</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -966,394 +804,402 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>42</lid>
+            <lid>36</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>43</lid>
+            <lid>37</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>44</lid>
+            <lid>38</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="8">
           <StaffText>
-            <lid>46</lid>
+            <lid>40</lid>
             <text>D.C. al Fine</text>
             </StaffText>
-          <KeySig>
-            <lid>47</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>48</lid>
+            <lid>41</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="9">
-          <KeySig>
-            <lid>50</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="8" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
           <Rest>
-            <lid>51</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>17280</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>15360</tick>
+        <Measure number="9">
+          <Rest>
+            <lid>43</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="10">
           <StaffText>
-            <lid>53</lid>
+            <lid>45</lid>
             <text>D.S. al Coda</text>
             </StaffText>
-          <KeySig>
-            <lid>54</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>55</lid>
+            <lid>46</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="11">
-          <KeySig>
-            <lid>57</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="10" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
           <Rest>
-            <lid>58</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>21120</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>19200</tick>
+        <Measure number="11">
+          <Rest>
+            <lid>48</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="12">
           <StaffText>
-            <lid>60</lid>
+            <lid>50</lid>
             <text>D.S. al Double Coda</text>
             </StaffText>
-          <KeySig>
-            <lid>61</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>62</lid>
+            <lid>51</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="13">
-          <KeySig>
-            <lid>64</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="12" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
           <Rest>
-            <lid>65</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>24960</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>23040</tick>
+        <Measure number="13">
+          <Rest>
+            <lid>53</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="14">
           <StaffText>
-            <lid>67</lid>
+            <lid>55</lid>
             <text>D.S. al Fine</text>
             </StaffText>
-          <KeySig>
-            <lid>68</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>69</lid>
+            <lid>56</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="15">
-          <KeySig>
-            <lid>71</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="14" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
           <Rest>
-            <lid>72</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>28800</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>26880</tick>
+        <Measure number="15">
+          <Rest>
+            <lid>58</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="16">
           <StaffText>
-            <lid>74</lid>
+            <lid>60</lid>
             <text>Da Segno Segno</text>
             </StaffText>
-          <KeySig>
-            <lid>75</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>76</lid>
+            <lid>61</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="17">
-          <KeySig>
-            <lid>78</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="16" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
           <Rest>
-            <lid>79</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>34560</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>30720</tick>
+        <Measure number="17">
+          <Rest>
+            <lid>63</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="18">
-          <KeySig>
-            <lid>81</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>82</lid>
+            <lid>65</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="19">
           <StaffText>
-            <lid>84</lid>
+            <lid>67</lid>
             <text>D.S.S. al Coda</text>
             </StaffText>
-          <KeySig>
-            <lid>85</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>86</lid>
+            <lid>68</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="20">
-          <KeySig>
-            <lid>88</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="19" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
           <Rest>
-            <lid>89</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>40320</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>36480</tick>
+        <Measure number="20">
+          <Rest>
+            <lid>70</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="21">
-          <KeySig>
-            <lid>91</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>92</lid>
+            <lid>72</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="22">
           <StaffText>
-            <lid>94</lid>
+            <lid>74</lid>
             <text>D.S.S. al Double Coda</text>
             </StaffText>
-          <KeySig>
-            <lid>95</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>96</lid>
+            <lid>75</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="23">
-          <KeySig>
-            <lid>98</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="22" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
           <Rest>
-            <lid>99</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>46080</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>42240</tick>
+        <Measure number="23">
+          <Rest>
+            <lid>77</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="24">
-          <KeySig>
-            <lid>101</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>102</lid>
+            <lid>79</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="25">
           <StaffText>
-            <lid>104</lid>
+            <lid>81</lid>
             <text>D.S.S. al Fine</text>
             </StaffText>
-          <KeySig>
-            <lid>105</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>106</lid>
+            <lid>82</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="26">
-          <KeySig>
-            <lid>108</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="25" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
           <Rest>
-            <lid>109</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>49920</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>48000</tick>
+        <Measure number="26">
+          <Rest>
+            <lid>84</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="27">
           <StaffText>
-            <lid>111</lid>
+            <lid>86</lid>
             <text>Da Coda</text>
             </StaffText>
-          <KeySig>
-            <lid>112</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>113</lid>
+            <lid>87</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="28">
-          <KeySig>
-            <lid>115</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="27" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
           <Rest>
-            <lid>116</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>53760</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>51840</tick>
+        <Measure number="28">
+          <Rest>
+            <lid>89</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="29">
           <StaffText>
-            <lid>118</lid>
+            <lid>91</lid>
             <text>Da Double Coda</text>
             </StaffText>
-          <KeySig>
-            <lid>119</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>120</lid>
+            <lid>92</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="30">
-          <KeySig>
-            <lid>122</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="29" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
           <Rest>
-            <lid>123</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>57600</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>55680</tick>
+        <Measure number="30">
+          <Rest>
+            <lid>94</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="31">
-          <KeySig>
-            <lid>125</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Symbol>
             <name>segno</name>
-            <lid>126</lid>
+            <lid>96</lid>
             </Symbol>
           <Rest>
-            <lid>127</lid>
+            <lid>97</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="32">
-          <KeySig>
-            <lid>129</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>130</lid>
+            <lid>99</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="33">
-          <KeySig>
-            <lid>132</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Symbol>
             <name>segno</name>
-            <lid>133</lid>
+            <lid>101</lid>
             </Symbol>
           <Symbol>
             <name>segno</name>
-            <lid>134</lid>
+            <lid>102</lid>
             </Symbol>
           <Symbol>
             <name>segno</name>
-            <lid>146</lid>
+            <lid>112</lid>
             </Symbol>
           <Rest>
-            <lid>135</lid>
+            <lid>103</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="34">
-          <KeySig>
-            <lid>137</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Symbol>
             <name>coda</name>
-            <lid>138</lid>
+            <lid>105</lid>
             </Symbol>
           <Rest>
-            <lid>139</lid>
+            <lid>106</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="35">
-          <KeySig>
-            <lid>141</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Symbol>
             <name>coda</name>
-            <lid>142</lid>
+            <lid>108</lid>
             </Symbol>
           <Symbol>
             <name>coda</name>
-            <lid>143</lid>
+            <lid>109</lid>
             </Symbol>
           <Symbol>
             <name>coda</name>
-            <lid>147</lid>
+            <lid>113</lid>
             </Symbol>
           <Rest>
-            <lid>144</lid>
+            <lid>110</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
@@ -1394,26 +1240,18 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>14</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>15</lid>
+            <lid>14</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>17</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>18</lid>
+            <lid>16</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>17</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -1421,39 +1259,31 @@
               </Note>
             </Chord>
           <Rest>
+            <lid>18</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <lid>19</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
             <lid>20</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <Rest>
-            <lid>21</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <Rest>
-            <lid>22</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="4">
-          <KeySig>
-            <lid>25</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>26</lid>
+            <lid>23</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="5">
-          <KeySig>
-            <lid>28</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>29</lid>
+            <lid>25</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>30</lid>
+              <lid>26</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -1461,39 +1291,31 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>31</lid>
+            <lid>27</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>32</lid>
+            <lid>28</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>33</lid>
+            <lid>29</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="6">
-          <KeySig>
-            <lid>36</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>37</lid>
+            <lid>32</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="7">
-          <KeySig>
-            <lid>39</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>40</lid>
+            <lid>34</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>41</lid>
+              <lid>35</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -1501,330 +1323,338 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>42</lid>
+            <lid>36</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>43</lid>
+            <lid>37</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>44</lid>
+            <lid>38</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="8">
-          <KeySig>
-            <lid>47</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Rest>
+            <lid>41</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="8" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>17280</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>15360</tick>
+        <Measure number="9">
+          <Rest>
+            <lid>43</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="10">
+          <Rest>
+            <lid>46</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="10" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>21120</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>19200</tick>
+        <Measure number="11">
           <Rest>
             <lid>48</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="9">
-          <KeySig>
-            <lid>50</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="12">
           <Rest>
             <lid>51</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="10">
-          <KeySig>
-            <lid>54</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="12" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
           <Rest>
-            <lid>55</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>24960</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>23040</tick>
+        <Measure number="13">
+          <Rest>
+            <lid>53</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="11">
-          <KeySig>
-            <lid>57</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="14">
+          <Rest>
+            <lid>56</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="14" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>28800</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>26880</tick>
+        <Measure number="15">
           <Rest>
             <lid>58</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="12">
-          <KeySig>
-            <lid>61</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="16">
           <Rest>
-            <lid>62</lid>
+            <lid>61</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="13">
-          <KeySig>
-            <lid>64</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="16" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>34560</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>30720</tick>
+        <Measure number="17">
+          <Rest>
+            <lid>63</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="18">
           <Rest>
             <lid>65</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="14">
-          <KeySig>
-            <lid>68</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="19">
           <Rest>
-            <lid>69</lid>
+            <lid>68</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="15">
-          <KeySig>
-            <lid>71</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="19" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>40320</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>36480</tick>
+        <Measure number="20">
+          <Rest>
+            <lid>70</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="21">
           <Rest>
             <lid>72</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="16">
-          <KeySig>
-            <lid>75</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="22">
           <Rest>
-            <lid>76</lid>
+            <lid>75</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="17">
-          <KeySig>
-            <lid>78</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="22" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>46080</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>42240</tick>
+        <Measure number="23">
+          <Rest>
+            <lid>77</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="24">
           <Rest>
             <lid>79</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="18">
-          <KeySig>
-            <lid>81</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="25">
           <Rest>
             <lid>82</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="19">
-          <KeySig>
-            <lid>85</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="25" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
           <Rest>
-            <lid>86</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>49920</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>48000</tick>
+        <Measure number="26">
+          <Rest>
+            <lid>84</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="20">
-          <KeySig>
-            <lid>88</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="27">
+          <Rest>
+            <lid>87</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="27" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>53760</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>51840</tick>
+        <Measure number="28">
           <Rest>
             <lid>89</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="21">
-          <KeySig>
-            <lid>91</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="29">
           <Rest>
             <lid>92</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="22">
-          <KeySig>
-            <lid>95</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="29" len="8/4">
+          <multiMeasureRest>2</multiMeasureRest>
           <Rest>
-            <lid>96</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>57600</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>55680</tick>
+        <Measure number="30">
+          <Rest>
+            <lid>94</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="23">
-          <KeySig>
-            <lid>98</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="31">
+          <Rest>
+            <lid>97</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="32">
           <Rest>
             <lid>99</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="24">
-          <KeySig>
-            <lid>101</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="33">
+          <Symbol>
+            <name>segno</name>
+            <lid>112</lid>
+            </Symbol>
           <Rest>
-            <lid>102</lid>
+            <lid>103</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="25">
-          <KeySig>
-            <lid>105</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="34">
           <Rest>
             <lid>106</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="26">
-          <KeySig>
-            <lid>108</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>109</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="27">
-          <KeySig>
-            <lid>112</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>113</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="28">
-          <KeySig>
-            <lid>115</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>116</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="29">
-          <KeySig>
-            <lid>119</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>120</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="30">
-          <KeySig>
-            <lid>122</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>123</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="31">
-          <KeySig>
-            <lid>125</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>127</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="32">
-          <KeySig>
-            <lid>129</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>130</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="33">
-          <KeySig>
-            <lid>132</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Symbol>
-            <name>segno</name>
-            <lid>146</lid>
-            </Symbol>
-          <Rest>
-            <lid>135</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="34">
-          <KeySig>
-            <lid>137</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>139</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
         <Measure number="35">
-          <KeySig>
-            <lid>141</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Symbol>
             <name>coda</name>
-            <lid>147</lid>
+            <lid>113</lid>
             </Symbol>
           <Rest>
-            <lid>144</lid>
+            <lid>110</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>

--- a/mtest/guitarpro/double-bar.gpx-ref.mscx
+++ b/mtest/guitarpro/double-bar.gpx-ref.mscx
@@ -161,15 +161,11 @@
           </BarLine>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>13</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>14</lid>
+          <lid>13</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>15</lid>
+            <lid>14</lid>
             <pitch>65</pitch>
             <tpc>13</tpc>
             <fret>6</fret>
@@ -177,10 +173,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>16</lid>
+          <lid>15</lid>
           <durationType>half</durationType>
           <Note>
-            <lid>17</lid>
+            <lid>16</lid>
             <pitch>52</pitch>
             <tpc>18</tpc>
             <fret>2</fret>
@@ -188,10 +184,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>18</lid>
+          <lid>17</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>19</lid>
+            <lid>18</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -386,15 +382,11 @@
             </BarLine>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>13</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>14</lid>
+            <lid>13</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <fret>6</fret>
@@ -402,10 +394,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>16</lid>
+            <lid>15</lid>
             <durationType>half</durationType>
             <Note>
-              <lid>17</lid>
+              <lid>16</lid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <fret>2</fret>
@@ -413,10 +405,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>18</lid>
+            <lid>17</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>18</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -474,15 +466,11 @@
             </BarLine>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>13</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>14</lid>
+            <lid>13</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <fret>6</fret>
@@ -490,10 +478,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>16</lid>
+            <lid>15</lid>
             <durationType>half</durationType>
             <Note>
-              <lid>17</lid>
+              <lid>16</lid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <fret>2</fret>
@@ -501,10 +489,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>18</lid>
+            <lid>17</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>18</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>

--- a/mtest/guitarpro/fermata.gpx-ref.mscx
+++ b/mtest/guitarpro/fermata.gpx-ref.mscx
@@ -147,15 +147,11 @@
           </Rest>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>12</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>13</lid>
+          <lid>12</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>14</lid>
+            <lid>13</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>12</fret>
@@ -163,14 +159,14 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>16</lid>
+          <lid>15</lid>
           <durationType>quarter</durationType>
           <Articulation>
             <subtype>fermata</subtype>
-            <lid>15</lid>
+            <lid>14</lid>
             </Articulation>
           <Note>
-            <lid>17</lid>
+            <lid>16</lid>
             <Accidental>
               <subtype>flat</subtype>
               </Accidental>
@@ -181,10 +177,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>18</lid>
+          <lid>17</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>19</lid>
+            <lid>18</lid>
             <pitch>55</pitch>
             <tpc>15</tpc>
             <fret>5</fret>
@@ -192,24 +188,20 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>20</lid>
+          <lid>19</lid>
           <durationType>quarter</durationType>
           </Rest>
         </Measure>
       <Measure number="3">
-        <KeySig>
-          <lid>22</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>24</lid>
+          <lid>22</lid>
           <durationType>quarter</durationType>
           <Articulation>
             <subtype>fermata</subtype>
-            <lid>23</lid>
+            <lid>21</lid>
             </Articulation>
           <Note>
-            <lid>25</lid>
+            <lid>23</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>12</fret>
@@ -217,21 +209,21 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>26</lid>
+          <lid>24</lid>
           <durationType>quarter</durationType>
           <Articulation>
             <subtype>fermata</subtype>
             </Articulation>
           </Rest>
         <Chord>
-          <lid>28</lid>
+          <lid>26</lid>
           <durationType>quarter</durationType>
           <Articulation>
             <subtype>fermata</subtype>
-            <lid>27</lid>
+            <lid>25</lid>
             </Articulation>
           <Note>
-            <lid>29</lid>
+            <lid>27</lid>
             <Accidental>
               <subtype>sharp</subtype>
               </Accidental>
@@ -242,24 +234,20 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>30</lid>
+          <lid>28</lid>
           <durationType>quarter</durationType>
           </Rest>
         </Measure>
       <Measure number="4">
-        <KeySig>
-          <lid>32</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>34</lid>
+          <lid>31</lid>
           <durationType>quarter</durationType>
           <Articulation>
             <subtype>fermata</subtype>
-            <lid>33</lid>
+            <lid>30</lid>
             </Articulation>
           <Note>
-            <lid>35</lid>
+            <lid>32</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>12</fret>
@@ -267,15 +255,15 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>36</lid>
+          <lid>33</lid>
           <durationType>quarter</durationType>
           </Rest>
         <Rest>
-          <lid>37</lid>
+          <lid>34</lid>
           <durationType>quarter</durationType>
           </Rest>
         <Rest>
-          <lid>38</lid>
+          <lid>35</lid>
           <durationType>quarter</durationType>
           </Rest>
         <BarLine>
@@ -452,15 +440,11 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>12</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>13</lid>
+            <lid>12</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>12</fret>
@@ -468,14 +452,14 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>16</lid>
+            <lid>15</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>fermata</subtype>
-              <lid>15</lid>
+              <lid>14</lid>
               </Articulation>
             <Note>
-              <lid>17</lid>
+              <lid>16</lid>
               <Accidental>
                 <subtype>flat</subtype>
                 </Accidental>
@@ -486,10 +470,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>18</lid>
+            <lid>17</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>18</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -497,24 +481,20 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>20</lid>
+            <lid>19</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>22</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>24</lid>
+            <lid>22</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>fermata</subtype>
-              <lid>23</lid>
+              <lid>21</lid>
               </Articulation>
             <Note>
-              <lid>25</lid>
+              <lid>23</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>12</fret>
@@ -522,21 +502,21 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>26</lid>
+            <lid>24</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>fermata</subtype>
               </Articulation>
             </Rest>
           <Chord>
-            <lid>28</lid>
+            <lid>26</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>fermata</subtype>
-              <lid>27</lid>
+              <lid>25</lid>
               </Articulation>
             <Note>
-              <lid>29</lid>
+              <lid>27</lid>
               <Accidental>
                 <subtype>sharp</subtype>
                 </Accidental>
@@ -547,24 +527,20 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>30</lid>
+            <lid>28</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="4">
-          <KeySig>
-            <lid>32</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>34</lid>
+            <lid>31</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>fermata</subtype>
-              <lid>33</lid>
+              <lid>30</lid>
               </Articulation>
             <Note>
-              <lid>35</lid>
+              <lid>32</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>12</fret>
@@ -572,15 +548,15 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>36</lid>
+            <lid>33</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>37</lid>
+            <lid>34</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>38</lid>
+            <lid>35</lid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>
@@ -620,15 +596,11 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>12</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>13</lid>
+            <lid>12</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>12</fret>
@@ -636,14 +608,14 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>16</lid>
+            <lid>15</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>fermata</subtype>
-              <lid>15</lid>
+              <lid>14</lid>
               </Articulation>
             <Note>
-              <lid>17</lid>
+              <lid>16</lid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               <fret>8</fret>
@@ -651,10 +623,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>18</lid>
+            <lid>17</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>18</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -662,24 +634,20 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>20</lid>
+            <lid>19</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>22</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>24</lid>
+            <lid>22</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>fermata</subtype>
-              <lid>23</lid>
+              <lid>21</lid>
               </Articulation>
             <Note>
-              <lid>25</lid>
+              <lid>23</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>12</fret>
@@ -687,21 +655,21 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>26</lid>
+            <lid>24</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>fermata</subtype>
               </Articulation>
             </Rest>
           <Chord>
-            <lid>28</lid>
+            <lid>26</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>fermata</subtype>
-              <lid>27</lid>
+              <lid>25</lid>
               </Articulation>
             <Note>
-              <lid>29</lid>
+              <lid>27</lid>
               <pitch>49</pitch>
               <tpc>21</tpc>
               <fret>4</fret>
@@ -709,24 +677,20 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>30</lid>
+            <lid>28</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="4">
-          <KeySig>
-            <lid>32</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>34</lid>
+            <lid>31</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>fermata</subtype>
-              <lid>33</lid>
+              <lid>30</lid>
               </Articulation>
             <Note>
-              <lid>35</lid>
+              <lid>32</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>12</fret>
@@ -734,15 +698,15 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>36</lid>
+            <lid>33</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>37</lid>
+            <lid>34</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>38</lid>
+            <lid>35</lid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>

--- a/mtest/guitarpro/fingering.gpx-ref.mscx
+++ b/mtest/guitarpro/fingering.gpx-ref.mscx
@@ -188,17 +188,13 @@
           </Chord>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>19</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>20</lid>
+          <lid>19</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>21</lid>
+            <lid>20</lid>
             <Fingering>
-              <lid>22</lid>
+              <lid>21</lid>
               <pos x="0.6498" y="-1.6"/>
               <text>3</text>
               </Fingering>
@@ -209,15 +205,15 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>23</lid>
+          <lid>22</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>24</lid>
+            <lid>23</lid>
             <Accidental>
               <subtype>flat</subtype>
               </Accidental>
             <Fingering>
-              <lid>25</lid>
+              <lid>24</lid>
               <pos x="0.6498" y="-1.6"/>
               <text>4</text>
               </Fingering>
@@ -228,15 +224,15 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>26</lid>
+          <lid>25</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>27</lid>
+            <lid>26</lid>
             <Accidental>
               <subtype>sharp</subtype>
               </Accidental>
             <Fingering>
-              <lid>28</lid>
+              <lid>27</lid>
               <pos x="0.6498" y="-1.6"/>
               <text>P</text>
               </Fingering>
@@ -247,15 +243,15 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>29</lid>
+          <lid>28</lid>
           <durationType>half</durationType>
           <Note>
-            <lid>30</lid>
+            <lid>29</lid>
             <Accidental>
               <subtype>natural</subtype>
               </Accidental>
             <Fingering>
-              <lid>31</lid>
+              <lid>30</lid>
               <pos x="0.6864" y="-1.6"/>
               <text>I</text>
               </Fingering>
@@ -267,17 +263,13 @@
           </Chord>
         </Measure>
       <Measure number="3">
-        <KeySig>
-          <lid>33</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>34</lid>
+          <lid>32</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>35</lid>
+            <lid>33</lid>
             <Fingering>
-              <lid>36</lid>
+              <lid>34</lid>
               <pos x="0.6498" y="-1.6"/>
               <text>M</text>
               </Fingering>
@@ -288,15 +280,15 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>37</lid>
+          <lid>35</lid>
           <durationType>half</durationType>
           <Note>
-            <lid>38</lid>
+            <lid>36</lid>
             <Accidental>
               <subtype>sharp</subtype>
               </Accidental>
             <Fingering>
-              <lid>39</lid>
+              <lid>37</lid>
               <pos x="0.6864" y="-1.6"/>
               <text>A</text>
               </Fingering>
@@ -307,12 +299,12 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>40</lid>
+          <lid>38</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>41</lid>
+            <lid>39</lid>
             <Fingering>
-              <lid>42</lid>
+              <lid>40</lid>
               <pos x="0.6498" y="-1.6"/>
               <text>C</text>
               </Fingering>
@@ -323,7 +315,7 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>43</lid>
+          <lid>41</lid>
           <durationType>quarter</durationType>
           </Rest>
         <BarLine>
@@ -541,17 +533,13 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>19</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>20</lid>
+            <lid>19</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>21</lid>
+              <lid>20</lid>
               <Fingering>
-                <lid>22</lid>
+                <lid>21</lid>
                 <pos x="0.6498" y="-1.6"/>
                 <text>3</text>
                 </Fingering>
@@ -562,15 +550,15 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>23</lid>
+            <lid>22</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>24</lid>
+              <lid>23</lid>
               <Accidental>
                 <subtype>flat</subtype>
                 </Accidental>
               <Fingering>
-                <lid>25</lid>
+                <lid>24</lid>
                 <pos x="0.6498" y="-1.6"/>
                 <text>4</text>
                 </Fingering>
@@ -581,15 +569,15 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>26</lid>
+            <lid>25</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>27</lid>
+              <lid>26</lid>
               <Accidental>
                 <subtype>sharp</subtype>
                 </Accidental>
               <Fingering>
-                <lid>28</lid>
+                <lid>27</lid>
                 <pos x="0.6498" y="-1.6"/>
                 <text>P</text>
                 </Fingering>
@@ -600,15 +588,15 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>29</lid>
+            <lid>28</lid>
             <durationType>half</durationType>
             <Note>
-              <lid>30</lid>
+              <lid>29</lid>
               <Accidental>
                 <subtype>natural</subtype>
                 </Accidental>
               <Fingering>
-                <lid>31</lid>
+                <lid>30</lid>
                 <pos x="0.6864" y="-1.6"/>
                 <text>I</text>
                 </Fingering>
@@ -620,17 +608,13 @@
             </Chord>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>33</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>34</lid>
+            <lid>32</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>35</lid>
+              <lid>33</lid>
               <Fingering>
-                <lid>36</lid>
+                <lid>34</lid>
                 <pos x="0.6498" y="-1.6"/>
                 <text>M</text>
                 </Fingering>
@@ -641,15 +625,15 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>37</lid>
+            <lid>35</lid>
             <durationType>half</durationType>
             <Note>
-              <lid>38</lid>
+              <lid>36</lid>
               <Accidental>
                 <subtype>sharp</subtype>
                 </Accidental>
               <Fingering>
-                <lid>39</lid>
+                <lid>37</lid>
                 <pos x="0.6864" y="-1.6"/>
                 <text>A</text>
                 </Fingering>
@@ -660,12 +644,12 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>40</lid>
+            <lid>38</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>41</lid>
+              <lid>39</lid>
               <Fingering>
-                <lid>42</lid>
+                <lid>40</lid>
                 <pos x="0.6498" y="-1.6"/>
                 <text>C</text>
                 </Fingering>
@@ -676,7 +660,7 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>43</lid>
+            <lid>41</lid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>
@@ -757,17 +741,13 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>19</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>20</lid>
+            <lid>19</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>21</lid>
+              <lid>20</lid>
               <Fingering>
-                <lid>22</lid>
+                <lid>21</lid>
                 <pos x="0.6498" y="-1.6"/>
                 <text>3</text>
                 </Fingering>
@@ -778,12 +758,12 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>23</lid>
+            <lid>22</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>24</lid>
+              <lid>23</lid>
               <Fingering>
-                <lid>25</lid>
+                <lid>24</lid>
                 <pos x="0.6498" y="-1.6"/>
                 <text>4</text>
                 </Fingering>
@@ -794,12 +774,12 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>26</lid>
+            <lid>25</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>27</lid>
+              <lid>26</lid>
               <Fingering>
-                <lid>28</lid>
+                <lid>27</lid>
                 <pos x="0.6498" y="-1.6"/>
                 <text>P</text>
                 </Fingering>
@@ -810,12 +790,12 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>29</lid>
+            <lid>28</lid>
             <durationType>half</durationType>
             <Note>
-              <lid>30</lid>
+              <lid>29</lid>
               <Fingering>
-                <lid>31</lid>
+                <lid>30</lid>
                 <pos x="0.6864" y="-1.6"/>
                 <text>I</text>
                 </Fingering>
@@ -827,17 +807,13 @@
             </Chord>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>33</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>34</lid>
+            <lid>32</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>35</lid>
+              <lid>33</lid>
               <Fingering>
-                <lid>36</lid>
+                <lid>34</lid>
                 <pos x="0.6498" y="-1.6"/>
                 <text>M</text>
                 </Fingering>
@@ -848,12 +824,12 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>37</lid>
+            <lid>35</lid>
             <durationType>half</durationType>
             <Note>
-              <lid>38</lid>
+              <lid>36</lid>
               <Fingering>
-                <lid>39</lid>
+                <lid>37</lid>
                 <pos x="0.6864" y="-1.6"/>
                 <text>A</text>
                 </Fingering>
@@ -864,12 +840,12 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>40</lid>
+            <lid>38</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>41</lid>
+              <lid>39</lid>
               <Fingering>
-                <lid>42</lid>
+                <lid>40</lid>
                 <pos x="0.6498" y="-1.6"/>
                 <text>C</text>
                 </Fingering>
@@ -880,7 +856,7 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>43</lid>
+            <lid>41</lid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>

--- a/mtest/guitarpro/free-time.gpx-ref.mscx
+++ b/mtest/guitarpro/free-time.gpx-ref.mscx
@@ -167,21 +167,17 @@
           </BarLine>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>16</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <TimeSig>
-          <lid>17</lid>
+          <lid>16</lid>
           <sigN>4</sigN>
           <sigD>4</sigD>
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <Chord>
-          <lid>18</lid>
+          <lid>17</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>19</lid>
+            <lid>18</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>12</fret>
@@ -189,10 +185,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>20</lid>
+          <lid>19</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>21</lid>
+            <lid>20</lid>
             <Accidental>
               <subtype>flat</subtype>
               </Accidental>
@@ -203,10 +199,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>22</lid>
+          <lid>21</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>23</lid>
+            <lid>22</lid>
             <pitch>55</pitch>
             <tpc>15</tpc>
             <fret>5</fret>
@@ -214,7 +210,7 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>24</lid>
+          <lid>23</lid>
           <durationType>quarter</durationType>
           </Rest>
         <BarLine>
@@ -411,21 +407,17 @@
             </BarLine>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>16</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <TimeSig>
-            <lid>17</lid>
+            <lid>16</lid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             <showCourtesySig>1</showCourtesySig>
             </TimeSig>
           <Chord>
-            <lid>18</lid>
+            <lid>17</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>18</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>12</fret>
@@ -433,10 +425,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>20</lid>
+            <lid>19</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>21</lid>
+              <lid>20</lid>
               <Accidental>
                 <subtype>flat</subtype>
                 </Accidental>
@@ -447,10 +439,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>22</lid>
+            <lid>21</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>23</lid>
+              <lid>22</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -458,7 +450,7 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>24</lid>
+            <lid>23</lid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>
@@ -502,15 +494,11 @@
             </BarLine>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>16</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>18</lid>
+            <lid>17</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>18</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>12</fret>
@@ -518,10 +506,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>20</lid>
+            <lid>19</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>21</lid>
+              <lid>20</lid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               <fret>8</fret>
@@ -529,10 +517,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>22</lid>
+            <lid>21</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>23</lid>
+              <lid>22</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -540,7 +528,7 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>24</lid>
+            <lid>23</lid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>

--- a/mtest/guitarpro/fret-diagram.gpx-ref.mscx
+++ b/mtest/guitarpro/fret-diagram.gpx-ref.mscx
@@ -105,53 +105,49 @@
           </Rest>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>8</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Dynamic>
           <subtype>f</subtype>
           <velocity>96</velocity>
-          <lid>9</lid>
+          <lid>8</lid>
           </Dynamic>
         <Beam id="1">
           <l1>-8</l1>
           <l2>-8</l2>
           </Beam>
         <Chord>
-          <lid>10</lid>
+          <lid>9</lid>
           <durationType>eighth</durationType>
           <Beam>1</Beam>
           <Note>
-            <lid>11</lid>
+            <lid>10</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>12</lid>
+            <lid>11</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>13</lid>
+            <lid>12</lid>
             <pitch>55</pitch>
             <tpc>15</tpc>
             <fret>5</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>14</lid>
+            <lid>13</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>15</lid>
+            <lid>14</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -159,25 +155,25 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>16</lid>
+          <lid>15</lid>
           <durationType>16th</durationType>
           <Beam>1</Beam>
           <Note>
-            <lid>17</lid>
+            <lid>16</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>18</lid>
+            <lid>17</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>19</lid>
+            <lid>18</lid>
             <Accidental>
               <subtype>sharp</subtype>
               </Accidental>
@@ -187,21 +183,21 @@
             <string>4</string>
             </Note>
           <Note>
-            <lid>20</lid>
+            <lid>19</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>7</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>21</lid>
+            <lid>20</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>22</lid>
+            <lid>21</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -209,46 +205,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>23</lid>
+          <lid>22</lid>
           <durationType>16th</durationType>
           <Beam>1</Beam>
           <Note>
-            <lid>24</lid>
+            <lid>23</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>25</lid>
+            <lid>24</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>26</lid>
+            <lid>25</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
+            </Note>
+          <Note>
+            <lid>26</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>27</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
-            </Note>
-          <Note>
-            <lid>28</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>29</lid>
+            <lid>28</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -256,46 +252,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>30</lid>
+          <lid>29</lid>
           <durationType>eighth</durationType>
           <Beam>1</Beam>
           <Note>
-            <lid>31</lid>
+            <lid>30</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>32</lid>
+            <lid>31</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>33</lid>
+            <lid>32</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>34</lid>
+            <lid>33</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>7</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>35</lid>
+            <lid>34</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>36</lid>
+            <lid>35</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -307,46 +303,46 @@
           <l2>-8</l2>
           </Beam>
         <Chord>
-          <lid>37</lid>
+          <lid>36</lid>
           <durationType>eighth</durationType>
           <Beam>2</Beam>
           <Note>
-            <lid>38</lid>
+            <lid>37</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>39</lid>
+            <lid>38</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>40</lid>
+            <lid>39</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
+            </Note>
+          <Note>
+            <lid>40</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>41</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
-            </Note>
-          <Note>
-            <lid>42</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>43</lid>
+            <lid>42</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -354,46 +350,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>44</lid>
+          <lid>43</lid>
           <durationType>16th</durationType>
           <Beam>2</Beam>
           <Note>
-            <lid>45</lid>
+            <lid>44</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>46</lid>
+            <lid>45</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>47</lid>
+            <lid>46</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
+            </Note>
+          <Note>
+            <lid>47</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>48</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
-            </Note>
-          <Note>
-            <lid>49</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>50</lid>
+            <lid>49</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -401,46 +397,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>51</lid>
+          <lid>50</lid>
           <durationType>16th</durationType>
           <Beam>2</Beam>
           <Note>
-            <lid>52</lid>
+            <lid>51</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>53</lid>
+            <lid>52</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>54</lid>
+            <lid>53</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
+            </Note>
+          <Note>
+            <lid>54</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>55</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
-            </Note>
-          <Note>
-            <lid>56</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>57</lid>
+            <lid>56</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -448,46 +444,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>58</lid>
+          <lid>57</lid>
           <durationType>eighth</durationType>
           <Beam>2</Beam>
           <Note>
-            <lid>59</lid>
+            <lid>58</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>60</lid>
+            <lid>59</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>61</lid>
+            <lid>60</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>62</lid>
+            <lid>61</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>7</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>63</lid>
+            <lid>62</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>64</lid>
+            <lid>63</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -495,7 +491,7 @@
             </Note>
           </Chord>
         <FretDiagram>
-          <lid>65</lid>
+          <lid>64</lid>
           <strings>7</strings>
           <string no="0">
             <marker>88</marker>
@@ -524,46 +520,46 @@
           <l2>-11</l2>
           </Beam>
         <Chord>
-          <lid>66</lid>
+          <lid>65</lid>
           <durationType>eighth</durationType>
           <Beam>3</Beam>
           <Note>
-            <lid>67</lid>
+            <lid>66</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>68</lid>
+            <lid>67</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>69</lid>
+            <lid>68</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
+            </Note>
+          <Note>
+            <lid>69</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>70</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
-            </Note>
-          <Note>
-            <lid>71</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>72</lid>
+            <lid>71</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -571,46 +567,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>73</lid>
+          <lid>72</lid>
           <durationType>16th</durationType>
           <Beam>3</Beam>
           <Note>
-            <lid>74</lid>
+            <lid>73</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>75</lid>
+            <lid>74</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>76</lid>
+            <lid>75</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
+            </Note>
+          <Note>
+            <lid>76</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>77</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
-            </Note>
-          <Note>
-            <lid>78</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>79</lid>
+            <lid>78</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -618,46 +614,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>80</lid>
+          <lid>79</lid>
           <durationType>16th</durationType>
           <Beam>3</Beam>
           <Note>
-            <lid>81</lid>
+            <lid>80</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>82</lid>
+            <lid>81</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>83</lid>
+            <lid>82</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
+            </Note>
+          <Note>
+            <lid>83</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>84</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
-            </Note>
-          <Note>
-            <lid>85</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>86</lid>
+            <lid>85</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -665,46 +661,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>87</lid>
+          <lid>86</lid>
           <durationType>eighth</durationType>
           <Beam>3</Beam>
           <Note>
-            <lid>88</lid>
+            <lid>87</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>89</lid>
+            <lid>88</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>90</lid>
+            <lid>89</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>91</lid>
+            <lid>90</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>7</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>92</lid>
+            <lid>91</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>93</lid>
+            <lid>92</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -716,46 +712,46 @@
           <l2>-11</l2>
           </Beam>
         <Chord>
-          <lid>94</lid>
+          <lid>93</lid>
           <durationType>eighth</durationType>
           <Beam>4</Beam>
           <Note>
-            <lid>95</lid>
+            <lid>94</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>96</lid>
+            <lid>95</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>97</lid>
+            <lid>96</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
+            </Note>
+          <Note>
+            <lid>97</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>98</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
-            </Note>
-          <Note>
-            <lid>99</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>100</lid>
+            <lid>99</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -763,46 +759,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>101</lid>
+          <lid>100</lid>
           <durationType>16th</durationType>
           <Beam>4</Beam>
           <Note>
-            <lid>102</lid>
+            <lid>101</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>103</lid>
+            <lid>102</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>104</lid>
+            <lid>103</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
+            </Note>
+          <Note>
+            <lid>104</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>105</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
-            </Note>
-          <Note>
-            <lid>106</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>107</lid>
+            <lid>106</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -810,46 +806,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>108</lid>
+          <lid>107</lid>
           <durationType>16th</durationType>
           <Beam>4</Beam>
           <Note>
-            <lid>109</lid>
+            <lid>108</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>110</lid>
+            <lid>109</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>111</lid>
+            <lid>110</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
+            </Note>
+          <Note>
+            <lid>111</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>112</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
-            </Note>
-          <Note>
-            <lid>113</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>114</lid>
+            <lid>113</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -857,46 +853,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>115</lid>
+          <lid>114</lid>
           <durationType>eighth</durationType>
           <Beam>4</Beam>
           <Note>
-            <lid>116</lid>
+            <lid>115</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>117</lid>
+            <lid>116</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>118</lid>
+            <lid>117</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>119</lid>
+            <lid>118</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>7</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>120</lid>
+            <lid>119</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>121</lid>
+            <lid>120</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -1035,53 +1031,49 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>8</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Dynamic>
             <subtype>f</subtype>
             <velocity>96</velocity>
-            <lid>9</lid>
+            <lid>8</lid>
             </Dynamic>
           <Beam id="5">
             <l1>-8</l1>
             <l2>-8</l2>
             </Beam>
           <Chord>
-            <lid>10</lid>
+            <lid>9</lid>
             <durationType>eighth</durationType>
             <Beam>5</Beam>
             <Note>
-              <lid>11</lid>
+              <lid>10</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>12</lid>
+              <lid>11</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>13</lid>
+              <lid>12</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1089,25 +1081,25 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>16</lid>
+            <lid>15</lid>
             <durationType>16th</durationType>
             <Beam>5</Beam>
             <Note>
-              <lid>17</lid>
+              <lid>16</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>18</lid>
+              <lid>17</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>19</lid>
+              <lid>18</lid>
               <Accidental>
                 <subtype>sharp</subtype>
                 </Accidental>
@@ -1117,21 +1109,21 @@
               <string>4</string>
               </Note>
             <Note>
-              <lid>21</lid>
+              <lid>20</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>20</lid>
+              <lid>19</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>22</lid>
+              <lid>21</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1139,46 +1131,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>23</lid>
+            <lid>22</lid>
             <durationType>16th</durationType>
             <Beam>5</Beam>
             <Note>
-              <lid>24</lid>
+              <lid>23</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>25</lid>
+              <lid>24</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>26</lid>
+              <lid>25</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>28</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             <Note>
               <lid>27</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <lid>26</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>29</lid>
+              <lid>28</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1186,46 +1178,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>30</lid>
+            <lid>29</lid>
             <durationType>eighth</durationType>
             <Beam>5</Beam>
             <Note>
-              <lid>31</lid>
+              <lid>30</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>32</lid>
+              <lid>31</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>33</lid>
+              <lid>32</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>35</lid>
+              <lid>34</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>34</lid>
+              <lid>33</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>36</lid>
+              <lid>35</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1237,46 +1229,46 @@
             <l2>-8</l2>
             </Beam>
           <Chord>
-            <lid>37</lid>
+            <lid>36</lid>
             <durationType>eighth</durationType>
             <Beam>6</Beam>
             <Note>
-              <lid>38</lid>
+              <lid>37</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>39</lid>
+              <lid>38</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>40</lid>
+              <lid>39</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>42</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             <Note>
               <lid>41</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <lid>40</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>43</lid>
+              <lid>42</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1284,46 +1276,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>44</lid>
+            <lid>43</lid>
             <durationType>16th</durationType>
             <Beam>6</Beam>
             <Note>
-              <lid>45</lid>
+              <lid>44</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>46</lid>
+              <lid>45</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>47</lid>
+              <lid>46</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>49</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             <Note>
               <lid>48</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <lid>47</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>50</lid>
+              <lid>49</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1331,46 +1323,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>51</lid>
+            <lid>50</lid>
             <durationType>16th</durationType>
             <Beam>6</Beam>
             <Note>
-              <lid>52</lid>
+              <lid>51</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>53</lid>
+              <lid>52</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>54</lid>
+              <lid>53</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>56</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             <Note>
               <lid>55</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <lid>54</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>57</lid>
+              <lid>56</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1378,46 +1370,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>58</lid>
+            <lid>57</lid>
             <durationType>eighth</durationType>
             <Beam>6</Beam>
             <Note>
-              <lid>59</lid>
+              <lid>58</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>60</lid>
+              <lid>59</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>61</lid>
+              <lid>60</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>63</lid>
+              <lid>62</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>62</lid>
+              <lid>61</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>64</lid>
+              <lid>63</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1425,7 +1417,7 @@
               </Note>
             </Chord>
           <FretDiagram>
-            <lid>65</lid>
+            <lid>64</lid>
             <strings>7</strings>
             <string no="0">
               <marker>88</marker>
@@ -1454,46 +1446,46 @@
             <l2>-11</l2>
             </Beam>
           <Chord>
-            <lid>66</lid>
+            <lid>65</lid>
             <durationType>eighth</durationType>
             <Beam>7</Beam>
             <Note>
-              <lid>67</lid>
+              <lid>66</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>68</lid>
+              <lid>67</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>69</lid>
+              <lid>68</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>71</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             <Note>
               <lid>70</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <lid>69</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>72</lid>
+              <lid>71</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1501,46 +1493,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>73</lid>
+            <lid>72</lid>
             <durationType>16th</durationType>
             <Beam>7</Beam>
             <Note>
-              <lid>74</lid>
+              <lid>73</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>75</lid>
+              <lid>74</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>76</lid>
+              <lid>75</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>78</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             <Note>
               <lid>77</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <lid>76</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>79</lid>
+              <lid>78</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1548,46 +1540,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>80</lid>
+            <lid>79</lid>
             <durationType>16th</durationType>
             <Beam>7</Beam>
             <Note>
-              <lid>81</lid>
+              <lid>80</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>82</lid>
+              <lid>81</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>83</lid>
+              <lid>82</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>85</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             <Note>
               <lid>84</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <lid>83</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>86</lid>
+              <lid>85</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1595,46 +1587,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>87</lid>
+            <lid>86</lid>
             <durationType>eighth</durationType>
             <Beam>7</Beam>
             <Note>
-              <lid>88</lid>
+              <lid>87</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>89</lid>
+              <lid>88</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>90</lid>
+              <lid>89</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>92</lid>
+              <lid>91</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>91</lid>
+              <lid>90</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>93</lid>
+              <lid>92</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1646,46 +1638,46 @@
             <l2>-11</l2>
             </Beam>
           <Chord>
-            <lid>94</lid>
+            <lid>93</lid>
             <durationType>eighth</durationType>
             <Beam>8</Beam>
             <Note>
-              <lid>95</lid>
+              <lid>94</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>96</lid>
+              <lid>95</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>97</lid>
+              <lid>96</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>99</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             <Note>
               <lid>98</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <lid>97</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>100</lid>
+              <lid>99</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1693,46 +1685,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>101</lid>
+            <lid>100</lid>
             <durationType>16th</durationType>
             <Beam>8</Beam>
             <Note>
-              <lid>102</lid>
+              <lid>101</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>103</lid>
+              <lid>102</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>104</lid>
+              <lid>103</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>106</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             <Note>
               <lid>105</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <lid>104</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>107</lid>
+              <lid>106</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1740,46 +1732,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>108</lid>
+            <lid>107</lid>
             <durationType>16th</durationType>
             <Beam>8</Beam>
             <Note>
-              <lid>109</lid>
+              <lid>108</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>110</lid>
+              <lid>109</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>111</lid>
+              <lid>110</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>113</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
               </Note>
             <Note>
               <lid>112</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
+              </Note>
+            <Note>
+              <lid>111</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>114</lid>
+              <lid>113</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1787,46 +1779,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>115</lid>
+            <lid>114</lid>
             <durationType>eighth</durationType>
             <Beam>8</Beam>
             <Note>
-              <lid>116</lid>
+              <lid>115</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>117</lid>
+              <lid>116</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>118</lid>
+              <lid>117</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>120</lid>
+              <lid>119</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>119</lid>
+              <lid>118</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>121</lid>
+              <lid>120</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1855,48 +1847,44 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>8</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Beam id="9">
             <l1>46</l1>
             <l2>46</l2>
             </Beam>
           <Chord>
-            <lid>10</lid>
+            <lid>9</lid>
             <durationType>eighth</durationType>
             <Beam>9</Beam>
             <Note>
-              <lid>11</lid>
+              <lid>10</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>12</lid>
+              <lid>11</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>13</lid>
+              <lid>12</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1904,46 +1892,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>16</lid>
+            <lid>15</lid>
             <durationType>16th</durationType>
             <Beam>9</Beam>
             <Note>
-              <lid>17</lid>
+              <lid>16</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>18</lid>
+              <lid>17</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>19</lid>
+              <lid>18</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>19</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>20</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>21</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>22</lid>
+              <lid>21</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1951,46 +1939,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>23</lid>
+            <lid>22</lid>
             <durationType>16th</durationType>
             <Beam>9</Beam>
             <Note>
-              <lid>24</lid>
+              <lid>23</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>25</lid>
+              <lid>24</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>26</lid>
+              <lid>25</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>26</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>27</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>28</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>29</lid>
+              <lid>28</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1998,46 +1986,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>30</lid>
+            <lid>29</lid>
             <durationType>eighth</durationType>
             <Beam>9</Beam>
             <Note>
-              <lid>31</lid>
+              <lid>30</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>32</lid>
+              <lid>31</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>33</lid>
+              <lid>32</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>34</lid>
+              <lid>33</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>35</lid>
+              <lid>34</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>36</lid>
+              <lid>35</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2049,46 +2037,46 @@
             <l2>46</l2>
             </Beam>
           <Chord>
-            <lid>37</lid>
+            <lid>36</lid>
             <durationType>eighth</durationType>
             <Beam>10</Beam>
             <Note>
-              <lid>38</lid>
+              <lid>37</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>39</lid>
+              <lid>38</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>40</lid>
+              <lid>39</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>40</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>41</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>42</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>43</lid>
+              <lid>42</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2096,46 +2084,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>44</lid>
+            <lid>43</lid>
             <durationType>16th</durationType>
             <Beam>10</Beam>
             <Note>
-              <lid>45</lid>
+              <lid>44</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>46</lid>
+              <lid>45</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>47</lid>
+              <lid>46</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>47</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>48</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>49</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>50</lid>
+              <lid>49</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2143,46 +2131,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>51</lid>
+            <lid>50</lid>
             <durationType>16th</durationType>
             <Beam>10</Beam>
             <Note>
-              <lid>52</lid>
+              <lid>51</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>53</lid>
+              <lid>52</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>54</lid>
+              <lid>53</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>54</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>55</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>56</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>57</lid>
+              <lid>56</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2190,46 +2178,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>58</lid>
+            <lid>57</lid>
             <durationType>eighth</durationType>
             <Beam>10</Beam>
             <Note>
-              <lid>59</lid>
+              <lid>58</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>60</lid>
+              <lid>59</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>61</lid>
+              <lid>60</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>62</lid>
+              <lid>61</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>63</lid>
+              <lid>62</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>64</lid>
+              <lid>63</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2241,46 +2229,46 @@
             <l2>46</l2>
             </Beam>
           <Chord>
-            <lid>66</lid>
+            <lid>65</lid>
             <durationType>eighth</durationType>
             <Beam>11</Beam>
             <Note>
-              <lid>67</lid>
+              <lid>66</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>68</lid>
+              <lid>67</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>69</lid>
+              <lid>68</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>69</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>70</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>71</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>72</lid>
+              <lid>71</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2288,46 +2276,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>73</lid>
+            <lid>72</lid>
             <durationType>16th</durationType>
             <Beam>11</Beam>
             <Note>
-              <lid>74</lid>
+              <lid>73</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>75</lid>
+              <lid>74</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>76</lid>
+              <lid>75</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>76</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>77</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>78</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>79</lid>
+              <lid>78</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2335,46 +2323,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>80</lid>
+            <lid>79</lid>
             <durationType>16th</durationType>
             <Beam>11</Beam>
             <Note>
-              <lid>81</lid>
+              <lid>80</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>82</lid>
+              <lid>81</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>83</lid>
+              <lid>82</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>83</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>84</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>85</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>86</lid>
+              <lid>85</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2382,46 +2370,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>87</lid>
+            <lid>86</lid>
             <durationType>eighth</durationType>
             <Beam>11</Beam>
             <Note>
-              <lid>88</lid>
+              <lid>87</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>89</lid>
+              <lid>88</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>90</lid>
+              <lid>89</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>91</lid>
+              <lid>90</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>92</lid>
+              <lid>91</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>93</lid>
+              <lid>92</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2433,46 +2421,46 @@
             <l2>46</l2>
             </Beam>
           <Chord>
-            <lid>94</lid>
+            <lid>93</lid>
             <durationType>eighth</durationType>
             <Beam>12</Beam>
             <Note>
-              <lid>95</lid>
+              <lid>94</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>96</lid>
+              <lid>95</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>97</lid>
+              <lid>96</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>97</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>98</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>99</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>100</lid>
+              <lid>99</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2480,46 +2468,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>101</lid>
+            <lid>100</lid>
             <durationType>16th</durationType>
             <Beam>12</Beam>
             <Note>
-              <lid>102</lid>
+              <lid>101</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>103</lid>
+              <lid>102</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>104</lid>
+              <lid>103</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>104</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>105</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>106</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>107</lid>
+              <lid>106</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2527,46 +2515,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>108</lid>
+            <lid>107</lid>
             <durationType>16th</durationType>
             <Beam>12</Beam>
             <Note>
-              <lid>109</lid>
+              <lid>108</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>110</lid>
+              <lid>109</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>111</lid>
+              <lid>110</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>111</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>112</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
-              </Note>
-            <Note>
-              <lid>113</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>114</lid>
+              <lid>113</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2574,46 +2562,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>115</lid>
+            <lid>114</lid>
             <durationType>eighth</durationType>
             <Beam>12</Beam>
             <Note>
-              <lid>116</lid>
+              <lid>115</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>117</lid>
+              <lid>116</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>118</lid>
+              <lid>117</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>119</lid>
+              <lid>118</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>120</lid>
+              <lid>119</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>121</lid>
+              <lid>120</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>

--- a/mtest/guitarpro/repeated-bars.gpx-ref.mscx
+++ b/mtest/guitarpro/repeated-bars.gpx-ref.mscx
@@ -168,12 +168,8 @@
           </Chord>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>15</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <RepeatMeasure>
-          <lid>16</lid>
+          <lid>15</lid>
           <duration z="4" n="4"/>
           </RepeatMeasure>
         <tick>3840</tick>
@@ -372,12 +368,8 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>15</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <RepeatMeasure>
-            <lid>16</lid>
+            <lid>15</lid>
             <duration z="4" n="4"/>
             </RepeatMeasure>
           <tick>3840</tick>
@@ -439,12 +431,8 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>15</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <RepeatMeasure>
-            <lid>16</lid>
+            <lid>15</lid>
             <duration z="4" n="4"/>
             </RepeatMeasure>
           <tick>3840</tick>

--- a/mtest/guitarpro/repeats.gpx-ref.mscx
+++ b/mtest/guitarpro/repeats.gpx-ref.mscx
@@ -151,29 +151,25 @@
         </Measure>
       <Measure number="2">
         <startRepeat/>
-        <KeySig>
-          <lid>11</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>12</lid>
+          <lid>11</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>13</lid>
+            <lid>12</lid>
             <pitch>48</pitch>
             <tpc>14</tpc>
             <fret>3</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>14</lid>
+            <lid>13</lid>
             <pitch>53</pitch>
             <tpc>13</tpc>
             <fret>3</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>15</lid>
+            <lid>14</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
@@ -183,15 +179,11 @@
         </Measure>
       <Measure number="3">
         <endRepeat>2</endRepeat>
-        <KeySig>
-          <lid>17</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>18</lid>
+          <lid>16</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>19</lid>
+            <lid>17</lid>
             <pitch>55</pitch>
             <tpc>15</tpc>
             <fret>5</fret>
@@ -376,29 +368,25 @@
           </Measure>
         <Measure number="2">
           <startRepeat/>
-          <KeySig>
-            <lid>11</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>12</lid>
+            <lid>11</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>13</lid>
+              <lid>12</lid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>3</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>3</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
@@ -408,15 +396,11 @@
           </Measure>
         <Measure number="3">
           <endRepeat>2</endRepeat>
-          <KeySig>
-            <lid>17</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>18</lid>
+            <lid>16</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>17</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -462,29 +446,25 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>11</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>12</lid>
+            <lid>11</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>13</lid>
+              <lid>12</lid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>3</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>3</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
@@ -493,15 +473,11 @@
             </Chord>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>17</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>18</lid>
+            <lid>16</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>17</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>

--- a/mtest/guitarpro/rest-centered.gpx-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gpx-ref.mscx
@@ -124,20 +124,16 @@
           </Rest>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>7</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Dynamic>
           <subtype>mf</subtype>
           <velocity>80</velocity>
-          <lid>8</lid>
+          <lid>7</lid>
           </Dynamic>
         <Chord>
-          <lid>9</lid>
+          <lid>8</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>10</lid>
+            <lid>9</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -146,12 +142,8 @@
           </Chord>
         </Measure>
       <Measure number="3">
-        <KeySig>
-          <lid>12</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>13</lid>
+          <lid>11</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
@@ -306,20 +298,16 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>7</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Dynamic>
             <subtype>mf</subtype>
             <velocity>80</velocity>
-            <lid>8</lid>
+            <lid>7</lid>
             </Dynamic>
           <Chord>
-            <lid>9</lid>
+            <lid>8</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>10</lid>
+              <lid>9</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -328,12 +316,8 @@
             </Chord>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>12</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>13</lid>
+            <lid>11</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
@@ -356,15 +340,11 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>7</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>9</lid>
+            <lid>8</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>10</lid>
+              <lid>9</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -373,12 +353,8 @@
             </Chord>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>12</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>13</lid>
+            <lid>11</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>

--- a/mtest/guitarpro/slide-out-up.gpx-ref.mscx
+++ b/mtest/guitarpro/slide-out-up.gpx-ref.mscx
@@ -188,12 +188,8 @@
           </Chord>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>19</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>20</lid>
+          <lid>19</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
@@ -412,12 +408,8 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>19</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>20</lid>
+            <lid>19</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
@@ -499,12 +491,8 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>19</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>20</lid>
+            <lid>19</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>

--- a/mtest/guitarpro/timer.gpx-ref.mscx
+++ b/mtest/guitarpro/timer.gpx-ref.mscx
@@ -50,8 +50,6 @@
           </System>
         <System>
           </System>
-        <System>
-          </System>
         </Page>
       </PageList>
     <Part>
@@ -178,72 +176,56 @@
           </Rest>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>15</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>16</lid>
+          <lid>15</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="3">
-        <KeySig>
-          <lid>18</lid>
-          <accidental>0</accidental>
-          </KeySig>
+        <Rest>
+          <lid>17</lid>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="4">
         <Rest>
           <lid>19</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
-      <Measure number="4">
-        <KeySig>
-          <lid>21</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>22</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
       <Measure number="5">
-        <KeySig>
-          <lid>24</lid>
-          <accidental>0</accidental>
-          </KeySig>
+        <Chord>
+          <lid>21</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>22</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>23</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>24</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
         <Chord>
           <lid>25</lid>
           <durationType>quarter</durationType>
           <Note>
             <lid>26</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>27</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>28</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>29</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>30</lid>
             <Text>
-              <lid>31</lid>
+              <lid>27</lid>
               <style></style>
               <halign>center</halign>
               <valign>center</valign>
@@ -258,10 +240,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>32</lid>
+          <lid>28</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>33</lid>
+            <lid>29</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -270,37 +252,33 @@
           </Chord>
         </Measure>
       <Measure number="6">
-        <KeySig>
+        <Chord>
+          <lid>31</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>32</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>33</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>34</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Chord>
           <lid>35</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Chord>
-          <lid>36</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>37</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>38</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>39</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>40</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>41</lid>
+            <lid>36</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
@@ -308,48 +286,78 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>42</lid>
+          <lid>37</lid>
           <durationType>quarter</durationType>
           </Rest>
         </Measure>
       <Measure number="7">
-        <KeySig>
-          <lid>44</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>45</lid>
+          <lid>39</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="8">
-        <KeySig>
-          <lid>47</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>48</lid>
+          <lid>41</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="9">
-        <KeySig>
-          <lid>50</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>51</lid>
+          <lid>43</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="10">
-        <KeySig>
-          <lid>53</lid>
-          <accidental>0</accidental>
-          </KeySig>
+        <Chord>
+          <lid>45</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>46</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>47</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>48</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>49</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>50</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>51</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>52</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="11">
         <Chord>
           <lid>54</lid>
           <durationType>quarter</durationType>
@@ -357,8 +365,8 @@
             <lid>55</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
+            <fret>5</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -368,8 +376,8 @@
             <lid>57</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
+            <fret>5</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -379,49 +387,37 @@
             <lid>59</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
+            <fret>5</fret>
+            <string>2</string>
             </Note>
           </Chord>
-        <Chord>
+        <Rest>
           <lid>60</lid>
           <durationType>quarter</durationType>
-          <Note>
-            <lid>61</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
+          </Rest>
         </Measure>
-      <Measure number="11">
-        <KeySig>
-          <lid>63</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Chord>
+      <Measure number="12">
+        <Rest>
+          <lid>62</lid>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="13">
+        <Rest>
           <lid>64</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>65</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Chord>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="14">
+        <Rest>
           <lid>66</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>67</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="15">
         <Chord>
           <lid>68</lid>
           <durationType>quarter</durationType>
@@ -429,58 +425,26 @@
             <lid>69</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
+            <fret>15</fret>
+            <string>4</string>
             </Note>
           </Chord>
-        <Rest>
+        <Chord>
           <lid>70</lid>
           <durationType>quarter</durationType>
-          </Rest>
-        </Measure>
-      <Measure number="12">
-        <KeySig>
+          <Note>
+            <lid>71</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
           <lid>72</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>73</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="13">
-        <KeySig>
-          <lid>75</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>76</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="14">
-        <KeySig>
-          <lid>78</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>79</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="15">
-        <KeySig>
-          <lid>81</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Chord>
-          <lid>82</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>83</lid>
+            <lid>73</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -488,32 +452,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>84</lid>
+          <lid>74</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>85</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>86</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>87</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>88</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>89</lid>
+            <lid>75</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -522,15 +464,11 @@
           </Chord>
         </Measure>
       <Measure number="16">
-        <KeySig>
-          <lid>91</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>92</lid>
+          <lid>77</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>93</lid>
+            <lid>78</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
@@ -538,10 +476,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>94</lid>
+          <lid>79</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>95</lid>
+            <lid>80</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
@@ -549,10 +487,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>96</lid>
+          <lid>81</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>97</lid>
+            <lid>82</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
@@ -560,70 +498,138 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>98</lid>
+          <lid>83</lid>
           <durationType>quarter</durationType>
           </Rest>
         </Measure>
       <Measure number="17">
-        <KeySig>
-          <lid>100</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>101</lid>
+          <lid>85</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="18">
-        <KeySig>
-          <lid>103</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>104</lid>
+          <lid>87</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="19">
-        <KeySig>
-          <lid>106</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Rest>
-          <lid>107</lid>
+          <lid>89</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
       <Measure number="20">
-        <KeySig>
-          <lid>109</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
+          <lid>91</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>92</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>93</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>94</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>95</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>96</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>97</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>98</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="21">
+        <Chord>
+          <lid>100</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>101</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>102</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>103</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>104</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>105</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Rest>
+          <lid>106</lid>
+          <durationType>quarter</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="22">
+        <Rest>
+          <lid>108</lid>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="23">
+        <Rest>
           <lid>110</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>111</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="24">
+        <Rest>
           <lid>112</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>113</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="25">
         <Chord>
           <lid>114</lid>
           <durationType>quarter</durationType>
@@ -646,126 +652,22 @@
             <string>4</string>
             </Note>
           </Chord>
-        </Measure>
-      <Measure number="21">
-        <KeySig>
-          <lid>119</lid>
-          <accidental>0</accidental>
-          </KeySig>
+        <Chord>
+          <lid>118</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>119</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
         <Chord>
           <lid>120</lid>
           <durationType>quarter</durationType>
           <Note>
             <lid>121</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>122</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>123</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>124</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>125</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Rest>
-          <lid>126</lid>
-          <durationType>quarter</durationType>
-          </Rest>
-        </Measure>
-      <Measure number="22">
-        <KeySig>
-          <lid>128</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>129</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="23">
-        <KeySig>
-          <lid>131</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>132</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="24">
-        <KeySig>
-          <lid>134</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>135</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="25">
-        <KeySig>
-          <lid>137</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Chord>
-          <lid>138</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>139</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>140</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>141</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>142</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>143</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>144</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>145</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -774,10 +676,123 @@
           </Chord>
         </Measure>
       <Measure number="26">
-        <KeySig>
-          <lid>147</lid>
-          <accidental>0</accidental>
-          </KeySig>
+        <Chord>
+          <lid>123</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>124</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>125</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>126</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>127</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>128</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Rest>
+          <lid>129</lid>
+          <durationType>quarter</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="27">
+        <Rest>
+          <lid>131</lid>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="28">
+        <Rest>
+          <lid>133</lid>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="29">
+        <Rest>
+          <lid>135</lid>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="30">
+        <Chord>
+          <lid>137</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>138</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>139</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>140</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>141</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>142</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>143</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>144</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="31">
+        <Chord>
+          <lid>146</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>147</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
         <Chord>
           <lid>148</lid>
           <durationType>quarter</durationType>
@@ -800,60 +815,66 @@
             <string>2</string>
             </Note>
           </Chord>
-        <Chord>
+        <Rest>
           <lid>152</lid>
           <durationType>quarter</durationType>
-          <Note>
-            <lid>153</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
+          </Rest>
+        </Measure>
+      <Measure number="32">
         <Rest>
           <lid>154</lid>
-          <durationType>quarter</durationType>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
           </Rest>
         </Measure>
-      <Measure number="27">
-        <KeySig>
+      <Measure number="33">
+        <Rest>
           <lid>156</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>157</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
-      <Measure number="28">
-        <KeySig>
-          <lid>159</lid>
-          <accidental>0</accidental>
-          </KeySig>
+      <Measure number="34">
         <Rest>
+          <lid>158</lid>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="35">
+        <Chord>
           <lid>160</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="29">
-        <KeySig>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>161</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
           <lid>162</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>163</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="30">
-        <KeySig>
-          <lid>165</lid>
-          <accidental>0</accidental>
-          </KeySig>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>163</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>164</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>165</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
         <Chord>
           <lid>166</lid>
           <durationType>quarter</durationType>
@@ -865,11 +886,13 @@
             <string>4</string>
             </Note>
           </Chord>
+        </Measure>
+      <Measure number="36">
         <Chord>
-          <lid>168</lid>
+          <lid>169</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>169</lid>
+            <lid>170</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -877,10 +900,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>170</lid>
+          <lid>171</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>171</lid>
+            <lid>172</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -888,10 +911,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>172</lid>
+          <lid>173</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>173</lid>
+            <lid>174</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -899,11 +922,7 @@
             </Note>
           </Chord>
         </Measure>
-      <Measure number="31">
-        <KeySig>
-          <lid>175</lid>
-          <accidental>0</accidental>
-          </KeySig>
+      <Measure number="37">
         <Chord>
           <lid>176</lid>
           <durationType>quarter</durationType>
@@ -942,44 +961,50 @@
           <durationType>quarter</durationType>
           </Rest>
         </Measure>
-      <Measure number="32">
-        <KeySig>
-          <lid>184</lid>
-          <accidental>0</accidental>
-          </KeySig>
+      <Measure number="38">
         <Rest>
-          <lid>185</lid>
+          <lid>184</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
-      <Measure number="33">
-        <KeySig>
-          <lid>187</lid>
-          <accidental>0</accidental>
-          </KeySig>
+      <Measure number="39">
+        <Rest>
+          <lid>186</lid>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="40">
         <Rest>
           <lid>188</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
-      <Measure number="34">
-        <KeySig>
+      <Measure number="41">
+        <Chord>
           <lid>190</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>191</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="35">
-        <KeySig>
-          <lid>193</lid>
-          <accidental>0</accidental>
-          </KeySig>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>191</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>192</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>193</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
         <Chord>
           <lid>194</lid>
           <durationType>quarter</durationType>
@@ -1002,182 +1027,174 @@
             <string>4</string>
             </Note>
           </Chord>
-        <Chord>
-          <lid>198</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>199</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>200</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>201</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
         </Measure>
-      <Measure number="36">
-        <KeySig>
+      <Measure number="42">
+        <Chord>
+          <lid>199</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>200</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>201</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>202</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Chord>
           <lid>203</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Chord>
-          <lid>204</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>205</lid>
+            <lid>204</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
+            <fret>5</fret>
+            <string>2</string>
             </Note>
           </Chord>
-        <Chord>
-          <lid>206</lid>
+        <Rest>
+          <lid>205</lid>
           <durationType>quarter</durationType>
-          <Note>
-            <lid>207</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>208</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>209</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
+          </Rest>
         </Measure>
-      <Measure number="37">
-        <KeySig>
+      <Measure number="43">
+        <Rest>
+          <lid>207</lid>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="44">
+        <Rest>
+          <lid>209</lid>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="45">
+        <Rest>
           <lid>211</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Chord>
-          <lid>212</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>213</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>214</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>215</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>216</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>217</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Rest>
-          <lid>218</lid>
-          <durationType>quarter</durationType>
-          </Rest>
-        </Measure>
-      <Measure number="38">
-        <KeySig>
-          <lid>220</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>221</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
-      <Measure number="39">
-        <KeySig>
-          <lid>223</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
+      <Measure number="46">
+        <Chord>
+          <lid>213</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>214</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>215</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>216</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>217</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>218</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        <Chord>
+          <lid>219</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>220</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="47">
+        <Chord>
+          <lid>222</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>223</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Chord>
           <lid>224</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="40">
-        <KeySig>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>225</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
+        <Chord>
           <lid>226</lid>
-          <accidental>0</accidental>
-          </KeySig>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>227</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>5</fret>
+            <string>2</string>
+            </Note>
+          </Chord>
         <Rest>
-          <lid>227</lid>
+          <lid>228</lid>
+          <durationType>quarter</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="48">
+        <Rest>
+          <lid>230</lid>
           <durationType>measure</durationType>
           <duration z="1" n="1"/>
           </Rest>
         </Measure>
-      <Measure number="41">
-        <KeySig>
-          <lid>229</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Chord>
-          <lid>230</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>231</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
+      <Measure number="49">
+        <Rest>
           <lid>232</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>233</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="50">
+        <Rest>
           <lid>234</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>235</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
+          <durationType>measure</durationType>
+          <duration z="1" n="1"/>
+          </Rest>
+        </Measure>
+      <Measure number="51">
         <Chord>
           <lid>236</lid>
           <durationType>quarter</durationType>
@@ -1189,12 +1206,17 @@
             <string>4</string>
             </Note>
           </Chord>
-        </Measure>
-      <Measure number="42">
-        <KeySig>
-          <lid>239</lid>
-          <accidental>0</accidental>
-          </KeySig>
+        <Chord>
+          <lid>238</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>239</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>15</fret>
+            <string>4</string>
+            </Note>
+          </Chord>
         <Chord>
           <lid>240</lid>
           <durationType>quarter</durationType>
@@ -1202,8 +1224,8 @@
             <lid>241</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
+            <fret>15</fret>
+            <string>4</string>
             </Note>
           </Chord>
         <Chord>
@@ -1211,232 +1233,8 @@
           <durationType>quarter</durationType>
           <Note>
             <lid>243</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>244</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>245</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Rest>
-          <lid>246</lid>
-          <durationType>quarter</durationType>
-          </Rest>
-        </Measure>
-      <Measure number="43">
-        <KeySig>
-          <lid>248</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>249</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="44">
-        <KeySig>
-          <lid>251</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>252</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="45">
-        <KeySig>
-          <lid>254</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>255</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="46">
-        <KeySig>
-          <lid>257</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Chord>
-          <lid>258</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>259</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>260</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>261</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>262</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>263</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>264</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>265</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        </Measure>
-      <Measure number="47">
-        <KeySig>
-          <lid>267</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Chord>
-          <lid>268</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>269</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>270</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>271</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>272</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>273</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>5</fret>
-            <string>2</string>
-            </Note>
-          </Chord>
-        <Rest>
-          <lid>274</lid>
-          <durationType>quarter</durationType>
-          </Rest>
-        </Measure>
-      <Measure number="48">
-        <KeySig>
-          <lid>276</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>277</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="49">
-        <KeySig>
-          <lid>279</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>280</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="50">
-        <KeySig>
-          <lid>282</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Rest>
-          <lid>283</lid>
-          <durationType>measure</durationType>
-          <duration z="1" n="1"/>
-          </Rest>
-        </Measure>
-      <Measure number="51">
-        <KeySig>
-          <lid>285</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <Chord>
-          <lid>286</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>287</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>288</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>289</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>290</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>291</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>15</fret>
-            <string>4</string>
-            </Note>
-          </Chord>
-        <Chord>
-          <lid>292</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>293</lid>
             <Text>
-              <lid>294</lid>
+              <lid>244</lid>
               <style></style>
               <halign>center</halign>
               <valign>center</valign>
@@ -1486,8 +1284,6 @@
       <showMargins>0</showMargins>
       <PageList>
         <Page>
-          <System>
-            </System>
           <System>
             </System>
           <System>
@@ -1655,72 +1451,68 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>15</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>16</lid>
+            <lid>15</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>7680</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
-          <KeySig>
-            <lid>18</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Rest>
+            <lid>17</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="4">
           <Rest>
             <lid>19</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="4">
-          <KeySig>
-            <lid>21</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>22</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
         <Measure number="5">
-          <KeySig>
-            <lid>24</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Chord>
+            <lid>21</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>22</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>23</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>24</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>25</lid>
             <durationType>quarter</durationType>
             <Note>
               <lid>26</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>27</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>28</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>29</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>30</lid>
               <Text>
-                <lid>31</lid>
+                <lid>27</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>
@@ -1735,10 +1527,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>32</lid>
+            <lid>28</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>33</lid>
+              <lid>29</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -1747,37 +1539,33 @@
             </Chord>
           </Measure>
         <Measure number="6">
-          <KeySig>
+          <Chord>
+            <lid>31</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>32</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>33</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>34</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>35</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>36</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>37</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>38</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>39</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>40</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>41</lid>
+              <lid>36</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -1785,48 +1573,90 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>42</lid>
+            <lid>37</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="7">
-          <KeySig>
-            <lid>44</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>45</lid>
+            <lid>39</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="8">
-          <KeySig>
-            <lid>47</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="7" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
           <Rest>
-            <lid>48</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>17280</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>13440</tick>
+        <Measure number="8">
+          <Rest>
+            <lid>41</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="9">
-          <KeySig>
-            <lid>50</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>51</lid>
+            <lid>43</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="10">
-          <KeySig>
-            <lid>53</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Chord>
+            <lid>45</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>46</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>47</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>48</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>49</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>50</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>51</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>52</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          </Measure>
+        <Measure number="11">
           <Chord>
             <lid>54</lid>
             <durationType>quarter</durationType>
@@ -1834,8 +1664,8 @@
               <lid>55</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
+              <fret>5</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1845,8 +1675,8 @@
               <lid>57</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
+              <fret>5</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1856,49 +1686,49 @@
               <lid>59</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
+              <fret>5</fret>
+              <string>2</string>
               </Note>
             </Chord>
-          <Chord>
+          <Rest>
             <lid>60</lid>
             <durationType>quarter</durationType>
-            <Note>
-              <lid>61</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
+            </Rest>
           </Measure>
-        <Measure number="11">
-          <KeySig>
-            <lid>63</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
+        <Measure number="12">
+          <Rest>
+            <lid>62</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="12" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>26880</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>23040</tick>
+        <Measure number="13">
+          <Rest>
             <lid>64</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>65</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="14">
+          <Rest>
             <lid>66</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>67</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="15">
           <Chord>
             <lid>68</lid>
             <durationType>quarter</durationType>
@@ -1906,58 +1736,26 @@
               <lid>69</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
+              <fret>15</fret>
+              <string>4</string>
               </Note>
             </Chord>
-          <Rest>
+          <Chord>
             <lid>70</lid>
             <durationType>quarter</durationType>
-            </Rest>
-          </Measure>
-        <Measure number="12">
-          <KeySig>
+            <Note>
+              <lid>71</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>72</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>73</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="13">
-          <KeySig>
-            <lid>75</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>76</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="14">
-          <KeySig>
-            <lid>78</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>79</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="15">
-          <KeySig>
-            <lid>81</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>82</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>83</lid>
+              <lid>73</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -1965,32 +1763,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>84</lid>
+            <lid>74</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>85</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>86</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>87</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>88</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>89</lid>
+              <lid>75</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -1999,15 +1775,11 @@
             </Chord>
           </Measure>
         <Measure number="16">
-          <KeySig>
-            <lid>91</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>92</lid>
+            <lid>77</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>93</lid>
+              <lid>78</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -2015,10 +1787,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>94</lid>
+            <lid>79</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>95</lid>
+              <lid>80</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -2026,10 +1798,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>96</lid>
+            <lid>81</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>97</lid>
+              <lid>82</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -2037,70 +1809,162 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>98</lid>
+            <lid>83</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="17">
-          <KeySig>
-            <lid>100</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>101</lid>
+            <lid>85</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="18">
-          <KeySig>
-            <lid>103</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="17" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
           <Rest>
-            <lid>104</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>36480</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>32640</tick>
+        <Measure number="18">
+          <Rest>
+            <lid>87</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="19">
-          <KeySig>
-            <lid>106</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>107</lid>
+            <lid>89</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="20">
-          <KeySig>
-            <lid>109</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
+            <lid>91</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>92</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>93</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>94</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>95</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>96</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>97</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>98</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          </Measure>
+        <Measure number="21">
+          <Chord>
+            <lid>100</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>101</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>102</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>103</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>104</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>105</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Rest>
+            <lid>106</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          </Measure>
+        <Measure number="22">
+          <Rest>
+            <lid>108</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="22" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>46080</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>42240</tick>
+        <Measure number="23">
+          <Rest>
             <lid>110</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>111</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="24">
+          <Rest>
             <lid>112</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>113</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="25">
           <Chord>
             <lid>114</lid>
             <durationType>quarter</durationType>
@@ -2123,126 +1987,22 @@
               <string>4</string>
               </Note>
             </Chord>
-          </Measure>
-        <Measure number="21">
-          <KeySig>
-            <lid>119</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Chord>
+            <lid>118</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>119</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>120</lid>
             <durationType>quarter</durationType>
             <Note>
               <lid>121</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>122</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>123</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>124</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>125</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Rest>
-            <lid>126</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          </Measure>
-        <Measure number="22">
-          <KeySig>
-            <lid>128</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>129</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="23">
-          <KeySig>
-            <lid>131</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>132</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="24">
-          <KeySig>
-            <lid>134</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>135</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="25">
-          <KeySig>
-            <lid>137</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>138</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>139</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>140</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>141</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>142</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>143</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>144</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>145</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -2251,10 +2011,135 @@
             </Chord>
           </Measure>
         <Measure number="26">
-          <KeySig>
-            <lid>147</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Chord>
+            <lid>123</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>124</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>125</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>126</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>127</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>128</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Rest>
+            <lid>129</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          </Measure>
+        <Measure number="27">
+          <Rest>
+            <lid>131</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="27" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>55680</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>51840</tick>
+        <Measure number="28">
+          <Rest>
+            <lid>133</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="29">
+          <Rest>
+            <lid>135</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="30">
+          <Chord>
+            <lid>137</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>138</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>139</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>140</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>141</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>142</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>143</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>144</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          </Measure>
+        <Measure number="31">
+          <Chord>
+            <lid>146</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>147</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>148</lid>
             <durationType>quarter</durationType>
@@ -2277,60 +2162,78 @@
               <string>2</string>
               </Note>
             </Chord>
-          <Chord>
+          <Rest>
             <lid>152</lid>
             <durationType>quarter</durationType>
-            <Note>
-              <lid>153</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
+            </Rest>
+          </Measure>
+        <Measure number="32">
           <Rest>
             <lid>154</lid>
-            <durationType>quarter</durationType>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="27">
-          <KeySig>
+        <Measure number="32" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>65280</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>61440</tick>
+        <Measure number="33">
+          <Rest>
             <lid>156</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>157</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="28">
-          <KeySig>
-            <lid>159</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="34">
           <Rest>
+            <lid>158</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="35">
+          <Chord>
             <lid>160</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="29">
-          <KeySig>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>161</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>162</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>163</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="30">
-          <KeySig>
-            <lid>165</lid>
-            <accidental>0</accidental>
-            </KeySig>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>163</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>164</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>165</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>166</lid>
             <durationType>quarter</durationType>
@@ -2342,11 +2245,13 @@
               <string>4</string>
               </Note>
             </Chord>
+          </Measure>
+        <Measure number="36">
           <Chord>
-            <lid>168</lid>
+            <lid>169</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>169</lid>
+              <lid>170</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -2354,10 +2259,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>170</lid>
+            <lid>171</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>171</lid>
+              <lid>172</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -2365,10 +2270,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>172</lid>
+            <lid>173</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>173</lid>
+              <lid>174</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -2376,11 +2281,7 @@
               </Note>
             </Chord>
           </Measure>
-        <Measure number="31">
-          <KeySig>
-            <lid>175</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="37">
           <Chord>
             <lid>176</lid>
             <durationType>quarter</durationType>
@@ -2419,44 +2320,62 @@
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
-        <Measure number="32">
-          <KeySig>
-            <lid>184</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="38">
           <Rest>
-            <lid>185</lid>
+            <lid>184</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="33">
-          <KeySig>
-            <lid>187</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="38" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>76800</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>72960</tick>
+        <Measure number="39">
+          <Rest>
+            <lid>186</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="40">
           <Rest>
             <lid>188</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="34">
-          <KeySig>
+        <Measure number="41">
+          <Chord>
             <lid>190</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>191</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="35">
-          <KeySig>
-            <lid>193</lid>
-            <accidental>0</accidental>
-            </KeySig>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>191</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>192</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>193</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>194</lid>
             <durationType>quarter</durationType>
@@ -2479,182 +2398,198 @@
               <string>4</string>
               </Note>
             </Chord>
-          <Chord>
-            <lid>198</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>199</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>200</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>201</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
           </Measure>
-        <Measure number="36">
-          <KeySig>
+        <Measure number="42">
+          <Chord>
+            <lid>199</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>200</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>201</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>202</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>203</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>204</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>205</lid>
+              <lid>204</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
+              <fret>5</fret>
+              <string>2</string>
               </Note>
             </Chord>
-          <Chord>
-            <lid>206</lid>
+          <Rest>
+            <lid>205</lid>
             <durationType>quarter</durationType>
-            <Note>
-              <lid>207</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>208</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>209</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
+            </Rest>
           </Measure>
-        <Measure number="37">
-          <KeySig>
+        <Measure number="43">
+          <Rest>
+            <lid>207</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="43" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>86400</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>82560</tick>
+        <Measure number="44">
+          <Rest>
+            <lid>209</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="45">
+          <Rest>
             <lid>211</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>212</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>213</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>214</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>215</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>216</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>217</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Rest>
-            <lid>218</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          </Measure>
-        <Measure number="38">
-          <KeySig>
-            <lid>220</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>221</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="39">
-          <KeySig>
-            <lid>223</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
+        <Measure number="46">
+          <Chord>
+            <lid>213</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>214</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>215</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>216</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>217</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>218</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>219</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>220</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          </Measure>
+        <Measure number="47">
+          <Chord>
+            <lid>222</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>223</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>224</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="40">
-          <KeySig>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>225</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>226</lid>
-            <accidental>0</accidental>
-            </KeySig>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>227</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
           <Rest>
-            <lid>227</lid>
+            <lid>228</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          </Measure>
+        <Measure number="48">
+          <Rest>
+            <lid>230</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="41">
-          <KeySig>
-            <lid>229</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>230</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>231</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
+        <Measure number="48" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>96000</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>92160</tick>
+        <Measure number="49">
+          <Rest>
             <lid>232</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>233</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="50">
+          <Rest>
             <lid>234</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>235</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="51">
           <Chord>
             <lid>236</lid>
             <durationType>quarter</durationType>
@@ -2666,12 +2601,17 @@
               <string>4</string>
               </Note>
             </Chord>
-          </Measure>
-        <Measure number="42">
-          <KeySig>
-            <lid>239</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Chord>
+            <lid>238</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>239</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>240</lid>
             <durationType>quarter</durationType>
@@ -2679,8 +2619,8 @@
               <lid>241</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
+              <fret>15</fret>
+              <string>4</string>
               </Note>
             </Chord>
           <Chord>
@@ -2688,232 +2628,8 @@
             <durationType>quarter</durationType>
             <Note>
               <lid>243</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>244</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>245</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Rest>
-            <lid>246</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          </Measure>
-        <Measure number="43">
-          <KeySig>
-            <lid>248</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>249</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="44">
-          <KeySig>
-            <lid>251</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>252</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="45">
-          <KeySig>
-            <lid>254</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>255</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="46">
-          <KeySig>
-            <lid>257</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>258</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>259</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>260</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>261</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>262</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>263</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>264</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>265</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          </Measure>
-        <Measure number="47">
-          <KeySig>
-            <lid>267</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>268</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>269</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>270</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>271</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>272</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>273</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Rest>
-            <lid>274</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          </Measure>
-        <Measure number="48">
-          <KeySig>
-            <lid>276</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>277</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="49">
-          <KeySig>
-            <lid>279</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>280</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="50">
-          <KeySig>
-            <lid>282</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>283</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="51">
-          <KeySig>
-            <lid>285</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>286</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>287</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>288</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>289</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>290</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>291</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>292</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>293</lid>
               <Text>
-                <lid>294</lid>
+                <lid>244</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>
@@ -2987,72 +2703,68 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>15</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>16</lid>
+            <lid>15</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>7680</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
-          <KeySig>
-            <lid>18</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Rest>
+            <lid>17</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="4">
           <Rest>
             <lid>19</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="4">
-          <KeySig>
-            <lid>21</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>22</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
         <Measure number="5">
-          <KeySig>
-            <lid>24</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Chord>
+            <lid>21</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>22</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>23</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>24</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>25</lid>
             <durationType>quarter</durationType>
             <Note>
               <lid>26</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>27</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>28</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>29</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>30</lid>
               <Text>
-                <lid>31</lid>
+                <lid>27</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>
@@ -3067,10 +2779,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>32</lid>
+            <lid>28</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>33</lid>
+              <lid>29</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -3079,37 +2791,33 @@
             </Chord>
           </Measure>
         <Measure number="6">
-          <KeySig>
+          <Chord>
+            <lid>31</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>32</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>33</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>34</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>35</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>36</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>37</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>38</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>39</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>40</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>41</lid>
+              <lid>36</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -3117,48 +2825,90 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>42</lid>
+            <lid>37</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="7">
-          <KeySig>
-            <lid>44</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>45</lid>
+            <lid>39</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="8">
-          <KeySig>
-            <lid>47</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="7" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
           <Rest>
-            <lid>48</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>17280</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>13440</tick>
+        <Measure number="8">
+          <Rest>
+            <lid>41</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="9">
-          <KeySig>
-            <lid>50</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>51</lid>
+            <lid>43</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="10">
-          <KeySig>
-            <lid>53</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Chord>
+            <lid>45</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>46</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>47</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>48</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>49</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>50</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>51</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>52</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          </Measure>
+        <Measure number="11">
           <Chord>
             <lid>54</lid>
             <durationType>quarter</durationType>
@@ -3166,8 +2916,8 @@
               <lid>55</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
+              <fret>5</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -3177,8 +2927,8 @@
               <lid>57</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
+              <fret>5</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -3188,49 +2938,49 @@
               <lid>59</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
+              <fret>5</fret>
+              <string>2</string>
               </Note>
             </Chord>
-          <Chord>
+          <Rest>
             <lid>60</lid>
             <durationType>quarter</durationType>
-            <Note>
-              <lid>61</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
+            </Rest>
           </Measure>
-        <Measure number="11">
-          <KeySig>
-            <lid>63</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
+        <Measure number="12">
+          <Rest>
+            <lid>62</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="12" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>26880</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>23040</tick>
+        <Measure number="13">
+          <Rest>
             <lid>64</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>65</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="14">
+          <Rest>
             <lid>66</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>67</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="15">
           <Chord>
             <lid>68</lid>
             <durationType>quarter</durationType>
@@ -3238,58 +2988,26 @@
               <lid>69</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
+              <fret>15</fret>
+              <string>4</string>
               </Note>
             </Chord>
-          <Rest>
+          <Chord>
             <lid>70</lid>
             <durationType>quarter</durationType>
-            </Rest>
-          </Measure>
-        <Measure number="12">
-          <KeySig>
+            <Note>
+              <lid>71</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>72</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>73</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="13">
-          <KeySig>
-            <lid>75</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>76</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="14">
-          <KeySig>
-            <lid>78</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>79</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="15">
-          <KeySig>
-            <lid>81</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>82</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>83</lid>
+              <lid>73</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -3297,32 +3015,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>84</lid>
+            <lid>74</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>85</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>86</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>87</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>88</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>89</lid>
+              <lid>75</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -3331,15 +3027,11 @@
             </Chord>
           </Measure>
         <Measure number="16">
-          <KeySig>
-            <lid>91</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>92</lid>
+            <lid>77</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>93</lid>
+              <lid>78</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -3347,10 +3039,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>94</lid>
+            <lid>79</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>95</lid>
+              <lid>80</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -3358,10 +3050,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>96</lid>
+            <lid>81</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>97</lid>
+              <lid>82</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -3369,70 +3061,162 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>98</lid>
+            <lid>83</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="17">
-          <KeySig>
-            <lid>100</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>101</lid>
+            <lid>85</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="18">
-          <KeySig>
-            <lid>103</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="17" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
           <Rest>
-            <lid>104</lid>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>36480</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>32640</tick>
+        <Measure number="18">
+          <Rest>
+            <lid>87</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="19">
-          <KeySig>
-            <lid>106</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Rest>
-            <lid>107</lid>
+            <lid>89</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
         <Measure number="20">
-          <KeySig>
-            <lid>109</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
+            <lid>91</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>92</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>93</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>94</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>95</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>96</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>97</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>98</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          </Measure>
+        <Measure number="21">
+          <Chord>
+            <lid>100</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>101</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>102</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>103</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>104</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>105</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Rest>
+            <lid>106</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          </Measure>
+        <Measure number="22">
+          <Rest>
+            <lid>108</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="22" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>46080</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>42240</tick>
+        <Measure number="23">
+          <Rest>
             <lid>110</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>111</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="24">
+          <Rest>
             <lid>112</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>113</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="25">
           <Chord>
             <lid>114</lid>
             <durationType>quarter</durationType>
@@ -3455,126 +3239,22 @@
               <string>4</string>
               </Note>
             </Chord>
-          </Measure>
-        <Measure number="21">
-          <KeySig>
-            <lid>119</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Chord>
+            <lid>118</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>119</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>120</lid>
             <durationType>quarter</durationType>
             <Note>
               <lid>121</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>122</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>123</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>124</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>125</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Rest>
-            <lid>126</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          </Measure>
-        <Measure number="22">
-          <KeySig>
-            <lid>128</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>129</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="23">
-          <KeySig>
-            <lid>131</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>132</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="24">
-          <KeySig>
-            <lid>134</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>135</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="25">
-          <KeySig>
-            <lid>137</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>138</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>139</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>140</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>141</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>142</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>143</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>144</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>145</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -3583,10 +3263,135 @@
             </Chord>
           </Measure>
         <Measure number="26">
-          <KeySig>
-            <lid>147</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Chord>
+            <lid>123</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>124</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>125</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>126</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>127</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>128</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Rest>
+            <lid>129</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          </Measure>
+        <Measure number="27">
+          <Rest>
+            <lid>131</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="27" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>55680</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>51840</tick>
+        <Measure number="28">
+          <Rest>
+            <lid>133</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="29">
+          <Rest>
+            <lid>135</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="30">
+          <Chord>
+            <lid>137</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>138</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>139</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>140</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>141</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>142</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>143</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>144</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          </Measure>
+        <Measure number="31">
+          <Chord>
+            <lid>146</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>147</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>148</lid>
             <durationType>quarter</durationType>
@@ -3609,60 +3414,78 @@
               <string>2</string>
               </Note>
             </Chord>
-          <Chord>
+          <Rest>
             <lid>152</lid>
             <durationType>quarter</durationType>
-            <Note>
-              <lid>153</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
+            </Rest>
+          </Measure>
+        <Measure number="32">
           <Rest>
             <lid>154</lid>
-            <durationType>quarter</durationType>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="27">
-          <KeySig>
+        <Measure number="32" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>65280</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>61440</tick>
+        <Measure number="33">
+          <Rest>
             <lid>156</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>157</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="28">
-          <KeySig>
-            <lid>159</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="34">
           <Rest>
+            <lid>158</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="35">
+          <Chord>
             <lid>160</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="29">
-          <KeySig>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>161</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>162</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>163</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="30">
-          <KeySig>
-            <lid>165</lid>
-            <accidental>0</accidental>
-            </KeySig>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>163</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>164</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>165</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>166</lid>
             <durationType>quarter</durationType>
@@ -3674,11 +3497,13 @@
               <string>4</string>
               </Note>
             </Chord>
+          </Measure>
+        <Measure number="36">
           <Chord>
-            <lid>168</lid>
+            <lid>169</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>169</lid>
+              <lid>170</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -3686,10 +3511,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>170</lid>
+            <lid>171</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>171</lid>
+              <lid>172</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -3697,10 +3522,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>172</lid>
+            <lid>173</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>173</lid>
+              <lid>174</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -3708,11 +3533,7 @@
               </Note>
             </Chord>
           </Measure>
-        <Measure number="31">
-          <KeySig>
-            <lid>175</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="37">
           <Chord>
             <lid>176</lid>
             <durationType>quarter</durationType>
@@ -3751,44 +3572,62 @@
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
-        <Measure number="32">
-          <KeySig>
-            <lid>184</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="38">
           <Rest>
-            <lid>185</lid>
+            <lid>184</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="33">
-          <KeySig>
-            <lid>187</lid>
-            <accidental>0</accidental>
-            </KeySig>
+        <Measure number="38" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>76800</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>72960</tick>
+        <Measure number="39">
+          <Rest>
+            <lid>186</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="40">
           <Rest>
             <lid>188</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="34">
-          <KeySig>
+        <Measure number="41">
+          <Chord>
             <lid>190</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>191</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="35">
-          <KeySig>
-            <lid>193</lid>
-            <accidental>0</accidental>
-            </KeySig>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>191</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>192</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>193</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>194</lid>
             <durationType>quarter</durationType>
@@ -3811,182 +3650,198 @@
               <string>4</string>
               </Note>
             </Chord>
-          <Chord>
-            <lid>198</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>199</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>200</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>201</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
           </Measure>
-        <Measure number="36">
-          <KeySig>
+        <Measure number="42">
+          <Chord>
+            <lid>199</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>200</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>201</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>202</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>203</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>204</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>205</lid>
+              <lid>204</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
+              <fret>5</fret>
+              <string>2</string>
               </Note>
             </Chord>
-          <Chord>
-            <lid>206</lid>
+          <Rest>
+            <lid>205</lid>
             <durationType>quarter</durationType>
-            <Note>
-              <lid>207</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>208</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>209</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
+            </Rest>
           </Measure>
-        <Measure number="37">
-          <KeySig>
+        <Measure number="43">
+          <Rest>
+            <lid>207</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="43" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>86400</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>82560</tick>
+        <Measure number="44">
+          <Rest>
+            <lid>209</lid>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="45">
+          <Rest>
             <lid>211</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>212</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>213</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>214</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>215</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>216</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>217</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Rest>
-            <lid>218</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          </Measure>
-        <Measure number="38">
-          <KeySig>
-            <lid>220</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>221</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="39">
-          <KeySig>
-            <lid>223</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
+        <Measure number="46">
+          <Chord>
+            <lid>213</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>214</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>215</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>216</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>217</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>218</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          <Chord>
+            <lid>219</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>220</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
+          </Measure>
+        <Measure number="47">
+          <Chord>
+            <lid>222</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>223</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>224</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="40">
-          <KeySig>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>225</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
+          <Chord>
             <lid>226</lid>
-            <accidental>0</accidental>
-            </KeySig>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>227</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>5</fret>
+              <string>2</string>
+              </Note>
+            </Chord>
           <Rest>
-            <lid>227</lid>
+            <lid>228</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          </Measure>
+        <Measure number="48">
+          <Rest>
+            <lid>230</lid>
             <durationType>measure</durationType>
             <duration z="1" n="1"/>
             </Rest>
           </Measure>
-        <Measure number="41">
-          <KeySig>
-            <lid>229</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>230</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>231</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
+        <Measure number="48" len="12/4">
+          <multiMeasureRest>3</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            </Rest>
+          <tick>96000</tick>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>92160</tick>
+        <Measure number="49">
+          <Rest>
             <lid>232</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>233</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="50">
+          <Rest>
             <lid>234</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>235</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
+            <durationType>measure</durationType>
+            <duration z="1" n="1"/>
+            </Rest>
+          </Measure>
+        <Measure number="51">
           <Chord>
             <lid>236</lid>
             <durationType>quarter</durationType>
@@ -3998,12 +3853,17 @@
               <string>4</string>
               </Note>
             </Chord>
-          </Measure>
-        <Measure number="42">
-          <KeySig>
-            <lid>239</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Chord>
+            <lid>238</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>239</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>15</fret>
+              <string>4</string>
+              </Note>
+            </Chord>
           <Chord>
             <lid>240</lid>
             <durationType>quarter</durationType>
@@ -4011,8 +3871,8 @@
               <lid>241</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
+              <fret>15</fret>
+              <string>4</string>
               </Note>
             </Chord>
           <Chord>
@@ -4020,232 +3880,8 @@
             <durationType>quarter</durationType>
             <Note>
               <lid>243</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>244</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>245</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Rest>
-            <lid>246</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          </Measure>
-        <Measure number="43">
-          <KeySig>
-            <lid>248</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>249</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="44">
-          <KeySig>
-            <lid>251</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>252</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="45">
-          <KeySig>
-            <lid>254</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>255</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="46">
-          <KeySig>
-            <lid>257</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>258</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>259</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>260</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>261</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>262</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>263</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>264</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>265</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          </Measure>
-        <Measure number="47">
-          <KeySig>
-            <lid>267</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>268</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>269</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>270</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>271</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>272</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>273</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>5</fret>
-              <string>2</string>
-              </Note>
-            </Chord>
-          <Rest>
-            <lid>274</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          </Measure>
-        <Measure number="48">
-          <KeySig>
-            <lid>276</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>277</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="49">
-          <KeySig>
-            <lid>279</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>280</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="50">
-          <KeySig>
-            <lid>282</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Rest>
-            <lid>283</lid>
-            <durationType>measure</durationType>
-            <duration z="1" n="1"/>
-            </Rest>
-          </Measure>
-        <Measure number="51">
-          <KeySig>
-            <lid>285</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <Chord>
-            <lid>286</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>287</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>288</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>289</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>290</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>291</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>15</fret>
-              <string>4</string>
-              </Note>
-            </Chord>
-          <Chord>
-            <lid>292</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>293</lid>
               <Text>
-                <lid>294</lid>
+                <lid>244</lid>
                 <style></style>
                 <halign>center</halign>
                 <valign>center</valign>

--- a/mtest/guitarpro/tremolo-bar.gpx-ref.mscx
+++ b/mtest/guitarpro/tremolo-bar.gpx-ref.mscx
@@ -152,26 +152,26 @@
           </Rest>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>13</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <TremoloBar>
           <point time="0" pitch="0" vibrato="0"/>
           <point time="50" pitch="150" vibrato="0"/>
           <point time="100" pitch="0" vibrato="0"/>
           </TremoloBar>
         <Chord>
-          <lid>15</lid>
+          <lid>14</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>16</lid>
+            <lid>15</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
             <string>4</string>
             </Note>
           </Chord>
+        <Rest>
+          <lid>16</lid>
+          <durationType>quarter</durationType>
+          </Rest>
         <Rest>
           <lid>17</lid>
           <durationType>quarter</durationType>
@@ -180,26 +180,18 @@
           <lid>18</lid>
           <durationType>quarter</durationType>
           </Rest>
-        <Rest>
-          <lid>19</lid>
-          <durationType>quarter</durationType>
-          </Rest>
         </Measure>
       <Measure number="3">
-        <KeySig>
-          <lid>21</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <TremoloBar>
           <point time="0" pitch="0" vibrato="0"/>
           <point time="50" pitch="-550" vibrato="0"/>
           <point time="100" pitch="-550" vibrato="0"/>
           </TremoloBar>
         <Chord>
-          <lid>23</lid>
+          <lid>21</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>24</lid>
+            <lid>22</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>1</fret>
@@ -212,10 +204,10 @@
           <point time="100" pitch="-400" vibrato="0"/>
           </TremoloBar>
         <Chord>
-          <lid>26</lid>
+          <lid>24</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>27</lid>
+            <lid>25</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -223,22 +215,33 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>28</lid>
+          <lid>26</lid>
           <durationType>quarter</durationType>
           </Rest>
         <Rest>
-          <lid>29</lid>
+          <lid>27</lid>
           <durationType>quarter</durationType>
           </Rest>
         </Measure>
       <Measure number="4">
-        <KeySig>
-          <lid>31</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <TremoloBar>
           <point time="0" pitch="0" vibrato="0"/>
           <point time="50" pitch="200" vibrato="0"/>
+          <point time="100" pitch="300" vibrato="0"/>
+          </TremoloBar>
+        <Chord>
+          <lid>30</lid>
+          <durationType>quarter</durationType>
+          <Note>
+            <lid>31</lid>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            <fret>1</fret>
+            <string>1</string>
+            </Note>
+          </Chord>
+        <TremoloBar>
+          <point time="0" pitch="300" vibrato="0"/>
           <point time="100" pitch="300" vibrato="0"/>
           </TremoloBar>
         <Chord>
@@ -252,27 +255,12 @@
             <string>1</string>
             </Note>
           </Chord>
-        <TremoloBar>
-          <point time="0" pitch="300" vibrato="0"/>
-          <point time="100" pitch="300" vibrato="0"/>
-          </TremoloBar>
-        <Chord>
-          <lid>36</lid>
-          <durationType>quarter</durationType>
-          <Note>
-            <lid>37</lid>
-            <pitch>60</pitch>
-            <tpc>14</tpc>
-            <fret>1</fret>
-            <string>1</string>
-            </Note>
-          </Chord>
         <Rest>
-          <lid>38</lid>
+          <lid>35</lid>
           <durationType>quarter</durationType>
           </Rest>
         <Rest>
-          <lid>39</lid>
+          <lid>36</lid>
           <durationType>quarter</durationType>
           </Rest>
         <BarLine>
@@ -454,26 +442,26 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>13</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <TremoloBar>
             <point time="0" pitch="0" vibrato="0"/>
             <point time="50" pitch="150" vibrato="0"/>
             <point time="100" pitch="0" vibrato="0"/>
             </TremoloBar>
           <Chord>
-            <lid>15</lid>
+            <lid>14</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>16</lid>
+              <lid>15</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
               <string>4</string>
               </Note>
             </Chord>
+          <Rest>
+            <lid>16</lid>
+            <durationType>quarter</durationType>
+            </Rest>
           <Rest>
             <lid>17</lid>
             <durationType>quarter</durationType>
@@ -482,26 +470,18 @@
             <lid>18</lid>
             <durationType>quarter</durationType>
             </Rest>
-          <Rest>
-            <lid>19</lid>
-            <durationType>quarter</durationType>
-            </Rest>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>21</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <TremoloBar>
             <point time="0" pitch="0" vibrato="0"/>
             <point time="50" pitch="-550" vibrato="0"/>
             <point time="100" pitch="-550" vibrato="0"/>
             </TremoloBar>
           <Chord>
-            <lid>23</lid>
+            <lid>21</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>24</lid>
+              <lid>22</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
@@ -514,10 +494,10 @@
             <point time="100" pitch="-400" vibrato="0"/>
             </TremoloBar>
           <Chord>
-            <lid>26</lid>
+            <lid>24</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>27</lid>
+              <lid>25</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -525,22 +505,33 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>28</lid>
+            <lid>26</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>29</lid>
+            <lid>27</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="4">
-          <KeySig>
-            <lid>31</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <TremoloBar>
             <point time="0" pitch="0" vibrato="0"/>
             <point time="50" pitch="200" vibrato="0"/>
+            <point time="100" pitch="300" vibrato="0"/>
+            </TremoloBar>
+          <Chord>
+            <lid>30</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>31</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
+          <TremoloBar>
+            <point time="0" pitch="300" vibrato="0"/>
             <point time="100" pitch="300" vibrato="0"/>
             </TremoloBar>
           <Chord>
@@ -554,27 +545,12 @@
               <string>1</string>
               </Note>
             </Chord>
-          <TremoloBar>
-            <point time="0" pitch="300" vibrato="0"/>
-            <point time="100" pitch="300" vibrato="0"/>
-            </TremoloBar>
-          <Chord>
-            <lid>36</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>37</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              </Note>
-            </Chord>
           <Rest>
-            <lid>38</lid>
+            <lid>35</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>39</lid>
+            <lid>36</lid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>
@@ -619,26 +595,26 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>13</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <TremoloBar>
             <point time="0" pitch="0" vibrato="0"/>
             <point time="50" pitch="150" vibrato="0"/>
             <point time="100" pitch="0" vibrato="0"/>
             </TremoloBar>
           <Chord>
-            <lid>15</lid>
+            <lid>14</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>16</lid>
+              <lid>15</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
               <string>4</string>
               </Note>
             </Chord>
+          <Rest>
+            <lid>16</lid>
+            <durationType>quarter</durationType>
+            </Rest>
           <Rest>
             <lid>17</lid>
             <durationType>quarter</durationType>
@@ -647,26 +623,18 @@
             <lid>18</lid>
             <durationType>quarter</durationType>
             </Rest>
-          <Rest>
-            <lid>19</lid>
-            <durationType>quarter</durationType>
-            </Rest>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>21</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <TremoloBar>
             <point time="0" pitch="0" vibrato="0"/>
             <point time="50" pitch="-550" vibrato="0"/>
             <point time="100" pitch="-550" vibrato="0"/>
             </TremoloBar>
           <Chord>
-            <lid>23</lid>
+            <lid>21</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>24</lid>
+              <lid>22</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>1</fret>
@@ -679,10 +647,10 @@
             <point time="100" pitch="-400" vibrato="0"/>
             </TremoloBar>
           <Chord>
-            <lid>26</lid>
+            <lid>24</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>27</lid>
+              <lid>25</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -690,22 +658,33 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>28</lid>
+            <lid>26</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>29</lid>
+            <lid>27</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
         <Measure number="4">
-          <KeySig>
-            <lid>31</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <TremoloBar>
             <point time="0" pitch="0" vibrato="0"/>
             <point time="50" pitch="200" vibrato="0"/>
+            <point time="100" pitch="300" vibrato="0"/>
+            </TremoloBar>
+          <Chord>
+            <lid>30</lid>
+            <durationType>quarter</durationType>
+            <Note>
+              <lid>31</lid>
+              <pitch>60</pitch>
+              <tpc>14</tpc>
+              <fret>1</fret>
+              <string>1</string>
+              </Note>
+            </Chord>
+          <TremoloBar>
+            <point time="0" pitch="300" vibrato="0"/>
             <point time="100" pitch="300" vibrato="0"/>
             </TremoloBar>
           <Chord>
@@ -719,27 +698,12 @@
               <string>1</string>
               </Note>
             </Chord>
-          <TremoloBar>
-            <point time="0" pitch="300" vibrato="0"/>
-            <point time="100" pitch="300" vibrato="0"/>
-            </TremoloBar>
-          <Chord>
-            <lid>36</lid>
-            <durationType>quarter</durationType>
-            <Note>
-              <lid>37</lid>
-              <pitch>60</pitch>
-              <tpc>14</tpc>
-              <fret>1</fret>
-              <string>1</string>
-              </Note>
-            </Chord>
           <Rest>
-            <lid>38</lid>
+            <lid>35</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>39</lid>
+            <lid>36</lid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>

--- a/mtest/guitarpro/updateReference
+++ b/mtest/guitarpro/updateReference
@@ -12,7 +12,7 @@ cp   $MSCORE/trill.gp4.mscx trill.gp4-ref.mscx
 cp   $MSCORE/dynamic.gp5.mscx dynamic.gp5-ref.mscx
 cp   $MSCORE/arpeggio_up_down.gp4.mscx arpeggio_up_down.gp4-ref.mscx
 cp   $MSCORE/ghost_note.gp3.mscx ghost_note.gp3-ref.mscx
-cp   $MSCORE/grace.gp5.mscx grace.gp5-ref.mscx
+#cp   $MSCORE/grace.gp5.mscx grace.gp5-ref.mscx
 cp   $MSCORE/volta.gp5.mscx volta.gp5-ref.mscx
 cp   $MSCORE/volta.gp4.mscx volta.gp4-ref.mscx
 cp   $MSCORE/volta.gp3.mscx volta.gp3-ref.mscx
@@ -77,7 +77,8 @@ cp   $MSCORE/arpeggio.gpx.mscx arpeggio.gpx-ref.mscx
 cp   $MSCORE/brush.gpx.mscx brush.gpx-ref.mscx
 cp   $MSCORE/brush.gp5.mscx brush.gp5-ref.mscx
 cp   $MSCORE/brush.gp4.mscx brush.gp4-ref.mscx
-cp   $MSCORE/repeats.gp4.mscx repeats.gp4-ref.mscx
+#cp   $MSCORE/repeats.gp4.mscx repeats.gp4-ref.mscx
+cp   $MSCORE/repeats.gpx.mscx repeats.gpx-ref.mscx
 cp   $MSCORE/volta.gpx.mscx volta.gpx-ref.mscx
 cp   $MSCORE/grace-before-beat.gpx.mscx grace-before-beat.gpx-ref.mscx
 cp   $MSCORE/grace-on-beat.gpx.mscx grace-on-beat.gpx-ref.mscx

--- a/mtest/guitarpro/vibrato.gpx-ref.mscx
+++ b/mtest/guitarpro/vibrato.gpx-ref.mscx
@@ -151,25 +151,25 @@
           </Rest>
         </Measure>
       <Measure number="2">
-        <KeySig>
-          <lid>13</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>15</lid>
+          <lid>14</lid>
           <durationType>quarter</durationType>
           <Articulation>
             <subtype>wigglevibratolargeslowest</subtype>
-            <lid>14</lid>
+            <lid>13</lid>
             </Articulation>
           <Note>
-            <lid>16</lid>
+            <lid>15</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
             <string>2</string>
             </Note>
           </Chord>
+        <Rest>
+          <lid>16</lid>
+          <durationType>quarter</durationType>
+          </Rest>
         <Rest>
           <lid>17</lid>
           <durationType>quarter</durationType>
@@ -178,58 +178,46 @@
           <lid>18</lid>
           <durationType>quarter</durationType>
           </Rest>
-        <Rest>
-          <lid>19</lid>
-          <durationType>quarter</durationType>
-          </Rest>
         </Measure>
       <Measure number="3">
-        <KeySig>
-          <lid>21</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>23</lid>
+          <lid>21</lid>
           <durationType>quarter</durationType>
           <Articulation>
             <subtype>wigglesawtooth</subtype>
-            <lid>22</lid>
+            <lid>20</lid>
             </Articulation>
           <Note>
-            <lid>24</lid>
+            <lid>22</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
             <string>2</string>
             </Note>
           </Chord>
+        <Rest>
+          <lid>23</lid>
+          <durationType>quarter</durationType>
+          </Rest>
+        <Rest>
+          <lid>24</lid>
+          <durationType>quarter</durationType>
+          </Rest>
         <Rest>
           <lid>25</lid>
           <durationType>quarter</durationType>
           </Rest>
-        <Rest>
-          <lid>26</lid>
-          <durationType>quarter</durationType>
-          </Rest>
-        <Rest>
-          <lid>27</lid>
-          <durationType>quarter</durationType>
-          </Rest>
         </Measure>
       <Measure number="4">
-        <KeySig>
-          <lid>29</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <Chord>
-          <lid>31</lid>
+          <lid>28</lid>
           <durationType>quarter</durationType>
           <Articulation>
             <subtype>wigglesawtoothwide</subtype>
-            <lid>30</lid>
+            <lid>27</lid>
             </Articulation>
           <Note>
-            <lid>32</lid>
+            <lid>29</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>5</fret>
@@ -237,15 +225,15 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>33</lid>
+          <lid>30</lid>
           <durationType>quarter</durationType>
           </Rest>
         <Rest>
-          <lid>34</lid>
+          <lid>31</lid>
           <durationType>quarter</durationType>
           </Rest>
         <Rest>
-          <lid>35</lid>
+          <lid>32</lid>
           <durationType>quarter</durationType>
           </Rest>
         <BarLine>
@@ -426,25 +414,25 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>13</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>15</lid>
+            <lid>14</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wigglevibratolargeslowest</subtype>
-              <lid>14</lid>
+              <lid>13</lid>
               </Articulation>
             <Note>
-              <lid>16</lid>
+              <lid>15</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
               <string>2</string>
               </Note>
             </Chord>
+          <Rest>
+            <lid>16</lid>
+            <durationType>quarter</durationType>
+            </Rest>
           <Rest>
             <lid>17</lid>
             <durationType>quarter</durationType>
@@ -453,58 +441,46 @@
             <lid>18</lid>
             <durationType>quarter</durationType>
             </Rest>
-          <Rest>
-            <lid>19</lid>
-            <durationType>quarter</durationType>
-            </Rest>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>21</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>23</lid>
+            <lid>21</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wigglesawtooth</subtype>
-              <lid>22</lid>
+              <lid>20</lid>
               </Articulation>
             <Note>
-              <lid>24</lid>
+              <lid>22</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
               <string>2</string>
               </Note>
             </Chord>
+          <Rest>
+            <lid>23</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <lid>24</lid>
+            <durationType>quarter</durationType>
+            </Rest>
           <Rest>
             <lid>25</lid>
             <durationType>quarter</durationType>
             </Rest>
-          <Rest>
-            <lid>26</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <Rest>
-            <lid>27</lid>
-            <durationType>quarter</durationType>
-            </Rest>
           </Measure>
         <Measure number="4">
-          <KeySig>
-            <lid>29</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>31</lid>
+            <lid>28</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wigglesawtoothwide</subtype>
-              <lid>30</lid>
+              <lid>27</lid>
               </Articulation>
             <Note>
-              <lid>32</lid>
+              <lid>29</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -512,15 +488,15 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>33</lid>
+            <lid>30</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>34</lid>
+            <lid>31</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>35</lid>
+            <lid>32</lid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>
@@ -564,25 +540,25 @@
             </Rest>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>13</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>15</lid>
+            <lid>14</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wigglevibratolargeslowest</subtype>
-              <lid>14</lid>
+              <lid>13</lid>
               </Articulation>
             <Note>
-              <lid>16</lid>
+              <lid>15</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
               <string>2</string>
               </Note>
             </Chord>
+          <Rest>
+            <lid>16</lid>
+            <durationType>quarter</durationType>
+            </Rest>
           <Rest>
             <lid>17</lid>
             <durationType>quarter</durationType>
@@ -591,58 +567,46 @@
             <lid>18</lid>
             <durationType>quarter</durationType>
             </Rest>
-          <Rest>
-            <lid>19</lid>
-            <durationType>quarter</durationType>
-            </Rest>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>21</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>23</lid>
+            <lid>21</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wigglesawtooth</subtype>
-              <lid>22</lid>
+              <lid>20</lid>
               </Articulation>
             <Note>
-              <lid>24</lid>
+              <lid>22</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
               <string>2</string>
               </Note>
             </Chord>
+          <Rest>
+            <lid>23</lid>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <lid>24</lid>
+            <durationType>quarter</durationType>
+            </Rest>
           <Rest>
             <lid>25</lid>
             <durationType>quarter</durationType>
             </Rest>
-          <Rest>
-            <lid>26</lid>
-            <durationType>quarter</durationType>
-            </Rest>
-          <Rest>
-            <lid>27</lid>
-            <durationType>quarter</durationType>
-            </Rest>
           </Measure>
         <Measure number="4">
-          <KeySig>
-            <lid>29</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>31</lid>
+            <lid>28</lid>
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>wigglesawtoothwide</subtype>
-              <lid>30</lid>
+              <lid>27</lid>
               </Articulation>
             <Note>
-              <lid>32</lid>
+              <lid>29</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>5</fret>
@@ -650,15 +614,15 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>33</lid>
+            <lid>30</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>34</lid>
+            <lid>31</lid>
             <durationType>quarter</durationType>
             </Rest>
           <Rest>
-            <lid>35</lid>
+            <lid>32</lid>
             <durationType>quarter</durationType>
             </Rest>
           <BarLine>

--- a/mtest/guitarpro/volta.gpx-ref.mscx
+++ b/mtest/guitarpro/volta.gpx-ref.mscx
@@ -150,29 +150,33 @@
         </Measure>
       <Measure number="2">
         <endRepeat>3</endRepeat>
-        <KeySig>
-          <lid>11</lid>
-          <accidental>0</accidental>
-          </KeySig>
+        <Volta id="2">
+          <lid>24</lid>
+          <beginText>
+            <style>Volta</style>
+            <text>1,2</text>
+            </beginText>
+          <endings></endings>
+          </Volta>
         <Chord>
-          <lid>12</lid>
+          <lid>11</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>14</lid>
+            <lid>13</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>0</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>13</lid>
+            <lid>12</lid>
             <pitch>53</pitch>
             <tpc>13</tpc>
             <fret>8</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>15</lid>
+            <lid>14</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
@@ -181,29 +185,34 @@
           </Chord>
         </Measure>
       <Measure number="3">
-        <KeySig>
-          <lid>17</lid>
-          <accidental>0</accidental>
-          </KeySig>
+        <endSpanner id="2"/>
+        <Volta id="3">
+          <lid>25</lid>
+          <beginText>
+            <style>Volta</style>
+            <text>3</text>
+            </beginText>
+          <endings></endings>
+          </Volta>
         <Chord>
-          <lid>18</lid>
+          <lid>16</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>19</lid>
+            <lid>17</lid>
             <pitch>48</pitch>
             <tpc>14</tpc>
             <fret>3</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>20</lid>
+            <lid>18</lid>
             <pitch>53</pitch>
             <tpc>13</tpc>
             <fret>3</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>21</lid>
+            <lid>19</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
@@ -212,16 +221,12 @@
           </Chord>
         </Measure>
       <Measure number="4">
-        <KeySig>
-          <lid>23</lid>
-          <accidental>0</accidental>
-          </KeySig>
-        <endSpanner id="2"/>
+        <endSpanner id="3"/>
         <Chord>
-          <lid>24</lid>
+          <lid>21</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>25</lid>
+            <lid>22</lid>
             <pitch>55</pitch>
             <tpc>15</tpc>
             <fret>5</fret>
@@ -405,29 +410,33 @@
           </Measure>
         <Measure number="2">
           <endRepeat>3</endRepeat>
-          <KeySig>
-            <lid>11</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <Volta id="4">
+            <lid>24</lid>
+            <beginText>
+              <style>Volta</style>
+              <text>1,2</text>
+              </beginText>
+            <endings></endings>
+            </Volta>
           <Chord>
-            <lid>12</lid>
+            <lid>11</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>0</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>13</lid>
+              <lid>12</lid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>8</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
@@ -436,29 +445,34 @@
             </Chord>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>17</lid>
-            <accidental>0</accidental>
-            </KeySig>
+          <endSpanner id="4"/>
+          <Volta id="5">
+            <lid>25</lid>
+            <beginText>
+              <style>Volta</style>
+              <text>3</text>
+              </beginText>
+            <endings></endings>
+            </Volta>
           <Chord>
-            <lid>18</lid>
+            <lid>16</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>17</lid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>3</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>20</lid>
+              <lid>18</lid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>3</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>21</lid>
+              <lid>19</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
@@ -467,16 +481,12 @@
             </Chord>
           </Measure>
         <Measure number="4">
-          <KeySig>
-            <lid>23</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <endSpanner id="3"/>
+          <endSpanner id="5"/>
           <Chord>
-            <lid>24</lid>
+            <lid>21</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>25</lid>
+              <lid>22</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -522,29 +532,25 @@
             </Chord>
           </Measure>
         <Measure number="2">
-          <KeySig>
-            <lid>11</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>12</lid>
+            <lid>11</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>14</lid>
+              <lid>13</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>0</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>13</lid>
+              <lid>12</lid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>8</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>14</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
@@ -553,29 +559,25 @@
             </Chord>
           </Measure>
         <Measure number="3">
-          <KeySig>
-            <lid>17</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>18</lid>
+            <lid>16</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>19</lid>
+              <lid>17</lid>
               <pitch>48</pitch>
               <tpc>14</tpc>
               <fret>3</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>20</lid>
+              <lid>18</lid>
               <pitch>53</pitch>
               <tpc>13</tpc>
               <fret>3</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>21</lid>
+              <lid>19</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
@@ -584,15 +586,11 @@
             </Chord>
           </Measure>
         <Measure number="4">
-          <KeySig>
-            <lid>23</lid>
-            <accidental>0</accidental>
-            </KeySig>
           <Chord>
-            <lid>24</lid>
+            <lid>21</lid>
             <durationType>whole</durationType>
             <Note>
-              <lid>25</lid>
+              <lid>22</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>


### PR DESCRIPTION
Aside from the "missing" key signatures and the resultant effect on the lid's of all subsequent elements, the diffs I saw were things where the tests are now correct but the original refs were not - like mmrests that used to be not generated because of the empty key sigs.  The hairpins and voltas in crescendo-and-diminuendo.gpx and volta.gpx seem correct, including after save / reload, so I'm assuming those too were "good" diffs.
