### PR TITLE
fix #40566: add text style for pedal, baseline alignment

### DIFF
--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -301,6 +301,7 @@ enum class TextStyleType : char {
       TEXTLINE,
       GLISSANDO,
       OTTAVA,
+      PEDAL,
       BENCH,
       HEADER,
       FOOTER,

--- a/libmscore/ottava.cpp
+++ b/libmscore/ottava.cpp
@@ -422,10 +422,8 @@ QVariant Ottava::propertyDefault(P_ID propertyId) const
             case P_ID::END_TEXT:
                   return QString("");
 
-            case P_ID::BEGIN_TEXT_STYLE:
-            case P_ID::CONTINUE_TEXT_STYLE:
-            case P_ID::END_TEXT_STYLE:
-                  return QVariant::fromValue(score()->textStyle(TextStyleType::OTTAVA));
+            case P_ID::TEXT_STYLE_TYPE:
+                  return int(TextStyleType::OTTAVA);
 
             case P_ID::END_HOOK:
                   return true;

--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -207,6 +207,9 @@ QVariant Pedal::propertyDefault(P_ID propertyId) const
             case P_ID::LINE_STYLE:
                   return int(score()->styleI(StyleIdx::pedalLineStyle));
 
+            case P_ID::TEXT_STYLE_TYPE:
+                  return int(TextStyleType::PEDAL);
+
             default:
                   return TextLine::propertyDefault(propertyId);
             }

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -355,6 +355,8 @@ void initStyle(MStyle* s)
 
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Ottava"),            ff, 12, false, true, false,
          AlignmentFlags::LEFT | AlignmentFlags::VCENTER, QPointF(), OffsetType::SPATIUM, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Pedal"),             ff, 12, false, false, false,
+         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0.0, 0.15), OffsetType::SPATIUM, true));
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Bend"),              ff, 8, false, false, false,
          AlignmentFlags::CENTER | AlignmentFlags::BOTTOM, QPointF(), OffsetType::SPATIUM, true));
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Header"),            ff, 8, false, false, false,

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -53,6 +53,12 @@ void TextLineSegment::setSelected(bool f)
             else if (textLine()->_continueText)
                   _text->setSelected(f);
             }
+      if (_endText) {
+            if (spannerSegmentType() == SpannerSegmentType::SINGLE || spannerSegmentType() == SpannerSegmentType::END) {
+                  if (textLine()->_endText)
+                        _endText->setSelected(f);
+                  }
+            }
       }
 
 //---------------------------------------------------------
@@ -444,7 +450,7 @@ void TextLine::createBeginTextElement()
       if (!_beginText) {
             _beginText = new Text(score());
             _beginText->setParent(this);
-            _beginText->setTextStyleType(TextStyleType::TEXTLINE);
+            _beginText->setTextStyleType(static_cast<TextStyleType>(propertyDefault(P_ID::TEXT_STYLE_TYPE).toInt()));
             }
       }
 
@@ -457,7 +463,7 @@ void TextLine::createContinueTextElement()
       if (!_continueText) {
             _continueText = new Text(score());
             _continueText->setParent(this);
-            _continueText->setTextStyleType(TextStyleType::TEXTLINE);
+            _continueText->setTextStyleType(static_cast<TextStyleType>(propertyDefault(P_ID::TEXT_STYLE_TYPE).toInt()));
             }
       }
 
@@ -470,7 +476,7 @@ void TextLine::createEndTextElement()
       if (!_endText) {
             _endText = new Text(score());
             _endText->setParent(this);
-            _endText->setTextStyleType(TextStyleType::TEXTLINE);
+            _endText->setTextStyleType(static_cast<TextStyleType>(propertyDefault(P_ID::TEXT_STYLE_TYPE).toInt()));
             }
       }
 
@@ -773,6 +779,7 @@ bool TextLine::readProperties(XmlReader& e)
             if (!_beginText) {
                   _beginText = new Text(score());
                   _beginText->setParent(this);
+                  _beginText->setTextStyleType(static_cast<TextStyleType>(propertyDefault(P_ID::TEXT_STYLE_TYPE).toInt()));
                   }
             else
                   _beginText->setText("");
