### PR TITLE
scale palette, selection filter, and inspector with -x option

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -793,6 +793,15 @@ InspectorEmpty::InspectorEmpty(QWidget* parent)
       }
 
 //---------------------------------------------------------
+//   sizeHint
+//---------------------------------------------------------
+
+QSize InspectorEmpty::sizeHint() const
+      {
+      return QSize(255 * guiScaling, 170 * guiScaling);
+      }
+
+//---------------------------------------------------------
 //   InspectorBarLine
 //---------------------------------------------------------
 

--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -338,7 +338,7 @@ class InspectorEmpty : public InspectorBase {
 
    public:
       InspectorEmpty(QWidget* parent);
-      virtual QSize sizeHint() const {return QSize(255,170);}
+      virtual QSize sizeHint() const;
       };
 
 } // namespace Ms

--- a/mscore/palettebox.cpp
+++ b/mscore/palettebox.cpp
@@ -338,5 +338,15 @@ void PaletteBox::displayMore(const QString& s)
       {
       mscore->showMasterPalette(s);
       }
+
+//---------------------------------------------------------
+//   sizeHint
+//---------------------------------------------------------
+
+QSize PaletteBoxScrollArea::sizeHint() const
+      {
+      return QSize(170 * guiScaling, 170 * guiScaling);
+      }
+
 }
 

--- a/mscore/palettebox.h
+++ b/mscore/palettebox.h
@@ -57,7 +57,7 @@ class PaletteBoxScrollArea : public QScrollArea {
        Q_OBJECT
 
     public:
-      virtual QSize sizeHint() const {return QSize(170,170);}
+      virtual QSize sizeHint() const;
       };
 
 } // namespace Ms

--- a/mscore/selectionwindow.cpp
+++ b/mscore/selectionwindow.cpp
@@ -132,4 +132,9 @@ void SelectionWindow::setScore(Score* score)
       updateFilteredElements();
       }
 
+QSize SelectionWindow::sizeHint() const
+      {
+      return QSize(170 * guiScaling, 170 * guiScaling);
+      }
+
 }

--- a/mscore/selectionwindow.h
+++ b/mscore/selectionwindow.h
@@ -23,7 +23,7 @@ private slots:
 public:
       SelectionWindow(QWidget *parent = 0, Score* score = 0);
       ~SelectionWindow();
-      virtual QSize sizeHint() const {return QSize(170,170);}
+      virtual QSize sizeHint() const;
       void setScore(Score*);
 
       };


### PR DESCRIPTION
There are any number of other hard-coded sizes in the source, but this covers the stuff I find myself having to redo every time I run with "-F" because of my high dpi display.  Well, the sizes of the panes in the file dialogs are not great either, but I'm not quite understanding how that works.
