### PR TITLE
fix #40556: focus lost after duration change

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2708,8 +2708,6 @@ void Score::padToggle(Pad n)
       if (!cr)
             return;
 
-      deselectAll();
-
       if (cr->type() == Element::Type::CHORD && (static_cast<Chord*>(cr)->noteType() != NoteType::NORMAL)) {
             //
             // handle appoggiatura and acciaccatura


### PR DESCRIPTION
This broke as a result of https://github.com/musescore/MuseScore/commit/cf92afb3a13c0f1a3b49573a1154bfdf5f204e36, which was to fix http://musescore.org/en/node/36511.  That did lots of good things, but maybe just went a bit too far.  As far as I can tell, simply removing the deselectAll() from padToggle fixes my issue here (40556) but still leaves 36511 fixed.  That's because changeCRlen() has explicit code to preserve selection (deselecting and reselecting as needed).
