### PR TITLE
fix #31856: add option to trim whitespace from exported PNG

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1667,6 +1667,36 @@ bool Element::isText() const
       }
 
 //---------------------------------------------------------
+//   isPrintable
+//---------------------------------------------------------
+
+bool Element::isPrintable() const
+      {
+      switch (type()) {
+            case Element::Type::PAGE:
+            case Element::Type::SYSTEM:
+            case Element::Type::MEASURE:
+            case Element::Type::SEGMENT:
+            case Element::Type::VBOX:
+            case Element::Type::HBOX:
+            case Element::Type::TBOX:
+            case Element::Type::FBOX:
+            case Element::Type::SPACER:
+            case Element::Type::SHADOW_NOTE:
+            case Element::Type::LASSO:
+            case Element::Type::RUBBERBAND:
+            case Element::Type::ELEMENT_LIST:
+            case Element::Type::STAFF_LIST:
+            case Element::Type::MEASURE_LIST:
+            case Element::Type::SELECTION:
+            case Element::Type::LAYOUT:
+                  return false;
+            default:
+                  return true;
+            }
+      }
+
+//---------------------------------------------------------
 //   findMeasure
 //---------------------------------------------------------
 

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -500,6 +500,7 @@ class Element : public QObject {
       qreal magS() const;
 
       bool isText() const;
+      bool isPrintable() const;
       virtual bool isSpanner() const           { return false; }
       virtual bool isSpannerSegment() const    { return false; }
 

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -856,5 +856,36 @@ qreal Page::rm() const
       return ((!pf->twosided() || isOdd()) ? pf->oddRightMargin() : pf->evenRightMargin()) * MScore::DPI;
       }
 
+//---------------------------------------------------------
+//   tbbox
+//    calculates and returns smallest rectangle containing all (visible) page elements
+//---------------------------------------------------------
+
+QRectF Page::tbbox()
+      {
+      qreal x1 = width();
+      qreal x2 = 0.0;
+      qreal y1 = height();
+      qreal y2 = 0.0;
+      const QList<const Element*> el = elements();
+      for (const Element* e : el) {
+            if (e == this || !e->isPrintable())
+                  continue;
+            QRectF ebbox = e->pageBoundingRect();
+            if (ebbox.left() < x1)
+                  x1 = ebbox.left();
+            if (ebbox.right() > x2)
+                  x2 = ebbox.right();
+            if (ebbox.top() < y1)
+                  y1 = ebbox.top();
+            if (ebbox.bottom() > y2)
+                  y2 = ebbox.bottom();
+            }
+      if (x1 < x2 && y1 < y2)
+            return QRectF(x1, y1, x2 - x1, y2 - y1);
+      else
+            return abbox();
+      }
+
 }
 

--- a/libmscore/page.h
+++ b/libmscore/page.h
@@ -167,6 +167,7 @@ class Page : public Element {
       MeasureBase* pos2measure(const QPointF&, int* staffIdx, int* pitch,
          Segment**, QPointF* offset) const;
       QList<const Element*> elements();         ///< list of visible elements
+      QRectF tbbox();                           // tight bounding box, excluding white space
       };
 
 extern const PaperSize paperSizes[];

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2161,6 +2161,43 @@ void MuseScore::addImage(Score* score, Element* e)
       score->undoAddElement(s);
       }
 
+#if 0
+//---------------------------------------------------------
+//   trim
+//    returns copy of source with whitespace trimmed and margin added
+//---------------------------------------------------------
+
+static QRect trim(QImage source, int margin)
+      {
+      int w = source.width();
+      int h = source.height();
+      int x1 = w;
+      int x2 = 0;
+      int y1 = h;
+      int y2 = 0;
+      for (int x = 0; x < w; ++x) {
+            for (int y = 0; y < h; ++y) {
+                  QRgb c = source.pixel(x, y);
+                  if (c != 0 && c != 0xffffffff) {
+                        if (x < x1)
+                              x1 = x;
+                        if (x > x2)
+                              x2 = x;
+                        if (y < y1)
+                              y1 = y;
+                        if (y > y2)
+                              y2 = y;
+                        }
+                  }
+            }
+      int x = qMax(x1 - margin, 0);
+      int y = qMax(y1 - margin, 0);
+      w = qMin(w, x2 + 1 + margin) - x;
+      h = qMin(h, y2 + 1 + margin) - y;
+      return QRect(x, y, w, h);
+      }
+#endif
+
 //---------------------------------------------------------
 //   savePng
 //    return true on success
