### PR TITLE
Fix #29761 & Fix #34391 TAB note and stem dot alignment

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2088,6 +2088,9 @@ void Chord::layoutTablature()
             lll = stemX - halfHeadWidth;
       if (rrr < stemX + halfHeadWidth)
             rrr = stemX + halfHeadWidth;
+      // align dots to the widest fret mark (not needed in all TAB styles, but harmless anyway)
+      if (segment())
+            segment()->setDotPosX(staffIdx(), headWidth);
       // if tab type is stemless or chord is stemless (possible when imported from MusicXML)
       // or duration longer than half (if halves have stems) or duration longer than crochet
       // remove stems

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2188,14 +2188,6 @@ void Chord::layoutTablature()
             // special case of system-initial glissando final note is handled in Glissando::layout() itself
             }
 
-      if (dots()) {
-            qreal x = dotPosX() + dotNoteDistance
-               + (dots()-1) * score()->styleS(StyleIdx::dotDotDistance).val() * _spatium;
-            x += symWidth(SymId::augmentationDot);
-            if (x > rrr)
-                  rrr = x;
-            }
-
       if (_hook) {
             if (beam())
                   score()->undoRemoveElement(_hook);
@@ -2207,6 +2199,27 @@ void Chord::layoutTablature()
                         rrr = qMax(rrr, x);
                         }
                   }
+            }
+
+      if (dots()) {
+            qreal x = 0.0;
+            // if stems are beside staff, dots are placed near to stem
+            if (!tab->stemThrough()) {
+                  // if there is an unbeamed hook, dots should start after the hook
+                  if (_hook && !beam())
+                        x = _hook->width() + dotNoteDistance;
+                  // if not, dots should start at a fixed distance right after the stem
+                  else
+                        x = STAFFTYPE_TAB_DEFAULTDOTDIST_X * _spatium;
+                  if (segment())
+                        segment()->setDotPosX(staffIdx(), x);
+                  }
+            // if stems are through staff, use dot position computed above on fret mark widths
+            else
+                  x = dotPosX() + dotNoteDistance
+                        + (dots()-1) * score()->styleS(StyleIdx::dotDotDistance).val() * _spatium;
+            x += symWidth(SymId::augmentationDot);
+            rrr = qMax(rrr, x);
             }
 
       _space.setLw(lll);

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1623,9 +1623,7 @@ void Note::layout2()
                   // setDotY() actually also manages creation/deletion of NoteDot's
                   setDotY(MScore::Direction::AUTO);
 
-                  // with TAB's, dotPosX is not set:
-                  // get dot X from width of fret text and use TAB default spacing
-                  x = width();
+                  // use TAB default note-to-dot spacing
                   dd = STAFFTYPE_TAB_DEFAULTDOTDIST_X * spatium();
                   d = dd * 0.5;
                   }

--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -191,8 +191,11 @@ void Stem::draw(QPainter* painter) const
       // with tablatures and stems beside staves, dots are not drawn near 'notes', but near stems
       int nDots = chord()->dots();
       if (nDots > 0 && !stt->stemThrough()) {
-            qreal y =  ( (STAFFTYPE_TAB_DEFAULTSTEMLEN_DN * 0.2) * sp) * (_up ? -1.0 : 1.0);
-            drawSymbol(SymId::augmentationDot, painter, QPointF(STAFFTYPE_TAB_DEFAULTDOTDIST_X * sp, y), nDots);
+            qreal x     = chord()->dotPosX();
+            qreal y     = ( (STAFFTYPE_TAB_DEFAULTSTEMLEN_DN * 0.2) * sp) * (_up ? -1.0 : 1.0);
+            qreal step  = score()->styleS(StyleIdx::dotDotDistance).val() * sp;
+            for (int dot = 0; dot < nDots; dot++, x += step)
+                  drawSymbol(SymId::augmentationDot, painter, QPointF(x, y));
             }
       }
 


### PR DESCRIPTION
Fix #29761 - TABs: note dots do not align if different fret marks width

In "Stems through" TAB style, if fret marks of a chord have different widths, augmentation dots are aligned with each fret mark width.

This fix aligns all the dots of a chord according to the widest fret mark.

Fix #34391 - TABs: dots on beside staff stems collide with hooks

In "Stems beside" TAB style, augm. dots are drawn near the stem/hook; moved the dots beyond the hook, if present.

Also, improved spacing of multiple dots.

Issues have been addressed by the same PR, as the they affect much the same code parts.