### PR TITLE
Fix height of some dialogs

### DIFF
--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>920</width>
-    <height>656</height>
+    <height>577</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1148</width>
-    <height>738</height>
+    <width>904</width>
+    <height>577</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/mscore/textproperties.ui
+++ b/mscore/textproperties.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>647</width>
-    <height>664</height>
+    <height>577</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
- fix #36641: Style/General window too large
- adjust the height of 2 more dialogs to fit on netbook screens (1024x600)

a better and permanent solution might be needed...

Qt Creator on Windows thinks the smallest possible sizes to be:
- editstyle.ui: 770x610 (changed from 1148x738 to to 904x577 in this PR, because that is what it was before a52827e)
- editstaff.ui: 613x596 (changed from 920x656 to 920x577 in this PR)
- textproperties.ui: 485x454 (changed from 647x664 to 647x577 in this PR)
