### PR TITLE
fix #45141: double click or backspace to reset mixer knobs

### DIFF
--- a/awl/aslider.cpp
+++ b/awl/aslider.cpp
@@ -129,14 +129,16 @@ void AbstractSlider::keyPressEvent(QKeyEvent* ev)
       double oval = _value;
 
       switch (ev->key()) {
-            case Qt::Key_Home:    _value = _minValue; break;
-            case Qt::Key_End:     _value = _maxValue; break;
+            case Qt::Key_Home:      _value = _minValue; break;
+            case Qt::Key_End:       _value = _maxValue; break;
             case Qt::Key_Up:
-            case Qt::Key_Left:    _value += lineStep(); break;
+            case Qt::Key_Left:      _value += lineStep(); break;
             case Qt::Key_Down:
-            case Qt::Key_Right:   _value -= lineStep(); break;
-            case Qt::Key_PageDown: _value -= pageStep(); break;
-            case Qt::Key_PageUp:   _value += pageStep(); break;
+            case Qt::Key_Right:     _value -= lineStep(); break;
+            case Qt::Key_PageDown:  _value -= pageStep(); break;
+            case Qt::Key_PageUp:    _value += pageStep(); break;
+            case Qt::Key_Delete:
+            case Qt::Key_Backspace: _value = ev->modifiers() & Qt::ShiftModifier ? dclickValue2() : dclickValue1(); break;
             default:
                   break;
             }
@@ -146,6 +148,19 @@ void AbstractSlider::keyPressEvent(QKeyEvent* ev)
             _value = _maxValue;
       if (oval != _value)
             valueChange();
+      }
+
+//---------------------------------------------------------
+//   mouseDoubleClickEvent
+//---------------------------------------------------------
+
+void AbstractSlider::mouseDoubleClickEvent(QMouseEvent* ev)
+      {
+      if (ev->button() == Qt::RightButton)
+            _value = _dclickValue2;
+      else
+            _value = _dclickValue1;
+      valueChange();
       }
 
 //---------------------------------------------------------

--- a/awl/aslider.h
+++ b/awl/aslider.h
@@ -54,10 +54,15 @@ class AbstractSlider : public QWidget {
       Q_PROPERTY(double pageStep READ pageStep WRITE setPageStep)
       Q_PROPERTY(bool   log      READ log      WRITE setLog)
 
+      Q_PROPERTY(double dclickValue1 READ dclickValue1 WRITE setDclickValue1)
+      Q_PROPERTY(double dclickValue2 READ dclickValue2 WRITE setDclickValue2)
+
    protected:
       int _id;
       double _value;
       double _minValue, _maxValue, _lineStep, _pageStep;
+      double _dclickValue1;
+      double _dclickValue2;
       bool _center;
       bool _invert;
       int _scaleWidth;        //! scale line width
@@ -67,6 +72,7 @@ class AbstractSlider : public QWidget {
 
       virtual void wheelEvent(QWheelEvent*);
       virtual void keyPressEvent(QKeyEvent*);
+      virtual void mouseDoubleClickEvent(QMouseEvent*);
       virtual void valueChange();
 
    signals:
@@ -123,6 +129,10 @@ class AbstractSlider : public QWidget {
       void setLineStep(double v) { _lineStep = v;    }
       double pageStep() const    { return _pageStep; }
       void setPageStep(double f) { _pageStep = f;    }
+      double dclickValue1() const      { return _dclickValue1; }
+      double dclickValue2() const      { return _dclickValue2; }
+      void setDclickValue1(double val) { _dclickValue1 = val;  }
+      void setDclickValue2(double val) { _dclickValue2 = val;  }
       void setEnabled(bool val);
       };
 

--- a/awl/slider.cpp
+++ b/awl/slider.cpp
@@ -60,20 +60,6 @@ void Slider::init()
       }
 
 //---------------------------------------------------------
-//   mouseDoubleClickEvent
-//---------------------------------------------------------
-
-void Slider::mouseDoubleClickEvent(QMouseEvent* ev)
-      {
-      if (ev->button() == Qt::RightButton)
-            _value = _dclickValue2;
-      else
-            _value = _dclickValue1;
-      valueChange();
-      }
-
-
-//---------------------------------------------------------
 //   sizeHint
 //---------------------------------------------------------
 

--- a/awl/slider.h
+++ b/awl/slider.h
@@ -39,8 +39,6 @@ class Slider : public AbstractSlider {
 
       Q_PROPERTY(Qt::Orientation orientation READ orientation WRITE setOrientation)
       Q_PROPERTY(QSize sliderSize READ sliderSize WRITE setSliderSize)
-      Q_PROPERTY(double dclickValue1 READ dclickValue1 WRITE setDclickValue1)
-      Q_PROPERTY(double dclickValue2 READ dclickValue2 WRITE setDclickValue2)
 
       Qt::Orientation orient;
       QSize _sliderSize;
@@ -48,8 +46,6 @@ class Slider : public AbstractSlider {
       QPoint startDrag;
       bool dragMode;
       int dragppos;
-      double _dclickValue1;
-      double _dclickValue2;
 
       virtual void mouseReleaseEvent(QMouseEvent*);
       virtual void mouseMoveEvent(QMouseEvent*);
@@ -60,7 +56,6 @@ class Slider : public AbstractSlider {
    protected:
       QPainterPath* points;
       virtual void mousePressEvent(QMouseEvent*);
-      virtual void mouseDoubleClickEvent(QMouseEvent*);
 
    signals:
       void sliderPressed(int);
@@ -79,10 +74,6 @@ class Slider : public AbstractSlider {
 
       virtual void setInvertedAppearance(bool val);
       virtual QSize sizeHint() const;
-      double dclickValue1() const      { return _dclickValue1; }
-      double dclickValue2() const      { return _dclickValue2; }
-      void setDclickValue1(double val) { _dclickValue1 = val;  }
-      void setDclickValue2(double val) { _dclickValue2 = val;  }
       };
 }
 

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -54,6 +54,7 @@ PartEdit::PartEdit(QWidget* parent)
 
 void PartEdit::setPart(Part* p, Channel* a)
       {
+      Channel dummy;
       channel = a;
       part    = p;
       QString s = part->partName();
@@ -63,9 +64,17 @@ void PartEdit::setPart(Part* p, Channel* a)
       mute->setChecked(a->mute);
       solo->setChecked(a->solo);
       volume->setValue(a->volume);
+      volume->setDclickValue1(dummy.volume);
+      volume->setDclickValue2(dummy.volume);
       reverb->setValue(a->reverb);
+      reverb->setDclickValue1(dummy.reverb);
+      reverb->setDclickValue2(dummy.reverb);
       chorus->setValue(a->chorus);
+      chorus->setDclickValue1(dummy.chorus);
+      chorus->setDclickValue2(dummy.chorus);
       pan->setValue(a->pan);
+      pan->setDclickValue1(0);
+      pan->setDclickValue2(0);
       for (int i = 0; i < patch->count(); ++i) {
             MidiPatch* p = (MidiPatch*)patch->itemData(i, Qt::UserRole).value<void*>();
             if (a->synti == p->synti && a->program == p->prog && a->bank == p->bank) {


### PR DESCRIPTION
I've had this at the back of my mind a while - a simple way to set a mixer knob back to its default value.  Useful when you're experimenting with levels as you try out different soundfonts, for example.  This recent issue gave me the incentive to look at it.

My specific choice of what user action should activate the reset is pretty arbitrary.  Double click seems natural enough.  Not sure what key makes the most sense, but Backsapce has a sense of going "back", also used for undo in other contexts within MuseScore, so it seemed a reasonable choice.