### PR TITLE
fix #31536: save staff move property for chords

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2451,7 +2451,7 @@ QVariant Chord::propertyDefault(P_ID propertyId) const
             case P_ID::SMALL:          return false;
             case P_ID::STEM_DIRECTION: return int(MScore::Direction::AUTO);
             default:
-                  return ChordRest::getProperty(propertyId);
+                  return ChordRest::propertyDefault(propertyId);
             }
       }
 


### PR DESCRIPTION
A typo was preventing cross staff move info from being saved - propertyDefault() always returned the current value the staff move property rather than the actual default (0).
