### PR TITLE
Adjustments for out-of-range Ms instruments in MIDI import

### DIFF
--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -806,10 +806,10 @@ std::pair<int, int> findMinMaxPitch(const MTrack &track)
 int findMaxPitchDiff(const std::pair<int, int> &minMaxPitch, const InstrumentTemplate *templ)
       {
       int diff = 0;
-      if (minMaxPitch.first < templ->minPitchA)
-            diff = templ->minPitchA - minMaxPitch.first;
-      if (minMaxPitch.second > templ->maxPitchA)
-            diff = qMax(diff, minMaxPitch.second - templ->maxPitchA);
+      if (minMaxPitch.first < templ->minPitchP)
+            diff = templ->minPitchP - minMaxPitch.first;
+      if (minMaxPitch.second > templ->maxPitchP)
+            diff = qMax(diff, minMaxPitch.second - templ->maxPitchP);
       return diff;
       }
 
@@ -841,11 +841,15 @@ std::vector<InstrumentTemplate *> findSuitableInstruments(const MTrack &track)
 
       const std::pair<int, int> minMaxPitch = findMinMaxPitch(track);
       sortInstrumentTemplates(templates, minMaxPitch);
-
-      for (auto it = std::next(templates.begin()); it != templates.end(); ++it) {
+                  // instruments here are sorted primarily by valid pitch range difference,
+                  // so first nonzero difference means that current
+                  // and all successive instruments are unsuitable;
+                  // but if all instruments are unsuitable then leave them all in list
+      for (auto it = templates.begin(); it != templates.end(); ++it) {
             const int diff = findMaxPitchDiff(minMaxPitch, *it);
             if (diff > 0) {
-                  templates.erase(it, templates.end());
+                  if (it != templates.begin())
+                        templates.erase(it, templates.end());
                   break;
                   }
             }

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -850,6 +850,8 @@ std::vector<InstrumentTemplate *> findSuitableInstruments(const MTrack &track)
             if (diff > 0) {
                   if (it != templates.begin())
                         templates.erase(it, templates.end());
+                  else              // add empty template option
+                        templates.push_back(nullptr);
                   break;
                   }
             }
@@ -909,7 +911,8 @@ void createInstruments(Score *score, QList<MTrack> &tracks)
                   const int instrIndex = opers.data()->trackOpers.msInstrIndex.value(
                                                                     track.indexOfOperation);
                   instr = instrList[instrIndex];
-                  part->initFromInstrTemplate(instr);
+                  if (instr)
+                        part->initFromInstrTemplate(instr);
                   }
 
             if (areNext3OrganStaff(idx, tracks))

--- a/mscore/importmidi/importmidi_clef.cpp
+++ b/mscore/importmidi/importmidi_clef.cpp
@@ -401,6 +401,8 @@ void createMainClefFromAveragePitch(Staff *staff, int strack)
 
 bool hasGFclefs(const InstrumentTemplate *templ)
       {
+      if (!templ)
+            return false;
       const int staveCount = templ->nstaves();
       bool hasG = false;
       bool hasF = false;
@@ -432,7 +434,7 @@ void createClefs(Staff *staff, int indexOfOperation, bool isDrumTrack)
       const int strack = staff->idx() * VOICES;
       bool mainClefWasSet = false;
       const int msInstrIndex = opers.msInstrIndex.value(indexOfOperation);
-      const bool canChangeClef = trackInstrList.empty()
+      const bool canChangeClef = trackInstrList.empty() || !trackInstrList[msInstrIndex]
                                   || hasGFclefs(trackInstrList[msInstrIndex]);
 
       if (opers.changeClef.value(indexOfOperation) && canChangeClef) {

--- a/mscore/importmidi/importmidi_model.cpp
+++ b/mscore/importmidi/importmidi_model.cpp
@@ -186,7 +186,7 @@ void TracksModel::reset(const MidiOperations::Opers &opers,
                   static QString instrName(const InstrumentTemplate *instr)
                         {
                         if (!instr)
-                              return "";
+                              return "-";
                         if (!instr->trackName.isEmpty())
                               return instr->trackName;
                         if (instr->longNames.isEmpty())

--- a/mscore/importmidi/importmidi_model.cpp
+++ b/mscore/importmidi/importmidi_model.cpp
@@ -21,6 +21,7 @@ class TracksModel::Column
       virtual int width() const { return -1; }
       virtual bool isEditable(int /*trackIndex*/) const { return true; }
       virtual bool isForAllTracksOnly() const { return false; }
+      virtual QVariant textColor(int /*trackIndex*/) const { return QVariant(); }
 
    protected:
       MidiOperations::Opers &_opers;
@@ -180,6 +181,23 @@ void TracksModel::reset(const MidiOperations::Opers &opers,
                         for (const InstrumentTemplate *instr: trackInstrList)
                               list.append(instrName(instr));
                         return list;
+                        }
+                  QVariant textColor(int trackIndex) const override
+                        {
+                        const auto &trackInstrList = _opers.msInstrList.value(trackIndex);
+                        if (trackInstrList.empty())
+                              return QVariant();         // default color
+                        const int instrIndex = _opers.msInstrIndex.value(trackIndex);
+                              // if the last instrument is empty - notes of each instrument
+                              // are out of corresponding "amateur" pitch range
+                              // (see suitable instruments search code in importmidi.cpp)
+                        const bool isValid = (trackInstrList.back() != nullptr);
+                        const bool isLastIndex = (instrIndex == (int)trackInstrList.size() - 1);
+                              // if the current instrument does not fit in pitch range
+                              // and insrument index is not last in the list
+                              // (which is empty instrument "-")
+                              // then show the "invalid" instrument in red
+                        return (!isValid && !isLastIndex) ? QBrush(Qt::red) : QVariant();
                         }
 
                private:
@@ -887,6 +905,12 @@ QVariant TracksModel::data(const QModelIndex &index, int role) const
                               }
                         }
                   break;
+            case Qt::ForegroundRole:
+                  if (_columns[index.column()]->isVisible(trackIndex)) {
+                        const QVariant color = _columns[index.column()]->textColor(trackIndex);
+                        if (color.type() == QVariant::Brush)
+                              return color;
+                        }
             case Qt::SizeHintRole:
                   return QSize(_columns[index.column()]->width(), -1);
                   break;


### PR DESCRIPTION
Changes in filtering of MuseScore instruments with notes out of amateur pitch range
and red color for such instruments in the MIDI import panel:

http://wstaw.org/m/2015/01/01/6_billions.png
http://wstaw.org/m/2015/01/01/6_billions_1.png

For this file http://psrtutorial.com/S/SM/GeorgiaOnMyMind-SM033k.mid
the track "Violin" does not have fully appropriate MuseScore instrument (notes are out of pitch range), however the track has a violin MIDI program.