### PR TITLE
Measure flag for system-initial double bar line

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -532,12 +532,13 @@ bool BarLine::acceptDrop(const DropData& data) const
       if (type == Element::Type::BAR_LINE) {
             if (parent() && parent()->type() == Element::Type::SEGMENT)
                   return true;
+/* can't drop to system-initial bar line
             if (parent() && parent()->type() == Element::Type::SYSTEM) {
                   BarLine* b = static_cast<BarLine*>(data.element);
                   return (b->barLineType() == BarLineType::BROKEN || b->barLineType() == BarLineType::DOTTED
                      || b->barLineType() == BarLineType::NORMAL || b->barLineType() == BarLineType::DOUBLE
                      || b->spanFrom() != 0 || b->spanTo() != DEFAULT_BARLINE_TO);
-                  }
+                  } */
             }
       else {
             return (type == Element::Type::ARTICULATION
@@ -1067,6 +1068,11 @@ void BarLine::remove(Element* e)
 
 void BarLine::updateCustomSpan()
       {
+      // system bar line span is internally managed: _customSpan can never be true
+      if (parent() && parent()->type() == Element::Type::SYSTEM) {
+            _customSpan = false;
+            return;
+            }
       // if barline belongs to a staff and any of the staff span params is different from barline's...
       if (staff())
             if (staff()->barLineSpan() != _span || staff()->barLineFrom() != _spanFrom || staff()->barLineTo() != _spanTo) {
@@ -1109,7 +1115,12 @@ void BarLine::updateCustomType()
                               break;
                         }
                   }
-            // if parent is not a segment, it can only be a system and NORMAL can be used as ref. type
+            // if parent is not a segment, it can only be a system and for systems
+            // bar line type is internally managed and _customSubtype can never be true
+            else {
+                  _customSubtype = false;
+                  return;
+                  }
             }
       _customSubtype = (_barLineType != refType);
       updateGenerated(!_customSubtype);         // if _customSubType, _genereated is surely false

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -150,6 +150,7 @@ Measure::Measure(Score* s)
       _irregular             = false;
       _breakMultiMeasureRest = false;
       _breakMMRest           = false;
+      _sysInitDblBar         = false;
       _endBarLineGenerated   = true;
       _endBarLineVisible     = true;
       _endBarLineType        = BarLineType::NORMAL;
@@ -185,6 +186,7 @@ Measure::Measure(const Measure& m)
       _irregular             = m._irregular;
       _breakMultiMeasureRest = m._breakMultiMeasureRest;
       _breakMMRest           = m._breakMMRest;
+      _sysInitDblBar         = m._sysInitDblBar;
       _endBarLineGenerated   = m._endBarLineGenerated;
       _endBarLineVisible     = m._endBarLineVisible;
       _endBarLineType        = m._endBarLineType;
@@ -1702,6 +1704,8 @@ void Measure::write(Xml& xml, int staff, bool writeSystemElements) const
                   xml.tag("stretch", _userStretch);
             if (_noOffset)
                   xml.tag("noOffset", _noOffset);
+            if (_sysInitDblBar)
+                  xml.tag("sysInitDblBar", _sysInitDblBar);
             }
       qreal _spatium = spatium();
       MStaff* mstaff = staves[staff];
@@ -2193,6 +2197,10 @@ void Measure::read(XmlReader& e, int staffIdx)
             else if (tag == "breakMultiMeasureRest") {
                   _breakMultiMeasureRest = true;
                   e.readNext();
+                  }
+            else if (tag == "sysInitDblBar") {
+                  _sysInitDblBar = e.readInt();
+//                  e.readNext();
                   }
             else if (tag == "Tuplet") {
                   Tuplet* tuplet = new Tuplet(score());
@@ -3915,6 +3923,8 @@ QVariant Measure::getProperty(P_ID propertyId) const
                   return noOffset();
             case P_ID::IRREGULAR:
                   return irregular();
+            case P_ID::SYSINIT_DBLBAR:
+                  return sysInitDblBar();
             default:
                   return MeasureBase::getProperty(propertyId);
             }
