### PR TITLE
  partial fix for #33726: avoid wrong partnames with SATB closed score

### DIFF
--- a/share/templates/02-Choral-SATB_Closed_Score.mscx
+++ b/share/templates/02-Choral-SATB_Closed_Score.mscx
@@ -53,7 +53,7 @@
           </StaffType>
         <bracket type="0" span="2"/>
         </Staff>
-      <trackName>Soprano/Alto</trackName>
+      <trackName>Soprano+Alto</trackName>
       <Instrument>
         <longName pos="0">S
 A</longName>
@@ -91,7 +91,7 @@ A</longName>
         <defaultClef>F</defaultClef>
         <bracket type="-1" span="0"/>
         </Staff>
-      <trackName>Tenor/Bass</trackName>
+      <trackName>Tenor+Bass</trackName>
       <Instrument>
         <longName pos="0">T
 B</longName>

--- a/share/templates/02-Choral-SATB_Closed_Score_with_Organ.mscx
+++ b/share/templates/02-Choral-SATB_Closed_Score_with_Organ.mscx
@@ -49,7 +49,7 @@
           </StaffType>
         <bracket type="0" span="2"/>
         </Staff>
-      <trackName>Soprano/Alto</trackName>
+      <trackName>Soprano+Alto</trackName>
       <Instrument>
         <longName pos="0">S A</longName>
         <trackName>Soprano/Alto</trackName>
@@ -86,7 +86,7 @@
         <defaultClef>F</defaultClef>
         <bracket type="-1" span="0"/>
         </Staff>
-      <trackName>Tenor/Bass</trackName>
+      <trackName>Tenor+Bass</trackName>
       <Instrument>
         <longName pos="0">T B</longName>
         <trackName>Tenor/Bass</trackName>

--- a/share/templates/02-Choral-SATB_Closed_Score_with_Piano.mscx
+++ b/share/templates/02-Choral-SATB_Closed_Score_with_Piano.mscx
@@ -51,7 +51,7 @@
           </StaffType>
         <bracket type="0" span="2"/>
         </Staff>
-      <trackName>Soprano/Alto</trackName>
+      <trackName>Soprano+Alto</trackName>
       <Instrument>
         <longName pos="0">S A</longName>
         <trackName>Soprano/Alto</trackName>
@@ -88,7 +88,7 @@
         <defaultClef>F</defaultClef>
         <bracket type="-1" span="0"/>
         </Staff>
-      <trackName>Tenor/Bass</trackName>
+      <trackName>Tenor+Bass</trackName>
       <Instrument>
         <longName pos="0">T B</longName>
         <trackName>Tenor/Bass</trackName>


### PR DESCRIPTION
due to the '/' in the partname "Soprano/Alto" and "Tenor/Bass", partnames get
truncated to which leads to part names of "Alto" and "Bass".
Change the offending "/" to "+" in the templates
See http://musescore.org/en/node/33726#comment-142726
