### PR TITLE
fix #45776: crash on select to end score with mmrest

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1938,13 +1938,13 @@ Element* Score::selectMove(const QString& cmd)
             el = measure->last()->nextChordRest(cr->track(), true);
             }
       else if (cmd == "select-begin-score") {
-            Measure* measure = first()->system()->firstMeasure();
+            Measure* measure = firstMeasureMM();
             if (!measure)
                   return 0;
             el = measure->first()->nextChordRest(cr->track());
             }
       else if (cmd == "select-end-score") {
-            Measure* measure = last()->system()->lastMeasure();
+            Measure* measure = lastMeasureMM();
             if (!measure)
                   return 0;
             el = measure->last()->nextChordRest(cr->track(), true);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1675,9 +1675,11 @@ Measure* Score::lastMeasure() const
 Measure* Score::lastMeasureMM() const
       {
       Measure* m = lastMeasure();
-      Measure* m1 = const_cast<Measure*>(m->mmRest1());
-      if (m1)
-           return m1;
+      if (m && styleB(StyleIdx::createMultiMeasureRests)) {
+            Measure* m1 = const_cast<Measure*>(m->mmRest1());
+            if (m1)
+                  return m1;
+            }
       return m;
       }
 


### PR DESCRIPTION
The original code crashed if the last measure had not been laid out yet - if it was within an mmrest and had been ever since the score was loaded.  I don't understand what the point ofthe original code was supposed to be, but looking at the rest of the selectMove() function, all of the other options use mmrests, and I don't see any reason we can't just use lastMeasureMM() here.  Ditto with firstMeasureMM() when selecting to start of score.

A bonus: selecting the mmrest as I do here fixes a glitch were the score would scroll offscreen upon selecting to end of score, as it it was attempting to position the canvas to the last known location of the "real" last measure, which isn't even visible currently.