### PR TITLE
Accessibility for Search (goto) dialog.

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -263,7 +263,7 @@ add_executable ( ${ExecutableName}
       resourceManager.cpp downloadUtils.cpp
       textcursor.cpp continuouspanel.cpp accessibletoolbutton.cpp scoreaccessibility.cpp
       startcenter.cpp scoreBrowser.cpp scorePreview.cpp scoreInfo.cpp
-      logindialog.cpp loginmanager.cpp uploadscoredialog.cpp breaksdialog.cpp
+      logindialog.cpp loginmanager.cpp uploadscoredialog.cpp breaksdialog.cpp searchComboBox.cpp
 
       ${OMR_FILES}
       ${AUDIO}

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -98,6 +98,7 @@
 #include "fluid/fluid.h"
 #include "qmlplugin.h"
 #include "accessibletoolbutton.h"
+#include "searchComboBox.h"
 
 #include "startcenter.h"
 
@@ -4347,17 +4348,6 @@ void MuseScore::updateDrumTools()
       }
 
 //---------------------------------------------------------
-//   searchTextChanged
-//---------------------------------------------------------
-
-void MuseScore::searchTextChanged(const QString& s)
-      {
-      if (cv == 0)
-            return;
-      cv->search(s);
-      }
-
-//---------------------------------------------------------
 //   endSearch
 //---------------------------------------------------------
 
@@ -4390,9 +4380,7 @@ void MuseScore::showSearchDialog()
 
             searchDialogLayout->addWidget(new QLabel(tr("Go To: ")));
 
-            searchCombo = new QComboBox;
-            searchCombo->setEditable(true);
-            searchCombo->setInsertPolicy(QComboBox::InsertAtTop);
+            searchCombo = new SearchComboBox;
             searchDialogLayout->addWidget(searchCombo);
 
             searchDialogLayout->addStretch(10);
@@ -4402,9 +4390,6 @@ void MuseScore::showSearchDialog()
 
             // does not work: connect(searchCombo->lineEdit(), SIGNAL(returnPressed()), SLOT(endSearch()));
             connect(searchCombo->lineEdit(), SIGNAL(editingFinished()), SLOT(endSearch()));
-
-            connect(searchCombo, SIGNAL(editTextChanged(const QString&)),
-               SLOT(searchTextChanged(const QString&)));
             }
 
       searchCombo->clearEditText();
@@ -4477,7 +4462,7 @@ int main(int argc, char* av[])
       QCoreApplication::setOrganizationDomain("musescore.org");
       QCoreApplication::setApplicationName("MuseScoreDevelopment");
       QAccessible::installFactory(AccessibleScoreView::ScoreViewFactory);
-
+      QAccessible::installFactory(AccessibleSearchBox::SearchBoxFactory);
       Q_INIT_RESOURCE(zita);
 
 #ifndef Q_OS_MAC

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -468,7 +468,6 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       virtual void cmd(QAction* a);
       void dirtyChanged(Score*);
       void setPos(int tick);
