### PR TITLE
fix #51391: crash on clone of null lyric

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -649,8 +649,11 @@ void cloneStaff(Staff* srcStaff, Staff* dstStaff)
                                     cloneTuplets(ocr, ncr, ot, tupletMap, m, dstTrack);
 
                               // remove lyrics from chord
-                              foreach (Lyrics* l, ncr->lyricsList())
-                                    l->unlink();
+                              // since only one set of lyrics is used with linked staves
+                              foreach (Lyrics* l, ncr->lyricsList()) {
+                                    if (l)
+                                          l->unlink();
+                                    }
                               qDeleteAll(ncr->lyricsList());
                               ncr->lyricsList().clear();
 
@@ -820,11 +823,6 @@ void cloneStaff2(Staff* srcStaff, Staff* dstStaff, int stick, int etick)
                                     ncr->setTuplet(nt);
                                     nt->add(ncr);
                                     }
-                              // remove lyrics from chord
-                              foreach (Lyrics* l, ncr->lyricsList())
-                                    l->unlink();
-                              qDeleteAll(ncr->lyricsList());
-                              ncr->lyricsList().clear();
 
                               foreach (Element* e, oseg->annotations()) {
                                     if (e->generated() || e->systemFlag())


### PR DESCRIPTION
Not sure I'm ready to merge this, but I wanted to see the result of Travis tests.  I'm still sorting out the relationship between cloneStaff and cloneStaff2.  Although the code is very similar, it seems their purpsoes are very different.  cloneStaff gets called when adding a linked staff to a score, cloneStaff2 gets called when rewriting a linked part after a time signature change.  It also seems a good chunk of cloneStaff2 is not relevant - annotations in particular are not present in the source, as they are handled separately.

The code involving lyrics specifically I added a few months back, and I think I should have added it to cloneStaff only, but didn't understand the purpose of cloneStaff2 so I added it there too.  The result is that rewriting time signatures deletes lyrics in parts.  I can't see any reason to keep that code.