### PR TITLE
fix #35351: tempo text cannot be added to track > 0

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1246,7 +1246,7 @@ void MuseScore::addTempo()
 
       TempoText* tt = new TempoText(cs);
       tt->setParent(cr->segment());
-      tt->setTrack(cr->track());
+      tt->setTrack(0);
       tt->setText(text);
       tt->setFollowText(true);
       //tt->setTempo(bps);


### PR DESCRIPTION
Track was not being set to 0 as it is for other system elements.
