### PR TITLE
fix warning reg. 'gridlayout6 is already in use'  

### DIFF
--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2019,7 +2019,7 @@
       <attribute name="title">
        <string>Score</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout6">
+      <layout class="QGridLayout" name="gridLayout61">
        <item row="1" column="0">
         <widget class="QGroupBox" name="groupBox_19">
          <property name="title">


### PR DESCRIPTION
Fixing this warning:
`...\MuseScore\mscore\prefsdialog.ui:-1: Warning: The name 'gridLayout6' (QGridLayout) is already in use, defaulting to 'gridLayout61'.`
