### PR TITLE
fix #50006: beam editing issues

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1511,6 +1511,7 @@ void Beam::layout2(QList<ChordRest*>crl, SpannerSegmentType, int frag)
                   //
                   // set stem direction for every chord
                   //
+                  bool relayoutGrace = false;
                   for (int i = 0; i < n; ++i) {
                         Chord* c = static_cast<Chord*>(crl.at(i));
                         if (c->type() == Element::Type::REST)
@@ -1521,10 +1522,18 @@ void Beam::layout2(QList<ChordRest*>crl, SpannerSegmentType, int frag)
                         if (c->up() != nup) {
                               c->setUp(nup);
                               // guess was wrong, have to relayout
-                              score()->layoutChords1(c->segment(), c->staffIdx());
+                              if (!_isGrace) {
+                                    score()->layoutChords1(c->segment(), c->staffIdx());
+                                    }
+                              else {
+                                    relayoutGrace = true;
+                                    score()->layoutChords3(c->notes(), c->staff(), 0);
+                                    }
                               }
                         }
                   _up = crl.front()->up();
+                  if (relayoutGrace)
+                        c1->parent()->layout();
                   }
             else if (_cross) {
                   qreal beamY   = 0.0;  // y position of main beam start
@@ -2117,6 +2126,8 @@ void Beam::reset()
 void Beam::startEdit(MuseScoreView*, const QPointF& p)
       {
       undoPushProperty(P_ID::BEAM_POS);
+      undoPushProperty(P_ID::USER_MODIFIED);
+      undoPushProperty(P_ID::GENERATED);
 
       QPointF pt(p - pagePos());
       qreal ydiff = 100000000.0;


### PR DESCRIPTION
Simple fix that took quite a while to get right.  This fix also addresses http://musescore.org/en/node/50066

The collapsing grace ntoes was caused by inappropriate "full" layout of the chord segment for beamed grace notes whose beam is dragged to the "wrong" position.  it is changed to only layout what is necessary (layoutChords3), then do a layout() on the parent chord to fix the spacing.  Works like a charm.

The undo issues - both the one in the original (50006) and the second issue I submitted (50066) were a matter of not saving/restoring the generated & user_modified properties on edit.  I see other palces in the code where this was handled a bit awkwardly using static members in the class to rememeber the old value in startEdit(), then calling undoPropertyChanged() in endEdit(), but then I found references to undoPushProperty() which does the job much more cleanly.  I guess it's new - added just last month?  Or maybe just moved.  Either way, I imagine we could probably use it elsewhere as well to clean up some other not-quite-undoable operations.