### PR TITLE
fix #41326: correct transposition of MIDI input

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1695,17 +1695,14 @@ bool Score::processMidiInput()
                         }
                   NoteVal nval(ev.pitch);
                   Staff* st = staff(inputState().track() / VOICES);
-                  Key key   = st->key(inputState().tick());
 
-                  if (styleB(StyleIdx::concertPitch)) {
-                        nval.tpc1 = pitch2tpc(nval.pitch, key, Prefer::NEAREST);
-                        nval.tpc2 = nval.tpc1;  // DEBUG
-                        }
-                  else {
+                  // if transposing, interpret MIDI pitch as representing desired written pitch
+                  // set pitch based on corresponding sounding pitch
+                  if (!styleB(StyleIdx::concertPitch))
                         nval.pitch += st->part()->instr(inputState().tick())->transpose().chromatic;
-                        nval.tpc2  = pitch2tpc(nval.pitch, key, Prefer::NEAREST);
-                        nval.tpc1 = nval.tpc2;  // DEBUG
-                        }
+                  // let addPitch calculate tpc values from pitch
+                  //Key key   = st->key(inputState().tick());
+                  //nval.tpc1 = pitch2tpc(nval.pitch, key, Prefer::NEAREST);
 
                   addPitch(nval, ev.chord);
                   }


### PR DESCRIPTION
Some back and forth on this bit of code over the past few months, but I've checked and tested and the following seems to be correct in all cases (transposing non-stransposing instrument; concert pitch on / off, tested playback and toggling concert pitch button after note entry.  it also has the advantage of also being simpler than anything else we've done here (setNval does the real work later).  I like fixing bugs by deleting code!
