### PR TITLE
Import chord names from XF Yamaha MIDI files

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -260,6 +260,7 @@ add_executable ( ${ExecutableName}
       importmidi/importmidi_tuplet_tonotes.cpp importmidi/importmidi_simplify.cpp
       importmidi/importmidi_voice.cpp importmidi/importmidi_view.cpp importmidi/importmidi_key.cpp
       importmidi/importmidi_tempo.cpp importmidi/importmidi_instrument.cpp
+      importmidi/importmidi_chordname.cpp
       resourceManager.cpp downloadUtils.cpp
       textcursor.cpp continuouspanel.cpp accessibletoolbutton.cpp scoreaccessibility.cpp
       startcenter.cpp scoreBrowser.cpp scorePreview.cpp scoreInfo.cpp

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -1025,8 +1025,12 @@ void convertMidi(Score *score, const MidiFile *mf)
       auto *sigmap = score->sigmap();
 
       auto tracks = createMTrackList(lastTick, sigmap, mf);
-      cleanUpMidiEvents(tracks);
+
       auto &opers = preferences.midiImportOperations;
+      if (opers.data()->processingsOfOpenedFile == 0)         // for newly opened MIDI file
+            MidiChordName::findChordNames(tracks);
+
+      cleanUpMidiEvents(tracks);
 
       if (opers.data()->processingsOfOpenedFile == 0) {       // for newly opened MIDI file
             opers.data()->trackCount = 0;

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -61,6 +61,7 @@
 #include "importmidi_operations.h"
 #include "importmidi_key.h"
 #include "importmidi_instrument.h"
+#include "importmidi_chordname.h"
 
 #include <set>
 
@@ -347,7 +348,7 @@ void MTrack::processMeta(int tick, const MidiEvent& mm)
                   cs->setMetaTag("copyright", QString((const char*)(mm.edata())));
                   break;
             case META_TIME_SIGNATURE:
-                  break;                  // added earlier
+                  break;                        // added earlier
             case META_PORT_CHANGE:
                   // TODO
                   break;
@@ -577,8 +578,7 @@ void MTrack::processPendingNotes(QList<MidiChord> &midiChords,
                   }
             startChordTick += len;
             }
-      fillGapWithRests(score, voice, startChordTick,
-                       nextChordTick - startChordTick, track);
+      fillGapWithRests(score, voice, startChordTick, nextChordTick - startChordTick, track);
       }
 
 void MTrack::createKeys(Key k)
@@ -1096,6 +1096,7 @@ void convertMidi(Score *score, const MidiFile *mf)
       MidiLyrics::setLyricsToScore(trackList);
       MidiTempo::setTempo(tracks, score);
       MidiKey::setMainKeySig(trackList);
+      MidiChordName::setChordNames(trackList);
       }
 
 void loadMidiData(MidiFile &mf)

--- a/mscore/importmidi/importmidi_chordname.cpp
+++ b/mscore/importmidi/importmidi_chordname.cpp
@@ -110,13 +110,18 @@ QString readChordName(const MidiEvent &e)
       if (e.len() >= 5)
             chordName += readChordType(data[4]);
 
-      QString bassChord;
-      if (e.len() >= 6)
-            bassChord += readChordRoot(data[5]);
-      if (e.len() >= 7)
-            bassChord += readChordType(data[6]);
-      if (!bassChord.isEmpty())
-            chordName += "/" + bassChord;
+      if (e.len() >= 6) {
+            const QString chordRoot = readChordRoot(data[5]);
+            if (!chordRoot.isEmpty()) {
+                  QString chordType;
+                  if (e.len() >= 7)
+                        chordType = readChordType(data[6]);
+                  if (chordRoot + chordType == chordName)
+                        chordName += "/" + chordRoot;
+                  else
+                        chordName += "/" + chordRoot + chordType;
+                  }
+            }
 
       return chordName;
       }

