### PR TITLE
allow cross staff move for selections & rests

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1509,12 +1509,12 @@ void Score::resetUserStretch()
 //   moveUp
 //---------------------------------------------------------
 
-void Score::moveUp(Chord* chord)
+void Score::moveUp(ChordRest* cr)
       {
-      Staff* staff  = chord->staff();
+      Staff* staff  = cr->staff();
       Part* part    = staff->part();
       int rstaff    = staff->rstaff();
-      int staffMove = chord->staffMove();
+      int staffMove = cr->staffMove();
 
       if ((staffMove == -1) || (rstaff + staffMove <= 0))
             return;
@@ -1527,19 +1527,19 @@ void Score::moveUp(Chord* chord)
             }
       else  {
             // move the chord up a staff
-            undo(new ChangeChordStaffMove(chord, staffMove - 1));
+            undo(new ChangeChordStaffMove(cr, staffMove - 1));
             }
       }
 //---------------------------------------------------------
 //   moveDown
 //---------------------------------------------------------
 
-void Score::moveDown(Chord* chord)
+void Score::moveDown(ChordRest* cr)
       {
-      Staff* staff  = chord->staff();
+      Staff* staff  = cr->staff();
       Part* part    = staff->part();
       int rstaff    = staff->rstaff();
-      int staffMove = chord->staffMove();
+      int staffMove = cr->staffMove();
       // calculate the number of staves available so that we know whether there is another staff to move down to
       int rstaves   = part->nstaves();
 
@@ -1556,7 +1556,7 @@ void Score::moveDown(Chord* chord)
             }
       else  {
             // move the chord down a staff
-            undo(new ChangeChordStaffMove(chord, staffMove + 1));
+            undo(new ChangeChordStaffMove(cr, staffMove + 1));
             }
       }
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -987,8 +987,8 @@ class Score : public QObject {
       QList<int> uniqueStaves() const;
       void transpositionChanged(Part*);
 
-      void moveUp(Chord*);
-      void moveDown(Chord*);
+      void moveUp(ChordRest*);
+      void moveDown(ChordRest*);
       Element* upAlt(Element*);
       Note* upAltCtrl(Note*) const;
       Element* downAlt(Element*);

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2725,27 +2725,27 @@ void ChangeStyleVal::flip()
 //   ChangeChordStaffMove
 //---------------------------------------------------------
 
-ChangeChordStaffMove::ChangeChordStaffMove(Chord* c, int v)
-   : chord(c), staffMove(v)
+ChangeChordStaffMove::ChangeChordStaffMove(ChordRest* cr, int v)
+   : chordRest(cr), staffMove(v)
       {
       }
 
 void ChangeChordStaffMove::flip()
       {
-      const LinkedElements* l = chord->links();
-      int v = chord->staffMove();
+      const LinkedElements* l = chordRest->links();
+      int v = chordRest->staffMove();
       if (l) {
             for (Element* e : *l) {
-                  Chord* c = static_cast<Chord*>(e);
-                  c->setStaffMove(staffMove);
-                  c->measure()->cmdUpdateNotes(c->staffIdx());
-                  c->score()->setLayoutAll(true);
+                  ChordRest* cr = static_cast<ChordRest*>(e);
+                  cr->setStaffMove(staffMove);
+                  cr->measure()->cmdUpdateNotes(cr->staffIdx());
+                  cr->score()->setLayoutAll(true);
                   }
             }
       else {
-            chord->setStaffMove(staffMove);
-            chord->measure()->cmdUpdateNotes(chord->staffIdx());
-            chord->score()->setLayoutAll(true);
+            chordRest->setStaffMove(staffMove);
+            chordRest->measure()->cmdUpdateNotes(chordRest->staffIdx());
+            chordRest->score()->setLayoutAll(true);
             }
       staffMove = v;
       }

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -850,12 +850,12 @@ class ChangeStyleVal : public UndoCommand {
 //---------------------------------------------------------
 
 class ChangeChordStaffMove : public UndoCommand {
-      Chord* chord;
+      ChordRest* chordRest;
       int staffMove;
       void flip();
 
    public:
-      ChangeChordStaffMove(Chord*, int);
+      ChangeChordStaffMove(ChordRest* cr, int);
       UNDO_NAME("ChangeChordStaffMove")
       };
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2655,17 +2655,27 @@ void ScoreView::cmd(const QAction* a)
       else if (cmd == "pitch-down-diatonic")
             score()->upDown(false, UpDownMode::DIATONIC);
       else if (cmd == "move-up") {
-            Element* el = score()->selection().element();
-            if (el && el->type() == Element::Type::NOTE) {
-                  Note* note = static_cast<Note*>(el);
-                  score()->moveUp(note->chord());
+            QList<Element*> el = score()->selection().uniqueElements();
+            foreach (Element* e, el) {
+                  ChordRest* cr = nullptr;
+                  if (e->type() == Element::Type::NOTE)
+                        cr = static_cast<Note*>(e)->chord();
+                  else if (e->type() == Element::Type::REST)
+                        cr = static_cast<Rest*>(e);
+                  if (cr)
+                        score()->moveUp(cr);
                   }
             }
       else if (cmd == "move-down") {
-            Element* el = score()->selection().element();
-            if (el && el->type() == Element::Type::NOTE) {
-                  Note* note = static_cast<Note*>(el);
-                  score()->moveDown(note->chord());
+            QList<Element*> el = score()->selection().uniqueElements();
+            foreach (Element* e, el) {
+                  ChordRest* cr = nullptr;
+                  if (e->type() == Element::Type::NOTE)
+                        cr = static_cast<Note*>(e)->chord();
+                  else if (e->type() == Element::Type::REST)
+                        cr = static_cast<Rest*>(e);
+                  if (cr)
+                        score()->moveDown(cr);
                   }
             }
       else if (cmd == "up-chord") {


### PR DESCRIPTION
This fixes issues:

http://musescore.org/en/node/36411
http://musescore.org/en/node/21512

The rest support was actually there already; all I did was enable it.

(I will update issues manually)
