### PR TITLE
fix #35826: layout time sig on staff add

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1139,6 +1139,7 @@ void Measure::cmdAddStaves(int sStaff, int eStaff, bool createRest)
                         timesig->setTrack(staffIdx * VOICES);
                         timesig->setParent(ts);
                         timesig->setSig(ots->sig(), ots->timeSigType());
+                        timesig->setNeedLayout(true);
                         score()->undoAddElement(timesig);
                         }
                   }


### PR DESCRIPTION
Either it's as simple as this - setting _needLayout when adding the time signature - or it's not worth doing for 2.0.  But I think it really *is* this simple.

I checked the log of the issue whose fix led to this - http://musescore.org/en/node/14548.  It seems this all had to do with the *representation* of the time signature, not the layout.  So I rather seriously doubt that forcing the layout is going to break anything having to do with that.  I did try to reproduce various aspects of that bug with my fix here in place, but couldn't get it to fail.