### PR TITLE
fix #31391: fix concert pitch switch to not affect linked scores

### DIFF
--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -457,11 +457,7 @@ void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickE
                         Key key  = st->key(s->tick());
                         Key nKey = transposeKey(key, interval);
                         KeySigEvent ke(nKey);
-                        QList<Element*> ll = ks->linkList();
-                        for (Element* e : ll) {
-                              KeySig* ks = static_cast<KeySig*>(e);
-                              undo(new ChangeKeySig(ks, ke, ks->showCourtesy()));
-                              }
+                        undo(new ChangeKeySig(ks, ke, ks->showCourtesy()));
                         }
                   }
             if (createKey) {


### PR DESCRIPTION
This had been working, but broke with a recent fix (https://github.com/musescore/MuseScore/commit/f05a051ea45087c29d27c23c470d602d6fe8676d) for a related bug (http://musescore.org/node/29616).

I have tested that my changes here (which reverts a portion of the above fix that was unnecessary) fixes the issue at hand while still fixing the original problem that previous commit addressed.
