### PR TITLE
Fix reading back note-anchored cross-staff spanners from a lower to a higher staff

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1087,6 +1087,7 @@ void Note::read(XmlReader& e)
                         sp->setTrack2(placeholder->track2());
                         sp->setTick(e.tick());                          // make sure tick2 will be correct
                         sp->setTick2(placeholder->tick2());
+                        static_cast<Note*>(placeholder->endElement())->addSpannerBack(sp);
                         // remove no longer needed place-holder before reading the new spanner,
                         // as reading it also adds it to XML reader list of spanners,
                         // which would overwrite the place-holder

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1054,16 +1054,45 @@ void Note::read(XmlReader& e)
                               }
                         e.removeSpanner(sp);
                         }
-                  else
-                        // TODO : manage endSpanner from one staff to a previous staff
-                        // (like from piano bass staff to treble staff), where endSpanner is
-                        // found before the spanner itself
-                        qDebug("Note::read(): cannot find spanner %d", id);
+                  else {
+                        // End of a spanner whose start element will appear later;
+                        // may happen for cross-staff spanner from a lower to a higher staff
+                        // (for instance a glissando from bass to treble staff of piano).
+                        // Create a place-holder spanner with end data
+                        // (a TextLine is used only because both Spanner or SLine are abstract,
+                        // the actual class does not matter, as long as it is derived from Spanner)
+                        int id = e.intAttribute("id", -1);
+                        if (id != -1) {
+                              Spanner* placeholder = new TextLine(score());
+                              placeholder->setAnchor(Spanner::Anchor::NOTE);
+                              placeholder->setEndElement(this);
+                              placeholder->setTrack2(track());
+                              placeholder->setTick(0);
+                              placeholder->setTick2(e.tick());
+                              e.addSpanner(id, placeholder);
+                              }
+                        }
                   e.readNext();
                   }
             else if (tag == "TextLine"
                   || tag == "Glissando") {
                   Spanner* sp = static_cast<Spanner*>(Element::name2Element(tag, score()));
+                  // check this is not a lower-to-higher cross-staff spanner we already got
+                  int id = e.intAttribute("id");
+                  Spanner* placeholder = e.findSpanner(id);
+                  if (placeholder) {
+                        // if it is, fill end data from place-holder
+                        sp->setAnchor(Spanner::Anchor::NOTE);           // make sure we can set a Note as end element
+                        sp->setEndElement(placeholder->endElement());
+                        sp->setTrack2(placeholder->track2());
+                        sp->setTick(e.tick());                          // make sure tick2 will be correct
+                        sp->setTick2(placeholder->tick2());
+                        // remove no longer needed place-holder before reading the new spanner,
+                        // as reading it also adds it to XML reader list of spanners,
+                        // which would overwrite the place-holder
+                        e.removeSpanner(placeholder);
+                        delete placeholder;
+                        }
                   sp->setTrack(track());
                   sp->read(e);
                   sp->setAnchor(Spanner::Anchor::NOTE);

--- a/mtest/libmscore/CMakeLists.txt
+++ b/mtest/libmscore/CMakeLists.txt
@@ -14,7 +14,7 @@
 subdirs(
       album barline beam breath chordsymbol clef clef_courtesy compat concertpitch copypaste
       copypastesymbollist dynamic element hairpin instrumentchange join keysig layout parts measure midi
-      note plugins repeat selectionfilter selectionrangedelete split splitstaff timesig tools transpose tuplet text
+      note plugins repeat selectionfilter selectionrangedelete spanners split splitstaff timesig tools transpose tuplet text
       )
 
 install(FILES

--- a/mtest/libmscore/spanners/CMakeLists.txt
+++ b/mtest/libmscore/spanners/CMakeLists.txt
@@ -1,0 +1,16 @@
+#=============================================================================
+#  MuseScore
+#  Music Composition & Notation
+#
+#  Copyright (C) 2011-2015 Werner Schweer & others
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2
+#  as published by the Free Software Foundation and appearing in
+#  the file LICENSE.GPL
+#=============================================================================
+
+set(TARGET tst_spanners)
+
+include(${PROJECT_SOURCE_DIR}/mtest/cmake.inc)
+

--- a/mtest/libmscore/spanners/glissando-crossstaff01-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-crossstaff01-ref.mscx
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <page-layout>
+        <page-height>1683.78</page-height>
+        <page-width>1190.55</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2"/>
+        <barLineSpan>2</barLineSpan>
+        </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <defaultClef>F</defaultClef>
+        <bracket type="-1" span="0"/>
+        <barLineSpan>0</barLineSpan>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName pos="0">Piano</longName>
+        <shortName pos="0">Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        <Chord>
+          <durationType>half</durationType>
+          <Note>
+            <pitch>84</pitch>
+            <tpc>14</tpc>
+            <endSpanner id="2"/>
+            </Note>
+          </Chord>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>2</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Chord>
+          <durationType>half</durationType>
+          <Note>
+            <pitch>36</pitch>
+            <tpc>14</tpc>
+            <Glissando id="2">
+              <text>gliss.</text>
+              <subtype>1</subtype>
+              <diagonal>1</diagonal>
+              <lineWidth>0.15</lineWidth>
+              <anchor>3</anchor>
+              </Glissando>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/spanners/glissando-crossstaff01.mscx
+++ b/mtest/libmscore/spanners/glissando-crossstaff01.mscx
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <page-layout>
+        <page-height>1683.78</page-height>
+        <page-width>1190.55</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="1" span="2"/>
+        <barLineSpan>2</barLineSpan>
+        </Staff>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <defaultClef>F</defaultClef>
+        <bracket type="-1" span="0"/>
+        <barLineSpan>0</barLineSpan>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName pos="0">Piano</longName>
+        <shortName pos="0">Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        <Chord>
+          <durationType>half</durationType>
+          <Note>
+            <pitch>84</pitch>
+            <tpc>14</tpc>
+            <endSpanner id="2"/>
+            </Note>
+          </Chord>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>2</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Chord>
+          <durationType>half</durationType>
+          <Note>
+            <pitch>36</pitch>
+            <tpc>14</tpc>
+            <Glissando id="2">
+              <text>gliss.</text>
+              <subtype>1</subtype>
+              <diagonal>1</diagonal>
+              <lineWidth>0.15</lineWidth>
+              <anchor>3</anchor>
+              </Glissando>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/spanners/tst_spanners.cpp
+++ b/mtest/libmscore/spanners/tst_spanners.cpp
@@ -1,0 +1,68 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2015 Werner Schweer & others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include <QtTest/QtTest>
+#include "mtest/testutils.h"
+//#include "libmscore/barline.h"
+//#include "libmscore/measure.h"
+#include "libmscore/score.h"
+//#include "libmscore/system.h"
+//#include "libmscore/undo.h"
+
+#define DIR QString("libmscore/spanners/")
+
+using namespace Ms;
+
+//---------------------------------------------------------
+//   TestClef
+//---------------------------------------------------------
+
+class TestSpanners : public QObject, public MTest
+      {
+      Q_OBJECT
+
+   private slots:
+      void initTestCase();
+      void spanners01();            // cross-staff glissando from lower to higher staff
+      };
+
+//---------------------------------------------------------
+//   initTestCase
+//---------------------------------------------------------
+
+void TestSpanners::initTestCase()
+      {
+      initMTest();
+      }
+
+//---------------------------------------------------------
+///  spanners01
+///   Check loading of score with a glissando from a lower to a higher staff:
+//    A score with:
+//          grand staff,
+//          glissando from a bass staff note to a treble staff note
+//    is loaded and laid out and saved: should be round-trip safe.
+//---------------------------------------------------------
+
+void TestSpanners::spanners01()
+      {
+      Score* score = readScore(DIR + "glissando-crossstaff01.mscx");
+      score->doLayout();
+
+      QVERIFY(saveCompareScore(score, "glissando-crsossstaff01.mscx", DIR + "glissando-crossstaff01-ref.mscx"));
+      delete score;
+      }
+
+
+QTEST_MAIN(TestSpanners)
+#include "tst_spanners.moc"
+


### PR DESCRIPTION
If a cross-staff spanner goes from a lower to a higher staff, the start point is saved **after** the end point.

When reading it back, the end point is ignored because a matching start point has not been met yet.

This applies for instance to glissandi from the bass to the treble staff of a grand staff.

Fixed by adding to the XML reader spanner map a temporary place-holder spanner with the end point data, to be looked for when meeting the start point.

This fix only deals with note-anchored spanners.