### PR TITLE
fix #32826: end repeat on mmrest

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1765,12 +1765,15 @@ void Score::createMMRests()
                   mmr->setNo(m->no());
                   mmr->setPageBreak(lm->pageBreak());
                   mmr->setLineBreak(lm->lineBreak());
-                  mmr->setRepeatFlags(m->repeatFlags());
 
-                  BarLineType t = lm->endBarLineGenerated() ? BarLineType::NORMAL : lm->endBarLineType();
+                  BarLineType t;
+                  if (lm->endBarLineGenerated() && !(lm->repeatFlags() & Repeat::END))
+                        t = BarLineType::NORMAL;
+                  else
+                        t = lm->endBarLineType();
                   mmr->setEndBarLineType(t, false, lm->endBarLineVisible(), lm->endBarLineColor());
 
-                  mmr->setRepeatFlags(m->repeatFlags());
+                  mmr->setRepeatFlags(m->repeatFlags() | lm->repeatFlags());
 
                   qDeleteAll(*mmr->el());
                   mmr->el()->clear();


### PR DESCRIPTION
According to my understanding after talking with @mgavioli, this code should be good.  endBarLineGenerated is normally true except double bars, dotted bars, etc.  End repeats do _not_ necessarily set endBarLineGenerated to false because in fact they _can_ generated from the repeatFlags.  So we need to check for the appropriate repeatFlag on the last measure.

I also changed the code here that sets the repeatFlag for the mmrest itself.  It was originally only using the last measure's repeat flags, then this was changed back in July to use only the first  measure's repeat flags - and the line to set those flags was duplicated, so it was being set twice.  I believe it makes sense for the mmrest to share the repeat flags of both the first & last measure, but I am less sure this is actually necessary or that there aren't reasons why it shouldn't.  But I've tested and seems things still work - including the case of the "phantom courtesy start repeat" at the end of a system before a system that begins with a start repeat.  These cases were fixed by @mgavioli already, and my change here does not appear to adversely affect that.
