### PR TITLE
Bar Lines: Correct width and alignment in small staves NICE SOLUTION

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -318,8 +318,8 @@ void BarLine::draw(QPainter* painter) const
       if (y2-y1 < 0.1)
             return;
 
-      qreal _spatium = score()->spatium();
-      qreal lw = score()->styleS(StyleIdx::barWidth).val() * _spatium;
+//      qreal _spatium = spatium();
+      qreal lw = point(score()->styleS(StyleIdx::barWidth));
 
       QPen pen(curColor(), lw, Qt::SolidLine, Qt::FlatCap);
       painter->setPen(pen);
@@ -341,8 +341,8 @@ void BarLine::draw(QPainter* painter) const
 
             case BarLineType::END:
                   {
-                  qreal lw2 = score()->styleS(StyleIdx::endBarWidth).val() * _spatium;
-                  qreal d   = score()->styleS(StyleIdx::endBarDistance).val() * _spatium;
+                  qreal lw2 = point(score()->styleS(StyleIdx::endBarWidth));
+                  qreal d   = point(score()->styleS(StyleIdx::endBarDistance));
 
                   painter->drawLine(QLineF(lw * .5, y1, lw * .5, y2));
                   pen.setWidthF(lw2);
@@ -895,7 +895,7 @@ void BarLine::endEditDrag()
 
 qreal BarLine::layoutWidth(Score* score, BarLineType type, qreal mag)
       {
-      qreal _spatium = score->spatium();
+      qreal _spatium = score->spatium() * mag;
       qreal dw = score->styleS(StyleIdx::barWidth).val() * _spatium;
 
       qreal dotwidth = score->scoreFont()->width(SymId::repeatDot, mag);

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3579,6 +3579,7 @@ void Measure::layoutX(qreal stretch)
             }
 
       for (Segment* s = first(); s; s = s->next(), ++seg) {
+            qreal barLineWidth = 0.0;
             for (int track = 0; track < tracks; ++track) {
                   if (!score()->staff(track/VOICES)->show()) {
                         track += VOICES-1;
@@ -3685,13 +3686,29 @@ void Measure::layoutX(qreal stretch)
                               e->adjustReadPos();
                               }
                         }
-                  else if (t == Element::Type::AMBITUS)
-                        e->adjustReadPos();
+                  else if (t == Element::Type::BAR_LINE)
+                        barLineWidth = qMax(barLineWidth, e->width());
                   else {
-                        e->setPos(-e->bbox().x(), 0.0);
+                        if (t != Element::Type::AMBITUS)
+                              e->setPos(-e->bbox().x(), 0.0);
                         e->adjustReadPos();
                         }
                   }
+            // align bar lines
+            if (s->segmentType() == Segment::Type::EndBarLine)
+                  for (int track = 0; track < tracks; ++track)
+                        if (s->element(track)) {
+                              BarLine*    bl    = static_cast<BarLine*>(s->element(track));
+                              qreal       delta = barLineWidth - bl->width();
+                              // right-align end bar lines, end-repeat bar lines and bar lines in last system measure
+                              if (bl->barLineType() == BarLineType::END || bl->barLineType() == BarLineType::END_REPEAT
+                                    || this == system()->lastMeasure())
+                                    bl->rxpos() = delta;
+                              // centre-align all other bar lines except start-repeat
+                              else if (bl->barLineType() != BarLineType::START_REPEAT)
+                                    bl->rxpos() = delta * 0.5;
+                              // leave start-repeat left aligned
+                              }
             }
       }
 


### PR DESCRIPTION
In small staves, some types of bar lines are drawn with small lines and some are not (mainly end bar lines). In addition all bar lines of a measure are left-aligned; when small and regular staves are mixed this looks untidy for mid-system bar lines and quite wrong for system-end bar lines. See http://musescore.org/en/node/44966 for a discussion and an example.

This patch tries to achieve the best-looking possible result:
- it lays out and draws all bar lines in small staves with small widths
- it right-aligns end bar lines, end-repeat bar lines and any bar line at system end
- it left-aligns start-repeat bar lines
- it centre-aligns any other bar line.