### PR TITLE
fix #38766: bad input position after timesig change

### DIFF
--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -605,6 +605,19 @@ void ScoreView::dropEvent(QDropEvent* event)
             dragElement = 0;
             setDropTarget(0); // this also resets dropRectangle and dropAnchor
             score()->endCmd();
+            // update input cursor position (must be done after layout)
+            if (noteEntryMode()) {
+                  // set input cursor to possibly re-written segment
+                  int icTick = cursorTick();
+                  Segment* icSegment = _score->tick2segment(icTick, false, Segment::Type::ChordRest);
+                  if (!icSegment) {
+                        Measure* icMeasure = _score->tick2measure(icTick);
+                        icSegment = icMeasure->first(Segment::Type::ChordRest);
+                        }
+                  _score->inputState().setSegment(icSegment);
+                  // even if segment wasn't rewritten, it may have changed position
+                  moveCursor();
+                  }
             mscore->endCmd();
             return;
             }


### PR DESCRIPTION
Input position segment is no longer valid after time signature change.  I tried fixing this closer to where the change happens (Score::cmdAddTimeSig()), but while you can get the right segment there, the new measure isn't laid out until later and further upstream, in ScoreView::dropEvent().  And by moving the fix here, it turns out we solve a couple other problems.  For example, dropping a key signature can also cause a significant layout shift, and while the old segment is still valid so there is no corruption, the cursor position may _look_ off.  This PR fixes that as well.
