### PR TITLE
fix #31571: key sig for new transposing instrument

### DIFF
--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -221,6 +221,10 @@ void MuseScore::editInstrList()
                   tmpKeymap[tick] = transposeKey(oKey, interval);
                   }
             }
+      // create initial keyevent for transposing instrument if necessary
+      auto i = tmpKeymap.begin();
+      if (i == tmpKeymap.end() || i->first != 0)
+            tmpKeymap[0] = Key::C;
 
       //
       // process modified partitur list


### PR DESCRIPTION
This PR fixes the listed issue without changing anything else about the management of key signatures.  Which is to say, it leaves a mess in the case of scores in "C".  Sometimes there will be initial "C" key signatures, sometimes there will not, depending on what you do and the order you do it in.

I figure, let's fix this bug now - the code should be good regardless of what we do later (at worst, it will turn out to be a little unnecessary insurance.
