### PR TITLE
Fix #47526 - TAB: Make tabs aware of staff transpositions.

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -807,7 +807,7 @@ NoteVal Score::noteValForPosition(Position pos, bool &error)
                         _is.setString(line);
                         nval.fret = 0;
                         }
-                  nval.pitch = stringData->getPitch(string, nval.fret);
+                  nval.pitch = stringData->getPitch(string, nval.fret, st, tick);
                   break;
                   }
 
@@ -1048,7 +1048,7 @@ void Score::putNote(const Position& p, bool replace)
                                           int fret = note->fret() * 10 + nval.fret;
                                           if (fret <= stringData->frets() ) {
                                                 nval.fret = fret;
-                                                nval.pitch = stringData->getPitch(nval.string, nval.fret);
+                                                nval.pitch = stringData->getPitch(nval.string, nval.fret, st, s->tick());
                                                 }
                                           else
                                                 qDebug("can't increase fret to %d", fret);

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -198,7 +198,7 @@ void FretDiagram::init(StringData* stringData, Chord* chord)
             foreach(const Note* note, chord->notes()) {
                   int string;
                   int fret;
-                  if (stringData->convertPitch(note->ppitch(), &string, &fret))
+                  if (stringData->convertPitch(note->pitch(), chord->staff(), chord->segment()->tick(), &string, &fret))
                         setDot(string, fret);
                   }
             _maxFrets = stringData->frets();

--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -89,7 +89,7 @@ void StringData::write(Xml& xml) const
 //   convertPitch
 //   Finds string and fret for a note.
 //
-//   Fills *string and *fret with suitable values for pitch
+//   Fills *string and *fret with suitable values for pitch at given tick of given staff,
 //   using the highest possible string.
 //   If note cannot be fretted, uses fret 0 on nearest string and returns false
 //
