### PR TITLE
Fix #46141 : in TAB staves, the ghost note command does not toggle

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1969,7 +1969,7 @@ void Score::cmdMirrorNoteHead()
             if (e->type() == Element::Type::NOTE) {
                   Note* note = static_cast<Note*>(e);
                   if (note->staff() && note->staff()->isTabStaff())
-                        note->score()->undoChangeProperty(e, P_ID::GHOST, true);
+                        note->score()->undoChangeProperty(e, P_ID::GHOST, !note->ghost());
                   else {
                         MScore::DirectionH d = note->userMirror();
                         if (d == MScore::DirectionH::AUTO)


### PR DESCRIPTION
Fix #46141 : in TAB staves, the ghost note command does not toggle

The "Mirror note head" command, which in TAB staves is used to change notes into ghost notes, works as a toggle in standard staves but does not in TAB staves.

As a consequence, TAB notes turned into ghost notes cannot be turned back to normal state.