### PR TITLE
fix #38991: cursor jump on up/down if layout changes

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3432,10 +3432,10 @@ void Score::setPos(POS pos, int tick)
       {
       if (tick < 0)
             tick = 0;
-      if (tick != _pos[int(pos)]) {
+      if (tick != _pos[int(pos)])
             _pos[int(pos)] = tick;
-            emit posChanged(pos, unsigned(tick));
-            }
+      // even though tick position might not have changed, layout might have
+      emit posChanged(pos, unsigned(tick));
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This is my proposed fix for an issue where up/down during note can possibly affect layout - the addition / removal of an accidental might change the number of measures that can fit on the line, as shown in the example in the issue report - and the note input cursor is not updated.

The code to move the cursor in Score::setPos() was only doing so if the tick had changed, but this ignores the possibility the cursor will need to be moved because the _layout_ has changed even if the tick has not.  This PR definitely fixes that problem, and I don't see any other ill effects.  But I can't really be sure there aren't some cases where doing a moveCursor here would be a bad idea.