@@ -105,7 +105,10 @@ bool StringData::convertPitch(int pitch, Staff* staff, int tick, int* string, in
 
 //---------------------------------------------------------
 //   getPitch
-//   Returns the pitch corresponding to the string / fret combination
+//    Returns the pitch corresponding to the string / fret combination
+//    at given tick of given staff.
+//    Returns INVALID_PITCH if not possible
+//    Note: frets above max fret are accepted.
 //---------------------------------------------------------
 
 int StringData::getPitch(int string, int fret, Staff* staff, int tick) const
@@ -116,7 +119,8 @@ int StringData::getPitch(int string, int fret, Staff* staff, int tick) const
 //---------------------------------------------------------
 //   fret
 //    Returns the fret corresponding to the pitch / string combination
-//    returns -1 if not possible
+//    at given tick of given staff.
+//    Returns FRET_NONE if not possible
 //---------------------------------------------------------
 
 int StringData::fret(int pitch, int string, Staff* staff, int tick) const
@@ -265,7 +269,7 @@ int StringData::pitchOffsetAt(Staff* staff, int /*tick*/)
 //   convertPitch
 //   Finds string and fret for a note.
 //
-//   Fills *string and *fret with suitable values for pitch
+//   Fills *string and *fret with suitable values for pitch / pitchOffset,
 //   using the highest possible string.
 //   If note cannot be fretted, uses fret 0 on nearest string and returns false
 //
@@ -311,7 +315,9 @@ bool StringData::convertPitch(int pitch, int pitchOffset, int* string, int* fret
 
 //---------------------------------------------------------
 //   getPitch
-//   Returns the pitch corresponding to the string / fret combination
+//    Returns the pitch corresponding to the string / fret / pitchOffset combination.
+//    Returns INVALID_PITCH if not possible
+//    Note: frets above max fret are accepted.
 //---------------------------------------------------------
 
 int StringData::getPitch(int string, int fret, int pitchOffset) const
@@ -325,8 +331,8 @@ int StringData::getPitch(int string, int fret, int pitchOffset) const
 
 //---------------------------------------------------------
 //   fret
-//    Returns the fret corresponding to the pitch / string combination
-//    returns -1 if not possible
+//    Returns the fret corresponding to the pitch / string / pitchOffset combination.
+//    returns FRET_NONE if not possible
 //---------------------------------------------------------
 
 int StringData::fret(int pitch, int string, int pitchOffset) const

--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -13,7 +13,9 @@
 #include "stringdata.h"
 #include "chord.h"
 #include "note.h"
+#include "part.h"
 #include "score.h"
+#include "staff.h"
 #include "undo.h"
 
 namespace Ms {
@@ -96,11 +98,189 @@ void StringData::write(Xml& xml) const
 //          from highest (0) to lowest (strings()-1)
 //---------------------------------------------------------
 
-bool StringData::convertPitch(int pitch, int* string, int* fret) const
+bool StringData::convertPitch(int pitch, Staff* staff, int tick, int* string, int* fret) const
+      {
+      return convertPitch(pitch, pitchOffsetAt(staff, tick), string, fret);
+      }
+
+//---------------------------------------------------------
+//   getPitch
+//   Returns the pitch corresponding to the string / fret combination
+//---------------------------------------------------------
+
+int StringData::getPitch(int string, int fret, Staff* staff, int tick) const
+      {
+      return getPitch(string, fret, pitchOffsetAt(staff, tick));
+      }
+
+//---------------------------------------------------------
+//   fret
+//    Returns the fret corresponding to the pitch / string combination
+//    returns -1 if not possible
+//---------------------------------------------------------
+
+int StringData::fret(int pitch, int string, Staff* staff, int tick) const
+      {
+      return fret(pitch, string, pitchOffsetAt(staff, tick));
+      }
+
+//---------------------------------------------------------
+//   fretChords
+//    Assigns fretting to all the notes of each chord in the same segment of chord
+//    re-using existing fretting wherever possible
+//
+//    Minimizes fret conflicts (multiple notes on the same string)
+//    but marks as fretConflict notes which cannot be fretted
+//    (outside tablature range) or which cannot be assigned
+//    a separate string
+//---------------------------------------------------------
+
+void StringData::fretChords(Chord * chord) const
+      {
+      int   nFret, minFret, maxFret, nNewFret, nTempFret;
+      int   nString, nNewString, nTempString;
+
+      if(bFretting)
+            return;
+      bFretting = true;
+
+      // we need to keep track of string allocation
+      int bUsed[strings()];                    // initially all strings are available
+      for(nString=0; nString<strings(); nString++)
+            bUsed[nString] = 0;
+      // we also need the notes sorted in order of string (from highest to lowest) and then pitch
+      QMap<int, Note *> sortedNotes;
+      int   count = 0;
+      // store staff pitch offset at this tick, to speed up actual note pitch calculations
+      // (ottavas not implemented yet)
+      int transp = chord->staff() ? chord->staff()->part()->instr()->transpose().chromatic : 0;
+      int pitchOffset = /*chord->staff()->pitchOffset(chord->segment()->tick())*/ - transp;
+      // if chord parent is not a segment, the chord is special (usually a grace chord):
+      // fret it by itself, ignoring the segment
+      if (chord->parent()->type() != Element::Type::SEGMENT)
+            sortChordNotes(sortedNotes, chord, pitchOffset, &count);
+      else {
+            // scan each chord of seg from same staff as 'chord', inserting each of its notes in sortedNotes
+            Segment* seg = chord->segment();
+            int trk;
+            int trkFrom = (chord->track() / VOICES) * VOICES;
+            int trkTo   = trkFrom + VOICES;
+            for(trk = trkFrom; trk < trkTo; ++trk) {
+                  Element* ch = seg->elist().at(trk);
+                  if (ch && ch->type() == Element::Type::CHORD)
+                        sortChordNotes(sortedNotes, static_cast<Chord*>(ch), pitchOffset, &count);
+                  }
+            }
+      // determine used range of frets
+      minFret = INT32_MAX;
+      maxFret = INT32_MIN;
+      foreach(Note* note, sortedNotes) {
+            if (note->string() != STRING_NONE)
+                  bUsed[note->string()]++;
+            if (note->fret() != FRET_NONE && note->fret() < minFret)
+                  minFret = note->fret();
+            if (note->fret() != FRET_NONE && note->fret() > maxFret)
+                  maxFret = note->fret();
+      }
+
+      // scan chord notes from highest, matching with strings from the highest
+      foreach(Note * note, sortedNotes) {
+            nString     = nNewString    = note->string();
+            nFret       = nNewFret      = note->fret();
+            note->setFretConflict(false);       // assume no conflicts on this note
+            // if no fretting (any invalid fretting has been erased by sortChordNotes() )
+            if (nString == STRING_NONE /*|| nFret == FRET_NONE || getPitch(nString, nFret) != note->pitch()*/) {
+                  // get a new fretting
+                  if (!convertPitch(note->pitch(), pitchOffset, &nNewString, &nNewFret) ) {
+                        // no way to fit this note in this tab:
+                        // mark as fretting conflict
+                        note->setFretConflict(true);
+                        // store fretting change without affecting chord context
+                        if (nFret != nNewFret)
+                              note->score()->undoChangeProperty(note, P_ID::FRET, nNewFret);
+                        if (nString != nNewString)
+                              note->score()->undoChangeProperty(note, P_ID::STRING, nNewString);
+                        continue;
+                        }
+                  // note can be fretted: use string
+                  else {
+                        bUsed[nNewString]++;
+                        }
+                  }
+
+            // if the note string (either original or newly assigned) is also used by another note
+            if (bUsed[nNewString] > 1) {
+                  // attempt to find a suitable string, from topmost
+                  for (nTempString=0; nTempString < strings(); nTempString++) {
+                        if (bUsed[nTempString] < 1
+                                    && (nTempFret=fret(note->pitch(), nTempString, pitchOffset)) != FRET_NONE) {
+                              bUsed[nNewString]--;    // free previous string
+                              bUsed[nTempString]++;   // and occupy new string
+                              nNewFret   = nTempFret;
+                              nNewString = nTempString;
+                              break;
+                              }
+                        }
+                  }
+
+            // TODO : try to optimize used fret range, avoiding eccessively open positions
+
+            // if fretting did change, store as a fret change
+            if (nFret != nNewFret)
+                  note->score()->undoChangeProperty(note, P_ID::FRET, nNewFret);
+            if (nString != nNewString)
+                  note->score()->undoChangeProperty(note, P_ID::STRING, nNewString);
+            }
+
+      // check for any remaining fret conflict
+      foreach(Note * note, sortedNotes)
+            if (bUsed[note->string()] > 1)
+                  note->setFretConflict(true);
+
+      bFretting = false;
+      }
+
+//********************
+// STATIC METHODS
+//********************
+
+//---------------------------------------------------------
+//   pitchOffsetAt
+//   Computes the pitch offset relevant for string data calculation at the given point.
+//
+//   For string data calculations, pitch offset may depend on transposition, capos and, possibly, ottavas.
+//---------------------------------------------------------
+
+int StringData::pitchOffsetAt(Staff* staff, int /*tick*/)
+      {
+      int transp = staff ? staff->part()->instr()->transpose().chromatic : 0;
+      return (/*staff->pitchOffset(tick)*/ - transp);
+      }
+
+//********************
+// PRIVATE METHODS
+//********************
+
+//---------------------------------------------------------
+//   convertPitch
+//   Finds string and fret for a note.
+//
+//   Fills *string and *fret with suitable values for pitch
+//   using the highest possible string.
+//   If note cannot be fretted, uses fret 0 on nearest string and returns false
+//
+//    Note: Strings are stored internally from lowest (0) to highest (strings()-1),
+//          but the returned *string value references strings in reversed, 'visual', order:
+//          from highest (0) to lowest (strings()-1)
+//---------------------------------------------------------
+
+bool StringData::convertPitch(int pitch, int pitchOffset, int* string, int* fret) const
       {
       int strings = stringTable.size();
       if (strings < 1)
             return false;
+
+      pitch += pitchOffset;
 
       // if above max fret on highest string, fret on first string, but return failure
       if(pitch > stringTable.at(strings-1).pitch + _frets) {
@@ -134,13 +314,13 @@ bool StringData::convertPitch(int pitch, int* string, int* fret) const
 //   Returns the pitch corresponding to the string / fret combination
 //---------------------------------------------------------
 
-int StringData::getPitch(int string, int fret) const
+int StringData::getPitch(int string, int fret, int pitchOffset) const
       {
       int strings = stringTable.size();
-      if (strings < 1 || string >= strings)
+      if (string < 0 || string >= strings)
             return INVALID_PITCH;
       instrString strg = stringTable.at(strings - string - 1);
-      return strg.pitch + (strg.open ? 0 : fret);
+      return strg.pitch - pitchOffset + (strg.open ? 0 : fret);
       }
 
 //---------------------------------------------------------
@@ -149,7 +329,7 @@ int StringData::getPitch(int string, int fret) const
 //    returns -1 if not possible
 //---------------------------------------------------------
 
-int StringData::fret(int pitch, int string) const
+int StringData::fret(int pitch, int string, int pitchOffset) const
       {
       int strings = stringTable.size();
       if (strings < 1)                          // no strings at all!
@@ -157,122 +337,14 @@ int StringData::fret(int pitch, int string) const
 
       if (string < 0 || string >= strings)      // no such a string
             return FRET_NONE;
+
+      pitch += pitchOffset;
+
       int fret = pitch - stringTable[strings - string - 1].pitch;
       // fret number is invalid or string cannot be fretted
       if (fret < 0 || fret >= _frets || (fret > 0 && stringTable[strings - string - 1].open))
             return FRET_NONE;
       return fret;
-      }
-
-//---------------------------------------------------------
-//   fretChords
-//    Assigns fretting to all the notes of each chord in the same segment of chord
-//    re-using existing fretting wherever possible
-//
-//    Minimizes fret conflicts (multiple notes on the same string)
-//    but marks as fretConflict notes which cannot be fretted
-//    (outside tablature range) or which cannot be assigned
-//    a separate string
-//---------------------------------------------------------
-
-void StringData::fretChords(Chord * chord) const
-      {
-      int   nFret, minFret, maxFret, nNewFret, nTempFret;
-      int   nString, nNewString, nTempString;
-
-      if(bFretting)
-            return;
-      bFretting = true;
-
-      // we need to keep track of string allocation
-      int bUsed[strings()];                    // initially all strings are available
-      for(nString=0; nString<strings(); nString++)
-            bUsed[nString] = 0;
-      // we also need the notes sorted in order of string (from highest to lowest) and then pitch
-      QMap<int, Note *> sortedNotes;
-      int   count = 0;
-      // if chord parent is not a segment, the chord is special (usually a grace chord):
-      // fret it by itself, ignoring the segment
-      if (chord->parent()->type() != Element::Type::SEGMENT)
-            sortChordNotes(sortedNotes, chord, &count);
-      else {
-            // scan each chord of seg from same staff as 'chord', inserting each of its notes in sortedNotes
-            Segment* seg = chord->segment();
-            int trk;
-            int trkFrom = (chord->track() / VOICES) * VOICES;
-            int trkTo   = trkFrom + VOICES;
-            for(trk = trkFrom; trk < trkTo; ++trk) {
-                  Element* ch = seg->elist().at(trk);
-                  if (ch && ch->type() == Element::Type::CHORD)
-                        sortChordNotes(sortedNotes, static_cast<Chord*>(ch), &count);
-                  }
-            }
-      // determine used range of frets
-      minFret = INT32_MAX;
-      maxFret = INT32_MIN;
-      foreach(Note* note, sortedNotes) {
-            if (note->string() != STRING_NONE)
-                  bUsed[note->string()]++;
-            if (note->fret() != FRET_NONE && note->fret() < minFret)
-                  minFret = note->fret();
-            if (note->fret() != FRET_NONE && note->fret() > maxFret)
-                  maxFret = note->fret();
-      }
-
-      // scan chord notes from highest, matching with strings from the highest
-      foreach(Note * note, sortedNotes) {
-            nString     = nNewString    = note->string();
-            nFret       = nNewFret      = note->fret();
-            note->setFretConflict(false);       // assume no conflicts on this note
-            // if no fretting (any invalid fretting has been erased by sortChordNotes() )
-            if (nString == STRING_NONE /*|| nFret == FRET_NONE || getPitch(nString, nFret) != note->pitch()*/) {
-                  // get a new fretting
-                  if (!convertPitch(note->pitch(), &nNewString, &nNewFret) ) {
-                        // no way to fit this note in this tab:
-                        // mark as fretting conflict
-                        note->setFretConflict(true);
-                        // store fretting change without affecting chord context
-                        if (nFret != nNewFret)
-                              note->score()->undoChangeProperty(note, P_ID::FRET, nNewFret);
-                        if (nString != nNewString)
-                              note->score()->undoChangeProperty(note, P_ID::STRING, nNewString);
-                        continue;
-                        }
-                  // note can be fretted: use string
-                  else {
-                        bUsed[nNewString]++;
-                        }
-                  }
-
-            // if the note string (either original or newly assigned) is also used by another note
-            if (bUsed[nNewString] > 1) {
-                  // attempt to find a suitable string, from topmost
-                  for (nTempString=0; nTempString < strings(); nTempString++) {
-                        if (bUsed[nTempString] < 1 && (nTempFret=fret(note->pitch(), nTempString)) != FRET_NONE) {
-                              bUsed[nNewString]--;    // free previous string
-                              bUsed[nTempString]++;   // and occupy new string
-                              nNewFret   = nTempFret;
-                              nNewString = nTempString;
-                              break;
-                              }
-                        }
-                  }
-
-            // TODO : try to optimize used fret range, avoiding eccessively open positions
-
-            // if fretting did change, store as a fret change
-            if (nFret != nNewFret)
-                  note->score()->undoChangeProperty(note, P_ID::FRET, nNewFret);
-            if (nString != nNewString)
-                  note->score()->undoChangeProperty(note, P_ID::STRING, nNewString);
-            }
-
-      // check for any remaining fret conflict
-      foreach(Note * note, sortedNotes)
-            if (bUsed[note->string()] > 1)
-                  note->setFretConflict(true);
-
-      bFretting = false;
       }
 
 //---------------------------------------------------------
@@ -286,7 +358,7 @@ void StringData::fretChords(Chord * chord) const
 //    Notes without a string assigned yet, are sorted according to the lowest string which can accommodate them.
 //---------------------------------------------------------
 
-void StringData::sortChordNotes(QMap<int, Note *>& sortedNotes, const Chord *chord, int* count) const
+void StringData::sortChordNotes(QMap<int, Note *>& sortedNotes, const Chord *chord, int pitchOffset, int* count) const
 {
       int   key, string, fret;
 
@@ -296,13 +368,13 @@ void StringData::sortChordNotes(QMap<int, Note *>& sortedNotes, const Chord *cho
             // if note not fretted yet or current fretting no longer valid,
             // use most convenient string as key
             if (string <= STRING_NONE || fret <= FRET_NONE
-                        || getPitch(string, fret) != note->pitch()) {
+                        || getPitch(string, fret, pitchOffset) != note->pitch()) {
                   note->setString(STRING_NONE);
                   note->setFret(FRET_NONE);
-                  convertPitch(note->pitch(), &string, &fret);
+                  convertPitch(note->pitch(), pitchOffset, &string, &fret);
                   }
             key = string * 100000;
-            key += -note->pitch() * 100 + *count;     // disambiguate notes of equal pitch
+            key += -(note->pitch()+pitchOffset) * 100 + *count;     // disambiguate notes of equal pitch
             sortedNotes.insert(key, note);
             (*count)++;
             }

--- a/libmscore/stringdata.h
+++ b/libmscore/stringdata.h
@@ -40,16 +40,20 @@ class StringData {
 
       static bool bFretting;
 
-      void sortChordNotes(QMap<int, Note *>& sortedNotes, const Chord* chord, int* count) const;
+      bool        convertPitch(int pitch, int pitchOffset, int* string, int* fret) const;
+      int         fret(int pitch, int string, int pitchOffset) const;
+      int         getPitch(int string, int fret, int pitchOffset) const;
+      void        sortChordNotes(QMap<int, Note *>& sortedNotes, const Chord* chord, int pitchOffset, int* count) const;
 
 public:
       StringData() {}
       StringData(int numFrets, int numStrings, int strings[]);
       StringData(int numFrets, QList<instrString>& strings);
-      bool        convertPitch(int pitch, int* string, int* fret) const;
-      int         fret(int pitch, int string) const;
+      bool        convertPitch(int pitch, Staff* staff, int tick, int* string, int* fret) const;
+      int         fret(int pitch, int string, Staff* staff, int tick) const;
       void        fretChords(Chord * chord) const;
-      int         getPitch(int string, int fret) const;
+      int         getPitch(int string, int fret, Staff* staff, int tick) const;
+      static int  pitchOffsetAt(Staff* staff, int tick);
       int         strings() const               { return stringTable.size(); }
       QList<instrString>  stringList() const    { return stringTable; }
       QList<instrString>&  stringList()         { return stringTable; }

--- a/mscore/importgtp-gp4.cpp
+++ b/mscore/importgtp-gp4.cpp
@@ -286,7 +286,7 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
                         fret = 0;
                   gn->setFret(fret);
                   gn->setString(string);
-                  int grace_pitch = note->staff()->part()->instr()->stringData()->getPitch(string, fret);
+                  int grace_pitch = note->staff()->part()->instr()->stringData()->getPitch(string, fret, nullptr, 0);
                   gn->setPitch(grace_pitch);
                   gn->setTpcFromPitch();
 
@@ -407,7 +407,7 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
       // dead note represented as high numbers - fix to zero
       if (fretNumber > 99 || fretNumber == -1)
             fretNumber = 0;
-      int pitch = staff->part()->instr()->stringData()->getPitch(string, fretNumber);
+      int pitch = staff->part()->instr()->stringData()->getPitch(string, fretNumber, nullptr, 0);
       note->setFret(fretNumber);
       note->setString(string);
       note->setPitch(pitch);

--- a/mscore/importgtp-gp5.cpp
+++ b/mscore/importgtp-gp5.cpp
@@ -632,7 +632,7 @@ bool GuitarPro5::readNoteEffects(Note* note)
                   }
             gn->setFret(fret);
             gn->setString(note->string());
-            int grace_pitch = note->staff()->part()->instr()->stringData()->getPitch(note->string(), fret);
+            int grace_pitch = note->staff()->part()->instr()->stringData()->getPitch(note->string(), fret, nullptr, 0);
             gn->setPitch(grace_pitch);
             gn->setTpcFromPitch();
 
@@ -864,7 +864,7 @@ bool GuitarPro5::readNote(int string, Note* note)
             note->setHeadGroup(NoteHead::Group::HEAD_CROSS);
             note->setGhost(true);
             }
-      int pitch = staff->part()->instr()->stringData()->getPitch(string, fretNumber);
+      int pitch = staff->part()->instr()->stringData()->getPitch(string, fretNumber, nullptr, 0);
       note->setFret(fretNumber);
       note->setString(string);
       note->setPitch(pitch);

--- a/mscore/importgtp-gp6.cpp
+++ b/mscore/importgtp-gp6.cpp
@@ -918,7 +918,7 @@ int GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* measure,
                                                             else if (!value.compare("1.8"))
                                                                   harmonicFret += 40;
                                                             harmonicNote->setFret(harmonicFret);
-                                                            harmonicNote->setPitch(staff->part()->instr()->stringData()->getPitch(musescoreString, harmonicFret));
+                                                            harmonicNote->setPitch(staff->part()->instr()->stringData()->getPitch(musescoreString, harmonicFret, nullptr, 0));
                                                             harmonicNote->setTpcFromPitch();
                                                             if (harmonicText.compare("Natural")) {
                                                                   harmonicNote->setFret(fretNum.toInt());
@@ -938,7 +938,7 @@ int GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* measure,
                                                       Staff* staff = note->staff();
                                                       int fretNumber = fretNum.toInt();
                                                       int musescoreString = staff->part()->instr()->stringData()->strings() - 1 - stringNum.toInt();
-                                                      auto pitch = staff->part()->instr()->stringData()->getPitch(musescoreString, fretNumber);
+                                                      auto pitch = staff->part()->instr()->stringData()->getPitch(musescoreString, fretNumber, nullptr, 0);
                                                       note->setFret(fretNumber);
                                                       // we need to turn this string number for GP to the the correct string number for musescore
                                                       note->setString(musescoreString);

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -1540,7 +1540,7 @@ void GuitarPro1::readNote(int string, Note* note)
                         fret = 0;
                   gn->setFret(fret);
                   gn->setString(string);
-                  int grace_pitch = note->staff()->part()->instr()->stringData()->getPitch(string, fret);
+                  int grace_pitch = note->staff()->part()->instr()->stringData()->getPitch(string, fret, nullptr, 0);
                   gn->setPitch(grace_pitch);
                   gn->setTpcFromPitch();
 
@@ -1630,7 +1630,7 @@ void GuitarPro1::readNote(int string, Note* note)
       // dead note represented as high numbers - fix to zero
       if (fretNumber > 99 || fretNumber == -1)
             fretNumber = 0;
-      int pitch = staff->part()->instr()->stringData()->getPitch(string, fretNumber);
+      int pitch = staff->part()->instr()->stringData()->getPitch(string, fretNumber, nullptr, 0);
 
       /* it's possible to specifiy extraordinarily high pitches by
       specifying fret numbers that don't exist. This is an issue that

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4281,7 +4281,7 @@ void ScoreView::cmdChangeEnharmonic(bool up)
                   continue;
             if (staff->isTabStaff()) {
                   int string = n->line() + (up ? 1 : -1);
-                  int fret   = staff->part()->instr()->stringData()->fret(n->pitch(), string);
+                  int fret   = staff->part()->instr()->stringData()->fret(n->pitch(), string, staff, n->chord()->tick());
                   if (fret != -1) {
                         score()->undoChangeProperty(n, P_ID::FRET, fret);
                         score()->undoChangeProperty(n, P_ID::STRING, string);

--- a/mtest/guitarpro/fret-diagram.gp4-ref.mscx
+++ b/mtest/guitarpro/fret-diagram.gp4-ref.mscx
@@ -144,7 +144,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -155,8 +155,8 @@
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>14</lid>
@@ -166,8 +166,8 @@
             <pitch>55</pitch>
             <tpc>27</tpc>
             <tpc2>21</tpc2>
-            <fret>5</fret>
-            <string>3</string>
+            <fret>4</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>15</lid>
@@ -177,8 +177,8 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>1</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>16</lid>
@@ -188,8 +188,8 @@
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Dynamic>
@@ -206,7 +206,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -217,8 +217,8 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>21</lid>
@@ -228,15 +228,15 @@
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>22</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -244,16 +244,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>24</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -265,7 +265,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -273,23 +273,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>28</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>29</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -297,16 +297,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>31</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -318,7 +318,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -326,23 +326,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>35</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>36</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -350,16 +350,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>38</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Beam id="2">
@@ -375,7 +375,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -383,23 +383,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>42</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>43</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -407,16 +407,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>45</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -428,7 +428,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -436,23 +436,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>49</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>50</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -460,16 +460,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>52</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -481,7 +481,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -489,23 +489,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>56</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>57</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -513,16 +513,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>59</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -534,7 +534,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -542,23 +542,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>63</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>64</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -566,16 +566,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>66</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <FretDiagram>
@@ -625,7 +625,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -633,23 +633,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>72</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>73</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -657,8 +657,8 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>75</lid>
@@ -668,8 +668,8 @@
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -681,7 +681,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -689,23 +689,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>79</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>80</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -713,16 +713,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>82</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -734,7 +734,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -742,23 +742,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>86</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>87</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -766,16 +766,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>89</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -787,7 +787,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -795,23 +795,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>93</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>94</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -819,16 +819,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>96</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Beam id="4">
@@ -844,7 +844,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -852,23 +852,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>100</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>101</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -876,16 +876,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>103</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -897,7 +897,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -905,23 +905,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>107</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>108</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -929,16 +929,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>110</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -950,7 +950,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -958,23 +958,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>114</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>115</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -982,16 +982,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>117</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -1003,7 +1003,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -1011,23 +1011,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>121</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>122</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -1035,16 +1035,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>124</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <BarLine>
@@ -1218,7 +1218,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1229,8 +1229,8 @@
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>14</lid>
@@ -1240,8 +1240,8 @@
               <pitch>55</pitch>
               <tpc>27</tpc>
               <tpc2>21</tpc2>
-              <fret>5</fret>
-              <string>3</string>
+              <fret>4</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>15</lid>
@@ -1251,8 +1251,8 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>1</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>16</lid>
@@ -1262,8 +1262,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Dynamic>
@@ -1280,7 +1280,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1291,8 +1291,8 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>21</lid>
@@ -1302,23 +1302,23 @@
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>23</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>22</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1326,8 +1326,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1339,7 +1339,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1347,31 +1347,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>28</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>30</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>29</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1379,8 +1379,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1392,7 +1392,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1400,31 +1400,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>35</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>37</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>36</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1432,8 +1432,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Beam id="6">
@@ -1449,7 +1449,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1457,31 +1457,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>42</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>44</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>43</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1489,8 +1489,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1502,7 +1502,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1510,31 +1510,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>49</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>51</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>50</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1542,8 +1542,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1555,7 +1555,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1563,31 +1563,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>56</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>58</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>57</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1595,8 +1595,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1608,7 +1608,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1616,31 +1616,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>63</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>65</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>64</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1648,8 +1648,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <FretDiagram>
@@ -1699,7 +1699,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1707,31 +1707,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>72</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>74</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>73</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1742,8 +1742,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1755,7 +1755,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1763,31 +1763,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>79</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>81</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>80</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1795,8 +1795,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1808,7 +1808,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1816,31 +1816,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>86</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>88</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>87</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1848,8 +1848,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1861,7 +1861,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1869,31 +1869,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>93</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>95</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>94</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1901,8 +1901,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Beam id="8">
@@ -1918,7 +1918,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1926,31 +1926,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>100</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>102</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>101</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1958,8 +1958,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1971,7 +1971,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1979,31 +1979,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>107</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>109</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>108</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2011,8 +2011,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2024,7 +2024,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2032,31 +2032,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>114</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>116</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>115</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2064,8 +2064,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2077,7 +2077,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2085,31 +2085,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>121</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>123</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>122</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2117,8 +2117,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <BarLine>
@@ -2160,7 +2160,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2168,32 +2168,32 @@
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>14</lid>
               <pitch>55</pitch>
               <tpc>27</tpc>
               <tpc2>21</tpc2>
-              <fret>5</fret>
-              <string>3</string>
+              <fret>4</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>15</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>1</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>16</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2205,7 +2205,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2213,23 +2213,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>21</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>22</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2237,16 +2237,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>24</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2258,7 +2258,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2266,23 +2266,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>28</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>29</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2290,16 +2290,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>31</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2311,7 +2311,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2319,23 +2319,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>35</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>36</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2343,16 +2343,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>38</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Beam id="10">
@@ -2368,7 +2368,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2376,23 +2376,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>42</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>43</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2400,16 +2400,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>45</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2421,7 +2421,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2429,23 +2429,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>49</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>50</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2453,16 +2453,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>52</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2474,7 +2474,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2482,23 +2482,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>56</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>57</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2506,16 +2506,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>59</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2527,7 +2527,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2535,23 +2535,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>63</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>64</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2559,16 +2559,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>66</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Beam id="11">
@@ -2584,7 +2584,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2592,23 +2592,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>72</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>73</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2616,16 +2616,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>75</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2637,7 +2637,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2645,23 +2645,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>79</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>80</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2669,16 +2669,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>82</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2690,7 +2690,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2698,23 +2698,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>86</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>87</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2722,16 +2722,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>89</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2743,7 +2743,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2751,23 +2751,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>93</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>94</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2775,16 +2775,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>96</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Beam id="12">
@@ -2800,7 +2800,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2808,23 +2808,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>100</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>101</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2832,16 +2832,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>103</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2853,7 +2853,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2861,23 +2861,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>107</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>108</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2885,16 +2885,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>110</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2906,7 +2906,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2914,23 +2914,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>114</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>115</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2938,16 +2938,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>117</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2959,7 +2959,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2967,23 +2967,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>121</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>122</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2991,16 +2991,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>124</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <BarLine>

--- a/mtest/guitarpro/fret-diagram.gp5-ref.mscx
+++ b/mtest/guitarpro/fret-diagram.gp5-ref.mscx
@@ -130,7 +130,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -141,8 +141,8 @@
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>12</lid>
@@ -152,8 +152,8 @@
             <pitch>55</pitch>
             <tpc>27</tpc>
             <tpc2>21</tpc2>
-            <fret>5</fret>
-            <string>3</string>
+            <fret>4</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>13</lid>
@@ -163,8 +163,8 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>1</fret>
+            <string>3</string>
             </Note>
           <Note>
             <lid>14</lid>
@@ -174,8 +174,8 @@
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Dynamic>
@@ -192,7 +192,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -203,8 +203,8 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>19</lid>
@@ -214,15 +214,15 @@
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>20</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -230,16 +230,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>22</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -251,7 +251,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -259,23 +259,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>26</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>27</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -283,16 +283,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>29</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -304,7 +304,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -312,23 +312,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>33</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>34</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -336,16 +336,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>36</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Beam id="2">
@@ -361,7 +361,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -369,23 +369,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>40</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>41</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -393,16 +393,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>43</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -414,7 +414,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -422,23 +422,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>47</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>48</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -446,16 +446,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>50</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -467,7 +467,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -475,23 +475,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>54</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>55</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -499,16 +499,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>57</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -520,7 +520,7 @@
             <pitch>38</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -528,23 +528,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>61</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <tpc2>14</tpc2>
-            <fret>9</fret>
-            <string>4</string>
+            <fret>8</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>62</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -552,16 +552,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>64</lid>
             <pitch>62</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>3</fret>
-            <string>1</string>
+            <fret>1</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <FretDiagram>
@@ -611,7 +611,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -619,23 +619,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>70</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>71</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -643,8 +643,8 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>73</lid>
@@ -654,8 +654,8 @@
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -667,7 +667,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -675,23 +675,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>77</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>78</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -699,16 +699,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>80</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -720,7 +720,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -728,23 +728,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>84</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>85</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -752,16 +752,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>87</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -773,7 +773,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -781,23 +781,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>91</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>92</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -805,16 +805,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>94</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Beam id="4">
@@ -830,7 +830,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -838,23 +838,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>98</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>99</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -862,16 +862,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>101</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -883,7 +883,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -891,23 +891,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>105</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>106</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -915,16 +915,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>108</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -936,7 +936,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -944,23 +944,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>112</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>113</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -968,16 +968,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>115</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <Chord>
@@ -989,7 +989,7 @@
             <pitch>40</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
+            <fret>0</fret>
             <string>6</string>
             </Note>
           <Note>
@@ -997,23 +997,23 @@
             <pitch>45</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>5</fret>
-            <string>5</string>
+            <fret>4</fret>
+            <string>6</string>
             </Note>
           <Note>
             <lid>119</lid>
             <pitch>50</pitch>
             <tpc>28</tpc>
             <tpc2>22</tpc2>
-            <fret>5</fret>
-            <string>4</string>
+            <fret>4</fret>
+            <string>5</string>
             </Note>
           <Note>
             <lid>120</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>7</fret>
+            <fret>1</fret>
             <string>3</string>
             </Note>
           <Note>
@@ -1021,16 +1021,16 @@
             <pitch>57</pitch>
             <tpc>17</tpc>
             <tpc2>11</tpc2>
-            <fret>2</fret>
-            <string>2</string>
+            <fret>6</fret>
+            <string>4</string>
             </Note>
           <Note>
             <lid>122</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <tpc2>12</tpc2>
-            <fret>5</fret>
-            <string>1</string>
+            <fret>3</fret>
+            <string>2</string>
             </Note>
           </Chord>
         <BarLine>
@@ -1190,7 +1190,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1201,8 +1201,8 @@
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>12</lid>
@@ -1212,8 +1212,8 @@
               <pitch>55</pitch>
               <tpc>27</tpc>
               <tpc2>21</tpc2>
-              <fret>5</fret>
-              <string>3</string>
+              <fret>4</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>13</lid>
@@ -1223,8 +1223,8 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>1</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>14</lid>
@@ -1234,8 +1234,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Dynamic>
@@ -1252,7 +1252,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1263,8 +1263,8 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>19</lid>
@@ -1274,23 +1274,23 @@
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>21</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>20</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1298,8 +1298,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1311,7 +1311,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1319,31 +1319,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>26</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>28</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>27</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1351,8 +1351,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1364,7 +1364,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1372,31 +1372,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>33</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>35</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>34</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1404,8 +1404,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Beam id="6">
@@ -1421,7 +1421,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1429,31 +1429,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>40</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>42</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>41</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1461,8 +1461,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1474,7 +1474,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1482,31 +1482,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>47</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>49</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>48</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1514,8 +1514,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1527,7 +1527,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1535,31 +1535,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>54</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>56</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>55</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1567,8 +1567,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1580,7 +1580,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1588,31 +1588,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>61</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>63</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>62</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1620,8 +1620,8 @@
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <FretDiagram>
@@ -1671,7 +1671,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1679,31 +1679,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>70</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>72</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>71</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1714,8 +1714,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1727,7 +1727,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1735,31 +1735,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>77</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>79</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>78</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1767,8 +1767,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1780,7 +1780,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1788,31 +1788,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>84</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>86</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>85</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1820,8 +1820,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1833,7 +1833,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1841,31 +1841,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>91</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>93</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>92</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1873,8 +1873,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Beam id="8">
@@ -1890,7 +1890,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1898,31 +1898,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>98</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>100</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>99</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1930,8 +1930,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1943,7 +1943,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -1951,31 +1951,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>105</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>107</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>106</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -1983,8 +1983,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -1996,7 +1996,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2004,31 +2004,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>112</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>114</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>113</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2036,8 +2036,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2049,7 +2049,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2057,31 +2057,31 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>119</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>121</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>120</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2089,8 +2089,8 @@
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <BarLine>
@@ -2128,7 +2128,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2136,32 +2136,32 @@
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>12</lid>
               <pitch>55</pitch>
               <tpc>27</tpc>
               <tpc2>21</tpc2>
-              <fret>5</fret>
-              <string>3</string>
+              <fret>4</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>13</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>1</fret>
+              <string>3</string>
               </Note>
             <Note>
               <lid>14</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2173,7 +2173,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2181,23 +2181,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>19</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>20</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2205,16 +2205,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>22</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2226,7 +2226,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2234,23 +2234,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>26</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>27</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2258,16 +2258,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>29</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2279,7 +2279,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2287,23 +2287,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>33</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>34</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2311,16 +2311,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>36</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Beam id="10">
@@ -2336,7 +2336,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2344,23 +2344,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>40</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>41</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2368,16 +2368,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>43</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2389,7 +2389,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2397,23 +2397,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>47</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>48</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2421,16 +2421,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>50</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2442,7 +2442,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2450,23 +2450,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>54</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>55</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2474,16 +2474,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>57</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2495,7 +2495,7 @@
               <pitch>38</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2503,23 +2503,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>61</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <tpc2>14</tpc2>
-              <fret>9</fret>
-              <string>4</string>
+              <fret>8</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>62</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2527,16 +2527,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>64</lid>
               <pitch>62</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>3</fret>
-              <string>1</string>
+              <fret>1</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Beam id="11">
@@ -2552,7 +2552,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2560,23 +2560,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>70</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>71</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2584,16 +2584,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>73</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2605,7 +2605,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2613,23 +2613,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>77</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>78</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2637,16 +2637,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>80</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2658,7 +2658,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2666,23 +2666,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>84</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>85</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2690,16 +2690,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>87</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2711,7 +2711,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2719,23 +2719,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>91</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>92</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2743,16 +2743,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>94</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Beam id="12">
@@ -2768,7 +2768,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2776,23 +2776,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>98</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>99</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2800,16 +2800,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>101</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2821,7 +2821,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2829,23 +2829,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>105</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>106</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2853,16 +2853,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>108</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2874,7 +2874,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2882,23 +2882,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>112</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>113</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2906,16 +2906,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>115</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <Chord>
@@ -2927,7 +2927,7 @@
               <pitch>40</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
+              <fret>0</fret>
               <string>6</string>
               </Note>
             <Note>
@@ -2935,23 +2935,23 @@
               <pitch>45</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>5</fret>
-              <string>5</string>
+              <fret>4</fret>
+              <string>6</string>
               </Note>
             <Note>
               <lid>119</lid>
               <pitch>50</pitch>
               <tpc>28</tpc>
               <tpc2>22</tpc2>
-              <fret>5</fret>
-              <string>4</string>
+              <fret>4</fret>
+              <string>5</string>
               </Note>
             <Note>
               <lid>120</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>7</fret>
+              <fret>1</fret>
               <string>3</string>
               </Note>
             <Note>
@@ -2959,16 +2959,16 @@
               <pitch>57</pitch>
               <tpc>17</tpc>
               <tpc2>11</tpc2>
-              <fret>2</fret>
-              <string>2</string>
+              <fret>6</fret>
+              <string>4</string>
               </Note>
             <Note>
               <lid>122</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <tpc2>12</tpc2>
-              <fret>5</fret>
-              <string>1</string>
+              <fret>3</fret>
+              <string>2</string>
               </Note>
             </Chord>
           <BarLine>


### PR DESCRIPTION
Fix #47526 : Make tabs aware of staff transposition

Feature has been requested and discussed at length in the forum thread: http://musescore.org/en/node/31016 and in the issue http://musescore.org/en/node/47526

To implement this, the fret-to-pitch relation has been made dependent of the staff, as each staff may have an individual transposition value in addition to the string data. And -- in addition -- on tick, in preparation of dealing with ottavas and capos.

**Note**: failing GTP import tests have been 'fixed' by updating them with the new string/fret values generated by the new support for transposing TAB's. It is possible, however, that importing of GTP scores with transpositions or capos (imported as transposition) be wrong, in which case tests are wrong anyway. I'll file appropriate issues in the issue tracker, to gather more info.