### PR TITLE
fix #56876: album load dialog confused with file open

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -822,6 +822,11 @@ QStringList MuseScore::getOpenScoreNames(const QString& filter, const QString& t
             loadScoreDialog->setAcceptMode(QFileDialog::AcceptOpen);
             loadScoreDialog->setDirectory(dir);
             }
+      else {
+            // dialog already exists, but set title and filter
+            loadScoreDialog->setWindowTitle(title);
+            loadScoreDialog->setNameFilter(filter);
+            }
 
       QStringList result;
       if (loadScoreDialog->exec())


### PR DESCRIPTION
This seems to work for me on Ubuntu.  As far as I know it shouldn't affect Windows or Mac, which would normally use the nativeDialogs code from what I can tell.