### PR TITLE
fix #40641: incorrect import/export of relative-x

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -4678,17 +4678,23 @@ double ExportMusicXml::getTenthsFromDots(double dots)
 
 void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd, int offset)
       {
-      double rx = h->userOff().x()*10;
-      QString relative;
-      if (rx > 0) {
-            relative = QString(" relative-x=\"%1\"").arg(QString::number(rx,'f',2));
-            }
+      // this code was probably in place to allow chord symbols shifted *right* to export with offset
+      // since this was at once time the only way to get a chord to appear over beat 3 in an empty 4/4 measure
+      // but the value was calculated incorrectly (should be divided by spatium) and would be better off using offset anyhow
+      // since we now support placement of chord symbols over "empty" beats directly,
+      // and wedon't generally export position info for other elements
+      // it's just as well to not bother doing so here
+      //double rx = h->userOff().x()*10;
+      //QString relative;
+      //if (rx > 0) {
+      //      relative = QString(" relative-x=\"%1\"").arg(QString::number(rx,'f',2));
+      //      }
       int rootTpc = h->rootTpc();
       if (rootTpc != Tpc::TPC_INVALID) {
             if (h->textStyle().hasFrame())
-                  xml.stag(QString("harmony print-frame=\"yes\"").append(relative));
+                  xml.stag(QString("harmony print-frame=\"yes\""));     // .append(relative));
             else
-                  xml.stag(QString("harmony print-frame=\"no\"").append(relative));
+                  xml.stag(QString("harmony print-frame=\"no\""));      // .append(relative));
             xml.stag("root");
             xml.tag("root-step", tpc2stepName(rootTpc));
             int alter = int(tpc2alter(rootTpc));
@@ -4761,9 +4767,9 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
             // which may contain arbitrary text
             //
             if (h->textStyle().hasFrame())
-                  xml.stag(QString("harmony print-frame=\"yes\"").append(relative));
+                  xml.stag(QString("harmony print-frame=\"yes\""));     // .append(relative));
             else
-                  xml.stag(QString("harmony print-frame=\"no\"").append(relative));
+                  xml.stag(QString("harmony print-frame=\"no\""));      // .append(relative));
             xml.stag("root");
             xml.tag("root-step text=\"\"", "C");
             xml.etag();       // root

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -5615,8 +5615,11 @@ void MusicXml::xmlHarmony(QDomElement e, int tick, Measure* measure, int staff)
       // type:
 
       // placement:
-      double rx = 0.1 * e.attribute("relative-x", "0").toDouble();
-      double ry = -0.1 * e.attribute("relative-y", "0").toDouble();
+      // in order to work correctly, this should probably be adjusted to account for spatium
+      // but in any case, we don't support import relative-x/y for other elements
+      // no reason to do so for chord symbols
+      double rx = 0.0;  // 0.1 * e.attribute("relative-x", "0").toDouble();
+      double ry = 0.0;  // -0.1 * e.attribute("relative-y", "0").toDouble();
 
       double styleYOff = score->textStyle(TextStyleType::HARMONY).offset().y();
       OffsetType offsetType = score->textStyle(TextStyleType::HARMONY).offsetType();


### PR DESCRIPTION
As discussed in issue, I think it makes sense for now to simply not import or export relative-x for chord symbols, since we don't do it for any other elements.  There is an existing "todo" note regarding support of offsets and relative-x.  I left the relative-x in but commented it out to have for reference if/wehn the time comes to revisit any of this.  It seems that is also the approach taken for various other places where relative-x was being used or considered for use at one time.
