### PR TITLE
fix #42061: fix crash due to old preference setting

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2019,7 +2019,7 @@ static void loadScores(const QStringList& argv)
                         case SessionStart::SCORE:
                               {
                               Score* score = mscore->readScore(preferences.startScore);
-                              if (preferences.startScore.startsWith(":/"))
+                              if (preferences.startScore.startsWith(":/") && score)
                                     score->setCreated(true);
                               if (score == 0) {
                                     score = mscore->readScore(":/data/My_First_Score.mscz");


### PR DESCRIPTION
Fixes crash after "Cannot read file :/data/My_First_Score.mscx:Unknown
error"
