### PR TITLE
proposed fix for keysigs on empty staves taking space

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2413,6 +2413,15 @@ void Score::hideEmptyStaves(System* system, bool isFirstSystem)
                   if (s->show()) {
                         systemIsEmpty = false;
                         }
+                  if (!s->show()) {
+                        Measure* m = system->firstMeasure();
+                        Segment* kss = m ? m->findSegment(Segment::Type::KeySig, m->tick()) : 0;
+                        if (kss) {
+                              KeySig* ks = static_cast<KeySig*>(kss->element(staff->idx() * VOICES));
+                              if (ks)
+                                    ks->setbbox(QRectF());
+                              }
+                        }
                   }
             else {
                   systemIsEmpty = false;


### PR DESCRIPTION
The problem is, keysigs in the system header for hidden (hide empty staves) staves still take room in layout.  My proposed fix: at the moment we decide to hide a staff, zero out the bbox for an initial keysig.  Combine this with lasconic's proposed change to generate keysigs for these staves, and maybe our problems are solved?