### PR TITLE
Let a plug-in to know its own path

### DIFF
--- a/mscore/mscorePlugins.cpp
+++ b/mscore/mscorePlugins.cpp
@@ -413,6 +413,7 @@ void MuseScore::pluginTriggered(int idx)
             }
 
       QmlPlugin* p = qobject_cast<QmlPlugin*>(obj);
+      p->setFilePath(pp.section('/', 0, -2));
 
       if (p->pluginType() == "dock" || p->pluginType() == "dialog") {
             QQuickView* view = new QQuickView(engine, 0);

--- a/mscore/pluginCreator.cpp
+++ b/mscore/pluginCreator.cpp
@@ -298,6 +298,7 @@ void PluginCreator::runClicked()
       run->setEnabled(false);
 
       item = qobject_cast<QmlPlugin*>(obj);
+      item->setFilePath(path.isEmpty() ? QString() : path.section('/', 0, -2));
 
       if (item->pluginType() == "dock" || item->pluginType() == "dialog") {
             view = new QQuickView(qml, 0);

--- a/mscore/qmlplugin.h
+++ b/mscore/qmlplugin.h
@@ -35,6 +35,7 @@ extern int updateVersion();
 //   QmlPlugin
 //   @@ MuseScore
 //   @P menuPath             QString           where the plugin is placed in menu
+//   @P filePath             QString           source file path, without the file name (read only)
 //   @P version              QString
 //   @P description          QString
 //   @P pluginType           QString
@@ -52,6 +53,7 @@ extern int updateVersion();
 class QmlPlugin : public QQuickItem {
       Q_OBJECT
       Q_PROPERTY(QString menuPath        READ menuPath WRITE setMenuPath)
+      Q_PROPERTY(QString filePath        READ filePath)
       Q_PROPERTY(QString version         READ version WRITE setVersion)
       Q_PROPERTY(QString description     READ description WRITE setDescription)
       Q_PROPERTY(QString pluginType      READ pluginType WRITE setPluginType)
@@ -73,6 +75,8 @@ class QmlPlugin : public QQuickItem {
       QString _version;
       QString _description;
 
+   protected:
+      QString _filePath;            // the path of the source file, without file name
    signals:
       void run();
 
@@ -86,6 +90,8 @@ class QmlPlugin : public QQuickItem {
       QString version() const              { return _version; }
       void setDescription(const QString& s) { _description = s; }
       QString description() const          { return _description; }
+      void setFilePath(const QString s)   { _filePath = s;        }
+      QString filePath() const            { return _filePath;     }
 
       void setPluginType(const QString& s) { _pluginType = s;    }
       QString pluginType() const           { return _pluginType; }


### PR DESCRIPTION
The full path a plug-in is run from is made known to the plug-in itself in the read-only property `filePath`. `filePath` contains the file path, without the file name and without trailing '/'.

This property is useful for the plug-in to access resources or assets it may rely on: icons, dialogues, data files, etc., through the standard `Loader` QML type or through the MuseScore-specific `FileIO` QML type.