### PR TITLE
partial fix for #51271: timesig and barline issues on 1-line staves

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -714,7 +714,6 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
             return;
             }
 
-
       if (ots && ots->sig().identical(ns) && ots->stretch() == ts->stretch()) {
             ots->undoChangeProperty(P_ID::TIMESIG, QVariant::fromValue(ns));
             ots->undoChangeProperty(P_ID::GROUPS,  QVariant::fromValue(ts->groups()));
@@ -812,6 +811,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                               nsig->setScore(score);
                               nsig->setTrack(staffIdx * VOICES);
                               nsig->setParent(seg);
+                              nsig->setNeedLayout(true);
                               undoAddElement(nsig);
                               }
                         else {

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4046,9 +4046,12 @@ void Score::updateBarLineSpans(int idx, int linesOld, int linesNew)
                   // if it has no bar line, set barLineTo to a default value
                   if(_staff->barLineSpan() == 0)
                         _staff->setBarLineTo( (linesNew-1) * 2);
-                  // if new line number is 1, set default From for 1-line staves
+                  // if new line count is 1, set default From for 1-line staves
                   else if(linesNew == 1)
                         _staff->setBarLineFrom(BARLINE_SPAN_1LINESTAFF_FROM);
+                  // if old line count was 1, set default From for normal staves
+                  else if (linesOld == 1)
+                        _staff->setBarLineFrom(0);
                   // if barLineFrom was below the staff middle position
                   // raise or lower it to account for new number of lines
                   else if(_staff->barLineFrom() > linesOld - 1)
@@ -4057,9 +4060,12 @@ void Score::updateBarLineSpans(int idx, int linesOld, int linesNew)
 
             // if the modified staff is the destination of the current staff bar span:
             if(sIdx + _staff->barLineSpan() - 1 == idx) {
-                  // if new line number is 1, set default To for 1-line staves
+                  // if new line count is 1, set default To for 1-line staves
                   if(linesNew == 1)
                         _staff->setBarLineTo(BARLINE_SPAN_1LINESTAFF_TO);
+                  // if old line count was 1, set default To for normal staves
+                  else if (linesOld == 1)
+                        _staff->setBarLineTo((linesNew - 1) * 2);
                   // if barLineTo was below its middle position, raise or lower it
                   else if(_staff->barLineTo() > linesOld - 1)
                         _staff->setBarLineTo(_staff->barLineTo() + (linesNew - linesOld)*2);

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1193,10 +1193,11 @@ bool Score::read(XmlReader& e)
                   st->setBarLineSpan(barLineSpan);
                   }
             // check spanFrom
-            if(st->barLineFrom() < MIN_BARLINE_SPAN_FROMTO)
-                  st->setBarLineFrom(MIN_BARLINE_SPAN_FROMTO);
-            if(st->barLineFrom() > st->lines()*2)
-                  st->setBarLineFrom(st->lines()*2);
+            int minBarLineFrom = st->lines() == 1 ? BARLINE_SPAN_1LINESTAFF_FROM : MIN_BARLINE_SPAN_FROMTO;
+            if (st->barLineFrom() < minBarLineFrom)
+                  st->setBarLineFrom(minBarLineFrom);
+            if (st->barLineFrom() > st->lines() * 2)
+                  st->setBarLineFrom(st->lines() * 2);
             // check spanTo
             Staff* stTo = st->barLineSpan() <= 1 ? st : staff(idx + st->barLineSpan() - 1);
             // 1-line staves have special bar line spans
@@ -1210,7 +1211,7 @@ bool Score::read(XmlReader& e)
                   st->setBarLineTo(maxBarLineTo);
             // on single staff span, check spanFrom and spanTo are distant enough
             if (st->barLineSpan() == 1) {
-                  if(st->barLineTo() - st->barLineFrom() < MIN_BARLINE_FROMTO_DIST) {
+                  if (st->barLineTo() - st->barLineFrom() < MIN_BARLINE_FROMTO_DIST) {
                         st->setBarLineFrom(0);
                         st->setBarLineTo(defaultBarLineTo);
                         }

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -1007,7 +1007,7 @@ void InspectorBarLine::manageSpanData()
       //          max = max possible according to number of staff lines
       min   = bl->span() < 2 ? bl->spanFrom() + MIN_BARLINE_FROMTO_DIST
                   : (staffToLines == 1 ? BARLINE_SPAN_1LINESTAFF_FROM : MIN_BARLINE_SPAN_FROMTO);
-      max   = staffFromLines == 1 ? BARLINE_SPAN_1LINESTAFF_TO : (staffToLines-1) * 2 + 2;
+      max   = staffToLines == 1 ? BARLINE_SPAN_1LINESTAFF_TO : (staffToLines-1) * 2 + 2;
       b.spanTo->setMinimum(min);
       b.spanTo->setMaximum(max);
       b.spanTo->setWrapping(false);


### PR DESCRIPTION
This part of the fix is simple enough - we need to layout the newly added time signature.

The issue also describes issues with barlines on one-line staves.  I am less sure how to fix those, but figured I'd submit the timesig fix first as is.