### PR TITLE
remove open/atonal key signature from basic palette

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -228,7 +228,7 @@ Palette* MuseScore::newDynamicsPalette(bool basic, bool master)
 //   newKeySigPalette
 //---------------------------------------------------------
 
-Palette* MuseScore::newKeySigPalette()
+Palette* MuseScore::newKeySigPalette(bool basic)
       {
       Palette* sp = new Palette;
       sp->setName(QT_TRANSLATE_NOOP("Palette", "Key Signatures"));
@@ -249,12 +249,15 @@ Palette* MuseScore::newKeySigPalette()
       KeySig* k = new KeySig(gscore);
       k->setKey(Key::C);
       sp->append(k, qApp->translate("MuseScore", keyNames[14]));
-      // atonal key signature
-      KeySigEvent nke;
-      nke.setCustom(true);
-      KeySig* nk = new KeySig(gscore);
-      nk->setKeySigEvent(nke);
-      sp->append(nk, qApp->translate("MuseScore", keyNames[15]));
+
+      if (!basic) {
+            // atonal key signature
+            KeySigEvent nke;
+            nke.setCustom(true);
+            KeySig* nk = new KeySig(gscore);
+            nk->setKeySigEvent(nke);
+            sp->append(nk, qApp->translate("MuseScore", keyNames[15]));
+            }
       return sp;
       }
 
@@ -1165,7 +1168,7 @@ void MuseScore::setBasicPalette()
       paletteBox->clear();
       paletteBox->addPalette(newGraceNotePalette(true));
       paletteBox->addPalette(newClefsPalette(true));
-      paletteBox->addPalette(newKeySigPalette());
+      paletteBox->addPalette(newKeySigPalette(true));
       paletteBox->addPalette(newTimePalette());
       paletteBox->addPalette(newBarLinePalette(true));
       paletteBox->addPalette(newLinesPalette(true));

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -659,7 +659,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       static Palette* newClefsPalette(bool basic);
       static Palette* newGraceNotePalette(bool basic);
       static Palette* newBagpipeEmbellishmentPalette();
-      static Palette* newKeySigPalette();
+      static Palette* newKeySigPalette(bool basic = false);
       static Palette* newAccidentalsPalette(bool basic = false);
       static Palette* newBarLinePalette(bool basic);
       static Palette* newLinesPalette(bool basic);


### PR DESCRIPTION
This replaces #1791 which had a bad merge.

Removes open/atonal key signature from basic palette, leaving it in advanced, new score wizard, and of course master.