### PR TITLE
fix crash when joining scores with breath or caesura after last note  

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -520,7 +520,10 @@ void Score::fixTicks()
                                           // find start tick of next note
                                           // currently, breaths are always added in voice 0
                                           Segment* next = s->nextCR(i);
-                                          tick = qMax(tick, next->tick());
+                                          if (next)
+                                                tick = qMax(tick, next->tick());
+                                          else
+                                                tick = lastSegment()->tick();
                                           }
                                     }
                               if (length != 0.0)


### PR DESCRIPTION
Thanks to @MarcSabatella for finding the cause of it...
It crashed on me and I found where it crashed, but not why, i.e. that it was related to breath/caesura at the end of a score ;-)
Also should fix playback if breath/caesura to really happen after the last note.