### PR TITLE
Latest fixes to default soundfont

### DIFF
--- a/share/sound/FluidR3MonoChangeLog.txt
+++ b/share/sound/FluidR3MonoChangeLog.txt
@@ -1,0 +1,8 @@
+Version 2.103 Remove Burst Noise preset which was overloading FluidSynth
+Version 2.102 Fix name problem for Bass & Lead
+Version 2.101 Fix typo in Accordion def
+Version 2.10   Raise level of drumkits
+Version 2.9     Panning fix to Clarinet
+Version 2.8     Fix Goblin Synth patch crashing FluidSynth in Windows
+Version 2.7     Fix missing drum in some drum kits
+Version 2.6     Beta release of mono soundfont

--- a/share/sound/FluidR3Mono_License.md
+++ b/share/sound/FluidR3Mono_License.md
@@ -1,11 +1,11 @@
 FluidR3Mono_GM.sf3
 ---
 
-Current version: 2.9
+Current version: 2.103 (28th February 2015)
 
 Original Stereo version by Frank Wen Copyright © 2000-2002
 
-Mono version by Michael Cowgill Copyright © 2014
+Mono version by Michael Cowgill Copyright © 2014-15
 
 This Mono version of FluidR3 GM is released under the MIT license as described in COPYING
 
@@ -59,7 +59,7 @@ Who knows, maybe I'll kick start this project again? ;)
 COPYING
 ---
 
-Mono version:  Copyright (c) 2014 Michael Cowgill 
+Mono version:  Copyright (c) 2014-15 Michael Cowgill 
 Copyright (c) 2000-2002, 2008 Frank Wen <getfrank@gmail.com>
 
 Permission is hereby granted, free of charge, to any person


### PR DESCRIPTION
FluidR3Mono_GM version 2.103 for 2.0 Release Candidate
See changelog for details - I don't see the need to include the changelog in the release - it is purely for internal MuseScore devlopment team information, but will be included in the sf2 zip distribution of future sondfont releases.