### PR TITLE
Accessibility for Play panel, Mixer and Synthesizer

### DIFF
--- a/awl/aslider.cpp
+++ b/awl/aslider.cpp
@@ -261,4 +261,48 @@ void AbstractSlider::init(const SyntiParameter& f)
       _pageStep   = _lineStep * 2.0;
       }
 #endif
+
+AccessibleAbstractSlider::AccessibleAbstractSlider(AbstractSlider* s) : QAccessibleWidget(s)
+      {
+      slider = s;
+      }
+
+QAccessible::Role AccessibleAbstractSlider::role() const
+      {
+      return QAccessible::Slider;
+      }
+
+QString AccessibleAbstractSlider::text(QAccessible::Text t) const
+      {
+      switch (t) {
+            case QAccessible::Name:
+                  return slider->accessibleName();
+            case QAccessible::Value:
+                  return QString::number(slider->value());
+            case QAccessible::Description:
+                  return slider->accessibleDescription();
+            default:
+                  return QString();
+            }
+      return QString();
+      }
+
+void AccessibleAbstractSlider::valueChanged(double value, int)
+      {
+      QAccessibleValueChangeEvent ev(slider, value);
+      QAccessible::updateAccessibility(&ev);
+      }
+
+QAccessibleInterface* AccessibleAbstractSlider::AbstractSliderFactory(const QString& /*classname*/, QObject *object)
+      {
+      QAccessibleInterface *iface = 0;
+      if (object && object->isWidgetType() && object->inherits("Awl::AbstractSlider")){
+            AbstractSlider* slider = static_cast<AbstractSlider*>(object);
+            AccessibleAbstractSlider* acc = new AccessibleAbstractSlider(slider);
+            QObject::connect(slider, SIGNAL(valueChanged(double,int)), acc, SLOT(valueChanged(double,int)));
+            iface = static_cast<QAccessibleInterface*>(acc);
+            }
+
+      return iface;
+      }
 }

--- a/awl/aslider.cpp
+++ b/awl/aslider.cpp
@@ -40,6 +40,7 @@ AbstractSlider::AbstractSlider(QWidget* parent)
       _invert     = false;
       _scaleWidth = 4;
       _log        = false;
+      _useActualValue = false;
       setFocusPolicy(Qt::StrongFocus);
       }
 
@@ -203,6 +204,21 @@ double AbstractSlider::value() const
       }
 
 //---------------------------------------------------------
+//   userValue (between 0 and 100)
+//---------------------------------------------------------
+
+QString AbstractSlider::userValue() const
+      {
+      double result;
+      if (_useActualValue)
+            result = value();
+      else
+            result = (_value - minValue())/ ((maxValue() - minValue())/100);
+
+      return QString::number(result, 'f', 2);
+      }
+
+//---------------------------------------------------------
 //   minLogValue
 //---------------------------------------------------------
 
@@ -278,7 +294,7 @@ QString AccessibleAbstractSlider::text(QAccessible::Text t) const
             case QAccessible::Name:
                   return slider->accessibleName();
             case QAccessible::Value:
-                  return QString::number(slider->value());
+                  return slider->userValue();
             case QAccessible::Description:
                   return slider->accessibleDescription();
             default:
@@ -287,9 +303,9 @@ QString AccessibleAbstractSlider::text(QAccessible::Text t) const
       return QString();
       }
 
-void AccessibleAbstractSlider::valueChanged(double value, int)
+void AccessibleAbstractSlider::valueChanged(double, int)
       {
-      QAccessibleValueChangeEvent ev(slider, value);
+      QAccessibleValueChangeEvent ev(slider, slider->userValue());
       QAccessible::updateAccessibility(&ev);
       }
 

--- a/awl/aslider.h
+++ b/awl/aslider.h
@@ -22,6 +22,7 @@
 #define __AWLASLIDER_H__
 
 // #include "synthesizer/sparm.h"
