### PR TITLE
Spacing of melisma syllables

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3564,11 +3564,9 @@ qreal Score::computeMinWidth(Segment* fs)
                                     if (!l->isEmpty()) {
                                           l->layout();
                                           lyrics = l;
-                                          if (!lyrics->isMelisma()) {
-                                                QRectF b(l->bbox().translated(l->pos()));
-                                                llw = qMax(llw, -(b.left()+lx+cx));
-                                                rrw = qMax(rrw, b.right()+rx+cx);
-                                                }
+                                          QRectF b(l->bbox().translated(l->pos()));
+                                          llw = qMax(llw, -(b.left()+lx+cx));
+                                          rrw = qMax(rrw, b.right()+rx+cx);
                                           }
                                     }
                               }

--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -77,7 +77,7 @@ class Lyrics : public Text {
       int ticks() const                { return _ticks;    }
       void setTicks(int tick)          { _ticks = tick;    }
       int endTick() const;
-      bool isMelisma() const           { return _ticks > 0; }
+      bool isMelisma() const;
 
       void clearSeparator()            { _separator.clear(); } // TODO: memory leak
       QList<Line*>* separatorList()    { return &_separator; }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3203,11 +3203,9 @@ void Measure::layoutX(qreal stretch)
                                     if (!l || l->isEmpty())
                                           continue;
                                     lyrics = l;
-                                    if (!lyrics->isMelisma()) {
-                                          QRectF b(l->bbox().translated(l->pos()));
-                                          llw = qMax(llw, -(b.left()+lx+cx));
-                                          rrw = qMax(rrw, b.right()+rx+cx);
-                                          }
+                                    QRectF b(l->bbox().translated(l->pos()));
+                                    llw = qMax(llw, -(b.left()+lx+cx));
+                                    rrw = qMax(rrw, b.right()+rx+cx);
                                     }
                               }
                         if (lyrics) {


### PR DESCRIPTION
Currently, syllables that represent melismas affect spacing differently depending on whether they have extenders or hyphens, but neither behavior is ideal, and the inconsistency is an issue in itself.

For syllables with extenders which are, by definition, always melismas), the syllable is actually completely ignored for note spacing purposes - deliberately.  This allows the syllable to overlap several notes, but it also risks collision with the next syllable that does occur.  See http://musescore.org/en/node/5261

For syllables that melismas but that use hyphens instead of extenders, the syllable is accounted for normally in spacing, leading to unnecessary space being allocated for the chord to which the syllable is attached but at least avoiding the risk of collision.  See http://musescore.org/en/node/33246

This PR changes the behavior to be consistent.  Melisma syllables of either type will be treated by default like the hyphenated type are currently - they will affect note spacing.  However, I added a way to get the current extender behavior (again, for either type): simply add a trailing Ctrl+Space to the syllable.  You still risk collision, but since you have to take this step manually, you take on that risk as well.  While I was at it, I also made this same trick work to disable allocation of leading space and give a manual workaround (that is similarly use-at-your-own-risk) for http://musescore.org/en/node/22696.

The ideal behavior for melismas, BTW, is for the layout to automatically detect how many segments the syllables would need to overlap, and divide the required space equally among them.  This is much easier said than done, however.  It's akin to what is done for chord symbols, but that code doesn't actually handle all cases well either, and in any cases, lyrics are more complex because there are multiple voices and multiple verses involved.
