### PR TITLE
fix #31721: crash after entry of empty harmony / fb

### DIFF
--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -101,13 +101,13 @@ void ScoreView::endEdit()
             harmonyEndEdit();
       else if (tp == Element::Type::FIGURED_BASS)
             figuredBassEndEdit();
-
-      if (editObject->isText()) {
+      else if (editObject->isText()) {
             Text* text = static_cast<Text*>(editObject);
             if (text->isEmpty())
                   _score->undoRemoveElement(text);
             editObject = nullptr;
             }
+
       _score->endCmd();
       mscore->endCmd();
 


### PR DESCRIPTION
harmonyEndEdit et al were already removing the element.  I could have just removed these functions, but one could imagine them having other purposes in addition to removing the empty element.
