### PR TITLE
Draw double line as a frozen columns separator in the MIDI import panel

### DIFF
--- a/mscore/importmidi/importmidi_view.h
+++ b/mscore/importmidi/importmidi_view.h
@@ -36,7 +36,9 @@ class SeparatorDelegate : public QStyledItemDelegate
             if (index.column() == _frozenColIndex) {
                   painter->save();
                   painter->setPen(option.palette.foreground().color());
-                  painter->drawLine(option.rect.topRight(), option.rect.bottomRight());
+                              // use -1 padding to create double-line effect
+                  const int x = option.rect.right() - 1;
+                  painter->drawLine(x, option.rect.top(), x, option.rect.bottom());
                   painter->restore();
                   }
             }


### PR DESCRIPTION
Double line instead of single one for more contrast separation from the frozen columns
(vertical line in the middle of the picture):
https://drive.google.com/file/d/0B5alKuFoSol2UGEyYmlNTGNWLW8/view?usp=sharing

Does it look better? Especially for horizontally-scrolled tracks. 
