### PR TITLE
fix #33966: voltaY & mmrest settings for parts in 1.3 scores

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -703,8 +703,6 @@ Score::FileError Score::read114(XmlReader& e)
       // adjust some styles
       qreal lmbd = styleD(StyleIdx::lyricsMinBottomDistance);
       style()->set(StyleIdx::lyricsMinBottomDistance, lmbd + 4.0);
-      if (style(StyleIdx::voltaY) == MScore::baseStyle()->value(StyleIdx::voltaY))
-            style()->set(StyleIdx::voltaY, -2.0f);
       if (style(StyleIdx::hideEmptyStaves).toBool()) // http://musescore.org/en/node/16228
             style()->set(StyleIdx::dontHideStavesInFirstSystem, false);
       if (style(StyleIdx::showPageNumberOne).toBool()) { // http://musescore.org/en/node/21207
@@ -752,8 +750,9 @@ Score::FileError Score::read114(XmlReader& e)
             if (!excerpt->parts().isEmpty()) {
                   Score* nscore = new Score(this);
                   excerpt->setScore(nscore);
-                  Ms::createExcerpt(nscore, excerpt->parts());
                   nscore->setName(excerpt->title());
+                  nscore->style()->set(StyleIdx::createMultiMeasureRests, true);
+                  Ms::createExcerpt(nscore, excerpt->parts());
                   nscore->rebuildMidiMapping();
                   nscore->updateChannel();
                   nscore->updateNotes();
@@ -761,6 +760,12 @@ Score::FileError Score::read114(XmlReader& e)
                   nscore->doLayout();
                   }
             }
+
+      // volta offsets in older scores are hardcoded to be relative to a voltaY of -2.0sp
+      // we'll force this and live with it for the score
+      // but we wait until now to do it so parts don't have this issue
+      if (style(StyleIdx::voltaY) == MScore::baseStyle()->value(StyleIdx::voltaY))
+            style()->set(StyleIdx::voltaY, -2.0f);
 
       fixTicks();
       rebuildMidiMapping();


### PR DESCRIPTION
1.3 scores were being imported with no mmrests.  We could force this in the Score(Score*) constructor as we do for concert pitch, but I elected instead to simply mimic how we do it when creating parts for new scores in excertpsdialog.cpp

Regarding volta, it appears their offsets in 1.3 scores were hardcoded to assume a default position of -2.0sp.  The current code was forcing the score to use that value for voltaY, but it doesn't make sense for parts to inherit that, since their voltas are all reset to default position and that is not a good default in general.  We could instead consider rebasing the voltas in 1.3 scores to assume a default of -3.0sp.  It kind of looks like that approach was attempted and abandoned - or maybe I am misinterpreting this:

https://github.com/musescore/MuseScore/commit/f5dc1766cef874851fb2284ea902dfc5f45fd975#diff-97d139714d630a8f95d269d78b4d8fb1R65
