### PR TITLE
Short lyrics syllabic dash at end of system

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -11,16 +11,17 @@
 //=============================================================================
 
 #include "line.h"
-#include "textline.h"
-#include "segment.h"
-#include "measure.h"
-#include "score.h"
-#include "xml.h"
-#include "system.h"
-#include "staff.h"
-#include "utils.h"
 #include "barline.h"
 #include "chord.h"
+#include "lyrics.h"
+#include "measure.h"
+#include "score.h"
+#include "segment.h"
+#include "staff.h"
+#include "system.h"
+#include "textline.h"
+#include "utils.h"
+#include "xml.h"
 
 namespace Ms {
 
@@ -528,13 +529,14 @@ QPointF SLine::linePos(GripLine grip, System** sys) const
                                           }
                                     }
                               }
-                        else if (type() == Element::Type::LYRICSLINE) {
-                              // layout to right edge of CR
+                        // layout lyrics melisma (but not dashes) to right edge of CR
+                        else if (type() == Element::Type::LYRICSLINE && static_cast<const LyricsLine*>(this)->lyrics()->ticks() > 0) {
                               if (cr)
                                     x = cr->width();
                               }
+                        // (also includes dash lyrics line)
                         else if (type() == Element::Type::HAIRPIN || type() == Element::Type::TRILL
-                                    || type() == Element::Type::TEXTLINE) {
+                                    || type() == Element::Type::TEXTLINE || type() == Element::Type::LYRICSLINE) {
                               // lay out to just before next CR or barline
                               if (cr && endElement()->parent() && endElement()->parent()->type() == Element::Type::SEGMENT) {
                                     qreal x2 = cr->x() + cr->space().rw();

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -684,6 +684,7 @@ void LyricsLineSegment::layout()
       {
       Lyrics*     lyr;
       System*     sys;
+      bool        endOfSystem = false;
       bool        isEndMelisma      = lyricsLine()->lyrics()->ticks() > 0;
       qreal       sp                = spatium();
 
@@ -698,11 +699,12 @@ void LyricsLineSegment::layout()
       if (!isEndMelisma && lyricsLine()->nextLyrics() != nullptr
                   && (spannerSegmentType() == SpannerSegmentType::END
                         || spannerSegmentType() == SpannerSegmentType::SINGLE)) {
-            lyr   = lyricsLine()->nextLyrics();
-            sys   = lyr->segment()->system();
+            lyr         = lyricsLine()->nextLyrics();
+            sys         = lyr->segment()->system();
+            endOfSystem = (sys != system());
             // if next lyrics is on a different sytem, this line segment is at the end of its system:
             // do not adjust for next lyrics position
-            if (sys == system()) {
+            if (!endOfSystem) {
                   qreal lyrX        = lyr->bbox().x();
                   qreal lyrXp       = lyr->pagePos().x();
                   qreal sysXp       = sys->pagePos().x();
@@ -742,22 +744,30 @@ void LyricsLineSegment::layout()
             }
       else {                              // dash(es)
 #if defined(USE_FONT_DASH_METRIC)
-            rypos()           += lyr->dashY();
-            _dashLength       = lyr->dashLength();
+            rypos()     += lyr->dashY();
+            _dashLength = lyr->dashLength();
 #else
-            rypos()           -= lyr->bbox().height() * LYRICS_DASH_Y_POS_RATIO;    // set conventional dash Y pos
-            _dashLength       = LYRICS_DASH_DEFAULT_LENGHT * sp;                    // and dash length
+            rypos()     -= lyr->bbox().height() * LYRICS_DASH_Y_POS_RATIO;    // set conventional dash Y pos
+            _dashLength = LYRICS_DASH_DEFAULT_LENGHT * sp;                    // and dash length
 #endif
             qreal len         = pos2().x();
-            if (len < LYRICS_DASH_MIN_LENGTH * sp)                                  // if no room for a dash
-                  _numOfDashes = 0;                                                 //    draw no dash
-            else if (len < (LYRICS_DASH_DEFAULT_STEP * TWICE * sp)) {               // if no room for two dashes
-                  _numOfDashes = 1;                                                 //    draw one dash
-                  if (_dashLength > len)                                            // if no room for a full dash
-                        _dashLength = len;                                          //    shorten it
+            qreal minDashLen  = LYRICS_DASH_MIN_LENGTH * sp;
+            if (len < minDashLen) {                                           // if no room for a dash
+                  if (endOfSystem) {                                          //   if at end of system
+                        rxpos2()          = minDashLen;                       //     draw minimal dash
+                        _numOfDashes      = 1;
+                        _dashLength       = minDashLen;
+                        }
+                  else                                                        //   if within system
+                        _numOfDashes = 0;                                     //     draw no dash
+                  }
+            else if (len < (LYRICS_DASH_DEFAULT_STEP * TWICE * sp)) {         // if no room for two dashes
+                  _numOfDashes = 1;                                           //    draw one dash
+                  if (_dashLength > len)                                      // if no room for a full dash
+                        _dashLength = len;                                    //    shorten it
                   }
             else
-                  _numOfDashes = len / (LYRICS_DASH_DEFAULT_STEP * sp);             // draw several dashes
+                  _numOfDashes = len / (LYRICS_DASH_DEFAULT_STEP * sp);       // draw several dashes
             }
 
       // set bounding box


### PR DESCRIPTION
When a syll. dash is too short to fit between two syllables, it is skipped. This looks badly at system end, where room for a short dash is usually available within the note-to-barline distance + barline width.

With this patch, a syll. dash at the end of a system is always drawn with at least the shortest acceptable length (or more, if more room is available), even if under normal conditions it would not fit. In a position where the in-word status of a syllable is not easy to guess, the occasional dash (very) slightly extending beyond the bar line seems more acceptable that no dash at all.

This patch also limits the `LyricsLine`-specific correction in `SLine::linePos()` to melisma only, using common processing for syllabic dash lines.