### PR TITLE
TAB (historical): add selector for repeating the same rhythm symbol.

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2175,7 +2175,12 @@ void Chord::layoutTablature()
             // OR previous CR is a rest
             // set a duration symbol (trying to re-use existing symbols where existing to minimize
             // symbol creation and deletion)
-            if (prevCR == 0 || prevCR->durationType().type() != durationType().type()
+            TablatureSymbolRepeat symRepeat = tab->symRepeat();
+            if (prevCR == 0
+                  || symRepeat == TablatureSymbolRepeat::ALWAYS
+                  || (symRepeat == TablatureSymbolRepeat::MEASURE && measure() != prevCR->measure())
+                  || (symRepeat == TablatureSymbolRepeat::SYSTEM && measure()->system() != prevCR->measure()->system())
+                  || prevCR->durationType().type() != durationType().type()
                   || prevCR->dots() != dots()
                   || prevCR->type() == Element::Type::REST) {
                   // symbol needed; if not exist, create; if exists, update duration

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -45,6 +45,7 @@ const QString StaffType::fileGroupNames[STAFF_GROUP_MAX] = { "pitched", "percuss
 StaffType::StaffType()
       {
       // set reasonable defaults for type-specific members */
+      _symRepeat = TablatureSymbolRepeat::NEVER;
       setDurationFontName(_durationFonts[0].displayName);
       setFretFontName(_fretFonts[0].displayName);
       }
@@ -62,8 +63,8 @@ StaffType::StaffType(StaffGroup sg, const QString& xml, const QString& name, int
    bool showBarLines, bool stemless, bool genTimesig,
    const QString& durFontName, qreal durFontSize, qreal durFontUserY, qreal genDur,
    const QString& fretFontName, qreal fretFontSize, qreal fretFontUserY,
-   bool linesThrough, TablatureMinimStyle minimStyle, bool onLines, bool showRests,
-   bool stemsDown, bool stemThrough, bool upsideDown, bool useNumbers)
+   TablatureSymbolRepeat symRepeat, bool linesThrough, TablatureMinimStyle minimStyle, bool onLines,
+   bool showRests, bool stemsDown, bool stemThrough, bool upsideDown, bool useNumbers)
       {
       _group   = sg;
       _xmlName = xml;
@@ -81,6 +82,7 @@ StaffType::StaffType(StaffGroup sg, const QString& xml, const QString& name, int
       setFretFontName(fretFontName);
       setFretFontSize(fretFontSize);
       setFretFontUserY(fretFontUserY);
+      setSymbolRepeat(symRepeat);
       setLinesThrough(linesThrough);
       setMinimStyle(minimStyle);
       setOnLines(onLines);
@@ -155,6 +157,7 @@ bool StaffType::isSameStructure(const StaffType& st) const
             }
       else {                                                // TAB-specific
             return st._genDurations == _genDurations
+               && st._symRepeat     == _symRepeat
                && st._linesThrough  == _linesThrough
                && st._minimStyle    == _minimStyle
                && st._onLines       == _onLines
@@ -227,6 +230,8 @@ void StaffType::write(Xml& xml) const
             xml.tag("fretFontName",     _fretFonts[_fretFontIdx].displayName);
             xml.tag("fretFontSize",     _fretFontSize);
             xml.tag("fretFontY",        _fretFontUserY);
+            if (_symRepeat != TablatureSymbolRepeat::NEVER)
+                  xml.tag("symbolRepeat",     int(_symRepeat));
             xml.tag("linesThrough",     _linesThrough);
             xml.tag("minimStyle",       int(_minimStyle));
             xml.tag("onLines",          _onLines);
@@ -291,6 +296,8 @@ void StaffType::read(XmlReader& e)
                   setFretFontSize(e.readDouble());
             else if (tag == "fretFontY")
                   setFretFontUserY(e.readDouble());
+            else if (tag == "symbolRepeat")
+                  setSymbolRepeat( (TablatureSymbolRepeat) e.readInt() );
             else if (tag == "linesThrough")
                   setLinesThrough(e.readBool());
             else if (tag == "minimStyle")
@@ -1013,20 +1020,20 @@ void StaffType::initStaffTypes()
          StaffType(StaffGroup::PERCUSSION, "perc1Line", QObject::tr("Perc. 1 line"),  1, 1, true, true, false, true, false, true),
          StaffType(StaffGroup::PERCUSSION, "perc3Line", QObject::tr("Perc. 3 lines"), 3, 2, true, true, false, true, false, true),
          StaffType(StaffGroup::PERCUSSION, "perc5Line", QObject::tr("Perc. 5 lines"), 5, 1, true, true, false, true, false, true),
-//                 group               xml-name,         human-readable-name         lin dist  clef   bars stemless time      duration font     size off genDur     fret font         size off  thru  minim style       onLin  rests  stmDn  stmThr upsDn  nums
-         StaffType(StaffGroup::TAB, "tab6StrSimple", QObject::tr("Tab. 6-str. simple"), 6, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab6StrCommon", QObject::tr("Tab. 6-str. common"), 6, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab6StrFull",   QObject::tr("Tab. 6-str. full"),   6, 1.5, true,  true, false, true,  "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true),
-         StaffType(StaffGroup::TAB, "tab4StrSimple", QObject::tr("Tab. 4-str. simple"), 4, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab4StrCommon", QObject::tr("Tab. 4-str. common"), 4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab4StrFull",   QObject::tr("Tab. 4-str. full"),   4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true),
-         StaffType(StaffGroup::TAB, "tab5StrSimple", QObject::tr("Tab. 5-str. simple"), 5, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab5StrCommon", QObject::tr("Tab. 5-str. common"), 5, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab5StrFull",   QObject::tr("Tab. 5-str. full"),   5, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true),
-         StaffType(StaffGroup::TAB, "tabUkulele",    QObject::tr("Tab. ukulele"),      4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, false, TablatureMinimStyle::SHORTER,true,  true,  true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tabBalajka",    QObject::tr("Tab. balalaika"),    3, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, false, TablatureMinimStyle::SHORTER,true,  true,  true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab6StrItalian",QObject::tr("Tab. 6-str. Italian"),6, 1.5, false, true, true,  true,  "MuseScore Tab Italian",15, 0, true,  "MuseScore Tab Renaiss",10, 0, true,  TablatureMinimStyle::NONE,   true,  true,  false, false, true,  true),
-         StaffType(StaffGroup::TAB, "tab6StrFrench", QObject::tr("Tab. 6-str. French"), 6, 1.5, false, true, true,  true,  "MuseScore Tab French", 15, 0, true,  "MuseScore Tab Renaiss",10, 0, true,  TablatureMinimStyle::NONE,   false, false, false, false, false, false)
+//                 group               xml-name,         human-readable-name         lin dist  clef   bars stemless time      duration font     size off genDur     fret font          size off  duration symbol repeat        thru  minim style                  onLin  rests  stmDn  stmThr upsDn  nums
+         StaffType(StaffGroup::TAB, "tab6StrSimple", QObject::tr("Tab. 6-str. simple"), 6, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true),
+         StaffType(StaffGroup::TAB, "tab6StrCommon", QObject::tr("Tab. 6-str. common"), 6, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true),
+         StaffType(StaffGroup::TAB, "tab6StrFull",   QObject::tr("Tab. 6-str. full"),   6, 1.5, true,  true, false, true,  "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true),
+         StaffType(StaffGroup::TAB, "tab4StrSimple", QObject::tr("Tab. 4-str. simple"), 4, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true),
+         StaffType(StaffGroup::TAB, "tab4StrCommon", QObject::tr("Tab. 4-str. common"), 4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true),
+         StaffType(StaffGroup::TAB, "tab4StrFull",   QObject::tr("Tab. 4-str. full"),   4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true),
+         StaffType(StaffGroup::TAB, "tab5StrSimple", QObject::tr("Tab. 5-str. simple"), 5, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true),
+         StaffType(StaffGroup::TAB, "tab5StrCommon", QObject::tr("Tab. 5-str. common"), 5, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true),
+         StaffType(StaffGroup::TAB, "tab5StrFull",   QObject::tr("Tab. 5-str. full"),   5, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true),
+         StaffType(StaffGroup::TAB, "tabUkulele",    QObject::tr("Tab. ukulele"),       4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  true,  true,  false, false, true),
+         StaffType(StaffGroup::TAB, "tabBalajka",    QObject::tr("Tab. balalaika"),     3, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  true,  true,  false, false, true),
+         StaffType(StaffGroup::TAB, "tab6StrItalian",QObject::tr("Tab. 6-str. Italian"),6, 1.5, false, true, true,  true,  "MuseScore Tab Italian",15, 0, true,  "MuseScore Tab Renaiss",10, 0, TablatureSymbolRepeat::NEVER, true,  TablatureMinimStyle::NONE,   true,  true,  false, false, true,  true),
+         StaffType(StaffGroup::TAB, "tab6StrFrench", QObject::tr("Tab. 6-str. French"), 6, 1.5, false, true, true,  true,  "MuseScore Tab French", 15, 0, true,  "MuseScore Tab Renaiss",10, 0, TablatureSymbolRepeat::NEVER, true,  TablatureMinimStyle::NONE,   false, false, false, false, false, false)
          };
       }
 }                 // namespace Ms

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -100,6 +100,13 @@ enum class TablatureMinimStyle : char {
       SLASHED                         // draw half notes with stem with two slashes
       };
 
+enum class TablatureSymbolRepeat : char {
+      NEVER = 0,                    // never repeat the same duration symbol
+      SYSTEM,                       // repeat at the begining of a new system
+      MEASURE,                      // repeat at the beginning of a new measure
+      ALWAYS                        // always repeat
+      };
+
 struct TablatureDurationFont {
       QString family;                 // the family of the physical font to use
       QString displayName;            // the name to display to the user
@@ -148,7 +155,7 @@ class StaffType {
       bool _genKeysig       = true;       // create key signature at beginning of system
       bool _showLedgerLines = true;
 
-      // configurable properties
+      // TAB: configurable properties
       qreal _durationFontSize = 15.0;     // the size (in points) for the duration symbol font
       qreal _durationFontUserY = 0.0;     // the vertical offset (spatium units) for the duration symb. font
                                           // user configurable
@@ -158,6 +165,7 @@ class StaffType {
       bool  _genDurations = false;        // whether duration symbols are drawn or not
       bool  _linesThrough = false;        // whether lines for strings and stems may pass through fret marks or not
       TablatureMinimStyle _minimStyle = TablatureMinimStyle::NONE;    // how to draw minim stems (stem-and-beam durations only)
+      TablatureSymbolRepeat _symRepeat = TablatureSymbolRepeat::NEVER;// if and when to repeat the same duration symbol
       bool  _onLines      = true;         // whether fret marks are drawn on the string lines or between them
       bool  _showRests    = false;        // whether to draw rests or not
       bool  _stemsDown    = true;         // stems are drawn downward (stem-and-beam durations only)
@@ -165,7 +173,7 @@ class StaffType {
       bool  _upsideDown   = false;        // whether lines are drawn with highest string at top (false) or at bottom (true)
       bool  _useNumbers   = true;         // true: use numbers ('0' - ...) for frets | false: use letters ('a' - ...)
 
-      // internally managed variables
+      // TAB: internally managed variables
       qreal _durationBoxH = 0.0;
       qreal _durationBoxY = 0.0;          // the height and the y rect.coord. (relative to staff top line)
                                           // of a box bounding all duration symbols (raster units) internally computed:
@@ -207,7 +215,7 @@ class StaffType {
       StaffType(StaffGroup sg, const QString& xml, const QString& name, int lines, qreal lineDist, bool genClef,
                   bool showBarLines, bool stemless, bool genTimesig,
                   const QString& durFontName, qreal durFontSize, qreal durFontUserY, qreal genDur,
-                  const QString& fretFontName, qreal fretFontSize, qreal fretFontUserY,
+                  const QString& fretFontName, qreal fretFontSize, qreal fretFontUserY, TablatureSymbolRepeat symRepeat,
                   bool linesThrough, TablatureMinimStyle minimStyle, bool onLines, bool showRests,
                   bool stemsDown, bool stemThrough, bool upsideDown, bool useNumbers);
 
@@ -284,7 +292,8 @@ class StaffType {
       qreal fretFontYOffset()             { setFretMetrics(); return _fretYOffset + _fretFontUserY * MScore::DPI*SPATIUM20; }
       bool  genDurations() const          { return _genDurations;       }
       bool  linesThrough() const          { return _linesThrough;       }
-      TablatureMinimStyle minimStyle () const   { return _minimStyle;   }
+      TablatureMinimStyle minimStyle() const    { return _minimStyle;   }
+      TablatureSymbolRepeat symRepeat() const   { return _symRepeat;    }
       bool  onLines() const               { return _onLines;            }
       bool  showRests() const             { return _showRests;          }
       bool  stemsDown() const             { return _stemsDown;          }
@@ -301,7 +310,8 @@ class StaffType {
       void  setFretFontUserY(qreal val)   { _fretFontUserY = val;       }
       void  setGenDurations(bool val)     { _genDurations = val;        }
       void  setLinesThrough(bool val)     { _linesThrough = val;        }
-      void  setMinimStyle(TablatureMinimStyle val)    { _minimStyle = val;    }
+      void  setMinimStyle(TablatureMinimStyle val)          { _minimStyle = val;    }
+      void  setSymbolRepeat(TablatureSymbolRepeat val)      { _symRepeat  = val;    }
       void  setOnLines(bool);
       void  setShowRests(bool val)        { _showRests = val;           }
       void  setStemsDown(bool val)        { _stemsDown = val;           }

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -102,14 +102,18 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
       connect(showLedgerLinesPercussion,  SIGNAL(toggled(bool)),  SLOT(updatePreview()));
       connect(stemlessPercussion,         SIGNAL(toggled(bool)),  SLOT(updatePreview()));
 
-      connect(noteValuesSymb, SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(noteValuesSymb, SIGNAL(toggled(bool)),              SLOT(tabStemsToggled(bool)));
       connect(noteValuesStems,SIGNAL(toggled(bool)),              SLOT(tabStemsToggled(bool)));
+      connect(valuesRepeatNever,  SIGNAL(toggled(bool)),          SLOT(updatePreview()));
+      connect(valuesRepeatSystem, SIGNAL(toggled(bool)),          SLOT(updatePreview()));
+      connect(valuesRepeatMeasure,SIGNAL(toggled(bool)),          SLOT(updatePreview()));
+      connect(valuesRepeatAlways, SIGNAL(toggled(bool)),          SLOT(updatePreview()));
       connect(stemBesideRadio,SIGNAL(toggled(bool)),              SLOT(updatePreview()));
       connect(stemThroughRadio,SIGNAL(toggled(bool)),             SLOT(tabStemThroughToggled(bool)));
       connect(stemAboveRadio, SIGNAL(toggled(bool)),              SLOT(updatePreview()));
       connect(stemBelowRadio, SIGNAL(toggled(bool)),              SLOT(updatePreview()));
-      connect(minimShortRadio,SIGNAL(toggled(bool)),              SLOT(tabMinimShortToggled(bool)));
-      connect(minimSlashedRadio,SIGNAL(toggled(bool)),            SLOT(updatePreview()));
+      connect(minimShortRadio,    SIGNAL(toggled(bool)),          SLOT(tabMinimShortToggled(bool)));
+      connect(minimSlashedRadio,  SIGNAL(toggled(bool)),          SLOT(updatePreview()));
       connect(showRests,      SIGNAL(toggled(bool)),              SLOT(updatePreview()));
       connect(durFontName,    SIGNAL(currentIndexChanged(int)),   SLOT(durFontNameChanged(int)));
       connect(durFontSize,    SIGNAL(valueChanged(double)),       SLOT(updatePreview()));
@@ -202,6 +206,11 @@ void EditStaffType::setValues()
                   minimNoneRadio->setChecked(minimStyle == TablatureMinimStyle::NONE);
                   minimShortRadio->setChecked(minimStyle == TablatureMinimStyle::SHORTER);
                   minimSlashedRadio->setChecked(minimStyle == TablatureMinimStyle::SLASHED);
+                  TablatureSymbolRepeat symRepeat = staffType.symRepeat();
+                  valuesRepeatNever->setChecked(symRepeat == TablatureSymbolRepeat::NEVER);
+                  valuesRepeatSystem->setChecked(symRepeat == TablatureSymbolRepeat::SYSTEM);
+                  valuesRepeatMeasure->setChecked(symRepeat == TablatureSymbolRepeat::MEASURE);
+                  valuesRepeatAlways->setChecked(symRepeat == TablatureSymbolRepeat::ALWAYS);
                   if (staffType.genDurations()) {
                         noteValuesNone->setChecked(false);
                         noteValuesSymb->setChecked(true);
@@ -348,6 +357,9 @@ void EditStaffType::setFromDlg()
       staffType.setLinesThrough(linesThroughRadio->isChecked());
       staffType.setMinimStyle(minimNoneRadio->isChecked() ? TablatureMinimStyle::NONE :
             (minimShortRadio->isChecked() ? TablatureMinimStyle::SHORTER : TablatureMinimStyle::SLASHED));
+      staffType.setSymbolRepeat(valuesRepeatNever->isChecked() ? TablatureSymbolRepeat::NEVER :
+            (valuesRepeatSystem->isChecked() ? TablatureSymbolRepeat::SYSTEM :
+                  valuesRepeatMeasure->isChecked() ? TablatureSymbolRepeat::MEASURE : TablatureSymbolRepeat::ALWAYS));
       staffType.setOnLines(onLinesRadio->isChecked());
       staffType.setShowRests(showRests->isChecked());
       staffType.setUpsideDown(upsideDown->isChecked());
@@ -392,6 +404,10 @@ void EditStaffType::blockSignals(bool block)
       onLinesRadio->blockSignals(block);
 
       upsideDown->blockSignals(block);
+      valuesRepeatNever->blockSignals(block);
+      valuesRepeatSystem->blockSignals(block);
+      valuesRepeatMeasure->blockSignals(block);
+      valuesRepeatAlways->blockSignals(block);
       stemAboveRadio->blockSignals(block);
       stemBelowRadio->blockSignals(block);
       stemBesideRadio->blockSignals(block);
@@ -413,6 +429,10 @@ void EditStaffType::blockSignals(bool block)
 
 void EditStaffType::tabStemsCompatibility(bool checked)
       {
+      valuesRepeatNever->setEnabled(noteValuesSymb->isChecked());
+      valuesRepeatSystem->setEnabled(noteValuesSymb->isChecked());
+      valuesRepeatMeasure->setEnabled(noteValuesSymb->isChecked());
+      valuesRepeatAlways->setEnabled(noteValuesSymb->isChecked());
       stemAboveRadio->setEnabled(checked && !stemThroughRadio->isChecked());
       stemBelowRadio->setEnabled(checked && !stemThroughRadio->isChecked());
       stemBesideRadio->setEnabled(checked);

--- a/mscore/editstafftype.ui
+++ b/mscore/editstafftype.ui
@@ -378,7 +378,7 @@
                </sizepolicy>
               </property>
               <property name="currentIndex">
-               <number>1</number>
+               <number>0</number>
               </property>
               <widget class="QWidget" name="tab">
                <attribute name="title">
@@ -745,12 +745,15 @@
                     <widget class="QLabel" name="durSymLabel">
                      <property name="minimumSize">
                       <size>
-                       <width>120</width>
+                       <width>115</width>
                        <height>0</height>
                       </size>
                      </property>
                      <property name="text">
                       <string>Shown as:</string>
+                     </property>
+                     <property name="textFormat">
+                      <enum>Qt::PlainText</enum>
                      </property>
                      <property name="buddy">
                       <cstring>noteValuesNone</cstring>
@@ -761,7 +764,7 @@
                     <widget class="QRadioButton" name="noteValuesNone">
                      <property name="minimumSize">
                       <size>
-                       <width>110</width>
+                       <width>100</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -814,6 +817,108 @@
                   <property name="frameShadow">
                    <enum>QFrame::Plain</enum>
                   </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_5_2">
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="valuesRepeatLabel">
+                     <property name="minimumSize">
+                      <size>
+                       <width>115</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>Repeat:</string>
+                     </property>
+                     <property name="textFormat">
+                      <enum>Qt::PlainText</enum>
+                     </property>
+                     <property name="buddy">
+                      <cstring>noteValuesNone</cstring>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QRadioButton" name="valuesRepeatNever">
+                     <property name="minimumSize">
+                      <size>
+                       <width>100</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>Never</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QRadioButton" name="valuesRepeatSystem">
+                     <property name="minimumSize">
+                      <size>
+                       <width>120</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>At new system</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QRadioButton" name="valuesRepeatMeasure">
+                     <property name="minimumSize">
+                      <size>
+                       <width>110</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>At new meas.</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QRadioButton" name="valuesRepeatAlways">
+                     <property name="text">
+                      <string>Always</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="horizontalSpacer_13_2">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QFrame" name="frame_6">
+                  <property name="frameShape">
+                   <enum>QFrame::NoFrame</enum>
+                  </property>
+                  <property name="frameShadow">
+                   <enum>QFrame::Plain</enum>
+                  </property>
                   <layout class="QHBoxLayout" name="horizontalLayout_17">
                    <property name="leftMargin">
                     <number>0</number>
@@ -831,12 +936,15 @@
                     <widget class="QLabel" name="stemStyleLabel">
                      <property name="minimumSize">
                       <size>
-                       <width>120</width>
+                       <width>115</width>
                        <height>0</height>
                       </size>
                      </property>
                      <property name="text">
                       <string>Stem style:</string>
+                     </property>
+                     <property name="textFormat">
+                      <enum>Qt::PlainText</enum>
                      </property>
                      <property name="buddy">
                       <cstring>stemBesideRadio</cstring>
@@ -847,7 +955,7 @@
                     <widget class="QRadioButton" name="stemBesideRadio">
                      <property name="minimumSize">
                       <size>
-                       <width>110</width>
+                       <width>100</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -880,7 +988,7 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QFrame" name="frame_6">
+                 <widget class="QFrame" name="frame_7">
                   <property name="frameShape">
                    <enum>QFrame::NoFrame</enum>
                   </property>
@@ -904,12 +1012,15 @@
                     <widget class="QLabel" name="stemPosLabel">
                      <property name="minimumSize">
                       <size>
-                       <width>120</width>
+                       <width>115</width>
                        <height>0</height>
                       </size>
                      </property>
                      <property name="text">
                       <string>Stem position:</string>
+                     </property>
+                     <property name="textFormat">
+                      <enum>Qt::PlainText</enum>
                      </property>
                      <property name="buddy">
                       <cstring>stemAboveRadio</cstring>
@@ -920,7 +1031,7 @@
                     <widget class="QRadioButton" name="stemAboveRadio">
                      <property name="minimumSize">
                       <size>
-                       <width>110</width>
+                       <width>100</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -953,7 +1064,7 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QFrame" name="frame_7">
+                 <widget class="QFrame" name="frame_8">
                   <property name="frameShape">
                    <enum>QFrame::NoFrame</enum>
                   </property>
@@ -977,12 +1088,15 @@
                     <widget class="QLabel" name="minimLabels">
                      <property name="minimumSize">
                       <size>
-                       <width>120</width>
+                       <width>115</width>
                        <height>0</height>
                       </size>
                      </property>
                      <property name="text">
                       <string>Half notes:</string>
+                     </property>
+                     <property name="textFormat">
+                      <enum>Qt::PlainText</enum>
                      </property>
                      <property name="buddy">
                       <cstring>minimNoneRadio</cstring>
@@ -996,7 +1110,7 @@
                      </property>
                      <property name="minimumSize">
                       <size>
-                       <width>110</width>
+                       <width>100</width>
                        <height>0</height>
                       </size>
                      </property>


### PR DESCRIPTION
Adds code and UI support to force display of a repeated rhythm symbol
- never (default and previous implementation)
- at new system
- at new measure
- always

The setting is written to the score file only if different from the default.