@@ -782,6 +789,7 @@ bool TextLine::readProperties(XmlReader& e)
             if (!_continueText) {
                   _continueText = new Text(score());
                   _continueText->setParent(this);
+                  _continueText->setTextStyleType(static_cast<TextStyleType>(propertyDefault(P_ID::TEXT_STYLE_TYPE).toInt()));
                   }
             else
                   _continueText->setText("");
@@ -791,6 +799,7 @@ bool TextLine::readProperties(XmlReader& e)
             if (!_endText) {
                   _endText = new Text(score());
                   _endText->setParent(this);
+                  _endText->setTextStyleType(static_cast<TextStyleType>(propertyDefault(P_ID::TEXT_STYLE_TYPE).toInt()));
                   }
             else
                   _endText->setText("");
@@ -919,6 +928,12 @@ QVariant TextLine::propertyDefault(P_ID id) const
                   return QString("");
             case P_ID::LINE_VISIBLE:
                   return true;
+            case P_ID::BEGIN_TEXT_STYLE:
+            case P_ID::CONTINUE_TEXT_STYLE:
+            case P_ID::END_TEXT_STYLE:
+                  return QVariant::fromValue(score()->textStyle(static_cast<TextStyleType>(propertyDefault(P_ID::TEXT_STYLE_TYPE).toInt())));
+            case P_ID::TEXT_STYLE_TYPE:
+                  return int(TextStyleType::TEXTLINE);
 
             default:
                   return SLine::propertyDefault(id);

--- a/libmscore/volta.cpp
+++ b/libmscore/volta.cpp
@@ -365,6 +365,9 @@ QVariant Volta::propertyDefault(P_ID propertyId) const
             case P_ID::END_HOOK_HEIGHT:
                   return score()->styleS(StyleIdx::voltaHook).val();
 
+            case P_ID::TEXT_STYLE_TYPE:
+                  return int(TextStyleType::VOLTA);
+
             default:
                   return TextLine::propertyDefault(propertyId);
             }

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -867,8 +867,8 @@ Palette* MuseScore::newLinesPalette(bool basic)
             pedal = new Pedal(gscore);
             pedal->setLen(w);
             pedal->setBeginText("<sym>keyboardPedalPed</sym>");
-            sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal"));
             pedal->setEndHook(true);
+            sp->append(pedal, QT_TRANSLATE_NOOP("Palette", "Pedal"));
             }
 
       pedal = new Pedal(gscore);

--- a/mtest/capella/io/testVolta1.capx-ref.mscx
+++ b/mtest/capella/io/testVolta1.capx-ref.mscx
@@ -113,7 +113,6 @@
         <Volta id="2">
           <endHook>1</endHook>
           <beginText>
-            <style>Volta</style>
             <text>1.</text>
             </beginText>
           <endings>1</endings>
@@ -130,7 +129,6 @@
         <endSpanner id="2"/>
         <Volta id="3">
           <beginText>
-            <style>Volta</style>
             <text>2.</text>
             </beginText>
           <endings>2</endings>

--- a/mtest/guitarpro/volta.gp3-ref.mscx
+++ b/mtest/guitarpro/volta.gp3-ref.mscx
@@ -106,7 +106,6 @@
         <Volta id="2">
           <lid>113</lid>
           <beginText>
-            <style>Volta</style>
             <text>1</text>
             </beginText>
           <endings>1</endings>
@@ -219,7 +218,6 @@
         <Volta id="3">
           <lid>114</lid>
           <beginText>
-            <style>Volta</style>
             <text>1,2</text>
             </beginText>
           <endings>1, 2</endings>
@@ -283,7 +281,6 @@
         <Volta id="4">
           <lid>115</lid>
           <beginText>
-            <style>Volta</style>
             <text>3</text>
             </beginText>
           <endings>3</endings>
@@ -402,7 +399,6 @@
         <Volta id="5">
           <lid>116</lid>
           <beginText>
-            <style>Volta</style>
             <text>4</text>
             </beginText>
           <endings>4</endings>
@@ -468,7 +464,6 @@
         <Volta id="6">
           <lid>117</lid>
           <beginText>
