### PR TITLE
partial fix for #49341: initial barline shown for single staff with hide...

### DIFF
--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -226,6 +226,7 @@ void System::layout(qreal xo1)
                   _leftMargin += bracketWidth[i] + bd;
             }
 
+      int nVisible = 0;
       for (int staffIdx = 0; staffIdx < nstaves; ++staffIdx) {
             SysStaff* s  = _staves[staffIdx];
             Staff* staff = score()->staff(staffIdx);
@@ -233,6 +234,7 @@ void System::layout(qreal xo1)
                   s->setbbox(QRectF());
                   continue;
                   }
+            ++nVisible;
             qreal staffMag = staff->mag();
             qreal h;
             if (staff->lines() == 1)
@@ -243,7 +245,7 @@ void System::layout(qreal xo1)
             s->bbox().setRect(_leftMargin + xo1, 0.0, 0.0, h);
             }
 
-      if ((nstaves > 1 && score()->styleB(StyleIdx::startBarlineMultiple)) || (nstaves <= 1 && score()->styleB(StyleIdx::startBarlineSingle))) {
+      if ((nVisible > 1 && score()->styleB(StyleIdx::startBarlineMultiple)) || (nVisible <= 1 && score()->styleB(StyleIdx::startBarlineSingle))) {
             if (_barLine == 0) {
                   BarLine* bl = new BarLine(score());
                   bl->setParent(this);


### PR DESCRIPTION
... empty staves

We have a style option to control whether an initial barline is generated for "single staff", and it defaults to off, but initial barline is nevertheless generated for a single staff that results from hide empty staves.  Even if that's what you want for some particular score, you can get that effect by enabling this option, so I think we should interpret this option as controlling initial barline for "single *visible* staff".  That's what this change does.

It's only a partial fix because if you toggle the Hide Empty Staves option it doesn't take effect until the *next* layout, because of the way Hide Empty Staves works.  It also doesn't take effect until the next layout after an initial load.  It seems to be the same basic issue as http://musescore.org/en/node/25168 - I think we are probably laying some things out before we really know what staves will turn out to be empty.  There might be another issue with a similar root cause.