--- a/mscore/importmidi/importmidi_chordname.cpp
+++ b/mscore/importmidi/importmidi_chordname.cpp
@@ -1,0 +1,167 @@
+#include "importmidi_chordname.h"
+#include "importmidi_inner.h"
+#include "importmidi_chord.h"
+#include "importmidi_fraction.h"
+#include "libmscore/score.h"
+#include "libmscore/staff.h"
+#include "libmscore/measure.h"
+#include "libmscore/harmony.h"
+#include "midi/midifile.h"
+
+
+// From XF Format Specifications V 2.01 (January 13, 1999, YAMAHA CORPORATION)
+
+namespace Ms {
+namespace MidiChordName {
+
+int readFirstHalf(uchar byte)
+      {
+      return (byte >> 4) & 0xf;
+      }
+
+int readSecondHalf(uchar byte)
+      {
+      return byte & 0xf;
+      }
+
+QString readChordRoot(uchar byte)
+      {
+      static const std::vector<QString> inversions = {
+            "bbb", "bb", "b", "", "#", "##", "###"
+            };
+      static const std::vector<QString> notes = {
+            "", "C", "D", "E", "F", "G", "A", "B"
+            };
+
+      QString chordRoot;
+
+      const size_t noteIndex = readSecondHalf(byte);
+      if (noteIndex < notes.size())
+            chordRoot += notes[noteIndex];
+
+      const size_t inversionIndex = readFirstHalf(byte);
+      if (inversionIndex < inversions.size())
+            chordRoot += inversions[inversionIndex];
+
+      return chordRoot;
+      }
+
+QString readChordType(uchar chordTypeIndex)
+      {
+      static const std::vector<QString> chordTypes = {
+            "Maj"
+          , "Maj6"
+          , "Maj7"
+          , "Maj7(#11)"
+          , "Maj(9)"
+          , "Maj7(9)"
+          , "Maj6(9)"
+          , "aug"
+          , "min"
+          , "min6"
+          , "min7"
+          , "min7b5"
+          , "min(9)"
+          , "min7(9)"
+          , "min7(11)"
+          , "minMaj7"
+          , "minMaj7(9)"
+          , "dim"
+          , "dim7"
+          , "7th"
+          , "7sus4"
+          , "7b5"
+          , "7(9)"
+          , "7(#11)"
+          , "7(13)"
+          , "7(b9)"
+          , "7(b13)"
+          , "7(#9)"
+          , "Maj7aug"
+          , "7aug"
+          , "1+8"
+          , "1+5"
+          , "sus4"
+          , "1+2+5"
+          , "cc"
+            };
+
+      if (chordTypeIndex < chordTypes.size())
+            return chordTypes[chordTypeIndex];
+      return "";
+      }
+
+QString readChordName(const MidiEvent &e)
+      {
+      if (e.type() != ME_META || e.metaType() != META_SPECIFIC)
+            return "";
+      if (e.len() < 4)
+            return "";
+
+      const uchar *data = e.edata();
+      if (data[0] != 0x43 || data[1] != 0x7B || data[2] != 0x01)
+            return "";
+
+      QString chordName;
+
+      if (e.len() >= 4)
+            chordName += readChordRoot(data[3]);
+      if (e.len() >= 5)
+            chordName += readChordType(data[4]);
+
+      QString bassChord;
+      if (e.len() >= 6)
+            bassChord += readChordRoot(data[5]);
+      if (e.len() >= 7)
+            bassChord += readChordType(data[6]);
+      if (!bassChord.isEmpty())
+            chordName += "/" + bassChord;
+
+      return chordName;
+      }
+
+QString findChordName(const QList<MidiNote> &notes, const std::multimap<int, MidiEvent>& events)
+      {
+      for (const MidiNote &note: notes) {
+            const auto range = events.equal_range(note.origOnTime.ticks());
+            if (range.second == range.first)
+                  continue;
+            for (auto it = range.first; it != range.second; ++it) {
+                  const MidiEvent &e = it->second;
+                  const QString chordName = readChordName(e);
+                  if (!chordName.isEmpty())
+                        return chordName;
+                  }
+            }
+      return "";
+      }
+
+// all notes should be already placed to the score
+
+void setChordNames(QList<MTrack> &tracks)
+      {
+      for (MTrack &track: tracks) {
+            for (const auto &chord: track.chords) {
+                  const MidiChord &c = chord.second;
+                  const QString chordName = findChordName(c.notes, track.mtrack->events());
+                  if (chordName.isEmpty())
+                        continue;
+
+                  Staff *staff = track.staff;
+                  Score *score = staff->score();
+                  const ReducedFraction &onTime = chord.first;
+
+                  Measure* measure = score->tick2measure(onTime.ticks());
+                  Segment* seg = measure->getSegment(Segment::Type::ChordRest, onTime.ticks());
+                  const int t = staff->idx() * VOICES;
+
+                  Harmony* h = new Harmony(score);
+                  h->setHarmony(chordName);
+                  h->setTrack(t);
+                  seg->add(h);
+                  }
+            }
+      }
+
+} // namespace MidiChordName
+} // namespace Ms

