### PR TITLE
fix #50461: corruption on paste of septuplet

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -447,6 +447,10 @@ void Score::pasteChordRest(ChordRest* cr, int tick, const Interval& srcTranspose
 
       int measureEnd = measure->endTick();
       bool isGrace = (cr->type() == Element::Type::CHORD) && (((Chord*)cr)->noteType() != NoteType::NORMAL);
+      // if note is too long to fit in measure, split it up with a tie across the barline
+      // exclude tuplets from consideration
+      // we have already disallowed a tuplet from crossing the barline, so there is no problem here
+      // but due to rounding, it might appear from actualTicks() that the last note is too long by a couple of ticks
       if (!isGrace && !cr->tuplet() && (tick + cr->actualTicks() > measureEnd || convertMeasureRest)) {
             if (cr->type() == Element::Type::CHORD) {
                   // split Chord

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -447,7 +447,7 @@ void Score::pasteChordRest(ChordRest* cr, int tick, const Interval& srcTranspose
 
       int measureEnd = measure->endTick();
       bool isGrace = (cr->type() == Element::Type::CHORD) && (((Chord*)cr)->noteType() != NoteType::NORMAL);
-      if (!isGrace && (tick + cr->actualTicks() > measureEnd || convertMeasureRest)) {
+      if (!isGrace && !cr->tuplet() && (tick + cr->actualTicks() > measureEnd || convertMeasureRest)) {
             if (cr->type() == Element::Type::CHORD) {
                   // split Chord
                   Chord* c = static_cast<Chord*>(cr);

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -223,9 +223,13 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                                                             }
                                                       }
                                                 }
-                                          // set shorten duration
-                                          cr->setDuration(Fraction::fromTicks(newLength));
-                                          cr->setDurationType(newLength);
+                                          if (!cr->tuplet()/*|| cr->actualTicks() - newLength > (cr->tuplet()->ratio().numerator() + 1 ) / 2*/) {
+                                                // shorten duration
+                                                // exempt notes in tuplets, since we don't allow copy of partial tuplet anyhow
+                                                // TODO: figure out a reasonable fudge factor to make sure shorten tuplets appropriately if we do ever copy a partial tuplet
+                                                cr->setDuration(Fraction::fromTicks(newLength));
+                                                cr->setDurationType(newLength);
+                                                }
                                           }
                                     pasteChordRest(cr, tick, e.transpose());
                                     }

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -159,7 +159,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                               Measure* measure = tick2measure(tick);
                               tuplet->setParent(measure);
                               tuplet->setTick(tick);
-                              int ticks = tuplet->duration().ticks();
+                              int ticks = tuplet->actualTicks();
                               int rticks = measure->endTick() - tick;
                               if (rticks < ticks) {
                                     qDebug("tuplet does not fit in measure");

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -980,13 +980,11 @@ static bool checkStart(Element* e)
       ChordRest* cr = static_cast<ChordRest*>(e);
       bool rv = false;
       if (cr->tuplet()) {
-            rv = true;
             Tuplet* tuplet = cr->tuplet();
             while (tuplet) {
-                  if (tuplet->elements().front() == e) {
-                        rv = false;
-                        break;
-                        }
+                  if (tuplet->elements().front() != e)
+                        return true;
+                  e = tuplet;
                   tuplet = tuplet->tuplet();
                   }
             }
@@ -1014,13 +1012,11 @@ static bool checkEnd(Element* e)
       ChordRest* cr = static_cast<ChordRest*>(e);
       bool rv = false;
       if (cr->tuplet()) {
-            rv = true;
             Tuplet* tuplet = cr->tuplet();
             while (tuplet) {
-                  if (tuplet->elements().back() == e) {
-                        rv = false;
-                        break;
-                        }
+                  if (tuplet->elements().back() != e)
+                        return true;
+                  e = tuplet;
                   tuplet = tuplet->tuplet();
                   }
             }

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -980,6 +980,7 @@ static bool checkStart(Element* e)
       ChordRest* cr = static_cast<ChordRest*>(e);
       bool rv = false;
       if (cr->tuplet()) {
+            // check that complete tuplet is selected, all thew way up to top level
             Tuplet* tuplet = cr->tuplet();
             while (tuplet) {
                   if (tuplet->elements().front() != e)
@@ -988,14 +989,12 @@ static bool checkStart(Element* e)
                   tuplet = tuplet->tuplet();
                   }
             }
-      else if (e->type() == Element::Type::CHORD) {
+      else if (cr->type() == Element::Type::CHORD) {
             rv = false;
-            Chord* chord = static_cast<Chord*>(e);
+            Chord* chord = static_cast<Chord*>(cr);
             if (chord->tremolo() && chord->tremolo()->twoNotes())
                   rv = chord->tremolo()->chord2() == chord;
             }
-      else
-            rv = false;
       return rv;
       }
 
@@ -1005,13 +1004,14 @@ static bool checkStart(Element* e)
 //     return true  if element is part of a tuplet, but not the end
 //---------------------------------------------------------
 
-static bool checkEnd(Element* e)
+static bool checkEnd(Element* e, int endTick)
       {
       if (e == 0 || !e->isChordRest())
             return false;
       ChordRest* cr = static_cast<ChordRest*>(e);
       bool rv = false;
       if (cr->tuplet()) {
+            // check that complete tuplet is selected, all thew way up to top level
             Tuplet* tuplet = cr->tuplet();
             while (tuplet) {
                   if (tuplet->elements().back() != e)
@@ -1019,15 +1019,17 @@ static bool checkEnd(Element* e)
                   e = tuplet;
                   tuplet = tuplet->tuplet();
                   }
+            // also check that the selection extends to the end of the top-level tuplet
+            tuplet = static_cast<Tuplet*>(e);
+            if (tuplet->elements().first()->tick() + tuplet->actualTicks() > endTick)
+                  return true;
             }
-      else if (e->type() == Element::Type::CHORD) {
+      else if (cr->type() == Element::Type::CHORD) {
             rv = false;
-            Chord* chord = static_cast<Chord*>(e);
+            Chord* chord = static_cast<Chord*>(cr);
             if (chord->tremolo() && chord->tremolo()->twoNotes())
                   rv = chord->tremolo()->chord1() == chord;
             }
-      else
-            rv = false;
       return rv;
       }
 
@@ -1042,10 +1044,17 @@ bool Selection::canCopy() const
       if (_state != SelState::RANGE)
             return true;
 
+      int endTick = _endSegment ? _endSegment->tick() : score()->lastSegment()->tick();
+
       for (int staffIdx = _staffStart; staffIdx != _staffEnd; ++staffIdx)
             for (int voice = 0; voice < VOICES; ++voice) {
                   int track = staffIdx * VOICES + voice;
-                  if (checkStart(_startSegment->element(track)))
+                  if (!canSelectVoice(track))
+                        continue;
+
+                  // check first cr in track within selection
+                  ChordRest* check = _startSegment->nextChordRest(track);
+                  if (check && check->tick() < endTick && checkStart(check))
                         return false;
 
                   if (! _endSegment)
@@ -1059,7 +1068,7 @@ bool Selection::canCopy() const
                         (endSegmentSelection->nextCR(track)->tick() < _endSegment->tick()))
                         endSegmentSelection = endSegmentSelection->nextCR(track);
 
-                  if (checkEnd(endSegmentSelection->element(track)))
+                  if (checkEnd(endSegmentSelection->element(track), endTick))
                         return false;
                   }
       return true;

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -980,7 +980,7 @@ static bool checkStart(Element* e)
       ChordRest* cr = static_cast<ChordRest*>(e);
       bool rv = false;
       if (cr->tuplet()) {
-            // check that complete tuplet is selected, all thew way up to top level
+            // check that complete tuplet is selected, all the way up to top level
             Tuplet* tuplet = cr->tuplet();
             while (tuplet) {
                   if (tuplet->elements().front() != e)
@@ -1011,7 +1011,7 @@ static bool checkEnd(Element* e, int endTick)
       ChordRest* cr = static_cast<ChordRest*>(e);
       bool rv = false;
       if (cr->tuplet()) {
-            // check that complete tuplet is selected, all thew way up to top level
+            // check that complete tuplet is selected, all the way up to top level
             Tuplet* tuplet = cr->tuplet();
             while (tuplet) {
                   if (tuplet->elements().back() != e)


### PR DESCRIPTION
A fix I made just before beta 1 may have not gone far enough to avoid corrupting the end of a tuplet on paste.  There is code to shorten the last note when pasting if necessary to fit the gap, to cover cases where a multi-voice selection includes a note that actual is longer than the selection itself.  This code was shortening tuplets incorrectly.  

My previous fix was here:

https://github.com/musescore/MuseScore/commit/5752215cff0feababc3c39bae35d771fdd016ce2

It took care of the basic case where there was no roundoff error or if the tick lengths in the tuplet were rounded *down*, so that the tick counts in the tuplet add up slightly short of the full value.  But it still results in the tuplet being truncated if the tick counts add up to slightly *more* than the full value, and that's the case here.  We could consider rounding tick counts down always as there are other bad effects from the overlap that results (it's hard to select just the tuplet), but that seems a riskier change, and in any case, my change here doesn't rule out make that other change as well.