### PR TITLE
Bar line user offset lost on score save and reload

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3699,6 +3699,7 @@ void Measure::layoutX(qreal stretch)
                   else if (t == Element::Type::BAR_LINE) {
                         e->setPos(QPointF());
                         barLineWidth = qMax(barLineWidth, e->width());
+                        e->adjustReadPos();
                         }
                   else {
                         if (t != Element::Type::AMBITUS)


### PR DESCRIPTION
Displacing bar line is probably not common, but perhaps with mid-measure bar lines it might be needed more frequently. And anyway, if it can be entered, why not to preserve it?