### PR TITLE
Show melisma line after first underscore

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -603,8 +603,12 @@ LyricsLine::LyricsLine(const LyricsLine& g)
 
 void LyricsLine::layout()
       {
+      bool tempMelismaTicks = (lyrics()->ticks() == Lyrics::TEMP_MELISMA_TICKS);
       if (lyrics()->ticks() > 0) {              // melisma
             setLineWidth(Spatium(MELISMA_DEFAULT_LINE_THICKNESS));
+            // if lyrics has a temporary one-chord melisma, set to 0 ticks (just its own chord)
+            if (tempMelismaTicks)
+                  lyrics()->setTicks(0);
             // Lyrics::_ticks points to the beginning of the last spanned segment,
             // but the line shall include it:
             // include the duration of this last segment in the melisma duration
@@ -635,8 +639,17 @@ void LyricsLine::layout()
             _nextLyrics = searchNextLyrics(lyrics()->segment(), staffIdx(), lyrics()->no());
             setTick2(_nextLyrics != nullptr ? _nextLyrics->segment()->tick() : tick());
       }
-      if (ticks())                  // only do layout if some time span
+      if (ticks()) {                // only do layout if some time span
+            // do layout with non-0 duration
+            if (tempMelismaTicks)
+                  lyrics()->setTicks(Lyrics::TEMP_MELISMA_TICKS);
             SLine::layout();
+            // if temp melisma and there is a first line segment,
+            // extend it to be after the lyrics syllable (otherwise
+            // the melisma segment will be often covered by the syllable itself)
+            if (tempMelismaTicks && segments.size() > 0)
+                  segmentAt(0)->rxpos2() += lyrics()->width();
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -49,6 +49,12 @@ class Lyrics : public Text {
 
    public:
       enum class Syllabic : char { SINGLE, BEGIN, END, MIDDLE };
+      // MELISMA FIRST UNDERSCORE:
+      // used as_ticks value to mark a melisma for which only the first chord has been spanned so far
+      // and to give the user a visible feedback that the undercore has been actually entered;
+      // it will be cleared to 0 by LyricsLine::layout(), so that it will not be carried over
+      // if the melisma is not extended beyond a signle chord
+      static const int  TEMP_MELISMA_TICKS      = 1;
 
    private:
       int _ticks;             ///< if > 0 then draw an underline to tick() + _ticks

--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -292,7 +292,12 @@ void ScoreView::lyricsUnderscore()
             segment = segment->prev1(Segment::Type::ChordRest);
             }
 
-      // if no place for a new lyrics found, update previous lyrics ticks and leave edit
+      // one-chord melisma?
+      // if still at melisma initial chord and there is a valid next chord (if not,
+      // there will be no melisma anyway), set a temporary melisma duration
+      if (oldLyrics == lyrics && nextSegment)
+            lyrics->setTicks(Lyrics::TEMP_MELISMA_TICKS);
+
       if (nextSegment == 0) {
             if (oldLyrics) {
                   switch(oldLyrics->syllabic()) {


### PR DESCRIPTION
While entering a melisma, the first underscore has no specific visual effect.

This patch displays a short melisma after the first underscore, by setting a conventional non-0 lyrics `_ticks` value.

Note: If no second underscore is entered (edit mode is exited or a new syllable is entered in the following chord), the short melisma is left behind as a left-over. It may be the case to reset to 0 the melisma ticks (= no melisma at all) for instance when the score is saved, or read back.