### PR TITLE
fix #46281: Change Regex to capture decimal numbers

### DIFF
--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -156,7 +156,7 @@ void TempoText::textChanged()
       QString s = text();
 
       for (unsigned i = 0; i < sizeof(tp)/sizeof(*tp); ++i) {
-            QRegExp re(QString(tp[i].pattern)+"\\s*=\\s*(\\d+)");      // 1/4
+            QRegExp re(QString(tp[i].pattern)+"\\s*=\\s*(\\d+([\.,]\\d+)?)");      // 1/4
             if (re.indexIn(s) != -1) {
                   QStringList sl = re.capturedTexts();
                   if (sl.size() == 2) {


### PR DESCRIPTION
Changed Regex to capture decimal numbers. 
Decimal numbers maybe in the form 80.5 or 80,5 as mentioned in http://musescore.org/en/node/46281#comment-215941