### PR TITLE
fix #40941: chord symbols don't transpose unless there are parts

### DIFF
--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -416,11 +416,8 @@ void Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
                         // undoTransposeHarmony does not do links
                         // because it is also used to handle transposing instruments
                         // and score / parts could be in different concert pitch states
-                        const LinkedElements* le = h->links();
-                        if (le) {
-                              for (Element* e : *le)
-                                    undoTransposeHarmony(static_cast<Harmony*>(e), rootTpc, baseTpc);
-                              }
+                        for (Element* e : h->linkList())
+                              undoTransposeHarmony(static_cast<Harmony*>(e), rootTpc, baseTpc);
                         }
                   }
             }

--- a/mtest/libmscore/chordsymbol/transpose-part-ref.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-part-ref.mscx
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <page-layout>
+        <page-height>1584</page-height>
+        <page-width>1224</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>90.1417</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>90.1417</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="-1" span="0"/>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument>
+        <longName pos="0">Flute</longName>
+        <shortName pos="0">Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="73"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <lid>9</lid>
+        </VBox>
+      <Measure number="1">
+        <TimeSig>
+          <lid>1</lid>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Harmony>
+          <root>17</root>
+          <name>7</name>
+          <lid>2</lid>
+          </Harmony>
+        <Chord>
+          <lid>3</lid>
+          <durationType>whole</durationType>
+          <Note>
+            <lid>4</lid>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
+            <pitch>73</pitch>
+            <tpc>21</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="2">
+        <Harmony>
+          <root>16</root>
+          <lid>5</lid>
+          </Harmony>
+        <Chord>
+          <lid>6</lid>
+          <durationType>whole</durationType>
+          <Note>
+            <lid>7</lid>
+            <pitch>74</pitch>
+            <tpc>16</tpc>
+            </Note>
+          </Chord>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          <lid>8</lid>
+          </BarLine>
+        </Measure>
+      </Staff>
+    <Score>
+      <LayerTag id="0" tag="default"></LayerTag>
+      <currentLayer>0</currentLayer>
+      <Division>480</Division>
+      <Style>
+        <createMultiMeasureRests>1</createMultiMeasureRests>
+        <page-layout>
+          <page-height>1584</page-height>
+          <page-width>1224</page-width>
+          <page-margins type="even">
+            <left-margin>56.6929</left-margin>
+            <right-margin>90.1417</right-margin>
+            <top-margin>56.6929</top-margin>
+            <bottom-margin>113.386</bottom-margin>
+            </page-margins>
+          <page-margins type="odd">
+            <left-margin>56.6929</left-margin>
+            <right-margin>90.1417</right-margin>
+            <top-margin>56.6929</top-margin>
+            <bottom-margin>113.386</bottom-margin>
+            </page-margins>
+          </page-layout>
+        <Spatium>1.76389</Spatium>
+        </Style>
+      <showInvisible>1</showInvisible>
+      <showUnprintable>1</showUnprintable>
+      <showFrames>1</showFrames>
+      <showMargins>0</showMargins>
+      <PageList>
+        <Page>
+          <System>
+            </System>
+          <System>
+            </System>
+          </Page>
+        </PageList>
+      <Part>
+        <Staff id="1">
+          <linkedTo>1</linkedTo>
+          <StaffType group="pitched">
+            <name>stdNormal</name>
+            </StaffType>
+          <bracket type="-1" span="0"/>
+          </Staff>
+        <trackName>Flute</trackName>
+        <Instrument>
+          <longName pos="0">Flute</longName>
+          <shortName pos="0">Fl.</shortName>
+          <trackName>Flute</trackName>
+          <minPitchP>59</minPitchP>
+          <maxPitchP>98</maxPitchP>
+          <minPitchA>60</minPitchA>
+          <maxPitchA>93</maxPitchA>
+          <Articulation>
+            <velocity>100</velocity>
+            <gateTime>95</gateTime>
+            </Articulation>
+          <Articulation name="staccatissimo">
+            <velocity>100</velocity>
+            <gateTime>33</gateTime>
+            </Articulation>
+          <Articulation name="staccato">
+            <velocity>100</velocity>
+            <gateTime>50</gateTime>
+            </Articulation>
+          <Articulation name="portato">
+            <velocity>100</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="tenuto">
+            <velocity>100</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Articulation name="marcato">
+            <velocity>120</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="sforzato">
+            <velocity>120</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Channel>
+            <program value="73"/>
+            </Channel>
+          </Instrument>
+        </Part>
+      <Staff id="1">
+        <VBox>
+          <height>10</height>
+          <lid>9</lid>
+          <Text>
+            <style>Instrument Name (Part)</style>
+            <text>Flute</text>
+            </Text>
+          </VBox>
+        <Measure number="1">
+          <TimeSig>
+            <lid>1</lid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            <showCourtesySig>1</showCourtesySig>
+            </TimeSig>
+          <Harmony>
+            <root>17</root>
+            <name>7</name>
+            <lid>2</lid>
+            </Harmony>
+          <Chord>
+            <lid>3</lid>
+            <durationType>whole</durationType>
+            <Note>
+              <lid>4</lid>
+              <Accidental>
+                <subtype>sharp</subtype>
+                </Accidental>
+              <pitch>73</pitch>
+              <tpc>21</tpc>
+              </Note>
+            </Chord>
+          </Measure>
+        <Measure number="2">
+          <Harmony>
+            <root>16</root>
+            <lid>5</lid>
+            </Harmony>
+          <Chord>
+            <lid>6</lid>
+            <durationType>whole</durationType>
+            <Note>
+              <lid>7</lid>
+              <pitch>74</pitch>
+              <tpc>16</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            <lid>8</lid>
+            </BarLine>
+          </Measure>
+        </Staff>
+      <name>Flute</name>
+      </Score>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/chordsymbol/transpose-part.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-part.mscx
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <page-layout>
+        <page-height>1584</page-height>
+        <page-width>1224</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>90.1417</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>90.1417</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="-1" span="0"/>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument>
+        <longName pos="0">Flute</longName>
+        <shortName pos="0">Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="73"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <lid>11</lid>
+        </VBox>
+      <Measure number="1">
+        <KeySig>
+          <lid>0</lid>
+          <accidental>0</accidental>
+          </KeySig>
+        <TimeSig>
+          <lid>1</lid>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Harmony>
+          <root>15</root>
+          <name>7</name>
+          <lid>2</lid>
+          </Harmony>
+        <Chord>
+          <lid>3</lid>
+          <durationType>whole</durationType>
+          <Note>
+            <lid>4</lid>
+            <pitch>71</pitch>
+            <tpc>19</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="2">
+        <Harmony>
+          <root>14</root>
+          <lid>6</lid>
+          </Harmony>
+        <Chord>
+          <lid>7</lid>
+          <durationType>whole</durationType>
+          <Note>
+            <lid>8</lid>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          <lid>9</lid>
+          </BarLine>
+        </Measure>
+      </Staff>
+    <Score>
+      <LayerTag id="0" tag="default"></LayerTag>
+      <currentLayer>0</currentLayer>
+      <Division>480</Division>
+      <Style>
+        <createMultiMeasureRests>1</createMultiMeasureRests>
+        <page-layout>
+          <page-height>1584</page-height>
+          <page-width>1224</page-width>
+          <page-margins type="even">
+            <left-margin>56.6929</left-margin>
+            <right-margin>90.1417</right-margin>
+            <top-margin>56.6929</top-margin>
+            <bottom-margin>113.386</bottom-margin>
+            </page-margins>
+          <page-margins type="odd">
+            <left-margin>56.6929</left-margin>
+            <right-margin>90.1417</right-margin>
+            <top-margin>56.6929</top-margin>
+            <bottom-margin>113.386</bottom-margin>
+            </page-margins>
+          </page-layout>
+        <Spatium>1.76389</Spatium>
+        </Style>
+      <showInvisible>1</showInvisible>
+      <showUnprintable>1</showUnprintable>
+      <showFrames>1</showFrames>
+      <showMargins>0</showMargins>
+      <PageList>
+        <Page>
+          <System>
+            </System>
+          <System>
+            </System>
+          </Page>
+        </PageList>
+      <Part>
+        <Staff id="1">
+          <linkedTo>1</linkedTo>
+          <StaffType group="pitched">
+            <name>stdNormal</name>
+            </StaffType>
+          <bracket type="-1" span="0"/>
+          </Staff>
+        <trackName></trackName>
+        <Instrument>
+          <longName pos="0">Flute</longName>
+          <shortName pos="0">Fl.</shortName>
+          <trackName>Flute</trackName>
+          <minPitchP>59</minPitchP>
+          <maxPitchP>98</maxPitchP>
+          <minPitchA>60</minPitchA>
+          <maxPitchA>93</maxPitchA>
+          <Articulation>
+            <velocity>100</velocity>
+            <gateTime>95</gateTime>
+            </Articulation>
+          <Articulation name="staccatissimo">
+            <velocity>100</velocity>
+            <gateTime>33</gateTime>
+            </Articulation>
+          <Articulation name="staccato">
+            <velocity>100</velocity>
+            <gateTime>50</gateTime>
+            </Articulation>
+          <Articulation name="portato">
+            <velocity>100</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="tenuto">
+            <velocity>100</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Articulation name="marcato">
+            <velocity>120</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="sforzato">
+            <velocity>120</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Channel>
+            <program value="73"/>
+            </Channel>
+          </Instrument>
+        </Part>
+      <Staff id="1">
+        <VBox>
+          <height>10</height>
+          <lid>11</lid>
+          <Text>
+            <style>Instrument Name (Part)</style>
+            <text>Flute</text>
+            </Text>
+          </VBox>
+        <Measure number="1">
+          <KeySig>
+            <lid>0</lid>
+            <accidental>0</accidental>
+            </KeySig>
+          <TimeSig>
+            <lid>1</lid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            <showCourtesySig>1</showCourtesySig>
+            </TimeSig>
+          <Harmony>
+            <root>15</root>
+            <name>7</name>
+            <lid>2</lid>
+            </Harmony>
+          <Chord>
+            <lid>3</lid>
+            <durationType>whole</durationType>
+            <Note>
+              <lid>4</lid>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          </Measure>
+        <Measure number="2">
+          <Harmony>
+            <root>14</root>
+            <lid>6</lid>
+            </Harmony>
+          <Chord>
+            <lid>7</lid>
+            <durationType>whole</durationType>
+            <Note>
+              <lid>8</lid>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            <lid>9</lid>
+            </BarLine>
+          </Measure>
+        </Staff>
+      <name>Flute</name>
+      </Score>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/chordsymbol/transpose-ref.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-ref.mscx
@@ -98,11 +98,9 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <lid>9</lid>
         </VBox>
       <Measure number="1">
         <TimeSig>
