### PR TITLE
Fix #49136 - Duplicate cross-page glissando.

### DIFF
--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -150,7 +150,10 @@ LineSegment* Glissando::createLineSegment()
 void Glissando::scanElements(void* data, void (*func)(void*, Element*), bool all)
       {
       func(data, this);
-      SLine::scanElements(data, func, all);
+      // don't scan segments belonging to systems; the systems themselves will scan them
+      for (SpannerSegment* seg : segments)
+            if (!seg->parent() || seg->parent()->type() != Element::Type::SYSTEM)
+                  seg->scanElements(data, func, all);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fix #49136 - Duplicate cross-page glissando.

`scanElements()` was scanning glissando segments both through the `Glissando` and through the system each segment belongs to.

Original issue: http://musescore.org/en/node/49136