### PR TITLE
Fix: menus don't close if Escape is pressed.

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2330,6 +2330,7 @@ bool MuseScore::eventFilter(QObject *obj, QEvent *event)
                   QKeyEvent* e = static_cast<QKeyEvent*>(event);
                   if(obj->isWidgetType() && e->key() == Qt::Key_Escape && e->modifiers() == Qt::NoModifier) {
                         if (isActiveWindow()) {
+                              obj->event(e);
                               if(currentScoreView())
                                     currentScoreView()->setFocus();
                               else


### PR DESCRIPTION
A side effect of a previous fix caused menus to remain open if escape is pressed. This PR fixes that by allowing the target object to do its own operations when Escape key is pressed and only after it finishes the focus is moved to the score.