### PR TITLE
fix #36656: width (of lines) vs. thickness

### DIFF
--- a/mscore/debugger/textline.ui
+++ b/mscore/debugger/textline.ui
@@ -42,7 +42,7 @@
         <item row="0" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
-           <string notr="true">line width:</string>
+           <string notr="true">Line thickness:</string>
           </property>
          </widget>
         </item>
@@ -56,7 +56,7 @@
         <item row="1" column="2">
          <widget class="QPushButton" name="endText">
           <property name="text">
-           <string notr="true">endText</string>
+           <string notr="true">EndText</string>
           </property>
          </widget>
         </item>

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -1636,7 +1636,7 @@
             <item row="4" column="0">
              <widget class="QLabel" name="label_29">
               <property name="text">
-               <string>Fix number of measures/system:</string>
+               <string>Fixed number of measures/system:</string>
               </property>
               <property name="buddy">
                <cstring>fixNumberMeasures</cstring>
@@ -1649,7 +1649,7 @@
             <item row="5" column="0">
              <widget class="QCheckBox" name="fixMeasureWidth">
               <property name="text">
-               <string>Fix measure width</string>
+               <string>Fixed measure width</string>
               </property>
              </widget>
             </item>
@@ -1675,7 +1675,7 @@
             <item row="0" column="0">
              <widget class="QLabel" name="label_91">
               <property name="text">
-               <string>System bracket width:</string>
+               <string>System bracket thickness:</string>
               </property>
               <property name="buddy">
                <cstring>bracketWidth</cstring>
@@ -1685,7 +1685,7 @@
             <item row="2" column="0">
              <widget class="QLabel" name="label_92">
               <property name="text">
-               <string>Brace width:</string>
+               <string>Brace thickness:</string>
               </property>
               <property name="buddy">
                <cstring>akkoladeWidth</cstring>
@@ -3491,7 +3491,7 @@
           <item row="3" column="0">
            <widget class="QLabel" name="label_10">
             <property name="text">
-             <string>Line break height:</string>
+             <string>Continue height:</string>
             </property>
             <property name="buddy">
              <cstring>hairpinContinueHeight</cstring>
@@ -4006,7 +4006,7 @@
           <item row="0" column="4">
            <widget class="QCheckBox" name="ottavaNumbersOnly">
             <property name="text">
-             <string>numbers only</string>
+             <string>Numbers only</string>
             </property>
            </widget>
           </item>

--- a/mscore/inspector/inspector_ambitus.ui
+++ b/mscore/inspector/inspector_ambitus.ui
@@ -180,7 +180,7 @@
      <item row="4" column="1">
       <widget class="QDoubleSpinBox" name="lineWidth">
        <property name="accessibleName">
-        <string>Line width</string>
+        <string>Line thickness</string>
        </property>
        <property name="suffix">
         <string>sp</string>
@@ -205,7 +205,7 @@
         <string>reset value</string>
        </property>
        <property name="accessibleName">
-        <string>Reset Line width value</string>
+        <string>Reset Line thickness value</string>
        </property>
        <property name="text">
         <string>...</string>
@@ -486,7 +486,7 @@
      <item row="4" column="0">
       <widget class="QLabel" name="label_10">
        <property name="text">
-        <string>Line width</string>
+        <string>Line thickness</string>
        </property>
       </widget>
      </item>
@@ -941,8 +941,6 @@
   <tabstop>bottomTpc</tabstop>
   <tabstop>bottomOctave</tabstop>
  </tabstops>
- <resources>
-  <include location="../musescore.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_line.ui
+++ b/mscore/inspector/inspector_line.ui
@@ -95,7 +95,7 @@
      <item row="3" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Line width</string>
+        <string>Line thickness</string>
        </property>
       </widget>
      </item>
@@ -151,7 +151,7 @@
      <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="lineWidth">
        <property name="accessibleName">
-        <string>Line width</string>
+        <string>Line thickness</string>
        </property>
        <property name="suffix">
         <string extracomment="Spatium unit">sp</string>
@@ -199,7 +199,7 @@
         <string>reset value</string>
        </property>
        <property name="accessibleName">
-        <string>Reset Line width value</string>
+        <string>Reset Line thickness value</string>
        </property>
        <property name="text">
         <string>...</string>
@@ -240,8 +240,6 @@
   <tabstop>lineStyle</tabstop>
   <tabstop>resetLineStyle</tabstop>
  </tabstops>
- <resources>
-  <include location="../musescore.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -362,7 +362,7 @@ InstrumentsWidget::InstrumentsWidget(QWidget* parent)
 
       instrumentList->setSelectionMode(QAbstractItemView::ExtendedSelection);
       partiturList->setSelectionMode(QAbstractItemView::SingleSelection);
-      QStringList header = (QStringList() << tr("Staves") << tr("Visib.") << tr("Clef") << tr("Link.") << tr("Staff type"));
+      QStringList header = (QStringList() << tr("Staves") << tr("Visible") << tr("Clef") << tr("Linked") << tr("Staff type"));
       partiturList->setHeaderLabels(header);
       partiturList->resizeColumnToContents(1);  // shrink "visible "and "linked" columns as much as possible
       partiturList->resizeColumnToContents(3);

--- a/mscore/textproperties.ui
+++ b/mscore/textproperties.ui
@@ -833,7 +833,7 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Border width:</string>
+              <string>Border thickness:</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -846,7 +846,7 @@
            <item row="0" column="1">
             <widget class="QDoubleSpinBox" name="frameWidth">
              <property name="toolTip">
-              <string>frame line width</string>
+              <string>Frame line thickness</string>
              </property>
              <property name="suffix">
               <string>sp</string>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -10,7 +10,7 @@
             <name>Orchestral instruments</name>
       </Genre>
       <Genre id="earlymusic">
-            <name>Early Music</name>
+            <name>Early music</name>
       </Genre>
       <Genre id="ethnic">
             <name>Ethnic instruments</name>

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -1,7 +1,7 @@
 QT_TRANSLATE_NOOP("InstrumentsXML", "Common instruments"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Jazz instruments"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Orchestral instruments"),
-QT_TRANSLATE_NOOP("InstrumentsXML", "Early Music"),
+QT_TRANSLATE_NOOP("InstrumentsXML", "Early music"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Ethnic instruments"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Woodwind"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Piccolo"),


### PR DESCRIPTION
and consolidate volta "Continue height".
Also change "Fix" to "Fixed" to make clearer it is an adjective, not a
noun or verb.
And make "Numbers only" Sentence style.
Get rid of unneeded abbreviations "Visib." and Link."
Change "Early music" to Sentence case.
