### PR TITLE
partial fix for #50316: better layout of key sigs with hide empty staves

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3168,7 +3168,7 @@ void Measure::layoutX(qreal stretch)
 #endif
 
             for (int staffIdx = 0; staffIdx < nstaves; ++staffIdx) {
-                  if (!score()->staff(staffIdx)->show())
+                  if (!score()->staff(staffIdx)->show() || !system()->staff(staffIdx)->show())
                         continue;
                   qreal minDistance = 0.0;
                   Space space;


### PR DESCRIPTION
While testing a proposed fix to the issue named above, I discovered a related long-standing bug (it's in 1.3): if hiding empty staves, the space for key signatures in the hidden staves is still reserved in the remaining staves.  See http://musescore.org/en/node/50316#comment-235636 and the image two responses later.

In #1876 I propose a fix that worked but in hindsight it seemed strange that it did, plus there were philosophical issues with zeroing on the bbox.  I started thinking about why the fix even worked - seems it should be too late too be zeroing out bboxes even if it were ok to do that.  It turns out it is _not_ too late, because of the two-stage nature of measure layout.  That is, first we compute minimum measure widths (computeMinWidth), and we use this decide which measures go on which systems.  Then later we actually layout the measures, using code in layoutX that is largely the same as computeMinWidth.  It turns out the hiding of empty staves happens between these two stages.  So in layoutX(), we have already hidden what is going to be hidden, and thus we can make use of that information to skip elements on the hidden staves when laying out the measures.  In fact, by the time layoutX is called, we've already done everything that actually affects layout - added system headers, courtesy signatures, etc.

So in practice, it appears to be safe to skip hidden staves within systems in layoutX.  Now, what this does mean is that we have overestimated the width of this measure, and the stretch might not be perfect.  One might worry that on the next layout, this measure may decide to float back to the previous system.  But it shouldn't - it still has the key signature in the hidden staff, computeMinWidth will still see it.  So we should be safe from the "ping-ponging layout" effect that occasionally plague us.

My take is, then, that if we implement this change, plus @lasconic fix to still generate the key signatures on the hidden staves as layout changes, we could actually consider 50316 fixed.  Of course, I realize it's late in the game to try to squeeze this into the RC, and that's fine - considering this issue has been with us for years, waiting a bit longer wouldn't be the end of the world.  But whether we consider it now or later, hopefully these comments help us remember what is going on.
