### PR TITLE
Svg icons for move track up/down buttons on the MIDI import panel

### DIFF
--- a/mscore/data/icons/arrow_down.svg
+++ b/mscore/data/icons/arrow_down.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   version="1.1"
+   width="24"
+   id="svg2"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow_up_.svg">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs20" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1680"
+     inkscape:window-height="998"
+     id="namedview18"
+     showgrid="false"
+     inkscape:zoom="13.906433"
+     inkscape:cx="3.6958105"
+     inkscape:cy="24.38613"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     style="fill:#3b3f45;fill-opacity:1;display:inline"
+     d="m 7.6225823,15.954584 c 0.5690034,0.803991 0.8307338,1.071288 1.7780367,2.383751 0.94731,1.312462 1.938612,2.686663 2.202911,3.05378 0.264289,0.367116 0.482772,0.664306 0.485505,0.660427 0.0029,-0.0035 0.563056,-0.810827 1.245151,-1.793214 1.276595,-1.838633 1.835684,-2.552089 2.706181,-3.797197 0.279479,-0.399756 0.34079,-0.460646 0.377935,-0.530819 0.151652,-0.286466 1.183744,-1.454387 0.957192,-1.54904 -0.184573,-0.07711 -1.446338,0.509235 -1.7325,0.610826 -0.119393,0.04239 -0.63494,0.256232 -1.061988,0.396774 l -0.916822,0.301728 0,-6.8720868 0,-6.872093 -1.621048,0 -1.621055,0 0,6.85446 c 0,3.7699468 -0.0072,6.8616518 -0.01596,6.8704408 -0.0088,0.0088 -0.4387737,-0.09941 -1.0021104,-0.287073 -0.6816797,-0.22708 -0.072824,-0.0095 -1.2118543,-0.451248 -0.8178372,-0.317177 -1.62155,-0.678757 -1.6395878,-0.48841 -0.021734,0.229357 0.7584204,1.032595 0.9082386,1.302255 z"
+     id="path3011"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csscsscscscccccssssscc" />
+</svg>

--- a/mscore/data/icons/arrow_up.svg
+++ b/mscore/data/icons/arrow_up.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   version="1.1"
+   width="24"
+   id="svg2"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="arrow_up.svg">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs20" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1680"
+     inkscape:window-height="998"
+     id="namedview18"
+     showgrid="false"
+     inkscape:zoom="13.906433"
+     inkscape:cx="3.6958105"
+     inkscape:cy="24.38613"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     style="fill:#3b3f45;fill-opacity:1;display:inline"
+     d="M 7.6225823,8.0454166 C 8.1915857,7.241425 8.4533161,6.9741284 9.400619,5.6616656 c 0.94731,-1.3124629 1.938612,-2.6866638 2.202911,-3.05378 0.264289,-0.3671164 0.482772,-0.6643064 0.485505,-0.6604279 0.0029,0.00353 0.563056,0.8108278 1.245151,1.7932144 1.276595,1.8386333 1.835684,2.5520891 2.706181,3.7971972 0.279479,0.3997554 0.34079,0.4606455 0.377935,0.5308191 0.151652,0.2864657 1.183744,1.4543872 0.957192,1.5490397 -0.184573,0.077114 -1.446338,-0.5092347 -1.7325,-0.610826 -0.119393,-0.042389 -0.63494,-0.2562322 -1.061988,-0.3967742 l -0.916822,-0.301728 0,6.8720871 0,6.872093 -1.621048,0 -1.621055,0 0,-6.85446 c 0,-3.769947 -0.0072,-6.861652 -0.01596,-6.8704408 -0.0088,-0.0088 -0.4387737,0.099414 -1.0021104,0.2870732 -0.6816797,0.2270795 -0.072824,0.0095 -1.2118543,0.4512478 C 7.3743191,9.383177 6.5706063,9.7447575 6.5525685,9.55441 6.5308341,9.3250529 7.3109889,8.5218148 7.4608071,8.2521554 z"
+     id="path3011"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csscsscscscccccssssscc" />
+</svg>

