### PR TITLE
Limit the effects of escape.

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -963,7 +963,7 @@ Shortcut Shortcut::_sc[] = {
          ShortcutFlags::A_CMD
          },
       {
-         MsWidget::MAIN_WINDOW,
+         MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT | STATE_LYRICS_EDIT
             | STATE_HARMONY_FIGBASS_EDIT | STATE_PLAY | STATE_FOTO,
          "escape",


### PR DESCRIPTION
If the focus is not in score, Esc will shift the focus to the
score, but without deselecting everything.
If the focus is in score, it will deselect everything.