### PR TITLE
fix #46926: issues with selection of current note in tab staff

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2933,7 +2933,8 @@ void Score::selectRange(Element* e, int staffIdx)
 
       _selection.setActiveTrack(activeTrack);
 
-      if (_selection.startSegment())
+      // doing this in note entry mode can clear selection
+      if (_selection.startSegment() && !noteEntryMode())
             setPlayPos(_selection.startSegment()->tick());
 
       _selection.updateSelectedElements();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1454,13 +1454,25 @@ void ScoreView::moveCursor()
             int         maxTrack = minTrack + VOICES;
             // get the physical string corresponding to current visual string
             strg = staff->staffType()->visualStringToPhys(strg);
-            for (int track = minTrack; track < maxTrack; track++) {
-                  Element* e = seg->element(track);
+            for (int t = minTrack; t < maxTrack; t++) {
+                  Element* e = seg->element(t);
                   if (e != nullptr && e->type() == Element::Type::CHORD)
                         for (Note* n : static_cast<Chord*>(e)->notes())
                               // if note found on this string, make it current
                               if (n->string() == strg) {
-                                    _score->select(n);
+                                    if (!n->selected()) {
+                                          _score->select(n);
+                                          // restore input state after selection
+                                          _score->inputState().setTrack(track);
+                                          }
+#if 0
+                                    // if using this code, we can delete the setTrack() call above
+                                    // the code below forces input state & cursor to match current note
+                                    _score->inputState().setTrack(t);
+                                    QColor c(MScore::selectColor[t % VOICES]);
+                                    c.setAlpha(50);
+                                    _cursor->setColor(c);
+#endif
                                     done = true;
                                     break;
                                     }


### PR DESCRIPTION
The crash on Ctrl+A in note input mode was due to moveCursor() selecting the note under the cursor position while still processing the command to select all - the selection was changing from range to list mid-stream.  Fixed by not calling setPlayPos() from selectRange() if in note input mode.

The fact that moveCursor always tries to select the note under the cursor is also the direct cause of the issue with change voice not working if the cursor is on a note in another voice.  The code to select the note on the current string while navigating in note input mode does so regardless of voice.  I simply removed the loop through voices, so we only select a note under the cursor if it is in the current voice.  I also check to see if the note is already selected, so we don't clear a range selection, which allows Ctrl+A to work.

@mgavioli : I do remember having specifically asked to have navigation autoamtically select the note under the cursor.  But I can't think of a good reason why it should be "voice-blind" as it currently is.  I realize tab and multiple voices are not the best of friends :-), but I do think only selecting notes if in the current voice makes more sense, and it fixes the issue with not being able to change voices if a note in another voice is under the cursor.  If there is some reason why you think it is better to select the note under the cursor even though it is not in the current voice, I could revert this portion of my change.