### PR TITLE
fix #56786: bend & tremolo bar on standard staff

### DIFF
--- a/libmscore/bend.cpp
+++ b/libmscore/bend.cpp
@@ -160,8 +160,6 @@ void Bend::layout()
 
 void Bend::draw(QPainter* painter) const
       {
-      if (staff() && !staff()->isTabStaff())
-            return;
       QPen pen(curColor(), _lw, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
       painter->setPen(pen);
       painter->setBrush(QBrush(Qt::black));

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1318,7 +1318,7 @@ bool Note::acceptDrop(const DropData& data) const
          || (type == Element::Type::HAIRPIN)
          || (type == Element::Type::STAFF_TEXT)
          || (type == Element::Type::TEMPO_TEXT)
-         || (type == Element::Type::BEND && (staff()->isTabStaff()))
+         || (type == Element::Type::BEND)
          || (type == Element::Type::TREMOLOBAR)
          || (type == Element::Type::FRET_DIAGRAM));
       }

--- a/libmscore/tremolobar.cpp
+++ b/libmscore/tremolobar.cpp
@@ -44,7 +44,6 @@ void TremoloBar::layout()
                   noteWidth = -_spatium*2;
                   notePos   = QPointF(0.0, _spatium*3);
                   }
-            return;
             }
 
       _lw = _spatium * 0.1;
