### PR TITLE
Fix #46586 - Misplaced barline with large spatium

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -950,7 +950,7 @@ void BarLine::layout()
 
       // bar lines not hidden
       else {
-            qreal dw = layoutWidth(score(), barLineType(), magS());
+            qreal dw = layoutWidth(score(), barLineType(), mag());
             QRectF r(0.0, y1, dw, y2-y1);
 
             if (score()->styleB(StyleIdx::repeatBarTips)) {


### PR DESCRIPTION
Fix #46586 - Misplaced barline with large spatium

In `BarLine::layout()`, `magS()` is passed to `layoutWidth()` to compute bar line width.

If bar lines are to be scaled, `layoutWidth()` uses it to multiply `spatium()`, but `magS()` already takes `spatium()` into account and this results in `spatium()` being accounted for twice.

Fixed by using `mag()` instead in the call to `layoutWidth()`.

Issue: http://musescore.org/en/node/46586 . Also fixes #47461 ( http://musescore.org/en/node/47461 ) which is a duplicate of #46586.