### PR TITLE
fix #42886: issues with multi-voice slash fill

### DIFF
--- a/mtest/libmscore/tools/tst_tools.cpp
+++ b/mtest/libmscore/tools/tst_tools.cpp
@@ -15,6 +15,7 @@
 #include "mtest/testutils.h"
 #include "libmscore/score.h"
 #include "libmscore/undo.h"
+#include "libmscore/measure.h"
 
 #define DIR QString("libmscore/tools/")
 
@@ -152,10 +153,9 @@ void TestTools::undoSlashFill()
       Score* score = readScore(readFile);
       score->doLayout();
 
-      // select all
-      score->startCmd();
-      score->cmdSelectAll();
-      score->endCmd();
+      // select
+      Segment* s = score->firstMeasure()->findSegment(Segment::Type::ChordRest, 960 /* MScore::division * 2 */);
+      score->selection().setRange(s, score->lastSegment(), 0, 2);
 
       // do
       score->startCmd();

--- a/mtest/libmscore/tools/undoSlashFill.mscx
+++ b/mtest/libmscore/tools/undoSlashFill.mscx
@@ -327,30 +327,69 @@
       </Part>
     <Staff id="1">
       <Measure number="1">
-        <KeySig>
-          <accidental>0</accidental>
-          </KeySig>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
+        <Chord>
+          <durationType>half</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
+          <durationType>half</durationType>
           </Rest>
         </Measure>
       <Measure number="2">
         <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
+          <durationType>half</durationType>
           </Rest>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="3">
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
+          <durationType>half</durationType>
           </Rest>
+        <tick>3840</tick>
+        <Chord>
+          <track>1</track>
+          <durationType>whole</durationType>
+          <Note>
+            <track>1</track>
+            <pitch>64</pitch>
+            <tpc>18</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="4">
         <LayoutBreak>

--- a/mtest/libmscore/tools/undoSlashFill01-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashFill01-ref.mscx
@@ -333,27 +333,10 @@
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <Chord>
-          <durationType>quarter</durationType>
-          <noStem>1</noStem>
+          <durationType>half</durationType>
           <Note>
-            <pitch>71</pitch>
-            <tpc>19</tpc>
-            <head>5</head>
-            <play>0</play>
-            <fixed>1</fixed>
-            <fixedLine>4</fixedLine>
-            </Note>
-          </Chord>
-        <Chord>
-          <durationType>quarter</durationType>
-          <noStem>1</noStem>
-          <Note>
-            <pitch>71</pitch>
-            <tpc>19</tpc>
-            <head>5</head>
-            <play>0</play>
-            <fixed>1</fixed>
-            <fixedLine>4</fixedLine>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
             </Note>
           </Chord>
         <Chord>
@@ -382,10 +365,30 @@
           </Chord>
         </Measure>
       <Measure number="2">
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
         <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <tick>1920</tick>
+        <Chord>
+          <track>1</track>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
+            <track>1</track>
             <pitch>71</pitch>
             <tpc>19</tpc>
             <head>5</head>
@@ -395,9 +398,11 @@
             </Note>
           </Chord>
         <Chord>
+          <track>1</track>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
+            <track>1</track>
             <pitch>71</pitch>
             <tpc>19</tpc>
             <head>5</head>
@@ -407,9 +412,11 @@
             </Note>
           </Chord>
         <Chord>
+          <track>1</track>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
+            <track>1</track>
             <pitch>71</pitch>
             <tpc>19</tpc>
             <head>5</head>
@@ -419,9 +426,11 @@
             </Note>
           </Chord>
         <Chord>
+          <track>1</track>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
+            <track>1</track>
             <pitch>71</pitch>
             <tpc>19</tpc>
             <head>5</head>
@@ -434,50 +443,94 @@
       <Measure number="3">
         <Chord>
           <durationType>quarter</durationType>
-          <noStem>1</noStem>
           <Note>
-            <pitch>71</pitch>
-            <tpc>19</tpc>
-            <head>5</head>
-            <play>0</play>
-            <fixed>1</fixed>
-            <fixedLine>4</fixedLine>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
             </Note>
           </Chord>
         <Chord>
           <durationType>quarter</durationType>
