### PR TITLE
Better Ms instrument search for MIDI import

### DIFF
--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -890,6 +890,32 @@ std::vector<const InstrumentTemplate *> findInstrumentsForProgram(const MTrack &
                               }
                         }
                   }
+            else if (program >= 80 && program <= 103) {
+                  for (const InstrumentGroup *group: instrumentGroups) {
+                        if (group->id == "electronic-instruments") {
+                              for (const InstrumentTemplate *templ: group->instrumentTemplates) {
+                                    if (templ->id == "effect-synth") {       // generic synth
+                                          suitableTemplates.push_back(templ);
+                                          break;
+                                          }
+                                    }
+                              break;
+                              }
+                        }
+                  }
+            else if (program >= 112 && program <= 127) {
+                  for (const InstrumentGroup *group: instrumentGroups) {
+                        if (group->id == "unpitched-percussion") {
+                              for (const InstrumentTemplate *templ: group->instrumentTemplates) {
+                                    if (templ->id == "snare-drum") {         // 1-line percussion staff
+                                          suitableTemplates.push_back(templ);
+                                          break;
+                                          }
+                                    }
+                              break;
+                              }
+                        }
+                  }
             else {          // find instrument with maximum MIDI program
                             // that is less than the track MIDI program, i.e. suitable instrument
                   int maxLessProgram = -1;

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -826,6 +826,24 @@ bool hasNotDefinedDrumPitch(const std::set<int> &trackPitches, const std::set<in
       return hasNotDefinedPitch;
       }
 
+const InstrumentTemplate* findInstrument(const QString &groupId, const QString &instrId)
+      {
+      const InstrumentTemplate* instr = nullptr;
+
+      for (const InstrumentGroup *group: instrumentGroups) {
+            if (group->id == groupId) {
+                  for (const InstrumentTemplate *templ: group->instrumentTemplates) {
+                        if (templ->id == instrId) {
+                              instr = templ;
+                              break;
+                              }
+                        }
+                  break;
+                  }
+            }
+      return instr;
+      }
+
 std::vector<const InstrumentTemplate *> findInstrumentsForProgram(const MTrack &track)
       {
       std::vector<const InstrumentTemplate *> suitableTemplates;
@@ -865,56 +883,24 @@ std::vector<const InstrumentTemplate *> findInstrumentsForProgram(const MTrack &
                   // so we will find the most matching instrument
 
             if (program == 55) {         // GM "Orchestra Hit" sound
-                  for (const InstrumentGroup *group: instrumentGroups) {
-                        if (group->id == "electronic-instruments") {
-                              for (const InstrumentTemplate *templ: group->instrumentTemplates) {
-                                    if (templ->id == "brass-synthesizer") {
-                                          suitableTemplates.push_back(templ);
-                                          break;
-                                          }
-                                    }
-                              break;
-                              }
-                        }
+                  auto instr = findInstrument("electronic-instruments", "brass-synthesizer");
+                  if (instr)
+                        suitableTemplates.push_back(instr);
                   }
             else if (program == 110) {        // GM "Fiddle" sound
-                  for (const InstrumentGroup *group: instrumentGroups) {
-                        if (group->id == "strings") {
-                              for (const InstrumentTemplate *templ: group->instrumentTemplates) {
-                                    if (templ->id == "violin") {
-                                          suitableTemplates.push_back(templ);
-                                          break;
-                                          }
-                                    }
-                              break;
-                              }
-                        }
+                  auto instr = findInstrument("strings", "violin");
+                  if (instr)
+                        suitableTemplates.push_back(instr);
                   }
             else if (program >= 80 && program <= 103) {
-                  for (const InstrumentGroup *group: instrumentGroups) {
-                        if (group->id == "electronic-instruments") {
-                              for (const InstrumentTemplate *templ: group->instrumentTemplates) {
-                                    if (templ->id == "effect-synth") {       // generic synth
-                                          suitableTemplates.push_back(templ);
-                                          break;
-                                          }
-                                    }
-                              break;
-                              }
-                        }
+                  auto instr = findInstrument("electronic-instruments", "effect-synth");
+                  if (instr)
+                        suitableTemplates.push_back(instr);       // generic synth
                   }
             else if (program >= 112 && program <= 127) {
-                  for (const InstrumentGroup *group: instrumentGroups) {
-                        if (group->id == "unpitched-percussion") {
-                              for (const InstrumentTemplate *templ: group->instrumentTemplates) {
-                                    if (templ->id == "snare-drum") {         // 1-line percussion staff
-                                          suitableTemplates.push_back(templ);
-                                          break;
-                                          }
-                                    }
-                              break;
-                              }
-                        }
+                  auto instr = findInstrument("unpitched-percussion", "snare-drum");
+                  if (instr)
+                        suitableTemplates.push_back(instr);       // 1-line percussion staff
                   }
             else {          // find instrument with maximum MIDI program
                             // that is less than the track MIDI program, i.e. suitable instrument

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -921,21 +921,6 @@ std::vector<InstrumentTemplate *> findSuitableInstruments(const MTrack &track)
 
       const std::pair<int, int> minMaxPitch = findMinMaxPitch(track);
       sortInstrumentTemplates(templates, minMaxPitch);
-                  // instruments here are sorted primarily by valid pitch range difference,
-                  // so first nonzero difference means that current
-                  // and all successive instruments are unsuitable;
-                  // but if all instruments are unsuitable then leave them all in list
-      for (auto it = templates.begin(); it != templates.end(); ++it) {
-            const int diff = findMaxPitchDiff(minMaxPitch, *it);
-            if (diff > 0) {
-                  if (it != templates.begin())
-                        templates.erase(it, templates.end());
-                  else              // add empty template option
-                        templates.push_back(nullptr);
-                  break;
-                  }
-            }
-
       return templates;
       }
 

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -927,6 +927,17 @@ std::vector<const InstrumentTemplate *> findInstrumentsForProgram(const MTrack &
                   if (instr)
                         suitableTemplates.push_back(instr);       // 1-line percussion staff
                   }
+            else if (program == 36 || program == 37) {
+                              // slightly improve slap bass match:
+                              // match to the instruments with program 33
+                              // instead of 35 according to the algorithm below
+                  auto instr = findInstrument("plucked-strings", "electric-bass");
+                  if (instr)
+                        suitableTemplates.push_back(instr);
+                  instr = findInstrument("plucked-strings", "5-string-electric-bass");
+                  if (instr)
+                        suitableTemplates.push_back(instr);
+                  }
             else {          // find instrument with maximum MIDI program
                             // that is less than the track MIDI program, i.e. suitable instrument
                   auto instr = findClosestInstrument(track);

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -974,6 +974,15 @@ int findMaxPitchDiff(const std::pair<int, int> &minMaxPitch, const InstrumentTem
       return diff;
       }
 
+bool hasCommonGenre(QList<InstrumentGenre *> genres)
+      {
+      for (InstrumentGenre *genre: genres) {
+            if (genre->id == "common")
+                  return true;
+            }
+      return false;
+      }
+
 void sortInstrumentTemplates(
             std::vector<const InstrumentTemplate *> &templates,
             const std::pair<int, int> &minMaxPitch)
@@ -991,6 +1000,13 @@ void sortInstrumentTemplates(
             if (templ1->drumset && !templ2->drumset)
                   return true;
             if (!templ1->drumset && templ2->drumset)
+                  return false;
+                        // prefer instruments with the "common" genre
+            const bool hasCommon1 = hasCommonGenre(templ1->genres);
+            const bool hasCommon2 = hasCommonGenre(templ2->genres);
+            if (hasCommon1 && !hasCommon2)
+                  return true;
+            if (!hasCommon1 && hasCommon2)
                   return false;
             return templ1->genres.size() > templ2->genres.size();
             });

--- a/mscore/importmidi/importmidi_model.cpp
+++ b/mscore/importmidi/importmidi_model.cpp
@@ -21,7 +21,6 @@ class TracksModel::Column
       virtual int width() const { return -1; }
       virtual bool isEditable(int /*trackIndex*/) const { return true; }
       virtual bool isForAllTracksOnly() const { return false; }
-      virtual QVariant textColor(int /*trackIndex*/) const { return QVariant(); }
 
    protected:
       MidiOperations::Opers &_opers;
@@ -181,23 +180,6 @@ void TracksModel::reset(const MidiOperations::Opers &opers,
                         for (const InstrumentTemplate *instr: trackInstrList)
                               list.append(instrName(instr));
                         return list;
-                        }
-                  QVariant textColor(int trackIndex) const override
-                        {
-                        const auto &trackInstrList = _opers.msInstrList.value(trackIndex);
-                        if (trackInstrList.empty())
-                              return QVariant();         // default color
-                        const int instrIndex = _opers.msInstrIndex.value(trackIndex);
-                              // if the last instrument is empty - notes of each instrument
-                              // are out of corresponding "amateur" pitch range
-                              // (see suitable instruments search code in importmidi.cpp)
-                        const bool isValid = (trackInstrList.back() != nullptr);
-                        const bool isLastIndex = (instrIndex == (int)trackInstrList.size() - 1);
-                              // if the current instrument does not fit in pitch range
-                              // and insrument index is not last in the list
-                              // (which is empty instrument "-")
-                              // then show the "invalid" instrument in red
-                        return (!isValid && !isLastIndex) ? QBrush(Qt::red) : QVariant();
                         }
 
                private:
@@ -905,12 +887,6 @@ QVariant TracksModel::data(const QModelIndex &index, int role) const
                               }
                         }
                   break;
-            case Qt::ForegroundRole:
-                  if (_columns[index.column()]->isVisible(trackIndex)) {
-                        const QVariant color = _columns[index.column()]->textColor(trackIndex);
-                        if (color.type() == QVariant::Brush)
-                              return color;
-                        }
             case Qt::SizeHintRole:
                   return QSize(_columns[index.column()]->width(), -1);
                   break;

--- a/mscore/importmidi/importmidi_operations.h
+++ b/mscore/importmidi/importmidi_operations.h
@@ -132,8 +132,9 @@ struct Opers
       TrackOp<int> channel = TrackOp<int>(int());
       TrackOp<std::string> staffName = TrackOp<std::string>(std::string());       // will be converted to unicode later
       TrackOp<QString> midiInstrName = TrackOp<QString>(QString());
-      TrackOp<std::vector<InstrumentTemplate *> > msInstrList
-            = TrackOp<std::vector<InstrumentTemplate *> >(std::vector<InstrumentTemplate *>());
+      TrackOp<std::vector<const InstrumentTemplate *> > msInstrList
+                        = TrackOp<std::vector<const InstrumentTemplate *> >(
+                                              std::vector<const InstrumentTemplate *>());
       TrackOp<bool> isDrumTrack = TrackOp<bool>(false);
 
                   // operations for all tracks

--- a/mtest/importmidi/perc_no_grand_staff.mscx
+++ b/mtest/importmidi/perc_no_grand_staff.mscx
@@ -100,15 +100,16 @@
       </Part>
     <Part>
       <Staff id="2">
-        <StaffType group="percussion">
-          <name>perc5Line</name>
-          <keysig>0</keysig>
+        <StaffType group="pitched">
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Percussion</trackName>
       <Instrument>
         <longName pos="0">Percussion</longName>
-        <trackName></trackName>
+        <shortName pos="0">Drs.</shortName>
+        <trackName>Drumset</trackName>
+        <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="35">
           <head>0</head>
@@ -292,6 +293,35 @@
           <name>Low Conga</name>
           <stem>1</stem>
           </Drum>
+        <clef>PERC</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
           <program value="16"/>
@@ -334,10 +364,6 @@
       </Staff>
     <Staff id="2">
       <Measure number="1">
-        <Clef>
-          <concertClefType>PERC</concertClefType>
-          <transposingClefType>PERC</transposingClefType>
-          </Clef>
         <TimeSig>
           <sigN>12</sigN>
           <sigD>8</sigD>

--- a/mtest/importmidi/perc_respect_beat.mscx
+++ b/mtest/importmidi/perc_respect_beat.mscx
@@ -42,15 +42,16 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="percussion">
-          <name>perc5Line</name>
-          <keysig>0</keysig>
+        <StaffType group="pitched">
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Percussion</trackName>
       <Instrument>
         <longName pos="0">Percussion</longName>
-        <trackName></trackName>
+        <shortName pos="0">Drs.</shortName>
+        <trackName>Drumset</trackName>
+        <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="35">
           <head>0</head>
@@ -234,6 +235,35 @@
           <name>Low Conga</name>
           <stem>1</stem>
           </Drum>
+        <clef>PERC</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
           <program value="51"/>
@@ -242,10 +272,6 @@
       </Part>
     <Staff id="1">
       <Measure number="1">
-        <Clef>
-          <concertClefType>PERC</concertClefType>
-          <transposingClefType>PERC</transposingClefType>
-          </Clef>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>

--- a/mtest/importmidi/perc_triplet.mscx
+++ b/mtest/importmidi/perc_triplet.mscx
@@ -42,15 +42,16 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="percussion">
-          <name>perc5Line</name>
-          <keysig>0</keysig>
+        <StaffType group="pitched">
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Percussion</trackName>
       <Instrument>
         <longName pos="0">Percussion</longName>
-        <trackName></trackName>
+        <shortName pos="0">Drs.</shortName>
+        <trackName>Drumset</trackName>
+        <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="35">
           <head>0</head>
@@ -234,6 +235,35 @@
           <name>Low Conga</name>
           <stem>1</stem>
           </Drum>
+        <clef>PERC</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
           <program value="51"/>
@@ -242,10 +272,6 @@
       </Part>
     <Staff id="1">
       <Measure number="1">
-        <Clef>
-          <concertClefType>PERC</concertClefType>
-          <transposingClefType>PERC</transposingClefType>
-          </Clef>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>

--- a/mtest/importmidi/perc_tuplet_simplify2.mscx
+++ b/mtest/importmidi/perc_tuplet_simplify2.mscx
@@ -42,15 +42,16 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="percussion">
-          <name>perc5Line</name>
-          <keysig>0</keysig>
+        <StaffType group="pitched">
           </StaffType>
+        <defaultClef>PERC</defaultClef>
         </Staff>
       <trackName>Percussion</trackName>
       <Instrument>
         <longName pos="0">Percussion</longName>
-        <trackName></trackName>
+        <shortName pos="0">Drs.</shortName>
+        <trackName>Drumset</trackName>
+        <instrumentId>drum.group.set</instrumentId>
         <useDrumset>1</useDrumset>
         <Drum pitch="35">
           <head>0</head>
@@ -234,6 +235,35 @@
           <name>Low Conga</name>
           <stem>1</stem>
           </Drum>
+        <clef>PERC</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
           <program value="21"/>
@@ -242,10 +272,6 @@
       </Part>
     <Staff id="1">
       <Measure number="1">
-        <Clef>
-          <concertClefType>PERC</concertClefType>
-          <transposingClefType>PERC</transposingClefType>
-          </Clef>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>


### PR DESCRIPTION
It's an implementation of the Marc Sabatella’s algorithm for Ms instrument matching 
to MIDI programs that are not listed in instruments.xml file.

For more detailes see http://musescore.org/en/node/44556.

Also red font color for out of pitch range instruments on the MIDI import panel was removed.