### PR TITLE
fix #44126: add tie chooses note before end duration of current chord

### DIFF
--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -727,7 +727,15 @@ Note* searchTieNote(Note* note)
             return note2;
             }
 
+      // end of current note duration
+      // but err on the safe side in case there is roundoff in tick count
+      int endTick = chord->tick() + chord->actualTicks() - 1;
+
       while ((seg = seg->next1(Segment::Type::ChordRest))) {
+            // skip ahead to end of current note duration
+            // but just in case, stop if we find element in current track
+            if (seg->tick() < endTick  && !seg->element(chord->track()))
+                  continue;
             for (int track = strack; track < etrack; ++track) {
                   Chord* c = static_cast<Chord*>(seg->element(track));
                   if (c == 0 || c->type() != Element::Type::CHORD)


### PR DESCRIPTION
The issue is that the code was accepting the first note of matching pitch it found, even if that note  starts before the end of the current note (which can happen if it's in a different voice).

Since we *do* want to support ties between voices, I change the code to skip ahead to the end of the current note's duration before looking for matching notes, and using actualTicks() seems to be the way to get this calculation to work in the presence of tuplets and/or time stretch from local time signatures.  However, even with the "- 1" fudge factor I added, I have my doubts how accurate this calculation might be in the presence of roundoff of tick counts relative to MScore::division.  So I included an additional sanity check - I stop skipping ahead if I find a chord in the current track.

The code works in all cases I tried - simple cases as well as various combinations of multiple voices that includes tuplets and local time signatures.  It may be I am being overly cautious, but there's no harm in that, is there?

I'll wait for someone else to review.