### PR TITLE
Improve default filename for parts when using ...

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1560,11 +1560,18 @@ bool MuseScore::exportFile()
 
       QString name;
 #ifdef Q_OS_WIN
-      if (QSysInfo::WindowsVersion == QSysInfo::WV_XP)
-            name = QString("%1/%2").arg(saveDirectory).arg(cs->name());
+      if (QSysInfo::WindowsVersion == QSysInfo::WV_XP) {
+            if (cs->parentScore())
+                  name = QString("%1/%2-%3").arg(saveDirectory).arg(cs->parentScore()->name()).arg(createDefaultFileName(cs->name()));
+            else
+                  name = QString("%1/%2").arg(saveDirectory).arg(cs->name());
+            }
       else
 #endif
-      name = QString("%1/%2.pdf").arg(saveDirectory).arg(cs->name());
+      if (cs->parentScore())
+            name = QString("%1/%2-%3.pdf").arg(saveDirectory).arg(cs->parentScore()->name()).arg(createDefaultFileName(cs->name()));
+      else
+            name = QString("%1/%2.pdf").arg(saveDirectory).arg(cs->name());
 
       QString filter = fl.join(";;");
       QString fn = getSaveScoreName(saveDialogTitle, name, filter);
@@ -2095,11 +2102,18 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy)
 
       QString name;
 #ifdef Q_OS_WIN
-      if (QSysInfo::WindowsVersion == QSysInfo::WV_XP)
-            name = QString("%1/%2").arg(saveDirectory).arg(cs->name());
+      if (QSysInfo::WindowsVersion == QSysInfo::WV_XP) {
+            if (cs->parentScore())
+                  name = QString("%1/%2-%3").arg(saveDirectory).arg(cs->parentScore()->name()).arg(createDefaultFileName(cs->name()));
+            else
+                  name = QString("%1/%2").arg(saveDirectory).arg(cs->name());
+            }
       else
 #endif
-      name = QString("%1/%2.mscz").arg(saveDirectory).arg(cs->name());
+      if (cs->parentScore())
+            name = QString("%1/%2-%3.mscz").arg(saveDirectory).arg(cs->parentScore()->name()).arg(createDefaultFileName(cs->name()));
+      else
+            name = QString("%1/%2.mscz").arg(saveDirectory).arg(cs->name());
 
       QString filter = fl.join(";;");
       QString fn     = mscore->getSaveScoreName(saveDialogTitle, name, filter);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1426,7 +1426,10 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
       else
             mag->setCurrentIndex(int(view->magIdx()));
 
-      setWindowTitle("MuseScore: " + cs->name());
+      if (cs->parentScore())
+            setWindowTitle("MuseScore: " + cs->parentScore()->name() + "-" + cs->name());
+      else
+            setWindowTitle("MuseScore: " + cs->name());
 
       QAction* a = getAction("concert-pitch");
       a->setChecked(cs->styleB(StyleIdx::concertPitch));


### PR DESCRIPTION
saveAs or exportFile, using the same method as in exportParts.
Also set window title accordingly.

Not sure whether the saveAs should better be treated like saveFile, i.e. save the rootScore rather than the part, even if a part is the currently active tab.
Similar question on exportFile.
But having some method of saving only a part seems a good idea.
