### PR TITLE
Secure plugin loading

### DIFF
--- a/mscore/mscorePlugins.cpp
+++ b/mscore/mscorePlugins.cpp
@@ -92,7 +92,11 @@ void MuseScore::registerPlugin(PluginDescription* plugin)
             foreach(QQmlError e, component.errors()) {
                   qDebug("   line %d: %s", e.line(), qPrintable(e.description()));
                   }
+            plugin->error = true;
             return;
+            }
+      else {
+            plugin->error = false;
             }
       //
       // load translation
@@ -385,6 +389,7 @@ bool MuseScore::loadPlugin(const QString& filename)
                   PluginDescription* p = new PluginDescription;
                   p->path = path;
                   p->load = false;
+                  p->error= false;
                   collectPluginMetaInformation(p);
                   registerPlugin(p);
                   result = true;
@@ -464,6 +469,7 @@ void MuseScore::continueLoadingPlugin()
                   foreach(QQmlError e, pd.component->errors()) {
                         qDebug("   line %d: %s", e.line(), qPrintable(e.description()));
                         }
+                  pd.error = true;
                   }
             else {
                   QObject *obj = pd.component->create();
@@ -498,43 +504,4 @@ void collectPluginMetaInformation(PluginDescription* d)
       else
            mscore->continueLoadingPlugin();
       }
-/*      bool result(false);
-      qreal cProgress;
-      QObject* obj;
-
-      QQmlComponent component(Ms::MScore::qml(), QUrl::fromLocalFile(d->path), QQmlComponent::Asynchronous);
-      qDebug("Collect meta for <%s>", qPrintable(d->path));
-
-      int loadDelay = 20;
-      while( !component.isReady() && loadDelay--) {
-            cProgress = component.progress();
-            qDebug("Component loading progress %f%%", cProgress);
-            if(cProgress == 1.0 || component.isError())
-                  break;
-            sleep(1);
-            }
-
-      if(component.isReady()) {
-            obj = component.create();
-            if(obj){
-                  result = true;
-                  QmlPlugin* item = qobject_cast<QmlPlugin*>(obj);
-                  if (item) {
-                        d->version      = item->version();
-                        d->description  = item->description();
-                        }
-                  delete obj;
-                  }
-            }
-
-      if (obj == 0 || !result) {
-            qDebug("creating component <%s> failed", qPrintable(d->path));
-            foreach(QQmlError e, component.errors()) {
-                  qDebug("   line %d: %s", e.line(), qPrintable(e.description()));
-                  }
-            }
-
-      return result;
-      } */
-
 }

