### PR TITLE
fix #56146: bad read/layout for 1.3 score with invalid symbol tick

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -731,12 +731,16 @@ bool Element::readProperties(XmlReader& e)
                   //   the tick is not needed for glissandi anyhow, so we can ignore it
                   // - another bug allowed text items attached to notes or chords to also have invalid tick values (#25616)
                   //   the text might be of any type, but we are now converting any text elements within notes into FINGERING
-                  // - at some point, a check for SYMBOL was included here, but it isn't clear what the issue was
-                  //   ignoring ticks for symbols means they will be positioned incorrectly if not at start of measure, and it is not safe in any case:
-                  //   it causes problems if there is also another item such as a STAFF_TEXT that was depending on the tick value of the symbol (http://musescore.org/en/node/25572)
-                  //   when we re-discover the issue that caused the check for SYMBOL to be added,
-                  //   we will need to find a different solution if possible
-                  if (score()->mscVersion() > 114 || (type() != Element::Type::GLISSANDO && type() != Element::Type::FINGERING))
+                  // - another bug allowed copy & paste of symbols attached to notes to produce invalid tick values (#56146)
+                  //   we can't ignore tick for all symbols, because it is needed for correct positioning of symbols attached to measures
+                  //   and it also can be relied upon by subsequent elements (http://musescore.org/en/node/25572)
+                  //   so honor tick only for elements attached to measures
+                  //   symbols attached to notes or other elements don't need the tick anyhow
+                  if (score()->mscVersion() <= 114 && type() == Element::Type::SYMBOL) {
+                        if (!parent() || parent()->type() != Element::Type::MEASURE)
+                              val = -1;
+                        }
+                  if (score()->mscVersion() > 114 || (type() != Element::Type::GLISSANDO && type() != Element::Type::FINGERING && val >= 0))
                         e.initTick(score()->fileDivision(val));
                   }
             }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2181,6 +2181,10 @@ void Measure::read(XmlReader& e, int staffIdx)
                || tag == "FiguredBass"
                ) {
                   Element* el = Element::name2Element(tag, score());
+                  // hack - needed because tick tags are unreliable in 1.3 scores
+                  // for symbols attached to anything but a measure
+                  if (score()->mscVersion() <= 114 && el->type() == Element::Type::SYMBOL)
+                        el->setParent(this);    // this will get reset when adding to segment
                   el->setTrack(e.track());
                   el->read(e);
                   segment = getSegment(Segment::Type::ChordRest, e.tick());


### PR DESCRIPTION
This fix is a bit of a hack, but I couldn't come up with a better way to do the job.  I guess it's a question of whether the job needs doing - the scores in question are definitely corrupt.  But they worked fine in 1.3.

The bottom line is, symbols can be attached to measures (in which case, they are actually parented to a segment) or to notes / other elements.  In the case of symbols attached to measures, 1.3 scores would sometimes write a tick value, and if the symbol was copied and pasted from elsewhere, it would be the *wrong* tick value.  At some point in 2.0 development it was discovered these scores would not read correctly, so code was added to skip the tick tag for symbols in 1.3 scores.  But this led to other problems - measure-attached (as opposed to note-attached) symbols need their tick tags.  So the change was reverted (by me), as I did not understand how to reproduce the original problem.  Now I do.

My fix is to temporarily set the parent of the symbol to "this" for 1.3 scores in Measure::read(), so measure-attached symbols can be identified later when reading the symbol properties.  When we encounter the tick tag for the symbol, if it's a 1.3 score and the parent is not set to a measure, we ignore the tick.  The tick isn't needed if attached to a note anyhow.