### PR TITLE
Fix #48751 : Ottava not played back after undoing a change in span

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -3342,7 +3342,10 @@ void ChangeProperty::flip()
             << property
             ;
 #endif
-      if (id == P_ID::SPANNER_TICK || id == P_ID::SPANNER_TICKS)
+      // Ottavas expect its spanner to be in the score lists while updating ticks as,
+      // while doing so, the parent staff calls updateOttava()
+      if ( (id == P_ID::SPANNER_TICK || id == P_ID::SPANNER_TICKS)
+                  && static_cast<Element*>(element)->type() != Element::Type::OTTAVA)
             static_cast<Element*>(element)->score()->removeSpanner(static_cast<Spanner*>(element));
 
       QVariant v       = element->getProperty(id);
@@ -3352,7 +3355,8 @@ void ChangeProperty::flip()
       else
             element->setProperty(id, property);
 
-      if (id == P_ID::SPANNER_TICK || id == P_ID::SPANNER_TICKS)
+      if ( (id == P_ID::SPANNER_TICK || id == P_ID::SPANNER_TICKS)
+                  && static_cast<Element*>(element)->type() != Element::Type::OTTAVA)
             static_cast<Element*>(element)->score()->addSpanner(static_cast<Spanner*>(element));
       property = v;
       propertyStyle = ps;

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -3342,10 +3342,7 @@ void ChangeProperty::flip()
             << property
             ;
 #endif
-      // Ottavas expect its spanner to be in the score lists while updating ticks as,
-      // while doing so, the parent staff calls updateOttava()
-      if ( (id == P_ID::SPANNER_TICK || id == P_ID::SPANNER_TICKS)
-                  && static_cast<Element*>(element)->type() != Element::Type::OTTAVA)
+      if (id == P_ID::SPANNER_TICK || id == P_ID::SPANNER_TICKS)
             static_cast<Element*>(element)->score()->removeSpanner(static_cast<Spanner*>(element));
 
       QVariant v       = element->getProperty(id);
@@ -3355,9 +3352,15 @@ void ChangeProperty::flip()
       else
             element->setProperty(id, property);
 
-      if ( (id == P_ID::SPANNER_TICK || id == P_ID::SPANNER_TICKS)
-                  && static_cast<Element*>(element)->type() != Element::Type::OTTAVA)
+      if (id == P_ID::SPANNER_TICK || id == P_ID::SPANNER_TICKS) {
             static_cast<Element*>(element)->score()->addSpanner(static_cast<Spanner*>(element));
+            // while updating ticks for an Ottava, the parent staff calls updateOttava()
+            // and expects to find the Ottava spanner(s) in the score lists;
+            // thus, the above (re)setProperty() left the staff pitchOffset map in a wrong state
+            // as the spanner has been removed from the score lists; redo the map here
+            if (static_cast<Element*>(element)->type() == Element::Type::OTTAVA)
+                  static_cast<Element*>(element)->staff()->updateOttava();
+            }
       property = v;
       propertyStyle = ps;
       }


### PR DESCRIPTION
Fix #48751 : Ottava not played back after undoing a change in span

As, when the span of an Ottava is changed, the staff it belongs to calls `Staff::updateOttava()` to rebuild its pitch offset map and expects to find the Ottava spanners in the score, removing it before updating the property and re-adding it after leaves the staff with a wrong pitch offset map.

Those lines to remove and re-add the spanner have been added with this commit:
https://github.com/musescore/MuseScore/commit/87ad7b4f25dc54e624f5e201b3400c59fdfdc1e0
the reason for them is not clear.

Maps for Ottavas are rebuild from scratch at any change anyway, so perhaps those lines are not needed for Ottavas; advice from core developers is welcome!