### PR TITLE
44156 addendum - melisma line length correction

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -534,7 +534,7 @@ QPointF SLine::linePos(GripLine grip, System** sys) const
                                     x = cr->width();
                               }
                         else if (type() == Element::Type::HAIRPIN || type() == Element::Type::TRILL
-                                    || type() == Element::Type::TEXTLINE || type() == Element::Type::LYRICSLINE) {
+                                    || type() == Element::Type::TEXTLINE) {
                               // lay out to just before next CR or barline
                               if (cr && endElement()->parent() && endElement()->parent()->type() == Element::Type::SEGMENT) {
                                     qreal x2 = cr->x() + cr->space().rw();

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -737,8 +737,8 @@ void LyricsLineSegment::layout()
       if (isEndMelisma) {                 // melisma
             _numOfDashes = 1;
             rypos()  -= lyricsLine()->lineWidth().val() * sp * HALF; // let the line 'sit on' the base line
-            // reduce length to have some 'air' after the line
-            rxpos2() -= score()->styleD(StyleIdx::minNoteDistance) * sp;
+            // extend slightly after the chord
+            rxpos2() += score()->styleD(StyleIdx::minNoteDistance) * sp;
             }
       else {                              // dash(es)
 #if defined(USE_FONT_DASH_METRIC)


### PR DESCRIPTION
The melisma line had an undershooting length correction; with the latest change, it is now too short.

Correction changed to overshoot the chord by `minNoteDistance`, as it is definitely less massive than the chord itself.

Also removed a useless test in `line.cpp`.