### PR TITLE
Skip over unnecessary data in dotted notes and better slide (chordline) layout for GP files

### DIFF
--- a/libmscore/chordline.h
+++ b/libmscore/chordline.h
@@ -42,6 +42,7 @@ class ChordLine : public Element {
       bool modified;
       float _lengthX;
       float _lengthY;
+      const int _initialLength = 2;
 
    public:
       ChordLine(Score*);

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -576,29 +576,29 @@ void GuitarPro::createSlide(int slide, ChordRest* cr, int staffIdx)
       // slide out downwards (fall)
       else if (slide == SLIDE_OUT_DOWN) {
             ChordLine* cl = new ChordLine(score);
-            cl->setChordLineType(ChordLineType::FALL);
             cl->setStraight(true);
+            cl->setChordLineType(ChordLineType::FALL);
             cr->add(cl);
             }
       // slide out upwards (doit)
       else if (slide == SLIDE_OUT_UP) {
             ChordLine* cl = new ChordLine(score);
-            cl->setChordLineType(ChordLineType::DOIT);
             cl->setStraight(true);
+            cl->setChordLineType(ChordLineType::DOIT);
             cr->add(cl);
             }
       // slide in from below (plop)
       else if (slide == SLIDE_IN_BELOW) {
             ChordLine* cl = new ChordLine(score);
-            cl->setChordLineType(ChordLineType::PLOP);
             cl->setStraight(true);
+            cl->setChordLineType(ChordLineType::PLOP);
             cr->add(cl);
             }
       // slide in from above (scoop)
       else if (slide == SLIDE_IN_ABOVE) {
             ChordLine* cl = new ChordLine(score);
-            cl->setChordLineType(ChordLineType::SCOOP);
             cl->setStraight(true);
+            cl->setChordLineType(ChordLineType::SCOOP);
             cr->add(cl);
             }
       }


### PR DESCRIPTION
Fixed potential issues stemming from dotted note information in old versions of guitar pro. Also a new slide layout for guitar pro files (see issue [#392391](http://musescore.org/en/node/39231)), fixes spacing problems described in the issue.
