### PR TITLE
fix #45001: crash & error dialogs in converter mode

### DIFF
--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -586,6 +586,8 @@ static Score::FileError doValidate(const QString& name, QIODevice* dev)
       else {
             qDebug("importMusicXml() file '%s' is not a valid MusicXML file", qPrintable(name));
             MScore::lastError = QObject::tr("File '%1' is not a valid MusicXML file").arg(name);
+            if (MScore::noGui)
+                  return Score::FileError::FILE_NO_ERROR;   // might as well try anyhow in converter mode
             if (musicXMLValidationErrorDialog(MScore::lastError, messageHandler.getErrors()) != QMessageBox::Yes)
                   return Score::FileError::FILE_USER_ABORT;
             }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2090,6 +2090,8 @@ static bool processNonGui()
       if (converterMode) {
             QString fn(outFileName);
             Score* cs = mscore->currentScore();
+            if (!cs)
+                  return false;
             if (!styleFile.isEmpty()) {
                   QFile f(styleFile);
                   if (f.open(QIODevice::ReadOnly)) {


### PR DESCRIPTION
Thanks to @Jojo-Schmitz for pointing to the source of the issues.  Crash averted by checking for valid score before trying to convert, dialog on validation error eliminated.  The suggestion was made to add an option to control whether or not MuseScore tries to convert MusicXML files that fail validation, and if that is deemed useful, it could obviously be added.  But it seems it would be harmless and more consistent with other applications to simply try to convert the file, so that's what I do here.  Basically, in converter mode, it's as if you answer "yes" to the question asked in the dialog - should MuseScore try to import the file even though it failed validation.