### PR TITLE
fix #50491: corruption changing length of measure back to nominal

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1580,9 +1580,10 @@ void Measure::adjustToLen(Fraction nf)
             // if just a single rest
             if (rests == 1 && chords == 0) {
                   // if measure value didn't change, stick to whole measure rest
-                  if (_timesig == nf)
-                        rest->undoChangeProperty(P_ID::DURATION,
-                           QVariant::fromValue<TDuration>(TDuration(TDuration::DurationType::V_MEASURE)));
+                  if (_timesig == nf) {
+                        rest->undoChangeProperty(P_ID::DURATION, QVariant::fromValue<Fraction>(nf));
+                        rest->undoChangeProperty(P_ID::DURATION_TYPE, QVariant::fromValue<TDuration>(TDuration::DurationType::V_MEASURE));
+                        }
                   else {      // if measure value did change, represent with rests actual measure value
                         // convert the measure duration in a list of values (no dots for rests)
                         QList<TDuration> durList = toDurationList(nf, false, 0);


### PR DESCRIPTION
Seems to fix the problem.  I verified the rest created has the same duration and duration type as other full measure rests (at least for the case I tried - going from 2/4 to 4/4) and that it works with undo & redo.