### PR TITLE
fix #56556: set correct track for volta

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -897,6 +897,7 @@ void Score::undoAddElement(Element* element)
                         int staffIdx1 = sp->track() / VOICES;
                         int staffIdx2 = sp->track2() / VOICES;
                         int diff = staffIdx2 - staffIdx1;
+                        nsp->setTrack(staffIdx * VOICES + (sp->track() % VOICES));
                         nsp->setTrack2((staffIdx + diff) * VOICES + (sp->track2() % VOICES));
                         undo(new AddElement(nsp));
                         }


### PR DESCRIPTION
The recent fix for a crash and other issues upon trying to add a volta to a staff other than the top had the side effect of making the volta actually *appear* on the staff to which you dragged it, rather than always appearing on the top staff only.  I am assuming this was inadvertent.  My change here fixes that, in a manner consistent with the rest of the code here.  There are other ways this could have been fixed, probably simpler too; see discussion in issue report.

If the intent really is to allow voltas to be attached to non-top staves, we should fix how they are linked to parts, probably also fix the dotted line to the top staff that appears while dragging the volta to your score.