### PR TITLE
Fix #48436 - Lyrics melisma and deleting measures / Fix #48491 - Ditto and time change

### DIFF
--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -158,10 +158,11 @@ class LyricsLine : public SLine {
       virtual Element::Type type() const override     { return Element::Type::LYRICSLINE; }
       virtual void layout() override;
       virtual LineSegment* createLineSegment() override;
+      virtual void removeUnmanaged() override;
 
       Lyrics*     lyrics() const                      { return (Lyrics*)parent();   }
       Lyrics*     nextLyrics() const                  { return _nextLyrics;         }
-      void        unchain();
+      virtual bool setProperty(P_ID propertyId, const QVariant& v) override;
       };
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1002,6 +1002,7 @@ class Score : public QObject {
       void addSpanner(Spanner*);
       void cmdAddSpanner(Spanner* e, const QPointF& pos);
       void checkSpanner(int startTick, int lastTick);
+      const std::set<Spanner*>unmanagedSpanners() { return _unmanagedSpanner; }
       void addUnmanagedSpanner(Spanner*);
       void removeUnmanagedSpanner(Spanner*);
 

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -157,6 +157,8 @@ class Spanner : public Element {
       virtual void startEdit(MuseScoreView*, const QPointF&) override;
       virtual void endEdit() override;
       bool removeSpannerBack();
+      virtual void removeUnmanaged();
+      virtual void undoInsertTimeUnmanaged(int tick, int len);
       virtual void setYoff(qreal) {}    // used in musicxml import
 
       QVariant getProperty(P_ID propertyId) const;

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2944,6 +2944,9 @@ void Score::undoInsertTime(int tick, int len)
                         }
                   }
             }
+
+      for (Spanner* s : _unmanagedSpanner)
+            s->undoInsertTimeUnmanaged(tick, len);
       }
 
 //---------------------------------------------------------
@@ -3046,10 +3049,16 @@ void InsertRemoveMeasures::removeMeasures()
       {
       Score* score = fm->score();
 
+      int tick1 = fm->tick();
+      int tick2 = lm->endTick();
       score->measures()->remove(fm, lm);
       score->fixTicks();
-      score->insertTime(fm->tick(), -(lm->endTick() - fm->tick()));
+      score->insertTime(tick1, -(tick2 - tick1));
       score->setLayoutAll(true);
+      for (Spanner* sp : score->unmanagedSpanners())
+            if ( (sp->tick() >= tick1 && sp->tick() < tick2)
+                        || (sp->tick2() >= tick1 && sp->tick2() < tick2) )
+                  sp->removeUnmanaged();
       score->connectTies(true);   // ??
       }
 


### PR DESCRIPTION
Fix #48436 - Lyrics melisma and deleting measures / Fix #48491 - Ditto and time change

**Deleting measures** When measures are deleted, spans of lyrics melismas and dashes involved (`LyricsLine`s) were not correctly adjusted.

Also fixes the general case of removing or adding some time span intersecting `LyricsLine` spans.

**Rewriting measures** while rewriting measures (as for time changes), existing `LyricsLine`s were left over and then re-added. Now they are deleted while removing measures (`InsertRemoveMeasures::removeMeasures()`).