### PR TITLE
fix #30631: bad vertical position of short ties on tab staves

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -600,8 +600,9 @@ void SlurSegment::layout(const QPointF& p1, const QPointF& p2)
       QRectF bbox = path.boundingRect();
 
       // adjust position to avoid staff line if necessary
+      Staff* st = staff();
       bool reverseAdjust = false;
-      if (slurTie()->type() == Element::Type::TIE) {
+      if (slurTie()->type() == Element::Type::TIE && st && !st->isTabStaff()) {
             // multinote chords with ties need special handling
             // otherwise, adjusted tie might crowd an unadjusted tie unnecessarily
             Tie* t = static_cast<Tie*>(slurTie());
@@ -609,7 +610,7 @@ void SlurSegment::layout(const QPointF& p1, const QPointF& p2)
             Chord* sc = sn ? sn->chord() : 0;
             // normally, the adjustment moves ties according to their direction (eg, up if tie is up)
             // but we will reverse this for notes within chords when appropriate
-            // for two-note chords, it looks better to have ties on notes with spaces outside the lines
+            // for two-note chords, it looks better to have notes on spaces tied outside the lines
             if (sc) {
                   int notes = sc->notes().size();
                   bool onLine = !(sn->line() & 1);
@@ -619,9 +620,8 @@ void SlurSegment::layout(const QPointF& p1, const QPointF& p2)
             }
       qreal sp = spatium();
       qreal minDistance = 0.5;
-      Staff* st = staff();
       autoAdjustOffset = QPointF();
-      if (bbox.height() < minDistance * 2 * sp && st) {
+      if (bbox.height() < minDistance * 2 * sp && st && !st->isTabStaff()) {
             // slur/tie is fairly flat
             bool up = slurTie()->up();
             qreal ld = st->lineDistance() * sp;


### PR DESCRIPTION
@mgavioli : for tab staves, this disables the code that make ties avoid staff lines.  I actually fixed the code for the most part too (disabling the code that sets the "reverseAdjust" flag is the key - the calculation was wrong, and unnecessary.  But since the adjustment itself doesn't seem necessary because ties on tab staves don't seem to ever overlap staff lines, and I can't guarantee I don't have other bad assumptions in my code, it seemed more prudent to disable it.

Feel free to comment if you know of any reason for me to look into this further.