### PR TITLE
fix #56651: Crash when importing/previewing MIDI files with high divisio...

### DIFF
--- a/mscore/importmidi/importmidi_fraction.cpp
+++ b/mscore/importmidi/importmidi_fraction.cpp
@@ -341,6 +341,14 @@ ReducedFraction toMuseScoreTicks(int tick, int oldDivision, bool isDivisionInTps
       if (isDivisionInTps)
             return ReducedFraction::fromTicks(tick);
 
+      // avoid overflow for high values of oldDivision
+      // if possible, divide tick and oldDivision by their gcd
+      int tmpQ = gcd(tick, oldDivision);
+      if (tmpQ > 1) {
+            tick = tick / tmpQ;
+            oldDivision = oldDivision / tmpQ;
+            }
+
       Q_ASSERT_X(!isMultiplicationOverflow(tick, MScore::division),
                  "ReducedFraction::toMuseScoreTicks", "Multiplication overflow");
       Q_ASSERT_X(!isAdditionOverflow(tick * MScore::division, oldDivision / 2),


### PR DESCRIPTION
To prevent an overflow of (tick * MScore::division) I divided numerator and denominator of the right side of the equation with the gcd of tick and oldDivision:
<pre>
                  tick * MScore::division + oldDivision / 2
MuseScoreTick =  -------------------------------------------
                                 oldDivision
</pre>
right side multiplied with (1/gcd) : (1/gcd) with gcd = greatest common divisor of tick and oldDivision.
Because of (1/gcd) : (1/gcd) = 1 and gcd != 0, this doesn't change the value of the right side.
<pre>
                 tick/gcd * MScore::division + (oldDivision/gcd) / 2
MuseScoreTick =  ----------------------------------------------------
                                  oldDivision / gcd
</pre>
That means we can simply replace
tick with (tick / gcd) and oldDivision with (oldDivision / gcd)
because we know, both can be divided by gcd.
As a result, we have a high chance of avoiding the multiplication overflow.