### PR TITLE
fix #37756: crash on drum entry

### DIFF
--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -99,12 +99,11 @@ void Stem::layout()
                   if (n->mirror())
                         _up *= -1;
                   y1 -= n->attach().y() * _up;
+                  rypos() = n->rypos();
                   }
             }
 
       line.setLine(0.0, y1, 0.0, l);
-
-      rypos() = (chord()->up() ? chord()->downNote() : chord()->upNote())->rypos();
 
       // compute bounding rectangle
       QRectF r(line.p1(), line.p2());


### PR DESCRIPTION
The line I changed was causing a crash on drum entry - I guess parent(0 is not set (yet) for when laying out the stems in the drum palette?  But this change also was causing problems in tab staves - see http://musescore.org/en/node/37776.

I could have left the line where it was and prefaced it with "if (chord() && !st->isTabStaff())".  But I noticed that just two lines earlier we are _already_ in a block that is active only in those cases.  Furthermore, we have already found the correct note to attach to.  So moving the line made it possible to simplify.  Only change in semantics is that this now happens before the call to line.setLine(), but I don't see how that can matter.
