### PR TITLE
fix #36981: add partName tag to parts on creation

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -158,6 +158,7 @@ void createExcerpt(Excerpt* excerpt)
             txt->setText(partLabel);
             txt->setTrack(0);
             measure->add(txt);
+            score->setMetaTag("partName", partLabel);
             }
 
       //

--- a/mtest/libmscore/chordsymbol/no-system-ref.mscx
+++ b/mtest/libmscore/chordsymbol/no-system-ref.mscx
@@ -272,6 +272,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Flute</metaTag>
       <PageList>
         <Page>
           <System>
@@ -410,6 +411,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto Saxophone</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-all-appendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-appendmeasures.mscx
@@ -969,6 +969,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1533,6 +1534,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-all-parts.mscx
+++ b/mtest/libmscore/parts/part-all-parts.mscx
@@ -957,6 +957,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1507,6 +1508,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
@@ -957,6 +957,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1515,6 +1516,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-breath-add.mscx
+++ b/mtest/libmscore/parts/part-breath-add.mscx
@@ -709,6 +709,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1088,6 +1089,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-breath-parts.mscx
+++ b/mtest/libmscore/parts/part-breath-parts.mscx
@@ -720,6 +720,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1094,6 +1095,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-breath-uadd.mscx
+++ b/mtest/libmscore/parts/part-breath-uadd.mscx
@@ -703,6 +703,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1076,6 +1077,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-breath-uradd.mscx
+++ b/mtest/libmscore/parts/part-breath-uradd.mscx
@@ -709,6 +709,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1088,6 +1089,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-chordline-add.mscx
+++ b/mtest/libmscore/parts/part-chordline-add.mscx
@@ -707,6 +707,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1084,6 +1085,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-chordline-del.mscx
+++ b/mtest/libmscore/parts/part-chordline-del.mscx
@@ -698,6 +698,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1066,6 +1067,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-chordline-parts.mscx
+++ b/mtest/libmscore/parts/part-chordline-parts.mscx
@@ -702,6 +702,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1064,6 +1065,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-chordline-uadd.mscx
+++ b/mtest/libmscore/parts/part-chordline-uadd.mscx
@@ -703,6 +703,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1076,6 +1077,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-chordline-udel.mscx
+++ b/mtest/libmscore/parts/part-chordline-udel.mscx
@@ -702,6 +702,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1074,6 +1075,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-chordline-uradd.mscx
+++ b/mtest/libmscore/parts/part-chordline-uradd.mscx
@@ -707,6 +707,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1084,6 +1085,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-chordline-urdel.mscx
+++ b/mtest/libmscore/parts/part-chordline-urdel.mscx
@@ -698,6 +698,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1066,6 +1067,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-empty-parts.mscx
+++ b/mtest/libmscore/parts/part-empty-parts.mscx
@@ -703,6 +703,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1066,6 +1067,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-fingering-add.mscx
+++ b/mtest/libmscore/parts/part-fingering-add.mscx
@@ -708,6 +708,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1086,6 +1087,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-fingering-del.mscx
+++ b/mtest/libmscore/parts/part-fingering-del.mscx
@@ -708,6 +708,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1086,6 +1087,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-fingering-parts.mscx
+++ b/mtest/libmscore/parts/part-fingering-parts.mscx
@@ -713,6 +713,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1086,6 +1087,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-fingering-uadd.mscx
+++ b/mtest/libmscore/parts/part-fingering-uadd.mscx
@@ -703,6 +703,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1076,6 +1077,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-fingering-udel.mscx
+++ b/mtest/libmscore/parts/part-fingering-udel.mscx
@@ -713,6 +713,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1096,6 +1097,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-fingering-uradd.mscx
+++ b/mtest/libmscore/parts/part-fingering-uradd.mscx
@@ -708,6 +708,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1086,6 +1087,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-fingering-urdel.mscx
+++ b/mtest/libmscore/parts/part-fingering-urdel.mscx
@@ -708,6 +708,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1086,6 +1087,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-image-parts.mscx
+++ b/mtest/libmscore/parts/part-image-parts.mscx
@@ -711,6 +711,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1093,6 +1094,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-symbol-add.mscx
+++ b/mtest/libmscore/parts/part-symbol-add.mscx
@@ -707,6 +707,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1084,6 +1085,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-symbol-del.mscx
+++ b/mtest/libmscore/parts/part-symbol-del.mscx
@@ -703,6 +703,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1076,6 +1077,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-symbol-parts.mscx
+++ b/mtest/libmscore/parts/part-symbol-parts.mscx
@@ -707,6 +707,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1074,6 +1075,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-symbol-uadd.mscx
+++ b/mtest/libmscore/parts/part-symbol-uadd.mscx
@@ -703,6 +703,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1076,6 +1077,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-symbol-udel.mscx
+++ b/mtest/libmscore/parts/part-symbol-udel.mscx
@@ -707,6 +707,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1084,6 +1085,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-symbol-uradd.mscx
+++ b/mtest/libmscore/parts/part-symbol-uradd.mscx
@@ -707,6 +707,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1084,6 +1085,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>

--- a/mtest/libmscore/parts/part-symbol-urdel.mscx
+++ b/mtest/libmscore/parts/part-symbol-urdel.mscx
@@ -703,6 +703,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Alto</metaTag>
       <PageList>
         <Page>
           <System>
@@ -1076,6 +1077,7 @@
       <showUnprintable>1</showUnprintable>
       <showFrames>1</showFrames>
       <showMargins>0</showMargins>
+      <metaTag name="partName">Tenor</metaTag>
       <PageList>
         <Page>
           <System>


### PR DESCRIPTION
using the same text as in title frame, for use in Header/Footer