### PR TITLE
Potential crash when deleting chords with lyrics.

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1564,7 +1564,8 @@ void Score::removeElement(Element* element)
                   if (cr->beam())
                         cr->beam()->remove(cr);
                   for (Lyrics* lyr : cr->lyricsList())
-                        lyr->removeFromScore();
+                        if (lyr)                // lyrics list may be sparse
+                              lyr->removeFromScore();
                   // TODO: check for tuplet?
                   }
                   break;


### PR DESCRIPTION
Deals with a possible crash when deleting a chord with lyrics, if the lyrics list has empty items.