### PR TITLE
fix #53161: chord ties created via duration change are connected wrong

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -205,10 +205,10 @@ Chord* Score::addChord(int tick, TDuration d, Chord* oc, bool genTie, Tuplet* tu
 
       foreach(Note* n, oc->notes()) {
             Note* nn = new Note(this);
-            chord->add(nn);
             nn->setPitch(n->pitch());
             nn->setTpc1(n->tpc1());
             nn->setTpc2(n->tpc2());
+            chord->add(nn);
             }
       undoAddCR(chord, measure, tick);
 


### PR DESCRIPTION
The problem itself is simple: the new chord is created with its pitches in the wrong order, and the subsequent code to connect the ties just connects note 0 to note 0, note 1 to note 1, etc.

My change here simply sets the pitches for the notes in the new chord before adding the notes to the chord, which is required in order them to be sorted automatically on add.  Other alternatives would be to explicitly sort the notes after build the chord, or to make the tie code smarter and look for matching pitches.  Mine seems to work though, unless someone can see a flaw in this.  As far as I know, we do generally set pitches for notes before adding them to chords in other situations, so this feels right to me.