-          <noStem>1</noStem>
           <Note>
-            <pitch>71</pitch>
-            <tpc>19</tpc>
-            <head>5</head>
-            <play>0</play>
-            <fixed>1</fixed>
-            <fixedLine>4</fixedLine>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
             </Note>
           </Chord>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        <tick>3840</tick>
         <Chord>
+          <track>1</track>
+          <durationType>whole</durationType>
+          <Note>
+            <track>1</track>
+            <pitch>64</pitch>
+            <tpc>18</tpc>
+            </Note>
+          </Chord>
+        <tick>3840</tick>
+        <Chord>
+          <offset x="0" y="-0.5"/>
+          <track>2</track>
+          <small>1</small>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
+            <track>2</track>
             <pitch>71</pitch>
             <tpc>19</tpc>
             <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
-            <fixedLine>4</fixedLine>
+            <fixedLine>-1</fixedLine>
             </Note>
           </Chord>
         <Chord>
+          <offset x="0" y="-0.5"/>
+          <track>2</track>
+          <small>1</small>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
+            <track>2</track>
             <pitch>71</pitch>
             <tpc>19</tpc>
             <head>5</head>
             <play>0</play>
             <fixed>1</fixed>
-            <fixedLine>4</fixedLine>
+            <fixedLine>-1</fixedLine>
+            </Note>
+          </Chord>
+        <Chord>
+          <offset x="0" y="-0.5"/>
+          <track>2</track>
+          <small>1</small>
+          <durationType>quarter</durationType>
+          <noStem>1</noStem>
+          <Note>
+            <track>2</track>
+            <pitch>71</pitch>
+            <tpc>19</tpc>
+            <head>5</head>
+            <play>0</play>
+            <fixed>1</fixed>
+            <fixedLine>-1</fixedLine>
+            </Note>
+          </Chord>
+        <Chord>
+          <offset x="0" y="-0.5"/>
+          <track>2</track>
+          <small>1</small>
+          <durationType>quarter</durationType>
+          <noStem>1</noStem>
+          <Note>
+            <track>2</track>
+            <pitch>71</pitch>
+            <tpc>19</tpc>
+            <head>5</head>
+            <play>0</play>
+            <fixed>1</fixed>
+            <fixedLine>-1</fixedLine>
             </Note>
           </Chord>
         </Measure>
@@ -547,30 +600,9 @@
           <sigD>4</sigD>
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
-        <Chord>
-          <durationType>quarter</durationType>
-          <noStem>1</noStem>
-          <Note>
-            <pitch>0</pitch>
-            <tpc>14</tpc>
-            <head>5</head>
-            <play>0</play>
-            <fixed>1</fixed>
-            <fixedLine>4</fixedLine>
-            </Note>
-          </Chord>
-        <Chord>
-          <durationType>quarter</durationType>
-          <noStem>1</noStem>
-          <Note>
-            <pitch>0</pitch>
-            <tpc>14</tpc>
-            <head>5</head>
-            <play>0</play>
-            <fixed>1</fixed>
-            <fixedLine>4</fixedLine>
-            </Note>
-          </Chord>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
         <Chord>
           <durationType>quarter</durationType>
           <noStem>1</noStem>

--- a/mtest/libmscore/tools/undoSlashFill02-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashFill02-ref.mscx
@@ -332,22 +332,64 @@
           <sigD>4</sigD>
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
+        <Chord>
+          <durationType>half</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
+          <durationType>half</durationType>
           </Rest>
         </Measure>
       <Measure number="2">
         <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
+          <durationType>half</durationType>
           </Rest>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="3">
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
+          <durationType>half</durationType>
           </Rest>
+        <tick>3840</tick>
+        <Chord>
+          <track>1</track>
+          <durationType>whole</durationType>
+          <Note>
+            <track>1</track>
+            <pitch>64</pitch>
+            <tpc>18</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="4">
         <LayoutBreak>


### PR DESCRIPTION
Fixes bug when adding slashes if start segment has no chordrest in selected voice.  Also extend algorithm to try to find an empty voice for the slashes.  mtest updated.
