### PR TITLE
Fix #29986 : Ottavas in TABs - Solution A)

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -235,7 +235,10 @@ void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos)
       int staffIdx;
       Segment* segment;
       MeasureBase* mb = pos2measure(pos, &staffIdx, 0, &segment, 0);
-      if (mb == 0 || mb->type() != Element::Type::MEASURE) {
+      Staff* st = staff(staffIdx);
+      // ignore if we do not have a measure or when droping an ottava onto a TAB staff
+      if (mb == 0 || mb->type() != Element::Type::MEASURE
+                  || (st->isTabStaff() && spanner->type() == Element::Type::OTTAVA) ) {
             qDebug("cmdAddSpanner: cannot put object here");
             delete spanner;
             return;
@@ -253,7 +256,7 @@ void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos)
             int tick2 = qMin(segment->measure()->tick() + segment->measure()->ticks(), lastTick);
             spanner->setTick2(tick2);
             }
-      else {      // Anchor::MEASURE
+      else {      // Anchor::MEASURE, Anchor::CHORD, Anchor::NOTE
             Measure* m = static_cast<Measure*>(mb);
             QRectF b(m->canvasBoundingRect());
 

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1715,6 +1715,18 @@ void Score::deleteItem(Element* el)
                   }
                   break;
 
+            case Element::Type::OTTAVA:
+                  {
+                  Ottava* o = static_cast<Ottava*>(el);
+                  // adjust pitches of linked TAB staves
+                  for (Staff* st : o->staff()->staffList()) {
+                        if (st->isTabStaff())
+                              st->score()->undo(new TabAdjustOttava(st, o->tick(), o->tick2(), -o->pitchShift()));
+                        }
+                  undoRemoveElement(el);
+                  }
+                  break;
+
             case Element::Type::OTTAVA_SEGMENT:
             case Element::Type::HAIRPIN_SEGMENT:
             case Element::Type::TRILL_SEGMENT:

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -73,6 +73,7 @@
 #include "tremolo.h"
 #include "sym.h"
 #include "utils.h"
+#include "stringdata.h"
 
 namespace Ms {
 
@@ -1027,6 +1028,12 @@ void Score::undoAddElement(Element* element)
                               case Element::Type::DYNAMIC:
                               case Element::Type::LYRICS:   // not normally segment-attached
                                     continue;
+                              case Element::Type::OTTAVA:
+                                    if (staff->isTabStaff()) {
+                                          Ottava* o = static_cast<Ottava*>(element);
+                                          undo(new TabAdjustOttava(staff,o->tick(), o->tick2(), o->pitchShift()));
+                                          continue;
+                                          }
                               default:
                                     break;
                               }
@@ -3677,6 +3684,42 @@ void ChangeDrumset::flip()
       Drumset d = *instrument->drumset();
       instrument->setDrumset(&drumset);
       drumset = d;
+      }
+
+//---------------------------------------------------------
+//   TabAdjustOttava::flip
+//---------------------------------------------------------
+
+void TabAdjustOttava::flip()
+      {
+      if (!staff->isTabStaff())           // only affect TAB staves
+            return;                       // (possibly overkill?)
+
+      int               fromTrack   = staff->idx() * VOICES;
+      int               toTrack     = fromTrack + VOICES;
+      Score*            score       = staff->score();
+      const StringData* stringData  = staff->part()->instr()->stringData();
+      // for each ChordRest segment spanned by ottava
+      for (Segment* s = score->tick2segment(fromTick, true, Segment::Type::ChordRest, false);
+                  s && s->tick() < toTick; s = s->nextCR()) {
+            Chord* chord = nullptr;
+            // for each segment element
+            for (int track = fromTrack; track < toTrack; track++) {
+                  Element* e = s->element(track);
+                  if (e && e->type() == Element::Type::CHORD) {
+                        if (chord == nullptr)
+                              chord = static_cast<Chord*>(e);     // at least one chord found
+                        // update pitch of each chord note (ottava shift does not change TPC's)
+                        for (Note* note : static_cast<Chord*>(e)->notes())
+                              note->setPitch(note->pitch() + pitchOffset, note->tpc1(), note->tpc2());
+                        }
+                  }
+            // for each segment, TAB chords from all voices are fretted cumulatively,
+            // by passing any chord in that segment of the TAB staff, as long as there is at least one
+            if (stringData && chord)
+                  stringData->fretChords(chord);
+            }
+      pitchOffset = -pitchOffset;         // next flip will reverse the offset
       }
 
 }

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -1384,6 +1384,23 @@ class ChangeDrumset : public UndoCommand {
       UNDO_NAME("ChangeDrumset")
       };
 
+//---------------------------------------------------------
+//   TabAdjustOttava
+//---------------------------------------------------------
+
+class TabAdjustOttava : public UndoCommand {
+      Staff*      staff;
+      int         fromTick, toTick;
+      int         pitchOffset;
+
+      void flip();
+
+   public:
+      TabAdjustOttava(Staff* st, int from, int to, int offset) :
+                  staff(st), fromTick(from), toTick(to), pitchOffset(offset) {}
+      UNDO_NAME("TabAdjustOttava")
+      };
+
 
 }     // namespace Ms
 #endif


### PR DESCRIPTION
Ottavas are not used in TAB staves, as they do not really make sense in TAB's. Yet, currently ottavas:

- can be dropped on TAB staves
- ottavas added to standard staves are duplicated in TAB staves linked to them

Fix:

- Ottavas cannot be dropped on TAB staves any longer. Attempting to drop an ottava on a TAB, results in the action being ignored.
- If an ottava is added to a standard staff linked to TAB staves, the standard staff operation is carried over exactly as before, but the `Ottava` element is not replicated in the TAB linked staff; instead, the actual pitches of corresponding notes in the TAB staff are shifted by the `pitchOffset` of the `Ottava`.
- If the `Ottava` span is later edited (in the standard staff, of course), the pitches of the corresponding TAB staff notes are updated accordingly.

Regarding adding ottavas directly to TAB staves, either linked or not, there is no difference between Solution A) and Solution B): with both, ottavas **cannot** be added to TAB staves.

When TABs are linked to standard staves and ottavas are added to the standard staff, the differences between Solution A) and B) are:

- A) does not create **any** `Ottava` element in TABs; B) creates hidden `Ottava` elements in the linked TAB.
- A) modifies the TAB note pitches to render the ottava effect; B) does not change the stored pitches, only the fretting.

I am not very fond of the hidden `Ottava` trick of Solution B), but that solution seems more in tune with the current code and easier to understand (and maintain).

This solution A) seems to me more orthodox, but probably less clear to the unaware developer, as each modification of the 'master' `Ottava` has to be reflected into the linked TAB, at the proper place and time with respect to undo/redo machinery.

My 'instinctive' preference is for Solution B), but advice is welcome!