### PR TITLE
plugins: allow for flag created to be unset for imported scores

### DIFF
--- a/mscore/qmlplugin.cpp
+++ b/mscore/qmlplugin.cpp
@@ -67,14 +67,21 @@ bool QmlPlugin::writeScore(Score* s, const QString& name, const QString& ext)
 
 //---------------------------------------------------------
 //   readScore
+//
+// noninteractive can be used to avoid a 'save changes'
+// dialog on closing a score that is either imported
+// or was created with an older version of MuseScore
 //---------------------------------------------------------
 
-Score* QmlPlugin::readScore(const QString& name)
+Score* QmlPlugin::readScore(const QString& name, bool noninteractive)
       {
       Score * score = msc->openScore(name);
       // tell QML not to garbage collect this score
-      if (score)
+      if (score) {
             QQmlEngine::setObjectOwnership(score, QQmlEngine::CppOwnership);
+            if (noninteractive)
+	          score->setCreated(false);
+            }
       return score;
       }
 

--- a/mscore/qmlplugin.h
+++ b/mscore/qmlplugin.h
@@ -115,7 +115,7 @@ class QmlPlugin : public QQuickItem {
       Q_INVOKABLE void cmd(const QString&);
       Q_INVOKABLE Ms::MsProcess* newQProcess();
       Q_INVOKABLE bool writeScore(Ms::Score*, const QString& name, const QString& ext);
-      Q_INVOKABLE Ms::Score* readScore(const QString& name);
+      Q_INVOKABLE Ms::Score* readScore(const QString& name, bool noninteractive = false);
       Q_INVOKABLE void closeScore(Ms::Score*);
 
       Q_INVOKABLE void log(const QString&);


### PR DESCRIPTION
This avoids a 'save changes' dialog window to come up if the plugin wants
to close a score, that is unmodified, but has been created by an older
MuseScore version or has been imported from a non .mscz/.mscx file.

This would be very useful for the batch converter plugin.
