### PR TITLE
fix #46701: note entry starts offscreen

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -82,7 +82,7 @@ ChordRest* Score::searchNote(int tick, int track) const
       {
       ChordRest* ipe = 0;
       Segment::Type st = Segment::Type::ChordRest;
-      for (Segment* segment = firstSegment(st); segment; segment = segment->next(st)) {
+      for (Segment* segment = firstSegment(st); segment; segment = segment->next1(st)) {
             ChordRest* cr = static_cast<ChordRest*>(segment->element(track));
             if (!cr)
                   continue;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3165,7 +3165,13 @@ void ScoreView::startNoteEntry()
       if (el == 0 || (el->type() != Element::Type::CHORD && el->type() != Element::Type::REST && el->type() != Element::Type::NOTE)) {
             // if no note/rest is selected, start with voice 0
             int track = is.track() == -1 ? 0 : (is.track() / VOICES) * VOICES;
-            el = _score->searchNote(0, track);
+            // try to find an appropriate measure to start in
+            while (el && el->type() != Element::Type::MEASURE)
+                  el = el->parent();
+            int tick = el ? static_cast<Measure*>(el)->tick() : 0;
+            el = _score->searchNote(tick, track);
+            if (!el)
+                  el = _score->searchNote(0, track);
             Q_ASSERT(el);
             }
       if (el->type() == Element::Type::CHORD) {
@@ -3183,6 +3189,7 @@ void ScoreView::startNoteEntry()
       is.update(el);
       is.setRest(false);
       is.setNoteEntryMode(true);
+      adjustCanvasPosition(el, false);
 
       getAction("pad-rest")->setChecked(false);
       setMouseTracking(true);


### PR DESCRIPTION
With no CR selected, we were starting note entry at measure 1, but it might well be offscreen.  other possibilites could make note entry start offscreen too - a valid selection, but you've scroll away from it.  I added an adjustCanvasPosition, and also made an attempt to find a better start measure than 1,  If any single item is selected (but not a chordrest), I look up ancestors until I find a measure, and start note entry there if found.  Should be a smoother experience on several counts.

BTW, Score::searchNote() was returning null any time you passed in a tick value past the first measurem, because it looped through segments with next(0 instead of next().  I fixed that.  It's only used in one other place, when adding a tie in note entry mode while there is also a slur pending.  I verified that the code that was supposed to be executed was not being hit, and an error message printed to console, so my change should also "fix" that.  But I couldn't actually get it to *do* anything bad.  That whole section of code in addPitch(NoteVal, bool) doesn't seem to be necessary?  It was only being hit in measure 1, but it seems to work with or without it.  Or maybe I just didn't find the right sequence of steps to make it fail.