--- a/mscore/importmidi/importmidi_chordname.h
+++ b/mscore/importmidi/importmidi_chordname.h
@@ -8,6 +8,7 @@ class MTrack;
 
 namespace MidiChordName {
 
+void findChordNames(const std::multimap<int, MTrack> &tracks);
 void setChordNames(QList<MTrack> &tracks);
 
 } // namespace MidiChordName

--- a/mscore/importmidi/importmidi_chordname.h
+++ b/mscore/importmidi/importmidi_chordname.h
@@ -1,0 +1,17 @@
+#ifndef IMPORTMIDI_CHORDNAME_H
+#define IMPORTMIDI_CHORDNAME_H
+
+
+namespace Ms {
+
+class MTrack;
+
+namespace MidiChordName {
+
+void setChordNames(QList<MTrack> &tracks);
+
+} // namespace MidiChordName
+} // namespace Ms
+
+
+#endif // IMPORTMIDI_CHORDNAME_H

--- a/mscore/importmidi/importmidi_model.cpp
+++ b/mscore/importmidi/importmidi_model.cpp
@@ -681,7 +681,7 @@ void TracksModel::reset(const MidiOperations::Opers &opers,
                                           "MIDI import operations", "Show\nchord names"); }
                   bool isEditable(int trackIndex) const override
                         {
-                        return _opers.hasChordNames.value(trackIndex);
+                        return trackIndex == -1 || _opers.hasChordNames.value(trackIndex);
                         }
                   QVariant value(int trackIndex) const override
                         {

--- a/mscore/importmidi/importmidi_model.cpp
+++ b/mscore/importmidi/importmidi_model.cpp
@@ -44,7 +44,8 @@ void TracksModel::reset(const MidiOperations::Opers &opers,
                         int trackCount,
                         const QString &midiFile,
                         bool hasHumanBeats,
-                        bool hasTempoText)
+                        bool hasTempoText,
+                        bool hasChordNames)
       {
       beginResetModel();
       _trackOpers = opers;
@@ -665,13 +666,6 @@ void TracksModel::reset(const MidiOperations::Opers &opers,
             }
 
       //-----------------------------------------------------------------------
-      bool hasChordNames = false;
-      for (int i = 0; i != _trackCount; ++i) {
-            if (_trackOpers.hasChordNames.value(i)) {
-                  hasChordNames = true;
-                  break;
-                  }
-            }
       if (hasChordNames) {
             struct ShowChordNames : Column {
                   ShowChordNames(MidiOperations::Opers &opers) : Column(opers)
@@ -679,21 +673,14 @@ void TracksModel::reset(const MidiOperations::Opers &opers,
                         }
                   QString headerName() const override { return QCoreApplication::translate(
                                           "MIDI import operations", "Show\nchord names"); }
-                  bool isEditable(int trackIndex) const override
+                  bool isForAllTracksOnly() const override { return true; }
+                  QVariant value(int /*trackIndex*/) const override
                         {
-                        return trackIndex == -1 || _opers.hasChordNames.value(trackIndex);
+                        return _opers.showChordNames.value();
                         }
-                  QVariant value(int trackIndex) const override
+                  void setValue(const QVariant &value, int /*trackIndex*/) override
                         {
-                        return _opers.showChordNames.value(trackIndex);
-                        }
-                  void setValue(const QVariant &value, int trackIndex) override
-                        {
-                        _opers.showChordNames.setValue(trackIndex, value.toBool());
-                        }
-                  bool isVisible(int trackIndex) const override
-                        {
-                        return isEditable(trackIndex);
+                        _opers.showChordNames.setValue(value.toBool());
                         }
                   };
             _columns.push_back(std::unique_ptr<Column>(new ShowChordNames(_trackOpers)));

--- a/mscore/importmidi/importmidi_model.cpp
+++ b/mscore/importmidi/importmidi_model.cpp
@@ -665,6 +665,41 @@ void TracksModel::reset(const MidiOperations::Opers &opers,
             }
 
       //-----------------------------------------------------------------------
+      bool hasChordNames = false;
+      for (int i = 0; i != _trackCount; ++i) {
+            if (_trackOpers.hasChordNames.value(i)) {
+                  hasChordNames = true;
+                  break;
+                  }
+            }
+      if (hasChordNames) {
+            struct ShowChordNames : Column {
+                  ShowChordNames(MidiOperations::Opers &opers) : Column(opers)
+                        {
+                        }
+                  QString headerName() const override { return QCoreApplication::translate(
+                                          "MIDI import operations", "Show\nchord names"); }
+                  bool isEditable(int trackIndex) const override
+                        {
+                        return _opers.hasChordNames.value(trackIndex);
+                        }
+                  QVariant value(int trackIndex) const override
+                        {
+                        return _opers.showChordNames.value(trackIndex);
+                        }
+                  void setValue(const QVariant &value, int trackIndex) override
+                        {
+                        _opers.showChordNames.setValue(trackIndex, value.toBool());
+                        }
+                  bool isVisible(int trackIndex) const override
+                        {
+                        return isEditable(trackIndex);
+                        }
+                  };
+            _columns.push_back(std::unique_ptr<Column>(new ShowChordNames(_trackOpers)));
+            }
+
+      //-----------------------------------------------------------------------
       struct PickupBar : Column {
             PickupBar(MidiOperations::Opers &opers) : Column(opers)
                   {

--- a/mscore/importmidi/importmidi_model.h
+++ b/mscore/importmidi/importmidi_model.h
@@ -19,7 +19,8 @@ class TracksModel : public QAbstractTableModel
                  int trackCount,
                  const QString &midiFile,
                  bool hasHumanBeats,
-                 bool hasTempoText);
+                 bool hasTempoText,
+                 bool hasChordNames);
       void clear();
       void updateCharset();
       void notifyAllApplied();

--- a/mscore/importmidi/importmidi_operations.h
+++ b/mscore/importmidi/importmidi_operations.h
@@ -166,6 +166,8 @@ struct Opers
       TrackOp<bool> removeDrumRests = TrackOp<bool>(true);
       TrackOp<int> lyricTrackIndex = TrackOp<int>(-1);         // empty lyric
       TrackOp<int> msInstrIndex = TrackOp<int>(-1);            // for empty instrument list
+      TrackOp<bool> showChordNames = TrackOp<bool>(true);
+      TrackOp<bool> hasChordNames = TrackOp<bool>(false);
       };
 
 struct HumanBeatData

--- a/mscore/importmidi/importmidi_operations.h
+++ b/mscore/importmidi/importmidi_operations.h
@@ -142,6 +142,7 @@ struct Opers
       Op<bool> searchPickupMeasure = Op<bool>(true);
       Op<bool> measureCount2xLess = Op<bool>(false);
       Op<bool> showTempoText = Op<bool>(true);
+      Op<bool> showChordNames = Op<bool>(true);
       Op<TimeSigNumerator> timeSigNumerator = Op<TimeSigNumerator>(TimeSigNumerator::_4);
       Op<TimeSigDenominator> timeSigDenominator = Op<TimeSigDenominator>(TimeSigDenominator::_4);
 
@@ -166,8 +167,6 @@ struct Opers
       TrackOp<bool> removeDrumRests = TrackOp<bool>(true);
       TrackOp<int> lyricTrackIndex = TrackOp<int>(-1);         // empty lyric
       TrackOp<int> msInstrIndex = TrackOp<int>(-1);            // for empty instrument list
-      TrackOp<bool> showChordNames = TrackOp<bool>(true);
-      TrackOp<bool> hasChordNames = TrackOp<bool>(false);
       };
 
 struct HumanBeatData
