### PR TITLE
Fix palette taking keyboard focus.

### DIFF
--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -180,6 +180,7 @@ void ScoreAccessibility::updateAccessibilityInfo()
       if ( (qApp->focusWidget() != w) &&
            !mscore->inspector()->isAncestorOf(qApp->focusWidget()) &&
            !(mscore->searchDialog() && mscore->searchDialog()->isAncestorOf(qApp->focusWidget())) ) {
+            mscore->activateWindow();
             w->setFocus();
             }
       QObject* obj = static_cast<QObject*>(w);


### PR DESCRIPTION
After adding an element to the score using the palette, the focus will go back to the score even if the palette is undocked.
The problem was that the undocked palette was seen as a different window and it was activated by clicking on it. Calling setFocus from the main window was not enough since it wasn't the active window resulting in the call being ignored.
http://musescore.org/en/node/45331