### PR TITLE
Fix #49126 Glissando and the Inspector / Fix #49141 - Glissando dragging

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -113,7 +113,6 @@ static const ElementName elementNames[] = {
       ElementName("TimeSig",              QT_TRANSLATE_NOOP("elementName", "Time Signature")),
       ElementName("Rest",                 QT_TRANSLATE_NOOP("elementName", "Rest")),
       ElementName("Breath",               QT_TRANSLATE_NOOP("elementName", "Breath")),
-      ElementName("Glissando",            QT_TRANSLATE_NOOP("elementName", "Glissando")),
       ElementName("RepeatMeasure",        QT_TRANSLATE_NOOP("elementName", "Repeat Measure")),
       ElementName("Image",                QT_TRANSLATE_NOOP("elementName", "Image")),
       ElementName("Tie",                  QT_TRANSLATE_NOOP("elementName", "Tie")),
@@ -167,6 +166,7 @@ static const ElementName elementNames[] = {
       ElementName("TextLine",             QT_TRANSLATE_NOOP("elementName", "Text Line")),
       ElementName("NoteLine",             QT_TRANSLATE_NOOP("elementName", "Note Line")),
       ElementName("LyricsLine",           QT_TRANSLATE_NOOP("elementName", "Melisma Line")),
+      ElementName("Glissando",            QT_TRANSLATE_NOOP("elementName", "Glissando")),
       ElementName("Segment",              QT_TRANSLATE_NOOP("elementName", "Segment")),
       ElementName("System",               QT_TRANSLATE_NOOP("elementName", "System")),
       ElementName("Compound",             QT_TRANSLATE_NOOP("elementName", "Compound")),
@@ -608,7 +608,8 @@ void Element::writeProperties(Xml& xml) const
       if (_links && (_links->size() > 1) && !xml.clipboardmode)
             xml.tag("lid", _links->lid());
       if (!userOff().isNull()) {
-            if (type() == Element::Type::VOLTA_SEGMENT || isChordRest())
+            if (type() == Element::Type::VOLTA_SEGMENT
+                        || type() == Element::Type::GLISSANDO_SEGMENT || isChordRest())
                   xml.tag("offset", userOff() / spatium());
             else
                   xml.tag("pos", pos() / score()->spatium());

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -208,7 +208,6 @@ class Element : public QObject, public ScoreElement {
             TIMESIG,
             REST,
             BREATH,
-            GLISSANDO,
 
             REPEAT_MEASURE,
             IMAGE,
@@ -264,6 +263,7 @@ class Element : public QObject, public ScoreElement {
             TEXTLINE,
             NOTELINE,
             LYRICSLINE,
+            GLISSANDO,
             SEGMENT,
             SYSTEM,
             COMPOUND,

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -106,8 +106,57 @@ void GlissandoSegment::draw(QPainter* painter) const
       }
 
 //---------------------------------------------------------
-//   Glissando
+//   getProperty
 //---------------------------------------------------------
+
+QVariant GlissandoSegment::getProperty(P_ID id) const
+      {
+      switch (id) {
+            // route properties of the whole Glissando element to it
+            case P_ID::GLISS_TYPE:
+            case P_ID::GLISS_TEXT:
+            case P_ID::GLISS_SHOW_TEXT:
+                  return glissando()->getProperty(id);
+            default:
+                  return LineSegment::getProperty(id);
+            }
+      }
+
+//---------------------------------------------------------
+//   setProperty
+//---------------------------------------------------------
+
+bool GlissandoSegment::setProperty(P_ID id, const QVariant& v)
+      {
+      switch (id) {
+            case P_ID::GLISS_TYPE:
+            case P_ID::GLISS_TEXT:
+            case P_ID::GLISS_SHOW_TEXT:
+                  return glissando()->setProperty(id, v);
+            default:
+                  return LineSegment::setProperty(id, v);
+            }
+      }
+
+//---------------------------------------------------------
+//   propertyDefault
+//---------------------------------------------------------
+
+QVariant GlissandoSegment::propertyDefault(P_ID id) const
+      {
+      switch (id) {
+      case P_ID::GLISS_TYPE:
+      case P_ID::GLISS_TEXT:
+      case P_ID::GLISS_SHOW_TEXT:
+                  return glissando()->propertyDefault(id);
+            default:
+                  return LineSegment::propertyDefault(id);
+            }
+      }
+
+//=========================================================
+//   Glissando
+//=========================================================
 
 Glissando::Glissando(Score* s)
   : SLine(s)

--- a/libmscore/glissando.h
+++ b/libmscore/glissando.h
@@ -43,6 +43,10 @@ class GlissandoSegment : public LineSegment {
       virtual GlissandoSegment* clone() const override      { return new GlissandoSegment(*this); }
       virtual void draw(QPainter*) const override;
       virtual void layout() override;
+
+      virtual QVariant getProperty(P_ID id) const override;
+      virtual bool setProperty(P_ID propertyId, const QVariant&) override;
+      virtual QVariant propertyDefault(P_ID id) const override;
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fix #49126 Glissando and the Inspector / Fix #49141 - Glissando dragging

**Common part**: Both issues stemmed by the fact that clicking a glissando sometime selected the whole `Glissando` and sometime one of its segments.

It depended on the order in which element types appear in `element.h` enum: for all other spanners the segment type is listed **before** the whole element type, while for `GLISSANDO` and `GLISSANDO_SEGMENT` it is opposite.

Changing the order ensures that the segment is always selected rather than the whole `Glissando` element.

**Inspector**: adding property management to `GlissandoSegment` routing whole `Glissando` properties from the segment to the `Glissando` fixes `Glissando` access in Inspector once one of its segment(s) is selected.

This is parallel to how other spanners are currently managed (see for instance, `TextLine` and `TextLineSegment`).

**Dragging** and Saving: fixed by treating glissando segment user offset as user offset rather as position component (parallel to how VOLTA is managed).