### PR TITLE
Fix #49856 - A copied glissando is not cloned into linked staff

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2661,6 +2661,22 @@ void Score::connectTies(bool silent)
                                     nnote->setTieBack(tie);
                                     }
                               }
+                        // connect a glissando without end note (can happen with glissandi cloned in linked staves)
+                        for (Spanner* spanner : n->spannerFor())
+                              if (spanner->endElement() == nullptr) {
+                                    n->removeSpannerFor(spanner);
+                                    if (spanner->type() == Element::Type::GLISSANDO) {
+                                          Note* endNote = Glissando::guessFinalNote(n->chord());
+                                          if (endNote != nullptr) {
+                                                spanner->setNoteSpan(n, endNote);
+                                                n->add(spanner);
+                                                }
+                                          else                    // if no end note found, remove glissando
+                                                delete spanner;
+                                          }
+                                    else                          // if another type of spanner, don't know
+                                          delete spanner;         // what to do: remove it
+                                    }
                         // connect a glissando without initial note (old glissando format)
                         for (Spanner* spanner : n->spannerBack())
                               if (spanner->type() == Element::Type::GLISSANDO

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -246,6 +246,16 @@ Note::Note(const Note& n, bool link)
       else
             _tieFor = 0;
       _tieBack  = 0;
+      // clone forward-spanners, leaving end note empty; at a later time,
+      // Score::connectTies() will hopefully find the correct end note
+      for (Spanner* oldSp : n._spannerFor) {
+            Spanner* newSp = static_cast<Spanner*>(oldSp->clone());
+            newSp->setStartElement(this);
+            newSp->setEndElement(nullptr);
+            if (link)
+                  newSp->linkTo(oldSp);
+            addSpannerFor(newSp);
+            }
       for (int i = 0; i < MAX_DOTS; ++i) {
             if (n._dots[i])
                   add(new NoteDot(*n._dots[i]));


### PR DESCRIPTION
Fix #49856 - A copied glissando is not cloned into linked staff

If a selection containing a glissando is copied into a staff which has another staff linked to it, the glissando is copied into the first staff but not cloned into the linked staff.

Original issue: http://musescore.org/en/node/49856

Fixed by adding to `Score::connectTies()` the same procedure used while dropping a glissando onto a note.

This ensures that:
- a glissando is created in both linked staves
- it ends into the right note in most 'normal' cases

It is sort of expected that, occasionally, the end note guessing may not locate the correct end note for the glissando in the linked staff; I could not find a specific case of this, though.