### PR TITLE
fix #51101: crash on delete key signature with linked staves

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1994,8 +1994,24 @@ void Score::cmdDeleteSelection()
             QList<Element*> el(selection().elements());
             if (el.isEmpty())
                   qDebug("...nothing selected");
-            for (Element* e : el)
-                  deleteItem(e);
+
+            // keep track of linked elements that are deleted implicitly
+            // so we don't try to delete them twice if they are also in selection
+            QList<ScoreElement*> deletedElements;
+
+            for (Element* e : el) {
+                  // these are the linked elements we are about to delete
+                  LinkedElements links = *e->links();
+
+                  // delete element if we have not done so already
+                  if (!deletedElements.contains(e))
+                        deleteItem(e);
+
+                  // add these linked elements to list of already-deleted elements
+                  for (ScoreElement* se : links)
+                        deletedElements.append(se);
+                  }
+
             }
       deselectAll();
       _layoutAll = true;


### PR DESCRIPTION
At first I started worrying this could be messy, but actually, the problem seems simple and with a simple and lcoalized solution.  When deleting a list selection, we need to be careful not to delete the same item twice if there are linked staves involved.