### PR TITLE
Don't request save score on 'Apply' call on unchanged score in MIDI import

### DIFF
--- a/mscore/importmidi/importmidi_panel.cpp
+++ b/mscore/importmidi/importmidi_panel.cpp
@@ -7,6 +7,7 @@
 #include "importmidi_inner.h"
 #include "mscore/preferences.h"
 #include "musescore.h"
+#include "libmscore/score.h"
 
 
 namespace Ms {
@@ -207,6 +208,8 @@ void ImportMidiPanel::applyMidiImport()
       _model->notifyAllApplied();
       opers.data()->trackOpers = _model->trackOpers();
       setReorderedIndexes();
+            // prevent from showing save request dialog on every 'apply MIDI import' call
+      mscore->currentScore()->setCreated(false);
 
       mscore->openScore(_midiFile);
       saveTableViewState();


### PR DESCRIPTION
Fix side effect of https://github.com/musescore/MuseScore/commit/1ad88b161a6d94f927c48c26c039d703e69ee7ed