### PR TITLE
fix #10576: hide context help too

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1007,8 +1007,10 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
 
       createElementPropertyMenu(obj, popup);
 
-      popup->addSeparator();
-      a = popup->addAction(tr("Help"));
+      if (enableExperimental) {
+            popup->addSeparator();
+            a = popup->addAction(tr("Help"));
+      }
       popup->addSeparator();
       a->setData("help");
       a = popup->addAction(tr("Debugger"));


### PR DESCRIPTION
behind -e option, until a proper handbook exists
