### PR TITLE
Fix #18415: Show MIDI channel number for tracks (MIDI import)

### DIFF
--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -849,6 +849,8 @@ void setTrackInfo(MidiType midiType, MTrack &mt)
       if (opers.data()->processingsOfOpenedFile == 0) {
             const int currentTrack = opers.currentTrack();
             opers.data()->trackOpers.instrumentName.setValue(currentTrack, instrName);
+                        // set channel number (from 1): number = index + 1
+            opers.data()->trackOpers.channel.setValue(currentTrack, mt.mtrack->outChannel() + 1);
             }
 
       if (mt.staff->isTop()) {

--- a/mscore/importmidi/importmidi_model.cpp
+++ b/mscore/importmidi/importmidi_model.cpp
@@ -73,6 +73,21 @@ void TracksModel::reset(const MidiOperations::Opers &opers,
       _columns.push_back(std::unique_ptr<Column>(new Import(_trackOpers)));
 
       //-----------------------------------------------------------------------
+      struct Channel : Column {
+            Channel(MidiOperations::Opers &opers) : Column(opers) {}
+            QString headerName() const { return QCoreApplication::translate(
+                                                      "MIDI import operations", "Channel"); }
+            bool isEditable() const { return false; }
+            QVariant value(int trackIndex) const
+                  {
+                  return QString::number(_opers.channel.value(trackIndex));
+                  }
+            void setValue(const QVariant &/*value*/, int /*trackIndex*/) {}
+            };
+      ++_frozenColCount;
+      _columns.push_back(std::unique_ptr<Column>(new Channel(_trackOpers)));
+
+      //-----------------------------------------------------------------------
       bool hasStaffName = false;
       for (int i = 0; i != _trackCount; ++i) {
             if (_trackOpers.staffName.value(i) != "") {

--- a/mscore/importmidi/importmidi_operations.h
+++ b/mscore/importmidi/importmidi_operations.h
@@ -128,6 +128,7 @@ class Op
 struct Opers
       {
                   // data that cannot be changed by the user
+      TrackOp<int> channel = TrackOp<int>(int());
       TrackOp<std::string> staffName = TrackOp<std::string>(std::string());       // will be converted to unicode later
       TrackOp<QString> instrumentName = TrackOp<QString>(QString());
       TrackOp<bool> isDrumTrack = TrackOp<bool>(false);


### PR DESCRIPTION
The channel info column was added to the MIDI import panel:
https://drive.google.com/file/d/0B5alKuFoSol2N1NQcmJRMUhZYWM/view?usp=sharing

Feature request: http://musescore.org/en/node/18415