-            <style>Volta</style>
             <text>5</text>
             </beginText>
           <endings>5</endings>
@@ -530,7 +525,6 @@
         <Volta id="7">
           <lid>118</lid>
           <beginText>
-            <style>Volta</style>
             <text>1,2,3,4,5,6</text>
             </beginText>
           <endings>1, 2, 3, 4, 5, 6</endings>
@@ -588,7 +582,6 @@
         <Volta id="8">
           <lid>119</lid>
           <beginText>
-            <style>Volta</style>
             <text>7,8</text>
             </beginText>
           <endings>7, 8</endings>
@@ -936,7 +929,6 @@
           <Volta id="9">
             <lid>113</lid>
             <beginText>
-              <style>Volta</style>
               <text>1</text>
               </beginText>
             <endings>1</endings>
@@ -1049,7 +1041,6 @@
           <Volta id="10">
             <lid>114</lid>
             <beginText>
-              <style>Volta</style>
               <text>1,2</text>
               </beginText>
             <endings>1, 2</endings>
@@ -1113,7 +1104,6 @@
           <Volta id="11">
             <lid>115</lid>
             <beginText>
-              <style>Volta</style>
               <text>3</text>
               </beginText>
             <endings>3</endings>
@@ -1232,7 +1222,6 @@
           <Volta id="12">
             <lid>116</lid>
             <beginText>
-              <style>Volta</style>
               <text>4</text>
               </beginText>
             <endings>4</endings>
@@ -1298,7 +1287,6 @@
           <Volta id="13">
             <lid>117</lid>
             <beginText>
-              <style>Volta</style>
               <text>5</text>
               </beginText>
             <endings>5</endings>
@@ -1360,7 +1348,6 @@
           <Volta id="14">
             <lid>118</lid>
             <beginText>
-              <style>Volta</style>
               <text>1,2,3,4,5,6</text>
               </beginText>
             <endings>1, 2, 3, 4, 5, 6</endings>
@@ -1418,7 +1405,6 @@
           <Volta id="15">
             <lid>119</lid>
             <beginText>
-              <style>Volta</style>
               <text>7,8</text>
               </beginText>
             <endings>7, 8</endings>

--- a/mtest/guitarpro/volta.gp4-ref.mscx
+++ b/mtest/guitarpro/volta.gp4-ref.mscx
@@ -123,7 +123,6 @@
         <Volta id="2">
           <lid>90</lid>
           <beginText>
-            <style>Volta</style>
             <text>1</text>
             </beginText>
           <endings>1</endings>
@@ -236,7 +235,6 @@
         <Volta id="3">
           <lid>91</lid>
           <beginText>
-            <style>Volta</style>
             <text>1,2</text>
             </beginText>
           <endings>1, 2</endings>
@@ -300,7 +298,6 @@
         <Volta id="4">
           <lid>92</lid>
           <beginText>
-            <style>Volta</style>
             <text>3</text>
             </beginText>
           <endings>3</endings>
@@ -419,7 +416,6 @@
         <Volta id="5">
           <lid>93</lid>
           <beginText>
-            <style>Volta</style>
             <text>4</text>
             </beginText>
           <endings>4</endings>
@@ -485,7 +481,6 @@
         <Volta id="6">
           <lid>94</lid>
           <beginText>
-            <style>Volta</style>
             <text>5</text>
             </beginText>
           <endings>5</endings>
@@ -547,7 +542,6 @@
         <Volta id="7">
           <lid>95</lid>
           <beginText>
-            <style>Volta</style>
             <text>1,2,3,4,5,6</text>
             </beginText>
           <endings>1, 2, 3, 4, 5, 6</endings>
@@ -605,7 +599,6 @@
         <Volta id="8">
           <lid>96</lid>
           <beginText>
-            <style>Volta</style>
             <text>7,8</text>
             </beginText>
           <endings>7, 8</endings>
@@ -817,7 +810,6 @@
           <Volta id="9">
             <lid>90</lid>
             <beginText>
-              <style>Volta</style>
               <text>1</text>
               </beginText>
             <endings>1</endings>
