### PR TITLE
fix #51596: corruption deleting global timesig after local

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -670,6 +670,9 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
       return true;
       }
 
+// instead of manually restoring aborted rewrites, rely on undo stack
+#define USE_UNWIND
+
 //---------------------------------------------------------
 //   cmdAddTimeSig
 //
@@ -750,7 +753,9 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
             //
             // rewrite all measures up to the next time signature
             //
+#ifndef USE_UNWIND
             QList<int> keepLocal;   // list of staves with local time signatures to preserve
+#endif
             if (fm == score->firstMeasure() && (fm->len() != fm->timesig())) {
                   // handle upbeat
                   undoChangeProperty(fm, P_ID::TIMESIG_NOMINAL, QVariant::fromValue(ns));
@@ -765,9 +770,14 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                         for (int i = 0; i < nstaves(); ++i) {
                               if (staff(i)->timeSig(tick) && staff(i)->timeSig(tick)->isLocal()) {
                                     if (!score->rewriteMeasures(fm, ns, i)) {
+#ifdef USE_UNWIND
+                                          undo()->current()->unwind();
+                                          return;
+#else
                                           // rewrite failed
                                           // keep local time signature for this staff
                                           keepLocal.append(i);
+#endif
                                           }
                                     }
                               }
@@ -780,10 +790,14 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
             // this means, however, that the rewrite cannot depend on the time signatures being in place
             if (fm) {
                   if (!score->rewriteMeasures(fm, ns, local ? staffIdx : -1)) {
+#ifdef USE_UNWIND
+                        undo()->current()->unwind();
+#else
                         // remove segment if empty
                         if (seg->isEmpty())
                               undoRemoveElement(seg);
                         delete ts;
+#endif
                         return;
                         }
                   }
@@ -811,12 +825,16 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                         }
                   for (int staffIdx = startStaffIdx; staffIdx < endStaffIdx; ++staffIdx) {
                         TimeSig* nsig = static_cast<TimeSig*>(seg->element(staffIdx * VOICES));
+#ifdef USE_UNWIND
+                        if (nsig == 0) {
+#else
                         if (score == this && keepLocal.contains(staffIdx)) {
                               // preserve local time signature if we were unable to rewrite staff
                               // TODO: get index for this score, so we can do the same for linked staves
                               nsig = new TimeSig(*staff(staffIdx)->timeSig(tick));
                               }
                         else if (nsig == 0) {
+#endif
                               nsig = new TimeSig(*ts);
                               nsig->setScore(score);
                               nsig->setTrack(staffIdx * VOICES);
@@ -860,6 +878,7 @@ void Score::cmdRemoveTimeSig(TimeSig* ts)
             return;
       int tick = m->tick();
 
+#ifndef USE_UNWIND
       // save time signatures for restoration later if the operation fails
       TimeSig* ots[nstaves()];
       for (int i = 0; i < nstaves(); ++i) {
@@ -867,19 +886,30 @@ void Score::cmdRemoveTimeSig(TimeSig* ts)
             if (sts) {
                   ots[i] = new TimeSig(*static_cast<TimeSig*>(sts));
                   // remove time signatures individually so map is consistent during rewriteMeasures()
-                  undoRemoveElement(sts);
+                  // this would improve detection of non-empty measures within local timesig
+                  // in cases where we delete a global timesig to reveal a local one
+                  // but it breaks deletion of the local time sig itself
+                  //undoRemoveElement(sts);
                   }
             else {
                   ots[i] = nullptr;
                   }
             }
-      // if we remove all time sigs from segment, segment is already removed
-      //undoRemoveElement(s);
+#endif
+      // if we remove all time sigs from segment, segment will be already removed by now
+      // but this would leave us no means of detecting that we have have measures in a local timesig
+      // in cases where we try deleting the local time sig
+      // known bug: this means we do not correctly detect non-empty measures when deleting global timesig change after a local one
+      // see http://musescore.org/en/node/51596
+      undoRemoveElement(s);
 
       Measure* pm = m->prevMeasure();
       Fraction ns(pm ? pm->timesig() : Fraction(4,4));
 
       if (!rewriteMeasures(m, ns, -1)) {
+#ifdef USE_UNWIND
+            undo()->current()->unwind();
+#else
             // restore deleted time signatures
             m = tick2measure(tick);       // old m may have been replaced
             if (m) {
@@ -904,6 +934,7 @@ void Score::cmdRemoveTimeSig(TimeSig* ts)
                               }
                         }
                   }
+#endif
             }
       else {
             m = tick2measure(tick);       // old m may have been replaced
@@ -923,13 +954,16 @@ void Score::cmdRemoveTimeSig(TimeSig* ts)
                               // fix measure rest duration
                               ChordRest* cr = nm->findChordRest(nm->tick(), i * VOICES);
                               if (cr && cr->type() == Element::Type::REST && cr->durationType() == TDuration::DurationType::V_MEASURE)
-                                    cr->setDuration(nm->stretchedLen(staff(i)));
+                                    cr->undoChangeProperty(P_ID::DURATION, QVariant::fromValue(nm->stretchedLen(staff(i))));
+                                    //cr->setDuration(nm->stretchedLen(staff(i)));
                               }
                         }
                   }
+#ifndef USE_UNWIND
             // clean up
             for (int i = 0; i < nstaves(); ++i)
                   delete ots[i];
+#endif
             }
       }
 

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -670,9 +670,6 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
       return true;
       }
 
-// instead of manually restoring aborted rewrites, rely on undo stack
-#define USE_UNWIND
-
 //---------------------------------------------------------
 //   cmdAddTimeSig
 //

--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -345,6 +345,9 @@ bool TrackList::write(Measure* measure) const
                               if ((_track % VOICES) == 0) {
                                     // write only for voice 1
                                     Rest* r = new Rest(score, TDuration::DurationType::V_MEASURE);
+                                    // ideally we should be using stretchedLen
+                                    // but this is not valid during rewrite when adding time signatures
+                                    // since the time signature has not been added yet
                                     //Fraction stretchedLen = m->stretchedLen(staff);
                                     //r->setDuration(stretchedLen);
                                     r->setDuration(m->len());

--- a/mtest/libmscore/timesig/tst_timesig.cpp
+++ b/mtest/libmscore/timesig/tst_timesig.cpp
@@ -71,8 +71,10 @@ void TestTimesig::timesig02()
       TimeSig* ts = new TimeSig(score);
       ts->setSig(Fraction(3, 4), TimeSigType::NORMAL);
 
+      score->startCmd();
       score->cmdAddTimeSig(m, 0, ts, false);
       score->doLayout();
+      score->endCmd();
 
       QVERIFY(saveCompareScore(score, "timesig-02a.mscx", DIR + "timesig-02-ref.mscx"));
       delete score;


### PR DESCRIPTION
Two aspects to the fix, as described in issue:

1) remove time sigs (not just the segment) before the rewrite, so sigmap is correct during the operation

2) fixup nominal measure durations after failure, and measure rest durations for local time sigs after success, because rewriteMeasures() is written to work with *adding* time sigs more so than *deleting* them and gets some details wrong.  Eventually we should fix that, but for now, it's much easier and safer to correct things in cmdRemoveTimeSig(). 