### PR TITLE
fix some window shortcuts

### DIFF
--- a/mscore/masterpalette.cpp
+++ b/mscore/masterpalette.cpp
@@ -60,6 +60,18 @@ void MuseScore::showMasterPalette(const QString& s)
             connect(masterPalette, SIGNAL(closed(bool)), a, SLOT(setChecked(bool)));
             mscore->stackUnder(masterPalette);
             }
+      // when invoked via other actions, the main "masterpalette" action is not toggled automatically
+      if (!s.isEmpty()) {
+            // display if not already
+            if (!a->isChecked())
+                  a->setChecked(true);
+            else {
+                  // master palette is open; close only if command match current item
+                  if (s == masterPalette->selectedItem())
+                        a->setChecked(false);
+                  // otherwise switch tabs
+                  }
+            }
       masterPalette->setVisible(a->isChecked());
       if (!s.isEmpty())
             masterPalette->selectItem(s);
@@ -94,6 +106,15 @@ void MasterPalette::selectItem(const QString& s)
                   break;
                   }
             }
+      }
+
+//---------------------------------------------------------
+//   selectedItem
+//---------------------------------------------------------
+
+QString MasterPalette::selectedItem()
+      {
+      return listWidget->currentItem()->text();
       }
 
 //---------------------------------------------------------

--- a/mscore/masterpalette.h
+++ b/mscore/masterpalette.h
@@ -43,6 +43,7 @@ class MasterPalette : public QWidget, Ui::MasterPalette
    public:
       MasterPalette(QWidget* parent = 0);
       void selectItem(const QString& s);
+      QString selectedItem();
       };
 
 } // namespace Ms

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2651,21 +2651,30 @@ Shortcut Shortcut::_sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "key-signatures",
          QT_TRANSLATE_NOOP("action","Key Signatures..."),
-         QT_TRANSLATE_NOOP("action","Show key signature palette")
+         QT_TRANSLATE_NOOP("action","Show key signature palette"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::ApplicationShortcut
          },
       {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "time-signatures",
          QT_TRANSLATE_NOOP("action","Time Signatures..."),
-         QT_TRANSLATE_NOOP("action","Show time signature palette")
+         QT_TRANSLATE_NOOP("action","Show time signature palette"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::ApplicationShortcut
          },
       {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "symbols",
          QT_TRANSLATE_NOOP("action","Symbols..."),
-         QT_TRANSLATE_NOOP("action","Show symbol palette")
+         QT_TRANSLATE_NOOP("action","Show symbol palette"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::ApplicationShortcut
          },
       {
          MsWidget::MAIN_WINDOW,

--- a/mscore/startcenter.cpp
+++ b/mscore/startcenter.cpp
@@ -30,6 +30,7 @@ void MuseScore::showStartcenter(bool val)
             startcenter->addAction(a);
             startcenter->readSettings(settings);
             connect(startcenter, SIGNAL(closed(bool)), a, SLOT(setChecked(bool)));
+            connect(startcenter, SIGNAL(rejected()), a, SLOT(toggle()));
             }
       startcenter->setVisible(val);
       }


### PR DESCRIPTION
First commit fixes Shift+K, Shift+T, and Z shortcuts to open key signature, time signature, and symbols portion of master palette.  This was working at one time, stopped working when the master palette command was made into a toggle.  The connection wasn't being made between these shortcuts and the main "masterpalette" action.  Fixed to these shortcuts toggle the master palette just as the regular Shift+F9 shortcut does - with the added bonus that if the window is already open but to a different tab, these shortcuts will change to the specified tab rather than the close the window.

Second commit fixes a related issue I've noticed a while now, where F4 doesn't always bring up start center - sometimes it takes two presses.  Turns out this was because pressing Esc wasn't clearing the checked state of the action (going to View menu after closing start center via Esc shows it still checked).