### PR TITLE
fix #31431: create mmrests in all parts

### DIFF
--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -288,7 +288,8 @@ void ExcerptsDialog::createExcerptClicked(QListWidgetItem* cur)
       e->setScore(nscore);
 
       nscore->setName(e->title()); // needed before AddExcerpt
-      
+      nscore->style()->set(StyleIdx::createMultiMeasureRests, true);
+
       score->startCmd();
       score->undo(new AddExcerpt(nscore));
       Ms::createExcerpt(nscore, e->parts());
@@ -298,7 +299,6 @@ void ExcerptsDialog::createExcerptClicked(QListWidgetItem* cur)
       nscore->updateChannel();
       nscore->addLayoutFlags(LayoutFlag::FIX_PITCH_VELO);
       nscore->setLayoutAll(true);
-      nscore->style()->set(StyleIdx::createMultiMeasureRests, true);
 
       partList->setEnabled(false);
       title->setEnabled(false);


### PR DESCRIPTION
This works, although I can't say I fully understand why it already worked for all but the last part.
