### PR TITLE
Fix play panel, synthesizer, mixer not getting focus when opened using keyboard.

### DIFF
--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -133,6 +133,7 @@ void Mixer::showEvent(QShowEvent* e)
       enablePlay->showEvent(e);
       QScrollArea::showEvent(e);
       activateWindow();
+      setFocus();
       }
 
 //---------------------------------------------------------

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -149,6 +149,7 @@ void PlayPanel::showEvent(QShowEvent* e)
       enablePlay->showEvent(e);
       QWidget::showEvent(e);
       activateWindow();
+      setFocus();
       }
 
 //---------------------------------------------------------

--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -133,6 +133,7 @@ void SynthControl::showEvent(QShowEvent* e)
       enablePlay->showEvent(e);
       QWidget::showEvent(e);
       activateWindow();
+      setFocus();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Due to another fix of mine which seemed unrelated, from another branch which got merged, these windows don't get focus when opened using menu and arrows (they do if opened with the mouse in the menu though).