### PR TITLE
fix #52506: Split Staff on particular slur crashes MuseScore

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2768,13 +2768,15 @@ void Score::checkSpanner(int startTick, int endTick)
 
             if (s->type() == Element::Type::SLUR) {
                   Segment* seg = tick2segmentMM(s->tick(), false, Segment::Type::ChordRest);
-                  if (!seg || !seg->element(s->track())) {
+                  if (!seg || !seg->element(s->track()) ||
+                     ((seg->element(s->track())->type() != Element::Type::CHORD) && !noteEntryMode())) {
                         qDebug("checkSpanner::remove (1)");
                         sl.append(s);
                         }
                   else {
                         seg = tick2segmentMM(s->tick2(), false, Segment::Type::ChordRest);
-                        if (!seg || !seg->element(s->track2())) {
+                        if (!seg || !seg->element(s->track2()) ||
+                           ((seg->element(s->track())->type() != Element::Type::CHORD) && !noteEntryMode())) {
                               qDebug("checkSpanner::remove (2) %d - tick %d track %d",
                                  s->tick(), s->tick2(), s->track2());
                               sl.append(s);

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1584,35 +1584,6 @@ RemoveElement::RemoveElement(Element* e)
 
       Score* score = element->score();
       if (element->isChordRest()) {
-#if 0
-            // do not delete pending slur in note entry mode
-            Slur* pendingSlur = 0;
-            for (Score* sc : score->scoreList()) {
-                  if (sc->noteEntryMode()) {
-                        pendingSlur = sc->inputState().slur();
-                        break;
-                        }
-                  }
-            // remove any slurs pointing to this chor/rest
-            QList<Spanner*> sl;
-            int tick = static_cast<ChordRest*>(element)->tick();
-            for (auto i : score->spanner()) {     // TODO: dont search whole list
-                  Spanner* s = i.second;
-                  if (pendingSlur && pendingSlur->linkList().contains(s)) {
-                        if (s->startElement() == e)
-                              s->setStartElement(nullptr);
-                        else if (s->endElement() == e)
-                              s->setEndElement(nullptr);
-                        continue;
-                        }
-                  if (s->type() == Element::Type::SLUR && (s->startElement() == e || s->endElement() == e))
-                        sl.append(s);
-                  else if ((s->tick() == tick) && (s->track() == element->track()))
-                        sl.append(s);
-                  }
-            for (auto s : sl)       // actually remove scheduled spanners
-                  score->undo(new RemoveElement(s));
-#endif
             ChordRest* cr = static_cast<ChordRest*>(element);
             if (cr->tuplet() && cr->tuplet()->elements().size() <= 1)
                   score->undo(new RemoveElement(cr->tuplet()));

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3324,6 +3324,10 @@ void ScoreView::endNoteEntry()
             const QList<SpannerSegment*>& el = is.slur()->spannerSegments();
             if (!el.isEmpty())
                   el.front()->setSelected(false);
+            _score->startCmd();
+            _score->undo(new RemoveElement(is.slur()));
+            _score->doLayout();
+            _score->endCmd();
             is.setSlur(nullptr);
             }
       setMouseTracking(false);


### PR DESCRIPTION
In checkSpanner, I make sure that we don't have slurs ending on a rest. The only case where it should happen is during note entry. So when exiting note entry, I delete the pending slur... I know it's a bit weird to do this at this place, so I made a PR. Comments welcome.