### PR TITLE
fix #40566: alignment of pedal text

### DIFF
--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -53,6 +53,12 @@ void TextLineSegment::setSelected(bool f)
             else if (textLine()->_continueText)
                   _text->setSelected(f);
             }
+      if (_endText) {
+            if (spannerSegmentType() == SpannerSegmentType::SINGLE || spannerSegmentType() == SpannerSegmentType::END) {
+                  if (textLine()->_endText)
+                        _endText->setSelected(f);
+                  }
+            }
       }
 
 //---------------------------------------------------------
@@ -445,6 +451,12 @@ void TextLine::createBeginTextElement()
             _beginText = new Text(score());
             _beginText->setParent(this);
             _beginText->setTextStyleType(TextStyleType::TEXTLINE);
+            if (type() == Element::Type::PEDAL) {
+                  TextStyle ts = _beginText->textStyle();
+                  ts.setAlign(AlignmentFlags::LEFT|AlignmentFlags::BASELINE);
+                  ts.setYoff(lineWidth().val());
+                  _beginText->setTextStyle(ts);
+                  }
             }
       }
 
@@ -471,6 +483,12 @@ void TextLine::createEndTextElement()
             _endText = new Text(score());
             _endText->setParent(this);
             _endText->setTextStyleType(TextStyleType::TEXTLINE);
+            if (type() == Element::Type::PEDAL) {
+                  TextStyle ts = _endText->textStyle();
+                  ts.setAlign(AlignmentFlags::LEFT|AlignmentFlags::BASELINE);
+                  ts.setYoff(lineWidth().val());
+                  _endText->setTextStyle(ts);
+                  }
             }
       }
 


### PR DESCRIPTION
Detailed description in issue report.  There is no perfect solution here.  This PR forces the text properties to baseline alignment, with a vertical offset equal to the line width, when first creating the text (which happens when creating palette or dragging it to score) for pedal lines.  It's the simplest, least invasive solution.

The "better" solution I proposed - adding a new Pedal text style - seems overkill for just this one element, and it would also require further changes elsewhere to force the text to be drawn relative to the bottom edge of the line rather than the top.  And it still won't fix existing 2.0 beta & nightly build scores that are already using Text Line.  Messier, for no real gain.  So I went with the simpler solution.

BTW, I do this for both begin & end text, to handle the "*" symbol sometimes used to pedal up.  Along the way, I noticed end text was not highlighted correctly when selecting a line segment, so I fixed that here too.