### PR TITLE
Make the "View | Show Frames" command toggle-able

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2144,7 +2144,7 @@ Shortcut Shortcut::_sc[] = {
          0,
          Icons::Invalid_ICON,
          Qt::WindowShortcut,
-         ShortcutFlags::A_SCORE
+         ShortcutFlags::A_SCORE | ShortcutFlags::A_CHECKABLE
          },
       {
          MsWidget::MAIN_WINDOW,


### PR DESCRIPTION
Currently the command cannot be toggled and using it hides the frames with no mean to show them back.
