### PR TITLE
fix #30266: Some button labels are not translated

### DIFF
--- a/share/locale/qt_ar.ts
+++ b/share/locale/qt_ar.ts
@@ -931,7 +931,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation type="unfinished">موافقة</translation>

--- a/share/locale/qt_bg.ts
+++ b/share/locale/qt_bg.ts
@@ -937,7 +937,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>Добре</translation>

--- a/share/locale/qt_ca.ts
+++ b/share/locale/qt_ca.ts
@@ -938,7 +938,7 @@ a
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>D&apos;acord</translation>

--- a/share/locale/qt_cs.ts
+++ b/share/locale/qt_cs.ts
@@ -1355,7 +1355,7 @@ na
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <location filename="../src/gui/dialogs/qmessagebox.cpp" line="+1872"/>
         <location line="+464"/>

--- a/share/locale/qt_da.ts
+++ b/share/locale/qt_da.ts
@@ -944,7 +944,7 @@ til
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>OK</translation>

--- a/share/locale/qt_de.ts
+++ b/share/locale/qt_de.ts
@@ -935,7 +935,7 @@ nach
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>OK</translation>
@@ -3391,19 +3391,19 @@ Bitte wählen Sie einen anderen Dateinamen.</translation>
     </message>
     <message>
         <source>Tab</source>
-        <translation>Tab</translation>
+        <translation>Tab →|</translation>
     </message>
     <message>
         <source>Backtab</source>
-        <translation>Rück-Tab</translation>
+        <translation>Rück-Tab |←</translation>
     </message>
     <message>
-        <source>Backspace</source>
-        <translation>Rücktaste</translation>
+        <source>Backspace </source>
+        <translation>Rücktaste ←</translation>
     </message>
     <message>
         <source>Return</source>
-        <translation>Return</translation>
+        <translation>Return ↵</translation>
     </message>
     <message>
         <source>Enter</source>
@@ -3427,7 +3427,7 @@ Bitte wählen Sie einen anderen Dateinamen.</translation>
     </message>
     <message>
         <source>SysReq</source>
-        <translation>SysReq</translation>
+        <translation>S-Abf</translation>
     </message>
     <message>
         <source>Home</source>
@@ -3439,39 +3439,39 @@ Bitte wählen Sie einen anderen Dateinamen.</translation>
     </message>
     <message>
         <source>Left</source>
-        <translation>Links</translation>
+        <translation>←</translation>
     </message>
     <message>
         <source>Up</source>
-        <translation>Hoch</translation>
+        <translation>↑</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation>Rechts</translation>
+        <translation>→</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation>Runter</translation>
+        <translation>↓</translation>
     </message>
     <message>
         <source>PgUp</source>
-        <translation>Bild aufwärts</translation>
+        <translation>Bild ↑</translation>
     </message>
     <message>
         <source>PgDown</source>
-        <translation>Bild abwärts</translation>
+        <translation>Bild ↓</translation>
     </message>
     <message>
         <source>CapsLock</source>
-        <translation>Feststelltaste</translation>
+        <translation>Feststelltaste ⇓</translation>
     </message>
     <message>
         <source>NumLock</source>
-        <translation>Zahlen-Feststelltaste</translation>
+        <translation>Num ⇓</translation>
     </message>
     <message>
         <source>ScrollLock</source>
-        <translation>Rollen-Feststelltaste</translation>
+        <translation>Rollen ⇓</translation>
     </message>
     <message>
         <source>Menu</source>
@@ -3643,27 +3643,27 @@ Bitte wählen Sie einen anderen Dateinamen.</translation>
     </message>
     <message>
         <source>Page Up</source>
-        <translation>Bild aufwärts</translation>
+        <translation>Bild ↑</translation>
     </message>
     <message>
         <source>Page Down</source>
-        <translation>Bild abwärts</translation>
+        <translation>Bild ↓</translation>
     </message>
     <message>
         <source>Caps Lock</source>
-        <translation>Feststelltaste</translation>
+        <translation>Feststelltaste ⇓</translation>
     </message>
     <message>
         <source>Num Lock</source>
-        <translation>Zahlen-Feststelltaste</translation>
+        <translation>Num ⇓</translation>
     </message>
     <message>
         <source>Number Lock</source>
-        <translation>Zahlen-Feststelltaste</translation>
+        <translation>Zahlen-Feststelltaste ⇓</translation>
     </message>
     <message>
         <source>Scroll Lock</source>
-        <translation>Rollen-Feststelltaste</translation>
+        <translation>Rollen ⇓</translation>
     </message>
     <message>
         <source>Insert</source>
@@ -3679,7 +3679,7 @@ Bitte wählen Sie einen anderen Dateinamen.</translation>
     </message>
     <message>
         <source>System Request</source>
-        <translation>System Request</translation>
+        <translation>System Abfrage</translation>
     </message>
     <message>
         <source>Select</source>
@@ -3727,7 +3727,7 @@ Bitte wählen Sie einen anderen Dateinamen.</translation>
     </message>
     <message>
         <source>Shift</source>
-        <translation>Umschalt</translation>
+        <translation>Umschalt ⇑</translation>
     </message>
     <message>
         <source>Alt</source>
@@ -3735,7 +3735,7 @@ Bitte wählen Sie einen anderen Dateinamen.</translation>
     </message>
     <message>
         <source>Meta</source>
