### PR TITLE
Fix imported file score path

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1977,7 +1977,6 @@ Score::FileError readScore(Score* score, QString name, bool ignoreVersionError)
       QFileInfo info(name);
       QString suffix  = info.suffix().toLower();
       score->setName(info.completeBaseName());
-      score->setImportedFilePath(name);
 
       if (suffix == "mscz" || suffix == "mscx") {
             Score::FileError rv = score->loadMsc(name, ignoreVersionError);

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -1081,6 +1081,7 @@ Score::FileError importMidi(Score *score, const QString &name)
       {
       if (name.isEmpty())
             return Score::FileError::FILE_NOT_FOUND;
+      score->setImportedFilePath(name);
 
       auto &opers = preferences.midiImportOperations;
 


### PR DESCRIPTION
importedFilePath should be empty for not imported files. I checked as Marc suggested - and it was always set to score name. 
It was supposed to set only for midi, kar, ... files - not score files.

Also there should be score->importedFilePath() != score->fileInfo()->canonicalFilePath()
in any case.

So very likely it IS a fix or one of the fixes for http://musescore.org/en/node/41251.

But the check from somebody else would be useful.
