### PR TITLE
fix #42851: issues setting SHOW_COURTESY for courtesy signatures

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -493,6 +493,8 @@ bool KeySig::setProperty(P_ID propertyId, const QVariant& v)
       {
       switch(propertyId) {
             case P_ID::SHOW_COURTESY:
+                  if (generated())
+                        return false;
                   setShowCourtesy(v.toBool());
                   break;
             default:
@@ -512,8 +514,9 @@ bool KeySig::setProperty(P_ID propertyId, const QVariant& v)
 QVariant KeySig::propertyDefault(P_ID id) const
       {
       switch(id) {
-            case P_ID::SHOW_COURTESY:      return true;
-            default:                   return Element::propertyDefault(id);
+            case P_ID::SHOW_COURTESY:     return true;
+            default:
+                  return Element::propertyDefault(id);
             }
       }
 

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -484,6 +484,8 @@ bool TimeSig::setProperty(P_ID propertyId, const QVariant& v)
       {
       switch(propertyId) {
             case P_ID::SHOW_COURTESY:
+                  if (generated())
+                        return false;
                   setShowCourtesySig(v.toBool());
                   break;
             case P_ID::NUMERATOR_STRING:
@@ -528,7 +530,8 @@ QVariant TimeSig::propertyDefault(P_ID id) const
             case P_ID::TIMESIG:            return QVariant::fromValue(Fraction(4,4));
             case P_ID::TIMESIG_GLOBAL:     return QVariant::fromValue(Fraction(1,1));
             case P_ID::TIMESIG_TYPE:       return int(TimeSigType::NORMAL);
-            default:                   return Element::propertyDefault(id);
+            default:
+                  return Element::propertyDefault(id);
             }
       }
 

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -492,6 +492,16 @@ InspectorTimeSig::InspectorTimeSig(QWidget* parent)
       mapSignals();
       }
 
+//   InspectorTimeSig::setElement
+
+void InspectorTimeSig::setElement()
+      {
+      InspectorBase::setElement();
+      TimeSig* ts = static_cast<TimeSig*>(inspector->element());
+      if (ts->generated())
+            t.showCourtesy->setEnabled(false);
+      }
+
 //---------------------------------------------------------
 //   InspectorKeySig
 //---------------------------------------------------------
@@ -514,6 +524,16 @@ InspectorKeySig::InspectorKeySig(QWidget* parent)
 //            { P_ID::SHOW_NATURALS,  0, 0, k.showNaturals,  k.resetShowNaturals  }
             };
       mapSignals();
+      }
+
+//   InspectorKeySig::setElement
+
+void InspectorKeySig::setElement()
+      {
+      InspectorBase::setElement();
+      KeySig* ks = static_cast<KeySig*>(inspector->element());
+      if (ks->generated())
+            k.showCourtesy->setEnabled(false);
       }
 
 //---------------------------------------------------------
@@ -589,7 +609,7 @@ void InspectorClef::setElement()
       InspectorBase::setElement();
 
       // try to locate the 'other clef' of a courtesy / main pair
-      Clef * clef = static_cast<Clef*>(inspector->element());
+      Clef* clef = static_cast<Clef*>(inspector->element());
       // if not in a clef-segment-measure hierachy, do nothing
       if (!clef->parent() || clef->parent()->type() != Element::Type::SEGMENT)
             return;

--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -168,6 +168,7 @@ class InspectorTimeSig : public InspectorBase {
 
    public:
       InspectorTimeSig(QWidget* parent);
+      virtual void setElement() override;
       };
 
 //---------------------------------------------------------
@@ -183,6 +184,7 @@ class InspectorKeySig : public InspectorBase {
 
    public:
       InspectorKeySig(QWidget* parent);
+      virtual void setElement() override;
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
The SHOW_COURTESY property really only applies to "main" key and time signatures, not to the corresponding courtesy signatures themselves.  Attempting to set this property via Inspector for courtesy signatures was leading to problems as described in referenced issue.  Fixed to disable the Inspector checkbox for generated key signatures when selected individually, but also changed setProperty to do nothing for generated key signatures, so the checkbox can still work for non-generated signatures when multiple signatures are selected.