### PR TITLE
Expose MuseScore::endCmd() to plugins

### DIFF
--- a/mscore/mscorePlugins.cpp
+++ b/mscore/mscorePlugins.cpp
@@ -419,7 +419,7 @@ void MuseScore::pluginTriggered(int idx)
             view->setSource(QUrl::fromLocalFile(pp));
             view->setTitle(p->menuPath().mid(p->menuPath().lastIndexOf(".") + 1));
             view->setColor(QApplication::palette().color(QPalette::Window));
-            //p->setParentItem(view->contentItem());
+            p->setParentItem(view->contentItem());
             //view->setWidth(p->width());
             //view->setHeight(p->height());
             view->setResizeMode(QQuickView::SizeRootObjectToView);

--- a/mscore/qmlplugin.cpp
+++ b/mscore/qmlplugin.cpp
@@ -14,12 +14,14 @@
 #include "shortcut.h"
 #include "musescoreCore.h"
 #include "libmscore/score.h"
+#include "musescore.h"
 
 #include <QQmlEngine>
 
 namespace Ms {
 
 extern MuseScoreCore* mscoreCore;
+extern MuseScore* mscore;
 
 //---------------------------------------------------------
 //   QmlPlugin
@@ -136,6 +138,18 @@ void QmlPlugin::cmd(const QString& s)
 MsProcess* QmlPlugin::newQProcess()
       {
       return 0; // TODO: new MsProcess(this);
+      }
+
+//---------------------------------------------------------
+//   endCmd
+//
+//   this calls MuseScore::endCmd which needs to be called
+//   if a plugin has changed a score
+//---------------------------------------------------------
+
+void QmlPlugin::endCmd()
+      {
+      mscore->endCmd();
       }
 }
 

--- a/mscore/qmlplugin.h
+++ b/mscore/qmlplugin.h
@@ -109,6 +109,7 @@ class QmlPlugin : public QQuickItem {
       Q_INVOKABLE Ms::MsProcess* newQProcess();
       Q_INVOKABLE bool writeScore(Ms::Score*, const QString& name, const QString& ext);
       Q_INVOKABLE Ms::Score* readScore(const QString& name);
+      Q_INVOKABLE void endCmd();
       };
 
 #endif

--- a/share/plugins/break.qml
+++ b/share/plugins/break.qml
@@ -77,6 +77,7 @@ MuseScore {
                         i++
                     }
                     curScore.endCmd()
+                    endCmd();
                     Qt.quit()
                 }
             }


### PR DESCRIPTION
MuseScore::endCmd() needs to be called if a plugin does some work outside onRun: (beeing triggered by the user at a later time). I added a wrapper to MuseScore::endCmd().

About mscorePlugins.cpp line 422: This was commented out by Lasconic about a year ago. Since I don't know why, here's the reason I put it back: With this line a score is immediately updated and marked dirty (if needed) after a plugin was triggered. Without this line the user has to click inside the score window first and the plugin even seems to need an extra call to curScore.doLayout().

I also updated the break.qml plugin which seems to be working now.
