### PR TITLE
Style of the initial bar line of a system.

### DIFF
--- a/libmscore/barline.h
+++ b/libmscore/barline.h
@@ -118,6 +118,7 @@ class BarLine : public Element {
       static QString userTypeName2(BarLineType);
 
       QString barLineTypeName() const;
+      static QString barLineTypeName(BarLineType t);
       void setBarLineType(const QString& s);
       void setBarLineType(BarLineType i) { _barLineType = i;     updateCustomType();      }
       BarLineType barLineType() const    { return _barLineType;  }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1477,8 +1477,14 @@ void Score::deleteItem(Element* el)
             case Element::Type::BAR_LINE:
                   {
                   BarLine* bl  = static_cast<BarLine*>(el);
-                  if (bl->parent()->type() != Element::Type::SEGMENT)
+                  // if system initial bar ine, route change to system first measure
+                  if (bl->parent()->type() == Element::Type::SYSTEM) {
+                        Measure* m = static_cast<System*>(bl->parent())->firstMeasure();
+                        if (m && m->systemInitialBarLineType() != BarLineType::NORMAL)
+                              undoChangeSystemBarLineType(m, BarLineType::NORMAL);
                         break;
+                        }
+                  // if regular measure bar line
                   Segment* seg   = static_cast<Segment*>(bl->parent());
                   bool normalBar = seg->measure()->endBarLineType() == BarLineType::NORMAL;
                   int tick       = seg->tick();

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2575,6 +2575,14 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
       bool needRelayout = false;
 
       foreach (System* system, sl) {
+            // set system initial bar line type here, as in System::layout...() methods
+            // it is either too early (in System::layout() measures are not added to the system yet)
+            // or too late (in System::layout2(), horizontal spacing has already been done
+            //    and bar line width will be ignored).
+            // We only set bar line type here; track and bar line span values are set in System::layout2()
+            if (system->barLine() && system->firstMeasure())
+                  system->barLine()->setBarLineType(system->firstMeasure()->systemInitialBarLineType());
+
             //
             //    add cautionary time/key signatures if needed
             //

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -154,6 +154,7 @@ Measure::Measure(Score* s)
       _endBarLineGenerated   = true;
       _endBarLineVisible     = true;
       _endBarLineType        = BarLineType::NORMAL;
+      _systemInitialBarLineType = BarLineType::NORMAL;
       _mmRest                = 0;
       _mmRestCount           = 0;
       setFlag(ElementFlag::MOVABLE, true);
@@ -189,6 +190,7 @@ Measure::Measure(const Measure& m)
       _endBarLineGenerated   = m._endBarLineGenerated;
       _endBarLineVisible     = m._endBarLineVisible;
       _endBarLineType        = m._endBarLineType;
+      _systemInitialBarLineType = m._systemInitialBarLineType;    // possibly should be reset to NORMAL?
       _mmRest                = m._mmRest;
       _mmRestCount           = m._mmRestCount;
       _playbackCount         = m._playbackCount;
@@ -1703,6 +1705,8 @@ void Measure::write(Xml& xml, int staff, bool writeSystemElements) const
                   xml.tag("stretch", _userStretch);
             if (_noOffset)
                   xml.tag("noOffset", _noOffset);
+            if (_systemInitialBarLineType != BarLineType::NORMAL)
+                  xml.tag("sysInitBarLineType", BarLine::barLineTypeName(_systemInitialBarLineType));
             }
       qreal _spatium = spatium();
       MStaff* mstaff = staves[staff];
@@ -2198,6 +2202,16 @@ void Measure::read(XmlReader& e, int staffIdx)
             else if (tag == "breakMultiMeasureRest") {
                   _breakMultiMeasureRest = true;
                   e.readNext();
+                  }
+            else if (tag == "sysInitBarLineType") {
+                  const QString& val(e.readElementText());
+                  _systemInitialBarLineType = BarLineType::NORMAL;
+                  for (unsigned i = 0; i < barLineTableSize(); ++i) {
+                        if (BarLine::barLineTypeName(BarLineType(i)) == val) {
+                              _systemInitialBarLineType = BarLineType(i);
+                              break;
+                              }
+                        }
                   }
             else if (tag == "Tuplet") {
                   Tuplet* tuplet = new Tuplet(score());

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -143,6 +143,7 @@ class Measure : public MeasureBase {
       bool        _endBarLineGenerated;
       bool        _endBarLineVisible;
       QColor      _endBarLineColor;
+      BarLineType _systemInitialBarLineType;    ///< type used for system bar line, when measure is initial
 
       int _playbackCount;     // temp. value used in RepeatList
                               // counts how many times this measure was already played
@@ -267,6 +268,8 @@ class Measure : public MeasureBase {
       void setEndBarLineGenerated(bool v)       { _endBarLineGenerated = v;    }
       bool endBarLineVisible() const            { return _endBarLineVisible;   }
       QColor endBarLineColor() const            { return _endBarLineColor;     }
+      void setSystemInitialBarLineType(BarLineType v) { _systemInitialBarLineType = v;    }
+      BarLineType systemInitialBarLineType() const    { return _systemInitialBarLineType; }
 
       RepeatMeasure* cmdInsertRepeatMeasure(int staffIdx);
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -521,6 +521,7 @@ class Score : public QObject {
       void undoChangeEndBarLineType(Measure*, BarLineType);
       void undoChangeBarLineSpan(Staff*, int span, int spanFrom, int spanTo);
       void undoChangeSingleBarLineSpan(BarLine* barLine, int span, int spanFrom, int spanTo);
+      void undoChangeSystemBarLineType(Measure* m, BarLineType subtype);
       void undoTransposeHarmony(Harmony*, int, int);
       void undoExchangeVoice(Measure* measure, int val1, int val2, int staff1, int staff2);
       void undoRemovePart(Part* part, int idx);

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -400,9 +400,8 @@ void System::layout2()
       if (_barLine) {
             _barLine->setTrack(firstStaffIdx * VOICES);
             _barLine->setSpan(lastStaffIdx - firstStaffIdx + 1);
-            if (score()->staff(0)->lines() == 1)
+            if (score()->staff(firstStaffIdx)->lines() == 1)
                   _barLine->setSpanFrom(BARLINE_SPAN_1LINESTAFF_FROM);
-
             int spanTo = (score()->staff(lastStaffIdx)->lines() == 1) ?
                               BARLINE_SPAN_1LINESTAFF_TO :
                               (score()->staff(lastStaffIdx)->lines()-1)*2;

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -628,6 +628,15 @@ void Score::undoChangeEndBarLineType(Measure* m, BarLineType subtype)
       }
 
 //---------------------------------------------------------
+//   undoChangeSystemBarLineType
+//---------------------------------------------------------
+
+void Score::undoChangeSystemBarLineType(Measure* m, BarLineType subtype)
+      {
+      undo(new ChangeSystemBarLineType(m, subtype));
+      }
+
+//---------------------------------------------------------
 //   undoChangeBarLineSpan
 //---------------------------------------------------------
 
@@ -2100,6 +2109,25 @@ void ChangeEndBarLineType::flip()
       measure->setEndBarLineType(subtype, endBarLineGenerated);
       subtype = typ;
       endBarLineGenerated = eblg;
+      }
+
+//---------------------------------------------------------
+//   ChangeSystemBarLineType
+//---------------------------------------------------------
+
+ChangeSystemBarLineType::ChangeSystemBarLineType(Measure* m, BarLineType st)
+      {
+      measure = m;
+      subtype = st;
+      }
+
+void ChangeSystemBarLineType::flip()
+      {
+      BarLineType typ = measure->systemInitialBarLineType();
+      measure->setSystemInitialBarLineType(subtype);
+      subtype = typ;
+      // without this, the system bar line is not laid out again
+      measure->score()->setLayoutAll(true);
       }
 
 //---------------------------------------------------------

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -465,6 +465,20 @@ class ChangeEndBarLineType : public UndoCommand {
       };
 
 //---------------------------------------------------------
+//   ChangeSystemBarLineType
+//---------------------------------------------------------
+
+class ChangeSystemBarLineType : public UndoCommand {
+      Measure* measure;
+      BarLineType subtype;
+      void flip();
+
+   public:
+      ChangeSystemBarLineType(Measure*, BarLineType subtype);
+      UNDO_NAME("ChangeSystemBarLineType")
+      };
+
+//---------------------------------------------------------
 //   ChangeBarLineSpan
 //---------------------------------------------------------
 


### PR DESCRIPTION
In some engraving styles (mainly jazz), a double system initial bar line is used at structural articulations of the piece.

The PR supports this style, by adding a `_systemInitialBarLineStyle` variable to the `Measure` class which controls the style of the system bar line when the measure is the first of the system and by default it is set to NORMAL. This variable is not accessed directly; rather it is controlled by manipulating the system bar line. A system bar line can be edited:
- by dropping on it a bar line style from the palette (structural styles, like any repeat or END are ignored);
- by selecting it and double clicking a bar line style from the palette (same note as above).

It can be reset:
- by undo;
- by dropping on it (or selecting and double clicking) a NORMAL bar line style from the palette;
- by selecting and deleting it.

As the system bar line style is stored in the measure, if the first measure of a system changes (because of some other editing), the system bar line style will follow accordingly.
