### PR TITLE
fix enable/disable of beam horizontal / user position in Inspector

### DIFF
--- a/mscore/inspector/inspectorBeam.cpp
+++ b/mscore/inspector/inspectorBeam.cpp
@@ -53,26 +53,32 @@ void InspectorBeam::valueChanged(int idx)
       {
       if (iList[idx].t == P_ID::USER_MODIFIED) {
             bool val = getValue(iList[idx]).toBool();
-            iList[8].w->setEnabled(!val);
-            iList[10].w->setEnabled(val);
-            iList[11].w->setEnabled(val);
+            b.noSlope->setEnabled(!val);
+            b.y1->setEnabled(val);
+            b.y2->setEnabled(val);
+            }
+      else if (iList[idx].t == P_ID::BEAM_NO_SLOPE) {
+            bool val = getValue(iList[idx]).toBool();
+            b.userPosition->setEnabled(!val);
+            b.y1->setEnabled(!val);
+            b.y2->setEnabled(!val);
             }
       InspectorBase::valueChanged(idx);
       }
 
-void InspectorBeam::setValue(const InspectorItem& ii, const QVariant& val)
+void InspectorBeam::setValue(const InspectorItem& ii, QVariant val)
       {
       if (ii.w == b.userPosition) {
             bool enable = val.toBool();
-            iList[8].w->setEnabled(!enable);
-            iList[10].w->setEnabled(enable);
-            iList[11].w->setEnabled(enable);
+            b.noSlope->setEnabled(!enable);
+            b.y1->setEnabled(enable);
+            b.y2->setEnabled(enable);
             }
       else if (ii.w == b.noSlope) {
             bool enable = !val.toBool();
-            iList[9].w->setEnabled(enable);
-            iList[10].w->setEnabled(enable);
-            iList[11].w->setEnabled(enable);
+            b.userPosition->setEnabled(enable);
+            b.y1->setEnabled(enable);
+            b.y2->setEnabled(enable);
             }
       InspectorBase::setValue(ii, val);
       }

--- a/mscore/inspector/inspectorBeam.h
+++ b/mscore/inspector/inspectorBeam.h
@@ -31,10 +31,10 @@ class InspectorBeam : public InspectorBase {
       Ui::InspectorBeam b;
 
    protected slots:
-      virtual void valueChanged(int idx);
+      virtual void valueChanged(int idx) override;
 
    protected:
-      virtual void setValue(const InspectorItem&, const QVariant& val);
+      virtual void setValue(const InspectorItem&, QVariant val) override;
 
    public:
       InspectorBeam(QWidget* parent);


### PR DESCRIPTION
Wrong prototype of inspectorBeam::setValue() prevented override, and missing code to handle BEAM_NO_SLOPE in inspectorBeam::valueChanged().