--- a/mscore/mscorePlugins.cpp
+++ b/mscore/mscorePlugins.cpp
@@ -387,9 +387,10 @@ bool MuseScore::loadPlugin(const QString& filename)
             if (fi.exists()) {
                   QString path(fi.filePath());
                   PluginDescription* p = new PluginDescription;
-                  p->path = path;
-                  p->load = false;
-                  p->error= false;
+                  p->path   = path;
+                  p->load   = false;
+                  p->error  = false;
+                  p->loaded = false;
                   collectPluginMetaInformation(p);
                   registerPlugin(p);
                   result = true;
@@ -464,7 +465,7 @@ void MuseScore::continueLoadingPlugin(QQmlComponent *targetComponent)
       const QList<PluginDescription> pl = preferences.pluginLoadingList;
 
       foreach(PluginDescription pd, pl) {
-            if(pd.component == targetComponent) {
+            if(pd.component == targetComponent && !pd.loaded) {
                   if (pd.component->isError()) {
                         qDebug("creating component <%s> failed", qPrintable(pd.path));
                         foreach(QQmlError e, pd.component->errors()) {
@@ -480,6 +481,7 @@ void MuseScore::continueLoadingPlugin(QQmlComponent *targetComponent)
                                     pd.version      = item->version();
                                     pd.description  = item->description();
                                     pd.error        = false;
+                                    pd.loaded       = true;
                                     }
                               delete obj;
                               preferences.pluginList.append(pd);

--- a/mscore/mscorePlugins.cpp
+++ b/mscore/mscorePlugins.cpp
@@ -491,7 +491,7 @@ void MuseScore::continueLoadingPlugin(QQmlComponent *targetComponent)
             }
       }
 
-void MuseScore::continueLoadingPluginSlot(int slotStatus) {
+void MuseScore::continueLoadingPluginSlot(QQmlComponent::Status status) {
       QQmlComponent* qSource = qobject_cast<QQmlComponent *>(QObject::sender());
       continueLoadingPlugin(qSource);
       }

--- a/mscore/mscorePlugins.cpp
+++ b/mscore/mscorePlugins.cpp
@@ -489,6 +489,11 @@ void MuseScore::continueLoadingPlugin(QQmlComponent *targetComponent)
             }
       }
 
+void MuseScore::continueLoadingPluginSlot(int slotStatus) {
+      QQmlComponent* qSource = qobject_cast<QQmlComponent *>(QObject::sender());
+      continueLoadingPlugin(qSource);
+      }
+
 //---------------------------------------------------------
 //   collectPluginMetaInformation
 //---------------------------------------------------------
@@ -502,7 +507,7 @@ void collectPluginMetaInformation(PluginDescription* d)
       pl.append(*d);
       if (component->isLoading())
             QObject::connect(component, SIGNAL(statusChanged(QQmlComponent::Status)),
-                           mscore, SLOT(continueLoadingPlugin(component)));
+                           mscore, SLOT(continueLoadingPluginSlot(QQmlComponent::Status)));
       else
            mscore->continueLoadingPlugin(component);
       }

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -504,7 +504,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void play(Element* e) const;
       void play(Element* e, int pitch) const;
       bool loadPlugin(const QString& filename);
-      void continueLoadingPlugin();
+      void continueLoadingPlugin(QQmlComponent *component);
       QString createDefaultName() const;
       void startAutoSave();
       double getMag(ScoreView*) const;

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -505,7 +505,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void play(Element* e, int pitch) const;
       bool loadPlugin(const QString& filename);
       void continueLoadingPlugin(QQmlComponent *component);
-      void continueLoadingPluginSlot(int slotStatus);
+      void continueLoadingPluginSlot(QQmlComponent::Status status);
       QString createDefaultName() const;
       void startAutoSave();
       double getMag(ScoreView*) const;

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -697,6 +697,6 @@ extern bool saveMxl(Score*, const QString& name);
 extern bool saveXml(Score*, const QString& name);
 
 struct PluginDescription;
-extern void collectPluginMetaInformation(PluginDescription*);
+extern bool collectPluginMetaInformation(PluginDescription*);
 } // namespace Ms
 #endif

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -505,6 +505,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void play(Element* e, int pitch) const;
       bool loadPlugin(const QString& filename);
       void continueLoadingPlugin(QQmlComponent *component);
+      void continueLoadingPluginSlot(int slotStatus);
       QString createDefaultName() const;
       void startAutoSave();
       double getMag(ScoreView*) const;

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -504,6 +504,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void play(Element* e) const;
       void play(Element* e, int pitch) const;
       bool loadPlugin(const QString& filename);
+      void continueLoadingPlugin();
       QString createDefaultName() const;
       void startAutoSave();
       double getMag(ScoreView*) const;
@@ -697,6 +698,7 @@ extern bool saveMxl(Score*, const QString& name);
 extern bool saveXml(Score*, const QString& name);
 
 struct PluginDescription;
-extern bool collectPluginMetaInformation(PluginDescription*);
+extern void collectPluginMetaInformation(PluginDescription*);
+extern void continueLoadingPlugin();
 } // namespace Ms
 #endif

--- a/mscore/pluginManager.cpp
+++ b/mscore/pluginManager.cpp
@@ -51,6 +51,7 @@ void PluginManager::init()
       preferences.updatePluginList();
       int n = preferences.pluginList.size();
       pluginList->clear();
