### PR TITLE
hide local handbook behind -e option, even via F1

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1223,7 +1223,8 @@ void MuseScore::helpBrowser(QString tag) const
       QUrl url(QUrl::fromLocalFile(path));
       if (!tag.isEmpty())
             url.setFragment(tag);
-      helpBrowser(url);
+      if (enableExperimental)
+            helpBrowser(url);
       }
 
 void MuseScore::helpBrowser(const QUrl& url) const


### PR DESCRIPTION
sorry, found that only now...
