### PR TITLE
Fix loop out playback on last note

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1519,6 +1519,9 @@ void Seq::setLoopOut()
             tick = cs->pos() + cs->inputState().ticks();   // Otherwise, use the selected note.
       if (tick <= cs->loopInTick())   // If Out pos <= In pos, reset In pos to beginning of score
             cs->setPos(POS::LEFT, 0);
+      else
+          if (tick > cs->lastMeasure()->endTick() - 1)
+              tick = cs->lastMeasure()->endTick() - 1;
       cs->setPos(POS::RIGHT, tick);
       if (state == Transport::PLAY)
             guiToSeq(SeqMsg(SeqMsgId::SEEK, tick));


### PR DESCRIPTION
Fix issue http://musescore.org/en/node/33981 : impossible to set loop out on last note of a score.
