### PR TITLE
fix #45921: dash removes wrong melisma

### DIFF
--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -248,6 +248,7 @@ void ScoreView::lyricsMinus()
                         oldLyrics->undoChangeProperty(P_ID::SYLLABIC, int(Lyrics::Syllabic::MIDDLE));
                         break;
                   }
+            oldLyrics->undoChangeProperty(P_ID::LYRIC_TICKS, 0);
             }
 
       if (newLyrics)
@@ -413,33 +414,8 @@ void ScoreView::lyricsReturn()
 void ScoreView::lyricsEndEdit()
       {
       Lyrics* lyrics = static_cast<Lyrics*>(editObject);
-      int endTick    = lyrics->segment()->tick();
-
-      // search previous lyric:
-      int verse = lyrics->no();
-      int track = lyrics->track();
-
-      // search previous lyric
-      Lyrics* oldLyrics = 0;
-      Segment* segment  = lyrics->segment();
-      while (segment) {
-            const QList<Lyrics*>* nll = segment->lyricsList(track);
-            if (nll) {
-                  oldLyrics = nll->value(verse);
-                  if (oldLyrics)
-                        break;
-                  }
-            segment = segment->prev1(Segment::Type::ChordRest);
-            }
-
       if (lyrics->isEmpty())
             lyrics->parent()->remove(lyrics);
-      else {
-            if (oldLyrics && oldLyrics->syllabic() == Lyrics::Syllabic::END) {
-                  if (oldLyrics->endTick() >= endTick)
-                        oldLyrics->undoChangeProperty(P_ID::LYRIC_TICKS, 0);
-                  }
-            }
       }
 
 }


### PR DESCRIPTION
Typing a dash while editing lyrics has exactly the wrong effect with respect to exist melismas: it deletes a melisma line on the syllable you are *approaching* (if you then hit Esc without editing that syllable), but it does not delete a melisma on the syllable you are *leaving* (unless that syllable happen to be preceded by a hyphen).  It's been like this since 1.3.

@mgavioli : does the code I am removing here look familiar?  I believe this is the code that caused pressing "space" to delete melisma lines, but only for Italian (multi-syllable) words :-)  Pressing "dash" does the same - it removes a melisma line, but only for the last syllable of a multi-syllable word.  Let me know if you know of some reason this code shouldn't simply be removed as I have done here (replaced by the one line I added in ScoreView::lyricsMinus()), 