### PR TITLE
fix #40846: require Ctrl+drag to create staff-only barline change

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -575,17 +575,17 @@ Element* BarLine::drop(const DropData& data)
                   return 0;
                   }
 
-            //parent is a segment
+            // parent is a segment
             Measure* m = static_cast<Segment*>(parent())->measure();
-
             // check if the new property can apply to this single bar line
             bool oldRepeat = (barLineType() == BarLineType::START_REPEAT || barLineType() == BarLineType::END_REPEAT
                         || barLineType() == BarLineType::END_START_REPEAT);
             bool newRepeat = (bl->barLineType() == BarLineType::START_REPEAT || bl->barLineType() == BarLineType::END_REPEAT
                         || bl->barLineType() == BarLineType::END_START_REPEAT);
-            // if repeats are not involved or drop refers to span rather than subtype =>
+            // if ctrl was used and repeats are not involved,
+            // or if drop refers to span rather than subtype =>
             // single bar line drop
-            if( (!oldRepeat && !newRepeat) || (bl->spanFrom() != 0 || bl->spanTo() != DEFAULT_BARLINE_TO) ) {
+            if (((data.modifiers & Qt::ControlModifier) && !oldRepeat && !newRepeat) || (bl->spanFrom() != 0 || bl->spanTo() != DEFAULT_BARLINE_TO) ) {
                   // if drop refers to span, update this bar line span
                   if(bl->spanFrom() != 0 || bl->spanTo() != DEFAULT_BARLINE_TO) {
                         // if dropped spanFrom or spanTo are below the middle of standard staff (5 lines)
@@ -595,7 +595,7 @@ Element* BarLine::drop(const DropData& data)
                         int spanTo     = bl->spanTo() > 4 ? bottomSpan - (8 - bl->spanTo()) : bl->spanTo();
                         score()->undoChangeSingleBarLineSpan(this, 1, spanFrom, spanTo);
                         }
-                  // if drop refer to subtype, update this bar line subtype
+                  // if drop refers to subtype, update this bar line subtype
                   else {
 //                        score()->undoChangeBarLine(m, bl->barLineType());
                         score()->undoChangeProperty(this, P_ID::SUBTYPE, int(bl->barLineType()));
@@ -612,7 +612,9 @@ Element* BarLine::drop(const DropData& data)
                         return 0;
                         }
                   }
-            m->drop(data);
+            score()->undoChangeBarLine(m, bl->barLineType());
+            delete e;
+            return 0;
             }
       else if (type == Element::Type::ARTICULATION) {
             Articulation* atr = static_cast<Articulation*>(e);

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1446,7 +1446,8 @@ qDebug("drop staffList");
                   {
                   BarLine* bl = static_cast<BarLine*>(e);
                   // if dropped bar line refers to span rather than to subtype
-                  if (bl->spanFrom() != 0 && bl->spanTo() != DEFAULT_BARLINE_TO) {
+                  // or if Ctrl key used
+                  if ((bl->spanFrom() != 0 && bl->spanTo() != DEFAULT_BARLINE_TO) || (data.modifiers & Qt::ControlModifier)) {
                         // get existing bar line for this staff, and drop the change to it
                         Segment* seg = undoGetSegment(Segment::Type::EndBarLine, tick() + ticks());
                         BarLine* cbl = static_cast<BarLine*>(seg->element(staffIdx * VOICES));


### PR DESCRIPTION
In 1.3, you could change to a double bar or other barline style by clicking the barline then double clicking the palette icon.  In 2.0, this behavior has changed - the abrline is applied only to the current staff.  Unless you know the trick of dragging the palette icon to the measure, it looks like you need to apply the barline to each staff one at a time, which would be as bad as when we had to apply key signatures one staff at a time in 1.3.  Worse, barlines applied in this manner "hide" repeat barlines, leading to the issue at hand: http://musescore.org/en/node/40846

Since we have already established the convention with key & time signatures of having ordinary drop affect the whole system but Ctrl+drop affects just the current staff, I have implemented this for barlines as well.  I am keeping the special casing for the "tick" styles - they always affect the current staff only even if dragged to the measure.

I tested this as well as I could, but I admit I don't understand all the ins and outs of the barline implementation.  But I can verfy that drag of each barline from palette to a measure works as expected, as do Ctrl+drag and double click.
