### PR TITLE
fix #51866: enharmonic changes made with J lost on save

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -790,7 +790,7 @@ void Note::write(Xml& xml) const
       writeProperty(xml, P_ID::PITCH);
       // write tpc1 before tpc2 !
       writeProperty(xml, P_ID::TPC1);
-      if ((_tpc[1] != _tpc[0]) && transposition())
+      if (_tpc[1] != _tpc[0])
             writeProperty(xml, P_ID::TPC2);
       writeProperty(xml, P_ID::SMALL);
       writeProperty(xml, P_ID::MIRROR_HEAD);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4414,10 +4414,20 @@ void ScoreView::cmdChangeEnharmonic(bool up)
                               break;
                               }
                         }
-                  if (i == 36)
+                  if (i == 36) {
                         qDebug("tpc %d not found", tpc);
-                  else
+                        }
+                  else {
                         n->undoSetTpc(tpc);
+                        if (up) {
+                              // change both spellings
+                              int t = n->transposeTpc(tpc);
+                              if (n->concertPitch())
+                                    n->undoSetTpc2(t);
+                              else
+                                    n->undoSetTpc1(t);
+                              }
+                        }
                   }
             }
       _score->endCmd();


### PR DESCRIPTION
My change does two things:

1) For the "J" command (but not "Ctrl+J", which remains otherwise identical to "J"), the spelling change made is transposed as appropriate and push to the "other" tpc, so the tpc'1 stay in sync when using "J".  If you want to have different spellings for concert pitch and transposed mode, you will need "Ctrl+J".

2) I reverted the change to only write tpc2 for transposing instruments.  That was the cause of this bug.  I do understand the reasons that change was made but feel it caused worse problems than it fixed.  However, if we did want to somehow force concert pitch instruments to always have the same tpc for both modes, I would propose a *different* fix.  First, for concert pitch instruments only, change my code above to do the same thing for "Ctrl+J" that it currently does only for "J", so you cannot force tpc1 and tpc2 to be out of sync that way.  Second, rather than always writing tpc1 and ignoring tpc2 for concert pitch instruments, instead, write the *current* tpc value for concert pitch instruments.  Not sure if code elsewhere expects tpc1 to always be written; if so, then copy tpc2 to tpc1 before writing if we are not in concert pitch mode and it is a concert pitch instrument.