@@ -3954,6 +3964,9 @@ bool Measure::setProperty(P_ID propertyId, const QVariant& value)
             case P_ID::IRREGULAR:
                   setIrregular(value.toBool());
                   break;
+            case P_ID::SYSINIT_DBLBAR:
+                  setSysInitDblBar(value.toBool());
+                  break;
             default:
                   return MeasureBase::setProperty(propertyId, value);
             }
@@ -3984,6 +3997,8 @@ QVariant Measure::propertyDefault(P_ID propertyId) const
             case P_ID::NO_OFFSET:
                   return 0;
             case P_ID::IRREGULAR:
+                  return false;
+            case P_ID::SYSINIT_DBLBAR:
                   return false;
             default:
                   break;

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -152,6 +152,8 @@ class Measure : public MeasureBase {
                               // 0 if this is the start of a mm rest (_mmRest != 0)
                               // < 0 if this measure is covered by a mm rest
 
+      bool _sysInitDblBar;    // if true, and this measure is the first of a system,
+                              // draw system double bar line
       void push_back(Segment* e);
       void push_front(Segment* e);
       void layoutCR0(ChordRest* cr, qreal m);
@@ -267,6 +269,8 @@ class Measure : public MeasureBase {
       void setEndBarLineGenerated(bool v)       { _endBarLineGenerated = v;    }
       bool endBarLineVisible() const            { return _endBarLineVisible;   }
       QColor endBarLineColor() const            { return _endBarLineColor;     }
+      bool sysInitDblBar() const                { return _sysInitDblBar;       }
+      void setSysInitDblBar(bool v)             { _sysInitDblBar = v;          }
 
       RepeatMeasure* cmdInsertRepeatMeasure(int staffIdx);
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -197,6 +197,7 @@ static const PropertyData propertyList[] = {
       { P_ID::USER_STRETCH,        false, "stretch",         P_TYPE::REAL },
       { P_ID::NO_OFFSET,           false, "noOffset",        P_TYPE::INT  },
       { P_ID::IRREGULAR,           true,  "irregular",       P_TYPE::BOOL },
+      { P_ID::SYSINIT_DBLBAR,      true,  "sysInitDblBar",   P_TYPE::BOOL },
 
       { P_ID::ANCHOR,              false,  "anchor",       P_TYPE::INT },
 

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -194,6 +194,7 @@ enum class P_ID : unsigned char {
       USER_STRETCH,
       NO_OFFSET,
       IRREGULAR,
+      SYSINIT_DBLBAR,
 
       ANCHOR,
 

--- a/mscore/measureproperties.cpp
+++ b/mscore/measureproperties.cpp
@@ -87,6 +87,7 @@ void MeasureProperties::setMeasure(Measure* _m)
 
       irregular->setChecked(m->irregular());
       breakMultiMeasureRest->setChecked(m->getBreakMultiMeasureRest());
+      sysInitDblBar->setChecked(m->sysInitDblBar());
       int n  = m->repeatCount();
       count->setValue(n);
       count->setEnabled(m->repeatFlags() & Repeat::END);
@@ -213,6 +214,7 @@ void MeasureProperties::apply()
       m->undoChangeProperty(P_ID::MEASURE_NUMBER_MODE, measureNumberMode->currentIndex());
       m->undoChangeProperty(P_ID::NO_OFFSET, measureNumberOffset->value());
       m->undoChangeProperty(P_ID::IRREGULAR, isIrregular());
+      m->undoChangeProperty(P_ID::SYSINIT_DBLBAR, sysInitDblBar->isChecked());
 
       if (m->len() != len())
             m->adjustToLen(len());

--- a/mscore/measureproperties.ui
+++ b/mscore/measureproperties.ui
@@ -145,6 +145,9 @@
             <property name="text">
              <string>Actual:</string>
             </property>
+            <property name="buddy">
+             <cstring>actualZ</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="1" colspan="2">
@@ -279,38 +282,8 @@
          </property>
          <layout class="QGridLayout" name="gridLayout1">
           <property name="horizontalSpacing">
-           <number>-1</number>
+           <number>6</number>
           </property>
-          <item row="0" column="0" colspan="2">
-           <widget class="QCheckBox" name="irregular">
-            <property name="toolTip">
-             <string>do not count</string>
-            </property>
-            <property name="text">
-             <string>Exclude from measure count</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QCheckBox" name="breakMultiMeasureRest">
-            <property name="text">
-             <string>Break multimeasure rest</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QLabel" name="label_5">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Repeat count:</string>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="4">
            <widget class="QSpinBox" name="count">
             <property name="sizePolicy">
@@ -327,21 +300,8 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="3">
-           <widget class="QLabel" name="label_8">
+          <item row="2" column="3">
+           <widget class="QLabel" name="label_5">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -349,59 +309,10 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Layout stretch:</string>
+             <string>Repeat count:</string>
             </property>
-           </widget>
-          </item>
-          <item row="1" column="4">
-           <widget class="QDoubleSpinBox" name="layoutStretch">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimum">
-             <double>0.900000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.200000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Add to measure number:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QSpinBox" name="measureNumberOffset">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimum">
-             <number>-9999</number>
-            </property>
-            <property name="maximum">
-             <number>9999</number>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Measure number mode:</string>
+            <property name="buddy">
+             <cstring>count</cstring>
             </property>
            </widget>
           </item>
@@ -424,6 +335,93 @@
             </item>
            </widget>
           </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="measureNumberOffset">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimum">
+             <number>-9999</number>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QLabel" name="label_8">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Layout stretch:</string>
+            </property>
+            <property name="buddy">
+             <cstring>layoutStretch</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Measure number mode:</string>
+            </property>
+            <property name="buddy">
+             <cstring>measureNumberMode</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Add to measure number:</string>
+            </property>
+            <property name="buddy">
+             <cstring>measureNumberOffset</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="4">
+           <widget class="QDoubleSpinBox" name="layoutStretch">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimum">
+             <double>0.900000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.200000000000000</double>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="5">
            <spacer name="horizontalSpacer_2">
             <property name="orientation">
@@ -436,6 +434,34 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item row="0" column="0" colspan="6">
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QCheckBox" name="irregular">
+              <property name="toolTip">
+               <string>do not count</string>
+              </property>
+              <property name="text">
+               <string>Exclude from measure count</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="breakMultiMeasureRest">
+              <property name="text">
+               <string>Break multimeasure rest</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="sysInitDblBar">
+              <property name="text">
+               <string>Double bar if system-initial</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -486,9 +512,21 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="musescore.qrc"/>
- </resources>
+ <tabstops>
+  <tabstop>staves</tabstop>
+  <tabstop>actualZ</tabstop>
+  <tabstop>actualN</tabstop>
+  <tabstop>irregular</tabstop>
+  <tabstop>breakMultiMeasureRest</tabstop>
+  <tabstop>sysInitDblBar</tabstop>
+  <tabstop>measureNumberMode</tabstop>
+  <tabstop>layoutStretch</tabstop>
+  <tabstop>measureNumberOffset</tabstop>
+  <tabstop>count</tabstop>
+  <tabstop>previousButton</tabstop>
+  <tabstop>nextButton</tabstop>
+ </tabstops>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>


### PR DESCRIPTION
Adds to the Measure class a flag which turns the system-initial bar line to double when the measure is the first of a system.

This is needed by some engraving styles (mostly jazz? @MarcSabatella raised the point); adding this flag allows:
- to set the system-initial bar line to double independently of actual system breaks (the flag triggers only if the measure is the first of a system and does nothing otherwise)
- to make the system-initial bar line non-selectable (and then non-editable), simplifying the bar line management.

UI for setting the flag is added to the Measure Properties dialogue box; this required to reorder some controls. Advice on text used and on dlg layout is welcome.
