### PR TITLE
fix #32956: crash due to enabling of edit mode during playback

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2382,6 +2382,11 @@ void MuseScore::changeState(ScoreState val)
 
 //      if (_sstate == val)
 //            return;
+
+      // disallow change to edit modes if currently in play mode
+      if (_sstate == STATE_PLAY && (val == STATE_EDIT || val & STATE_ALLTEXTUAL_EDIT || val & STATE_NOTE_ENTRY))
+            return;
+
       static const char* stdNames[] = {
             "note-longa", "note-breve", "pad-note-1", "pad-note-2", "pad-note-4",
       "pad-note-8", "pad-note-16", "pad-note-32", "pad-note-64", "pad-note-128", "pad-rest", "rest"};
@@ -2437,7 +2442,6 @@ void MuseScore::changeState(ScoreState val)
 
       if (getAction("file-part-export")->isEnabled())
             getAction("file-part-export")->setEnabled(cs && cs->rootScore()->excerpts().size() > 0);
-
 
       // disabling top level menu entries does not
       // work for MAC


### PR DESCRIPTION
I don't think anyone fully understands this crash or the extent to which it is or is not reproducible at this point, but my change here just prevents one from activating any of the edit modes during playback.  It's not *normally* possible anyhow, but apparently if you double click with enough diligence, you can catch a window where it will put you into edit mode even though playback is continuing.  We could probably get away with disabling everything but staying in PLAY mode or returning to NORMAL, but this seems a little more conservative.  I'm just disallowing any modes that could change the score.