### PR TITLE
fix #41721: bad layout of melisma lines in parts

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -39,8 +39,15 @@ Lyrics::Lyrics(const Lyrics& l)
       _no       = l._no;
       _ticks    = l._ticks;
       _syllabic = l._syllabic;
-      for (const Line* line : l._separator)
-            _separator.append(new Line(*line));
+#if 0
+      // if we copy lines at all, they need to be parented to new lyric
+      // but they will be regenerated upon layout anyhow
+      for (const Line* line : l._separator) {
+            Line* nline = new Line(*line);
+            nline->setParent(this);
+            _separator.append(nline);
+            }
+#endif
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
There are two fixes that seem to work equaly well in my brief testing.  Either don't clone lyric lines at all when creating parts (they are re-generated on layout), or be sure to re-parent the copied lines to the new lyric.  I implemented the latter but then ifdef'ed out the whole copy, meaning I'm really doing the former.  I realize the implementation of melisma lines may be changing soon anyhow, but even so, seems this code could be useful to reference.  Also, even though I don't know of any visible bugs with hyphen layout, they presumably have the same underlying issue (wrong parent), which this PR fixes as well.
