### PR TITLE
Fix #48721 - Glissando cloning

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -448,29 +448,10 @@ void cloneStaves(Score* oscore, Score* score, const QList<int>& map)
                                                 // makes sure the 'other' spanner anchor element is already set up)
                                                 // 'on' is the old spanner end note and 'nn' is the new spanner end note
                                                 for (Spanner* oldSp : on->spannerBack()) {
-                                                      // determining the new spanner start element:
-                                                      Note* oldStart    = static_cast<Note*>(oldSp->startElement());
-                                                      Note* newStart    = nullptr;
-                                                      // determine the track offset from the spanner end to the spanner start
-                                                      int   newTrack    = nn->track() + (on->track() - oldStart->track());
-                                                      // look in notes linked to oldStart for a note with the same
-                                                      // score as new score and required track offset
-                                                      for (ScoreElement* newEl : oldStart->linkList())
-                                                            if (static_cast<Note*>(newEl)->score() == score
-                                                                        && static_cast<Note*>(newEl)->track() == newTrack) {
-                                                                  newStart = static_cast<Note*>(newEl);
-                                                                  break;
-                                                            }
+                                                      Note* newStart = Spanner::startElementFromSpanner(oldSp, nn);
                                                       if (newStart != nullptr) {
                                                             Spanner* newSp = static_cast<Spanner*>(oldSp->linkedClone());
-                                                            newSp->setScore(score);
-                                                            newSp->setParent(newStart);
-                                                            newSp->setStartElement(newStart);
-                                                            newSp->setEndElement(nn);
-                                                            newSp->setTick(newStart->chord()->tick());
-                                                            newSp->setTick2(nch->tick());
-                                                            newSp->setTrack(newTrack);
-                                                            newSp->setTrack2(nn->track());
+                                                            newSp->setNoteSpan(newStart, nn);
                                                             score->addElement(newSp);
                                                             }
                                                       else {
@@ -724,29 +705,10 @@ void cloneStaff(Staff* srcStaff, Staff* dstStaff)
                                           // makes sure the 'other' spanner anchor element is already set up)
                                           // 'on' is the old spanner end note and 'nn' is the new spanner end note
                                           for (Spanner* oldSp : on->spannerBack()) {
-                                                // determining the new spanner start element:
-                                                Note* oldStart    = static_cast<Note*>(oldSp->startElement());
-                                                Note* newStart    = nullptr;
-                                                // determine the track offset from the spanner end to the spanner start
-                                                int   newTrack    = nn->track() + (on->track() - oldStart->track());
-                                                // look in notes linked to oldStart for a note with the same
-                                                // score as new score and required track offset
-                                                for (ScoreElement* newEl : oldStart->linkList())
-                                                      if (static_cast<Note*>(newEl)->score() == score
-                                                                  && static_cast<Note*>(newEl)->track() == newTrack) {
-                                                            newStart = static_cast<Note*>(newEl);
-                                                            break;
-                                                      }
+                                                Note* newStart = Spanner::startElementFromSpanner(oldSp, nn);
                                                 if (newStart != nullptr) {
                                                       Spanner* newSp = static_cast<Spanner*>(oldSp->linkedClone());
-                                                      newSp->setScore(score);
-                                                      newSp->setParent(newStart);
-                                                      newSp->setStartElement(newStart);
-                                                      newSp->setEndElement(nn);
-                                                      newSp->setTick(newStart->chord()->tick());
-                                                      newSp->setTick2(nch->tick());
-                                                      newSp->setTrack(newTrack);
-                                                      newSp->setTrack2(nn->track());
+                                                      newSp->setNoteSpan(newStart, nn);
                                                       score->addElement(newSp);
                                                       }
                                                 else {

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -22,6 +22,7 @@ class Spanner;
 class System;
 class Chord;
 class ChordRest;
+class Note;
 
 //---------------------------------------------------------
 //   SpannerSegmentType
@@ -164,6 +165,9 @@ class Spanner : public Element {
 
       void computeStartElement();
       void computeEndElement();
+      static Note* endElementFromSpanner(Spanner* sp, Element* newStart);
+      static Note* startElementFromSpanner(Spanner* sp, Element* newEnd);
+      void setNoteSpan(Note* startNote, Note* endNote);
 
       Element* startElement() const    { return _startElement; }
       Element* endElement() const      { return _endElement;   }

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -74,6 +74,7 @@
 #include "sym.h"
 #include "utils.h"
 #include "stringdata.h"
+#include "glissando.h"
 
 namespace Ms {
 
@@ -946,7 +947,22 @@ void Score::undoAddElement(Element* element)
                   }
             foreach (ScoreElement* ee, *links) {
                   Element* e = static_cast<Element*>(ee);
-                  Element* ne = (e == parent) ? element : element->linkedClone();
+                  Element* ne;
+                  if (e == parent)
+                        ne = element;
+                  else {
+                        if (element->type() == Element::Type::GLISSANDO) {    // and other spanners with Anchor::NOTE
+                              Note* newEnd = Spanner::endElementFromSpanner(static_cast<Glissando*>(element), e);
+                              if (newEnd) {
+                                    ne = element->linkedClone();
+                                    static_cast<Spanner*>(ne)->setNoteSpan(static_cast<Note*>(e), newEnd);
+                                    }
+                              else              //couldn't find suitable start note
+                                    continue;
+                              }
+                        else
+                              ne = element->linkedClone();
+                        }
                   ne->setScore(e->score());
                   ne->setSelected(false);
                   ne->setParent(e);


### PR DESCRIPTION
Fix #48721 - Glissando cloning

When a glissando is added to a staff which has linked clones (either linked staves or excerpts), the cloned `Glissando` added to the cloned staff is left with the same start and end element of the original `Glissando`.

Added a little of `Spanner` infrastructure to manage note-anchored spanners.