### PR TITLE
fix #41711: crash on load of score with one-plet

### DIFF
--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -36,6 +36,7 @@ Tuplet::Tuplet(Score* s)
       setFlags(ElementFlag::MOVABLE | ElementFlag::SELECTABLE);
       _numberType   = Tuplet::NumberType::SHOW_NUMBER;
       _bracketType  = Tuplet::BracketType::AUTO_BRACKET;
+      _ratio        = Fraction(1, 1);
       _number       = 0;
       _hasBracket   = false;
       _isUp         = true;
@@ -925,7 +926,7 @@ QVariant Tuplet::propertyDefault(P_ID id) const
                   return int(Tuplet::BracketType::AUTO_BRACKET);
             case P_ID::NORMAL_NOTES:
             case P_ID::ACTUAL_NOTES:
-                  return 1;
+                  return 0;
             case P_ID::P1:
             case P_ID::P2:
                   return QPointF();


### PR DESCRIPTION
The change to the Tuplet constructor allows current scores with no actualNotes tag to load without crashing.  The change to propertyDefault ensures future scores get actualNotes tags.
