### PR TITLE
Fix # 44256 : Wrong position of lyrics separator in continuous view

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -531,7 +531,7 @@ QPointF SLine::linePos(GripLine grip, System** sys) const
                         else if (type() == Element::Type::LYRICSLINE) {
                               // layout to right edge of CR
                               if (cr)
-                                    x = cr->width();
+                                    x = cr->pos().x() + cr->width();
                               }
                         else if (type() == Element::Type::HAIRPIN || type() == Element::Type::TRILL
                                     || type() == Element::Type::TEXTLINE) {

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -728,17 +728,19 @@ void LyricsLineSegment::layout()
             rxpos2()          -= offsetX;
             }
 
-      // VERTICAL POSITION: at the base line of the syllable text relative to the system
-      qreal lyrY  = lyr->y();
-      qreal sysY  = sys->y();
-      rypos()     = lyrY - sysY;
+      // VERTICAL POSITION: at the base line of the syllable text
+      rypos()     = lyr->y();
 
       // MELISMA vs. DASHES
       if (isEndMelisma) {                 // melisma
             _numOfDashes = 1;
             rypos()  -= lyricsLine()->lineWidth().val() * sp * HALF; // let the line 'sit on' the base line
-            // extend slightly after the chord
-            rxpos2() += score()->styleD(StyleIdx::minNoteDistance) * sp;
+            qreal offsetX = score()->styleD(StyleIdx::minNoteDistance) * sp;
+            // if final segment, extend slightly after the chord, otherwise shorten it
+            rxpos2() +=
+                  (spannerSegmentType() == SpannerSegmentType::BEGIN ||
+                        spannerSegmentType() == SpannerSegmentType::MIDDLE)
+                  ? -offsetX : +offsetX;
             }
       else {                              // dash(es)
 #if defined(USE_FONT_DASH_METRIC)


### PR DESCRIPTION
Fix # 44256 : Wrong position of lyrics separator in continuous view

Also includes:
- adjust melisma line end for chord user offset
- differentiate between melisma end overshooting for last segment and undershooting for previous segments