### PR TITLE
scripting: added modifiedTime() to FileIO

### DIFF
--- a/libmscore/plugins.cpp
+++ b/libmscore/plugins.cpp
@@ -129,6 +129,21 @@ bool FileIO::exists()
       return file.exists();
       }
 
+int FileIO::modifiedTime()
+      {
+      if (mSource.isEmpty()) {
+            emit error("source is empty");
+            return 0;
+            }
+      QUrl url(mSource);
+      QString source(mSource);
+      if(url.isValid() && url.isLocalFile()) {
+            source = url.toLocalFile();
+            }
+      QFileInfo fileInfo(source);
+      return fileInfo.lastModified().toTime_t();
+      }
+
 //---------------------------------------------------------
 //   setScore
 //---------------------------------------------------------

--- a/libmscore/plugins.h
+++ b/libmscore/plugins.h
@@ -42,6 +42,7 @@ class FileIO : public QObject {
       Q_INVOKABLE bool write(const QString& data);
       Q_INVOKABLE bool remove();
       Q_INVOKABLE QString tempPath() {QDir dir; return dir.tempPath();};
+      Q_INVOKABLE int modifiedTime();
 
       QString source() { return mSource; };
 


### PR DESCRIPTION
The batch export plugin needs a way to compare file modification times to detect if a conversion is needed. 
Using FolderListModel's fileModified property is not possible since it returns a human readable string depending on the locale setting.