### PR TITLE
fix #46451: tie from normal note to grace before next note

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3694,7 +3694,7 @@ qreal Score::computeMinWidth(Segment* fs, bool firstMeasureInSystem)
                                           sp = qMax(bad, bnd - diff);
                                           }
                                     else if (grace)
-                                          sp = styleS(StyleIdx::barAccidentalDistance).val() * _spatium;
+                                          sp = styleS(StyleIdx::barGraceDistance).val() * _spatium;
                                     else
                                           sp = bnd;
                                     if (pt & Segment::Type::TimeSig)


### PR DESCRIPTION
I previously added support for ties between normal notes and their own grace notes (from a grace note before to the main note, or from the main note to grace note after).  But I didn't deal with the case at hand: from a normal note to a grace before the *next* normal note.  Or from a grace after to the next normal note (although that case did happen to work some of the time).

This PR gets all of these cases working.