### PR TITLE
fix #24100: bad layout of horizontal frame

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2280,6 +2280,7 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
 
             if (!empty && (minWidth + ww > systemWidth)) {
                   curMeasure->setSystem(oldSystem);
+                  continueFlag = false;
                   break;
                   }
             if (curMeasure->type() == Element::Type::MEASURE)
@@ -2310,6 +2311,7 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
                ) {
                   if (_layoutMode != LayoutMode::SYSTEM)
                         system->setPageBreak(curMeasure->pageBreak());
+                  minWidth += ww;
                   curMeasure = nextMeasure;
                   break;
                   }


### PR DESCRIPTION
Simple two-line change with big payoff.

The first line I added fixes the original bug for http://musescore.org/en/node/24100 - a horizontal frame added at the beginning of a line is laid out incorrectly unless the previous system ends with a line/page break.  This is simple - we were not clearing the continueFlag after deciding the frame wouldn't fit, so we kept trying to pile on more measures even though we had already hit the limit.

The second line I added fixes the issue shown in - http://musescore.org/en/node/24100#comment-233416 - a horizontal frame in the middle of a "system" (system row) is mostly ignored for the purposes of deciding how many measures can fit on the line, potentially leading to some spectacularly bad results results as shown.  We were not adding the frame width into the accumulated system row width.

I wasn't sure if this line should be added just for horizontal frame or not, but it turns out it needs to be there always to fix the glitch where last system fill doesn't work properly if there is a line break on the last measure of the piece.