### PR TITLE
Fix #32541 - Some artic. anchor not saved in style dlg

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -692,12 +692,13 @@ void EditStyle::setValues()
                   continue;
             ArticulationAnchor st  = lstyle.articulationAnchor(i);
             int idx = 0;
-            if (st == ArticulationAnchor::TOP_STAFF)
-                  idx = 0;
-            else if (st == ArticulationAnchor::BOTTOM_STAFF)
-                  idx = 1;
-            else if (st == ArticulationAnchor::CHORD)
-                  idx = 2;
+            switch (st) {
+                  case ArticulationAnchor::TOP_STAFF:       idx = 0;    break;
+                  case ArticulationAnchor::BOTTOM_STAFF:    idx = 1;    break;
+                  case ArticulationAnchor::CHORD:           idx = 2;    break;
+                  case ArticulationAnchor::TOP_CHORD:       idx = 3;    break;
+                  case ArticulationAnchor::BOTTOM_CHORD:    idx = 4;    break;
+                  }
             cb->setCurrentIndex(idx);
             }
 


### PR DESCRIPTION
If some values are used for articulation anchors in the "Style | General" dlg box, they are not restored when opening the dlg again and presumably lost.

See http://musescore.org/en/node/32541 for details.
