### PR TITLE
Fix #46291 : custom instruments.xml requires Unix-style line endings

### DIFF
--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -628,7 +628,7 @@ bool saveInstrumentTemplates1(const QString& instrTemplates)
 bool loadInstrumentTemplates(const QString& instrTemplates)
       {
       QFile qf(instrTemplates);
-      if (!qf.open(QIODevice::ReadOnly)) {
+      if (!qf.open(QIODevice::Text | QIODevice::ReadOnly)) {
             qDebug("cannot load instrument templates at <%s>", qPrintable(instrTemplates));
             return false;
             }


### PR DESCRIPTION
Fix #46291 : custom `instruments.xml` not loaded if not with Unix-style line ending

Regardless of OS, a custom instruments.xml is not loaded if it does not have Unix-style line endings (CR, opposed to Windows CR LF).

See issue at http://musescore.org/en/node/46291 for details.