### PR TITLE
fix #38041: pedal not exported to MIDI

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -431,6 +431,8 @@ class Score : public QObject {
       bool rewriteMeasures(Measure* fm, Measure* lm, const Fraction&);
       bool rewriteMeasures(Measure* fm, const Fraction& ns);
       void updateVelo();
+      void swingAdjustParams(Chord*, int&, int&, int, int);
+      bool isSubdivided(ChordRest*, int);
       void addAudioTrack();
       void parseVersion(const QString&);
       QList<Fraction> splitGapToMeasureBoundaries(ChordRest*, Fraction);
@@ -438,7 +440,6 @@ class Score : public QObject {
       void init();
       void removeGeneratedElements(Measure* mb, Measure* end);
       qreal cautionaryWidth(Measure* m, bool& hasCourtesy);
-      void createPlayEvents();
 
       void selectSingle(Element* e, int staffIdx);
       void selectAdd(Element* e);
@@ -737,9 +738,7 @@ class Score : public QObject {
       void pasteSymbols(XmlReader& e, ChordRest* dst);
       void renderMidi(EventMap* events);
       void renderStaff(EventMap* events, Staff*);
-
-      void swingAdjustParams(Chord*, int&, int&, int, int);
-      bool isSubdivided(ChordRest*, int);
+      void renderSpanners(EventMap* events, int staffIdx);
 
       int mscVersion() const    { return _mscVersion; }
       void setMscVersion(int v) { _mscVersion = v; }
@@ -756,6 +755,7 @@ class Score : public QObject {
       void rebuildMidiMapping();
       void updateChannel();
       void updateSwing();
+      void createPlayEvents();
 
       void cmdConcertPitchChanged(bool, bool /*useSharpsFlats*/);
 

--- a/mscore/exportmidi.cpp
+++ b/mscore/exportmidi.cpp
@@ -222,6 +222,8 @@ bool ExportMidi::write(const QString& name, bool midiExpandRepeats)
       for (int i = 0; i < cs->nstaves(); ++i)
             tracks.append(MidiTrack());
 
+      cs->updateSwing();
+      cs->createPlayEvents();
       cs->updateRepeatList(midiExpandRepeats);
       writeHeader();
 
@@ -236,6 +238,7 @@ bool ExportMidi::write(const QString& name, bool midiExpandRepeats)
             // Render each staff only once
             EventMap events;
             cs->renderStaff(&events, staff);
+            cs->renderSpanners(&events, staffIdx);
 
             // Pass throught the all instruments in the part
             const InstrumentList* il = part->instrList();


### PR DESCRIPTION
Pedal events were not being collected at all during export - only during playback.  I factored that out so the same code is used for both playback and export.  Swing was also not being exported correctly if you tried exporting before listening to playback within MuseScore; I fixed that as well.  There are some other things that are done in Score::renderMidi() but not in ExportMidi::write() - like calling updateVelo() - but this appears to not be necessary as updateVelo is called on every doLayout() (something we could consider eliminating, BTW).
