### PR TITLE
fix #53936: incomplete MusicXML text for 7sus4

### DIFF
--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -809,9 +809,11 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
             // eat spaces
             while (i < len && s[i] == ' ')
                   ++i;
-            // get second token - up to first non-digit
+            // get second token - a number <= 13
             for (j = 0, tok2 = ""; i < len; ++i) {
                   if (!s[i].isDigit())
+                        break;
+                  if (j == 1 && (tok2[0] != '1' || s[i] > '3'))
                         break;
                   tok2[j++] = s[i];
                   }
@@ -887,6 +889,8 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
                         d = 0;
                   else
                         d = tok2L.toInt();
+                  if (d > 13)
+                        d = 13;
                   QString degree;
                   bool alter = false;
                   if (tok1L == "add") {
@@ -947,6 +951,10 @@ bool ParsedChord::parse(const QString& s, const ChordList* cl, bool syntaxOnly, 
                         _xmlText = tok1 + tok2;
                         if (_extension == "7" || _extension == "9" || _extension == "11" || _extension == "13") {
                               _xmlDegrees += (_quality == "major") ? "add#7" : "add7";
+                              // hack for programs that cannot assemble names well
+                              // even though the kind is suspended, set text to also include the extension
+                              // in export, we will set the degree text to null
+                              _xmlText = _extension + _xmlText;
                               degree = "";
                               }
                         else if (_extension != "")

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -4972,8 +4972,9 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
 
             if (!h->xmlKind().isEmpty()) {
                   QString s = "kind";
+                  QString kindText = h->xmlText();
                   if (h->xmlText() != "")
-                        s += " text=\"" + h->xmlText() + "\"";
+                        s += " text=\"" + kindText + "\"";
                   if (h->xmlSymbols() == "yes")
                         s += " use-symbols=\"yes\"";
                   if (h->xmlParens() == "yes")
@@ -4982,7 +4983,24 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
                   QStringList l = h->xmlDegrees();
                   if (!l.isEmpty()) {
                         foreach(QString tag, l) {
-                              xml.stag("degree");
+                              QString degreeText;
+                              if (h->xmlKind().startsWith("suspended")
+                                  && tag.startsWith("add") && tag[3].isDigit()
+                                  && !kindText.isEmpty() && kindText[0].isDigit()) {
+                                    // hack to correct text for suspended chords whose kind text has degree information baked in
+                                    // (required by some other applications)
+                                    int tagDegree = tag.mid(3).toInt();
+                                    QString kindTextExtension;
+                                    for (int i = 0; i < kindText.length() && kindText[i].isDigit(); ++i)
+                                          kindTextExtension[i] = kindText[i];
+                                    int kindExtension = kindTextExtension.toInt();
+                                    if (tagDegree <= kindExtension && (tagDegree & 1) && (kindExtension & 1))
+                                          degreeText = "\"\"";
+                                    }
+                              if (degreeText.isEmpty())
+                                    xml.stag("degree");
+                              else
+                                    xml.stag("degree text=" + degreeText);
                               int alter = 0;
                               int idx = 3;
                               if (tag[idx] == '#') {


### PR DESCRIPTION
Previously, for 7sus4, we exported kind of suspended-fourth, text of "sus4", and the 7 was a degree tag with no specific text.  We import this just fine, but other applications apparently would interpret this as "sus4add9".  So on advice of Michael Good, we now export the kind text as "7sus4", and explicitly set the degree text for the 7 to "".  Similarly for 9sus4 etc.

This PR also fixes a chord parsing issue where we would try to parse b913 as b 913, rather than b9 13, potentially leading to a crash.