### PR TITLE
fix #31601: (Mac) Fix toolbar focus 

### DIFF
--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -179,7 +179,7 @@ void ScoreAccessibility::updateAccessibilityInfo()
       //when this method is called
       if ( (qApp->focusWidget() != w) &&
            !mscore->inspector()->isAncestorOf(qApp->focusWidget()) &&
-           (mscore->searchDialog() && !mscore->searchDialog()->isAncestorOf(qApp->focusWidget()))) {
+           !(mscore->searchDialog() && mscore->searchDialog()->isAncestorOf(qApp->focusWidget())) ) {
             w->setFocus();
             }
       QObject* obj = static_cast<QObject*>(w);


### PR DESCRIPTION
It was a regression from writing an incorect condition when I fixed the search dialog issue #30271.
