### PR TITLE
fix #44841: reconcile lyricsline length adjustments

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -511,8 +511,8 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                           }
                                     }
                               }
-#if 0
-                        else if (type() == Element::Type::LYRICSLINE) {
+                        else if (type() == Element::Type::LYRICSLINE && static_cast<Lyrics*>(parent())->ticks() > 0) {
+                              // melisma line
                               // it is possible CR won't be in correct track
                               // prefer element in current track if available
                               if (cr->track() != track()) {
@@ -536,16 +536,9 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                     x = maxRight; // cr->width()
                                     }
                              }
-#else
-                        // layout lyrics melisma (but not dashes) to right edge of CR
-                        else if (type() == Element::Type::LYRICSLINE && static_cast<const LyricsLine*>(this)->lyrics()->ticks() > 0) {
-                              if (cr)
-                                    x = cr->width();
-                              }
-                        // (also includes dash lyrics line)
-#endif
                         else if (type() == Element::Type::HAIRPIN || type() == Element::Type::TRILL
                                     || type() == Element::Type::TEXTLINE || type() == Element::Type::LYRICSLINE) {
+                              // (for LYRICSLINE, this is hyphen; melisma line is handled above)
                               // lay out to just before next CR or barline
                               if (cr && endElement()->parent() && endElement()->parent()->type() == Element::Type::SEGMENT) {
                                     qreal x2 = cr->x() + cr->space().rw();
@@ -560,7 +553,9 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                                 break;
                                                 }
                                           else if (seg->segmentType() == Segment::Type::EndBarLine) {
-                                                x2 = qMax(x2, seg->x() - sp);
+                                                // allow lyrics hyphen to extend to barline; other lines stop 1sp short
+                                                qreal gap = (type() == Element::Type::LYRICSLINE) ? 0.0 : sp;
+                                                x2 = qMax(x2, seg->x() - gap);
                                                 break;
                                                 }
                                           }


### PR DESCRIPTION
This change re-instates the portion of my code from #1638 that conflicted with @mgavioli changes in #1643, while preserving his changes as well.

This should now properly handle the layout of both types of LYRICSLINE in SLine::linePos().  Melisma lines get my code to calculate the endpoint more accurately relative to the righthand edge of the chord, hyphens get the original code to initially extend all the way to the next chord or end barline (this is adjusted later in LyricsLineSegment::layout()).

I also made an adjustment to in SLine::linePos() to allow hyphens to extend all the way to the end barline.  Other lines in this category (HAIRPIN, TRILL, TEXTLINE) are terminated 1sp short of the barline, but this isn't appropriate for hyphens.  The result was that a hyphen on the last note of a crowded system was being rendered shorter than necessary, with an extra 1sp of legroom going to waste.

@wschweer : I have been testing and reviewing things as thoroughly as I can, and so far so good.  I fixed one crash that resulted from an unexpected interaction between commits, but aside from that and this one area where we knew there a potential conflict, all the code seems to be working well together.

Thanks, @mgavioli for undertaking this!  An awful lot of lyric annoyances have been eliminated.