### PR TITLE
update tooltip for baseline vertical alignment (text style/properties)

### DIFF
--- a/mscore/textproperties.ui
+++ b/mscore/textproperties.ui
@@ -681,7 +681,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>Center text vertical to text baseline</string>
+            <string>Align baseline of text to reference point</string>
            </property>
            <property name="text">
             <string notr="true">...</string>


### PR DESCRIPTION
The tooltip for the "baseline" vertical alignment button in text style / text properties makes no sense to me.  I have changed it to what I think it really means and made it more consistent with the wording of the other vertical alignment options.