@@ -930,7 +922,6 @@
           <Volta id="10">
             <lid>91</lid>
             <beginText>
-              <style>Volta</style>
               <text>1,2</text>
               </beginText>
             <endings>1, 2</endings>
@@ -994,7 +985,6 @@
           <Volta id="11">
             <lid>92</lid>
             <beginText>
-              <style>Volta</style>
               <text>3</text>
               </beginText>
             <endings>3</endings>
@@ -1113,7 +1103,6 @@
           <Volta id="12">
             <lid>93</lid>
             <beginText>
-              <style>Volta</style>
               <text>4</text>
               </beginText>
             <endings>4</endings>
@@ -1179,7 +1168,6 @@
           <Volta id="13">
             <lid>94</lid>
             <beginText>
-              <style>Volta</style>
               <text>5</text>
               </beginText>
             <endings>5</endings>
@@ -1241,7 +1229,6 @@
           <Volta id="14">
             <lid>95</lid>
             <beginText>
-              <style>Volta</style>
               <text>1,2,3,4,5,6</text>
               </beginText>
             <endings>1, 2, 3, 4, 5, 6</endings>
@@ -1299,7 +1286,6 @@
           <Volta id="15">
             <lid>96</lid>
             <beginText>
-              <style>Volta</style>
               <text>7,8</text>
               </beginText>
             <endings>7, 8</endings>

--- a/mtest/guitarpro/volta.gp5-ref.mscx
+++ b/mtest/guitarpro/volta.gp5-ref.mscx
@@ -1373,7 +1373,6 @@
         <Volta id="2">
           <lid>193</lid>
           <beginText>
-            <style>Volta</style>
             <text>1</text>
             </beginText>
           <endings>1</endings>
@@ -1435,7 +1434,6 @@
         <Volta id="3">
           <lid>194</lid>
           <beginText>
-            <style>Volta</style>
             <text>2,3,6,8</text>
             </beginText>
           <endings>2, 3, 6, 8</endings>
@@ -2885,7 +2883,6 @@
           <Volta id="4">
             <lid>193</lid>
             <beginText>
-              <style>Volta</style>
               <text>1</text>
               </beginText>
             <endings>1</endings>
@@ -2947,7 +2944,6 @@
           <Volta id="5">
             <lid>194</lid>
             <beginText>
-              <style>Volta</style>
               <text>2,3,6,8</text>
               </beginText>
             <endings>2, 3, 6, 8</endings>

--- a/mtest/guitarpro/volta.gpx-ref.mscx
+++ b/mtest/guitarpro/volta.gpx-ref.mscx
@@ -166,7 +166,6 @@
         <Volta id="2">
           <lid>24</lid>
           <beginText>
-            <style>Volta</style>
             <text>1,2</text>
             </beginText>
           <endings></endings>
@@ -202,7 +201,6 @@
         <Volta id="3">
           <lid>25</lid>
           <beginText>
-            <style>Volta</style>
             <text>3</text>
             </beginText>
           <endings></endings>
@@ -439,7 +437,6 @@
           <Volta id="4">
             <lid>24</lid>
             <beginText>
-              <style>Volta</style>
               <text>1,2</text>
               </beginText>
             <endings></endings>
@@ -475,7 +472,6 @@
           <Volta id="5">
             <lid>25</lid>
             <beginText>
-              <style>Volta</style>
               <text>3</text>
               </beginText>
             <endings></endings>

--- a/mtest/libmscore/selectionfilter/selectionfilter15-base-ref.xml
+++ b/mtest/libmscore/selectionfilter/selectionfilter15-base-ref.xml
@@ -8,7 +8,6 @@
       <track>0</track>
       <lineWidth>0.15</lineWidth>
       <beginText>
-        <style>Text Line</style>
         <text>VII</text>
         </beginText>
       </TextLine>


### PR DESCRIPTION
This PR adds a new "Pedal" text style, used by Pedal lines.  There were some bugs with how text style was used in TextLine, such as http://musescore.org/en/node/41081; this PR cleans up this handling so we always use the proper default text style for each line type (while still allowing you to override it of course).

I kind of expect tests to fail with this; I'll let Travis help me figure out which tests to run manually myself to fix.