### PR TITLE
fix #34576: hide note input shadow note until mouse move

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3111,6 +3111,7 @@ void ScoreView::startNoteEntry()
       // set cursor after setting the stafftype-dependent state
       moveCursor();
       mscore->updateInputState(_score);
+      shadowNote->setVisible(false);
       setCursorOn(true);
       }
 


### PR DESCRIPTION
This is my proposed fix for the fact that the duration is incorrect until you move the mouse - simply suppress the shadow note until you move the mouse.  I actually like this _better_ than getting the duration correct, since only mouse users want to see the shadow note anyhow.  The shadow note just gets in my way.  With my fix, keyboard users never have to see the shadow note, and mouse users will see it as soon as they move to enter a note.

But FWIW, if someone _does_ want to fix the duration, we'd also want to get the position correct too.  Right now, it's just whatever position was left over from last time you left note input mode.
