### PR TITLE
[plugins] fix adding notes using newElement() and cursor.add()

### DIFF
--- a/libmscore/cursor.cpp
+++ b/libmscore/cursor.cpp
@@ -145,6 +145,12 @@ void Cursor::add(Element* s)
             s->setParent(m);
             _score->undoAddElement(s);
             }
+      else if (s->type() == Element::Type::NOTE) {
+            // note needs parent set to chord it belongs to
+            Note* note = static_cast<Note*>(s);
+            note->setChord(static_cast<Chord*>(element()));
+            _score->undoAddElement(s);
+            }
       else {
             _score->undoAddElement(s);
             }

--- a/libmscore/cursor.cpp
+++ b/libmscore/cursor.cpp
@@ -168,6 +168,26 @@ void Cursor::addNote(int pitch)
       }
 
 //---------------------------------------------------------
+//   remove
+//---------------------------------------------------------
+
+void Cursor::remove(Element* s)
+      {
+      if (!_segment)
+            return;
+
+      // some safety checks
+      if (!s)
+            return;
+      if (!(s->score() == _score))
+            return;
+      if (!s->parent())
+            return;
+
+      _score->undoRemoveElement(s);
+      }
+
+//---------------------------------------------------------
 //   setDuration
 //---------------------------------------------------------
 

--- a/libmscore/cursor.cpp
+++ b/libmscore/cursor.cpp
@@ -184,6 +184,14 @@ void Cursor::remove(Element* s)
       if (!s->parent())
             return;
 
+      // make sure not to remove last note of chord
+      // since this will crash
+      if (s->type() == Element::Type::NOTE) {
+            Note* note = static_cast<Note*>(s);
+            if (note->chord()->notes().size() < 2)
+                  return;
+            }
+
       _score->undoRemoveElement(s);
       }
 

--- a/libmscore/cursor.h
+++ b/libmscore/cursor.h
@@ -105,6 +105,7 @@ class Cursor : public QObject {
       Q_INVOKABLE bool next();
       Q_INVOKABLE bool nextMeasure();
       Q_INVOKABLE void add(Ms::Element*);
+      Q_INVOKABLE void remove(Ms::Element*);
 
       Q_INVOKABLE void addNote(int pitch);
 

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2703,7 +2703,8 @@ void Note::setAccidentalType(AccidentalType type)
 //   not be passed to the undo system.
 //---------------------------------------------------------
 
-void Note::qmlSetPitch(int pitch) {
+void Note::qmlSetPitch(int pitch) 
+      {
       if (pitch < 0 || pitch > 127)
             // invalid pitch
             return;
@@ -2718,7 +2719,8 @@ void Note::qmlSetPitch(int pitch) {
             }
       }
 
-void Note::qmlSetTpc1(int v) {
+void Note::qmlSetTpc1(int v) 
+      {
       if (!tpcIsValid(v))
             // invalid tpc
             return;
@@ -2733,7 +2735,8 @@ void Note::qmlSetTpc1(int v) {
             }
       }
 
-void Note::qmlSetTpc2(int v) {
+void Note::qmlSetTpc2(int v) 
+      {
       if (!tpcIsValid(v))
             // invalid tpc
             return;

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2695,5 +2695,56 @@ void Note::setAccidentalType(AccidentalType type)
       	_score->changeAccidental(this, type);
       }
 
+//---------------------------------------------------------
+//   qml wrappers for pitch, tpc1 and tpc2 properties
+//
+//   notes that have not been added to the score and thus
+//   don't have a valid pointer chord() must
+//   not be passed to the undo system.
+//---------------------------------------------------------
 
+void Note::qmlSetPitch(int pitch) {
+      if (pitch < 0 || pitch > 127)
+            // invalid pitch
+            return;
+
+      if (chord()) {
+            // use undo function since we're included in the score
+            undoSetPitch(pitch);
+            }
+      else {
+            // change the property since we're not included in the score
+            _pitch = pitch;
+            }
+      }
+
+void Note::qmlSetTpc1(int v) {
+      if (!tpcIsValid(v))
+            // invalid tpc
+            return;
+
+      if (chord()) {
+            // use undo function since we're included in the score
+            undoSetTpc1(v);
+            }
+      else {
+            // change the property since we're not included in the score
+            setTpc1(v);
+            }
+      }
+
+void Note::qmlSetTpc2(int v) {
+      if (!tpcIsValid(v))
+            // invalid tpc
+            return;
+
+      if (chord()) {
+            // use undo function since we're included in the score
+            undoSetTpc2(v);
+            }
+      else {
+            // change the property since we're not included in the score
+            setTpc2(v);
+            }
+      }
 }

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2703,7 +2703,7 @@ void Note::setAccidentalType(AccidentalType type)
 //   not be passed to the undo system.
 //---------------------------------------------------------
 
-void Note::qmlSetPitch(int pitch) 
+void Note::qmlSetPitch(int pitch)
       {
       if (pitch < 0 || pitch > 127)
             // invalid pitch
@@ -2719,7 +2719,7 @@ void Note::qmlSetPitch(int pitch)
             }
       }
 
-void Note::qmlSetTpc1(int v) 
+void Note::qmlSetTpc1(int v)
       {
       if (!tpcIsValid(v))
             // invalid tpc
@@ -2735,7 +2735,7 @@ void Note::qmlSetTpc1(int v)
             }
       }
 
-void Note::qmlSetTpc2(int v) 
+void Note::qmlSetTpc2(int v)
       {
       if (!tpcIsValid(v))
             // invalid tpc

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -152,9 +152,9 @@ class Note : public Element {
       Q_PROPERTY(int fret                                READ fret             WRITE undoSetFret)
       Q_PROPERTY(int string                              READ string           WRITE undoSetString)
       Q_PROPERTY(int tpc                                 READ tpc)
-      Q_PROPERTY(int tpc1                                READ tpc1             WRITE undoSetTpc1)
-      Q_PROPERTY(int tpc2                                READ tpc2             WRITE undoSetTpc2)
-      Q_PROPERTY(int pitch                               READ pitch            WRITE undoSetPitch)
+      Q_PROPERTY(int tpc1                                READ tpc1             WRITE qmlSetTpc1)
+      Q_PROPERTY(int tpc2                                READ tpc2             WRITE qmlSetTpc2)
+      Q_PROPERTY(int pitch                               READ pitch            WRITE qmlSetPitch)
       Q_PROPERTY(int ppitch                              READ ppitch)
       Q_PROPERTY(bool ghost                              READ ghost            WRITE undoSetGhost)
       Q_PROPERTY(bool hidden                             READ hidden)
@@ -280,6 +280,9 @@ class Note : public Element {
       void setPitch(int val);
       void undoSetPitch(int val);
       void setPitch(int pitch, int tpc1, int tpc2);
+      void qmlSetPitch(int pitch);
+      void qmlSetTpc1(int v);
+      void qmlSetTpc2(int v);
       int pitch() const                   { return _pitch;    }
       int ppitch() const;           ///< playback pitch
       int epitch() const;           ///< effective pitch


### PR DESCRIPTION
This provides a way for a plugin to add and remove notes to/from existing chords.
<s>(see implode.qml and explode.qml at https://github.com/heuchi/plode for a demonstration)</s>

Added wrappers for properties pitch, tpc1 and tpc2 in Note to avoid crashes due to uninitialized pointer.
Fixed cursor.add to take care of setting a note's chord property to avoid crashes.
Added cursor.remove to safely remove Elements of the current score.

---

Edit: I removed the plode branch of my repository since implode and explode got included in the main core. I forgot I was mentioning it here.
