### PR TITLE
fix #33996 :Restore note input near the last selected element, even after escape.

### DIFF
--- a/libmscore/input.h
+++ b/libmscore/input.h
@@ -36,6 +36,8 @@ class InputState {
       int         _drumNote    { -1 };
       int         _track       { 0 };
       int         _prevTrack   { 0 };                       // used for navigation
+      int         _lastSelectedTrack { 0 };
+      int         _lastSelectedTick  { 0 };
       Segment*    _lastSegment { 0 };
       Segment*    _segment     { 0 };                       // current segment
       int         _string      { VISUAL_STRING_NONE };      // visual string selected for input (TAB staves only)
@@ -75,6 +77,10 @@ class InputState {
       int track() const                   { return _track;          }
       void setTrack(int v)                { _prevTrack = _track; _track = v; }
       int prevTrack() const               { return _prevTrack;      }
+      void setLastSelectedTrack(int v)    {  v < 0 ? _lastSelectedTrack = 0 : _lastSelectedTrack = v; }
+      void setLastSelectedTick(int v)     {  _lastSelectedTick = v; }
+      int  lastSelectedTick() const       { return _lastSelectedTick;  }
+      int  lastSelectedTrack() const      { return _lastSelectedTrack; }
 
       int string() const                  { return _string;             }
       void setString(int val)             { _string = val;              }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2655,6 +2655,34 @@ void Score::padToggle(Pad n)
 
       }
 
+void Score::recordSelection(Element* e)
+      {
+      if (e == 0)
+            return;
+      Element* p = e;
+      _is.setLastSelectedTrack(e->track());
+      while(p && p->type() != Element::Type::SYSTEM) {
+            if (p->type() == Element::Type::SEGMENT) {
+                  Segment* s = static_cast<Segment*>(p);
+                  _is.setLastSelectedTick(s->tick());
+                  return;
+                  }
+            if (p->type() == Element::Type::MEASURE) {
+                  Measure* m = static_cast<Measure*>(p);
+                  _is.setLastSelectedTick(m->tick());
+                  return;
+                  }
+            if (p->isSpannerSegment())
+                  p = static_cast<SpannerSegment*>(p)->spanner();
+            if (p->isSpanner()) {
+                  Segment* s = static_cast<Spanner*>(p)->startSegment();
+                  _is.setLastSelectedTick(s->tick());
+                  return;
+                  }
+            p = p->parent();
+            }
+      }
+
 //---------------------------------------------------------
 //   deselect
 //---------------------------------------------------------
@@ -2712,13 +2740,15 @@ void Score::selectSingle(Element* e, int staffIdx)
             refresh |= e->abbox();
             _selection.add(e);
             _is.setTrack(e->track());
+            recordSelection(e);
             selState = SelState::LIST;
             if (e->type() == Element::Type::NOTE) {
                   e = e->parent();
                   }
             if (e->type() == Element::Type::REST || e->type() == Element::Type::CHORD) {
                   _is.setLastSegment(_is.segment());
-                  _is.setSegment(static_cast<ChordRest*>(e)->segment());
+                  ChordRest* ch = static_cast<ChordRest*>(e);
+                  _is.setSegment(ch->segment());
                   }
             }
       _selection.setActiveSegment(0);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -671,6 +671,7 @@ class Score : public QObject {
       void selectSimilar(Element* e, bool sameStaff);
       void selectSimilarInRange(Element* e);
       static void collectMatch(void* data, Element* e);
+      void recordSelection(Element* e);
       void deselect(Element* obj);
       void deselectAll()                    { _selection.deselectAll(); }
       void updateSelection()                { _selection.update(); }

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -260,6 +260,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void cmdMoveCR(bool left);
       void cmdGotoElement(Element*);
       bool checkCopyOrCut();
+      void restoreInputState();
 
    private slots:
       void enterState();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -717,6 +717,17 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL,
+         "restore-input-state",
+         QT_TRANSLATE_NOOP("action","Restore input state"),
+         QT_TRANSLATE_NOOP("action","Restore input state"),
+         QT_TRANSLATE_NOOP("action","Restore input state"),
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CMD | ShortcutFlags::A_SCORE
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL,
          "prev-element",
          QT_TRANSLATE_NOOP("action","Previous element"),
          QT_TRANSLATE_NOOP("action","Accessibility: previous element"),


### PR DESCRIPTION
Not sure if it's the right way to do this, so please let me know your opinions.
Bassically, I'm recording the tick and the track of the last selection and I'm restoring the note input there, or the closest location.
