### PR TITLE
fix #46971: corrupt clipboard in screenshot mode

### DIFF
--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -701,7 +701,14 @@ void ScoreView::fotoModeCopy()
       printer.fill(transparent ? 0 : 0xffffffff);
       QPainter p(&printer);
       paintRect(true, p, r, mag);
+#if defined(Q_OS_WIN)
+      // workaround for apparent Qt 5.4 bug; corrupt clipboard when using setImage()
+      QPixmap px;
+      px.convertFromImage(printer);
+      QApplication::clipboard()->setPixmap(px);
+#else
       QApplication::clipboard()->setImage(printer);
+#endif
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This is apparently a bug in Qt 5.4 for Windows - setting the clipboard to a QImage via setImage() is unreliable.  Converting to QPixmap first seems to work around the problem.  Because this is known to be less efficient, this doesn't make sense except on Windows, so I have it ifdef'ed.