@@ -2168,7 +2205,7 @@ void MuseScore::addImage(Score* score, Element* e)
 
 bool MuseScore::savePng(Score* score, const QString& name)
       {
-      return savePng(score, name, false, true, converterDpi, QImage::Format_ARGB32_Premultiplied );
+      return savePng(score, name, false, preferences.pngTransparent, converterDpi, trimMargin, QImage::Format_ARGB32_Premultiplied);
       }
 
 //---------------------------------------------------------
@@ -2176,7 +2213,7 @@ bool MuseScore::savePng(Score* score, const QString& name)
 //    return true on success
 //---------------------------------------------------------
 
-bool MuseScore::savePng(Score* score, const QString& name, bool screenshot, bool transparent, double convDpi, QImage::Format format)
+bool MuseScore::savePng(Score* score, const QString& name, bool screenshot, bool transparent, double convDpi, int trimMargin, QImage::Format format)
       {
       bool rv = true;
       score->setPrinting(!screenshot);    // dont print page break symbols etc.
@@ -2196,7 +2233,13 @@ bool MuseScore::savePng(Score* score, const QString& name, bool screenshot, bool
       for (int pageNumber = 0; pageNumber < pages; ++pageNumber) {
             Page* page = pl.at(pageNumber);
 
-            QRectF r = page->abbox();
+            QRectF r;
+            if (trimMargin >= 0) {
+                  QMarginsF margins(trimMargin, trimMargin, trimMargin, trimMargin);
+                  r = page->tbbox() + margins;
+                  }
+            else
+                  r = page->abbox();
             int w = lrint(r.width()  * convDpi / MScore::DPI);
             int h = lrint(r.height() * convDpi / MScore::DPI);
 
@@ -2208,10 +2251,11 @@ bool MuseScore::savePng(Score* score, const QString& name, bool screenshot, bool
 
             double mag = convDpi / MScore::DPI;
             QPainter p(&printer);
-
             p.setRenderHint(QPainter::Antialiasing, true);
             p.setRenderHint(QPainter::TextAntialiasing, true);
             p.scale(mag, mag);
+            if (trimMargin >= 0)
+                  p.translate(-r.topLeft());
 
             QList<const Element*> pel = page->elements();
             qStableSort(pel.begin(), pel.end(), elementLessThan);
@@ -2378,8 +2422,16 @@ bool MuseScore::saveSvg(Score* score, const QString& saveName)
       const PageFormat* pf = cs->pageFormat();
       double mag = converterDpi / MScore::DPI;
 
-      qreal w = pf->width() * MScore::DPI * score->pages().size();
-      qreal h = pf->height() * MScore::DPI;
+      QRectF r;
+      if (trimMargin >= 0 && score->npages() == 1) {
+            QMarginsF margins(trimMargin, trimMargin, trimMargin, trimMargin);
+            r = score->pages().first()->tbbox() + margins;
+            }
+      else
+            r = QRectF(0, 0, pf->width() * MScore::DPI * score->pages().size(), pf->height() * MScore::DPI);
+      qreal w = r.width();
+      qreal h = r.height();
+
       printer.setSize(QSize(w * mag, h * mag));
       printer.setViewBox(QRectF(0.0, 0.0, w * mag, h * mag));
 
@@ -2389,6 +2441,8 @@ bool MuseScore::saveSvg(Score* score, const QString& saveName)
       p.setRenderHint(QPainter::Antialiasing, true);
       p.setRenderHint(QPainter::TextAntialiasing, true);
       p.scale(mag, mag);
+      if (trimMargin >= 0 && score->npages() == 1)
+            p.translate(-r.topLeft());
 
       foreach (Page* page, score->pages()) {
             QList<const Element*> pel = page->elements();

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -595,6 +595,9 @@ void ScoreView::fotoContextPopup(QContextMenuEvent* ev)
       bgAction->setData("set-bg");
 
       popup->addSeparator();
+      a = new QAction(tr("Auto-resize to page"), this);
+      a->setData("resizePage");
+      popup->addAction(a);
       for (int i = 0; i < 4; ++i) {
             a = new QAction(qApp->translate("fotomode", resizeEntry[i].text), this);
             a->setData(resizeEntry[i].label);
@@ -638,6 +641,15 @@ void ScoreView::fotoContextPopup(QContextMenuEvent* ev)
             if (ok) {
                   preferences.pngResolution = resolution;
                   preferences.dirty = true;
+                  }
+            }
+      else if (cmd == "resizePage") {
+            QRectF r = _foto->rect();
+            Page* page = point2page(r.center());
+            if (page) {
+                  r = page->tbbox().translated(page->canvasPos());
+                  _foto->setRect(r);
+                  updateGrips();
                   }
             }
       else if (cmd.startsWith("resize")) {

--- a/mscore/globals.h
+++ b/mscore/globals.h
@@ -32,6 +32,7 @@ extern bool midiOutputTrace;  ///< debug option: dump midi output
 extern bool converterMode;
 extern double converterDpi;
 extern double guiScaling;
+extern int trimMargin;
 
 //---------------------------------------------------------
 // MsWidget

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -127,6 +127,7 @@ static bool pluginMode = false;
 static bool startWithNewScore = false;
 double converterDpi = 0;
 double guiScaling = 1.0;
+int trimMargin = -1;
 
 QString mscoreGlobalShare;
 
@@ -1248,6 +1249,7 @@ static void usage()
         "   -O        dump midi output\n"
         "   -o file   export to 'file'; format depends on file extension\n"
         "   -r dpi    set output resolution for image export\n"
+        "   -T margin trim exported image with specified margin (in pixels)\n"
         "   -x factor set scaling factor for GUI elements\n"
         "   -S style  load style file\n"
         "   -p name   execute named plugin\n"
@@ -4591,6 +4593,11 @@ int main(int argc, char* av[])
                         if (argv.size() - i < 2)
                               usage();
                         converterDpi = argv.takeAt(i + 1).toDouble();
+                        break;
+                  case 'T':
+                        if (argv.size() - i < 2)
+                              usage();
+                        trimMargin = argv.takeAt(i + 1).toInt();
                         break;
                   case 'x':
                         if (argv.size() - i < 2)

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -607,7 +607,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       bool saveSelection(Score*);
       void addImage(Score*, Element*);
 
-      bool savePng(Score*, const QString& name, bool screenshot, bool transparent, double convDpi, QImage::Format format);
+      bool savePng(Score*, const QString& name, bool screenshot, bool transparent, double convDpi, int trimMargin, QImage::Format format);
       bool saveAudio(Score*, const QString& name);
       bool saveMp3(Score*, const QString& name);
       bool saveSvg(Score*, const QString& name);


### PR DESCRIPTION
Added command line option "-T margin" to trim exported PNG with specified number of pixels as margin (0 works; if margin is too big for page in any direction, it stops at that page edge).  Along the way, discovered user preference for transparency was being ignored on export (honored only for screenshot mode) and fixed this.

I would love to also have the trim option working for SVG export, but the way it is implemented is totally different from PNG, so there was no easy way I could find to make this work.  I'm sure someone with a deeper knowledge of Qt graphics and/or the representation of page elements in MuseScore could pull it off.
