### PR TITLE
fix #41766: use double sharp/flat where appropriate when transposing

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -391,12 +391,12 @@ void Score::cmdAddInterval(int val, const QList<Note*>& nl)
                         if (styleB(StyleIdx::concertPitch)) {
                               v.flip();
                               ntpc1 = ntpc;
-                              ntpc2 = Ms::transposeTpc(ntpc, v, false);
+                              ntpc2 = Ms::transposeTpc(ntpc, v, true);
                               }
                         else {
                               npitch += v.chromatic;
                               ntpc2 = ntpc;
-                              ntpc1 = Ms::transposeTpc(ntpc, v, false);
+                              ntpc1 = Ms::transposeTpc(ntpc, v, true);
                               }
                         }
                   }

--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -192,8 +192,8 @@ void createExcerpt(Excerpt* excerpt)
                               if ((e->type() != Element::Type::HARMONY) || (e->track() < startTrack) || (e->track() >= endTrack))
                                     continue;
                               Harmony* h  = static_cast<Harmony*>(e);
-                              int rootTpc = Ms::transposeTpc(h->rootTpc(), interval, false);
-                              int baseTpc = Ms::transposeTpc(h->baseTpc(), interval, false);
+                              int rootTpc = Ms::transposeTpc(h->rootTpc(), interval, true);
+                              int baseTpc = Ms::transposeTpc(h->baseTpc(), interval, true);
                               score->undoTransposeHarmony(h, rootTpc, baseTpc);
                               }
                         }

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -201,8 +201,8 @@ void Harmony::write(Xml& xml) const
             if (staff()) {
                   const Interval& interval = staff()->part()->instr()->transpose();
                   if (xml.clipboardmode && !score()->styleB(StyleIdx::concertPitch) && interval.chromatic) {
-                        rRootTpc = transposeTpc(_rootTpc, interval, false);
-                        rBaseTpc = transposeTpc(_baseTpc, interval, false);
+                        rRootTpc = transposeTpc(_rootTpc, interval, true);
+                        rBaseTpc = transposeTpc(_baseTpc, interval, true);
                         }
                   }
             if (rRootTpc != Tpc::TPC_INVALID) {
@@ -749,8 +749,8 @@ void Harmony::endEdit()
                         if (!interval.isZero()) {
                               if (!h->score()->styleB(StyleIdx::concertPitch))
                                     interval.flip();
-                              int rootTpc = transposeTpc(h->rootTpc(), interval, false);
-                              int baseTpc = transposeTpc(h->baseTpc(), interval, false);
+                              int rootTpc = transposeTpc(h->rootTpc(), interval, true);
+                              int baseTpc = transposeTpc(h->baseTpc(), interval, true);
                               //score()->undoTransposeHarmony(h, rootTpc, baseTpc);
                               h->setRootTpc(rootTpc);
                               h->setBaseTpc(baseTpc);

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -443,10 +443,10 @@ int Note::transposeTpc(int tpc)
             return tpc;
       if (concertPitch()) {
             v.flip();
-            return Ms::transposeTpc(tpc, v, false);
+            return Ms::transposeTpc(tpc, v, true);
             }
       else
-            return Ms::transposeTpc(tpc, v, false);
+            return Ms::transposeTpc(tpc, v, true);
       }
 
 //---------------------------------------------------------
@@ -1128,13 +1128,13 @@ void Note::read(XmlReader& e)
                   if (v.isZero())
                         _tpc[1] = _tpc[0];
                   else
-                        _tpc[1] = Ms::transposeTpc(_tpc[0], v, false);
+                        _tpc[1] = Ms::transposeTpc(_tpc[0], v, true);
                   }
             else {
                   if (v.isZero())
                         _tpc[0] = _tpc[1];
                   else
-                        _tpc[0] = Ms::transposeTpc(_tpc[1], v, false);
+                        _tpc[0] = Ms::transposeTpc(_tpc[1], v, true);
                   }
             }
       }
@@ -2154,7 +2154,7 @@ void Note::setNval(const NoteVal& nval, int tick)
                   _tpc[1] = _tpc[0];
             else {
                   v.flip();
-                  _tpc[1] = Ms::transposeTpc(_tpc[0], v, false);
+                  _tpc[1] = Ms::transposeTpc(_tpc[0], v, true);
                   }
             }
 

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -258,8 +258,8 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                               Interval interval = partDest->instr()->transpose();
                               if (!styleB(StyleIdx::concertPitch) && !interval.isZero()) {
                                     interval.flip();
-                                    int rootTpc = transposeTpc(harmony->rootTpc(), interval, false);
-                                    int baseTpc = transposeTpc(harmony->baseTpc(), interval, false);
+                                    int rootTpc = transposeTpc(harmony->rootTpc(), interval, true);
+                                    int baseTpc = transposeTpc(harmony->baseTpc(), interval, true);
                                     undoTransposeHarmony(harmony, rootTpc, baseTpc);
                                     }
 
