### PR TITLE
fix #9351: add atonal / open key signature

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -37,7 +37,8 @@ const char* keyNames[] = {
       QT_TRANSLATE_NOOP("MuseScore", "Bb major, G minor"),
       QT_TRANSLATE_NOOP("MuseScore", "C# major, A# minor"),
       QT_TRANSLATE_NOOP("MuseScore", "F major, D minor"),
-      QT_TRANSLATE_NOOP("MuseScore", "C major, A minor")
+      QT_TRANSLATE_NOOP("MuseScore", "C major, A minor"),
+      QT_TRANSLATE_NOOP("MuseScore", "Open key signature")
       };
 
 //---------------------------------------------------------
@@ -251,6 +252,11 @@ void KeySig::draw(QPainter* p) const
       p->setPen(curColor());
       for (const KeySym& ks: _sig.keySymbols())
             drawSymbol(ks.sym, p, QPointF(ks.pos.x(), ks.pos.y()));
+      if (!parent() && isCustom() && _sig.keySymbols().isEmpty()) {
+            // atonal key signature - draw something for palette
+            p->setPen(Qt::gray);
+            drawSymbol(SymId::timeSigX, p, QPointF(symWidth(SymId::timeSigX) * -0.5, 2.0 * spatium()));
+            }
       }
 
 //---------------------------------------------------------
@@ -545,8 +551,12 @@ Element* KeySig::prevElement()
 QString KeySig::accessibleInfo()
       {
       QString keySigType;
-      if (isCustom())
-            return tr("%1: Custom").arg(Element::accessibleInfo());
+      if (isCustom()) {
+            if (keySigEvent().keySymbols().isEmpty())
+                  return tr("%1: Open").arg(Element::accessibleInfo());
+            else
+                  return tr("%1: Custom").arg(Element::accessibleInfo());
+            }
 
       if (key() == Key::C)
             return QString("%1: %2").arg(Element::accessibleInfo()).arg(qApp->translate("MuseScore", keyNames[14]));

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -612,7 +612,7 @@ void MuseScore::newFile()
                               // transpose key
                               //
                               KeySigEvent nKey = ks;
-                              if (part->instr()->transpose().chromatic && !score->styleB(StyleIdx::concertPitch)) {
+                              if (!nKey.custom() && part->instr()->transpose().chromatic && !score->styleB(StyleIdx::concertPitch)) {
                                     int diff = -part->instr()->transpose().chromatic;
                                     nKey.setKey(transposeKey(nKey.key(), diff));
                                     }

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -249,6 +249,12 @@ Palette* MuseScore::newKeySigPalette()
       KeySig* k = new KeySig(gscore);
       k->setKey(Key::C);
       sp->append(k, qApp->translate("MuseScore", keyNames[14]));
+      // atonal key signature
+      KeySigEvent nke;
+      nke.setCustom(true);
+      KeySig* nk = new KeySig(gscore);
+      nk->setKeySigEvent(nke);
+      sp->append(nk, qApp->translate("MuseScore", keyNames[15]));
       return sp;
       }
 


### PR DESCRIPTION
The actual support for atonal key signatures is not new with this PR - I am using the existing custom key signature facility.  I am simply adding an empty custom key signature to the palette, with appropriate support so it renders in palette as something distinct from C major, so there is a reaosnable tooltip & accessibiity info, etc.  Here is how it looks in the Create New Score wizard:

![open](https://cloud.githubusercontent.com/assets/1799936/6098518/73bf7cbc-af9e-11e4-8eba-7837322e5875.png)