+      int xn = pluginList->count();
       for (int i = 0; i < n; ++i) {
             const PluginDescription& d = preferences.pluginList[i];
             QListWidgetItem* item = new QListWidgetItem(QFileInfo(d.path).baseName(),  pluginList);

--- a/mscore/pluginManager.cpp
+++ b/mscore/pluginManager.cpp
@@ -43,10 +43,13 @@ void PluginManager::init()
       //    changes on "Abort"
       //
       qDeleteAll(localShortcuts);
+      disconnect(pluginList, 0, 0, 0);
       localShortcuts.clear();
       foreach(const Shortcut* s, Shortcut::shortcuts())
             localShortcuts[s->key()] = new Shortcut(*s);
       shortcutsChanged = false;
+      QBrush ebr = QBrush(Qt::red);
+      QBrush nbr = QBrush(Qt::black);
 
       preferences.updatePluginList();
       int n = preferences.pluginList.size();
@@ -56,7 +59,8 @@ void PluginManager::init()
             const PluginDescription& d = preferences.pluginList[i];
             QListWidgetItem* item = new QListWidgetItem(QFileInfo(d.path).baseName(),  pluginList);
             item->setFlags(item->flags() | Qt::ItemIsEnabled);
-            item->setCheckState(d.load ? Qt::Checked : Qt::Unchecked);
+            item->setCheckState(d.load && !d.error ? Qt::Checked : Qt::Unchecked);
+            item->setForeground(d.error ? ebr : nbr);
             item->setData(Qt::UserRole, i);
             }
       prefs = preferences;
@@ -137,7 +141,9 @@ void PluginManager::pluginLoadToggled(QListWidgetItem* item)
       {
       int idx = item->data(Qt::UserRole).toInt();
       PluginDescription* d = &prefs.pluginList[idx];
-      d->load = (item->checkState() == Qt::Checked);
+      if(d->error)
+                  item->setCheckState(Qt::Unchecked);
+      d->load = (item->checkState() == Qt::Checked) && !d->error;
       prefs.dirty = true;
       }
 

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -1833,8 +1833,7 @@ static void updatePluginList(QList<QString>& pluginPathList, const QString& plug
                               PluginDescription p;
                               p.path = path;
                               p.load = false;
-                              if( collectPluginMetaInformation(&p) )
-                                    pluginList.append(p);
+                              collectPluginMetaInformation(&p);
                               }
                         }
                   }

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -1833,8 +1833,8 @@ static void updatePluginList(QList<QString>& pluginPathList, const QString& plug
                               PluginDescription p;
                               p.path = path;
                               p.load = false;
-                              collectPluginMetaInformation(&p);
-                              pluginList.append(p);
+                              if( collectPluginMetaInformation(&p) )
+                                    pluginList.append(p);
                               }
                         }
                   }

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -1746,6 +1746,7 @@ bool Preferences::readPluginList()
                         const QStringRef& tag(e.name());
                         if (tag == "Plugin") {
                               PluginDescription d;
+                              d.error = true;
                               while (e.readNextStartElement()) {
                                     const QStringRef& tag(e.name());
                                     if (tag == "path")

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -76,6 +76,7 @@ struct PluginDescription {
       QString menuPath;
       QQmlComponent *component;
       bool error;
+      bool loaded;
       };
 
 //---------------------------------------------------------

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -74,6 +74,8 @@ struct PluginDescription {
       bool load;
       Shortcut shortcut;
       QString menuPath;
+      QQmlComponent *component;
+      bool error;
       };
 
 //---------------------------------------------------------
@@ -174,6 +176,7 @@ struct Preferences {
       bool dirty;
 
       QList<PluginDescription> pluginList;
+      QList<PluginDescription> pluginLoadingList;
 
       bool readPluginList();
       void writePluginList();
@@ -199,6 +202,7 @@ class ShortcutItem : public QTreeWidgetItem {
       };
 
 extern Preferences preferences;
+// extern PluginDescription plugindescription;
 extern bool useALSA, useJACK, usePortaudio, usePulseAudio;
 
 } // namespace Ms


### PR DESCRIPTION
This PR stops invalid QML files crashing MuseScore via Plugin Manager and prevents them being marked as loadable at startup.

Faulty plugin scripts are highlighted in red in plugin manager and the "load" checkbox cannot be marked as checked for these scripts.

I can't find any examples of tests for dialogs, modal or otherwise, so haven't been able to work out how to write any.