--- a/mscore/icons.cpp
+++ b/mscore/icons.cpp
@@ -145,7 +145,9 @@ static const char* iconNames[] = {
       "timesig_prolatio11.svg",
       "edit.svg",
       "edit-reset.svg",
-      "window-close.svg"
+      "window-close.svg",
+      "arrow_up.svg",
+      "arrow_down.svg"
       };
 
 void genIcons()

--- a/mscore/icons.h
+++ b/mscore/icons.h
@@ -53,6 +53,7 @@ enum class Icons : signed char { Invalid_ICON = -1,
       timesig_allabreve_ICON, timesig_common_ICON, timesig_prolatio01_ICON, timesig_prolatio02_ICON,
       timesig_prolatio03_ICON, timesig_prolatio04_ICON, timesig_prolatio05_ICON, timesig_prolatio07_ICON,
       timesig_prolatio08_ICON, timesig_prolatio10_ICON, timesig_prolatio11_ICON, edit_ICON, reset_ICON, close_ICON,
+      arrowUp_ICON, arrowDown_ICON,
       voice1_ICON, voice2_ICON, voice3_ICON, voice4_ICON,
       ICONS
       };

--- a/mscore/importmidi/importmidi_panel.cpp
+++ b/mscore/importmidi/importmidi_panel.cpp
@@ -118,6 +118,9 @@ bool ImportMidiPanel::isMidiFile(const QString &fileName)
 
 void ImportMidiPanel::setupUi()
       {
+      _ui->pushButtonUp->setIcon(*icons[int(Icons::arrowUp_ICON)]);
+      _ui->pushButtonDown->setIcon(*icons[int(Icons::arrowDown_ICON)]);
+
       connect(_updateUiTimer, SIGNAL(timeout()), this, SLOT(updateUi()));
       connect(_ui->pushButtonApply, SIGNAL(clicked()), SLOT(applyMidiImport()));
       connect(_ui->pushButtonCancel, SIGNAL(clicked()), SLOT(cancelChanges()));

--- a/mscore/importmidi/importmidi_panel.ui
+++ b/mscore/importmidi/importmidi_panel.ui
@@ -121,7 +121,11 @@
            <string>Move track up</string>
           </property>
           <property name="text">
-           <string>Up</string>
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../musescore.qrc">
+            <normaloff>:/data/icons/arrow_up.svg</normaloff>:/data/icons/arrow_up.svg</iconset>
           </property>
          </widget>
         </item>
@@ -140,7 +144,11 @@
            <string>Move track down</string>
           </property>
           <property name="text">
-           <string>Down</string>
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../musescore.qrc">
+            <normaloff>:/data/icons/arrow_down.svg</normaloff>:/data/icons/arrow_down.svg</iconset>
           </property>
          </widget>
         </item>

--- a/mscore/musescore.qrc
+++ b/mscore/musescore.qrc
@@ -1,5 +1,4 @@
-<!DOCTYPE RCC>
-<RCC version="1.0">
+<RCC>
     <qresource prefix="/">
         <file>data/shortcuts.xml</file>
         <file>data/paper1.png</file>
@@ -152,5 +151,7 @@
         <file>data/icons/dialog-information.svg</file>
         <file>data/icons/dialog-question.svg</file>
         <file>data/icons/dialog-warning.svg</file>
+        <file>data/icons/arrow_down.svg</file>
+        <file>data/icons/arrow_up.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Add svg arrows instead of captions "Up", "Down" for buttons on the MIDI import panel.

Light theme:
https://drive.google.com/file/d/0B5alKuFoSol2NVB4MXVGa3JRWHM/view?usp=sharing
Dark theme:
https://drive.google.com/file/d/0B5alKuFoSol2R0haWldLS2lxVEk/view?usp=sharing
