### PR TITLE
consistently remove "compressed", add "uncompressed" and use "File(s)" rather than "Format"

### DIFF
--- a/mscore/album.cpp
+++ b/mscore/album.cpp
@@ -130,7 +130,7 @@ void Album::createScore()
       {
       if (_scores.isEmpty())
             return;
-      QString filter = QWidget::tr("Compressed MuseScore File (*.mscz);;");
+      QString filter = QWidget::tr("MuseScore File (*.mscz);;");
       QSettings settings;
       if (mscore->lastSaveDirectory.isEmpty())
             mscore->lastSaveDirectory = settings.value("lastSaveDirectory", preferences.myScoresPath).toString();

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -366,8 +366,8 @@ bool MuseScore::saveFile(Score* score)
             if (t)
                   fn = t->plainText(true);
             QString name = createDefaultFileName(fn);
-            QString f1 = tr("Compressed MuseScore File (*.mscz)");
-            QString f2 = tr("MuseScore File (*.mscx)");
+            QString f1 = tr("MuseScore File (*.mscz)");
+            QString f2 = tr("Uncompressed MuseScore File (*.mscx)");
 
             QSettings settings;
             if (mscore->lastSaveDirectory.isEmpty())
@@ -1508,9 +1508,9 @@ bool MuseScore::exportFile()
 #endif
       fl.append(tr("MP3 Audio (*.mp3)"));
       fl.append(tr("Standard MIDI File (*.mid)"));
-      fl.append(tr("MusicXML Format (*.xml)"));
-      fl.append(tr("Compressed MusicXML Format (*.mxl)"));
-      fl.append(tr("Uncompressed MuseScore Format (*.mscx)"));
+      fl.append(tr("MusicXML File (*.xml)"));
+      fl.append(tr("Compressed MusicXML File (*.mxl)"));
+      fl.append(tr("Uncompressed MuseScore File (*.mscx)"));
 
       QString saveDialogTitle = tr("MuseScore: Export");
 
@@ -1560,10 +1560,10 @@ bool MuseScore::exportParts()
 #endif
       fl.append(tr("MP3 Audio (*.mp3)"));
       fl.append(tr("Standard MIDI File (*.mid)"));
-      fl.append(tr("MusicXML Format (*.xml)"));
-      fl.append(tr("Compressed MusicXML Format (*.mxl)"));
-      fl.append(tr("MuseScore Format (*.mscz)"));
-      fl.append(tr("Uncompressed MuseScore Format (*.mscx)"));
+      fl.append(tr("MusicXML File (*.xml)"));
+      fl.append(tr("Compressed MusicXML File (*.mxl)"));
+      fl.append(tr("MuseScore File (*.mscz)"));
+      fl.append(tr("Uncompressed MuseScore File (*.mscx)"));
 
       QString saveDialogTitle = tr("MuseScore: Export Parts");
 
@@ -1995,8 +1995,8 @@ Score::FileError readScore(Score* score, QString name, bool ignoreVersionError)
 bool MuseScore::saveAs(Score* cs, bool saveCopy)
       {
       QStringList fl;
-      fl.append(tr("MuseScore Format (*.mscz)"));
-      fl.append(tr("MuseScore Format (*.mscx)"));     // for debugging purposes
+      fl.append(tr("MuseScore File (*.mscz)"));
+      fl.append(tr("Uncompressed MuseScore File (*.mscx)"));     // for debugging purposes
       fl.append(tr("All Files (*)"));
       QString saveDialogTitle = saveCopy ? tr("MuseScore: Save a Copy") :
                                            tr("MuseScore: Save As");
@@ -2043,7 +2043,7 @@ bool MuseScore::saveSelection(Score* cs)
             return false;
             }
       QStringList fl;
-      fl.append(tr("MuseScore Format (*.mscz)"));
+      fl.append(tr("MuseScore File (*.mscz)"));
       fl.append(tr("All Files (*)"));
       QString saveDialogTitle = tr("MuseScore: Save Selection");
 

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -1171,7 +1171,7 @@ void PreferenceDialog::selectStartWith()
          this,
          tr("Choose Starting Score"),
          sessionScore->text(),
-         tr("MuseScore Files (*.mscz *.mscx *.msc);;All (*)")
+         tr("MuseScore Files (*.mscz *.mscx);;All (*)")
          );
       if (!s.isNull())
             sessionScore->setText(s);


### PR DESCRIPTION
on 'save', 'save as', open', 'export' etc.
(Exceptions: MusicXML and Compressed MusicXML)
The mixup had lead me to a wrong translation once,
where I accidentially (and stupidly) 'translated' the extension too...
