### PR TITLE
add clef / keysig map check to measure insert tests

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1057,6 +1057,9 @@ class Score : public QObject {
 
       Q_INVOKABLE void cropPage(qreal margins);
 
+      bool checkKeys();
+      bool checkClefs();
+
       friend class ChangeSynthesizerState;
       friend class Chord;
       };

--- a/mtest/libmscore/measure/measure-insert_bf_clef-2-ref.mscx
+++ b/mtest/libmscore/measure/measure-insert_bf_clef-2-ref.mscx
@@ -51,13 +51,13 @@
           </StaffType>
         <bracket type="-1" span="0"/>
         </Staff>
-      <trackName>C Trumpet</trackName>
+      <trackName>Flute</trackName>
       <Instrument>
-        <trackName>C Trumpet</trackName>
-        <minPitchP>54</minPitchP>
-        <maxPitchP>85</maxPitchP>
-        <minPitchA>54</minPitchA>
-        <maxPitchA>82</maxPitchA>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
         <Articulation>
           <velocity>100</velocity>
           <gateTime>100</gateTime>
@@ -75,10 +75,7 @@
           <gateTime>100</gateTime>
           </Articulation>
         <Channel>
-          <program value="56"/>
-          </Channel>
-        <Channel name="mute">
-          <program value="59"/>
+          <program value="73"/>
           </Channel>
         </Instrument>
       </Part>
@@ -88,9 +85,6 @@
           <concertClefType>G</concertClefType>
           <transposingClefType>G</transposingClefType>
           </Clef>
-        <KeySig>
-          <accidental>-2</accidental>
-          </KeySig>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>
@@ -123,32 +117,29 @@
         <Chord>
           <durationType>whole</durationType>
           <Note>
-            <pitch>70</pitch>
-            <tpc>12</tpc>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>double</subtype>
-          <span>1</span>
-          </BarLine>
+        <Clef>
+          <concertClefType>F</concertClefType>
+          <transposingClefType>F</transposingClefType>
+          </Clef>
         </Measure>
       <Measure number="6">
-        <KeySig>
-          <accidental>1</accidental>
-          </KeySig>
-        <Chord>
-          <durationType>whole</durationType>
-          <Note>
-            <pitch>71</pitch>
-            <tpc>19</tpc>
-            </Note>
-          </Chord>
-        </Measure>
-      <Measure number="7">
         <Rest>
           <durationType>measure</durationType>
           <duration z="4" n="4"/>
           </Rest>
+        </Measure>
+      <Measure number="7">
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="8">
         <Rest>
@@ -157,6 +148,12 @@
           </Rest>
         </Measure>
       <Measure number="9">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="10">
         <Rest>
           <durationType>measure</durationType>
           <duration z="4" n="4"/>

--- a/mtest/libmscore/measure/measure-insert_bf_clef-ref.mscx
+++ b/mtest/libmscore/measure/measure-insert_bf_clef-ref.mscx
@@ -133,10 +133,13 @@
           </Clef>
         </Measure>
       <Measure number="7">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="8">
         <Rest>

--- a/mtest/libmscore/measure/measure-insert_bf_clef.mscx
+++ b/mtest/libmscore/measure/measure-insert_bf_clef.mscx
@@ -127,10 +127,13 @@
           </Clef>
         </Measure>
       <Measure number="6">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>60</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="7">
         <Rest>

--- a/mtest/libmscore/measure/measure-insert_bf_key-2-ref.mscx
+++ b/mtest/libmscore/measure/measure-insert_bf_key-2-ref.mscx
@@ -136,6 +136,12 @@
         <KeySig>
           <accidental>1</accidental>
           </KeySig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="7">
         <Chord>
           <durationType>whole</durationType>
           <Note>
@@ -144,12 +150,6 @@
             </Note>
           </Chord>
         </Measure>
-      <Measure number="7">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
-        </Measure>
       <Measure number="8">
         <Rest>
           <durationType>measure</durationType>
@@ -157,6 +157,12 @@
           </Rest>
         </Measure>
       <Measure number="9">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="10">
         <Rest>
           <durationType>measure</durationType>
           <duration z="4" n="4"/>

--- a/mtest/libmscore/measure/measure-insert_bf_key-ref.mscx
+++ b/mtest/libmscore/measure/measure-insert_bf_key-ref.mscx
@@ -142,10 +142,13 @@
         <KeySig>
           <accidental>1</accidental>
           </KeySig>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>71</pitch>
+            <tpc>19</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="8">
         <Rest>

--- a/mtest/libmscore/measure/tst_measure.cpp
+++ b/mtest/libmscore/measure/tst_measure.cpp
@@ -135,9 +135,21 @@ void TestMeasure::insertBfClefChange()
       score->startCmd();
       score->insertMeasure(Element::Type::MEASURE, m);
       score->endCmd();
+      QVERIFY(score->checkClefs());
       QVERIFY(saveCompareScore(score, "measure-insert_bf_clef.mscx", DIR + "measure-insert_bf_clef-ref.mscx"));
       score->undo()->undo();
-      score->doLayout();
+      score->endUndoRedo();
+      QVERIFY(score->checkClefs());
+      QVERIFY(saveCompareScore(score, "measure-insert_bf_clef_undo.mscx", DIR + "measure-insert_bf_clef.mscx"));
+      m = score->firstMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure();
+      score->startCmd();
+      score->insertMeasure(Element::Type::MEASURE, m);
+      score->endCmd();
+      QVERIFY(score->checkClefs());
+      QVERIFY(saveCompareScore(score, "measure-insert_bf_clef-2.mscx", DIR + "measure-insert_bf_clef-2-ref.mscx"));
+      score->undo()->undo();
+      score->endUndoRedo();
+      QVERIFY(score->checkClefs());
       QVERIFY(saveCompareScore(score, "measure-insert_bf_clef_undo.mscx", DIR + "measure-insert_bf_clef.mscx"));
       delete score;
       }
@@ -157,9 +169,21 @@ void TestMeasure::insertBfKeyChange()
       score->startCmd();
       score->insertMeasure(Element::Type::MEASURE, m);
       score->endCmd();
+      QVERIFY(score->checkKeys());
       QVERIFY(saveCompareScore(score, "measure-insert_bf_key.mscx", DIR + "measure-insert_bf_key-ref.mscx"));
       score->undo()->undo();
-      score->doLayout();
+      score->endUndoRedo();
+      QVERIFY(score->checkKeys());
+      QVERIFY(saveCompareScore(score, "measure-insert_bf_key_undo.mscx", DIR + "measure-insert_bf_key.mscx"));
+      m = score->firstMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure()->nextMeasure();
+      score->startCmd();
+      score->insertMeasure(Element::Type::MEASURE, m);
+      score->endCmd();
+      QVERIFY(score->checkKeys());
+      QVERIFY(saveCompareScore(score, "measure-insert_bf_key-2.mscx", DIR + "measure-insert_bf_key-2-ref.mscx"));
+      score->undo()->undo();
+      score->endUndoRedo();
+      QVERIFY(score->checkKeys());
       QVERIFY(saveCompareScore(score, "measure-insert_bf_key_undo.mscx", DIR + "measure-insert_bf_key.mscx"));
       delete score;
       }


### PR DESCRIPTION
Checks the saved score but also the maps after inserting a measure directly in front of key change and inserting directly in front of clef change.  Also checks after inserting earlier in score (both case have been broken at various times).