### PR TITLE
Accessibility for position slider and position label in Play panel

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -265,7 +265,7 @@ add_executable ( ${ExecutableName}
       resourceManager.cpp downloadUtils.cpp
       textcursor.cpp continuouspanel.cpp accessibletoolbutton.cpp scoreaccessibility.cpp
       startcenter.cpp scoreBrowser.cpp scorePreview.cpp scoreInfo.cpp
-      logindialog.cpp loginmanager.cpp uploadscoredialog.cpp breaksdialog.cpp searchComboBox.cpp
+      logindialog.cpp loginmanager.cpp uploadscoredialog.cpp breaksdialog.cpp searchComboBox.cpp playpositionslider.cpp
       help.cpp help.h
 
       ${OMR_FILES}

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4563,7 +4563,7 @@ int main(int argc, char* av[])
       QAccessible::installFactory(AccessibleScoreView::ScoreViewFactory);
       QAccessible::installFactory(AccessibleSearchBox::SearchBoxFactory);
       QAccessible::installFactory(Awl::AccessibleAbstractSlider::AbstractSliderFactory);
-
+      QAccessible::installFactory(AccessiblePlayPosSlider::PlayPosSliderFactory);
       Q_INIT_RESOURCE(zita);
 
 #ifndef Q_OS_MAC

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -51,7 +51,7 @@ PlayPanel::PlayPanel(QWidget* parent)
       move(settings.value("playPanel/pos", QPoint(DEFAULT_POS_X, DEFAULT_POS_Y)).toPoint());
 
       setScore(0);
-
+      posSlider->setPlayPanel(this);
       playButton->setDefaultAction(getAction("play"));
       rewindButton->setDefaultAction(getAction("rewind"));
       countInButton->setDefaultAction(getAction("countin"));
@@ -66,7 +66,7 @@ PlayPanel::PlayPanel(QWidget* parent)
       tempoSlider->setUseActualValue(true);
 
       connect(volumeSlider, SIGNAL(valueChanged(double,int)), SLOT(volumeChanged(double,int)));
-      connect(posSlider,    SIGNAL(sliderMoved(int)),         SLOT(setPos(int)));
+      connect(posSlider,    SIGNAL(valueChanged(int)),        SLOT(setPos(int)));
       connect(tempoSlider,  SIGNAL(valueChanged(double,int)), SLOT(relTempoChanged(double,int)));
       connect(tempoSlider,  SIGNAL(sliderPressed(int)),       SLOT(tempoSliderPressed(int)));
       connect(tempoSlider,  SIGNAL(sliderReleased(int)),      SLOT(tempoSliderReleased(int)));
@@ -202,6 +202,16 @@ void PlayPanel::setScore(Score* s)
       }
 
 //---------------------------------------------------------
+//   score
+//---------------------------------------------------------
+
+Score* PlayPanel::score() const
+      {
+      return cs;
+      }
+
+
+//---------------------------------------------------------
 //   setEndpos
 //---------------------------------------------------------
 
@@ -259,6 +269,7 @@ void PlayPanel::setPos(int utick)
             return;
       if (cachedTickPosition != utick)
             emit posChange(utick);
+
       updatePosLabel(utick);
       updateTimeLabel(cs->utick2utime(utick));
       }
@@ -327,6 +338,24 @@ void PlayPanel::tempoSliderPressed(int)
       }
 
 //---------------------------------------------------------
+//   position
+//---------------------------------------------------------
+
+QLabel* PlayPanel::position() const
+      {
+      return posLabel;
+      }
+
+//---------------------------------------------------------
+//   time
+//---------------------------------------------------------
+
+QLabel* PlayPanel::time() const
+      {
+      return timeLabel;
+      }
+
+//---------------------------------------------------------
 //   tempoSliderReleased
 //---------------------------------------------------------
 
@@ -334,5 +363,6 @@ void PlayPanel::tempoSliderReleased(int)
       {
       tempoSliderIsPressed = false;
       }
+
 }
 

--- a/mscore/playpanel.h
+++ b/mscore/playpanel.h
@@ -74,7 +74,11 @@ class PlayPanel : public QWidget, private Ui::PlayPanelBase {
 
       void setEndpos(int);
       void setScore(Score* s);
+      Score* score() const;
       bool isTempoSliderPressed() {return tempoSliderIsPressed;}
+      QLabel* position() const;
+      QLabel* time() const;
+
       };
 
 

--- a/mscore/playpanel.ui
+++ b/mscore/playpanel.ui
@@ -147,7 +147,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QSlider" name="posSlider">
+      <widget class="Ms::PlayPositionSlider" name="posSlider">
        <property name="focusPolicy">
         <enum>Qt::TabFocus</enum>
        </property>
@@ -987,6 +987,11 @@
    <class>Awl::VolSlider</class>
    <extends>Awl::Slider</extends>
    <header>awl/volslider.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Ms::PlayPositionSlider</class>
