### PR TITLE
fix #44916: crash on edit element without grips

### DIFF
--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -127,6 +127,7 @@ void ScoreView::endEdit()
 
       editObject = nullptr;
       grips      = 0;
+      curGrip    = Grip::NO_GRIP;
       }
 
 //---------------------------------------------------------

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -284,7 +284,7 @@ void ScoreView::editKey(QKeyEvent* ev)
       ed.view    = this;
       ed.hRaster = mscore->hRaster();
       ed.vRaster = mscore->vRaster();
-      if (curGrip != Grip::NO_GRIP)
+      if (curGrip != Grip::NO_GRIP && int(curGrip) < grips)
             ed.pos = grip[int(curGrip)].center() + delta;
       editObject->editDrag(ed);
       updateGrips();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1230,6 +1230,7 @@ void ScoreView::updateGrips()
       for (QRectF& gr : grip)
             gr = r;
 
+      defaultGrip = Grip::NO_GRIP;  // will be set by updateGrips for elements with grips
       editObject->updateGrips(&defaultGrip, grip);
 
       // updateGrips returns grips in page coordinates,


### PR DESCRIPTION
The change in Scoreview::updateGrips() is the "real" fix here - making sure curGrip is set to Grip::NO_GRIP when editing an element without grips.  The other two changes are just sanity checks.