### PR TITLE
fix #42326: Allow adding an InstrumentChange to the first note

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -862,6 +862,13 @@ Element* ChordRest::drop(const DropData& data)
             case Element::Type::STAFF_TEXT:
             case Element::Type::STAFF_STATE:
             case Element::Type::INSTRUMENT_CHANGE:
+                  if(e->type() == Element::Type::INSTRUMENT_CHANGE
+                     && staff()->part()->instrList()->find(tick()) != staff()->part()->instrList()->end()) {
+                        qDebug()<<"InstrumentChange already exists at tick = "<<tick();
+                        delete e;
+                        return 0;
+                        }
+                  // fall through
             case Element::Type::REHEARSAL_MARK:
                   e->setParent(segment());
                   e->setTrack((track() / VOICES) * VOICES);

--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -119,7 +119,7 @@ void createExcerpt(Excerpt* excerpt)
 
       foreach (Part* part, parts) {
             Part* p = new Part(score);
-            p->setInstrument(*part->instr(), 0);
+            p->setInstrument(*part->instr());
 
             foreach (Staff* staff, *part->staves()) {
                   Staff* s = new Staff(score);

--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -34,7 +34,7 @@ Part::Part(Score* s)
    : ScoreElement(s)
       {
       _show  = true;
-      setInstrument(Instrument(), 0);     // default instrument
+      setInstrument(Instrument());     // default instrument
       }
 
 //---------------------------------------------------------
@@ -45,7 +45,7 @@ void Part::initFromInstrTemplate(const InstrumentTemplate* t)
       {
       _partName = t->trackName;
       Instrument instr = Instrument::fromTemplate(t);
-      setInstrument(instr, 0);
+      setInstrument(instr);
       }
 
 //---------------------------------------------------------
@@ -73,11 +73,11 @@ void Part::read(XmlReader& e)
                   staff->read(e);
                   }
             else if (tag == "Instrument")
-                  instr(0)->read(e);
+                  instr()->read(e);
             else if (tag == "name")
-                  instr(0)->setLongName(e.readElementText());
+                  instr()->setLongName(e.readElementText());
             else if (tag == "shortName")
-                  instr(0)->setShortName(e.readElementText());
+                  instr()->setShortName(e.readElementText());
             else if (tag == "trackName")
                   _partName = e.readElementText();
             else if (tag == "show")
@@ -86,7 +86,7 @@ void Part::read(XmlReader& e)
                   e.unknown();
             }
       if (_partName.isEmpty())
-            _partName = instr(0)->trackName();
+            _partName = instr()->trackName();
       }
 
 //---------------------------------------------------------
@@ -101,7 +101,7 @@ void Part::write(Xml& xml) const
       if (!_show)
             xml.tag("show", _show);
       xml.tag("trackName", _partName);
-      instr(0)->write(xml);
+      instr()->write(xml);
       xml.etag();
       }
 
@@ -176,56 +176,56 @@ void Part::removeStaff(Staff* staff)
 
 void Part::setMidiProgram(int program, int bank)
       {
-      Channel c = instr(0)->channel(0);
+      Channel c = instr()->channel(0);
       c.program = program;
       c.bank    = bank;
       c.updateInitList();
-      instr(0)->setChannel(0, c);
+      instr()->setChannel(0, c);
       }
 
 int Part::volume() const
       {
-      return instr(0)->channel(0).volume;
+      return instr()->channel(0).volume;
       }
 
 void Part::setVolume(int volume)
       {
-      instr(0)->channel(0).volume = volume;
+      instr()->channel(0).volume = volume;
       }
 
 bool Part::mute() const
-{
-      return instr(0)->channel(0).mute;
-}
+      {
+      return instr()->channel(0).mute;
+      }
 
 void Part::setMute(bool mute)
-{
-      instr(0)->channel(0).mute = mute;
-}
+      {
+      instr()->channel(0).mute = mute;
+      }
 
 int Part::reverb() const
       {
-      return instr(0)->channel(0).reverb;
+      return instr()->channel(0).reverb;
       }
 
 int Part::chorus() const
       {
-      return instr(0)->channel(0).chorus;
+      return instr()->channel(0).chorus;
       }
 
 int Part::pan() const
       {
-      return instr(0)->channel(0).pan;
+      return instr()->channel(0).pan;
       }
 
 void Part::setPan(int pan)
       {
-      instr(0)->channel(0).pan = pan;
+      instr()->channel(0).pan = pan;
       }
 
 int Part::midiProgram() const
       {
-      return instr(0)->channel(0).program;
+      return instr()->channel(0).program;
       }
 
 //---------------------------------------------------------