+   <extends>QSlider</extends>
+   <header>playpositionslider.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/mscore/playpositionslider.cpp
+++ b/mscore/playpositionslider.cpp
@@ -1,0 +1,116 @@
+#include "playpanel.h"
+#include "libmscore/score.h"
+#include "libmscore/measure.h"
+#include "libmscore/mscore.h"
+#include "libmscore/fraction.h"
+
+namespace Ms {
+
+PlayPositionSlider::PlayPositionSlider(QWidget *p) : QSlider(p)
+      {
+      setAccessibleDescription(tr("Use Left and Right arrow keys to move beat by beat. Use Ctrl + Left and Right arrow keys to move measure by measure."));
+      }
+
+void PlayPositionSlider::keyPressEvent(QKeyEvent* e)
+      {
+      if (playPanel->score()) {
+            Measure* m = playPanel->score()->tick2measure(value());
+            float ratio = 4.0f / m->timesig().denominator();
+            int increment = static_cast<int>(round(MScore::division*ratio));
+            int offset = (value() - m->tick()) % increment; // align to the beat
+
+            if (e->key() == Qt::Key_Right) {
+                  if (e->modifiers() == Qt::NoModifier) {
+                        setValue(value() - offset + increment);
+                        return;
+                        }
+                  else if (e->modifiers() == Qt::ControlModifier && m->nextMeasureMM()) {
+                        setValue(m->nextMeasureMM()->tick());
+                        return;
+                        }
+                  }
+
+            if (e->key() == Qt::Key_Left) {
+                  if (e->modifiers() == Qt::NoModifier) {
+                        setValue(value() - offset - increment);
+                        return;
+                        }
+                  else if (e->modifiers() == Qt::ControlModifier && m->prevMeasureMM()) {
+                        setValue(m->prevMeasureMM()->tick());
+                        return;
+                        }
+                  }
+            }
+      QSlider::keyPressEvent(e);
+      }
+
+QLabel* PlayPositionSlider::posLabel() const
+      {
+      return playPanel->position();
+      }
+
+QLabel* PlayPositionSlider::timeLabel() const
+      {
+      return playPanel->time();
+      }
+
+AccessiblePlayPosSlider::AccessiblePlayPosSlider(PlayPositionSlider* s) : QAccessibleWidget(s)
+      {
+      posSlider = s;
+      connect(posSlider, SIGNAL(updateAccessibleValue()), this, SLOT(updateValue()));
+      }
+
+QString AccessiblePlayPosSlider::text(QAccessible::Text t) const
+      {
+      if (t == QAccessible::Value) {
+            QStringList measurebeat = posSlider->posLabel()->text().split(".");
+            QStringList time = posSlider->timeLabel()->text().split(":");
+            QString measure = measurebeat.at(0);
+
+            while (measure.at(0) == '0') {
+                  measure = measure.mid(1);
+                  }
+
+            QString beat = measurebeat.at(1);
+            if (beat.at(0) == '0')
+                  beat = beat.mid(1);
+
+            QString minute = time.at(1);
+            if (minute.at(0) == '0' )
+                  minute = minute.mid(1);
+
+            QString second = time.at(2);
+            if (second.at(0) == '0')
+                  second = second.mid(1);
+
+            QString measureBeatString = tr("Measure %1 Beat %2").arg(measure).arg(beat);
+            QString timeString = tr("Minute %1 Second %2").arg(minute).arg(second);
+            QString hour = time.at(0);
+
+            if (hour != "0") {
+                  timeString = tr("Hour %1 ").arg(hour) + timeString;
+                  }
+
+            return QString("%1 %2").arg(measureBeatString).arg(timeString);
+            }
+
+      return QAccessibleWidget::text(t);
+      }
+
+void AccessiblePlayPosSlider::updateValue()
+      {
+      QAccessibleValueChangeEvent ev(posSlider, text(QAccessible::Value));
+      QAccessible::updateAccessibility(&ev);
+      }
+
+QAccessibleInterface* AccessiblePlayPosSlider::PlayPosSliderFactory(const QString &classname, QObject *object)
+      {
+      QAccessibleInterface *iface = 0;
+      if (classname == QLatin1String("Ms::PlayPositionSlider") && object && object->isWidgetType()) {
+           iface = static_cast<QAccessibleInterface*>(new AccessiblePlayPosSlider(static_cast<PlayPositionSlider*>(object)));
+           }
+
+          return iface;
+      }
+
+}

--- a/mscore/playpositionslider.h
+++ b/mscore/playpositionslider.h
@@ -1,0 +1,36 @@
+#ifndef __PLAYPOSITIONSLIDER__
+#define __PLAYPOSITIONSLIDER__
+#include <QAccessibleWidget>
+
+namespace Ms {
+class PlayPanel;
+
+class PlayPositionSlider : public QSlider {
+      Q_OBJECT
+      PlayPanel* playPanel;
+      virtual void keyPressEvent(QKeyEvent*) override;
+public:
+      PlayPositionSlider(QWidget* p = 0);
+      void setPlayPanel(PlayPanel* p)  { playPanel = p;     }
+      QLabel* posLabel() const;
+      QLabel* timeLabel() const;
+signals:
+      void updateAccessibleValue();
+      };
+
+class AccessiblePlayPosSlider : public QObject, QAccessibleWidget  {
+      Q_OBJECT
+
+      PlayPositionSlider* posSlider;
+      virtual QString text(QAccessible::Text t) const override;
+public:
+      AccessiblePlayPosSlider(PlayPositionSlider*);
+      static QAccessibleInterface* PlayPosSliderFactory(const QString &classname, QObject *object);
+
+public slots:
+      void updateValue();
+      };
+
+}
+
+#endif


### PR DESCRIPTION
fix #47276 fix #47276
The value of the position label is now read by the screen-reader for the position slider, instead of the current tick as it was before.
Pressing right/left arrow key increments/decrements the beat in the position label.
Pressing Ctrl+right/left arrow key increments/decrements the measure.

When changing the value of the slider either by using the mouse or by using the keys the screen-reader is notified.
