### PR TITLE
fix #42521: don't include volta in range select / copy

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1376,6 +1376,10 @@ void Score::writeSegments(Xml& xml, int strack, int etrack,
                               if (s->generated() || !xml.canWrite(s))
                                     continue;
 
+                              // don't write voltas to clipboard
+                              if (clip && s->type() == Element::Type::VOLTA)
+                                    continue;
+
                               if (s->track() == track) {
                                     bool end = false;
                                     if (s->anchor() == Spanner::Anchor::CHORD || s->anchor() == Spanner::Anchor::NOTE)

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -497,6 +497,9 @@ void Selection::updateSelectedElements()
             // ignore spanners belonging to other tracks
             if (sp->track() < startTrack || sp->track() >= endTrack)
                   continue;
+            // ignore voltas
+            if (sp->type() == Element::Type::VOLTA)
+                  continue;
             if (sp->type() == Element::Type::SLUR) {
                 if ((sp->tick() >= stick && sp->tick() < etick) || (sp->tick2() >= stick && sp->tick2() < etick))
                       if (canSelect(sp->startCR()) && canSelect(sp->endCR()))

--- a/mtest/libmscore/selectionfilter/selectionfilter15-base-ref.xml
+++ b/mtest/libmscore/selectionfilter/selectionfilter15-base-ref.xml
@@ -3,15 +3,15 @@
   <Staff id="0">
     <voice id="0">0</voice>
     <tick>0</tick>
-    <Volta id="2">
+    <TextLine id="2">
       <endHook>1</endHook>
       <track>0</track>
+      <lineWidth>0.15</lineWidth>
       <beginText>
-        <style>Volta</style>
-        <text>1.</text>
+        <style>Text Line</style>
+        <text>VII</text>
         </beginText>
-      <endings>1</endings>
-      </Volta>
+      </TextLine>
     <Chord>
       <track>0</track>
       <durationType>quarter</durationType>

--- a/mtest/libmscore/selectionfilter/selectionfilter15.mscx
+++ b/mtest/libmscore/selectionfilter/selectionfilter15.mscx
@@ -101,7 +101,7 @@
         <height>10</height>
         <Text>
           <style>Title</style>
-          <text>selection-filter-volta</text>
+          <text>selection-filter-other-lines</text>
           </Text>
         </VBox>
       <Measure number="1">
@@ -109,22 +109,19 @@
           <concertClefType>G</concertClefType>
           <transposingClefType>G</transposingClefType>
           </Clef>
-        <KeySig>
-          <accidental>0</accidental>
-          </KeySig>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
-        <Volta id="2">
+        <TextLine id="2">
           <endHook>1</endHook>
+          <lineWidth>0.15</lineWidth>
           <beginText>
-            <style>Volta</style>
-            <text>1.</text>
+            <style>Text Line</style>
+            <text>VII</text>
             </beginText>
-          <endings>1</endings>
-          </Volta>
+          </TextLine>
         <Chord>
           <durationType>quarter</durationType>
           <Note>
@@ -153,10 +150,6 @@
             <tpc>13</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="2">
         <endSpanner id="2"/>
@@ -173,50 +166,30 @@
         <Rest>
           <durationType>half</durationType>
           </Rest>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="3">
         <Rest>
           <durationType>measure</durationType>
           <duration z="4" n="4"/>
           </Rest>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="4">
         <Rest>
           <durationType>measure</durationType>
           <duration z="4" n="4"/>
           </Rest>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="5">
         <Rest>
           <durationType>measure</durationType>
           <duration z="4" n="4"/>
           </Rest>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="6">
         <Rest>
           <durationType>measure</durationType>
           <duration z="4" n="4"/>
           </Rest>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="7">
         <Rest>


### PR DESCRIPTION
Change to not mark voltas as selected in a range selection and to exclude them from the mimedata when writing to clipboard.