### PR TITLE
fix #41371: preserve score position when switching page/continuous view

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4344,6 +4344,11 @@ void MuseScore::switchLayoutMode(int val)
       if (cs) {
             cs->startCmd();
             LayoutMode mode;
+            // find a measure to use as reference, if possible
+            QRectF view = cv->toLogical(QRect(0.0, 0.0, width(), height()));
+            MeasureBase* m = cs->measures()->first();
+            while (m && !view.intersects(m->canvasBoundingRect()))
+                  m = m->nextMM();
             if (val == 0)
                   mode = LayoutMode::PAGE;
             else
@@ -4351,6 +4356,13 @@ void MuseScore::switchLayoutMode(int val)
             cs->undo(new ChangeLayoutMode(cs, mode));
             cv->loopUpdate(getAction("loop")->isChecked());
             cs->endCmd();
+            // adjustCanvasPosition often tries to preserve Y position
+            // but this doesn't make sense when switching modes
+            // also, better positioning is usually achieved if you start from the top
+            // and there is really no better place to position canvas if we were all the way off page previously
+            cv->pageTop();
+            if (m)
+                  cv->adjustCanvasPosition(m, false);
             endCmd();
             }
       }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3648,7 +3648,7 @@ void ScoreView::pagePrev()
 void ScoreView::pageTop()
       {
       if (score()->layoutMode() == LayoutMode::LINE)
-            setOffset(0.0, yoffset());
+            setOffset(0.0, 0.0);
       else
             setOffset(10.0, 10.0);
       update();
@@ -3686,6 +3686,7 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack)
             return;
 
       if (score()->layoutMode() == LayoutMode::LINE) {
+
             if (!el)
                   return;
 


### PR DESCRIPTION
When changing views, find first measure in old view, position canvas to that measure in new view.  Also make Home key (pageTop) return to top left corner in Line view, so it always displays something reasonable.  This is used during the view change as well to position view at top of page where it makes sense.
