### PR TITLE
Do not enter melisma(s) over rests

### DIFF
--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -290,6 +290,9 @@ void ScoreView::lyricsUnderscore()
                         break;
                   }
             segment = segment->prev1(Segment::Type::ChordRest);
+            // if the segment has a rest in this track, stop going back
+            if (segment && segment->elementAt(track)->type() != Element::Type::CHORD)
+                  break;
             }
 
       if (nextSegment == 0) {


### PR DESCRIPTION
If underscore is pressed on a lyrics followed by rest(s), the previous melisma line is extended across the rests.

This patch stops the melisma before the rests, while still placing the lyrics cursor after the rests ready to enter a new syllable.