### PR TITLE
fix #39341: crash on tab entry

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2674,7 +2674,9 @@ void Score::select(Element* e, SelectType type, int staffIdx)
             Element* ee = e;
             if (ee->type() == Element::Type::NOTE)
                   ee = ee->parent();
-            setPlayPos(static_cast<ChordRest*>(ee)->segment()->tick());
+            int tick = static_cast<ChordRest*>(ee)->segment()->tick();
+            if (playPos() != tick)
+                  setPlayPos(tick);
             }
       if (MScore::debugMode)
             qDebug("select element <%s> type %hhd(state %hhd) staff %d",
@@ -3439,6 +3441,8 @@ void Score::setPos(POS pos, int tick)
       if (tick != _pos[int(pos)])
             _pos[int(pos)] = tick;
       // even though tick position might not have changed, layout might have
+      // so we should update cursor here
+      // however, we must be careful not to call setPos() again while handling posChanged, or recursion results
       emit posChanged(pos, unsigned(tick));
       }
 


### PR DESCRIPTION
My recent fix for a cursor position bug, in #1453, removed what was effectively a recusion control check in Score::setPos().  Since I still don't see a better way to solve the original cursor position issue, I left that fix in place, but added a similar recursion check slightly further upstream.  It does appear this is the only place in the code where this would be an issue - none of the other calls to Score::setPlayPos() (which is where the call to setPos() happen anywhere that would be involved in the recursion chain.
