### PR TITLE
adjust the SATB closed score templates' ranges

### DIFF
--- a/share/templates/02-Choral-SATB_Closed_Score.mscx
+++ b/share/templates/02-Choral-SATB_Closed_Score.mscx
@@ -61,7 +61,7 @@ A</longName>
         <minPitchP>55</minPitchP>
         <maxPitchP>84</maxPitchP>
         <minPitchA>55</minPitchA>
-        <maxPitchA>81</maxPitchA>
+        <maxPitchA>79</maxPitchA>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -96,10 +96,10 @@ A</longName>
         <longName pos="0">T
 B</longName>
         <trackName>Tenor/Bass</trackName>
-        <minPitchP>38</minPitchP>
-        <maxPitchP>69</maxPitchP>
+        <minPitchP>40</minPitchP>
+        <maxPitchP>72</maxPitchP>
         <minPitchA>41</minPitchA>
-        <maxPitchA>67</maxPitchA>
+        <maxPitchA>69</maxPitchA>
         <clef>F</clef>
         <Articulation>
           <velocity>100</velocity>

--- a/share/templates/02-Choral-SATB_Closed_Score_with_Organ.mscx
+++ b/share/templates/02-Choral-SATB_Closed_Score_with_Organ.mscx
@@ -56,7 +56,7 @@
         <minPitchP>55</minPitchP>
         <maxPitchP>84</maxPitchP>
         <minPitchA>55</minPitchA>
-        <maxPitchA>81</maxPitchA>
+        <maxPitchA>79</maxPitchA>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -90,10 +90,10 @@
       <Instrument>
         <longName pos="0">T B</longName>
         <trackName>Tenor/Bass</trackName>
-        <minPitchP>38</minPitchP>
-        <maxPitchP>69</maxPitchP>
+        <minPitchP>40</minPitchP>
+        <maxPitchP>72</maxPitchP>
         <minPitchA>41</minPitchA>
-        <maxPitchA>67</maxPitchA>
+        <maxPitchA>69</maxPitchA>
         <clef>F</clef>
         <Articulation>
           <velocity>100</velocity>

--- a/share/templates/02-Choral-SATB_Closed_Score_with_Piano.mscx
+++ b/share/templates/02-Choral-SATB_Closed_Score_with_Piano.mscx
@@ -58,7 +58,7 @@
         <minPitchP>55</minPitchP>
         <maxPitchP>84</maxPitchP>
         <minPitchA>55</minPitchA>
-        <maxPitchA>81</maxPitchA>
+        <maxPitchA>79</maxPitchA>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -92,10 +92,10 @@
       <Instrument>
         <longName pos="0">T B</longName>
         <trackName>Tenor/Bass</trackName>
-        <minPitchP>38</minPitchP>
-        <maxPitchP>69</maxPitchP>
+        <minPitchP>40</minPitchP>
+        <maxPitchP>72</maxPitchP>
         <minPitchA>41</minPitchA>
-        <maxPitchA>67</maxPitchA>
+        <maxPitchA>69</maxPitchA>
         <clef>F</clef>
         <Articulation>
           <velocity>100</velocity>


### PR DESCRIPTION
to match instruments.xml, the higher voices defining the max. pitches,
the lower voice defining the min. pitches