@@ -198,6 +197,7 @@ struct FileData
                   // QList of lyric tracks - there can be multiple lyric tracks,
                   // lyric track count != MIDI track count in general
       QList<std::multimap<ReducedFraction, std::string>> lyricTracks;
+      std::multimap<ReducedFraction, QString> chordNames;
       HumanBeatData humanBeatData;
       };
 

--- a/mscore/importmidi/importmidi_panel.cpp
+++ b/mscore/importmidi/importmidi_panel.cpp
@@ -59,7 +59,8 @@ void ImportMidiPanel::setMidiFile(const QString &fileName)
                           opers.data()->trackCount,
                           _midiFile,
                           !opers.data()->humanBeatData.beatSet.empty(),
-                          opers.data()->hasTempoText);
+                          opers.data()->hasTempoText,
+                          !opers.data()->chordNames.empty());
             saveTableViewState();
             }
       else {            // switch to already opened MIDI file
@@ -68,7 +69,8 @@ void ImportMidiPanel::setMidiFile(const QString &fileName)
                           opers.data()->trackCount,
                           _midiFile,
                           !opers.data()->humanBeatData.beatSet.empty(),
-                          opers.data()->hasTempoText);
+                          opers.data()->hasTempoText,
+                          !opers.data()->chordNames.empty());
             restoreTableViewState();
             }
 
