### PR TITLE
Fix #29986 : Ottavas in TABs - Solution B

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -235,7 +235,10 @@ void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos)
       int staffIdx;
       Segment* segment;
       MeasureBase* mb = pos2measure(pos, &staffIdx, 0, &segment, 0);
-      if (mb == 0 || mb->type() != Element::Type::MEASURE) {
+      Staff* st = staff(staffIdx);
+      // ignore if we do not have a measure or when droping an ottava onto a TAB staff
+      if (mb == 0 || mb->type() != Element::Type::MEASURE
+                  || (st->isTabStaff() && spanner->type() == Element::Type::OTTAVA) ) {
             qDebug("cmdAddSpanner: cannot put object here");
             delete spanner;
             return;
@@ -253,7 +256,7 @@ void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos)
             int tick2 = qMin(segment->measure()->tick() + segment->measure()->ticks(), lastTick);
             spanner->setTick2(tick2);
             }
-      else {      // Anchor::MEASURE
+      else {      // Anchor::MEASURE, Anchor::CHORD, Anchor::NOTE
             Measure* m = static_cast<Measure*>(mb);
             QRectF b(m->canvasBoundingRect());
 

--- a/libmscore/ottava.cpp
+++ b/libmscore/ottava.cpp
@@ -310,6 +310,29 @@ void Ottava::read(XmlReader& e)
       }
 
 //---------------------------------------------------------
+//   layout
+//---------------------------------------------------------
+
+void Ottava::layout()
+      {
+      if (staff() && staff()->isTabStaff())           // in TABs ottavas have no output
+            setbbox(QRectF());
+      else
+            TextLine::layout();
+      }
+
+//---------------------------------------------------------
+//   draw
+//---------------------------------------------------------
+
+void Ottava::draw(QPainter* painter) const
+      {
+      if (staff() && staff()->isTabStaff())           // do not draw ottavas in TABs
+            return;
+      TextLine::draw(painter);
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 

--- a/libmscore/ottava.h
+++ b/libmscore/ottava.h
@@ -105,6 +105,8 @@ class Ottava : public TextLine {
       virtual void endEdit() override;
       virtual void write(Xml& xml) const override;
       virtual void read(XmlReader& de) override;
+      virtual void layout() override;
+      virtual void draw(QPainter* painter) const override;
 
       virtual QVariant getProperty(P_ID propertyId) const override;
       virtual bool setProperty(P_ID propertyId, const QVariant&) override;

--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -158,7 +158,7 @@ void StringData::fretChords(Chord * chord) const
       // store staff pitch offset at this tick, to speed up actual note pitch calculations
       // (ottavas not implemented yet)
       int transp = chord->staff() ? chord->staff()->part()->instr()->transpose().chromatic : 0;
-      int pitchOffset = /*chord->staff()->pitchOffset(chord->segment()->tick())*/ - transp;
+      int pitchOffset = chord->staff()->pitchOffset(chord->segment()->tick()) - transp;
       // if chord parent is not a segment, the chord is special (usually a grace chord):
       // fret it by itself, ignoring the segment
       if (chord->parent()->type() != Element::Type::SEGMENT)


### PR DESCRIPTION
Ottavas are not used in TAB staves, as they do not really make sense in TAB's. Yet, currently ottavas:

- can be dropped on TAB staves
- ottavas added to standard staves are duplicated in TAB staves linked to them

Fix:

- Ottavas cannot be dropped on TAB staves any longer. Attempting to drop an ottava on a TAB, results in the action being ignored.
- If an ottava is added to a standard staff linked to TAB staves, the `Ottava` element IS cloned to the TAB staves (as prior), but:
  - the `Ottava` element is laid out to a 0-sized point and not displayed in any way
  - the fretting of the TAB notes are shifted by the `pitchOffset` of the `Ottava` (from the staff pitch offset map), but note pitches are not actually changed.
- If the ottava span is later edited (in the standard staff, of course), the corresponding (hidden) `Ottava` in the TAB also changes and note fretting updates accordingly.

Regarding adding ottavas directly to TAB staves, either linked or not, there is no difference between Solution A) and Solution B): with both, ottavas **cannot** be added to TAB staves.

When TABs are linked to standard staves and ottavas are added to the standard staff, the differences between Solution A) and B) are:

- A) does not create **any** `Ottava` element in TABs; B) creates hidden `Ottava` elements in the linked TAB.
- A) modifies the TAB note pitches to render the ottava effect; B) does not change the stored pitches, only the fretting.

I am not very fond of the hidden `Ottava` trick, but this solution seems more in tune with the current code and easier to understand (and maintain). The other solution seems to me less tricky, but probably less clear to the unaware developer.

Advices about which solution to prefer are welcome!

I am not very fond of the hidden `Ottava` trick of this solution, but if seems more in tune with the current code and easier to understand (and maintain).

Solution A) seems to me more orthodox, but probably less clear to the unaware developer, as each modification of the 'master' `Ottava` has to be reflected into the linked TAB, at the proper place and time with respect to undo/redo machinery.

My 'instinctive' preference is for this Solution B), but advice is welcome!