### PR TITLE
fix #44851: crash on navigate after delete

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1511,8 +1511,11 @@ void Score::deleteItem(Element* el)
                   Rest* rest = static_cast<Rest*>(el);
                   if (rest->tuplet() && rest->tuplet()->elements().empty())
                         undoRemoveElement(rest->tuplet());
-                  if (el->voice() != 0)
+                  if (el->voice() != 0) {
                         undoRemoveElement(el);
+                        if (noteEntryMode())
+                              _is.moveToNextInputPos();
+                        }
                   }
                   break;
 

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -146,6 +146,8 @@ Element* Selection::element() const
 ChordRest* Selection::cr() const
       {
       Element* e = element();
+      if (!e)
+            return 0;
       if (e->type() == Element::Type::NOTE)
             e = e->parent();
       if (e->isChordRest())


### PR DESCRIPTION
The crash was in Selection::cr(), which is not safe to call if there is no selection, and there is no selection after a delete.  I fixed Selection::cr(0 to be safe, and also made it so deleting a rest while in note input mode moves the note input cursor forward so it isn't on a segment with no element for this track.  Otherwise, navigation doesn't crash, but it won't go anywhere either.