### PR TITLE
fix #49651: Changes in mixer do not affect instruments

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2416,6 +2416,7 @@ void ChangePatch::flip()
       event.setValue(channel->program);
 
       MScore::seq->sendEvent(event);
+      channel->updateInitList();
       }
 
 //---------------------------------------------------------

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -265,6 +265,7 @@ void PartEdit::patchChanged(int n)
             score->setLayoutAll(true);
             score->endCmd();
             }
+      channel->updateInitList();
       }
 
 //---------------------------------------------------------
@@ -276,6 +277,7 @@ void PartEdit::volChanged(double val)
       int iv = lrint(val);
       seq->setController(channel->channel, CTRL_VOLUME, iv);
       channel->volume = iv;
+      channel->updateInitList();
       }
 
 //---------------------------------------------------------
@@ -287,6 +289,7 @@ void PartEdit::panChanged(double val)
       int iv = lrint(val);
       seq->setController(channel->channel, CTRL_PANPOT, iv);
       channel->pan = iv;
+      channel->updateInitList();
       }
 
 //---------------------------------------------------------
@@ -298,6 +301,7 @@ void PartEdit::reverbChanged(double val)
       int iv = lrint(val);
       seq->setController(channel->channel, CTRL_REVERB_SEND, iv);
       channel->reverb = iv;
+      channel->updateInitList();
       }
 
 //---------------------------------------------------------
@@ -309,6 +313,7 @@ void PartEdit::chorusChanged(double val)
       int iv = lrint(val);
       seq->setController(channel->channel, CTRL_CHORUS_SEND, iv);
       channel->chorus = iv;
+      channel->updateInitList();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This happens because we don't update channels' init list immediately after changing parameters in mixer. When we hit "Play" we init instruments and rewrite its' values with old parameters.
This bug occurs only if "Use Jack MIDI" option enabled.