### PR TITLE
Fix visibility issues in ContinuousPanel

### DIFF
--- a/mscore/continuouspanel.cpp
+++ b/mscore/continuouspanel.cpp
@@ -96,14 +96,6 @@ void ContinuousPanel::paint(const QRect& /*r*/, QPainter& p)
             _width  = s->x();
 
       //
-      // Don't show panel if staff names are visible
-      //
-      if (_sv->xoffset() / _sv->mag() + _width >= 0) {
-            _visible = false;
-            return;
-            }
-
-      //
       // Set panel height for whole system
       //
       _height = 6 * _spatium;
@@ -161,6 +153,15 @@ void ContinuousPanel::paint(const QRect& /*r*/, QPainter& p)
       if (_currentMeasure == nullptr)
             return;
       findElementWidths(elementsCurrent);
+
+      //
+      // Don't show panel if staff names are visible
+      if (_sv->xoffset() / _sv->mag() + _xPosMeasure > 0) {
+            _visible = false;
+            return;
+            }
+      //qDebug() << "_sv->xoffset()=" <<_sv->xoffset() << " _sv->mag()="<< _sv->mag() <<" s->x=" << s->x() << " width=" << _width << " currentMeasue=" << _currentMeasure->x() << " _xPosMeasure=" << _xPosMeasure;
+
       draw(p, elementsCurrent);
       _visible = true;
       }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3714,8 +3714,8 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack)
             qreal marginLeft = width() * 0.05;
             qreal marginRight = width() * 0.05; // leaves 5% margin to the right
 
-            if (_continuousPanel->visible())
-                  marginLeft += _continuousPanel->width();
+            if (_continuousPanel->active())
+                  marginLeft += _continuousPanel->width() * mag();
 
             if (round(curPosMagR) > round(width() - marginRight)) {
                   xo = -curPosL * mag() + marginLeft;


### PR DESCRIPTION
Fix issues  :
- In Continuous View, the last visible measure is moved under the continuous panel (http://musescore.org/en/node/32886#comment-139406)
- Improved detection of when to start showing panel at the beginning of a score.