-          <lid>1</lid>
           <sigN>4</sigN>
           <sigD>4</sigD>
           <showCourtesySig>1</showCourtesySig>
@@ -110,13 +108,10 @@
         <Harmony>
           <root>17</root>
           <name>7</name>
-          <lid>2</lid>
           </Harmony>
         <Chord>
-          <lid>3</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>4</lid>
             <Accidental>
               <subtype>sharp</subtype>
               </Accidental>
@@ -128,13 +123,10 @@
       <Measure number="2">
         <Harmony>
           <root>16</root>
-          <lid>5</lid>
           </Harmony>
         <Chord>
-          <lid>6</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>7</lid>
             <pitch>74</pitch>
             <tpc>16</tpc>
             </Note>
@@ -142,152 +134,8 @@
         <BarLine>
           <subtype>end</subtype>
           <span>1</span>
-          <lid>8</lid>
           </BarLine>
         </Measure>
       </Staff>
-    <Score>
-      <LayerTag id="0" tag="default"></LayerTag>
-      <currentLayer>0</currentLayer>
-      <Division>480</Division>
-      <Style>
-        <createMultiMeasureRests>1</createMultiMeasureRests>
-        <page-layout>
-          <page-height>1584</page-height>
-          <page-width>1224</page-width>
-          <page-margins type="even">
-            <left-margin>56.6929</left-margin>
-            <right-margin>90.1417</right-margin>
-            <top-margin>56.6929</top-margin>
-            <bottom-margin>113.386</bottom-margin>
-            </page-margins>
-          <page-margins type="odd">
-            <left-margin>56.6929</left-margin>
-            <right-margin>90.1417</right-margin>
-            <top-margin>56.6929</top-margin>
-            <bottom-margin>113.386</bottom-margin>
-            </page-margins>
-          </page-layout>
-        <Spatium>1.76389</Spatium>
-        </Style>
-      <showInvisible>1</showInvisible>
-      <showUnprintable>1</showUnprintable>
-      <showFrames>1</showFrames>
-      <showMargins>0</showMargins>
-      <PageList>
-        <Page>
-          <System>
-            </System>
-          <System>
-            </System>
-          </Page>
-        </PageList>
-      <Part>
-        <Staff id="1">
-          <linkedTo>1</linkedTo>
-          <StaffType group="pitched">
-            <name>stdNormal</name>
-            </StaffType>
-          <bracket type="-1" span="0"/>
-          </Staff>
-        <trackName>Flute</trackName>
-        <Instrument>
-          <longName pos="0">Flute</longName>
-          <shortName pos="0">Fl.</shortName>
-          <trackName>Flute</trackName>
-          <minPitchP>59</minPitchP>
-          <maxPitchP>98</maxPitchP>
-          <minPitchA>60</minPitchA>
-          <maxPitchA>93</maxPitchA>
-          <Articulation>
-            <velocity>100</velocity>
-            <gateTime>95</gateTime>
-            </Articulation>
-          <Articulation name="staccatissimo">
-            <velocity>100</velocity>
-            <gateTime>33</gateTime>
-            </Articulation>
-          <Articulation name="staccato">
-            <velocity>100</velocity>
-            <gateTime>50</gateTime>
-            </Articulation>
-          <Articulation name="portato">
-            <velocity>100</velocity>
-            <gateTime>67</gateTime>
-            </Articulation>
-          <Articulation name="tenuto">
-            <velocity>100</velocity>
-            <gateTime>100</gateTime>
-            </Articulation>
-          <Articulation name="marcato">
-            <velocity>120</velocity>
-            <gateTime>67</gateTime>
-            </Articulation>
-          <Articulation name="sforzato">
-            <velocity>120</velocity>
-            <gateTime>100</gateTime>
-            </Articulation>
-          <Channel>
-            <program value="73"/>
-            </Channel>
-          </Instrument>
-        </Part>
-      <Staff id="1">
-        <VBox>
-          <height>10</height>
-          <lid>9</lid>
-          <Text>
-            <style>Instrument Name (Part)</style>
-            <text>Flute</text>
-            </Text>
-          </VBox>
-        <Measure number="1">
-          <TimeSig>
-            <lid>1</lid>
-            <sigN>4</sigN>
-            <sigD>4</sigD>
-            <showCourtesySig>1</showCourtesySig>
-            </TimeSig>
-          <Harmony>
-            <root>17</root>
-            <name>7</name>
-            <lid>2</lid>
-            </Harmony>
-          <Chord>
-            <lid>3</lid>
-            <durationType>whole</durationType>
-            <Note>
-              <lid>4</lid>
-              <Accidental>
-                <subtype>sharp</subtype>
-                </Accidental>
-              <pitch>73</pitch>
-              <tpc>21</tpc>
-              </Note>
-            </Chord>
-          </Measure>
-        <Measure number="2">
-          <Harmony>
-            <root>16</root>
-            <lid>5</lid>
-            </Harmony>
-          <Chord>
-            <lid>6</lid>
-            <durationType>whole</durationType>
-            <Note>
-              <lid>7</lid>
-              <pitch>74</pitch>
-              <tpc>16</tpc>
-              </Note>
-            </Chord>
-          <BarLine>
-            <subtype>end</subtype>
-            <span>1</span>
-            <lid>8</lid>
-            </BarLine>
-          </Measure>
-        </Staff>
-      <name>Flute</name>
-      </Score>
     </Score>
   </museScore>

