### PR TITLE
remove open/atonal keysig from basic palette

### DIFF
--- a/mscore/keyedit.cpp
+++ b/mscore/keyedit.cpp
@@ -278,7 +278,7 @@ KeyEditor::KeyEditor(QWidget* parent)
       l->setContentsMargins(0, 0, 0, 0);
       frame->setLayout(l);
 
-      sp = MuseScore::newKeySigPalette();
+      sp = MuseScore::newKeySigPalette(false);
       sp->setReadOnly(false);
 
       _keyPalette = new PaletteScrollArea(sp);

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -228,7 +228,7 @@ Palette* MuseScore::newDynamicsPalette(bool basic, bool master)
 //   newKeySigPalette
 //---------------------------------------------------------
 
-Palette* MuseScore::newKeySigPalette()
+Palette* MuseScore::newKeySigPalette(bool basic)
       {
       Palette* sp = new Palette;
       sp->setName(QT_TRANSLATE_NOOP("Palette", "Key Signatures"));
@@ -249,12 +249,15 @@ Palette* MuseScore::newKeySigPalette()
       KeySig* k = new KeySig(gscore);
       k->setKey(Key::C);
       sp->append(k, qApp->translate("MuseScore", keyNames[14]));
-      // atonal key signature
-      KeySigEvent nke;
-      nke.setCustom(true);
-      KeySig* nk = new KeySig(gscore);
-      nk->setKeySigEvent(nke);
-      sp->append(nk, qApp->translate("MuseScore", keyNames[15]));
+
+      if (!basic) {
+            // atonal key signature
+            KeySigEvent nke;
+            nke.setCustom(true);
+            KeySig* nk = new KeySig(gscore);
+            nk->setKeySigEvent(nke);
+            sp->append(nk, qApp->translate("MuseScore", keyNames[15]));
+            }
       return sp;
       }
 
@@ -1072,7 +1075,7 @@ void MuseScore::setAdvancedPalette()
       paletteBox->clear();
       paletteBox->addPalette(newGraceNotePalette(false));
       paletteBox->addPalette(newClefsPalette(false));
-      paletteBox->addPalette(newKeySigPalette());
+      paletteBox->addPalette(newKeySigPalette(false));
       paletteBox->addPalette(newTimePalette());
       paletteBox->addPalette(newBarLinePalette(false));
       paletteBox->addPalette(newLinesPalette(false));
@@ -1165,7 +1168,7 @@ void MuseScore::setBasicPalette()
       paletteBox->clear();
       paletteBox->addPalette(newGraceNotePalette(true));
       paletteBox->addPalette(newClefsPalette(true));
-      paletteBox->addPalette(newKeySigPalette());
+      paletteBox->addPalette(newKeySigPalette(true));
       paletteBox->addPalette(newTimePalette());
       paletteBox->addPalette(newBarLinePalette(true));
       paletteBox->addPalette(newLinesPalette(true));

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -659,7 +659,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       static Palette* newClefsPalette(bool basic);
       static Palette* newGraceNotePalette(bool basic);
       static Palette* newBagpipeEmbellishmentPalette();
-      static Palette* newKeySigPalette();
+      static Palette* newKeySigPalette(bool basic);
       static Palette* newAccidentalsPalette(bool basic = false);
       static Palette* newBarLinePalette(bool basic);
       static Palette* newLinesPalette(bool basic);

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -348,7 +348,7 @@ NewWizardPage5::NewWizardPage5(QWidget* parent)
       QGroupBox* b1 = new QGroupBox;
       b1->setTitle(tr("Key Signature"));
       b1->setAccessibleName(title());
-      sp = MuseScore::newKeySigPalette();
+      sp = MuseScore::newKeySigPalette(false);
       sp->setSelectable(true);
       sp->setDisableDoubleClick(true);
       sp->setSelected(14);
@@ -367,7 +367,6 @@ NewWizardPage5::NewWizardPage5(QWidget* parent)
       _tempo->setAccessibleName(tr("Beats per minute"));
       _tempo->setRange(20.0, 400.0);
       _tempo->setValue(100.0);
-      _tempo->setDecimals(1);
       QHBoxLayout* l2 = new QHBoxLayout;
       l2->addWidget(bpm);
       l2->addWidget(_tempo);


### PR DESCRIPTION
Seems like a good idea.  Although I do think it should still be in the new score wizard, so maybe it's just as well to leave it in basic palette too?  Anyhow, if we want to remove it from the basic palette (and leave it in new ascore wizard), this PR does it.