### PR TITLE
fix #40556: focus lost after change duration of note on offbeat

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1048,6 +1048,8 @@ qDebug("  ChangeCRLen:: %d += %d(actual=%d)", tick, f2.ticks(), f2.ticks() * tim
                                     }
                               if (first) {
                                     // select(oc, SelectType::SINGLE, 0);
+                                    if (selElement)
+                                          select(selElement, SelectType::SINGLE, 0);
                                     first = false;
                                     }
                               tick += oc->actualTicks();


### PR DESCRIPTION
I looked at the git history and mostly understand what is going on here.  I see that code was added to remember the selected element and then restore it later.  The code was simply not added to the case of notes on offbeats (or more generally, whatever is actually being tested for in https://github.com/musescore/MuseScore/blame/master/libmscore/cmd.cpp#L1007).

My change here seems totally safe, and does fix the issue I see now.  I simply restore the selection to selElement in the off-the-beat case just as we do in the on-the-beat case.

What I don't know is if there are also situations in this off-the-beat case where we should still be selecting "oc" like we do at https://github.com/musescore/MuseScore/blame/master/libmscore/cmd.cpp#L1024 in the on-the-beat case, and like we used to do at https://github.com/musescore/MuseScore/blame/master/libmscore/cmd.cpp#L1049 in the off-the-beat case before that line was commented out.  That's because I don't know how to hit this line in the on-the-beat case, so I can't see if we need it here in the off-the-beat case too.

What I _can_ see is, in the on-the-beat case, we only get here if "oc" is not zero, but in the off-the-beat case, it could be zero.  So if we _do_ choose to select it, it should probably as "else if (oc)" not just "else".
