### PR TITLE
Fix #37846: MIDI import panel is not displayed when opening a MIDI file

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3553,5 +3553,14 @@ void Score::setName(QString s)
       info.setFile(s);
       }
 
+//---------------------------------------------------------
+//   setImportedFilePath
+//---------------------------------------------------------
+
+void Score::setImportedFilePath(const QString& filePath)
+      {
+      _importedFilePath = filePath;
+      }
+
 }
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -313,6 +313,7 @@ class Score : public QObject {
       QFileInfo info;
       bool _created;          ///< file is never saved, has generated name
       QString _tmpName;       ///< auto saved with this name if not empty
+      QString _importedFilePath;    // file from which the score was imported, or empty
 
       // the following variables are reset on startCmd()
       //   modified during cmd processing and used in endCmd() to
@@ -670,6 +671,9 @@ class Score : public QObject {
 
       QString name() const           { return info.completeBaseName(); }
       void setName(QString s);
+
+      QString importedFilePath() const           { return _importedFilePath; }
+      void setImportedFilePath(const QString& filePath);
 
       bool isSavable() const;
       bool dirty() const;

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -583,7 +583,7 @@ void MuseScore::newFile()
             }
       //delete unused measures if any
       if (nm->nextMeasure())
-      	score->undoRemoveMeasures(nm->nextMeasure(), score->lastMeasure());
+            score->undoRemoveMeasures(nm->nextMeasure(), score->lastMeasure());
 
       int tick = 0;
       for (MeasureBase* mb = score->measures()->first(); mb; mb = mb->next()) {
@@ -1933,6 +1933,7 @@ Score::FileError readScore(Score* score, QString name, bool ignoreVersionError)
       QFileInfo info(name);
       QString suffix  = info.suffix().toLower();
       score->setName(info.completeBaseName());
+      score->setImportedFilePath(name);
 
       if (suffix == "mscz" || suffix == "mscx") {
             Score::FileError rv = score->loadMsc(name, ignoreVersionError);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1544,7 +1544,7 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
             cs = 0;
 
                   // set midi import panel
-      QString fileName = cs ? cs->fileInfo()->filePath() : "";
+      QString fileName = cs ? cs->importedFilePath() : "";
       midiPanelOnSwitchToFile(fileName);
 
       if (enableExperimental) {
@@ -1675,7 +1675,7 @@ void MuseScore::setMidiReopenInProgress(const QString &file)
 void MuseScore::showMidiImportPanel()
       {
       importmidiPanel->setPreferredVisible(true);
-      QString fileName = cs ? cs->fileInfo()->filePath() : "";
+      QString fileName = cs ? cs->importedFilePath() : "";
       if (ImportMidiPanel::isMidiFile(fileName))
             importmidiPanel->setVisible(true);
       importmidiShowPanel->hide();
@@ -2026,7 +2026,7 @@ void MuseScore::removeTab(int i)
       int idx1      = tab1->currentIndex();
       bool firstTab = tab1->view(idx1) == cv;
 
-      midiPanelOnCloseFile(score->fileInfo()->filePath());
+      midiPanelOnCloseFile(score->importedFilePath());
       scoreList.removeAt(i);
 
       tab1->blockSignals(true);


### PR DESCRIPTION
Stored imported file path in the Score class.
