### PR TITLE
fix 33961: 'Set as default' now enabled after removing a soundfont

### DIFF
--- a/fluid/fluidgui.cpp
+++ b/fluid/fluidgui.cpp
@@ -95,6 +95,8 @@ void FluidGui::synthesizerChanged()
       QStringList sfonts = fluid()->soundFonts();
       soundFonts->clear();
       soundFonts->addItems(sfonts);
+      updateUpDownButtons();
+      emit sfChanged();
       }
 
 //---------------------------------------------------------
@@ -113,6 +115,7 @@ void FluidGui::soundFontUpClicked()
       soundFonts->clear();
       soundFonts->addItems(sfonts);
       soundFonts->setCurrentRow(row-1);
+      emit sfChanged();
       }
 
 //---------------------------------------------------------
@@ -133,6 +136,7 @@ void FluidGui::soundFontDownClicked()
       soundFonts->clear();
       soundFonts->addItems(sfonts);
       soundFonts->setCurrentRow(row+1);
+      emit sfChanged();
       }
 
 //---------------------------------------------------------
@@ -146,6 +150,7 @@ void FluidGui::soundFontDeleteClicked()
             QString s(soundFonts->item(row)->text());
             fluid()->removeSoundFont(s);
             delete soundFonts->takeItem(row);
+            emit sfChanged();
             emit valueChanged();
             }
       updateUpDownButtons();

--- a/mscore/synthcontrol.h
+++ b/mscore/synthcontrol.h
@@ -37,7 +37,6 @@ class SynthControl : public QWidget, Ui::SynthControl {
       Score* _score;
       virtual void closeEvent(QCloseEvent*);
       void updateGui();
-      void updateUpDownButtons();
 
    private slots:
       void gainChanged(double, int);


### PR DESCRIPTION
Fixed #11096, checked every button related to Fluid in Synthesizer window ===> fixed many possible crashes.
