### PR TITLE
fix #4905: Crescendo/decrescendo playback

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -449,7 +449,9 @@ void Score::updateHairpin(Hairpin* h)
 
       int endVelo = velo;
       if (incr == 0)
-            endVelo = st->velocities().nextVelo(tick2+1);
+            endVelo = st->velocities().nextVelo(tick2-1);
+      else if (h->hairpinType() == Hairpin::Type::DECRESCENDO)
+            endVelo -= incr;
       else
             endVelo += incr;
 
@@ -562,6 +564,13 @@ void Score::updateVelo()
                                     break;
                               }
                         }
+                  }
+            for (std::pair<int,Spanner*> sp : _spanner.map()) {
+                  Spanner* s = sp.second;
+                  if (s->type() != Element::Type::HAIRPIN || sp.second->staffIdx() != staffIdx)
+                        continue;
+                  Hairpin* h = static_cast<Hairpin*>(s);
+                  updateHairpin(h);
                   }
             }
       }

--- a/mscore/inspector/inspector_dynamic.ui
+++ b/mscore/inspector/inspector_dynamic.ui
@@ -108,6 +108,9 @@
        <property name="accessibleName">
         <string>Velocity</string>
        </property>
+       <property name="maximum">
+        <number>127</number>
+       </property>
       </widget>
      </item>
      <item row="0" column="1">

--- a/mscore/inspector/inspector_hairpin.ui
+++ b/mscore/inspector/inspector_hairpin.ui
@@ -180,6 +180,9 @@
        <property name="accessibleName">
         <string>Velocity change</string>
        </property>
+       <property name="maximum">
+        <number>127</number>
+       </property>
       </widget>
      </item>
      <item row="3" column="0">


### PR DESCRIPTION
As Marc Sabetella pointed out, the code for this was already present, but not working. Let's start with updateHairpin(). It adds ramp/fixed anchor points to an overall velocity envelope of a staff so that calls to velo() would return the fixed amount, or interpolate between the current velocity and the Velocity Change parameter. If Velocity Change is 0, it will use the following fixed velocity as the end anchor (probably a dynamic that immediately follows). The only thing wrong with this code was handling of decrescendos. The user needs know what he's doing when setting Velocity Change to 0, or else a "p decrescendo f" will actually crescendo (if he sets Velocity Change to 20, it will go down and immediately jump back up to f, which is probably the correct interpretation).

updateHairpin() seemed to get called whenever it should, updating staff velocity anchor points whenever it got changed (paste/undo etc.). However, when renderMidi() calls updateVelo(), it clears the entire velocity event list. updateVelo() then creates new velocity events where dynamics are, but not where hairpins are. I changed the code to fix this, so after the velocity events are created for all the dynamics of a staff, updateHairpin() is called for all of its hairpins, thus creating a proper velocity envelope.

Finally, I changed the Inspector to allow values up to 127 in the Velocity/Velocity Change fields for dynamics and hairpins, respectively.
