### PR TITLE
Entering lyrics underscore at score end

### DIFF
--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -292,6 +292,7 @@ void ScoreView::lyricsUnderscore()
             segment = segment->prev1(Segment::Type::ChordRest);
             }
 
+      // if no place for a new lyrics found, update previous lyrics ticks and leave edit
       if (nextSegment == 0) {
             if (oldLyrics) {
                   switch(oldLyrics->syllabic()) {
@@ -305,8 +306,15 @@ void ScoreView::lyricsUnderscore()
                   if (oldLyrics->segment()->tick() < endTick)
                         oldLyrics->undoChangeProperty(P_ID::LYRIC_TICKS, endTick - oldLyrics->segment()->tick());
                   }
+            // leave edit mode, select something (just for user feedback) and update to show extended melisam
+            mscore->changeState(STATE_NORMAL);
+            if (oldLyrics)
+                  _score->select(oldLyrics, SelectType::SINGLE, 0);
+            _score->update();
             return;
             }
+
+      // if a place for a new lyrics has been found, create a lyrics there
       _score->startCmd();
 
       const QList<Lyrics*>* ll = nextSegment->lyricsList(track);


### PR DESCRIPTION
If a lyrics underscore is entered at score end (or where there is no place for a suitable new/next lyrics to move to):

- the last underscore gives no visual feedback, until the score is re-laid out
- the score view is left in a vague state (lyrics edit mode with no current lyrics)

Fixed by updating lyrics melisma display and leaving edit mode.

The lyrics whose melisma is being edited is also selected to give the user some 'cursor'.