### PR TITLE
Fix plugin Cursor.rewind()

### DIFF
--- a/libmscore/cursor.cpp
+++ b/libmscore/cursor.cpp
@@ -33,8 +33,8 @@ namespace Ms {
 Cursor::Cursor(Score* s)
    : QObject(0)
       {
-      _track   = 0;
-      _segment = 0;
+      _segment = s->firstSegment();       // position at first segment
+      _track = 0;
       setScore(s);
       }
 
@@ -53,22 +53,31 @@ void Cursor::setScore(Score* s)
 
 void Cursor::rewind(int type)
       {
-      if (type == 0) {
-            _segment = 0;
-            Measure* m = _score->firstMeasure();
-            if (m) {
-                  _segment = m->first(Segment::Type::ChordRest);
-                  firstChordRestInTrack();
-                  }
-            }
-      else if (type == 1) {
-            _segment  = _score->selection().startSegment();
-            _track    = _score->selection().staffStart() * VOICES;
-            firstChordRestInTrack();
-            }
-      else if (type == 2) {
-            _segment  = _score->selection().endSegment();
-            _track    = (_score->selection().staffEnd() * VOICES) - 1;  // be sure _track exists
+      switch(type) {
+            case 0:                 // score start of current track
+                  _segment = _score->firstSegment();
+                  break;
+            case 1:                 // selection start
+                  _segment  = _score->selection().startSegment();
+                  _track    = _score->selection().staffStart() * VOICES;
+                  // if no selection, return score start
+                  if (_segment == nullptr) {
+                        _segment = _score->firstSegment();
+                        _track = 0;
+                        }
+                  break;
+            case 2:                 // selection end
+                  _segment = _score->selection().endSegment();
+                  _track = (_score->selection().staffEnd() * VOICES) - 1;  // be sure _track exists
+                  // if no selection, return score end
+                  if (_segment == nullptr) {
+                        _segment = _score->lastSegment();
+                        _track = _score->ntracks() - 1;
+                        }
+                  break;
+            case 3:                 // score end of current track
+                  _segment = _score->lastSegment();
+                  break;
             }
       _score->inputState().setTrack(_track);
       _score->inputState().setSegment(_segment);

--- a/libmscore/cursor.h
+++ b/libmscore/cursor.h
@@ -91,9 +91,10 @@ class Cursor : public QObject {
       int qmlKeySignature();
 
       //@ rewind cursor
-      //@   type=0      rewind to start of score
+      //@   type=0      rewind current track to start of score
       //@   type=1      rewind to start of selection
       //@   type=2      rewind to end of selection
+      //@   type=3      rewind current track to end of score
       Q_INVOKABLE void rewind(int type);
 
       Q_INVOKABLE bool next();


### PR DESCRIPTION
Changes:
- `rewind()` now returns the first/last segment **of whatever type**, not necessarily of `ChordRest` type, as plugins may be interested in elements of any type and have to be prepared anyway to detect / ignore elements they are not interested in;
- `rewind(1 | 2)` now always return valid values; if there is no selection, they fall back to whole score;
- for symmetry, added a `rewind(3)` advancing to the last score segment.

Summary of operations:

- `rewind(0)` always return the first segment of whatever type in current track;
- `rewind(1)` returns the first segment (of whatever type) / first track in current selection; if there is no selection, it returns the first segment / first track of the score;
- `rewind(2)` returns the last segment (of whatever type) / last track  in current selection; if there is no selection, it returns the last segment / last track of the score;
- `rewind(3)` always returns the last segment (of whatever type) in current track.