### PR TITLE
Fix #32396 : Bugs in TAB note inputs.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1162,16 +1162,8 @@ void Score::upDown(bool up, UpDownMode mode)
                                           qDebug("upDown tab chromatic: getPitch(%d,%d) returns -1", string, fret);
                                           newPitch = oNote->pitch();
                                           }
-                                    int nTpc = pitch2tpc(newPitch, key, up ? Prefer::SHARPS : Prefer::FLATS);
-                                    if (oNote->concertPitch()) {
-                                          newTpc1 = nTpc;
-                                          newTpc2 = oNote->tpc2default(newPitch);
-                                          }
-                                    else {
-                                          newTpc2 = nTpc;
-                                          newTpc1 = oNote->tpc1default(newPitch);
-                                          }
-
+                                    // TAB's are by definition non-transposing
+                                    newTpc1 = newTpc2 = pitch2tpc(newPitch, key, up ? Prefer::SHARPS : Prefer::FLATS);
                                     // store the fretting change before undoChangePitch() chooses
                                     // a fretting of its own liking!
                                     undoChangeProperty(oNote, P_ID::FRET, fret);

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -971,27 +971,10 @@ qDebug("putNote at tick %d staff %d line %d clef %d",
                                           else
                                                 qDebug("can't increase fret to %d", fret);
                                           }
-                                    // set fret number (orignal or combined) in all linked notes
-                                    // int tpc1 = pitch2tpc(nval.pitch, Key::C, Prefer::NEAREST);
-                                    foreach (Element* e, note->linkList()) {
-                                          Note* linkedNote = static_cast<Note*>(e);
-                                          int tpc1 = linkedNote->tpc1default(nval.pitch);
-                                          int tpc2 = linkedNote->tpc2default(nval.pitch);
-                                          Staff* staff = linkedNote->staff();
-                                          if (staff->isTabStaff()) {
-                                                linkedNote->undoChangeProperty(P_ID::PITCH, nval.pitch);
-                                                linkedNote->undoChangeProperty(P_ID::TPC1,  tpc1);
-                                                linkedNote->undoChangeProperty(P_ID::TPC2,  tpc2);
-                                                linkedNote->undoChangeProperty(P_ID::FRET,  nval.fret);
-                                                linkedNote->undoChangeProperty(P_ID::STRING,nval.string);
-                                                nval.tpc = linkedNote->tpc();
-                                                }
-                                          else if (staff->isPitchedStaff()) {
-                                                // TODO: check tpc2
-                                                int tpc2 = linkedNote->tpc2default(nval.pitch);
-                                                undoChangePitch(linkedNote, nval.pitch, nval.tpc, tpc2);
-                                                }
-                                          }
+                                    // set fret number (original or combined) in all linked notes
+                                    int tpc1 = note->tpc1default(nval.pitch);
+                                    int tpc2 = note->tpc2default(nval.pitch);
+                                    undoChangeFretting(note, nval.pitch, nval.string, nval.fret, tpc1, tpc2);
                                     return;
                                     }
                         }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -514,6 +514,7 @@ class Score : public QObject {
       void undoChangeChordRestSize(ChordRest* cr, bool small);
       void undoChangeChordNoStem(Chord* cr, bool noStem);
       void undoChangePitch(Note* note, int pitch, int tpc1, int tpc2);
+      void undoChangeFretting(Note* note, int pitch, int string, int fret, int tpc1, int tpc2);
       void spellNotelist(QList<Note*>& notes);
       void undoChangeTpc(Note* note, int tpc);
       void undoChangeChordRestLen(ChordRest* cr, const TDuration&);

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -332,6 +332,24 @@ class ChangePitch : public UndoCommand {
       };
 
 //---------------------------------------------------------
+//   ChangeFretting
+//---------------------------------------------------------
+
+class ChangeFretting : public UndoCommand {
+      Note* note;
+      int pitch;
+      int string;
+      int fret;
+      int tpc1;
+      int tpc2;
+      void flip();
+
+   public:
+      ChangeFretting(Note* note, int pitch, int string, int fret, int tpc1, int tpc2);
+      UNDO_NAME("ChangeFretting")
+      };
+
+//---------------------------------------------------------
 //   ChangeKeySig
 //---------------------------------------------------------
 


### PR DESCRIPTION
Fix #32396 : Bugs in TAB note inputs.

Several inconsistencies accumulated in TAB note input during recent updates.

The main point is that currently the pitch, fret and string of a note -- if all are known -- must be changed in a single step; otherwise, the fretting algorithm intervening after each intermediate step notices they are inconsistent and refrets (potentially) the whole chord, which leads to loosing the fretting entered by the user.

A specific `undoChangeFretting()` function has been added, to be used with TAB's instead of `undoChangePitch()` when all the new fretting data (pitch, fret and string) are known in advance. This new function already takes care of linked notes.

Also, the fretting algorithm has been changed to be more conservative, i.e. to keep the current note fretting (potentially entered by the user) as much as possible.