+#include <QAccessibleWidget>
 
 namespace Awl {
 
@@ -135,6 +136,18 @@ class AbstractSlider : public QWidget {
       void setDclickValue2(double val) { _dclickValue2 = val;  }
       void setEnabled(bool val);
       };
+
+class AccessibleAbstractSlider : public QObject, QAccessibleWidget {
+      Q_OBJECT
+      AbstractSlider* slider;
+      QAccessible::Role role() const Q_DECL_OVERRIDE;
+      QString text(QAccessible::Text t) const Q_DECL_OVERRIDE;
+public:
+      static QAccessibleInterface* AbstractSliderFactory(const QString &classname, QObject *object);
+      AccessibleAbstractSlider(AbstractSlider*);
+public slots:
+      void valueChanged(double,int);
+};
 
 }
 

--- a/awl/aslider.h
+++ b/awl/aslider.h
@@ -70,6 +70,7 @@ class AbstractSlider : public QWidget {
       QColor _scaleColor;
       QColor _scaleValueColor;
       bool _log;
+      bool _useActualValue; //! for user value
 
       virtual void wheelEvent(QWheelEvent*);
       virtual void keyPressEvent(QKeyEvent*);
@@ -109,6 +110,7 @@ class AbstractSlider : public QWidget {
       void setId(int i) { _id = i; }
 
       virtual double value() const;
+      virtual QString userValue() const;
 
       double minValue() const { return _minValue; }
       void setMinValue(double v) { _minValue = v; }
@@ -135,6 +137,7 @@ class AbstractSlider : public QWidget {
       void setDclickValue1(double val) { _dclickValue1 = val;  }
       void setDclickValue2(double val) { _dclickValue2 = val;  }
       void setEnabled(bool val);
+      void setUseActualValue(bool v)   { _useActualValue = v;  }
       };
 
 class AccessibleAbstractSlider : public QObject, QAccessibleWidget {

--- a/fluid/fluid_gui.ui
+++ b/fluid/fluid_gui.ui
@@ -15,7 +15,11 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QListWidget" name="soundFonts"/>
+    <widget class="QListWidget" name="soundFonts">
+     <property name="accessibleName">
+      <string>Sound Fonts</string>
+     </property>
+    </widget>
    </item>
    <item row="0" column="1">
     <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -30,6 +34,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="text">
         <string>Up</string>
        </property>
@@ -42,6 +49,9 @@
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
        </property>
        <property name="text">
         <string>Down</string>
@@ -69,6 +79,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="text">
         <string>Delete</string>
        </property>
@@ -76,6 +89,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="soundFontAdd">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -238,7 +238,7 @@ add_executable ( ${ExecutableName}
       inspector/inspectorGroupElement.cpp dragdrop.cpp inspector/inspectorImage.cpp
       inspector/inspectorFret.cpp
       waveview.cpp helpBrowser.cpp inspector/inspectorLasso.cpp
-      editelement.cpp inspector/inspectorVolta.cpp inspector/inspectorOttava.cpp
+      editelement.cpp inspector/inspectorVolta.cpp inspector/inspectorOttava.cpp enableplayforwidget.cpp
       inspector/inspectorTrill.cpp
       inspector/inspectorHairpin.cpp qmlplugin.cpp editlyrics.cpp
       musicxmlfonthandler.cpp musicxmlsupport.cpp exportxml.cpp importxml.cpp importxmlfirstpass.cpp

--- a/mscore/enableplayforwidget.cpp
+++ b/mscore/enableplayforwidget.cpp
@@ -1,0 +1,66 @@
+#include "enableplayforwidget.h"
+#include "musescore.h"
+
+namespace Ms {
+
+
+EnablePlayForWidget::EnablePlayForWidget(QWidget* target)
+      {
+      QAction* playAction = getAction("play");
+      _target = target;
+      _localPlayAction = new QAction(_target);
+      _localPlayAction->setData(playAction->data());
+      _localPlayAction->setCheckable(playAction->isCheckable());
+      _localPlayAction->setChecked(playAction->isChecked());
+      _localPlayAction->setShortcuts(playAction->shortcuts());
+      _localPlayAction->setShortcutContext(Qt::WidgetShortcut);
+      _target->addAction(_localPlayAction);
+      qApp->installEventFilter(_target);
+      QObject::connect(_localPlayAction, SIGNAL(triggered()), mscore->playButton(), SLOT(click()));
+      }
+
+void EnablePlayForWidget::showEvent(QShowEvent*)
+      {
+      _target->setFocus();
+      }
+
+//--------------------------------------------------------------------------------------------------
+// eventFilter
+//
+// If any child of the target widget has focus when Escape Key is pressed it loses the focus
+// and the target gains focus
+// Also, it makes sure that the global play action and _localPlayAction always have the same shortcut
+//--------------------------------------------------------------------------------------------------
+bool EnablePlayForWidget::eventFilter(QObject* obj, QEvent* e)
+      {
+      if (obj == getAction("play")) {
+            _localPlayAction->setShortcuts(getAction("play")->shortcuts());
+            }
+
+      if (obj->isWidgetType() &&
+          e->type() == QEvent::KeyPress &&
+          obj != _target && // if obj == target, it means that the target has the focus. this case is handled by target::keyPressEvent
+          _target->isAncestorOf(static_cast<QWidget*>(obj))) {
+            QKeyEvent* ev = static_cast<QKeyEvent*>(e);
+            if (ev->key() == Qt::Key_Escape && ev->modifiers() == Qt::NoModifier) {
+                  _target->setFocus();
+                  return true;
+                  }
+            }
+      return false;
+      }
+
+//-----------------------------------------------------------------------
+// connectLocalPlayToDifferentSlot
+//
+// Note: the _localPlayAction will always be connected to only one slot
+// in order not to trigger the global play action twice
+// By default it's set to click the play button from the main window
+//-----------------------------------------------------------------------
+
+void EnablePlayForWidget::connectLocalPlayToDifferentSlot(QObject *obj, const char *id)
+      {
+      _localPlayAction->disconnect();
+      QObject::connect(_localPlayAction, SIGNAL(triggered()), obj, id);
+      }
+}

--- a/mscore/enableplayforwidget.h
+++ b/mscore/enableplayforwidget.h
@@ -1,0 +1,30 @@
+
+#ifndef __ENABLEPLAYWIDGET__
+#define __ENABLEPLAYWIDGET__
+
+/*
+ This class was created for keyboard accessibility purposes.
+ It should be used by widgets that want to allow score playback if they have focus, but not their children.
+ Additionally, if one of its children widgets has focus and Escape is pressed the target widget will gain focus.
+ The shortcut for this target widget's play action will always be the same as the global one ( getAction("play") )
+
+ NOTE: The client is responsible for setting the appropriate Focus Policies for its controllers and forwards the
+ calls of showEvent and eventFilter to their reference of EnablePlayForWidget object.
+
+*/
+namespace Ms {
+
+class EnablePlayForWidget {
+      QAction* _localPlayAction;
+      QWidget* _target;
+
+public:
+      void showEvent(QShowEvent *);
+      bool eventFilter(QObject* obj, QEvent* e);
+      EnablePlayForWidget(QWidget* target);
+      void connectLocalPlayToDifferentSlot(QObject* obj, const char* id);
+};
+
+}
+
+#endif

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -104,6 +104,7 @@ Mixer::Mixer(QWidget* parent)
       area->setLayout(vb);
       setWidget(area);
 
+      enablePlay = new EnablePlayForWidget(this);
       if (!useFactorySettings) {
             QSettings settings;
             settings.beginGroup("Mixer");
@@ -122,6 +123,37 @@ void Mixer::closeEvent(QCloseEvent* ev)
       emit closed(false);
       QWidget::closeEvent(ev);
       }
+
+//---------------------------------------------------------
+//   showEvent
+//---------------------------------------------------------
+
+void Mixer::showEvent(QShowEvent* e)
+      {
+      enablePlay->showEvent(e);
+      QScrollArea::showEvent(e);
+      activateWindow();
+      }
+
+//---------------------------------------------------------
+//   eventFilter
+//---------------------------------------------------------
+
+bool Mixer::eventFilter(QObject* obj, QEvent* e)
+      {
+      if (enablePlay->eventFilter(obj, e))
+            return true;
+      return QScrollArea::eventFilter(obj, e);
+      }
+
+void Mixer::keyPressEvent(QKeyEvent* ev) {
+      if (ev->key() == Qt::Key_Escape && ev->modifiers() == Qt::NoModifier) {
+            close();
+            return;
+            }
+      QWidget::keyPressEvent(ev);
+      }
+
 
 //---------------------------------------------------------
 //   updateAll

--- a/mscore/mixer.h
+++ b/mscore/mixer.h
@@ -23,7 +23,7 @@
 
 #include "ui_mixer.h"
 #include "libmscore/instrument.h"
-
+#include "enableplayforwidget.h"
 namespace Ms {
 
 class Score;
@@ -69,8 +69,12 @@ class Mixer : public QScrollArea
       Score*       cs;
       QScrollArea* sa;
       QVBoxLayout* vb;
+      EnablePlayForWidget* enablePlay;
 
       virtual void closeEvent(QCloseEvent*);
+      virtual void showEvent(QShowEvent*) override;
+      virtual bool eventFilter(QObject*, QEvent*) override;
+      virtual void keyPressEvent(QKeyEvent*) override;
 
    private slots:
       void updateSolo(bool);

--- a/mscore/mixer.ui
+++ b/mscore/mixer.ui
@@ -16,6 +16,9 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="focusPolicy">
+   <enum>Qt::ClickFocus</enum>
+  </property>
   <property name="windowTitle">
    <string/>
   </property>
@@ -70,6 +73,9 @@
         <property name="toolTip">
          <string>Part name</string>
         </property>
+        <property name="accessibleName">
+         <string>Part Name</string>
+        </property>
         <property name="readOnly">
          <bool>true</bool>
         </property>
@@ -103,8 +109,17 @@
             <height>16777215</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::TabFocus</enum>
+          </property>
           <property name="toolTip">
            <string>Volume</string>
+          </property>
+          <property name="accessibleName">
+           <string>Volume</string>
+          </property>
+          <property name="accessibleDescription">
+           <string>Use arrows to modify</string>
           </property>
           <property name="invertedAppearance" stdset="0">
            <bool>false</bool>
@@ -150,8 +165,17 @@
             <height>16777215</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::TabFocus</enum>
+          </property>
           <property name="toolTip">
            <string>Panorama position</string>
+          </property>
+          <property name="accessibleName">
+           <string>Panorama position</string>
+          </property>
+          <property name="accessibleDescription">
+           <string>Use arrows to modify</string>
           </property>
           <property name="scaleWidth" stdset="0">
            <number>5</number>
@@ -178,8 +202,17 @@
             <height>16777215</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::TabFocus</enum>
+          </property>
           <property name="toolTip">
            <string>Reverb</string>
+          </property>
+          <property name="accessibleName">
+           <string>Reverb</string>
+          </property>
+          <property name="accessibleDescription">
+           <string>Use arrows to modify</string>
           </property>
           <property name="scaleWidth" stdset="0">
            <number>5</number>
@@ -215,8 +248,17 @@
             <height>16777215</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::TabFocus</enum>
+          </property>
           <property name="toolTip">
            <string>Chorus</string>
+          </property>
+          <property name="accessibleName">
+           <string>Chorus</string>
+          </property>
+          <property name="accessibleDescription">
+           <string>Use arrows to modify</string>
           </property>
           <property name="scaleWidth" stdset="0">
            <number>5</number>
@@ -353,6 +395,9 @@
         </property>
         <item>
          <widget class="QCheckBox" name="mute">
+          <property name="accessibleName">
+           <string>Mute</string>
+          </property>
           <property name="text">
            <string>Mute</string>
           </property>
@@ -360,6 +405,9 @@
         </item>
         <item>
          <widget class="QCheckBox" name="solo">
+          <property name="accessibleName">
+           <string>Solo</string>
+          </property>
           <property name="text">
            <string>Solo</string>
           </property>
@@ -413,6 +461,9 @@
           <property name="toolTip">
            <string>MIDI sound</string>
           </property>
+          <property name="accessibleName">
+           <string>Sound</string>
+          </property>
          </widget>
         </item>
        </layout>
@@ -434,6 +485,16 @@
    <header>awl/midipanknob.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>partName</tabstop>
+  <tabstop>mute</tabstop>
+  <tabstop>solo</tabstop>
+  <tabstop>patch</tabstop>
+  <tabstop>volume</tabstop>
+  <tabstop>pan</tabstop>
+  <tabstop>reverb</tabstop>
+  <tabstop>chorus</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -99,9 +99,9 @@
 #include "qmlplugin.h"
 #include "accessibletoolbutton.h"
 #include "searchComboBox.h"
-
 #include "startcenter.h"
 #include "help.h"
+#include "awl/aslider.h"
 
 #ifdef AEOLUS
 extern Ms::Synthesizer* createAeolus();
@@ -533,7 +533,8 @@ MuseScore::MuseScore()
       transportTools->addSeparator();
 #endif
       transportTools->addWidget(new AccessibleToolButton(transportTools, getAction("rewind")));
-      transportTools->addWidget(new AccessibleToolButton(transportTools, getAction("play")));
+      _playButton = new AccessibleToolButton(transportTools, getAction("play"));
+      transportTools->addWidget(_playButton);
       transportTools->addWidget(new AccessibleToolButton(transportTools, getAction("loop")));
       transportTools->addSeparator();
       transportTools->addWidget(new AccessibleToolButton(transportTools, getAction("repeat")));
@@ -4534,6 +4535,8 @@ int main(int argc, char* av[])
       QCoreApplication::setApplicationName("MuseScoreDevelopment");
       QAccessible::installFactory(AccessibleScoreView::ScoreViewFactory);
       QAccessible::installFactory(AccessibleSearchBox::SearchBoxFactory);
+      QAccessible::installFactory(Awl::AccessibleAbstractSlider::AbstractSliderFactory);
+
       Q_INIT_RESOURCE(zita);
 
 #ifndef Q_OS_MAC

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -368,11 +368,11 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       QLabel* cornerLabel;
       QStringList _recentScores;
+      QToolButton* _playButton;
 
       //---------------------
 
       virtual void closeEvent(QCloseEvent*);
-
       virtual void dragEnterEvent(QDragEnterEvent*);
       virtual void dropEvent(QDropEvent*);
 
@@ -492,6 +492,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       ~MuseScore();
       bool checkDirty(Score*);
       PlayPanel* getPlayPanel() const { return playPanel; }
+      Mixer* getMixer() const { return mixer; }
       QMenu* genCreateMenu(QWidget* parent = 0);
       virtual int appendScore(Score*);
       void midiCtrlReceived(int controller, int value);
@@ -665,6 +666,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       Inspector* inspector()           { return _inspector; }
       PluginCreator* pluginCreator()   { return _pluginCreator; }
       ScoreView* currentScoreView() const { return cv; }
+      QToolButton* playButton()        { return _playButton;    }
       void showMessage(const QString& s, int timeout);
       void showHelp(QString);
       void showHelp(const QUrl&);

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -51,6 +51,7 @@ PlayPanel::PlayPanel(QWidget* parent)
       move(settings.value("playPanel/pos", QPoint(DEFAULT_POS_X, DEFAULT_POS_Y)).toPoint());
 
       setScore(0);
+
       playButton->setDefaultAction(getAction("play"));
       rewindButton->setDefaultAction(getAction("rewind"));
       countInButton->setDefaultAction(getAction("countin"));
@@ -58,6 +59,7 @@ PlayPanel::PlayPanel(QWidget* parent)
       loopButton->setDefaultAction(getAction("loop"));
       loopInButton->setDefaultAction(getAction("loop-in"));
       loopOutButton->setDefaultAction(getAction("loop-out"));
+      enablePlay = new EnablePlayForWidget(this);
 
       tempoSlider->setDclickValue1(100.0);
       tempoSlider->setDclickValue2(100.0);
@@ -135,6 +137,36 @@ void PlayPanel::hideEvent(QHideEvent* ev)
       settings.setValue("playPanel/pos", pos());
       settings.setValue("playPanel/geometry", saveGeometry());
       QWidget::hideEvent(ev);
+      }
+
+//---------------------------------------------------------
+//   showEvent
+//---------------------------------------------------------
+
+void PlayPanel::showEvent(QShowEvent* e)
+      {
+      enablePlay->showEvent(e);
+      QWidget::showEvent(e);
+      activateWindow();
+      }
+
+//---------------------------------------------------------
+//   eventFilter
+//---------------------------------------------------------
+
+bool PlayPanel::eventFilter(QObject* obj, QEvent* e)
+      {
+      if (enablePlay->eventFilter(obj, e))
+            return true;
+      return QWidget::eventFilter(obj, e);
+      }
+
+void PlayPanel::keyPressEvent(QKeyEvent* ev) {
+      if (ev->key() == Qt::Key_Escape && ev->modifiers() == Qt::NoModifier) {
+            close();
+            return;
+            }
+      QWidget::keyPressEvent(ev);
       }
 
 //---------------------------------------------------------

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -63,6 +63,7 @@ PlayPanel::PlayPanel(QWidget* parent)
 
       tempoSlider->setDclickValue1(100.0);
       tempoSlider->setDclickValue2(100.0);
+      tempoSlider->setUseActualValue(true);
 
       connect(volumeSlider, SIGNAL(valueChanged(double,int)), SLOT(volumeChanged(double,int)));
       connect(posSlider,    SIGNAL(sliderMoved(int)),         SLOT(setPos(int)));

--- a/mscore/playpanel.h
+++ b/mscore/playpanel.h
@@ -22,7 +22,7 @@
 #define __PLAYPANEL_H__
 
 #include "ui_playpanel.h"
-
+#include "enableplayforwidget.h"
 namespace Ms {
 
 class Score;
@@ -36,10 +36,14 @@ class PlayPanel : public QWidget, private Ui::PlayPanelBase {
       int cachedTickPosition;
       int cachedTimePosition;
       bool tempoSliderIsPressed;
+      EnablePlayForWidget* enablePlay;
 
       Score* cs;
       virtual void closeEvent(QCloseEvent*);
       virtual void hideEvent (QHideEvent* event);
+      virtual void showEvent(QShowEvent *);
+      virtual bool eventFilter(QObject *, QEvent *);
+      virtual void keyPressEvent(QKeyEvent*) override;
       void updateTimeLabel(int sec);
       void updatePosLabel(int utick);
 

--- a/mscore/playpanel.ui
+++ b/mscore/playpanel.ui
@@ -16,6 +16,9 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="focusPolicy">
+   <enum>Qt::ClickFocus</enum>
+  </property>
   <property name="windowTitle">
    <string>MuseScore: Play Panel</string>
   </property>
@@ -145,6 +148,12 @@
      </item>
      <item>
       <widget class="QSlider" name="posSlider">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+       <property name="accessibleName">
+        <string>Playback Position</string>
+       </property>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -329,8 +338,17 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Relative tempo</string>
+       </property>
+       <property name="accessibleName">
+        <string>Relative Tempo to 120 beats per minute</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>Use up and down arrows to change value</string>
        </property>
        <property name="value" stdset="0">
         <double>100.000000000000000</double>
@@ -360,8 +378,20 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Master volume</string>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="accessibleName">
+        <string>Master Volume</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>Use up and down arrows to change value</string>
        </property>
       </widget>
      </item>
@@ -908,6 +938,12 @@
      </item>
      <item row="1" column="0">
       <widget class="QDoubleSpinBox" name="relTempoBox">
+       <property name="accessibleName">
+        <string>Relative tempo to 120 beats per minute</string>
+       </property>
+       <property name="accessibleDescription">
+        <string/>
+       </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -8,8 +8,12 @@
 #include "libmscore/measure.h"
 #include "inspector/inspector.h"
 #include "selectionwindow.h"
+#include "playpanel.h"
+#include "synthcontrol.h"
+#include "mixer.h"
 
 namespace Ms{
+
 AccessibleScoreView::AccessibleScoreView(ScoreView* scView) : QAccessibleWidget(scView){
       s = scView;
       }
@@ -181,7 +185,11 @@ void ScoreAccessibility::updateAccessibilityInfo()
       if ( (qApp->focusWidget() != w) &&
            !mscore->inspector()->isAncestorOf(qApp->focusWidget()) &&
            !(mscore->searchDialog() && mscore->searchDialog()->isAncestorOf(qApp->focusWidget())) &&
-           !(mscore->getSelectionWindow() && mscore->getSelectionWindow()->isAncestorOf(qApp->focusWidget()))) {
+           !(mscore->getSelectionWindow() && mscore->getSelectionWindow()->isAncestorOf(qApp->focusWidget())) &&
+           !(mscore->getPlayPanel() && mscore->getPlayPanel()->isAncestorOf(qApp->focusWidget())) &&
+           !(mscore->getSynthControl() && mscore->getSynthControl()->isAncestorOf(qApp->focusWidget())) &&
+           !(mscore->getMixer() && mscore->getMixer()->isAncestorOf(qApp->focusWidget())) &&
+           !(mscore->searchDialog() && mscore->searchDialog()->isAncestorOf(qApp->focusWidget())) ) {
             mscore->activateWindow();
             w->setFocus();
             }

--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -91,6 +91,7 @@ SynthControl::SynthControl(QWidget* parent)
       recallButton->setEnabled(false);
       changeTuningButton->setEnabled(false);
 
+      enablePlay = new EnablePlayForWidget(this);
       connect(effectA,      SIGNAL(currentIndexChanged(int)), SLOT(effectAChanged(int)));
       connect(effectB,      SIGNAL(currentIndexChanged(int)), SLOT(effectBChanged(int)));
       connect(gain,         SIGNAL(valueChanged(double,int)), SLOT(gainChanged(double,int)));
@@ -121,6 +122,36 @@ void SynthControl::closeEvent(QCloseEvent* ev)
       {
       emit closed(false);
       QWidget::closeEvent(ev);
+      }
+
+//---------------------------------------------------------
+//   showEvent
+//---------------------------------------------------------
+
+void SynthControl::showEvent(QShowEvent* e)
+      {
+      enablePlay->showEvent(e);
+      QWidget::showEvent(e);
+      activateWindow();
+      }
+
+//---------------------------------------------------------
+//   eventFilter
+//---------------------------------------------------------
+
+bool SynthControl::eventFilter(QObject* obj, QEvent* e)
+      {
+      if(enablePlay->eventFilter(obj, e))
+            return true;
+      return QWidget::eventFilter(obj, e);
+      }
+
+void SynthControl::keyPressEvent(QKeyEvent* ev) {
+      if (ev->key() == Qt::Key_Escape && ev->modifiers() == Qt::NoModifier) {
+            close();
+            return;
+            }
+      QWidget::keyPressEvent(ev);
       }
 
 //---------------------------------------------------------

--- a/mscore/synthcontrol.h
+++ b/mscore/synthcontrol.h
@@ -22,6 +22,7 @@
 #define __SYNTHCONTROL_H__
 
 #include "ui_synthcontrol.h"
+#include "enableplayforwidget.h"
 
 namespace Ms {
 
@@ -35,7 +36,12 @@ class SynthControl : public QWidget, Ui::SynthControl {
       Q_OBJECT
 
       Score* _score;
+      EnablePlayForWidget* enablePlay;
+
       virtual void closeEvent(QCloseEvent*);
+      virtual void showEvent(QShowEvent*);
+      virtual bool eventFilter(QObject*, QEvent*);
+      virtual void keyPressEvent(QKeyEvent*) override;
       void updateGui();
 
    private slots:

--- a/mscore/synthcontrol.ui
+++ b/mscore/synthcontrol.ui
@@ -2,13 +2,19 @@
 <ui version="4.0">
  <class>SynthControl</class>
  <widget class="QWidget" name="SynthControl">
+  <property name="windowModality">
+   <enum>Qt::NonModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>697</width>
+    <width>742</width>
     <height>281</height>
    </rect>
+  </property>
+  <property name="focusPolicy">
+   <enum>Qt::ClickFocus</enum>
   </property>
   <property name="windowTitle">
    <string>Synthesizer</string>
@@ -24,6 +30,9 @@
     <layout class="QGridLayout" name="gridLayout_4">
      <item row="0" column="3">
       <widget class="QPushButton" name="storeButton">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="text">
         <string>Set as Default</string>
        </property>
@@ -31,6 +40,9 @@
      </item>
      <item row="0" column="0">
       <widget class="QPushButton" name="saveButton">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Save to score</string>
        </property>
@@ -54,6 +66,9 @@
      </item>
      <item row="0" column="1">
       <widget class="QPushButton" name="loadButton">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="toolTip">
         <string>Load from score</string>
        </property>
@@ -64,6 +79,9 @@
      </item>
      <item row="0" column="4">
       <widget class="QPushButton" name="recallButton">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="text">
         <string>Load Default</string>
        </property>
@@ -74,11 +92,20 @@
    <item row="0" column="2" rowspan="3">
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="Awl::MeterSlider" name="gain">
+      <widget class="Awl::MeterSlider" name="gain" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="statusTip">
         <string>Master volume</string>
        </property>
-       <property name="channel">
+       <property name="accessibleName">
+        <string>Master volume</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>Use up and down arrows to modify</string>
+       </property>
+       <property name="channel" stdset="0">
         <number>2</number>
        </property>
       </widget>
@@ -102,14 +129,23 @@
     </layout>
    </item>
    <item row="0" column="1">
-    <widget class="Awl::VolSlider" name="mgain">
+    <widget class="Awl::VolSlider" name="mgain" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="center">
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+     <property name="accessibleName">
+      <string>Metronome gain</string>
+     </property>
+     <property name="accessibleDescription">
+      <string>Use up and down arrows to modify</string>
+     </property>
+     <property name="center" stdset="0">
       <bool>true</bool>
      </property>
     </widget>
@@ -117,7 +153,7 @@
    <item row="0" column="0" rowspan="2">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="masterEffectsTab">
       <attribute name="title">
@@ -161,6 +197,9 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="accessibleName">
+          <string>Effect A</string>
+         </property>
         </widget>
        </item>
        <item row="2" column="0" colspan="6">
@@ -200,6 +239,9 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="accessibleName">
+          <string>Effect B</string>
+         </property>
         </widget>
        </item>
        <item row="0" column="2">
@@ -231,6 +273,12 @@
        </item>
        <item row="0" column="1">
         <widget class="QDoubleSpinBox" name="masterTuning">
+         <property name="accessibleName">
+          <string>Master tunning</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>Hertz</string>
+         </property>
          <property name="suffix">
           <string extracomment="Frequency Herz">Hz</string>
          </property>
@@ -276,6 +324,9 @@
        </item>
        <item row="2" column="0">
         <widget class="QPushButton" name="changeTuningButton">
+         <property name="focusPolicy">
+          <enum>Qt::TabFocus</enum>
+         </property>
          <property name="text">
           <string>Change Tuning</string>
          </property>
@@ -313,15 +364,17 @@
  </customwidgets>
  <tabstops>
   <tabstop>tabWidget</tabstop>
-  <tabstop>metronome</tabstop>
-  <tabstop>saveButton</tabstop>
-  <tabstop>loadButton</tabstop>
-  <tabstop>storeButton</tabstop>
-  <tabstop>recallButton</tabstop>
   <tabstop>effectA</tabstop>
   <tabstop>effectB</tabstop>
   <tabstop>masterTuning</tabstop>
   <tabstop>changeTuningButton</tabstop>
+  <tabstop>metronome</tabstop>
+  <tabstop>mgain</tabstop>
+  <tabstop>gain</tabstop>
+  <tabstop>saveButton</tabstop>
+  <tabstop>loadButton</tabstop>
+  <tabstop>storeButton</tabstop>
+  <tabstop>recallButton</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/zerberus/zerberus_gui.ui
+++ b/zerberus/zerberus_gui.ui
@@ -31,6 +31,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="remove">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="text">
         <string>Delete</string>
        </property>
@@ -38,6 +41,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="add">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>


### PR DESCRIPTION
I finally figured out why there is a difference between Windows, Linux on one side and Mac on the other side when it comes to tab focus. The option All controls should be selected as shown in the link below:
http://www.mactricksandtips.com/2008/10/use-tab-to-switch-between-dialog-buttons.html

I will remove all the other OS dependent code when it comes to focus policies in a different PR, but the code from this PR assumes that if the user wants to use the keyboard for tabbing he must select the All controls option.