### PR TITLE
Update Gootville to version 1.12 of SMuFL and Bravura 1.12

### DIFF
--- a/fonts/gootville/readme.txt
+++ b/fonts/gootville/readme.txt
@@ -3,7 +3,7 @@ GOOTVILLE 1.0 SMuFL - README
 
 This font is designed by Grzegorz Pruchniakowski and licensed under the SIL Open Font License (http://scripts.sil.org/OFL).
 
-The Gootville font templates based on SMuFL 1.0 and Bravura 1.02, designed by Daniel Spreadbury at Steinberg.
+The Gootville font templates based on SMuFL 1.12 and Bravura 1.12, designed by Daniel Spreadbury at Steinberg.
 
 Please inform me when you modify the font files.
 


### PR DESCRIPTION
https://onedrive.live.com/redir?resid=2CA050E53852F58F!2684&authkey=!ALThTHOKUxfXExk&ithint=folder%2cjson

This is a link to Gootville fonts in my OneDrive. Please add these files to MuseScore repository. The newest versions of Gootville will always be here.

Changes:
 - updated to SMuFL 1.12 and Bravura 1.12
 - sizes of Codas, Segnos and Ottavas in GootvilleText.otf - now are the same as in Gootville.otf

Greetings,
Gootector