### PR TITLE
fix #42941: text properties not copied on copy/paste or palette add

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -761,8 +761,9 @@ void ChordRest::layoutArticulations()
 
 Element* ChordRest::drop(const DropData& data)
       {
-      Element* e = data.element;
-      Measure* m  = measure();
+      Element* e       = data.element;
+      Measure* m       = measure();
+      bool fromPalette = (e->track() == -1);
       switch (e->type()) {
             case Element::Type::BREATH:
                   {
@@ -811,9 +812,12 @@ Element* ChordRest::drop(const DropData& data)
             case Element::Type::TEMPO_TEXT:
                   {
                   TempoText* tt = static_cast<TempoText*>(e);
+                  tt->setTrack(0);
                   tt->setParent(segment());
                   TextStyleType st = tt->textStyleType();
-                  tt->setTextStyleType(st);
+                  //tt->setTextStyleType(st);
+                  if (st >= TextStyleType::DEFAULT && fromPalette)
+                        tt->textStyle().restyle(MScore::baseStyle()->textStyle(st), score()->textStyle(st));
                   score()->undoAddElement(tt);
                   }
                   return e;
@@ -823,7 +827,9 @@ Element* ChordRest::drop(const DropData& data)
                   Dynamic* d = static_cast<Dynamic*>(e);
                   d->setTrack(track());
                   TextStyleType st = d->textStyleType();
-                  d->setTextStyleType(st);
+                  //d->setTextStyleType(st);
+                  if (st >= TextStyleType::DEFAULT && fromPalette)
+                        d->textStyle().restyle(MScore::baseStyle()->textStyle(st), score()->textStyle(st));
                   d->setParent(segment());
                   score()->undoAddElement(d);
                   }
@@ -860,12 +866,16 @@ Element* ChordRest::drop(const DropData& data)
                   e->setParent(segment());
                   e->setTrack((track() / VOICES) * VOICES);
                   {
-                  Text* f = static_cast<Text*>(e);
-                  TextStyleType st = f->textStyleType();
-                  if (st >= TextStyleType::DEFAULT)
-                        f->setTextStyleType(st);
+                  Text* t = static_cast<Text*>(e);
+                  TextStyleType st = t->textStyleType();
+                  // for palette items, we want to use current score text style settings
+                  // except where the source element had explicitly overridden these via text properties
+                  // palette text style will be relative to baseStyle, so rebase this to score
+                  //f->setTextStyleType(st);
+                  if (st >= TextStyleType::DEFAULT && fromPalette)
+                        t->textStyle().restyle(MScore::baseStyle()->textStyle(st), score()->textStyle(st));
                   if (e->type() == Element::Type::REHEARSAL_MARK)
-                        f->setText(score()->createRehearsalMarkText(static_cast<RehearsalMark*>(e)));
+                        t->setText(score()->createRehearsalMarkText(static_cast<RehearsalMark*>(e)));
                   }
                   score()->undoAddElement(e);
                   return e;

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1285,6 +1285,7 @@ bool Note::acceptDrop(const DropData& data) const
 Element* Note::drop(const DropData& data)
       {
       Element* e = data.element;
+      bool fromPalette = (e->track() == -1);
 
       Chord* ch = chord();
       switch(e->type()) {
@@ -1304,7 +1305,9 @@ Element* Note::drop(const DropData& data)
                   // set style
                   Fingering* f = static_cast<Fingering*>(e);
                   TextStyleType st = f->textStyleType();
-                  f->setTextStyleType(st);
+                  //f->setTextStyleType(st);
+                  if (st >= TextStyleType::DEFAULT && fromPalette)
+                        f->textStyle().restyle(MScore::baseStyle()->textStyle(st), score()->textStyle(st));
                   }
                   return e;
 

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -1155,7 +1155,7 @@ void Text::createLayout()
 
 //---------------------------------------------------------
 //   sameLayout
-//   Undates the text, but keeps the same postition and textStyle
+//   Updates the text, but keeps the same postition and textStyle
 //---------------------------------------------------------
 
 void Text::sameLayout()

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -961,7 +961,10 @@ Palette* MuseScore::newTempoPalette()
       for (unsigned i = 0; i < sizeof(tp)/sizeof(*tp); ++i) {
             TempoText* tt = new TempoText(gscore);
             tt->setFollowText(true);
-            tt->setTrack(0);
+            // leave track at default (-1) to make it possible
+            // for drop() to tell that this came from palette
+            // (it will then be set to 0 there)
+            //tt->setTrack(0);
             tt->setTempo(tp[i].f);
             tt->setText(tp[i].pattern);
             sp->append(tt, tr("Tempo text"), QString(), 1.5);
@@ -998,7 +1001,6 @@ Palette* MuseScore::newTextPalette()
       sp->append(st, tr("Swing"));
 
       RehearsalMark* rhm = new RehearsalMark(gscore);
-      rhm->setTrack(0);
       rhm->setText("B1");
       sp->append(rhm, tr("Rehearsal mark"));
 


### PR DESCRIPTION
Originally, we always did a setTextStyleType() on each drop of a text.  This allowed palette items to be added using the current text style, but it clobbered any custom text properties present in the palette item, and it also did the same for copy & paste of individual text items.  I eliminated the call to setTextStyleType, which preserves text properties, but for palette items (only), I added a call to textStyle().restyle() to rebase the text style from gscore to the current score.  This has the effect of apply the text style as usual for most palette items, but for any that had custom text properties, those are preserved.

Everything works fine, but there is one thing worth looking at.  First is the method I use to determin if the item being dropped came from the palette or from copy/paste.  parent is always 0, so that didn't help, nor does clipboardmode seem relevant (although I could be wrong about that).  The only way I can see to differentiate is based on the track, which is usually -1 for items added from the palette.  It was 0 for rehearsal marks and tempo texts, but I found that I could remove the setTrack(0) from where the palette items are created as long as I make sure I set it in drop() after checking the value to see if it is -1.

So everything should be fine unless there is some other way of adding tempo texts or rehearsal marks from the palette to a score other than dropping on a chord or rest.  Note the setTrack(0) for remains in place when adding tempo or rehearsal marks via keyboard / menu commands; i only removed it from the palette, and made sure it is set in ChordRest::drop().