-      void searchTextChanged(const QString& s);
       void pluginTriggered(int);
       void handleMessage(const QString& message);
       void setCurrentScoreView(ScoreView*);

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -384,9 +384,9 @@ class ScoreView : public QWidget, public MuseScoreView {
       QRectF toLogical(const QRectF& r) const  { return imatrix.mapRect(r); }
       QRect toPhysical(const QRectF& r) const  { return _matrix.mapRect(r).toRect(); }
 
-      void search(const QString& s);
-      void searchMeasure(int i);
-      void searchPage(int i);
+      bool searchMeasure(int i);
+      bool searchPage(int i);
+      bool searchRehearsalMark(const QString& s);
       void gotoMeasure(Measure*);
       void selectMeasure(int m);
       void postCmd(const char* cmd)   { sm->postEvent(new CommandEvent(cmd)); }

--- a/mscore/searchComboBox.cpp
+++ b/mscore/searchComboBox.cpp
@@ -1,0 +1,117 @@
+#include "searchComboBox.h"
+#include "musescore.h"
+#include "scoreview.h"
+#include "libmscore/score.h"
+#include "scoreaccessibility.h"
+
+namespace Ms {
+
+SearchComboBox::SearchComboBox(QWidget* p) : QComboBox(p)
+      {
+      setAccessibleName(tr("Search Box"));
+      setAccessibleDescription(tr("Type to search. Press Enter to return to score."));
+      setEditable(true);
+      setInsertPolicy(QComboBox::InsertAtTop);
+      _found = false;
+      _searchType = SearchType::NO_SEARCH;
+      connect(this, SIGNAL(editTextChanged(QString)), this, SLOT(searchTextChanged(QString)));
+      }
+
+void SearchComboBox::searchInit()
+      {
+      _searchType = SearchType::NO_SEARCH;
+      _found = false;
+      }
+
+void SearchComboBox::setSearchType(SearchType s)
+      {
+      _searchType = s;
+      }
+
+void SearchComboBox::searchTextChanged(const QString& s)
+      {
+      searchInit();
+      if (s.isEmpty())
+            return;
+      ScoreView* cv = mscore->currentScoreView();
+      if (cv == 0)
+            return;
+
+      bool ok;
+
+      int n = s.toInt(&ok);
+      if (ok && n >= 0) {
+            setSearchType(SearchType::SEARCH_MEASURE);
+            _found = cv->searchMeasure(n);
+            }
+      else {
+            if (s.size() >= 2 && s[0].toLower() == 'p' && s[1].isNumber()) {
+                  n = s.mid(1).toInt(&ok);
+                  if (ok && n >= 0) {
+                        setSearchType(SearchType::SEARCH_PAGE);
+                        _found = cv->searchPage(n);
+                        }
+                  }
+
+            if (searchType() != SearchType::SEARCH_PAGE) {
+                  setSearchType(SearchType::SEARCH_REHEARSAL_MARK);
+                  _found = cv->searchRehearsalMark(s);
+                  }
+            }
+      //updating status bar
+      ScoreAccessibility::instance()->updateAccessibilityInfo();
+      emit currentSearchFinished();
+      }
+
+AccessibleSearchBox::AccessibleSearchBox(SearchComboBox *comboBox) : QAccessibleWidget(comboBox)
+      {
+      searchBox = comboBox;
+      }
+
+QAccessibleInterface* AccessibleSearchBox::SearchBoxFactory(const QString &classname, QObject *object)
+      {
+          QAccessibleInterface *iface = 0;
+          if (classname == QLatin1String("Ms::SearchComboBox") && object && object->isWidgetType()){
+                qDebug("Creating interface for SearchComboBox object");
+                SearchComboBox* s = static_cast<SearchComboBox*>(object);
+                AccessibleSearchBox* a = new AccessibleSearchBox(s);
+                QObject::connect(s, SIGNAL(currentSearchFinished()), a, SLOT(searchFinished()));
+                iface = static_cast<QAccessibleInterface*>(a);
+                }
+
+          return iface;
+      }
+
+QString AccessibleSearchBox::text(QAccessible::Text t) const
+      {
+      QString type;
+      QString value = searchBox->currentText();
+      if (t == QAccessible::Value) {
+            switch (searchBox->searchType()) {
+                  case SearchComboBox::SearchType::NO_SEARCH:
+                        return QString();
+                  case SearchComboBox::SearchType::SEARCH_MEASURE:
+                        type = tr("Measure");
+                        break;
+                  case SearchComboBox::SearchType::SEARCH_PAGE:
+                        type = tr("Page");
+                        value = value.mid(1);
+                        break;
+                  case SearchComboBox::SearchType::SEARCH_REHEARSAL_MARK:
+                        type = tr("Rehearsal Mark");
+                        break;
+                  }
+            QString found = searchBox->found() ? "" : tr("Not found ");
+            return QString("%1 %2 %3%4").arg(type).arg(value).arg(found).arg(mscore->currentScoreView()->score()->accessibleInfo());
+            }
+
+      return QAccessibleWidget::text(t);
+      }
+
+void AccessibleSearchBox::searchFinished()
+      {
+      QAccessibleValueChangeEvent ev(searchBox, text(QAccessible::Value));
+      QAccessible::updateAccessibility(&ev);
+      }
+
+}

--- a/mscore/searchComboBox.h
+++ b/mscore/searchComboBox.h
@@ -1,0 +1,46 @@
+#ifndef __SEARCHCOMBOBOX__
+#define __SEARCHCOMBOBOX__
+#include  <QAccessibleWidget>
+
+namespace Ms {
+
+class SearchComboBox : public QComboBox {
+      Q_OBJECT
+public:
+      enum SearchType {
+            SEARCH_MEASURE,
+            SEARCH_PAGE,
+            SEARCH_REHEARSAL_MARK,
+            NO_SEARCH
+            };
+private:
+      SearchType _searchType;
+      bool _found;
+      void searchInit();
+      void setSearchType(SearchType s);
+private slots:
+      void searchTextChanged(const QString& s);
+public:
+      SearchType searchType() { return _searchType; }
+      bool found()            { return _found;      }
+      SearchComboBox(QWidget* p = 0);
+signals:
+      void currentSearchFinished();
+};
+
+class AccessibleSearchBox : public  QObject, QAccessibleWidget {
+      Q_OBJECT
+      SearchComboBox* searchBox;
+      QAccessible::Role role() const Q_DECL_OVERRIDE { return QAccessible::ComboBox; }
+      QString text(QAccessible::Text t) const Q_DECL_OVERRIDE;
+public:
+      AccessibleSearchBox(SearchComboBox* comboBox);
+      static QAccessibleInterface* SearchBoxFactory(const QString &classname, QObject *object);
+
+public slots:
+      void searchFinished();
+};
+
+}
+
+#endif

--- a/mscore/searchComboBox.h
+++ b/mscore/searchComboBox.h
@@ -31,7 +31,8 @@ signals:
 class AccessibleSearchBox : public  QObject, QAccessibleWidget {
       Q_OBJECT
       SearchComboBox* searchBox;
-      QAccessible::Role role() const Q_DECL_OVERRIDE { return QAccessible::ComboBox; }
+      //JAWS compatibility - no idea why yet. Adjustments needs to be made to the JawsScript.
+      //QAccessible::Role role() const Q_DECL_OVERRIDE { return QAccessible::ComboBox; }
       QString text(QAccessible::Text t) const Q_DECL_OVERRIDE;
 public:
       AccessibleSearchBox(SearchComboBox* comboBox);


### PR DESCRIPTION
The actual code for searching is mostly the same. I only moved it from one place to another.
The only things that actually changed for the search are: the searchPage, searchMeasure, searchRehearsalMark return a boolean value and searching something like "p1b" will be seen as rehearsal mark search instead of page search. Only strings like "p[0-9]*" will be seen as page search.

Everything else is for accessibility feedback. The feedback might be a bit verbose, but it's easier to remove some it after testing, then it is to add afterwards.
Works great with NVDA. Doesn't work very well with Jaws, some changes might be needed to the JawsScript.