### PR TITLE
expose class BarLine with property barLineType to scripting

### DIFF
--- a/libmscore/barline.h
+++ b/libmscore/barline.h
@@ -56,10 +56,12 @@ struct BarLineTableItem {
 
 //---------------------------------------------------------
 //   @@ BarLine
+//   @P barLineType  enum  (NORMAL, DOUBLE, START_REPEAT ...) (read only)
 //---------------------------------------------------------
 
 class BarLine : public Element {
       Q_OBJECT
+      Q_PROPERTY(int barLineType READ qmlBarLineType)
 
       BarLineType _barLineType { BarLineType::NORMAL };
       bool _customSpan         { false };
@@ -83,7 +85,14 @@ class BarLine : public Element {
       void updateGenerated(bool canBeTrue = true);
 
    public:
-      BarLine(Score*);
+      enum QmlBarLineType {
+            NORMAL, DOUBLE, START_REPEAT, END_REPEAT,
+            BROKEN, END, END_START_REPEAT, DOTTED
+            };
+      Q_ENUMS(QmlBarLineType)
+      int qmlBarLineType() const { return int(_barLineType); }
+
+      BarLine(Score* s = 0);
       BarLine &operator=(const BarLine&) = delete;
 
       virtual BarLine* clone() const override     { return new BarLine(*this); }
@@ -157,5 +166,8 @@ class BarLine : public Element {
       virtual QString accessibleExtraInfo() override;
       };
 }     // namespace Ms
+
+Q_DECLARE_METATYPE(Ms::BarLine::QmlBarLineType);
+
 #endif
 

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -55,6 +55,7 @@
 #include "stemslash.h"
 #include "fraction.h"
 #include "excerpt.h"
+#include "barline.h"
 
 namespace Ms {
 
@@ -338,6 +339,7 @@ QQmlEngine* MScore::qml()
             qmlRegisterType<StemSlash>  ("MuseScore", 1, 0, "StemSlash");
             qmlRegisterType<Beam>       ("MuseScore", 1, 0, "Beam");
             qmlRegisterType<Excerpt>    ("MuseScore", 1, 0, "Excerpt");
+            qmlRegisterType<BarLine>    ("MuseScore", 1, 0, "BarLine");
             qmlRegisterType<FractionWrapper>   ("MuseScore", 1, 1, "Fraction");
             qRegisterMetaType<FractionWrapper*>("FractionWrapper*");
 

--- a/mtest/scripting/tst_scripting.cpp
+++ b/mtest/scripting/tst_scripting.cpp
@@ -17,6 +17,8 @@
 #include "libmscore/musescoreCore.h"
 #include "mscore/preferences.h"
 #include "mscore/qmlplugin.h"
+#include "libmscore/mscore.h"
+#include "libmscore/barline.h"
 
 #define DIR QString("scripting/")
 
@@ -31,10 +33,12 @@ class TestScripting : public QObject, public MTest
       Q_OBJECT
 
       void read1(const char*, const char*);
+      void testBarLineType();
 
    private slots:
       void initTestCase();
       void test1() { read1("s1", "p1"); }
+      void test2() { testBarLineType(); }
       };
 
 //---------------------------------------------------------
@@ -85,6 +89,25 @@ void TestScripting::read1(const char* file, const char* script)
 
       QVERIFY(compareFiles("p1.log", DIR + "p1.log.ref"));
       delete score;
+      }
+
+//---------------------------------------------------------
+//   testBarLineType
+//
+//   test if enums BarLineType and BarLine::QmlBarLineType match
+//---------------------------------------------------------
+
+void TestScripting::testBarLineType()
+      {
+      initMTest();
+      QVERIFY((int)BarLineType::NORMAL == (int)BarLine::QmlBarLineType::NORMAL);
+      QVERIFY((int)BarLineType::DOUBLE == (int)BarLine::QmlBarLineType::DOUBLE);
+      QVERIFY((int)BarLineType::START_REPEAT == (int)BarLine::QmlBarLineType::START_REPEAT);
+      QVERIFY((int)BarLineType::END_REPEAT == (int)BarLine::QmlBarLineType::END_REPEAT);
+      QVERIFY((int)BarLineType::BROKEN == (int)BarLine::QmlBarLineType::BROKEN);
+      QVERIFY((int)BarLineType::END == (int)BarLine::QmlBarLineType::END);
+      QVERIFY((int)BarLineType::END_START_REPEAT == (int)BarLine::QmlBarLineType::END_START_REPEAT);
+      QVERIFY((int)BarLineType::DOTTED == (int)BarLine::QmlBarLineType::DOTTED);
       }
 
 QTEST_MAIN(TestScripting)


### PR DESCRIPTION
This exposes BarLine and the BarLineType enum the same way as AccidentalType is exposed (using a QmlBarLineType enum).
While trying to use the barLineType property, I noticed that class BarLine was not yet registered in mscore.cpp.

Once again needed for my courtesy accidental plugin.