-        <translation>Meta</translation>
+        <translation>Alt Gr</translation>
     </message>
     <message>
         <source>+</source>

--- a/share/locale/qt_el.ts
+++ b/share/locale/qt_el.ts
@@ -930,7 +930,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation type="unfinished">Ναι</translation>

--- a/share/locale/qt_es.ts
+++ b/share/locale/qt_es.ts
@@ -939,7 +939,7 @@ a
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>Aceptar</translation>

--- a/share/locale/qt_eu.ts
+++ b/share/locale/qt_eu.ts
@@ -890,7 +890,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation type="unfinished"></translation>

--- a/share/locale/qt_fa.ts
+++ b/share/locale/qt_fa.ts
@@ -921,7 +921,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation type="unfinished"></translation>

--- a/share/locale/qt_fi.ts
+++ b/share/locale/qt_fi.ts
@@ -922,7 +922,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>OK</translation>

--- a/share/locale/qt_fr.ts
+++ b/share/locale/qt_fr.ts
@@ -934,7 +934,7 @@ en
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>OK</translation>

--- a/share/locale/qt_gl.ts
+++ b/share/locale/qt_gl.ts
@@ -937,7 +937,7 @@ a
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>Aceptar</translation>

--- a/share/locale/qt_he.ts
+++ b/share/locale/qt_he.ts
@@ -1185,7 +1185,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <location filename="../src/gui/dialogs/qmessagebox.cpp" line="+1866"/>
         <location line="+464"/>

--- a/share/locale/qt_hu.ts
+++ b/share/locale/qt_hu.ts
@@ -943,7 +943,7 @@ erre:
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>OK</translation>

--- a/share/locale/qt_id.ts
+++ b/share/locale/qt_id.ts
@@ -921,7 +921,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation type="unfinished"></translation>

--- a/share/locale/qt_it.ts
+++ b/share/locale/qt_it.ts
@@ -933,7 +933,7 @@ in
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation></translation>

--- a/share/locale/qt_ja.ts
+++ b/share/locale/qt_ja.ts
@@ -1124,7 +1124,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <location filename="" line="326436454"/>
         <source>OK</source>

--- a/share/locale/qt_ko.ts
+++ b/share/locale/qt_ko.ts
@@ -936,7 +936,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>확인</translation>

--- a/share/locale/qt_lt.ts
+++ b/share/locale/qt_lt.ts
@@ -972,7 +972,7 @@ nepavyksta pervadinti į
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>Gerai</translation>

--- a/share/locale/qt_nl.ts
+++ b/share/locale/qt_nl.ts
@@ -938,7 +938,7 @@ niet hernoemen naar
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>Ok</translation>

--- a/share/locale/qt_pl.ts
+++ b/share/locale/qt_pl.ts
@@ -1124,7 +1124,7 @@ Proszę wybrać inną nazwę pliku.</translation>
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>OK</translation>

--- a/share/locale/qt_pt.ts
+++ b/share/locale/qt_pt.ts
@@ -939,7 +939,7 @@ para
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>OK</translation>

--- a/share/locale/qt_pt_BR.ts
+++ b/share/locale/qt_pt_BR.ts
@@ -938,7 +938,7 @@ para
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>OK</translation>

--- a/share/locale/qt_ro.ts
+++ b/share/locale/qt_ro.ts
@@ -923,7 +923,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation type="unfinished"></translation>

--- a/share/locale/qt_ru.ts
+++ b/share/locale/qt_ru.ts
@@ -931,7 +931,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation type="unfinished">OK</translation>

--- a/share/locale/qt_sk.ts
+++ b/share/locale/qt_sk.ts
@@ -900,7 +900,7 @@ na
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>OK</translation>

--- a/share/locale/qt_sl.ts
+++ b/share/locale/qt_sl.ts
@@ -1282,7 +1282,7 @@ v
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <location filename="../src/gui/dialogs/qmessagebox.cpp" line="+1872"/>
         <location line="+464"/>

--- a/share/locale/qt_sv.ts
+++ b/share/locale/qt_sv.ts
@@ -944,7 +944,7 @@ till
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>OK</translation>

--- a/share/locale/qt_tr.ts
+++ b/share/locale/qt_tr.ts
@@ -931,7 +931,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>TAMAM</translation>

--- a/share/locale/qt_uk.ts
+++ b/share/locale/qt_uk.ts
@@ -932,7 +932,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>Гаразд</translation>

--- a/share/locale/qt_vi.ts
+++ b/share/locale/qt_vi.ts
@@ -892,7 +892,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translatorcomment></translatorcomment>

--- a/share/locale/qt_zh_CN.ts
+++ b/share/locale/qt_zh_CN.ts
@@ -944,7 +944,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>确定</translation>

--- a/share/locale/qt_zh_TW.ts
+++ b/share/locale/qt_zh_TW.ts
@@ -936,7 +936,7 @@ to
     </message>
 </context>
 <context>
-    <name>QDialogButtonBox</name>
+    <name>QPlatformTheme</name>
     <message>
         <source>OK</source>
         <translation>確定</translation>


### PR DESCRIPTION
Fixed by replacing QDialogBottonBox by QPlatformTheme, which seems what
Qt 5.2 (?) and 5.3 (!) needs as the context, to load the right
translations for these button labels.

Also some more cosmetic fixes for the German translation