@@ -82,8 +81,6 @@ void TremoloBar::layout()
 
 void TremoloBar::draw(QPainter* painter) const
       {
-      if (staff() && !staff()->isTabStaff())
-            return;
       QPen pen(curColor(), _lw, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
       painter->setPen(pen);
       painter->setBrush(QBrush(Qt::black));

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1027,6 +1027,7 @@ void Score::undoAddElement(Element* element)
          && et != Element::Type::TREMOLO
          && et != Element::Type::ARPEGGIO
          && et != Element::Type::SYMBOL
+         && et != Element::Type::TREMOLOBAR
          && et != Element::Type::FRET_DIAGRAM
          && et != Element::Type::HARMONY)
             ) {
@@ -1127,6 +1128,7 @@ void Score::undoAddElement(Element* element)
             //
             else if (element->type() == Element::Type::SYMBOL
                || element->type() == Element::Type::IMAGE
+               || element->type() == Element::Type::TREMOLOBAR
                || element->type() == Element::Type::DYNAMIC
                || element->type() == Element::Type::STAFF_TEXT
                || element->type() == Element::Type::FRET_DIAGRAM

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -438,8 +438,10 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
       else if (cmd == "tr-props") {
             TremoloBar* tb = static_cast<TremoloBar*>(e);
             TremoloBarProperties bp(tb, 0);
-            if (bp.exec())
-                  score()->undo(new ChangeTremoloBar(tb, bp.points()));
+            if (bp.exec()) {
+                  for (ScoreElement* b : tb->linkList())
+                        score()->undo(new ChangeTremoloBar(static_cast<TremoloBar*>(b), bp.points()));
+                  }
             }
       if (cmd == "ts-courtesy") {
             TimeSig* ts = static_cast<TimeSig*>(e);

--- a/mtest/guitarpro/tremolo-bar.gpx-ref.mscx
+++ b/mtest/guitarpro/tremolo-bar.gpx-ref.mscx
@@ -140,6 +140,11 @@
           <lid>6</lid>
           <text><sym>unicodeNoteQuarterUp</sym> = 120</text>
           </Tempo>
+        <TremoloBar>
+          <point time="0" pitch="0" vibrato="0"/>
+          <point time="50" pitch="-125" vibrato="0"/>
+          <point time="100" pitch="-250" vibrato="0"/>
+          </TremoloBar>
         <Chord>
           <lid>7</lid>
           <durationType>quarter</durationType>
@@ -165,6 +170,11 @@
           </Rest>
         </Measure>
       <Measure number="2">
+        <TremoloBar>
+          <point time="0" pitch="0" vibrato="0"/>
+          <point time="50" pitch="150" vibrato="0"/>
+          <point time="100" pitch="0" vibrato="0"/>
+          </TremoloBar>
         <TremoloBar>
           <point time="0" pitch="0" vibrato="0"/>
           <point time="50" pitch="150" vibrato="0"/>
@@ -200,6 +210,11 @@
           <point time="50" pitch="-550" vibrato="0"/>
           <point time="100" pitch="-550" vibrato="0"/>
           </TremoloBar>
+        <TremoloBar>
+          <point time="0" pitch="0" vibrato="0"/>
+          <point time="50" pitch="-550" vibrato="0"/>
+          <point time="100" pitch="-550" vibrato="0"/>
+          </TremoloBar>
         <Chord>
           <lid>21</lid>
           <durationType>quarter</durationType>
@@ -211,6 +226,11 @@
             <string>1</string>
             </Note>
           </Chord>
+        <TremoloBar>
+          <point time="0" pitch="-550" vibrato="0"/>
+          <point time="50" pitch="-550" vibrato="0"/>
+          <point time="100" pitch="-400" vibrato="0"/>
+          </TremoloBar>
         <TremoloBar>
           <point time="0" pitch="-550" vibrato="0"/>
           <point time="50" pitch="-550" vibrato="0"/>
@@ -242,6 +262,11 @@
           <point time="50" pitch="200" vibrato="0"/>
           <point time="100" pitch="300" vibrato="0"/>
           </TremoloBar>
+        <TremoloBar>
+          <point time="0" pitch="0" vibrato="0"/>
+          <point time="50" pitch="200" vibrato="0"/>
+          <point time="100" pitch="300" vibrato="0"/>
+          </TremoloBar>
         <Chord>
           <lid>30</lid>
           <durationType>quarter</durationType>
@@ -253,6 +278,10 @@
             <string>1</string>
             </Note>
           </Chord>
+        <TremoloBar>
+          <point time="0" pitch="300" vibrato="0"/>
+          <point time="100" pitch="300" vibrato="0"/>
+          </TremoloBar>
         <TremoloBar>
           <point time="0" pitch="300" vibrato="0"/>
           <point time="100" pitch="300" vibrato="0"/>
@@ -443,6 +472,11 @@
             <lid>6</lid>
             <text><sym>unicodeNoteQuarterUp</sym> = 120</text>
             </Tempo>
+          <TremoloBar>
+            <point time="0" pitch="0" vibrato="0"/>
+            <point time="50" pitch="-125" vibrato="0"/>
+            <point time="100" pitch="-250" vibrato="0"/>
+            </TremoloBar>
           <Chord>
             <lid>7</lid>
             <durationType>quarter</durationType>
@@ -468,6 +502,11 @@
             </Rest>
           </Measure>
         <Measure number="2">
+          <TremoloBar>
+            <point time="0" pitch="0" vibrato="0"/>
+            <point time="50" pitch="150" vibrato="0"/>
+            <point time="100" pitch="0" vibrato="0"/>
+            </TremoloBar>
           <TremoloBar>
             <point time="0" pitch="0" vibrato="0"/>
             <point time="50" pitch="150" vibrato="0"/>
@@ -503,6 +542,11 @@
             <point time="50" pitch="-550" vibrato="0"/>
             <point time="100" pitch="-550" vibrato="0"/>
             </TremoloBar>
+          <TremoloBar>
+            <point time="0" pitch="0" vibrato="0"/>
+            <point time="50" pitch="-550" vibrato="0"/>
+            <point time="100" pitch="-550" vibrato="0"/>
+            </TremoloBar>
           <Chord>
             <lid>21</lid>
             <durationType>quarter</durationType>
@@ -514,6 +558,11 @@
               <string>1</string>
               </Note>
             </Chord>
+          <TremoloBar>
+            <point time="0" pitch="-550" vibrato="0"/>
+            <point time="50" pitch="-550" vibrato="0"/>
+            <point time="100" pitch="-400" vibrato="0"/>
+            </TremoloBar>
           <TremoloBar>
             <point time="0" pitch="-550" vibrato="0"/>
             <point time="50" pitch="-550" vibrato="0"/>
@@ -545,6 +594,11 @@
             <point time="50" pitch="200" vibrato="0"/>
             <point time="100" pitch="300" vibrato="0"/>
             </TremoloBar>
+          <TremoloBar>
+            <point time="0" pitch="0" vibrato="0"/>
+            <point time="50" pitch="200" vibrato="0"/>
+            <point time="100" pitch="300" vibrato="0"/>
+            </TremoloBar>
           <Chord>
             <lid>30</lid>
             <durationType>quarter</durationType>
@@ -556,6 +610,10 @@
               <string>1</string>
               </Note>
             </Chord>
+          <TremoloBar>
+            <point time="0" pitch="300" vibrato="0"/>
+            <point time="100" pitch="300" vibrato="0"/>
+            </TremoloBar>
           <TremoloBar>
             <point time="0" pitch="300" vibrato="0"/>
             <point time="100" pitch="300" vibrato="0"/>


### PR DESCRIPTION
As far as I can tell, the only reason bend and tremolo bar elements are not working on standard staves is that we explicitly disable them.  But the code works fine from what I can see if I remove the checks that disable it.  Only thing I needed to do on top of that is make sure they are handed properly with respect to linked staves.

It should eb noted the tremolo bar properties dialog is messed up - looks like too literal a clone of the bend properties dialog.  I didn't attempt to fix that.  See https://musescore.org/en/node/53236.  But at least changes made using this dialog will now be propagated in linked staves.