### PR TITLE
add subtype selection (verse number) for lyrics

### DIFF
--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -64,6 +64,8 @@ class Lyrics : public Text {
 
       virtual void write(Xml& xml) const override;
       virtual void read(XmlReader&) override;
+      virtual int subtype() const         { return _no; }
+      virtual QString subtypeName() const { return tr("Verse %1").arg(_no + 1); }
       void setNo(int n);
       int no() const                { return _no; }
       void setSyllabic(Syllabic s)  { _syllabic = s; }


### PR DESCRIPTION
This came up during a forum discussion - http://musescore.org/en/node/38291.  I was about to post that in 2.0 it would be easier to select a single verse, then I realized this wasn't so.

Adding these subtype selectors is very easy, as you can see, but I also understand we are trying to limit feature creep.
