### PR TITLE
fix #23473: avoid dots for notes which may result in 256th notes/rests or shorter

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2626,13 +2626,13 @@ void Score::padToggle(Pad n)
                   _is.setRest(!_is.rest());
                   break;
             case Pad::DOT:
-                  if (_is.duration().dots() == 1)
+                  if ((_is.duration().dots() == 1) || (_is.duration() == TDuration::DurationType::V_128TH))
                         _is.setDots(0);
                   else
                         _is.setDots(1);
                   break;
             case Pad::DOTDOT:
-                  if (_is.duration().dots() == 2)
+                  if ((_is.duration().dots() == 2) || (_is.duration() == TDuration::DurationType::V_64TH) || (_is.duration() == TDuration::DurationType::V_128TH))
                         _is.setDots(0);
                   else
                         _is.setDots(2);

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -319,6 +319,21 @@ void MuseScore::updateInputState(Score* score)
       getAction("pad-rest")->setChecked(is.rest());
       getAction("pad-dot")->setChecked(is.duration().dots() == 1);
       getAction("pad-dotdot")->setChecked(is.duration().dots() == 2);
+      if ((mscore->state() & STATE_NORMAL) | (mscore->state() & STATE_NOTE_ENTRY)) {
+            getAction("pad-dot")->setEnabled(true);
+            getAction("pad-dotdot")->setEnabled(true);
+            }
+      switch (is.duration().type()) {
+            case TDuration::DurationType::V_128TH:
+                  getAction("pad-dot")->setChecked(false);
+                  getAction("pad-dot")->setEnabled(false);
+            case TDuration::DurationType::V_64TH:
+                  getAction("pad-dotdot")->setChecked(false);
+                  getAction("pad-dotdot")->setEnabled(false);
+                  break;
+            default:
+                  break;
+            }
 
       getAction("note-longa")->setChecked(is.duration()  == TDuration::DurationType::V_LONG);
       getAction("note-breve")->setChecked(is.duration()  == TDuration::DurationType::V_BREVE);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2488,6 +2488,8 @@ void MuseScore::changeState(ScoreState val)
                         qDebug("disable synth control");
                   a->setEnabled(driver);
                   }
+            else if (s->key() == "pad-dot" || s->key() == "pad-dot-dot")
+                        a->setEnabled(!(val & (STATE_ALLTEXTUAL_EDIT | STATE_EDIT)));
             else {
                   a->setEnabled(s->state() & val);
                   }


### PR DESCRIPTION
based on @AntonioBL's PR #544 and with his and @lasconic's help