### PR TITLE
fix #41401: crash when joining files via album

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2087,6 +2087,8 @@ bool Score::appendScore(Score* score)
       TieMap  tieMap;
 
       MeasureBase* lastMeasure = last();
+      if (!lastMeasure)
+            return false;
       int tickLen = lastMeasure->endTick();
 
       if (!lastMeasure->lineBreak() && !lastMeasure->pageBreak()) {


### PR DESCRIPTION
and none of the files in that album file are found, e.g. because they had been moved elsewhere.
