### PR TITLE
fix #38766: bad input position after timesig change

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -431,6 +431,21 @@ bool Score::rewriteMeasures(Measure* fm, Measure* lm, const Fraction& ns)
             qFatal("Cannot write measures");
       connectTies(true);
 
+      if (noteEntryMode()) {
+            // set input cursor to possibly re-written segment
+            int icTick = inputPos();
+            Segment* icSegment = tick2segment(icTick, false, Segment::Type::ChordRest);
+            if (!icSegment) {
+                  // this can happen if cursor was on a rest
+                  // and in the rewriting it got subsumed into a full measure rest
+                  Measure* icMeasure = tick2measure(icTick);
+                  if (!icMeasure)                     // shouldn't happen, but just in case
+                        icMeasure = firstMeasure();
+                  icSegment = icMeasure->first(Segment::Type::ChordRest);
+                  }
+            inputState().setSegment(icSegment);
+            }
+
       return true;
       }
 

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -605,6 +605,9 @@ void ScoreView::dropEvent(QDropEvent* event)
             dragElement = 0;
             setDropTarget(0); // this also resets dropRectangle and dropAnchor
             score()->endCmd();
+            // update input cursor position (must be done after layout)
+            if (noteEntryMode())
+                  moveCursor();
             mscore->endCmd();
             return;
             }


### PR DESCRIPTION
Input position segment is no longer valid after time signature change.  I tried fixing this closer to where the change happens (Score::cmdAddTimeSig()), but while you can get the right segment there, the new measure isn't laid out until later and further upstream, in ScoreView::dropEvent().  And by moving the fix here, it turns out we solve a couple other problems.  For example, dropping a key signature can also cause a significant layout shift, and while the old segment is still valid so there is no corruption, the cursor position may _look_ off.  This PR fixes that as well.

(Somehow the history got lost when I closed and re-opened this), except for the original message.  This current PR does move the segment recalculation to where the problem occurs (in Score::rewriteMeasures()), while keeping the moveCursor() call in ScoreView::dropEvent() so it can also work for other drop events that cause a layout change.
