### PR TITLE
fix #41121: crash when trying to open recent score, that doesn't exist anymore

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -328,7 +328,8 @@ Score* MuseScore::readScore(const QString& name)
             score = 0;
             }
       allowShowMidiPanel(name);
-      addRecentScore(score);
+      if (score)
+            addRecentScore(score);
       return score;
       }
 


### PR DESCRIPTION
alternative would be a "return 0;" instead of the "score = 0;" 3 lines above?