@@ -234,7 +234,7 @@ int Part::midiProgram() const
 
 int Part::midiChannel() const
       {
-      return score()->midiChannel(instr(0)->channel(0).channel);
+      return score()->midiChannel(instr()->channel(0).channel);
       }
 
 //---------------------------------------------------------
@@ -243,7 +243,7 @@ int Part::midiChannel() const
 
 int Part::midiPort() const
       {
-      return score()->midiPort(instr(0)->channel(0).channel);
+      return score()->midiPort(instr()->channel(0).channel);
       }
 
 //---------------------------------------------------------
@@ -335,7 +335,7 @@ QString Part::shortName(int tick) const
 
 void Part::setLongName(const QString& s)
       {
-      instr(0)->setLongName(s);
+      instr()->setLongName(s);
       }
 
 //---------------------------------------------------------
@@ -344,7 +344,7 @@ void Part::setLongName(const QString& s)
 
 void Part::setShortName(const QString& s)
       {
-      instr(0)->setShortName(s);
+      instr()->setShortName(s);
       }
 
 //---------------------------------------------------------

--- a/libmscore/part.h
+++ b/libmscore/part.h
@@ -75,16 +75,16 @@ class Part : public QObject, public ScoreElement {
       int startTrack() const;
       int endTrack() const;
 
-      QString longName(int tick = 0) const;
-      QString shortName(int tick = 0) const;
-      QString instrumentName(int tick = 0) const;
-      QString instrumentId(int tick = 0) const;
+      QString longName(int tick = -1) const;
+      QString shortName(int tick = -1) const;
+      QString instrumentName(int tick = -1) const;
+      QString instrumentId(int tick = -1) const;
 
-      const QList<StaffName>& longNames(int tick = 0) const  { return instr(tick)->longNames();  }
-      const QList<StaffName>& shortNames(int tick = 0) const { return instr(tick)->shortNames(); }
+      const QList<StaffName>& longNames(int tick = -1) const  { return instr(tick)->longNames();  }
+      const QList<StaffName>& shortNames(int tick = -1) const { return instr(tick)->shortNames(); }
 
-      void setLongNames(QList<StaffName>& s, int tick = 0);
-      void setShortNames(QList<StaffName>& s, int tick = 0);
+      void setLongNames(QList<StaffName>& s, int tick = -1);
+      void setShortNames(QList<StaffName>& s, int tick = -1);
 
       void setLongName(const QString& s);
       void setShortName(const QString& s);
@@ -112,9 +112,9 @@ class Part : public QObject, public ScoreElement {
       bool show() const                        { return _show;  }
       void setShow(bool val)                   { _show = val;   }
 
-      Instrument* instr(int tick = 0);
-      const Instrument* instr(int tick = 0) const;
-      void setInstrument(const Instrument&, int tick = 0);
+      Instrument* instr(int tick = -1);
+      const Instrument* instr(int tick = -1) const;
+      void setInstrument(const Instrument&, int tick = -1);
       void removeInstrument(int tick);
 
       QString partName() const                 { return _partName; }

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -233,7 +233,7 @@ void Part::read114(XmlReader& e)
                   staff->read114(e);
                   }
             else if (tag == "Instrument") {
-                  Instrument* instrument = instr(0);
+                  Instrument* instrument = instr();
                   instrument->read(e);
                   // add string data from MIDI program number, if possible
                   if (instrument->stringData()->strings() == 0
@@ -251,7 +251,7 @@ void Part::read114(XmlReader& e)
                         else if (program == 42)                   // cello and other bass string instr.
                               instrument->setStringData(StringData(24, 4, g_celloStrings));
                         }
-                  Drumset* d = const_cast<Drumset*>(instr(0)->drumset());
+                  Drumset* d = const_cast<Drumset*>(instr()->drumset());
                   Staff*   st = staff(0);
                   if (d && st && st->lines() != 5) {
                         int n = 0;
@@ -264,13 +264,13 @@ void Part::read114(XmlReader& e)
             else if (tag == "name") {
                   Text* t = new Text(score());
                   t->read(e);
-                  instr(0)->setLongName(t->text());
+                  instr()->setLongName(t->text());
                   delete t;
                   }
             else if (tag == "shortName") {
                   Text* t = new Text(score());
                   t->read(e);
-                  instr(0)->setShortName(t->text());
+                  instr()->setShortName(t->text());
                   delete t;
                   }
             else if (tag == "trackName")
@@ -281,9 +281,9 @@ void Part::read114(XmlReader& e)
                   e.unknown();
             }
       if (_partName.isEmpty())
-            _partName = instr(0)->trackName();
+            _partName = instr()->trackName();
 
-      if (instr(0)->useDrumset() != DrumsetKind::NONE) {
+      if (instr()->useDrumset() != DrumsetKind::NONE) {
             foreach(Staff* staff, _staves) {
                   int lines = staff->lines();
                   int bf    = staff->barLineFrom();
@@ -306,7 +306,7 @@ void Part::read114(XmlReader& e)
       articulations.append(MidiArticulation("staccato", "", 100, 50));
       articulations.append(MidiArticulation("tenuto", "", 100, 100));
       articulations.append(MidiArticulation("sforzato", "", 120, 100));
-      instr(0)->setArticulation(articulations);
+      instr()->setArticulation(articulations);
       }
 
 //---------------------------------------------------------

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -405,7 +405,7 @@ void Staff::write(Xml& xml) const
 
       // for copy/paste we need to know the actual transposition
       if (xml.clipboardmode) {
-            Interval v = part()->instr(0)->transpose();
+            Interval v = part()->instr()->transpose();
             if (v.diatonic)
                   xml.tag("transposeDiatonic", v.diatonic);
             if (v.chromatic)

--- a/mscore/importgtp-gp6.cpp
+++ b/mscore/importgtp-gp6.cpp
@@ -393,35 +393,35 @@ void GuitarPro6::readTracks(QDomNode* track)
                         // use an array as a map instead?
                         if (!ref.compare("e-gtr6")) {
                               *instr = instr->fromTemplate(Ms::searchTemplate("electric-guitar"));
-                              part->setInstrument(*instr, 0);
+                              part->setInstrument(*instr);
                               }
                         else if (!ref.compare("tnr-s")) {
                               *instr = instr->fromTemplate(Ms::searchTemplate("voice"));
-                              part->setInstrument(*instr, 0);
+                              part->setInstrument(*instr);
                               }
                         else if (!ref.compare("s-gtr6")) {
                               *instr = instr->fromTemplate(Ms::searchTemplate("guitar-steel"));
-                              part->setInstrument(*instr, 0);
+                              part->setInstrument(*instr);
                               }
                         else if (!ref.compare("snt-lead-ss")) {
                               *instr = instr->fromTemplate(Ms::searchTemplate("poly-synth"));
-                              part->setInstrument(*instr, 0);
+                              part->setInstrument(*instr);
                               }
                         else if (!ref.compare("f-bass5")) {
                               *instr = instr->fromTemplate(Ms::searchTemplate("bass-guitar"));
-                              part->setInstrument(*instr, 0);
+                              part->setInstrument(*instr);
                               }
                         else if (!ref.compare("snt-bass-ss")) {
                               *instr = instr->fromTemplate(Ms::searchTemplate("metallic-synth"));
-                              part->setInstrument(*instr, 0);
+                              part->setInstrument(*instr);
                               }
                         else if (!ref.compare("mrcs")) {
                               *instr = instr->fromTemplate(Ms::searchTemplate("maracas"));
-                              part->setInstrument(*instr, 0);
+                              part->setInstrument(*instr);
                              }
                         else if (!ref.compare("drmkt")) {
                               *instr = instr->fromTemplate(Ms::searchTemplate("drumset"));
-                              part->setInstrument(*instr, 0);
+                              part->setInstrument(*instr);
                               }
                         }
                   else if (nodeName == "Properties") {

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -114,10 +114,10 @@ void StaffListItem::initStaffTypeCombo(bool forceRecreate)
       // or in Instruments Wizard
       if (part) {
             const StringData* stringData = part->it ? &(part->it->stringData) :
-                        ( (part->part && part->part->instr(0)) ? part->part->instr(0)->stringData() : 0);
+                        ( (part->part && part->part->instr()) ? part->part->instr()->stringData() : 0);
             canUseTabs = stringData && stringData->strings() > 0;
             canUsePerc = part->it ? part->it->useDrumset :
-                        ( (part->part && part->part->instr(0)) ? part->part->instr(0)->useDrumset() : DrumsetKind::NONE);
+                        ( (part->part && part->part->instr()) ? part->part->instr()->useDrumset() : DrumsetKind::NONE);
             }
       _staffTypeCombo = new QComboBox();
       _staffTypeCombo->setAutoFillBackground(true);
@@ -818,7 +818,7 @@ StaffListItem* InstrumentsWidget::on_belowButton_clicked()
       if (pli->it)
             clefType = pli->it->clefType(ridx);
       else
-            clefType = pli->part->instr(0)->clefType(ridx);
+            clefType = pli->part->instr()->clefType(ridx);
       nsli->setDefaultClefType(clefType);
       pli->updateClefs();
 


### PR DESCRIPTION
InstrumentList is a std::map&lt;const int, Instrument&gt;, where const int is a tick.
Since all keys in std::map are unique, I forbade adding several InstrumentChanges to one note/chord/rest.
Also I set default instrument's key to -1, so default instrument will not be replaced if user adds an InstrumentChange to the first note.