### PR TITLE
fix #42881: selection rectangle does not encompass measure rest

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1966,11 +1966,19 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                   x1  = x2;
                   x2  = pt.x() + _spatium * 2;
 
-                  // HACK for whole measure rest & RepeatMeasure
                   if (ns == 0 || ns == es) {    // last segment?
-                        Element* e = s->element(staffStart * VOICES);
-                        if (e && ((e->type() == Element::Type::REST && static_cast<Rest*>(e)->durationType().type() == TDuration::DurationType::V_MEASURE) || e->type() == Element::Type::REPEAT_MEASURE) )
-                              x2 = s->measure()->abbox().right() - _spatium * 0.5;
+                        // if any staff in selection has measure rest or repeat measure in last measure,
+                        // extend rectangle to bar line
+                        Segment* fs = s->measure()->first(Segment::Type::ChordRest);
+                        for (int i = staffStart; i < staffEnd; ++i) {
+                              if (!score()->staff(i)->show())
+                                    continue;
+                              ChordRest* cr = static_cast<ChordRest*>(fs->element(i * VOICES));
+                              if (cr && (cr->type() == Element::Type::REPEAT_MEASURE || cr->durationType() == TDuration::DurationType::V_MEASURE)) {
+                                    x2 = s->measure()->abbox().right() - _spatium * 0.5;
+                                    break;
+                                    }
+                              }
                         }
 
                   if (system2 != system1)


### PR DESCRIPTION
The existing code to make the selection rectangle encompass the full measure rest was on the right track, it just didn't go far enough - it only worked for single-staff selections, or for multi-staff selections if there was only one segment in the measure.  Simple matter to be sure to check the first segment and to loop through the staves.