### PR TITLE
Plug-ins: expose Spanner::startElement and ::endElement

### DIFF
--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -93,9 +93,11 @@ class SpannerSegment : public Element {
 //   @@ Spanner
 ///   Virtual base class for slurs, ties, lines etc.
 //
-//    @P tick      int                  tick start position
-//    @P tick2     int                  tick end position
-//    @P anchor    Ms::Spanner::Anchor  (SEGMENT, MEASURE, CHORD, NOTE)
+//    @P anchor         Ms::Spanner::Anchor     (SEGMENT, MEASURE, CHORD, NOTE)
+//    @P endElement     MS::Element             the element the spanner end is anchored to (read-only)
+//    @P startElement   MS::Element             the element the spanner start is anchored to (read-only)
+//    @P tick           int                     tick start position
+//    @P tick2          int                     tick end position
 //----------------------------------------------------------------------------------
 
 class Spanner : public Element {
@@ -107,9 +109,11 @@ class Spanner : public Element {
             SEGMENT, MEASURE, CHORD, NOTE
             };
    private:
-      Q_PROPERTY(int                 tick    READ tick    WRITE setTick)
-      Q_PROPERTY(int                 tick2   READ tick2   WRITE setTick2)
-      Q_PROPERTY(Ms::Spanner::Anchor anchor  READ anchor  WRITE setAnchor)
+      Q_PROPERTY(Ms::Spanner::Anchor      anchor            READ anchor       WRITE setAnchor)
+      Q_PROPERTY(Ms::Element*             endElement        READ endElement)
+      Q_PROPERTY(Ms::Element*             startElement      READ startElement)
+      Q_PROPERTY(int                      tick              READ tick         WRITE setTick)
+      Q_PROPERTY(int                      tick2             READ tick2        WRITE setTick2)
 
       Element* _startElement { 0  };
       Element* _endElement   { 0  };


### PR DESCRIPTION
Makes the `Spanner::startElement` and `Spanner::endElement` available in the `Spanner.startElement` and `Spanner.endElement` read-only properties.

Use cases include navigating across ties (rather than simply learning that a note has a tie) or working on spanners according to extrema properties.