### PR TITLE
fix #47556: don't delete volta when deleting selection

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1813,6 +1813,8 @@ void Score::cmdDeleteSelection()
             int track2  = selection().staffEnd() * VOICES;
             for (auto i : _spanner.findOverlapping(stick1, stick2 - 1)) {
                   Spanner* sp = i.value;
+                  if (sp->type() == Element::Type::VOLTA)
+                        continue;
                   if (sp->track() >= track1 && sp->track() < track2) {
                         if (sp->tick() >= stick1 && sp->tick() < stick2
                             && sp->tick2() >= stick1 && sp->tick2() < stick2) {


### PR DESCRIPTION
See also #1586.  I had added code to exclude voltas from being included int selections and thus not be included in copy & paste, but I didn't see there was also separate code for deleting the selection.  So now I have added an exclusion for voltas there too

Ideally, I was thinking we should be able to check here for selected() instead of special-casing on VOLTA.  However, it seems that even though a voltas are excluded from the selection, they still show as selected().  This has nothing to do with that code I added previously, as far as I can tell.  I think there is an issue with management of selected status between the Spanner and the SpannerSegment, where the volta just never gets fully deselected even when clicking in a blank area of the score, whereas other spanners do.  The management of that is beyond what I wanted to tackle.  My change here is simle and fixes the immediate problem.