### PR TITLE
fix #34641: allow actual flat & sharp symbols when typing chord symbols

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -622,7 +622,7 @@ bool Harmony::edit(MuseScoreView* view, int grip, int key, Qt::KeyboardModifiers
 void Harmony::endEdit()
       {
       Text::endEdit();
-      setHarmony(text());
+      setHarmony(plainText(true));
       layout();
       if (links()) {
             foreach(Element* e, *links()) {


### PR DESCRIPTION
Uses the code I added recently to handle chord symbols imported from 1.3 - any actual flat and sharp glyphs in the text now get converted to "b" and "#" before parsing.
