### PR TITLE
fix #50896: nextCR() fails if track == -1

### DIFF
--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -338,15 +338,17 @@ Segment* Segment::nextCR(int track, bool sameStaff) const
       {
       int strack = track;
       int etrack = track + 1;
-      if (sameStaff) {
+      if (sameStaff && track != -1) {
             strack = (track / VOICES) * VOICES;
             etrack = strack + VOICES;
             }
       Segment* seg = next1();
       for (; seg; seg = seg->next1()) {
             if (seg->segmentType() == Type::ChordRest) {
+                  if (track == -1)
+                        return seg;
                   for (int t = strack; t < etrack; ++t) {
-                        if (track != -1 && seg->element(t))
+                        if (seg->element(t))
                               return seg;
                         }
                   }


### PR DESCRIPTION
Right now, the issue with ambitus is the symptom I *know* of that is caused by this; there are probably others though.