--- a/mtest/libmscore/chordsymbol/transpose.mscx
+++ b/mtest/libmscore/chordsymbol/transpose.mscx
@@ -98,13 +98,9 @@
     <Staff id="1">
       <VBox>
         <height>10</height>
-        <lid>11</lid>
+        <lid>9</lid>
         </VBox>
       <Measure number="1">
-        <KeySig>
-          <lid>0</lid>
-          <accidental>0</accidental>
-          </KeySig>
         <TimeSig>
           <lid>1</lid>
           <sigN>4</sigN>
@@ -129,13 +125,13 @@
       <Measure number="2">
         <Harmony>
           <root>14</root>
-          <lid>6</lid>
+          <lid>5</lid>
           </Harmony>
         <Chord>
-          <lid>7</lid>
+          <lid>6</lid>
           <durationType>whole</durationType>
           <Note>
-            <lid>8</lid>
+            <lid>7</lid>
             <pitch>72</pitch>
             <tpc>14</tpc>
             </Note>
@@ -143,153 +139,9 @@
         <BarLine>
           <subtype>end</subtype>
           <span>1</span>
-          <lid>9</lid>
+          <lid>8</lid>
           </BarLine>
         </Measure>
       </Staff>
-    <Score>
-      <LayerTag id="0" tag="default"></LayerTag>
-      <currentLayer>0</currentLayer>
-      <Division>480</Division>
-      <Style>
-        <createMultiMeasureRests>1</createMultiMeasureRests>
-        <page-layout>
-          <page-height>1584</page-height>
-          <page-width>1224</page-width>
-          <page-margins type="even">
-            <left-margin>56.6929</left-margin>
-            <right-margin>90.1417</right-margin>
-            <top-margin>56.6929</top-margin>
-            <bottom-margin>113.386</bottom-margin>
-            </page-margins>
-          <page-margins type="odd">
-            <left-margin>56.6929</left-margin>
-            <right-margin>90.1417</right-margin>
-            <top-margin>56.6929</top-margin>
-            <bottom-margin>113.386</bottom-margin>
-            </page-margins>
-          </page-layout>
-        <Spatium>1.76389</Spatium>
-        </Style>
-      <showInvisible>1</showInvisible>
-      <showUnprintable>1</showUnprintable>
-      <showFrames>1</showFrames>
-      <showMargins>0</showMargins>
-      <PageList>
-        <Page>
-          <System>
-            </System>
-          <System>
-            </System>
-          </Page>
-        </PageList>
-      <Part>
-        <Staff id="1">
-          <linkedTo>1</linkedTo>
-          <StaffType group="pitched">
-            <name>stdNormal</name>
-            </StaffType>
-          <bracket type="-1" span="0"/>
-          </Staff>
-        <trackName></trackName>
-        <Instrument>
-          <longName pos="0">Flute</longName>
-          <shortName pos="0">Fl.</shortName>
-          <trackName>Flute</trackName>
-          <minPitchP>59</minPitchP>
-          <maxPitchP>98</maxPitchP>
-          <minPitchA>60</minPitchA>
-          <maxPitchA>93</maxPitchA>
-          <Articulation>
-            <velocity>100</velocity>
-            <gateTime>95</gateTime>
-            </Articulation>
-          <Articulation name="staccatissimo">
-            <velocity>100</velocity>
-            <gateTime>33</gateTime>
-            </Articulation>
-          <Articulation name="staccato">
-            <velocity>100</velocity>
-            <gateTime>50</gateTime>
-            </Articulation>
-          <Articulation name="portato">
-            <velocity>100</velocity>
-            <gateTime>67</gateTime>
-            </Articulation>
-          <Articulation name="tenuto">
-            <velocity>100</velocity>
-            <gateTime>100</gateTime>
-            </Articulation>
-          <Articulation name="marcato">
-            <velocity>120</velocity>
-            <gateTime>67</gateTime>
-            </Articulation>
-          <Articulation name="sforzato">
-            <velocity>120</velocity>
-            <gateTime>100</gateTime>
-            </Articulation>
-          <Channel>
-            <program value="73"/>
-            </Channel>
-          </Instrument>
-        </Part>
-      <Staff id="1">
-        <VBox>
-          <height>10</height>
-          <lid>11</lid>
-          <Text>
-            <style>Instrument Name (Part)</style>
-            <text>Flute</text>
-            </Text>
-          </VBox>
-        <Measure number="1">
-          <KeySig>
-            <lid>0</lid>
-            <accidental>0</accidental>
-            </KeySig>
-          <TimeSig>
-            <lid>1</lid>
-            <sigN>4</sigN>
-            <sigD>4</sigD>
-            <showCourtesySig>1</showCourtesySig>
-            </TimeSig>
-          <Harmony>
-            <root>15</root>
-            <name>7</name>
-            <lid>2</lid>
-            </Harmony>
-          <Chord>
-            <lid>3</lid>
-            <durationType>whole</durationType>
-            <Note>
-              <lid>4</lid>
-              <pitch>71</pitch>
-              <tpc>19</tpc>
-              </Note>
-            </Chord>
-          </Measure>
-        <Measure number="2">
-          <Harmony>
-            <root>14</root>
-            <lid>6</lid>
-            </Harmony>
-          <Chord>
-            <lid>7</lid>
-            <durationType>whole</durationType>
-            <Note>
-              <lid>8</lid>
-              <pitch>72</pitch>
-              <tpc>14</tpc>
-              </Note>
-            </Chord>
-          <BarLine>
-            <subtype>end</subtype>
-            <span>1</span>
-            <lid>9</lid>
-            </BarLine>
-          </Measure>
-        </Staff>
-      <name>Flute</name>
-      </Score>
     </Score>
   </museScore>

--- a/mtest/libmscore/chordsymbol/tst_chordsymbol.cpp
+++ b/mtest/libmscore/chordsymbol/tst_chordsymbol.cpp
@@ -46,6 +46,7 @@ class TestChordSymbol : public QObject, public MTest {
       void testAddPart();
       void testNoSystem();
       void testTranspose();
+      void testTransposePart();
       };
 
 //---------------------------------------------------------
@@ -183,6 +184,16 @@ void TestChordSymbol::testTranspose()
       score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
       score->endCmd();
       test_post(score, "transpose");
+      }
+
+void TestChordSymbol::testTransposePart()
+      {
+      Score* score = test_pre("transpose-part");
+      score->startCmd();
+      score->cmdSelectAll();
+      score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
+      score->endCmd();
+      test_post(score, "transpose-part");
       }
 
 QTEST_MAIN(TestChordSymbol)


### PR DESCRIPTION
Bug introduced as a result of bad fix for http://musescore.org/en/node/40506 - I fixed the case where there are parts (and added a test), but broke the case where there aren't.  Both cases now work, and have tests.
