### PR TITLE
Glissando in Inspector

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -225,6 +225,9 @@ void Inspector::setElements(const QList<Element*>& l)
                         case Element::Type::GLISSANDO:
                               ie = new InspectorGlissando(this);
                               break;
+                        case Element::Type::GLISSANDO_SEGMENT:
+                              ie = new InspectorGlissando(this);
+                              break;
                         case Element::Type::TEMPO_TEXT:
                               ie = new InspectorTempoText(this);
                               break;


### PR DESCRIPTION
Selecting a glissando segment does not always bring the glissando properties up in the Inspector.

Added the relevant `case` to `inspector.cpp`