### PR TITLE
fix #47666: crash on delete of section break added after parts generated

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -977,6 +977,7 @@ void Score::undoAddElement(Element* element)
                               undo(new AddElement(lb));
                         else {
                               Element* e = lb->linkedClone();
+                              e->setScore(s);
                               Measure* nm = s->tick2measure(m->tick());
                               e->setParent(nm);
                               undo(new AddElement(e));


### PR DESCRIPTION
Linked clone of the break was being added to parts without calling setScore() to make it belong to the part.