### PR TITLE
fix #46036: allow mid-measure clef change at start of bar

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2511,9 +2511,13 @@ void Score::removeGeneratedElements(Measure* sm, Measure* em)
                                     clef->setSmall(small);
                                     m->setDirty();
                                     }
+#if 0
                               //
                               // if measure is not the first in the system, the clef at
                               // measure start has to be moved to the end of the previous measure
+                              // TODO: DEBUG - is this code needed?
+                              // clefs should now be placed in correct measure when adding them (cmdInsertClef)
+                              // and it is good to support clefs at beginning of measures, for use in cues
                               //
                               if (s->firstMeasure() != m && seg->tick() == m->tick()) {
                                     undoRemoveElement(el);
@@ -2525,6 +2529,7 @@ void Score::removeGeneratedElements(Measure* sm, Measure* em)
                                     m->setDirty();
                                     pm->setDirty();
                                     }
+#endif
                               }
                         }
                   }


### PR DESCRIPTION
This code allows "mid-measure" clef changes at the start of a bar, regardless of whether that bar has a key signature or existing generated clef (start of system).  We were already allowing in some places but not others - adding a clef change to the first note of a measure with no key signature or clef automatically moved the clef to the previous measure.  This might seem a good idea, but supporting "mid-measure" clef change at the start of a measure is useful for cues, for example.  And I believe the *intent* is to support this for other reasons.  For example, see http://musescore.org/en/developers-handbook/scrapbook#More-flexible-clef-changes, which I believe is from the Open Goldberg project?  This PR should make the behavior more consistent.

Unfortunately, in testing my change, I discovered a couple of other bugs having to do with the clef implementation.  These bugs exist without or without my code, so this PR would be safe to merge as is, but it could make sense to hold off until perhaps all of these can be looked at together.  See:

http://musescore.org/en/node/46106
http://musescore.org/en/node/23254

The latter would be made worse by my code - basically, undoing any "mid-measure" clef change at the start of a system would create this same corruption of the clef map.

BTW, in the event we decide we don't wish to support these "mid-measure" clef changes at the start of a measure, I also fixed the code to be more consistent in moving them before the barline.  A single "#if" in cmd.cpp switches between the two behaviors.  The code I put in "#if 0" in layout.cpp was formerly used to do these moves in some cases, but I believe it to no longer be needed.  Even if we do want to move the clefs before the barline, the code in cmd.cpp should do this if enabled.