### PR TITLE
Fix #48746 : Spanner span wrong after moving start anchor and undoing

### DIFF
--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -326,7 +326,8 @@ void Spanner::endEdit()
             score()->undoPropertyChanged(this, P_ID::SPANNER_TICK, editTick);
             rebuild = true;
             }
-      if (editTick2 != tick2()) {
+      // ticks may also change by moving initial anchor, without moving ending anchor
+      if (editTick2 != tick2() || editTick2 - editTick != tick2() - tick()) {
             score()->undoPropertyChanged(this, P_ID::SPANNER_TICKS, editTick2 - editTick);
             rebuild = true;
             }


### PR DESCRIPTION
Fix #48746 : Spanner span wrong after moving start anchor and undoing

The change in span length (`Spanner::_ticks`) was not noticed nor pushed unto the undo stack.