### PR TITLE
fix #41611: shift on print

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1484,6 +1484,8 @@ void MuseScore::printFile()
 
       printerDev.setCreator("MuseScore Version: " VERSION);
       printerDev.setFullPage(true);
+      if (!printerDev.setPageMargins(QMarginsF()))
+            qDebug("unable to clear printer margins");
       printerDev.setColorMode(QPrinter::Color);
       printerDev.setDocName(cs->name());
       printerDev.setDoubleSidedPrinting(pf->twosided());
@@ -1855,6 +1857,8 @@ bool MuseScore::savePdf(Score* cs, const QString& saveName)
 
       printerDev.setCreator("MuseScore Version: " VERSION);
       printerDev.setFullPage(true);
+      if (!printerDev.setPageMargins(QMarginsF()))
+            qDebug("unable to clear printer margins");
       printerDev.setColorMode(QPrinter::Color);
       printerDev.setDocName(cs->name());
       printerDev.setDoubleSidedPrinting(pf->twosided());
@@ -1906,6 +1910,8 @@ bool MuseScore::savePdf(QList<Score*> cs, const QString& saveName)
 
       printerDev.setCreator("MuseScore Version: " VERSION);
       printerDev.setFullPage(true);
+      if (!printerDev.setPageMargins(QMarginsF()))
+            qDebug("unable to clear printer margins");
       printerDev.setColorMode(QPrinter::Color);
       printerDev.setDocName(firstScore->name());
       printerDev.setDoubleSidedPrinting(pf->twosided());


### PR DESCRIPTION
It seems this problem is caused by a Qt bug (see https://bugreports.qt.io/browse/QTBUG-5363) that apparently affects Windows only.  Or maybe it's the wa y it is supposed to work, in which case it is poorly documented and apparently broken on Linux & Mac.  But in case, calling setPullPage(true) is not sufficient to be able to print to the full page - you need to also explicitly clear the printer margins.  Since doing so is harmless, and I can't prove this behavior won't appear on other platforms in the future, I elected to just do it always, and while I'm at it, do it for PDF export as well to be safe.