### PR TITLE
fix #53266: corruption pasting or lengthening note into tuplet

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -144,7 +144,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                               int tick = e.readInt();
                               e.initTick(tick);
                               int shift = tick - tickStart;
-                              if (makeGap && !makeGap1(dstTick, dstStaffIdx, Fraction::fromTicks(tickLen),voiceOffset)) {
+                              if (makeGap && !makeGap1(dstTick, dstStaffIdx, Fraction::fromTicks(tickLen), voiceOffset)) {
                                     qDebug("cannot make gap in staff %d at tick %d", dstStaffIdx, dstTick + shift);
                                     done = true; // break main loop, cannot make gap
                                     break;


### PR DESCRIPTION
This fixes two separate but related bugs.  See especially https://musescore.org/en/node/53266#comment-258286 for a description of the bugs and the root cause.

My fix here works for these cases as well others I have tested.  My concern is that since makeGap() is used in other contexts as well, I sure hope I didn't break anything.  I tried a bunch of things and couldn't find any problems.  But it would definitely help if someone with a clearer sense of the different ways makeGap() might be used could really think this through.