### PR TITLE
fix #49641: mismatched margins

### DIFF
--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -422,7 +422,7 @@ void PageFormat::read(XmlReader& e, Score* score)
             _size.transpose();
       qreal w1 = _size.width() - _oddLeftMargin - _oddRightMargin;
       qreal w2 = _size.width() - _evenLeftMargin - _evenRightMargin;
-      _printableWidth = qMax(w1, w2);     // silently adjust right margins
+      _printableWidth = qMin(w1, w2);     // silently adjust right margins
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
I assume the only reason w1 would be not be equal to w2 here is mismatched margins, and using the maximum rather than the minimum page width is what causes the zero right margin on the page with the larger left margin.  Seems using the min is better - results in larger right margin on the page with the smaller left margin.

I suppose this is not as important to fix as I thought at first - I think I misunderstood the issue when i first added it to my hit list :-)