### PR TITLE
Fix #35136 : Tremolo bar always on top staff + crash on delete

### DIFF
--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -549,17 +549,18 @@ void Segment::remove(Element* el)
                   break;
 
             case Element::Type::DYNAMIC:
-            case Element::Type::HARMONY:
-            case Element::Type::SYMBOL:
-            case Element::Type::FRET_DIAGRAM:
-            case Element::Type::TEMPO_TEXT:
-            case Element::Type::STAFF_TEXT:
-            case Element::Type::REHEARSAL_MARK:
-            case Element::Type::MARKER:
-            case Element::Type::IMAGE:
-            case Element::Type::TEXT:
-            case Element::Type::TAB_DURATION_SYMBOL:
             case Element::Type::FIGURED_BASS:
+            case Element::Type::FRET_DIAGRAM:
+            case Element::Type::HARMONY:
+            case Element::Type::IMAGE:
+            case Element::Type::MARKER:
+            case Element::Type::REHEARSAL_MARK:
+            case Element::Type::STAFF_TEXT:
+            case Element::Type::SYMBOL:
+            case Element::Type::TAB_DURATION_SYMBOL:
+            case Element::Type::TEMPO_TEXT:
+            case Element::Type::TEXT:
+            case Element::Type::TREMOLOBAR:
                   removeAnnotation(el);
                   break;
 

--- a/libmscore/tremolobar.cpp
+++ b/libmscore/tremolobar.cpp
@@ -27,6 +27,7 @@ namespace Ms {
 TremoloBar::TremoloBar(Score* s)
    : Element(s)
       {
+      setFlag(ElementFlag::ON_STAFF, true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fix #35136 : Tremolo bar always on top staff + crash on delete

A) A tremolo bar is always displayed on the top staff, regardless of the staff is it applied to:
corrected by adding the ON_STAFF flag to a new `TremoloBar` object

B) Deleting a tremolo bar crashes the programme:
corrected by adding the relevant case to the `Segment::remove()` method
