### PR TITLE
Fix #29761 - TABs: note dots do not align if different fret marks width

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2088,6 +2088,9 @@ void Chord::layoutTablature()
             lll = stemX - halfHeadWidth;
       if (rrr < stemX + halfHeadWidth)
             rrr = stemX + halfHeadWidth;
+      // align dots to the widest fret mark (not needed in all TAB styles, but harmless anyway)
+      if (segment())
+            segment()->setDotPosX(staffIdx(), headWidth);
       // if tab type is stemless or chord is stemless (possible when imported from MusicXML)
       // or duration longer than half (if halves have stems) or duration longer than crochet
       // remove stems

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1623,9 +1623,7 @@ void Note::layout2()
                   // setDotY() actually also manages creation/deletion of NoteDot's
                   setDotY(MScore::Direction::AUTO);
 
-                  // with TAB's, dotPosX is not set:
-                  // get dot X from width of fret text and use TAB default spacing
-                  x = width();
+                  // use TAB default note-to-dot spacing
                   dd = STAFFTYPE_TAB_DEFAULTDOTDIST_X * spatium();
                   d = dd * 0.5;
                   }


### PR DESCRIPTION
Fix #29761 - TABs: note dots do not align if different fret marks width

In "Stems thought" TAB style, if fret marks of a chord have different widths, augmentation dots are aligned with each fret mark width.

This fix aligns all the dots of a chord according to the widest fret mark.