### PR TITLE
fix #32651: Key signature at system break with canceling naturals should not repeat naturals at beginning of following system

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -154,6 +154,11 @@ void KeySig::layout()
             (prevMeas && prevMeas->sectionBreak() == nullptr
             && (score()->styleI(StyleIdx::keySigNaturals) != int(KeySigNatural::NONE) || t1 == 0) );
 
+      // Don't repeat naturals if shown in courtesy
+      if (prevMeas && prevMeas->findSegment(Segment::Type::KeySigAnnounce, measure()->tick()) != 0
+          && segment()->segmentType() != Segment::Type::KeySigAnnounce )
+            naturalsOn = false;
+
       int coffset = 0;
       Key t2      = Key::C;
       if (naturalsOn) {


### PR DESCRIPTION
Had to undo a separate bug's commits - I guess you shouldn't git rebase master if you're working on multiple bugs.
This change will force key signatures to never show naturals if they are at the system header, even if it's a change to C/Am. We could make this a style option, but this should be the default behavior.
