### PR TITLE
44156 melisma long

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -528,6 +528,11 @@ QPointF SLine::linePos(GripLine grip, System** sys) const
                                           }
                                     }
                               }
+                        else if (type() == Element::Type::LYRICSLINE) {
+                              // layout to right edge of CR
+                              if (cr)
+                                    x = cr->width();
+                              }
                         else if (type() == Element::Type::HAIRPIN || type() == Element::Type::TRILL
                                     || type() == Element::Type::TEXTLINE || type() == Element::Type::LYRICSLINE) {
                               // lay out to just before next CR or barline

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -609,7 +609,7 @@ void LyricsLine::layout()
       if (lyrics()->ticks() > 0) {              // melisma
             setLineWidth(Spatium(MELISMA_DEFAULT_LINE_THICKNESS));
             // Lyrics::_ticks points to the beginning of the last spanned segment,
-            // but the line shall go (almost) to the end of it:
+            // but the line shall include it:
             // include the duration of this last segment in the melisma duration
             bool        ticksSet    = false;
             Segment*    lastSeg     = score()->tick2segment(lyrics()->endTick(), false, Segment::Type::ChordRest, false);

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -231,33 +231,30 @@ void Lyrics::draw(QPainter* painter) const
       Text::draw(painter);
       }
 */
+
 //---------------------------------------------------------
 //   isMelisma
 //---------------------------------------------------------
 
 bool Lyrics::isMelisma() const
       {
-/* This is not working: if called before the whole system has been laid out, there might not be a next lyrics yet;
-      and, in any case, the next lyrics is not necessarily in the next CR.
-
       // entered as melisma using underscore?
       if (_ticks > 0)
             return true;
 
       // hyphenated?
+      // if so, it is a melisma only if there is no lyric in same verse on next CR
       if (_syllabic == Syllabic::BEGIN || _syllabic == Syllabic::MIDDLE) {
             // find next CR on same track and check for existence of lyric in same verse
             ChordRest* cr = chordRest();
             Segment* s = cr->segment()->next1();
             ChordRest* ncr = s ? s->nextChordRest(cr->track()) : nullptr;
-            if (ncr && ncr->lyrics(_no))
+            if (ncr && !ncr->lyrics(_no))
                   return true;
             }
 
       // default - not a melisma
-      return false; */
-
-      return (_ticks > 0 || _syllabic == Syllabic::BEGIN || _syllabic == Syllabic::MIDDLE);
+      return false;
 }
 
 //---------------------------------------------------------
@@ -358,7 +355,7 @@ void Lyrics::layout1()
       rxpos() += x;
       rypos() += y;
 
-      if (isMelisma()) {
+      if (_ticks > 0 || _syllabic == Syllabic::BEGIN || _syllabic == Syllabic::MIDDLE) {
             if (_separator == nullptr) {
                   _separator = new LyricsLine(score());
                   _separator->setTick(cr->tick());


### PR DESCRIPTION
Fixes two layout issues with new lyric separator implementation:

- Melisma extender lines were drawn too long.  They were using the SLine code that applies to hairpins - extending the full duration of last note - when it would be more appropriate to use something more liek the code that applies to ottavs (ending with the right edge of the last note.  Actually, slightly different, as ottavs need to account for all notes in that segment for the staff; lyric lines need only account for the parent note.

- Hyphenated syllables are not necessarily melismas.  The new implementation changed the meaning of this function from true melisma detection to something more like "does this syllable need a separator", which is a different question.  I reverted the function to its original purpose and replaced the call that was actually just trying to determine if a separator is needed to determined that directly.