### PR TITLE
fix #47621: crash on copy tab note to non-existing string

### DIFF
--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -137,7 +137,7 @@ bool StringData::convertPitch(int pitch, int* string, int* fret) const
 int StringData::getPitch(int string, int fret) const
       {
       int strings = stringTable.size();
-      if (strings < 1)
+      if (strings < 1 || string >= strings)
             return INVALID_PITCH;
       instrString strg = stringTable.at(strings - string - 1);
       return strg.pitch + (strg.open ? 0 : fret);


### PR DESCRIPTION
The fix for the crash is very straightforward.  Whether the actual behavior when copying and pasting tablature between instruments with different numebr / tuning of strings is optimal I'll let others worry about, but it does seem to otherwise work as I personally would expect.