### PR TITLE
Temporary fix for 46796.

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4010,6 +4010,11 @@ bool ScoreView::event(QEvent* event)
       else if (event->type() == QEvent::Gesture) {
             return gestureEvent(static_cast<QGestureEvent*>(event));
             }
+      else if (event->type() == QEvent::MouseButtonPress && qApp->focusWidget() != this) {
+            QMouseEvent* me = static_cast<QMouseEvent*>(event);
+            if (me->button() == Qt::LeftButton)
+                  this->setFocus();
+            }
       return QWidget::event(event);
       }
 


### PR DESCRIPTION
The fix is temporary in the sense that I haven't found yet what changed in the code to cause this. That setFocus() call should not be required, it should be made by the Qt engine. My guess is that somewhere a mouse click event does not get to forwarded to the base class (QWidget), but I was unable to find it. While I keep looking for that, this  PR should fix the problem with documents in split screen.