### PR TITLE
Round beats per second tempo to beats per minute (fix mtest on Windows)

### DIFF
--- a/mscore/importmidi/importmidi_tempo.cpp
+++ b/mscore/importmidi/importmidi_tempo.cpp
@@ -73,12 +73,17 @@ void setTempoToScore(Score *score, int tick, double beatsPerSecond)
             }
       }
 
+double roundToBpm(double beatsPerSecond)
+      {
+      return qRound(beatsPerSecond * 60.0) / 60.0;
+      }
+
 void applyAllTempoEvents(const std::multimap<int, MTrack> &tracks, Score *score)
       {
       for (const auto &track: tracks) {
             if (track.second.isDivisionInTps) {     // ticks per second
                   const double ticksPerBeat = MScore::division;
-                  const double beatsPerSecond = track.second.division / ticksPerBeat;
+                  const double beatsPerSecond = roundToBpm(track.second.division / ticksPerBeat);
                   setTempoToScore(score, 0, beatsPerSecond);
                   }
             else {      // beats per second
@@ -88,9 +93,8 @@ void applyAllTempoEvents(const std::multimap<int, MTrack> &tracks, Score *score)
                               const auto tick = toMuseScoreTicks(
                                                 ie.first, track.second.division, false);
                               const uchar* data = (uchar*)e.edata();
-                              const unsigned tempo = data[2] + (data[1] << 8)
-                                                             + (data[0] << 16);
-                              const double beatsPerSecond = 1000000.0 / tempo;
+                              const unsigned tempo = data[2] + (data[1] << 8) + (data[0] << 16);
+                              const double beatsPerSecond = roundToBpm(1000000.0 / tempo);
                               setTempoToScore(score, tick.ticks(), beatsPerSecond);
                               }
                         }
@@ -134,7 +138,7 @@ void setTempo(const std::multimap<int, MTrack> &tracks, Score *score)
             averageTempoFactor /= counter;
 
             const double basicTempo = MidiTempo::findBasicTempo(tracks, true);
-            const double tempo = basicTempo * averageTempoFactor;
+            const double tempo = roundToBpm(basicTempo * averageTempoFactor);
 
             score->tempomap()->clear();         // use only one tempo marking for all score
             setTempoToScore(score, 0, tempo);

--- a/mtest/importmidi/human_tempo.mscx
+++ b/mtest/importmidi/human_tempo.mscx
@@ -72,7 +72,7 @@
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <Tempo>
-          <tempo>2.19233</tempo>
+          <tempo>2.2</tempo>
           <text><sym>unicodeNoteQuarterUp</sym> = 132</text>
           </Tempo>
         <Rest>


### PR DESCRIPTION
On Linux and on Windows double values of tempo for human-performed MIDI files appeared to be slightly different due to different results of beat detection (very small difference). 

In mtest win tempo = 2.1921, linux tempo = 2.1923 that was saved in compared score and lead to test failure.

I think that change bps double tempo value to rounded bpm [qRound(bps \* 60.0) / 60.0] = 2.2 in example above is resounable.
