### PR TITLE
Fix #32261 : Local edit of bar line affects all bar lines

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -656,6 +656,18 @@ void BarLine::endEdit()
       {
       shiftDrag = false;
 
+      // if no change, do nothing
+      if (_span == _origSpan &&_spanFrom == _origSpanFrom && _spanTo == _origSpanTo) {
+            ctrlDrag = false;
+            return;
+            }
+      // if bar line has custom span, assume any span edit is local to this bar line
+      if (_customSpan == true)
+            ctrlDrag = true;
+      // if bar line belongs to a system (system-initial bar line), edit is local
+      if (parent() && parent()->type() == Element::Type::SYSTEM)
+            ctrlDrag = true;
+
       if (ctrlDrag) {                      // if single bar line edit
             ctrlDrag = false;
             _customSpan       = true;           // mark bar line as custom spanning


### PR DESCRIPTION
Fix #32261 : Local edit of bar line affects all bar lines

The use case detailed in the original issue (http://musescore.org/en/node/32261) was the following:

If edit mode is entered for a bar line with user-edit span (e.g. a tick) and then exited without any edit, as [Ctrl] has never been pressed, the edit is assumed to be global and the span of all the bar lines is changed to that specific bar line span.

Adds the following fixes:
- Entering and exiting bar line edit mode without doing anything actually does nothing.
- Any further span edit of a bar line whose span is already user-customized is assumed to be local to that bar line only. This makes using [Ctrl] for any further editing of a single bar line redundant.

Additionally:
- Any change in the span of system-initial bar line is always assumed to be local and no longer affects all the bar lines, as before.
