### PR TITLE
fix #33476: select similar and other mmrest issues

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -979,6 +979,15 @@ void Measure::change(Element* o, Element* n)
             }
       }
 
+//---------------------------------------------------------
+//   spatiumChanged
+//---------------------------------------------------------
+
+void Measure::spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/)
+      {
+      setDirty();
+      }
+
 //-------------------------------------------------------------------
 //   moveTicks
 //    Also adjust endBarLine if measure len has changed. For this
@@ -2401,9 +2410,8 @@ void Measure::scanElements(void* data, void (*func)(void*, Element*), bool all)
                   func(data, ms->noText());
             }
 
-      for (Segment* s = first(); s; s = s->next()) {
-            s->scanElements(data,func,all);
-            }
+      for (Segment* s = first(); s; s = s->next())
+            s->scanElements(data, func, all);
       }
 
 //---------------------------------------------------------

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -176,6 +176,7 @@ class Measure : public MeasureBase {
       virtual void add(Element*) override;
       virtual void remove(Element*) override;
       virtual void change(Element* o, Element* n) override;
+      virtual void spatiumChanged(qreal oldValue, qreal newValue) override;
 
       System* system() const               { return (System*)parent(); }
       QList<MStaff*>* staffList()          { return &staves;      }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1772,8 +1772,15 @@ int Score::inputPos() const
 
 void Score::scanElements(void* data, void (*func)(void*, Element*), bool all)
       {
-      for (MeasureBase* m = first(); m; m = m->next())
-            m->scanElements(data, func, all);
+      for (MeasureBase* mb = first(); mb; mb = mb->next()) {
+            mb->scanElements(data, func, all);
+            if (mb->type() == Element::Type::MEASURE) {
+                  Measure* m = static_cast<Measure*>(mb);
+                  Measure* mmr = m->mmRest();
+                  if (mmr)
+                        mmr->scanElements(data, func, all);
+                  }
+            }
       for (Page* page : pages())
             page->scanElements(data, func, all);
       }
@@ -1785,8 +1792,14 @@ void Score::scanElements(void* data, void (*func)(void*, Element*), bool all)
 void Score::scanElementsInRange(void* data, void (*func)(void*, Element*), bool all)
       {
       Segment* startSeg = _selection.startSegment();
-      for (Segment* s = startSeg; s && s!=_selection.endSegment(); s = s->next1MM()) {
-            s->scanElements(data,func,all);
+      for (Segment* s = startSeg; s && s !=_selection.endSegment(); s = s->next1()) {
+            s->scanElements(data, func, all);
+            Measure* m = s->measure();
+            if (m && s == m->first()) {
+                  Measure* mmr = m->mmRest();
+                  if (mmr)
+                        mmr->scanElements(data, func, all);
+                  }
             }
       }
 


### PR DESCRIPTION
See issue thread for technical discussion.  Summary: I am making sure Score::scanElements() covers both regular and mmrests which fixes most issues, also adding a spatiumChanged override for Measure objects. which fixes some remaining issues with mmrest layout after change of scale.