### PR TITLE
improve rhythmic slash notation for drum staves

### DIFF
--- a/mtest/libmscore/tools/undoSlashRhythm01-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashRhythm01-ref.mscx
@@ -970,7 +970,6 @@
           </Rest>
         <tick>3840</tick>
         <Chord>
-          <offset x="0" y="-0.5"/>
           <track>6</track>
           <small>1</small>
           <durationType>quarter</durationType>
@@ -978,7 +977,6 @@
             <track>6</track>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>-1</fixedLine>
@@ -986,11 +984,10 @@
           </Chord>
         <Beam id="13">
           <track>6</track>
-          <l1>-15</l1>
-          <l2>-15</l2>
+          <l1>-13</l1>
+          <l2>-13</l2>
           </Beam>
         <Chord>
-          <offset x="0" y="-0.5"/>
           <track>6</track>
           <small>1</small>
           <durationType>eighth</durationType>
@@ -999,14 +996,12 @@
             <track>6</track>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>-1</fixedLine>
             </Note>
           </Chord>
         <Chord>
-          <offset x="0" y="-0.5"/>
           <track>6</track>
           <small>1</small>
           <durationType>eighth</durationType>
@@ -1018,7 +1013,6 @@
               </Tie>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>-1</fixedLine>
@@ -1026,11 +1020,10 @@
           </Chord>
         <Beam id="14">
           <track>6</track>
-          <l1>-15</l1>
-          <l2>-15</l2>
+          <l1>-13</l1>
+          <l2>-13</l2>
           </Beam>
         <Chord>
-          <offset x="0" y="-0.5"/>
           <track>6</track>
           <small>1</small>
           <durationType>eighth</durationType>
@@ -1040,14 +1033,12 @@
             <endSpanner id="8"/>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>-1</fixedLine>
             </Note>
           </Chord>
         <Chord>
-          <offset x="0" y="-0.5"/>
           <track>6</track>
           <small>1</small>
           <durationType>eighth</durationType>
@@ -1056,14 +1047,12 @@
             <track>6</track>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>-1</fixedLine>
             </Note>
           </Chord>
         <Chord>
-          <offset x="0" y="-0.5"/>
           <track>6</track>
           <small>1</small>
           <durationType>quarter</durationType>
@@ -1071,7 +1060,6 @@
             <track>6</track>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>-1</fixedLine>
@@ -1089,7 +1077,6 @@
           </BarLine>
         <tick>5760</tick>
         <Chord>
-          <offset x="0" y="0.5"/>
           <track>7</track>
           <small>1</small>
           <durationType>quarter</durationType>
@@ -1097,7 +1084,6 @@
             <track>7</track>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>9</fixedLine>
@@ -1105,11 +1091,10 @@
           </Chord>
         <Beam id="15">
           <track>7</track>
-          <l1>31</l1>
-          <l2>31</l2>
+          <l1>29</l1>
+          <l2>29</l2>
           </Beam>
         <Chord>
-          <offset x="0" y="0.5"/>
           <track>7</track>
           <small>1</small>
           <durationType>eighth</durationType>
@@ -1118,14 +1103,12 @@
             <track>7</track>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>9</fixedLine>
             </Note>
           </Chord>
         <Chord>
-          <offset x="0" y="0.5"/>
           <track>7</track>
           <small>1</small>
           <durationType>eighth</durationType>
@@ -1137,7 +1120,6 @@
               </Tie>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>9</fixedLine>
@@ -1145,11 +1127,10 @@
           </Chord>
         <Beam id="16">
           <track>7</track>
-          <l1>31</l1>
-          <l2>31</l2>
+          <l1>29</l1>
+          <l2>29</l2>
           </Beam>
         <Chord>
-          <offset x="0" y="0.5"/>
           <track>7</track>
           <small>1</small>
           <durationType>eighth</durationType>
@@ -1159,14 +1140,12 @@
             <endSpanner id="9"/>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>9</fixedLine>
             </Note>
           </Chord>
         <Chord>
-          <offset x="0" y="0.5"/>
           <track>7</track>
           <small>1</small>
           <durationType>eighth</durationType>
@@ -1175,14 +1154,12 @@
             <track>7</track>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>9</fixedLine>
             </Note>
           </Chord>
         <Chord>
-          <offset x="0" y="0.5"/>
           <track>7</track>
           <small>1</small>
           <durationType>quarter</durationType>
@@ -1190,7 +1167,6 @@
             <track>7</track>
             <pitch>38</pitch>
             <tpc>16</tpc>
-            <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
             <fixedLine>9</fixedLine>

--- a/mtest/libmscore/tools/undoSlashRhythm02-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashRhythm02-ref.mscx
@@ -825,8 +825,8 @@
           </Chord>
         <Beam id="13">
           <track>6</track>
-          <l1>-15</l1>
-          <l2>-15</l2>
+          <l1>-13</l1>
+          <l2>-13</l2>
           </Beam>
         <Chord>
           <track>6</track>
@@ -855,8 +855,8 @@
           </Chord>
         <Beam id="14">
           <track>6</track>
-          <l1>-15</l1>
-          <l2>-15</l2>
+          <l1>-13</l1>
+          <l2>-13</l2>
           </Beam>
         <Chord>
           <track>6</track>
@@ -914,8 +914,8 @@
           </Chord>
         <Beam id="15">
           <track>7</track>
-          <l1>31</l1>
-          <l2>31</l2>
+          <l1>29</l1>
+          <l2>29</l2>
           </Beam>
         <Chord>
           <track>7</track>
@@ -944,8 +944,8 @@
           </Chord>
         <Beam id="16">
           <track>7</track>
-          <l1>31</l1>
-          <l2>31</l2>
+          <l1>29</l1>
+          <l2>29</l2>
           </Beam>
         <Chord>
           <track>7</track>


### PR DESCRIPTION
On examination of drum scores & books, it seems that "rhythmic slash notation" more commonly uses regular noteheads as opposed to slashes, and places them directly above the staff, not floating higher.   But slash heads & floating above is more common / better for non-drum staves.  So I tweaked the code to differentiate by staff type.  Updated mtest.  Here, BTW, is an image showing the type of notation that is produced:

![drumset-rhythmic-slash](https://cloud.githubusercontent.com/assets/1799936/5194668/3ecc376c-74ce-11e4-9b44-c79e7fab2645.png)
