### PR TITLE
fix #49096: reset text to style too limited

### DIFF
--- a/mscore/inspector/inspectorText.cpp
+++ b/mscore/inspector/inspectorText.cpp
@@ -63,10 +63,13 @@ void InspectorText::setElement()
 
 void InspectorText::resetToStyle()
       {
-      Text* text = static_cast<Text*>(inspector->element());
-      Score* score = text->score();
+      Score* score = inspector->element()->score();
       score->startCmd();
-      text->undoChangeProperty(P_ID::TEXT, text->plainText());
+      for (Element* e : inspector->el()) {
+            Text* text = static_cast<Text*>(e);
+            text->undoChangeProperty(P_ID::TEXT_STYLE, QVariant::fromValue(score->textStyle(text->textStyleType())));
+            text->undoChangeProperty(P_ID::TEXT, text->plainText());
+            }
       score->endCmd();
       }
 


### PR DESCRIPTION
This allows the new "Reset Text to Style" button in Inspector to affect all selected text, not just the current element.

It also resets the style itself - not the text style type (which is left unchanged), but the style, to the score defaults for the given text style type.  This allows the button to reset changes made in Text Properties as well as changes made in the text toolbar.