### PR TITLE
melisma updates

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -541,8 +541,9 @@ QPointF SLine::linePos(GripLine grip, System** sys) const
                                     qreal maxRight = 0.0;
                                     if (cr->type() == Element::Type::CHORD) {
                                           // chord bbox() is unreliable, look at notes
+                                          // this also allows us to more easily ignore ledger lines
                                           for (Note* n : static_cast<Chord*>(cr)->notes())
-                                                maxRight = qMax(maxRight, cr->x() + n->x() + n->width());
+                                                maxRight = qMax(maxRight, cr->x() + n->x() + n->headWidth());
                                           }
                                     else {
                                           // rest - won't normally happen

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -529,10 +529,28 @@ QPointF SLine::linePos(GripLine grip, System** sys) const
                                     }
                               }
                         else if (type() == Element::Type::LYRICSLINE) {
+                              // it is possible CR won't be in correct track
+                              // prefer element in current track if available
+                              if (cr->track() != track()) {
+                                    Element* e = cr->segment()->element(track());
+                                    if (e)
+                                          cr = static_cast<ChordRest*>(e);
+                                    }
                               // layout to right edge of CR
-                              if (cr)
-                                    x = cr->width();
-                              }
+                              if (cr) {
+                                    qreal maxRight = 0.0;
+                                    if (cr->type() == Element::Type::CHORD) {
+                                          // chord bbox() is unreliable, look at notes
+                                          for (Note* n : static_cast<Chord*>(cr)->notes())
+                                                maxRight = qMax(maxRight, cr->x() + n->x() + n->width());
+                                          }
+                                    else {
+                                          // rest - won't normally happen
+                                          maxRight = cr->x() + cr->width();
+                                          }
+                                    x = maxRight; // cr->width()
+                                    }
+                             }
                         else if (type() == Element::Type::HAIRPIN || type() == Element::Type::TRILL
                                     || type() == Element::Type::TEXTLINE) {
                               // lay out to just before next CR or barline

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -765,7 +765,16 @@ void LyricsLineSegment::layout()
             }
 
       // VERTICAL POSITION: at the base line of the syllable text
-      rypos()     = lyr->y();
+      if (spannerSegmentType() != SpannerSegmentType::END)
+            rypos() = lyr->y();
+      else {
+            // use Y position of *next* syllable if there is one on same system
+            Lyrics* nextLyr = searchNextLyrics(lyr->segment(), lyr->staffIdx(), lyr->no());
+            if (nextLyr && nextLyr->segment()->system() == system())
+                  rypos() = nextLyr->y();
+            else
+                  rypos() = lyr->y();
+            }
 
       // MELISMA vs. DASHES
       if (isEndMelisma) {                 // melisma


### PR DESCRIPTION
This replaces #1634, which I had closed to update but I guess I cannot re-open because I rebase it.

This PR fixes several issues with melisma layout:

- line length takes manual adjustments and voice offset of chords into consideration
- end chord corrected in multi-voice context (see http://musescore.org/en/node/44271)
- after an edit that removes end chord, lyrics tick count is updated so melisma ends with chord nearest original end (see http://musescore.org/en/node/44291)

It includes two fixes borrowed from @mgavioli:

- for line continued across systems, start segment is shortened to end before barline
- vertical position fixed for continuous view (see http://musescore.org/en/node/44256)

it seems there might be a merge conflict with #1636, as we touch one of the same functions, although separated a bit and I don't think there are actually any issues.  Assuming #1636 is merged first (and I see no reason it shouldn't), I will rebase and re-test this.