### PR TITLE
fix corruptions on measure rewrite

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -669,6 +669,16 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                   }
             if (fm) {
                   if (!score->rewriteMeasures(fm, ns, local ? staffIdx : -1)) {
+                        // remove segment if empty
+                        bool empty = true;
+                        for (int i = 0; i < nstaves(); ++i) {
+                              if (seg->element(i * VOICES)) {
+                                    empty = false;
+                                    break;
+                                    }
+                              }
+                        if (empty)
+                              undoRemoveElement(seg);
                         delete ts;
                         return;
                         }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -728,6 +728,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
 void Score::cmdRemoveTimeSig(TimeSig* ts)
       {
       Measure* m = ts->measure();
+      TimeSig* ots = ts->clone();   // save a copy in case we need to restore it
 
       //
       // we cannot remove a courtesy time signature
@@ -740,7 +741,16 @@ void Score::cmdRemoveTimeSig(TimeSig* ts)
       Measure* pm = m->prevMeasure();
       Fraction ns(pm ? pm->timesig() : Fraction(4,4));
 
-      rewriteMeasures(m, ns, -1);
+      if (!rewriteMeasures(m, ns, -1)) {
+            // restore deleted time signature
+            Segment* s = m->undoGetSegment(Segment::Type::TimeSig, m->tick());
+            ots->setParent(s);
+            undoAddElement(ots);
+            select(ots, SelectType::SINGLE);
+            }
+      else {
+            delete ots;
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -670,14 +670,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
             if (fm) {
                   if (!score->rewriteMeasures(fm, ns, local ? staffIdx : -1)) {
                         // remove segment if empty
-                        bool empty = true;
-                        for (int i = 0; i < nstaves(); ++i) {
-                              if (seg->element(i * VOICES)) {
-                                    empty = false;
-                                    break;
-                                    }
-                              }
-                        if (empty)
+                        if (seg->isEmpty())
                               undoRemoveElement(seg);
                         delete ts;
                         return;


### PR DESCRIPTION
Fixes http://musescore.org/en/node/51216 and http://musescore.org/en/node/51231 - corruptions on time signature changes and deletions that fail, either because of tuplet measure crossing or non-empty measures with local time signatures.  The fix is to restore the former state on failure.