### PR TITLE
fix #32866: score jumping issues

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3753,8 +3753,8 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack)
                   showRect.setY(p.y());
                   showRect.setHeight(el->height());
                   }
-            else {
-                  // otherwise, just keep current vertical position
+            else if (sys->page()->systems()->size() == 1) {
+                  // otherwise, just keep current vertical position if possible
                   // see issue #7724
                   showRect.setY(r.y());
                   showRect.setHeight(r.height());


### PR DESCRIPTION
There are a bunch of related issues I am trying to fix together.  The fixes are related enough that I think it best to make and test them together, but  I will annotate the changes in the commentsto show which issue is actually fixed by which change.

The underlying problem here is that adjustCanvasPosition is called too often and/or with too broad a target.  This is in part because Score objects emit posChanged signals any time you click a note:

https://github.com/musescore/MuseScore/blob/396c44f97d090d7fcfbcc8f1e40506e7c5647c28/libmscore/score.cpp#L3431

This causes all scoreviews to respond, when really, only the current scoreview usually needs to.  Furthermore, there is not enough of the original context (eg, which note was clicked to trigger this) to be able to position the score well.  I guess there isn't a more focused call to adjustCanvasPosition in order to maintain the separation between libmscore and mscore.  Or may it is intended that in some cases, all scoreviews _should_ respond.  In any case, I elected to leave this alone, and instead deal with the problems on the scoreview side.

There are also other places where adjustCanvasPosition is called unnecessarily, or with to broad a target.
