### PR TITLE
fix #45171: octave for shift+letter

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4897,13 +4897,15 @@ void ScoreView::cmdAddPitch(int note, bool addFlag)
                   }
             }
       else {
+            static const int tab[] = { 0, 2, 4, 5, 7, 9, 11 };
+
             // if adding notes, add above the upNote of the current chord
             Element* el = score()->selection().element();
             if (addFlag && el && el->type() == Element::Type::NOTE) {
                   Chord* chord = static_cast<Note*>(el)->chord();
                   Note* n = chord->upNote();
                   octave = n->epitch() / 12;
-                  if (note < n->epitch() / (octave * 7))
+                  if (tab[note] < n->epitch() % 12)
                         octave++;
                   }
             else {
@@ -4937,7 +4939,6 @@ void ScoreView::cmdAddPitch(int note, bool addFlag)
                         octave = curPitch / 12;
                         }
 
-                  static const int tab[] = { 0, 2, 4, 5, 7, 9, 11 };
                   int delta = octave * 12 + tab[note] - curPitch;
                   if (delta > 6)
                         --octave;


### PR DESCRIPTION
The current algorithm for deciding on the octave for Shift+letter in note entry is a bit buggy.  The comment suggests it should add a note above the top note, but in practicew, it sometimes comes out above, sometimes below.  My change here fixes the code to do what it says it will do.

it's somewhat of an open question to me if this is actually the *best* thing to do - some might prefer a "closest-to most-recently-entered-note" approach.  So D Shift+C would enter the C below the D rather than above.  But it seems clear from the comment in the code and from how we choose the cotave for the *next* chord (when typing a letter *without* shift) that the algorithm is intended to optimize the case of building chords bottom-up, so I am thinking we might as well actually do that.