### PR TITLE
fix #42541: drum grace notes laid out incorrectly on load

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1629,9 +1629,11 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
       int gnb = getGraceNotesBefore(&graceNotesBefore);
       if (gnb) {
             for (Chord* ch : graceNotesBefore) {
-                  QList<Note*> notes(ch->notes());  // we need a copy!
-                  for (Note* note : notes)
-                        note->updateAccidental(as);
+                  if (staffGroup != StaffGroup::PERCUSSION) {
+                        QList<Note*> notes(ch->notes());  // we need a copy!
+                        for (Note* note : notes)
+                              note->updateAccidental(as);
+                        }
                   ch->sortNotes();
                   }
             }
@@ -1664,13 +1666,16 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
                         }
                   }
             }
+
       QList<Chord*> graceNotesAfter;
       int gna = getGraceNotesAfter(&graceNotesAfter);
       if (gna) {
             for (Chord* ch : graceNotesAfter) {
-                  QList<Note*> notes(ch->notes());  // we need a copy!
-                  for (Note* note : notes)
-                        note->updateAccidental(as);
+                  if (staffGroup != StaffGroup::PERCUSSION) {
+                        QList<Note*> notes(ch->notes());  // we need a copy!
+                        for (Note* note : notes)
+                              note->updateAccidental(as);
+                        }
                   ch->sortNotes();
                   }
             }

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1923,7 +1923,7 @@ int Note::line() const
       }
 
 //---------------------------------------------------------
-//   setLine
+//   setAccidentalType
 //---------------------------------------------------------
 
 void Note::setAccidentalType(Accidental::Type type)


### PR DESCRIPTION
See detailed comments in issue thread.  The following fixes the issue and shouldn't cause worse problems.  But I still have questions whether we need to explicitly set line of drum grace notes here and why we  are doing so for drum regular notes.