@@ -577,8 +577,8 @@ void Score::pasteSymbols(XmlReader& e, ChordRest* dst)
                               Interval interval = partDest->instr()->transpose();
                               if (!styleB(StyleIdx::concertPitch) && !interval.isZero()) {
                                     interval.flip();
-                                    int rootTpc = transposeTpc(el->rootTpc(), interval, false);
-                                    int baseTpc = transposeTpc(el->baseTpc(), interval, false);
+                                    int rootTpc = transposeTpc(el->rootTpc(), interval, true);
+                                    int baseTpc = transposeTpc(el->baseTpc(), interval, true);
                                     undoTransposeHarmony(el, rootTpc, baseTpc);
                                     }
                               el->setParent(harmSegm);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2555,8 +2555,8 @@ void Score::cmdConcertPitchChanged(bool flag, bool /*useDoubleSharpsFlats*/)
                         if ((e->type() != Element::Type::HARMONY) || (e->track() < startTrack) || (e->track() >= endTrack))
                               continue;
                         Harmony* h  = static_cast<Harmony*>(e);
-                        int rootTpc = transposeTpc(h->rootTpc(), interval, false);
-                        int baseTpc = transposeTpc(h->baseTpc(), interval, false);
+                        int rootTpc = transposeTpc(h->rootTpc(), interval, true);
+                        int baseTpc = transposeTpc(h->baseTpc(), interval, true);
                         undoTransposeHarmony(h, rootTpc, baseTpc);
                         }
                   }

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -304,8 +304,8 @@ void Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
                                           transposeInterval, key, trKeys, useDoubleSharpsFlats);
                         }
                         else {
-                              rootTpc = transposeTpc(h->rootTpc(), interval, false);
-                              baseTpc = transposeTpc(h->baseTpc(), interval, false);
+                              rootTpc = transposeTpc(h->rootTpc(), interval, useDoubleSharpsFlats);
+                              baseTpc = transposeTpc(h->baseTpc(), interval, useDoubleSharpsFlats);
                               }
                         undoTransposeHarmony(h, rootTpc, baseTpc);
                         }
@@ -414,8 +414,8 @@ void Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
                                           transposeInterval, key, trKeys, useDoubleSharpsFlats);
                               }
                         else {
-                              rootTpc = transposeTpc(h->rootTpc(), interval, false);
-                              baseTpc = transposeTpc(h->baseTpc(), interval, false);
+                              rootTpc = transposeTpc(h->rootTpc(), interval, useDoubleSharpsFlats);
+                              baseTpc = transposeTpc(h->baseTpc(), interval, useDoubleSharpsFlats);
                               }
                         // undoTransposeHarmony does not do links
                         // because it is also used to handle transposing instruments

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1127,8 +1127,8 @@ void Score::undoAddElement(Element* element)
                               if (!interval.isZero()) {
                                     if (!score->styleB(StyleIdx::concertPitch))
                                           interval.flip();
-                                    int rootTpc = transposeTpc(h->rootTpc(), interval, false);
-                                    int baseTpc = transposeTpc(h->baseTpc(), interval, false);
+                                    int rootTpc = transposeTpc(h->rootTpc(), interval, true);
+                                    int baseTpc = transposeTpc(h->baseTpc(), interval, true);
                                     score->undoTransposeHarmony(h, rootTpc, baseTpc);
                                     }
                               }

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -180,7 +180,7 @@ static void xmlSetPitch(Note* n, char step, int alter, int octave, Ottava* (&ott
       static int table1[7]  = { 5, 6, 0, 1, 2, 3, 4 };
       int istep = step - 'A';
       int tpc2 = step2tpc(table1[istep], AccidentalVal(alter));
-      int tpc1 = Ms::transposeTpc(tpc2, intval, false);
+      int tpc1 = Ms::transposeTpc(tpc2, intval, true);
       n->setPitch(pitch, tpc1, tpc2);
       //qDebug("  pitch=%d tpc1=%d tpc2=%d", n->pitch(), n->tpc1(), n->tpc2());
       }


### PR DESCRIPTION
In 1.3, we used double sharp/flat on notes when transposing via Concert Pitch toggle, I see no reason not to continue doing so.  We should also use it for chord symbols now that we support this.  Unless we wanted to add a style option or staff property to control this - along, perhaps, with some sort of control over key simfplification (turning C# major into Db).  If so, then all the places I turned "false" to "true" here would become references to that style option.  Or maybe a new function that encapsulates that.

But unless we do decide to go with an option to control this, I think we should use double flat/sharp for both notes and chord symbols.  User can always change the spelling manually if he wants.
