### PR TITLE
Enter Edit Mode on an element only if isEditable()

### DIFF
--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -36,6 +36,10 @@ namespace Ms {
 
 void ScoreView::startEdit(Element* e)
       {
+      if (!e || !e->isEditable()) {
+            qDebug("The element cannot be edited");
+            return;
+            }
       if (e->type() == Element::Type::TBOX)
             e = static_cast<TBox*>(e)->getText();
       editObject = e;
@@ -49,6 +53,10 @@ void ScoreView::startEdit(Element* e)
 
 void ScoreView::startEdit(Element* element, int startGrip)
       {
+      if (!element || !element->isEditable()) {
+            qDebug("The element cannot be edited");
+            return;
+            }
       editObject = element;
       startEdit();
       if (startGrip == -1)

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2583,7 +2583,7 @@ void ScoreView::cmd(const QAction* a)
 
       else if (cmd == "edit-element") {
             Element* e = _score->selection().element();
-            if (e) {
+            if (e && e->isEditable()) {
                   _score->setLayoutAll(false);
                   startEdit(e);
                   }


### PR DESCRIPTION
Currently, `Element::isEditable()` is not checked before entering edit mode. This PR adds the checks.

**Note**: Given the variety of conditions which may determine the editability of an element and the fact that so far the `isEditable()` method has been under-utilized, this may lead to making un-editable elements previously editable (possibly correctly or possibly not).
