### PR TITLE
fix #48231: don't adjust brackets and barlines when adding staves

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -797,8 +797,12 @@ void Score::undoInsertStaff(Staff* staff, int ridx, bool createRests)
             if (m->hasMMRest())
                   m->mmRest()->cmdAddStaves(idx, idx+1, false);
             }
-
-      adjustBracketsIns(idx, idx+1);
+      // when newly adding an instrument,
+      // this was already set when we created the staff
+      // we don't have any better info at this point
+      // and it dooesn't work to adjust bracket & barlines until all staves are added
+      // TODO: adjust brackets only when appropriate
+      //adjustBracketsIns(idx, idx+1);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
The problem - both symptoms and cause - is explained in the issue report.  My fix here is not ideal as it means we basically make no attempt to adjust brackets and barline spans when adding staves, but user can always do that manually.  I think this beats the current situation where simply adding an instrument can creat bad brackets and barline staves.  If someone wants to try to figure out how to get it "right", go for it, but I get the esne it won't be easy.  There may have been a whole bunch of changes made in the instrument dialog, adding and deleting staves, rearranging them, etc.  I guess the trick might be to wait until we're done with all of that, that make a second pass fixing brackets and barline staves.  But it would seem low priority to me, unless there is some downside to not adjusting brackets and barline spans right away beyond the fact that the user will have to do so himself.