### PR TITLE
fix #48836: correct key signature creating score from template with keys...

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -531,6 +531,9 @@ void MuseScore::newFile()
                               }
                         s = ns;
                         }
+                  // clear key map
+                  for (int i = 0; i < score->nstaves(); ++i)
+                        score->staff(i)->keyList()->clear();
                   }
             foreach (Excerpt* excerpt, score->excerpts()) {
                   Score* exScore =  excerpt->partScore();


### PR DESCRIPTION
... other than C

Another one of the special cases for C major key signatures we don't quite get right.  See issue report for full analysis.  But problem is very simple: when reading a template, we remove all notes & key signatures, but we don't clear the key maps.  Creating a score with a C key signature is therefore impossible if the original template had a key signature other than C.  We go out of our way to avoid creating the C key signature in the new score, but the old key signature is left in the key map, and layoutSystemRow() dutifully inserts key signatures for us on this basis.

It turns out there are a number of related issues that all get fixed by simply clearing the key maps after deleting the key signatures (try creating a template that has a key other than C, or that changes key mid-score - these all leave stuff behind in the key map that mess up scores created from them).