### PR TITLE
fix #35091: measure properties dialog fixes

### DIFF
--- a/mscore/measureproperties.cpp
+++ b/mscore/measureproperties.cpp
@@ -55,6 +55,7 @@ void MeasureProperties::gotoNextMeasure()
             setMeasure(m->nextMeasure());
       nextButton->setEnabled(m->nextMeasure() != 0);
       previousButton->setEnabled(m->prevMeasure() != 0);
+      m->score()->end();
       }
 
 //---------------------------------------------------------
@@ -67,6 +68,7 @@ void MeasureProperties::gotoPreviousMeasure()
             setMeasure(m->prevMeasure());
       nextButton->setEnabled(m->nextMeasure() != 0);
       previousButton->setEnabled(m->prevMeasure() != 0);
+      m->score()->end();
       }
 
 //---------------------------------------------------------
@@ -77,6 +79,9 @@ void MeasureProperties::setMeasure(Measure* _m)
       {
       m = _m;
       setWindowTitle(QString(tr("MuseScore: Measure Properties for Measure %1")).arg(m->no()+1));
+      m->score()->select(0, SelectType::SINGLE, 0);
+      m->score()->select(m, SelectType::ADD, 0);
+
       actualZ->setValue(m->len().numerator());
       int index = actualN->findText(QString::number(m->len().denominator()));
       if (index == -1)
@@ -217,8 +222,7 @@ void MeasureProperties::apply()
       if (m->len() != len())
             m->adjustToLen(len());
 
-      score->select(0, SelectType::SINGLE, 0);
-      score->end();
+      score->update();
       }
 }
 

--- a/mscore/measureproperties.ui
+++ b/mscore/measureproperties.ui
@@ -279,7 +279,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout1">
           <property name="horizontalSpacing">
-           <number>-1</number>
+           <number>6</number>
           </property>
           <item row="0" column="0" colspan="2">
            <widget class="QCheckBox" name="irregular">
@@ -362,10 +362,13 @@
              </sizepolicy>
             </property>
             <property name="minimum">
-             <double>0.900000000000000</double>
+             <double>0.000000000000000</double>
             </property>
             <property name="singleStep">
-             <double>0.200000000000000</double>
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -486,9 +489,7 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="musescore.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>


### PR DESCRIPTION
Apply button was applying changes but not doing an update() to force relayout.  It also lost selection.  I fixed that too, and actually made it so the selection tracks if you press the next/previous measure buttons, so you can see which measure you are actually working on.  I thought I remembered an older issue for that but cannot find it.  I also fix the minimum value for the "Layout stretch" control, which was stuck at 0.90 and would not show you values less than that even if you reduced stretch less than that with the keyboard shortcut.
