### PR TITLE
fix #57226: crash pasting chord symbols if no destination staff

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -603,6 +603,11 @@ void Score::pasteSymbols(XmlReader& e, ChordRest* dst)
                                     Measure* meas     = tick2measure(destTick);
                                     harmSegm          = meas->getSegment(Segment::Type::ChordRest, destTick);
                               }
+                              if (destTrack >= maxTrack) {
+                                    qDebug("PasteSymbols: no track for %s", tag.toUtf8().data());
+                                    e.skipCurrentElement();       // ignore
+                                    continue;
+                                    }
                               Harmony* el = new Harmony(this);
                               el->setTrack(trackZeroVoice(destTrack));
                               el->read(e);


### PR DESCRIPTION
Simple error easily corrected; the code is borrowed from the "else" clause which was already performing the proper check.  So it's only a problem for chord symbols.