### PR TITLE
fix #30681

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2115,7 +2115,7 @@ void Measure::read(XmlReader& e, int staffIdx)
                         cr->add(element);
                   }
             else if (tag == "Text") {
-                  Text* t = new Text(score());
+                  Text* t = new StaffText(score());
                   t->setTrack(e.track());
                   t->read(e);
                   // previous versions stored measure number, delete it


### PR DESCRIPTION
In principle, Text class is not directly used for text annotations. This PR substitutes the use of "Text" with "StaffText" for annotations within a measure. Measure numbers ("Text" objects) were already being discarded.
