### PR TITLE
cheap partial fix for #42341: disable editing of local value in time sig...

### DIFF
--- a/mscore/timesigproperties.cpp
+++ b/mscore/timesigproperties.cpp
@@ -138,6 +138,10 @@ void TimeSigProperties::accept()
             timesig->setDenominatorString(QString());
             }
 
+      // TODO: fix http://musescore.org/en/node/42341
+      // for now, editing of actual (local) time sig is disabled in dialog
+      // but more importantly, the dialog should make it clear that this is "local" change only
+      // and not normally the right way to add 7/4 to a score
       Fraction actual(zActual->value(), nActual->value());
       Fraction nominal(zNominal->value(), nNominal->value());
       timesig->setSig(actual, ts);

--- a/mscore/timesigproperties.ui
+++ b/mscore/timesigproperties.ui
@@ -150,6 +150,9 @@
             <layout class="QHBoxLayout" name="horizontalLayout_3">
              <item>
               <widget class="QSpinBox" name="zActual">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                  <horstretch>0</horstretch>
@@ -176,6 +179,9 @@
              </item>
              <item>
               <widget class="QSpinBox" name="nActual">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                  <horstretch>0</horstretch>


### PR DESCRIPTION
...nature properties

All I did was literally disable the spinboxes and add a comment to the source about why.  Aside from the fact that it doesn't work (as per the bug), I think people are using this dialog to "create" time signatures they aren't finding on the palette, but they aren't realizing they are actually creating a "local" time signature only.  I suggest we not make it so easy to shoot oneself in the foot like that, and I don't think there is a great need to be able to edit local time signatures in this fashion.  We can always re-enable the feature when the bugs are fixed.