### PR TITLE
fix #32441: bad layout with empty key signature

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3516,7 +3516,7 @@ qreal Score::computeMinWidth(Segment* fs)
                                     }
                               else {
                                     // if (pt & (Segment::Type::KeySig | Segment::Type::Clef))
-                                    bool firstClef = (segmentIdx == 1) && (pt == Segment::Type::Clef);
+                                    bool firstClef = (pt == Segment::Type::Clef) && (pSeg && pSeg->rtick() == 0);
                                     if ((pt & Segment::Type::KeySig) || firstClef)
                                           minDistance = qMax(minDistance, clefKeyRightMargin);
                                     }
@@ -3592,6 +3592,10 @@ qreal Score::computeMinWidth(Segment* fs)
                               minDistance = styleP(StyleIdx::clefLeftMargin);
                         else if (segType == Segment::Type::StartRepeatBarLine)
                               minDistance = .5 * _spatium;
+                        else if (segType == Segment::Type::TimeSig && pt == Segment::Type::Clef) {
+                              // missing key signature, but allocate default margin anyhow
+                              minDistance = styleP(StyleIdx::keysigLeftMargin);
+                              }
                         else if ((segType == Segment::Type::EndBarLine) && segmentIdx) {
                               if (pt == Segment::Type::Clef)
                                     minDistance = styleP(StyleIdx::clefBarlineDistance);

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3163,7 +3163,7 @@ void Measure::layoutX(qreal stretch)
                                     minDistance = qMax(minDistance, minNoteDistance);
                                     }
                               else {
-                                    bool firstClef = (segmentIdx == 1) && (pt == Segment::Type::Clef);
+                                    bool firstClef = (pt == Segment::Type::Clef) && (pSeg && pSeg->rtick() == 0);
                                     if ((pt & Segment::Type::KeySig) || firstClef)
                                           minDistance = qMax(minDistance, clefKeyRightMargin);
                                     }
@@ -3251,6 +3251,10 @@ void Measure::layoutX(qreal stretch)
                               minDistance = score()->styleS(StyleIdx::clefLeftMargin).val() * _spatium;
                         else if (segType == Segment::Type::StartRepeatBarLine)
                               minDistance = .5 * _spatium;
+                        else if (segType == Segment::Type::TimeSig && pt == Segment::Type::Clef) {
+                              // missing key signature, but allocate default margin anyhow
+                              minDistance = score()->styleS(StyleIdx::keysigLeftMargin).val() * _spatium;
+                              }
                         else if ((segType == Segment::Type::EndBarLine) && segmentIdx) {
                               if (pt == Segment::Type::Clef)
                                     minDistance = score()->styleS(StyleIdx::clefBarlineDistance).val() * _spatium;
@@ -3482,8 +3486,7 @@ void Measure::layoutX(qreal stretch)
                         continue;
                   Element::Type t = e->type();
                   Rest* rest = static_cast<Rest*>(e);
-                  if (((track % VOICES) == 0) &&
-                     (t == Element::Type::REPEAT_MEASURE || (t == Element::Type::REST && (isMMRest() || rest->isFullMeasureRest())))) {
+                  if (t == Element::Type::REPEAT_MEASURE || (t == Element::Type::REST && (isMMRest() || rest->isFullMeasureRest()))) {
                         //
                         // element has to be centered in free space
                         //    x1 - left measure position of free space
@@ -3495,11 +3498,13 @@ void Measure::layoutX(qreal stretch)
                               //
                               qreal x1 = 0.0, x2;
                               Segment* ss = first();
-                              for (; ss->segmentType() != Segment::Type::ChordRest; ss = ss->next())
-                                    ;
-                              // if (s != first()) {
-                              if (ss != first()) {
-                                    ss = ss->prev();
+                              Segment* ps = nullptr;
+                              for (; ss->segmentType() != Segment::Type::ChordRest; ss = ss->next()) {
+                                    if (!ss->isEmpty())
+                                          ps = ss;
+                                    }
+                              if (ps) {
+                                    ss = ps;
                                     for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
                                           int track = staffIdx * VOICES;
                                           Element* e = ss->element(track);
@@ -3536,10 +3541,13 @@ void Measure::layoutX(qreal stretch)
                               qreal x1 = 0.0;
                               qreal x2 = this->width();
                               Segment* ss = first();
-                              for (; ss->segmentType() != Segment::Type::ChordRest; ss = ss->next())
-                                    ;
-                              if (ss != first()) {
-                                    ss = ss->prev();
+                              Segment* ps = nullptr;
+                              for (; ss->segmentType() != Segment::Type::ChordRest; ss = ss->next()) {
+                                    if (!ss->isEmpty())
+                                          ps = ss;
+                                    }
+                              if (ps) {
+                                    ss = ps;
                                     for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
                                           int track = staffIdx * VOICES;
                                           Element* e = ss->element(track);
@@ -3555,7 +3563,7 @@ void Measure::layoutX(qreal stretch)
                               if (ns)
                                     x2 = ns->x();
 
-                              rest->rxpos() = (x2 - x1 - e->width()) * .5 + x1 - s->x();
+                              rest->rxpos() = (x2 - x1 - e->width()) * .5 + x1 - s->x() - e->bbox().x();
                               rest->adjustReadPos();
                               }
                         }

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -591,7 +591,6 @@ void Segment::remove(Element* el)
                   _elist[track] = 0;
                   if (!el->generated())
                         el->staff()->removeKey(tick());
-                  empty = false;
                   break;
 
             case Element::Type::CLEF:


### PR DESCRIPTION
There are a number of layout issues that result when a measure contains an empty key signature segment, or even a key signature segment that contains no elements for the current staff.  This PR addresses the cases I could find, all of which are handled in different places in the code:
- space between clef and time signature
- space between clef and first normal chord / rest
- space between clef and mmrest symbol
- space between clef and full measure rest (also fixed the centering to work for multiple voices - both the ledger line on top voice, also the possibility of full measure rest in voice 2, which can happen currently after change in length to a voice 2 note in previous measure)
