### PR TITLE
expose Rest::isFullMeasureRest() to plugins

### DIFF
--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -23,10 +23,12 @@ enum class SymId;
 //---------------------------------------------------------
 //    @@ Rest
 ///     This class implements a rest.
+//    @P isFullMeasure  bool  (read only)
 //---------------------------------------------------------
 
 class Rest : public ChordRest {
       Q_OBJECT
+      Q_PROPERTY(bool  isFullMeasure  READ isFullMeasureRest)
 
       ElementList _el;              ///< symbols or images
 


### PR DESCRIPTION
Add property 'isFullMeasure' to qml object Rest.

I'm using this in my courtesy accidental plugin.