### PR TITLE
Make resource manager text cells not editable

### DIFF
--- a/mscore/resourceManager.ui
+++ b/mscore/resourceManager.ui
@@ -44,6 +44,9 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
          <property name="alternatingRowColors">
           <bool>true</bool>
          </property>


### PR DESCRIPTION
If I understand correctly, editable text cells make no sence.
Buttons are "pushable" as usual.
