### PR TITLE
fix #37191: playback of breath & section break pauses

### DIFF
--- a/libmscore/breath.cpp
+++ b/libmscore/breath.cpp
@@ -35,6 +35,7 @@ Breath::Breath(Score* s)
   : Element(s)
       {
       _breathType = 0;
+      _pause = 0.0;
       setFlags(ElementFlag::MOVABLE | ElementFlag::SELECTABLE);
       }
 
@@ -57,6 +58,7 @@ void Breath::write(Xml& xml) const
             return;
       xml.stag("Breath");
       xml.tag("subtype", _breathType);
+      writeProperty(xml, P_ID::PAUSE);
       Element::writeProperties(xml);
       xml.etag();
       }
@@ -68,8 +70,11 @@ void Breath::write(Xml& xml) const
 void Breath::read(XmlReader& e)
       {
       while (e.readNextStartElement()) {
-            if (e.name() == "subtype")
+            const QStringRef& tag(e.name());
+            if (tag == "subtype")
                   _breathType = e.readInt();
+            else if (tag == "pause")
+                  _pause = e.readDouble();
             else if (!Element::readProperties(e))
                   e.unknown();
             }
@@ -107,6 +112,55 @@ QPointF Breath::pagePos() const
       if (system)
             yp += system->staff(staffIdx())->y() + system->y();
       return QPointF(pageX(), yp);
+      }
+
+//---------------------------------------------------------
+//   getProperty
+//---------------------------------------------------------
+
+QVariant Breath::getProperty(P_ID propertyId) const
+      {
+      switch(propertyId) {
+            case P_ID::PAUSE:
+                  return _pause;
+            default:
+                  return Element::getProperty(propertyId);
+            }
+      }
+
+//---------------------------------------------------------
+//   setProperty
+//---------------------------------------------------------
+
+bool Breath::setProperty(P_ID propertyId, const QVariant& v)
+      {
+      switch(propertyId) {
+            case P_ID::PAUSE:
+                  setPause(v.toDouble());
+                  score()->addLayoutFlags(LayoutFlag::FIX_TICKS);
+                  break;
+            default:
+                  if (!Element::setProperty(propertyId, v))
+                        return false;
+                  break;
+            }
+      score()->setLayoutAll(true);
+      setGenerated(false);
+      return true;
+      }
+
+//---------------------------------------------------------
+//   propertyDefault
+//---------------------------------------------------------
+
+QVariant Breath::propertyDefault(P_ID id) const
+      {
+      switch(id) {
+            case P_ID::PAUSE:
+                  return 0.0;
+            default:
+                  return Element::propertyDefault(id);
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/breath.h
+++ b/libmscore/breath.h
@@ -30,6 +30,7 @@ class Breath : public Element {
       Q_OBJECT
 
       int _breathType;
+      qreal _pause;
       static const int breathSymbols = 4;
       static SymId symList[breathSymbols];
 
@@ -40,6 +41,8 @@ class Breath : public Element {
 
       int breathType() const           { return _breathType; }
       void setBreathType(int v)        { _breathType = v; }
+      qreal pause() const              { return _pause; }
+      void setPause(qreal v)           { _pause = v; }
 
       Segment* segment() const         { return (Segment*)parent(); }
       virtual Space space() const override;
@@ -49,6 +52,10 @@ class Breath : public Element {
       virtual void write(Xml&) const override;
       virtual void read(XmlReader&) override;
       virtual QPointF pagePos() const override;      ///< position in page coordinates
+
+      virtual QVariant getProperty(P_ID propertyId) const override;
+      virtual bool setProperty(P_ID propertyId, const QVariant&) override;
+      virtual QVariant propertyDefault(P_ID) const override;
 
       virtual Element* nextElement() override;
       virtual Element* prevElement() override;

--- a/libmscore/layoutbreak.cpp
+++ b/libmscore/layoutbreak.cpp
@@ -231,6 +231,7 @@ bool LayoutBreak::setProperty(P_ID propertyId, const QVariant& v)
                   break;
             case P_ID::PAUSE:
                   setPause(v.toDouble());
+                  score()->addLayoutFlags(LayoutFlag::FIX_TICKS);
                   break;
             default:
                   if (!Element::setProperty(propertyId, v))

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1419,7 +1419,7 @@ qDebug("drop staffList");
                               }
                         break;
                         }
-                  lb->setTrack(-1);       // this are system elements
+                  lb->setTrack(-1);       // these are system elements
                   lb->setParent(this);
                   score()->undoAddElement(lb);
                   return lb;

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -160,7 +160,8 @@ void MeasureBase::remove(Element* el)
                         break;
                   case LayoutBreak::Type::SECTION:
                         _sectionBreak = 0;
-                        score()->tempomap()->setPause(endTick(), 0);
+                        score()->setPause(endTick(), 0);
+                        score()->addLayoutFlags(LayoutFlag::FIX_TICKS);
                         score()->setLayoutAll(true);
                         break;
                   }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -68,6 +68,7 @@
 #include "cursor.h"
 #include "sym.h"
 #include "rehearsalmark.h"
+#include "breath.h"
 
 namespace Ms {
 
@@ -501,7 +502,7 @@ void Score::fixTicks()
                   //
                   //  implement section break rest
                   //
-                  if (m->sectionBreak())
+                  if (m->sectionBreak() && m->pause() != 0.0)
                         setPause(m->tick() + m->ticks(), m->pause());
 
                   //
@@ -509,8 +510,24 @@ void Score::fixTicks()
                   //
 
                   for (Segment* s = m->first(); s; s = s->next()) {
-                        if (s->segmentType() == Segment::Type::Breath)
-                              setPause(s->tick(), .1);
+                        if (s->segmentType() == Segment::Type::Breath) {
+                              qreal length = 0.0;
+                              int tick = s->tick();
+                              // find breath elements
+                              for (int i = 0, n = ntracks(); i < n; ++i) {
+                                    Element* e = s->element(i);
+                                    if (e && e->type() == Element::Type::BREATH) {
+                                          Breath* b = static_cast<Breath*>(e);
+                                          length = qMax(length, b->pause());
+                                          // find start tick of next note
+                                          // currently, breaths are always added in voice 0
+                                          Segment* next = s->nextCR(i);
+                                          tick = qMax(tick, next->tick());
+                                          }
+                                    }
+                              if (length != 0.0)
+                                    setPause(tick, length);
+                              }
                         else if (s->segmentType() == Segment::Type::TimeSig) {
                               for (int staffIdx = 0; staffIdx < _staves.size(); ++staffIdx) {
                                     TimeSig* ts = static_cast<TimeSig*>(s->element(staffIdx * VOICES));
@@ -1456,6 +1473,13 @@ void Score::addElement(Element* element)
                   if (cr->type() == Element::Type::CHORD)
                          createPlayEvents(static_cast<Chord*>(cr));
                   }
+                  break;
+            case Element::Type::BREATH:
+                  addLayoutFlags(LayoutFlag::FIX_TICKS);
+                  break;
+            case Element::Type::LAYOUT_BREAK:
+                  if (static_cast<LayoutBreak*>(element)->layoutBreakType() == LayoutBreak::Type::SECTION)
+                        addLayoutFlags(LayoutFlag::FIX_TICKS);
                   break;
             default:
                   break;

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -602,9 +602,15 @@ void Segment::remove(Element* el)
                   // fall through
 
             case Element::Type::BAR_LINE:
-            case Element::Type::BREATH:
             case Element::Type::AMBITUS:
                   _elist[track] = 0;
+                  break;
+
+            case Element::Type::BREATH:
+                  _elist[track] = 0;
+                  score()->setPause(tick(), 0);
+                  score()->addLayoutFlags(LayoutFlag::FIX_TICKS);
+                  score()->setLayoutAll(true);
                   break;
 
             default:

--- a/libmscore/tempo.h
+++ b/libmscore/tempo.h
@@ -17,14 +17,17 @@ namespace Ms {
 
 class Xml;
 
-enum class TempoType : char { INVALID, FIX, RAMP };
+enum class TempoType : char { INVALID = 0x0, PAUSE = 0x1, FIX = 0x2, RAMP = 0x4};
+
+typedef QFlags<TempoType> TempoTypes;
+Q_DECLARE_OPERATORS_FOR_FLAGS(TempoTypes);
 
 //---------------------------------------------------------
 //   Tempo Event
 //---------------------------------------------------------
 
 struct TEvent {
-      TempoType type;
+      TempoTypes type;
       qreal tempo;     // beats per second
       qreal pause;     // pause in seconds
       qreal time;      // precomputed time for tick in sec
@@ -32,7 +35,7 @@ struct TEvent {
       TEvent();
       TEvent(const TEvent& e);
       TEvent(qreal bps, qreal seconds, TempoType t);
-      bool valid() const { return type != TempoType::INVALID; }
+      bool valid() const;
       };
 
 //---------------------------------------------------------

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2028,6 +2028,10 @@ void ChangeElement::flip()
             }
       else if (newElement->type() == Element::Type::DYNAMIC)
             newElement->score()->addLayoutFlags(LayoutFlag::FIX_PITCH_VELO);
+      else if (newElement->type() == Element::Type::LAYOUT_BREAK && static_cast<LayoutBreak*>(newElement)->layoutBreakType() == LayoutBreak::Type::SECTION)
+            newElement->score()->addLayoutFlags(LayoutFlag::FIX_TICKS);
+      else if (newElement->type() == Element::Type::BREATH)
+            newElement->score()->addLayoutFlags(LayoutFlag::FIX_TICKS);
       else if (newElement->type() == Element::Type::TEMPO_TEXT) {
             TempoText* t = static_cast<TempoText*>(oldElement);
             score->setTempo(t->segment(), t->tempo());

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -599,10 +599,13 @@ Palette* MuseScore::newBreathPalette()
                   continue;
             Breath* a = new Breath(gscore);
             a->setBreathType(i);
-            if (i < 2)
+            if (i < 2) {
                   sp->append(a, tr("Breath"));
-            else
+                  }
+            else {
                   sp->append(a, tr("Caesura"));
+                  a->setPause(2.0);
+                  }
             }
       return sp;
       }


### PR DESCRIPTION
Turns out this was a bit of a can of worms - the basic support for playback of pauses (breaths, caesuras, section breaks) has long been present, but there were quite a few interrelated problems with the implementation.  This PR fixes everything I could find that was not working well, and puts the framework in place - but no UI yet - for customizing the length of breaths and caesuras.

The basic issues I saw and fixed include:

1. breath/caesura & section break playback not honored on add until next rebuild of tempo map
2. same for removal, and undo of either add or removal
3. breath playback comes the note it follows, not after
4. when adding tempo changes, the tempo reverts to original at next pause
5. having both a pause and a tempo change on same tick caused them to adversely affect each other
6. breath playback too long (should not actually pause); caesura too short

The fixes are mostly quite innocuous - setting LayoutFlag::FIX_TICKS in a few key places, calculating proper tick for breath/caesura playback.  The two most noteworthy changes are:

- breaths & pause now get PAUSE property like section breaks do, with full read/write support (meaning a slight format change; files using new caesuras won't load in older builds - I didn't bump the version number yet though)

- tempo map event altered slightly to record type as a set of flags rather a plain enum.  I use this to track which events were created via setTempo() versus setPause() during normalize() and del(), to make sure the different types of tempo events don't interfere with each other (see 4 & 5 above).  This is the one section of code that deserves review the most, as they are the only changes that I could see breaking anything if I got something wrong.