### PR TITLE
Fix compilation for C++ lib versions without std::map::emplace()

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -986,7 +986,7 @@ void Score::renderMidi(EventMap* events)
 
                   int idx = s->staff()->channel(s->tick(), 0);
                   int channel = s->staff()->part()->instr(s->tick())->channel(idx).channel;
-                  channelPedalEvents.emplace(channel, std::vector<std::pair<int, bool>>());
+                  channelPedalEvents.insert({channel, std::vector<std::pair<int, bool>>()});
                   std::vector<std::pair<int, bool>> pedalEventList = channelPedalEvents.at(channel);
                   std::pair<int, bool> lastEvent;
 


### PR DESCRIPTION
With gcc 4.7.2 on my computer (Kubuntu 12.10) it doesn't compile.

---

Surprised why Travis failed - Ms and tests compiled on my machine.
