### PR TITLE
fix #46281: Follow text doesn't work for tempo marking with decimal

### DIFF
--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -154,15 +154,15 @@ void TempoText::textChanged()
       if (!_followText)
             return;
       QString s = text();
-
+      s.replace(QString(","), QString("."));
       for (unsigned i = 0; i < sizeof(tp)/sizeof(*tp); ++i) {
-            QRegExp re(QString(tp[i].pattern)+"\\s*=\\s*(\\d+)");      // 1/4
+            QRegExp re(QString(tp[i].pattern)+"\\s*=\\s*(\\d+[.]{0,1}\\d*)");
             if (re.indexIn(s) != -1) {
                   QStringList sl = re.capturedTexts();
                   if (sl.size() == 2) {
-                        qreal nt = qreal(sl[1].toInt()) * tp[i].f;
+                        qreal nt = qreal(sl[1].toDouble()) * tp[i].f;
                         if (nt != _tempo) {
-                              _tempo = qreal(sl[1].toInt()) * tp[i].f;
+                              _tempo = qreal(sl[1].toDouble()) * tp[i].f;
                               if(segment())
                                     score()->setTempo(segment(), _tempo);
                               score()->setPlaylistDirty();


### PR DESCRIPTION
* Fixed issues brought up from original bug fix attempt [here](https://github.com/musescore/MuseScore/pull/1779)
* Fixed initial bug where view inspector does not properly display decimals
* Updated original fix to also allow decimal commas