### PR TITLE
Do not expect padding for lyrics syllabic dashes in Measure layout

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3740,13 +3740,6 @@ qreal Score::computeMinWidth(Segment* fs, bool firstMeasureInSystem)
                                           QRectF b(l->bbox().translated(l->pos()));
                                           llw = qMax(llw, -(b.left()+lx+cx));
                                           rrw = qMax(rrw, b.right()+rx+cx);
-                                          // hyphen will be drawn using actual (perhaps minimum) note distance
-                                          // but since we are adding padding in System::layoutLyrics(),
-                                          // make enough room for that here
-                                          // (TODO: make padding amount a style setting)
-                                          Lyrics::Syllabic ls = l->syllabic();
-                                          if (ls == Lyrics::Syllabic::BEGIN || ls == Lyrics::Syllabic::MIDDLE)
-                                                rrw += 0.2 * _spatium;
                                           }
                                     }
                               }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3260,13 +3260,6 @@ void Measure::layoutX(qreal stretch)
                                     QRectF b(l->bbox().translated(l->pos()));
                                     llw = qMax(llw, -(b.left()+lx+cx));
                                     rrw = qMax(rrw, b.right()+rx+cx);
-                                    // hyphen will be drawn using actual (perhaps minimum) note distance
-                                    // but since we are adding padding in System::layoutLyrics(),
-                                    // make enough room for that here
-                                    // (TODO: make padding amount a style setting)
-                                    Lyrics::Syllabic ls = l->syllabic();
-                                    if (ls == Lyrics::Syllabic::BEGIN || ls == Lyrics::Syllabic::MIDDLE)
-                                          rrw += 0.2 * _spatium;
                                     }
                               }
                         if (lyrics) {


### PR DESCRIPTION
In `Measure::layoutX()` and in `Score::computeMinWidth()` there is code to add room for dash padding in lyrics syllables, with a reference to `System::layoutLyrics()`.

As `System_layoutLyrics()` no longer exists and as `LyricsLineSegment::layout()` now adjusts (and occasionally skips) dash width to actual note distance, this is now redundant and may in some cases interfere with the `LyricsLineSegment::layout()` calculations.

Some tests with rather dense polyphonic scores did show that some space may be spared, without raising any evident 'crowding' problem.