### PR TITLE
Bar Lines: Correct width and alignment in small staves CHEAP SOLUTION

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -354,8 +354,8 @@ void BarLine::draw(QPainter* painter) const
 
             case BarLineType::DOUBLE:
                   {
-                  lw      = point(score()->styleS(StyleIdx::doubleBarWidth));
-                  qreal d = point(score()->styleS(StyleIdx::doubleBarDistance));
+                  lw      = score()->styleS(StyleIdx::doubleBarWidth).val() * _spatium;
+                  qreal d = score()->styleS(StyleIdx::doubleBarDistance).val() * _spatium;
 
                   pen.setWidthF(lw);
                   painter->setPen(pen);
@@ -368,8 +368,8 @@ void BarLine::draw(QPainter* painter) const
 
             case BarLineType::START_REPEAT:
                   {
-                  qreal lw2 = point(score()->styleS(StyleIdx::endBarWidth));
-                  qreal d1  = point(score()->styleS(StyleIdx::endBarDistance));
+                  qreal lw2 = score()->styleS(StyleIdx::endBarWidth).val() * _spatium;
+                  qreal d1  = score()->styleS(StyleIdx::endBarDistance).val() * _spatium;
 
                   qreal x2   =  lw2 * .5;                               // thick line (lw2)
                   qreal x1   =  lw2 + d1 + lw * .5;                     // thin line (lw)
@@ -392,8 +392,8 @@ void BarLine::draw(QPainter* painter) const
 
             case BarLineType::END_REPEAT:
                   {
-                  qreal lw2  = point(score()->styleS(StyleIdx::endBarWidth));
-                  qreal d1   = point(score()->styleS(StyleIdx::endBarDistance));
+                  qreal lw2  = score()->styleS(StyleIdx::endBarWidth).val() * _spatium;
+                  qreal d1   = score()->styleS(StyleIdx::endBarDistance).val() * _spatium;
                   qreal dotw = symWidth(SymId::repeatDot);
                   qreal x1   =  dotw + d1 + lw * .5;
                   qreal x2   =  dotw + d1 + lw + d1 + lw2 * .5;
@@ -415,8 +415,8 @@ void BarLine::draw(QPainter* painter) const
 
             case BarLineType::END_START_REPEAT:
                   {
-                  qreal lw2  = point(score()->styleS(StyleIdx::endBarWidth));
-                  qreal d1   = point(score()->styleS(StyleIdx::endBarDistance));
+                  qreal lw2  = score()->styleS(StyleIdx::endBarWidth).val() * _spatium;
+                  qreal d1   = score()->styleS(StyleIdx::endBarDistance).val() * _spatium;
                   qreal dotw = symWidth(SymId::repeatDot);
 
                   qreal x1   =  dotw + d1 + lw * .5;                                // thin bar


### PR DESCRIPTION
In small staves, some types of bar lines are drawn with small lines and some are not (mainly end bar lines). In addition all bar lines of a measure are left-aligned; when small and regular staves are mixed this looks untidy for mid-system bar lines and quite wrong for system-end bar lines. See http://musescore.org/en/node/44966 for a discussion and an example.

This patch implements the simplest and cheap(est?) solution:
- it lays out and draws all bar lines in small staves with regular widths
- as all the similar bar lines in a segment have the same width, they are automatically aligned
- if a segment contains different types of bar lines, they are also left-aligned regardless of their individual widths