### PR TITLE
fix #31671: recognize major triads for legacy files without chords.xml

### DIFF
--- a/share/styles/cchords_muse.xml
+++ b/share/styles/cchords_muse.xml
@@ -378,6 +378,7 @@
   <renderBase>/ m:0:1 :n :a m:0:-1</renderBase>
 
   <chord id="1">
+    <name></name>
     <render></render>
     </chord>
   <chord id="2">

--- a/share/styles/cchords_nrb.xml
+++ b/share/styles/cchords_nrb.xml
@@ -378,6 +378,7 @@
   <renderBase>/ m:0:1 :n :a m:0:-1</renderBase>
 
   <chord id="1">
+    <name></name>
     <render></render>
     </chord>
   <chord id="2">

--- a/share/styles/cchords_rb.xml
+++ b/share/styles/cchords_rb.xml
@@ -378,6 +378,7 @@
   <renderBase>/ m:0:1 :n :a m:0:-1</renderBase>
 
   <chord id="1">
+    <name></name>
     <render></render>
     </chord>
   <chord id="2">

--- a/share/styles/cchords_sym.xml
+++ b/share/styles/cchords_sym.xml
@@ -378,6 +378,7 @@
   <renderBase>/ m:0:1 :n :a m:0:-1</renderBase>
 
   <chord id="1">
+    <name></name>
     <render></render>
     </chord>
   <chord id="2">

--- a/share/styles/jazzchords.xml
+++ b/share/styles/jazzchords.xml
@@ -80,6 +80,7 @@
   <renderBase>/ m:0:1 :n :a m:0:-1</renderBase>
 
   <chord id="1">
+    <name></name>
     <render></render>
     </chord>
   <chord id="2">

--- a/share/styles/stdchords.xml
+++ b/share/styles/stdchords.xml
@@ -76,6 +76,7 @@
   <renderBase>m:-0.2:1 / m:0.2:1 :n :a m:0:-2</renderBase>
 
   <chord id="1">
+    <name></name>
     <render></render>
     </chord>
   <chord id="2">


### PR DESCRIPTION
The legacy chord description files are obsolete now, but people will probably still try to use them, and won't know to check the "Load chords.xml" box.  This change fix an issue where triads render with an explicit "major" abbreviation in these cases.
