### PR TITLE
don't offset voice 1 rest if matching voice 2 rest hidden

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -440,7 +440,56 @@ int Rest::computeLineOffset()
       {
       int lineOffset = 0;
       int lines = staff() ? staff()->lines() : 5;
-      if (segment() && measure() && measure()->mstaff(staffIdx())->hasVoices) {
+      Segment* s = segment();
+      bool offsetVoices = s && measure() && measure()->mstaff(staffIdx())->hasVoices;
+      if (offsetVoices && voice() == 0) {
+            // do not offset voice 1 rest if there exists a matching invisible rest in voice 2;
+            Element* e = s->element(track() + 1);
+            if (e && e->type() == Element::Type::REST && !e->visible()) {
+                  Rest* r = static_cast<Rest*>(e);
+                  if (r->globalDuration() == globalDuration()) {
+                        offsetVoices = false;
+                        }
+                  }
+            }
+#if 0
+      if (offsetVoices && staff()->mergeMatchingRests())
+            // automatically merge matching rests in voices 1 & 2 if nothing in any other voice
+            // this is not always the right thing to do do, but is useful in choral music
+            // and perhaps could be made enabled via a staff property
+            // so choral staves can be treated differently than others
+            bool matchFound = false;
+            bool nothingElse = true;
+            int baseTrack = staffIdx() * VOICES;
+            for (int v = 0; v < VOICES; ++v) {
+                  if (v == voice())
+                        continue;
+                  Element* e = s->element(baseTrack + v);
+                  if (v <= 1) {
+                        // try to find match in other voice (1 or 2)
+                        if (e && e->type() == Element::Type::REST) {
+                              Rest* r = static_cast<Rest*>(e);
+                              if (r->globalDuration() == globalDuration()) {
+                                    matchFound = true;
+                                    continue;
+                                    }
+                              }
+                        // no match found; no sense looking for anything else
+                        break;
+                        }
+                  else {
+                        // if anything in another voice, do not merge
+                        if (e) {
+                              nothingElse = false;
+                              break;
+                              }
+                        }
+                  }
+            if (matchFound && nothingElse)
+                  offsetVoices = false;
+            }
+#endif
+      if (offsetVoices) {
             // move rests in a multi voice context
             bool up = (voice() == 0) || (voice() == 2);       // TODO: use style values
             switch(durationType().type()) {


### PR DESCRIPTION
See http://musescore.org/en/node/41646 and http://musescore.org/en/node/34511 for some passionate discussion of the topic.

The issue is whether to merge matching (same duration) voice 1 & 2 rests vertically.  This is normal and expected in some contexts (homophonic choral music in particular), not in others (contrpuntal piano music).  Long story short - I think it makes sense to keep the default as it is (matching rests offset since multiple voices are present), but to make it easier to get the "merging" behavior.  In one of those threads, it was suggested we don't offset a voice 1 rest if there is a matching voice 2 rest that is marked invisible, and I liked that.  So that is what I do here.  It gives the user a one click solution to merge matrching rests - simply mark the voice 2 rest invisible - without affecting layout in other cases.

I also added code to automatically detect opportunities to merge rests even if neither rest is hidden, but given that it would only be appropriate for some types of music, I have it ifdef'ed out, and protected by an as-yet-nont-existent staff property.