### PR TITLE
Plug-in framework: Cursor methods for seeking

### DIFF
--- a/libmscore/cursor.h
+++ b/libmscore/cursor.h
@@ -67,6 +67,7 @@ class Cursor : public QObject {
 
       // utility methods
       void nextInTrack();
+      void prevInTrack();
 
    public:
       Cursor(Score* c = 0);
@@ -96,17 +97,33 @@ class Cursor : public QObject {
 
       int qmlKeySignature();
 
-      //@ rewind cursor
-      //@   type=0      rewind to start of score
-      //@   type=1      rewind to start of selection
-      //@   type=2      rewind to end of selection
-      Q_INVOKABLE void rewind(int type);
-
+      //@ moves cursor to first element of current track in score (filtered by 'filter')
+      Q_INVOKABLE void scoreStart();
+      //@ moves cursor to last element of current track in score (filtered by 'filter')
+      Q_INVOKABLE void scoreEnd();
+      //@ moves cursor to first element of current track in selection (filtered by 'filter');
+      //@ if there is no selection, same as scoreStart()
+      Q_INVOKABLE void selectionStart();
+      //@ moves cursor to last element of current track in selection (filtered by 'filter');
+      //@ if there is no selection, same as scoreEnd()
+      Q_INVOKABLE void selectionEnd();
+      //@ moves cursor to next element of current track (filtered by 'filter')
       Q_INVOKABLE bool next();
+      //@ moves cursor to first segment of current track in next measure (filtered by 'filter');
+      //@ returns false if end of score is reached
       Q_INVOKABLE bool nextMeasure();
-      Q_INVOKABLE void add(Ms::Element*);
 
+      //@ adds an Element to the current cursor segment in the current track
+      Q_INVOKABLE void add(Ms::Element*);
+      //@ adds a note of pitch 'pitch' to the chord in current track of current segment;
+      //@ chord must already exist
       Q_INVOKABLE void addNote(int pitch);
+
+      // rewind cursor
+      //   type=0      rewind to start of score
+      //   type=1      rewind to start of selection
+      //   type=2      rewind to end of selection
+      Q_INVOKABLE void rewind(int type);  // obsolete; replaced by scoreStart/End() and selectionStart/End():
 
       //@ set duration
       //@   z: numerator

--- a/mtest/scripting/cursor_seek.mscx
+++ b/mtest/scripting/cursor_seek.mscx
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <page-layout>
+        <page-height>1683.36</page-height>
+        <page-width>1190.88</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">s1</metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="-1" span="0"/>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument>
+        <longName pos="0">Flute</longName>
+        <shortName pos="0">Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="73"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="-1" span="0"/>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument>
+        <longName pos="0">Flute</longName>
+        <shortName pos="0">Fl.</shortName>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="73"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="2">
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        <tick>1920</tick>
+        <Rest>
+          <track>1</track>
+          <durationType>half</durationType>
+          </Rest>
+        <Rest>
+          <track>1</track>
+          <durationType>half</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="3">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="2">
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="3">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/scripting/cursor_seek2.log.ref
+++ b/mtest/scripting/cursor_seek2.log.ref
@@ -1,0 +1,84 @@
+test script cursor_seek
+SELECTION: from track 0 to track 7
+FILTER: 128
+TRACK: 0
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  0
+	Sel. end:   	cursor tick:  3840
+	Score end:  	cursor tick:  3840
+TRACK: 1
+	Score start:	cursor tick:  1920
+	Sel. start: 	cursor tick:  1920
+	Sel. end:   	cursor tick:  2880
+	Score end:  	cursor tick:  2880
+TRACK: 2
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 3
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 4
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  0
+	Sel. end:   	cursor tick:  3840
+	Score end:  	cursor tick:  3840
+TRACK: 5
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 6
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 7
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+FILTER: 384
+TRACK: 0
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  0
+	Sel. end:   	cursor tick:  5760
+	Score end:  	cursor tick:  5760
+TRACK: 1
+	Score start:	cursor tick:  1920
+	Sel. start: 	cursor tick:  1920
+	Sel. end:   	cursor tick:  2880
+	Score end:  	cursor tick:  2880
+TRACK: 2
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 3
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 4
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  0
+	Sel. end:   	cursor tick:  5760
+	Score end:  	cursor tick:  5760
+TRACK: 5
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 6
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 7
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL

--- a/mtest/scripting/cursor_seek2.qml
+++ b/mtest/scripting/cursor_seek2.qml
@@ -1,0 +1,54 @@
+import QtQuick 2.0
+import MuseScore 1.0
+
+MuseScore
+{
+	menuPath: "Plugins.cursor_seek"
+	onRun:
+	{
+		openLog("cursor_seek2.log");
+		logn("test script cursor_seek");
+
+		var	cursor			= curScore.newCursor();
+		logn("SELECTION: from track " + curScore.selectionFirstTrack + " to track " + curScore.selectionLastTrack);
+
+		cursor.filter		= Segment.ChordRest;
+		cursorSeek(cursor);
+
+		// use a temporary variable as, for some unkown reason, direct assignment
+		// to Cursor.filter gives wrong results with flag combinations
+		var filter			= (Segment.EndBarLine + Segment.ChordRest);
+		cursor.filter		= filter;
+		cursorSeek(cursor);
+
+		closeLog();
+		Qt.quit();
+	}
+
+	function cursorSeek(cursor)
+	{
+		logn("FILTER: " + cursor.filter);
+		for (var currTrack = 0; currTrack <= curScore.ntracks - 1; currTrack++)
+		{
+			cursor.track = currTrack;
+			log2("TRACK: ", cursor.track);
+			cursor.scoreStart();
+			log("	Score start:");
+			cursorStats(cursor);
+			cursor.selectionStart();
+			log("	Sel. start: ");
+			cursorStats(cursor);
+			cursor.selectionEnd();
+			log("	Sel. end:   ");
+			cursorStats(cursor);
+			cursor.scoreEnd();
+			log("	Score end:  ");
+			cursorStats(cursor);
+		}
+	}
+
+	function cursorStats(cursor)
+	{
+		log2("	cursor tick:  ", (cursor.segment ? cursor.tick : "NULL") );
+	}
+}

--- a/mtest/scripting/cursor_seek3.log.ref
+++ b/mtest/scripting/cursor_seek3.log.ref
@@ -1,0 +1,84 @@
+test script cursor_seek
+SELECTION: from track 4 to track 7
+FILTER: 128
+TRACK: 0
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  3840
+TRACK: 1
+	Score start:	cursor tick:  1920
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  2880
+TRACK: 2
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 3
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 4
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  960
+	Sel. end:   	cursor tick:  1920
+	Score end:  	cursor tick:  3840
+TRACK: 5
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 6
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 7
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+FILTER: 384
+TRACK: 0
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  5760
+TRACK: 1
+	Score start:	cursor tick:  1920
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  2880
+TRACK: 2
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 3
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 4
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  960
+	Sel. end:   	cursor tick:  1920
+	Score end:  	cursor tick:  5760
+TRACK: 5
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 6
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 7
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL

--- a/mtest/scripting/cursor_seek3.qml
+++ b/mtest/scripting/cursor_seek3.qml
@@ -1,0 +1,54 @@
+import QtQuick 2.0
+import MuseScore 1.0
+
+MuseScore
+{
+	menuPath: "Plugins.cursor_seek"
+	onRun:
+	{
+		openLog("cursor_seek3.log");
+		logn("test script cursor_seek");
+
+		var	cursor			= curScore.newCursor();
+		logn("SELECTION: from track " + curScore.selectionFirstTrack + " to track " + curScore.selectionLastTrack);
+
+		cursor.filter		= Segment.ChordRest;
+		cursorSeek(cursor);
+
+		// use a temporary variable as, for some unkown reason, direct assignment
+		// to Cursor.filter gives wrong results with flag combinations
+		var filter			= (Segment.EndBarLine + Segment.ChordRest);
+		cursor.filter		= filter;
+		cursorSeek(cursor);
+
+		closeLog();
+		Qt.quit();
+	}
+
+	function cursorSeek(cursor)
+	{
+		logn("FILTER: " + cursor.filter);
+		for (var currTrack = 0; currTrack <= curScore.ntracks - 1; currTrack++)
+		{
+			cursor.track = currTrack;
+			log2("TRACK: ", cursor.track);
+			cursor.scoreStart();
+			log("	Score start:");
+			cursorStats(cursor);
+			cursor.selectionStart();
+			log("	Sel. start: ");
+			cursorStats(cursor);
+			cursor.selectionEnd();
+			log("	Sel. end:   ");
+			cursorStats(cursor);
+			cursor.scoreEnd();
+			log("	Score end:  ");
+			cursorStats(cursor);
+		}
+	}
+
+	function cursorStats(cursor)
+	{
+		log2("	cursor tick:  ", (cursor.segment ? cursor.tick : "NULL") );
+	}
+}

--- a/mtest/scripting/cursor_seek4.log.ref
+++ b/mtest/scripting/cursor_seek4.log.ref
@@ -1,0 +1,84 @@
+test script cursor_seek
+SELECTION: from track 4 to track 7
+FILTER: 128
+TRACK: 0
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  3840
+TRACK: 1
+	Score start:	cursor tick:  1920
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  2880
+TRACK: 2
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 3
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 4
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  3840
+	Sel. end:   	cursor tick:  3840
+	Score end:  	cursor tick:  3840
+TRACK: 5
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 6
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 7
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+FILTER: 384
+TRACK: 0
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  5760
+TRACK: 1
+	Score start:	cursor tick:  1920
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  2880
+TRACK: 2
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 3
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 4
+	Score start:	cursor tick:  0
+	Sel. start: 	cursor tick:  3840
+	Sel. end:   	cursor tick:  5760
+	Score end:  	cursor tick:  5760
+TRACK: 5
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 6
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL
+TRACK: 7
+	Score start:	cursor tick:  NULL
+	Sel. start: 	cursor tick:  NULL
+	Sel. end:   	cursor tick:  NULL
+	Score end:  	cursor tick:  NULL

--- a/mtest/scripting/cursor_seek4.qml
+++ b/mtest/scripting/cursor_seek4.qml
@@ -1,0 +1,54 @@
+import QtQuick 2.0
+import MuseScore 1.0
+
+MuseScore
+{
+	menuPath: "Plugins.cursor_seek"
+	onRun:
+	{
+		openLog("cursor_seek4.log");
+		logn("test script cursor_seek");
+
+		var	cursor			= curScore.newCursor();
+		logn("SELECTION: from track " + curScore.selectionFirstTrack + " to track " + curScore.selectionLastTrack);
+
+		cursor.filter		= Segment.ChordRest;
+		cursorSeek(cursor);
+
+		// use a temporary variable as, for some unkown reason, direct assignment
+		// to Cursor.filter gives wrong results with flag combinations
+		var filter			= (Segment.EndBarLine + Segment.ChordRest);
+		cursor.filter		= filter;
+		cursorSeek(cursor);
+
+		closeLog();
+		Qt.quit();
+	}
+
+	function cursorSeek(cursor)
+	{
+		logn("FILTER: " + cursor.filter);
+		for (var currTrack = 0; currTrack <= curScore.ntracks - 1; currTrack++)
+		{
+			cursor.track = currTrack;
+			log2("TRACK: ", cursor.track);
+			cursor.scoreStart();
+			log("	Score start:");
+			cursorStats(cursor);
+			cursor.selectionStart();
+			log("	Sel. start: ");
+			cursorStats(cursor);
+			cursor.selectionEnd();
+			log("	Sel. end:   ");
+			cursorStats(cursor);
+			cursor.scoreEnd();
+			log("	Score end:  ");
+			cursorStats(cursor);
+		}
+	}
+
+	function cursorStats(cursor)
+	{
+		log2("	cursor tick:  ", (cursor.segment ? cursor.tick : "NULL") );
+	}
+}

--- a/mtest/scripting/tst_scripting.cpp
+++ b/mtest/scripting/tst_scripting.cpp
@@ -12,11 +12,12 @@
 //=============================================================================
 
 #include <QtTest/QtTest>
-#include "mtest/testutils.h"
-#include "libmscore/score.h"
+#include "libmscore/measure.h"
 #include "libmscore/musescoreCore.h"
+#include "libmscore/score.h"
 #include "mscore/preferences.h"
 #include "mscore/qmlplugin.h"
+#include "mtest/testutils.h"
 
 #define DIR QString("scripting/")
 
@@ -30,11 +31,16 @@ class TestScripting : public QObject, public MTest
       {
       Q_OBJECT
 
-      void read1(const char*, const char*);
+      void readTest1(const char*scoreFName, const char*scriptFName, const char* logFName);
+      void read1(const char* scoreFName);
+      void doTest(Score* score, const char* scriptFName, const char* logFName);
 
    private slots:
       void initTestCase();
-      void test1() { read1("s1", "p1"); }
+      void test1() { readTest1("s1", "p1", "p1"); }
+      void test2();           // cursor seeking methods without any selection
+      void test3();           // cursor seeking methods with middle selection on second staff
+      void test4();           // cursor seeking methods with selection up to score end
       };
 
 //---------------------------------------------------------
@@ -48,23 +54,113 @@ void TestScripting::initTestCase()
       }
 
 //---------------------------------------------------------
-//   read1
-//   read a score, apply script and compare script output with
-//    reference
+//   test2
+//   test cursor seeking methods (scoreStart(), scoreEnd(), selectionStart() and selectionEnd() )
+//    in absence of any selection
 //---------------------------------------------------------
 
-void TestScripting::read1(const char* file, const char* script)
+void TestScripting::test2()
       {
-      Score* score = readScore(DIR + file + ".mscx");
+      // load a score with two staves and three measures
+      read1("cursor_seek");
+      Score*      score = MuseScoreCore::mscoreCore->currentScore();
+
+      // apply script and test
+      doTest(score, "cursor_seek2", "cursor_seek2");
+      }
+
+//---------------------------------------------------------
+//   test3
+//   test cursor seeking methods (scoreStart(), scoreEnd(), selectionStart() and selectionEnd() )
+//    with a middle selection on second staff
+//---------------------------------------------------------
+
+void TestScripting::test3()
+      {
+      // load a score with two staves and three measures
+      read1("cursor_seek");
+      Score*      score = MuseScoreCore::mscoreCore->currentScore();
+
+      // from second rest of first measure
+      Measure*    msr   = score->firstMeasure();
+      QVERIFY(msr);
+      Segment* segFrom  = msr->first(Segment::Type::ChordRest);
+      segFrom     = segFrom->next1();
+      // to beyond first rest of second measure
+      msr = msr->nextMeasure();
+      QVERIFY(msr);
+      Segment* segTo    = msr->first(Segment::Type::ChordRest);
+      segTo       = segTo->next1();
+      Selection&  sel   = score->selection();
+
+      sel.setStartSegment(segFrom);
+      sel.setEndSegment(segTo);
+      sel.setStaffStart(1);               // select staff no. 1 (2nd staff)
+      sel.setStaffEnd(2);
+      sel.setState(SelState::RANGE);
+
+      // apply script and test
+      doTest(score, "cursor_seek3", "cursor_seek3");
+      }
+
+//---------------------------------------------------------
+//   test4
+//   test cursor seeking methods (scoreStart(), scoreEnd(), selectionStart() and selectionEnd() )
+//    with a selection on second staff up to score end
+//---------------------------------------------------------
+
+void TestScripting::test4()
+      {
+      // load a score with two staves and three measures
+      read1("cursor_seek");
+      Score*      score = MuseScoreCore::mscoreCore->currentScore();
+
+      // 'go' to third measure
+      Measure*    msr   = score->firstMeasure();
+      QVERIFY(msr);
+      msr = msr->nextMeasure();
+      QVERIFY(msr);
+      msr = msr->nextMeasure();
+      QVERIFY(msr);
+
+      // select last measure of second staff
+      Selection&  sel   = score->selection();
+      Segment* segFrom  = msr->first();
+      sel.setStartSegment(segFrom);
+      sel.setEndSegment(nullptr);         // beyond end of score
+      sel.setStaffStart(1);               // select staff no. 1 (2nd staff)
+      sel.setStaffEnd(2);
+      sel.setState(SelState::RANGE);
+
+      // apply script and test
+      doTest(score, "cursor_seek4", "cursor_seek4");
+      }
+
+//---------------------------------------------------------
+//   read1
+//   read a score, make it current and return it, if successful
+//---------------------------------------------------------
+
+void TestScripting::read1(const char* scoreFName)
+      {
+      Score* score = readScore(DIR + scoreFName + ".mscx");
       MuseScoreCore::mscoreCore->setCurrentScore(score);
 
       QVERIFY(score);
       score->doLayout();
+      }
 
+//---------------------------------------------------------
+//   doTest
+//   apply script to current score and compare script output with reference
+//---------------------------------------------------------
+
+void TestScripting::doTest(Score* score, const char* scriptFName, const char* logFName)
+      {
       QQmlEngine* engine = Ms::MScore::qml();
       QVERIFY(engine);
 
-      QString scriptPath = root + "/" + DIR + script + ".qml";
+      QString scriptPath = root + "/" + DIR + scriptFName + ".qml";
 
       QFileInfo fi(scriptPath);
       QVERIFY(fi.exists());
@@ -83,8 +179,20 @@ void TestScripting::read1(const char* file, const char* script)
       QmlPlugin* item = qobject_cast<QmlPlugin*>(obj);
       item->runPlugin();
 
-      QVERIFY(compareFiles("p1.log", DIR + "p1.log.ref"));
+      QVERIFY(compareFiles(QString(logFName) + ".log", DIR + logFName + ".log.ref"));
       delete score;
+      }
+
+//---------------------------------------------------------
+//   readTest1
+//   read a score, apply script and compare script output with reference
+//---------------------------------------------------------
+
+void TestScripting::readTest1(const char* scoreFName, const char* scriptFName, const char* logFName)
+      {
+      read1(scoreFName);
+      Score* score = MuseScoreCore::mscoreCore->currentScore();
+      doTest(score, scriptFName, logFName);
       }
 
 QTEST_MAIN(TestScripting)


### PR DESCRIPTION
Implements the following method of the `Cursor` type:
- `scoreStart()`
- `scoreEnd()`
- `selectionStart()`
- `selectionEnd()`

All methods obey the current track and the current filter:
- `xxxStart()` move to first segment of type included in `Cursor.filter` which has an element in the current track.
- `xxxEnd()` move to last segment of type included in `Cursor.filter` which has an element in the current track.

`selectionStart/End()` default to `scoreStart/End()` if there is no selection.
The old `Cursor.rewind(int)` method remains unchanged for legacy compatibility.

Any method may result in `Cursor.segment` being set to `null` if there is no segment satisfying the conditions.

---

Additionally:
- added a test to `tst_scripting` for these new methods
- added comments for the manual to all `Cursor` methods
- added the read-only informative properties `Score.selectionFirstTrack` and `Score.selectionLastTrack`
