### PR TITLE
allow subsequent scores to have less staves/parts

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2137,14 +2137,14 @@ void Score::removeAudio()
 
 bool Score::appendScore(Score* score)
       {
-      if (parts().size() != score->parts().size() || staves().size() != score->staves().size())
+      if (parts().size() < score->parts().size() || staves().size() < score->staves().size())
             return false;
       TieMap  tieMap;
 
       MeasureBase* lastMeasure = last();
       int tickLen = lastMeasure->endTick();
 
-      if (!lastMeasure->lineBreak()) {
+      if (!lastMeasure->lineBreak() && !lastMeasure->pageBreak()) {
             lastMeasure->undoSetBreak(true, LayoutBreak::Type::LINE);
             }
 


### PR DESCRIPTION
than the first when joining.
And a small optimization: don't append a line break if a page break is already present
