### PR TITLE
Fix #52131 - Shortcut conflict detection does not take states into account

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -1728,6 +1728,8 @@ bool Preferences::readPluginList()
                                     else
                                           e.unknown();
                                     }
+                              d.shortcut.setState(STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT |
+                                          STATE_ALLTEXTUAL_EDIT | STATE_PLAY | STATE_FOTO | STATE_LOCK );
                               if (d.path.endsWith(".qml"))
                                     pluginList.append(d);
                               }

--- a/mscore/shortcut.h
+++ b/mscore/shortcut.h
@@ -143,6 +143,7 @@ class Shortcut {
       void reset();           //! reset to buildin
       void addShortcut(const QKeySequence&);
       int state() const                        { return _state; }
+      void setState(int v)                      { _state = v;     }
       bool needsScore() const                  { return _flags & ShortcutFlags::A_SCORE; }
       bool isCmd() const                       { return _flags & ShortcutFlags::A_CMD; }
       bool isCheckable() const                 { return _flags & ShortcutFlags::A_CHECKABLE; }

--- a/mscore/shortcutcapturedialog.cpp
+++ b/mscore/shortcutcapturedialog.cpp
@@ -137,8 +137,8 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
       foreach (Shortcut* ss, localShortcuts) {
             if (s == ss)
                   continue;
-//            if (!(s->state() & ss->state()))    // no conflict if states do not overlap
-//                  continue;
+            if (!(s->state() & ss->state()))    // no conflict if states do not overlap
+                  continue;
             foreach(const QKeySequence& ks, ss->keys()) {
                   if (ks == key) {
                         msgString = tr("Shortcut conflicts with ") + ss->descr();


### PR DESCRIPTION
Fix #52131 - Shortcut conflict detection does not take states into account

In the dlg box for entering shortcut key sequences, since commit https://github.com/musescore/MuseScore/commit/2ab813d69f1d634cdc02cde54b090826f0edf3d0 shortcut states are no longer taken into account.

This leads to detect non-existent conflicts between shortcuts having non-overlapping states and to rejecting legitimate key sequences.

Apparently, this has been changed because, with shortcuts for plugins, conflicts were never detected because plugin shortcuts have no state defined.

Fixed by:
- setting plugin shortcut states to all (well, to all existent states)
- re-enabling the state check in `ShortcutCaptureDialog::keyPress()`.