### PR TITLE
Remove RPNs from MIDI export

### DIFF
--- a/mscore/exportmidi.cpp
+++ b/mscore/exportmidi.cpp
@@ -235,18 +235,18 @@ bool ExportMidi::write(const QString& name, bool midiExpandRepeats)
 
             if (staff->isTop()) {
                   // set pitch bend sensitivity to 12 semitones:
-                  track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 0));
-                  track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 0));
-                  track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HDATA, 12));
+                  //track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 0));
+                  //track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 0));
+                  //track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HDATA, 12));
 
                   // reset fine tuning
-                  track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 1));
-                  track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 0));
-                  track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HDATA, 64));
+                  //track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 1));
+                  //track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 0));
+                  //track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HDATA, 64));
 
                   // deactivate rpn
-                  track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 127));
-                  track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 127));
+                  //track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_LRPN, 127));
+                  //track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_HRPN, 127));
 
                   if (part->midiProgram() != -1)
                         track.insert(0, MidiEvent(ME_CONTROLLER, channel, CTRL_PROGRAM, part->midiProgram()));
@@ -262,15 +262,14 @@ bool ExportMidi::write(const QString& name, bool midiExpandRepeats)
 
             for (auto i = events.begin(); i != events.end(); ++i) {
                   NPlayEvent event(i->second);
-                  int eventChannel = cs->midiChannel(event.channel());
-                  if (channel != eventChannel)
+                  if (event.channel() != channel)
                         continue;
                   if (event.type() == ME_NOTEON) {
-                        track.insert(i->first, MidiEvent(ME_NOTEON, channel,
+                        track.insert(i->first, MidiEvent(ME_NOTEON, event.channel(),
                            event.pitch(), event.velo()));
                         }
                   else if (event.type() == ME_CONTROLLER) {
-                        track.insert(i->first, MidiEvent(ME_CONTROLLER, channel,
+                        track.insert(i->first, MidiEvent(ME_CONTROLLER, event.channel(),
                            event.controller(), event.value()));
                         }
                   else {


### PR DESCRIPTION
The pitch bend sensitivity RPN was causing problems with Sonar X2. But it is not a good idea to set these at the beginning of a file anyway - particularly tuning, which may cause unforeseen problems with 3rd party
synth setups which may have custom tuning for different temperaments.