@@ -224,7 +226,8 @@ void ImportMidiPanel::cancelChanges()
                     opers.data()->trackCount,
                     _midiFile,
                     !opers.data()->humanBeatData.beatSet.empty(),
-                    opers.data()->hasTempoText);
+                    opers.data()->hasTempoText,
+                    !opers.data()->chordNames.empty());
 
       restoreTableViewState();
       _ui->comboBoxCharset->setCurrentText(opers.data()->charset);

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(
       ${PROJECT_SOURCE_DIR}/mscore/importmidi/importmidi_tempo.cpp
       ${PROJECT_SOURCE_DIR}/mscore/importmidi/importmidi_model.cpp
       ${PROJECT_SOURCE_DIR}/mscore/importmidi/importmidi_instrument.cpp
+      ${PROJECT_SOURCE_DIR}/mscore/importmidi/importmidi_chordname.cpp
       ${PROJECT_SOURCE_DIR}/mscore/exportmidi.cpp
       ${PROJECT_SOURCE_DIR}/mscore/importxml.cpp
       ${PROJECT_SOURCE_DIR}/mscore/importxmlfirstpass.cpp

--- a/mtest/importmidi/tst_importmidi.cpp
+++ b/mtest/importmidi/tst_importmidi.cpp
@@ -1175,7 +1175,8 @@ void TestImportMidi::testGuiTracksModel()
                   opers.data()->trackCount,
                   midiFileFullPath,
                   !opers.data()->humanBeatData.beatSet.empty(),
-                  opers.data()->hasTempoText);
+                  opers.data()->hasTempoText,
+                  !opers.data()->chordNames.empty());
 
       QVERIFY(model.trackCount() == 1);
 

--- a/synthesizer/event.h
+++ b/synthesizer/event.h
@@ -75,7 +75,8 @@ enum {
       META_EOT             = 0x2f,  // end of track
       META_TEMPO           = 0x51,
       META_TIME_SIGNATURE  = 0x58,
-      META_KEY_SIGNATURE   = 0x59
+      META_KEY_SIGNATURE   = 0x59,
+      META_SPECIFIC        = 0x7F   // sequencer specific
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
This is a new feature - import chord names from XF Yamaha MIDI files.
It was requested in http://musescore.org/en/node/39511.

Here is a test MIDI file: http://musescore.org/sites/musescore.org/files/issues/Chord+Lyric-Test-Midi.mid 

Sequencer-specific MIDI messages in that MIDI file:
http://wstaw.org/m/2015/02/02/plasma-desktopTM1937.png

MuseScore MIDI import of the file with chord names (Kubuntu 14.01, 64 bit):
http://wstaw.org/m/2015/02/02/plasma-desktopbW1937.png

Sibelius 6:
http://wstaw.org/m/2015/02/02/plasma-desktopDe1937.png

Sibelius 7:
http://wstaw.org/m/2015/02/02/plasma-desktopop1937.png
http://wstaw.org/m/2015/02/02/plasma-desktopFa1937.png

In the MIDI import panel visibility of chord names is controlled via a checkbox:
https://drive.google.com/file/d/0B5alKuFoSol2SUgxcE9Vci1MUXM/view?usp=sharing