### PR TITLE
Translation issues

### DIFF
--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -284,7 +284,7 @@ AccidentalVal Accidental::subtype2value(AccidentalType st)
 
 const char* Accidental::subtype2name(AccidentalType st)
       {
-      return accList[int(st)].tag;
+      return accList[int(st)].name;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
* fix #57096: Status bar contains untranslated text for rests. Not quite sure why this is needed, but it does solve the problem
*   fix #57271: translate accidental subtypes in select dialog  