### PR TITLE
More correct percussion staff type setting in MIDI import (+ fix #29591)

### DIFF
--- a/mscore/importmidi/importmidi_clef.cpp
+++ b/mscore/importmidi/importmidi_clef.cpp
@@ -425,17 +425,17 @@ void createClefs(Staff *staff, int indexOfOperation, bool isDrumTrack)
       {
       const auto &opers = preferences.midiImportOperations.data()->trackOpers;
       const auto &trackInstrList = opers.msInstrList.value(indexOfOperation);
+      const int msInstrIndex = opers.msInstrIndex.value(indexOfOperation);
+      const bool hasInstrument = !trackInstrList.empty() && trackInstrList[msInstrIndex];
 
-      if (isDrumTrack && trackInstrList.empty()) {
+      if (isDrumTrack && !hasInstrument) {
             createClef(ClefType::PERC, staff, 0);
             return;
             }
 
       const int strack = staff->idx() * VOICES;
       bool mainClefWasSet = false;
-      const int msInstrIndex = opers.msInstrIndex.value(indexOfOperation);
-      const bool canChangeClef = trackInstrList.empty() || !trackInstrList[msInstrIndex]
-                                  || hasGFclefs(trackInstrList[msInstrIndex]);
+      const bool canChangeClef = !hasInstrument || hasGFclefs(trackInstrList[msInstrIndex]);
 
       if (opers.changeClef.value(indexOfOperation) && canChangeClef) {
             MidiTie::TieStateMachine tieTracker;

--- a/mscore/importmidi/importmidi_instrument.cpp
+++ b/mscore/importmidi/importmidi_instrument.cpp
@@ -231,7 +231,11 @@ std::vector<const InstrumentTemplate *> findInstrumentsForProgram(const MTrack &
                         suitableTemplates.push_back(instr);
                   }
             else if (program >= 80 && program <= 103) {
-                  auto instr = findInstrument("electronic-instruments", "effect-synth");
+                  const InstrumentTemplate *instr = nullptr;
+                  if (track.mtrack->drumTrack())
+                        instr = findInstrument("electronic-instruments", "percussion-synthesizer");
+                  else
+                        instr = findInstrument("electronic-instruments", "effect-synth");
                   if (instr)
                         suitableTemplates.push_back(instr);       // generic synth
                   }

--- a/mscore/importmidi/importmidi_instrument.cpp
+++ b/mscore/importmidi/importmidi_instrument.cpp
@@ -395,10 +395,12 @@ void createInstruments(Score *score, QList<MTrack> &tracks)
                   part->setStaves(1);
 
             if (part->nstaves() == 1) {
-                  if (!instr && track.mtrack->drumTrack()) {
+                  if (track.mtrack->drumTrack()) {
                         part->staff(0)->setStaffType(StaffType::preset(StaffTypes::PERC_DEFAULT));
-                        part->instr()->setDrumset(smDrumset);
-                        part->instr()->setUseDrumset(DrumsetKind::DEFAULT_DRUMS);
+                        if (!instr) {
+                              part->instr()->setDrumset(smDrumset);
+                              part->instr()->setUseDrumset(DrumsetKind::DEFAULT_DRUMS);
+                              }
                         }
                   }
             else {
@@ -415,6 +417,8 @@ void createInstruments(Score *score, QList<MTrack> &tracks)
 
             if (instr) {
                   for (int i = 0; i != part->nstaves(); ++i) {
+                        if (instr->staffTypePreset)
+                              part->staff(i)->setStaffType(instr->staffTypePreset);
                         part->staff(i)->setLines(instr->staffLines[i]);
                         part->staff(i)->setSmall(instr->smallStaff[i]);
                         part->staff(i)->setDefaultClefType(instr->clefTypes[i]);

--- a/mtest/importmidi/perc_drums.mscx
+++ b/mtest/importmidi/perc_drums.mscx
@@ -42,7 +42,9 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="pitched">
+        <StaffType group="percussion">
+          <name>perc5Line</name>
+          <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>

--- a/mtest/importmidi/perc_no_grand_staff.mscx
+++ b/mtest/importmidi/perc_no_grand_staff.mscx
@@ -42,11 +42,12 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="pitched">
+        <StaffType group="percussion">
+          <name>perc1Line</name>
           <lines>1</lines>
+          <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
-        <barLineSpan from="0" to="8">1</barLineSpan>
         </Staff>
       <trackName>Percussion</trackName>
       <Instrument>
@@ -100,7 +101,9 @@
       </Part>
     <Part>
       <Staff id="2">
-        <StaffType group="pitched">
+        <StaffType group="percussion">
+          <name>perc5Line</name>
+          <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>

--- a/mtest/importmidi/perc_remove_ties.mscx
+++ b/mtest/importmidi/perc_remove_ties.mscx
@@ -42,7 +42,9 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="pitched">
+        <StaffType group="percussion">
+          <name>perc5Line</name>
+          <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>

--- a/mtest/importmidi/perc_respect_beat.mscx
+++ b/mtest/importmidi/perc_respect_beat.mscx
@@ -42,7 +42,9 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="pitched">
+        <StaffType group="percussion">
+          <name>perc5Line</name>
+          <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>

--- a/mtest/importmidi/perc_triplet.mscx
+++ b/mtest/importmidi/perc_triplet.mscx
@@ -42,7 +42,9 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="pitched">
+        <StaffType group="percussion">
+          <name>perc5Line</name>
+          <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>

--- a/mtest/importmidi/perc_tuplet_simplify.mscx
+++ b/mtest/importmidi/perc_tuplet_simplify.mscx
@@ -42,7 +42,9 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="pitched">
+        <StaffType group="percussion">
+          <name>perc5Line</name>
+          <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>

--- a/mtest/importmidi/perc_tuplet_simplify2.mscx
+++ b/mtest/importmidi/perc_tuplet_simplify2.mscx
@@ -42,7 +42,9 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="pitched">
+        <StaffType group="percussion">
+          <name>perc5Line</name>
+          <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>

--- a/mtest/importmidi/perc_tuplet_voice.mscx
+++ b/mtest/importmidi/perc_tuplet_voice.mscx
@@ -42,7 +42,9 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <StaffType group="pitched">
+        <StaffType group="percussion">
+          <name>perc5Line</name>
+          <keysig>0</keysig>
           </StaffType>
         <defaultClef>PERC</defaultClef>
         </Staff>


### PR DESCRIPTION
Fix http://musescore.org/en/node/29591 again, regression after MuseScore instrument setting for tracks in MIDI import (old fix: https://github.com/musescore/MuseScore/commit/f62d764bb68791ca04b9dd2487b4c43ed453c035)
Also set percussion clef for drum tracks if the user selected empty MuseScore instrument on the MIDI import panel.