### PR TITLE
fix #46356: crash after undo of paste with tie forward

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -69,6 +69,7 @@
 #include "sym.h"
 #include "rehearsalmark.h"
 #include "breath.h"
+#include "tie.h"
 
 namespace Ms {
 
@@ -1568,6 +1569,15 @@ void Score::removeElement(Element* element)
                   break;
 
             case Element::Type::CHORD:
+                  {
+                  Chord* c = static_cast<Chord*>(element);
+                  for (Note* n : c->notes()) {
+                        Tie* t = n->tieFor();
+                        if (t)
+                              n->remove(t);
+                        }
+                  }
+                  // fall through
             case Element::Type::REST:
                   {
                   ChordRest* cr = static_cast<ChordRest*>(element);


### PR DESCRIPTION
There are probably other ways of solving the problem, but this does fix the problem as far as I can tell.  I tested with accidentals too to make sure things are updated, and they seem to be. 