### PR TITLE
Fix #32966 - TAB: hide fingerings

### DIFF
--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -12,6 +12,7 @@
 
 #include "fingering.h"
 #include "score.h"
+#include "staff.h"
 #include "undo.h"
 #include "xml.h"
 
@@ -51,6 +52,29 @@ void Fingering::read(XmlReader& e)
             if (!Text::readProperties(e))
                   e.unknown();
             }
+      }
+
+//---------------------------------------------------------
+//   layout
+//---------------------------------------------------------
+
+void Fingering::layout()
+      {
+      if (staff() && staff()->isTabStaff())     // in TAB staves
+            setbbox(QRectF());                  // fingerings have no area
+      else
+            Text::layout();
+      }
+
+//---------------------------------------------------------
+//   draw
+//---------------------------------------------------------
+
+void Fingering::draw(QPainter* painter) const
+      {
+      if (staff() && staff()->isTabStaff())     // hide fingering in TAB staves
+            return;
+      Text::draw(painter);
       }
 
 //---------------------------------------------------------

--- a/libmscore/fingering.h
+++ b/libmscore/fingering.h
@@ -33,6 +33,8 @@ class Fingering : public Text {
 
       Note* note() const { return (Note*)parent(); }
 
+      virtual void draw(QPainter*) const override;
+      virtual void layout() override;
       virtual void write(Xml&) const override;
       virtual void read(XmlReader&) override;
       virtual void reset() override;


### PR DESCRIPTION
Fix #32966 - TAB: hide fingerings

Simple and cheap fix which just hides `Fingering` elements in TAB's. No change to the linking / copying stuff: elements are still there, but generate no visible output in TAB. See issue http://musescore.org/en/node/32966 for details and discussion.

Should an option for hiding / showing these elements be added in the future, as discussed in the forum issue, the change would be easy to implement.

This does not affect lute-specific RH fingerings recently added, as luckily they are not real `Fingering`s, but `Articulation`s.