### PR TITLE
fix #53196: chord symbols on mmrests not transposed

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2543,7 +2543,13 @@ void Score::cmdConcertPitchChanged(bool flag, bool /*useDoubleSharpsFlats*/)
                         Harmony* h  = static_cast<Harmony*>(e);
                         int rootTpc = transposeTpc(h->rootTpc(), interval, true);
                         int baseTpc = transposeTpc(h->baseTpc(), interval, true);
-                        undoTransposeHarmony(h, rootTpc, baseTpc);
+                        for (ScoreElement* e : h->linkList()) {
+                              // don't transpose all links
+                              // just ones resulting from mmrests
+                              Harmony* he = static_cast<Harmony*>(e);
+                              if (he->staff() == h->staff())
+                                    undoTransposeHarmony(he, rootTpc, baseTpc);
+                              }
                         }
                   }
             }


### PR DESCRIPTION
This works, but I am not sure if there is a better way to do it.  I want to make sure I transpose both the regular and mmrest version of a chord symbol.  The existing loop is only finding the regular version, so I am just adding another loop through the links for each chord, ignoring any that don't have the same staff().  The idea being, don't transpose the corresponding chord in a different linked score/part, and also don't transpose the corresponding chord in a linked staff within the same score (because it's turn comes later, when we hit that staff in the outer loop).