### PR TITLE
fix #41251: duplicate recents when using symlinks

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1195,7 +1195,7 @@ void MuseScore::addRecentScore(Score* score)
       {
       QString path = score->importedFilePath(); // defined for scores imported from e.g. MIDI files
       addRecentScore(path);
-      path = score->fileInfo()->canonicalFilePath();
+      path = score->fileInfo()->absoluteFilePath();
       addRecentScore(path);
       if (startcenter)
             startcenter->updateRecentScores();


### PR DESCRIPTION
Fixes problem by using absolutel rather than canonical name.  We should consider why we always call addRecentScore twice.  I guess the expectation was thet importedFilePath would be empty for native scores, but it currently is not.  #1564 addresses that.  I think having both of these in place probably makes sense.
