### PR TITLE
fix #42021: color of drum palette notes

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -727,7 +727,9 @@ void Palette::paintEvent(QPaintEvent* /*event*/)
                   if (idx != selectedIdx) {
                         // show voice colors for notes
                         if (el->type() == Element::Type::CHORD) {
-                              el->setSelected(true);
+                              Chord* c = static_cast<Chord*>(el);
+                              for (Note* n : c->notes())
+                                    n->setSelected(true);
                               color = el->curColor();
                               }
                         else


### PR DESCRIPTION
Formerly, Chord::setSelected() used to set all of its notes as well, but that was changed recently.  It's actually a no-op now - it doesn't even mark the chord itself selected.  So I simply select the notes instead of the chord to force the drum palette to display in voice color.

BTW, el->curColor() doesn't really return anything useful here as far as color goes, but we don't need it to - the notes draw themselves in their proper colors.
