### PR TITLE
fix #51121: initial rests linked to wrong staves

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -638,6 +638,8 @@ void MuseScore::newFile()
                                           k++;
                                           }
                                     }
+                              if (!staff->linkedStaves())
+                                    puRests.clear();
                               }
                         else {
                               if (rest && staff->linkedStaves())
@@ -649,6 +651,8 @@ void MuseScore::newFile()
                               rest->setTrack(staffIdx * VOICES);
                               Segment* seg = measure->getSegment(rest, tick);
                               seg->add(rest);
+                              if (!staff->linkedStaves())
+                                    rest = nullptr;
                               }
                         }
                   }


### PR DESCRIPTION
This fixes the problem in my tests, and it seems to make sense.  But I know this section of code underwent a lot of change lately and I didn't make an attempt to completely understand it all.  So hopefully others can review, and ignore this if it's not a good fix.