### PR TITLE
fix #38891: phantom measures after delete all in continuous view

### DIFF
--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -479,13 +479,15 @@ void Page::doRebuildBspTree()
 
       int n = el.size();
       if (score()->layoutMode() == LayoutMode::LINE) {
-            if (_systems.isEmpty())
-                  return;
-            if (_systems.front()->measures().isEmpty())
-                  return;
-            qreal h = _systems.front()->height();
-            MeasureBase* mb = _systems.front()->measures().back();
-            qreal w = mb->x() + mb->width();
+            qreal w = 0.0;
+            qreal h = 0.0;
+            if (!_systems.isEmpty()) {
+                  h = _systems.front()->height();
+                  if (!_systems.front()->measures().isEmpty()) {
+                        MeasureBase* mb = _systems.front()->measures().back();
+                        w = mb->x() + mb->width();
+                        }
+                  }
             bspTree.initialize(QRectF(0.0, 0.0, w, h), n);
             }
       else


### PR DESCRIPTION
As I mention in the issue report, I don't fully understand what is going on, but I can see that we need to clear the bspTree and aren't.  So I decided to try passing in 0 for h and/or w in cases where there are no systems and/or measures.  It works in the tests I did, and still fixes the crashes that the code I am replacing was designed to fix (as far as I can tell).
