### PR TITLE
fix #47541: add buttons to select notes / rests to Inspector for group s...

### DIFF
--- a/mscore/inspector/inspectorGroupElement.cpp
+++ b/mscore/inspector/inspectorGroupElement.cpp
@@ -32,6 +32,36 @@ InspectorGroupElement::InspectorGroupElement(QWidget* parent)
       connect(ge.setColor, SIGNAL(clicked()), SLOT(setColor()));
       connect(ge.setVisible, SIGNAL(clicked()), SLOT(setVisible()));
       connect(ge.setInvisible, SIGNAL(clicked()), SLOT(setInvisible()));
+
+      //
+      // Select
+      //
+      QLabel* l = new QLabel;
+      l->setText(tr("Select"));
+      QFont font(l->font());
+      font.setBold(true);
+      l->setFont(font);
+      l->setAlignment(Qt::AlignHCenter);
+      _layout->addWidget(l);
+      QFrame* f = new QFrame;
+      f->setFrameStyle(QFrame::HLine | QFrame::Raised);
+      f->setLineWidth(2);
+      _layout->addWidget(f);
+      QHBoxLayout* hbox = new QHBoxLayout;
+
+      notes = new QToolButton(this);
+      notes->setText(tr("Notes"));
+      notes->setEnabled(true);
+      hbox->addWidget(notes);
+
+      rests = new QToolButton(this);
+      rests->setText(tr("Rests"));
+      rests->setEnabled(true);
+      hbox->addWidget(rests);
+
+      _layout->addLayout(hbox);
+      connect(notes, SIGNAL(clicked()), SLOT(notesClicked()));
+      connect(rests, SIGNAL(clicked()), SLOT(restsClicked()));
       }
 
 //---------------------------------------------------------
@@ -83,6 +113,52 @@ void InspectorGroupElement::setInvisible()
                   e->score()->undoChangeProperty(e, P_ID::VISIBLE, false);
             }
       score->endCmd();
+      }
+
+//---------------------------------------------------------
+//   notesClicked
+//---------------------------------------------------------
+
+void InspectorGroupElement::notesClicked()
+      {
+      Score* score = inspector->el().front()->score();
+      QList<Element*> el = score->selection().elements();
+      QList<Element*> nel;
+      bool elementFound = false;
+      for (Element* e : el) {
+            if (e->type() == Element::Type::NOTE) {
+                  nel.append(e);
+                  if (!elementFound)
+                        score->deselectAll();
+                  score->selection().add(e);
+                  elementFound = true;
+                  }
+            }
+      inspector->setElements(nel);
+      score->end();
+      }
+
+//---------------------------------------------------------
+//   restsClicked
+//---------------------------------------------------------
+
+void InspectorGroupElement::restsClicked()
+      {
+      Score* score = inspector->el().front()->score();
+      QList<Element*> el = score->selection().elements();
+      QList<Element*> nel;
+      bool elementFound = false;
+      for (Element* e : el) {
+            if (e->type() == Element::Type::REST) {
+                  nel.append(e);
+                  if (!elementFound)
+                        score->deselectAll();
+                  score->selection().add(e);
+                  elementFound = true;
+                  }
+            }
+      inspector->setElements(nel);
+      score->end();
       }
 
 }

--- a/mscore/inspector/inspectorGroupElement.h
+++ b/mscore/inspector/inspectorGroupElement.h
@@ -27,11 +27,15 @@ class InspectorGroupElement : public InspectorBase {
       Q_OBJECT
 
       Ui::InspectorGroupElement ge;
+      QToolButton* notes;
+      QToolButton* rests;
 
    private slots:
       void setColor();
       void setVisible();
       void setInvisible();
+      void notesClicked();
+      void restsClicked();
 
    public:
       InspectorGroupElement(QWidget* parent);


### PR DESCRIPTION
...election

Uses same basic layout as the Select buttons that already exist to select Stem, Tuplet, etc in the Inspector for Note and Rest.  With a group selection, a "Select" label appears at bottom of Inspector with two buttons below - "Notes" and "Rests".  Pressing either clears current selection and replaces with just notes or just rests, then updates Inspector so it will show the Note or Rest controls.