### PR TITLE
attempt to expose class NoteHead

### DIFF
--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -317,6 +317,7 @@ QQmlEngine* MScore::qml()
             qmlRegisterType<Slur>       ("MuseScore", 1, 0, "Slur");
             qmlRegisterType<Tie>        ("MuseScore", 1, 0, "Tie");
             qmlRegisterType<NoteDot>    ("MuseScore", 1, 0, "NoteDot");
+            qmlRegisterType<NoteHead>   ("MuseScore", 1, 0, "NoteHead");
             qmlRegisterType<FiguredBass>("MuseScore", 1, 0, "FiguredBass");
             qmlRegisterType<Text>       ("MuseScore", 1, 0, "MText");
             qmlRegisterType<Lyrics>     ("MuseScore", 1, 0, "Lyrics");

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -174,6 +174,8 @@ class Note : public Element {
       Q_PROPERTY(Ms::Tie* tieFor                         READ tieFor)
       Q_PROPERTY(Ms::Tie* tieBack                        READ tieBack)
       Q_ENUMS(ValueType)
+      Q_ENUMS(Ms::NoteHead::Group)
+      Q_ENUMS(Ms::NoteHead::Type)
       Q_ENUMS(Ms::MScore::Direction)
       Q_ENUMS(Ms::MScore::DirectionH)
 

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -51,6 +51,8 @@ static const int MAX_DOTS = 3;
 
 class NoteHead : public Symbol {
       Q_OBJECT
+      Q_ENUMS(Group)
+      Q_ENUMS(Type)
 
    public:
       enum class Group : signed char {
@@ -80,6 +82,7 @@ class NoteHead : public Symbol {
             HEAD_TYPES
             };
 
+      NoteHead() : Symbol(0) {}
       NoteHead(Score* s) : Symbol(s) {}
       NoteHead &operator=(const NoteHead&) = delete;
       virtual NoteHead* clone() const    { return new NoteHead(*this); }
@@ -171,8 +174,6 @@ class Note : public Element {
       Q_PROPERTY(Ms::Tie* tieFor                         READ tieFor)
       Q_PROPERTY(Ms::Tie* tieBack                        READ tieBack)
       Q_ENUMS(ValueType)
-      Q_ENUMS(Ms::NoteHead::Group)
-      Q_ENUMS(Ms::NoteHead::Type)
       Q_ENUMS(Ms::MScore::Direction)
       Q_ENUMS(Ms::MScore::DirectionH)
 


### PR DESCRIPTION
This is my attempt to expose NoteHead to the plugin framework.
NoteHead is needed because it contains the enum NoteHead::Group which is needed to change a note's head to slash for example. (Slash plugin would need that.)
The problem is, that a class needs a default constructor to be used with qmlRegisterType. NoteHead, however, is derived from Symbol which doesn't have one. So I added this to class NoteHead (line 85):
  NoteHead() : Symbol(0) {}
I don't know if that's the way it should be done, while it seems to work.