### PR TITLE
fix #32231: width of measures with key signatures in continuous view

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2964,12 +2964,24 @@ bool Measure::systemHeader() const
 qreal Measure::minWidth1() const
       {
       if (_minWidth1 == 0.0) {
+            int nstaves = score()->nstaves();
             Segment* s = first();
             Segment::Type st = Segment::Type::Clef | Segment::Type::KeySig | Segment::Type::StartRepeatBarLine;
-            while ((s->segmentType() & st)
-               && s->next()
-               && (!s->element(0) || s->element(0)->generated())
-               ) {
+            while ((s->segmentType() & st) && s->next()) {
+                  // found a segment that we might be able to skip
+                  // we can do so only if it contains no non-generated elements
+                  // note that it is possible for the same segment to contain both generated and non-generated elements
+                  // consider, a keysig segment at the start of a system in which one staff has a local key change
+                  bool generated = true;
+                  for (int i = 0; i < nstaves; ++i) {
+                        Element* e = s->element(i * VOICES);
+                        if (e && !e->generated()) {
+                              generated = false;
+                              break;
+                              }
+                        }
+                  if (!generated)
+                        break;
                   s = s->next();
                   }
             _minWidth1 = score()->computeMinWidth(s, false);


### PR DESCRIPTION
Two separate but related issues fixed:

1) width measures with key signatures not rendered correctly if top staff contains either no key signature (eg, a drum staff) or only a generated key signature (eg, generated key signature at start of a system in page view that happens to coincide with a "real" key signature change in one staff only)

2) continuous view not correctly accounting for width of header, resulting in "cramped" rendering of the first measure even for single staves if no key signature

Note this involves a change to the logic of Measure::minWidth1() - not skipping initial segments if they contain _any_ non-generated elements, as oppsoed to looking at the first staff only.  I tested as well as I could, but more review would be welcome!
