### PR TITLE
fix #43761: repeats not cloned to parts

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -481,13 +481,24 @@ void cloneStaves(Score* oscore, Score* score, const QList<int>& map)
                         }
                   int track = -1;
                   if (e->track() != -1) {
+                        // try to map track
                         track = mapTrack(e->track(), map);
-                        if (track == -1)
-                              continue;
+                        if (track == -1) {
+                              // even if track not in excerpt, we need to clone system elements
+                              if (e->systemFlag())
+                                    track = 0;
+                              else
+                                    continue;
+                              }
                         }
 
                   Element* ne;
-                  if (e->type() == Element::Type::TEXT || e->type() == Element::Type::LAYOUT_BREAK) // link the title, subtitle etc...
+                  // link text - title, subtitle, also repeats (eg, coda/segno)
+                  // measure numbers are not stored in this list, but they should not be cloned anyhow
+                  // layout breaks other than section were skipped above,
+                  // but section breaks do need to be cloned & linked
+                  // other measure-attached elements (?) are cloned but not linked
+                  if (e->isText() || e->type() == Element::Type::LAYOUT_BREAK)
                         ne = e->linkedClone();
                   else
                         ne = e->clone();


### PR DESCRIPTION
Fixed so that measure-attached system elements are always cloned.  Repeats also need to be linked, and this is fixed as well (by testing for isText() rather than the specific TEXT type).  Only question in my mind is what type of measure-attached elements should *not* be linked when cloning.  We link section breaks & text; but "other" measure-attached elements get cloned with no link.  What type of elements are we trying to handle with this?  What else can appear in the el() list for a measure?

But my change doesn't cause anything that was formerly cloned and/or linked not to be any more; it just clones some things that weren't (system elements) and links some things that weren't (text elements of type other than TEXT).