### PR TITLE
Plugin Manual - Documentation update for classes A-D

### DIFF
--- a/libmscore/accidental.h
+++ b/libmscore/accidental.h
@@ -85,20 +85,20 @@ struct SymElement {
 
 //---------------------------------------------------------
 //   @@ Accidental
+//   @P acctype     enum  (???.NONE, .SHARP, .FLAT, .SHARP2, .FLAT2, .NATURAL, .FLAT_SLASH, .FLAT_SLASH2, .MIRRORED_FLAT2, .MIRRORED_FLAT, .MIRRORED_FLAT_SLASH, .FLAT_FLAT_SLASH, .SHARP_SLASH, .SHARP_SLASH2, .SHARP_SLASH3, .SHARP_SLASH4, .SHARP_ARROW_UP, .SHARP_ARROW_DOWN, .SHARP_ARROW_BOTH, .FLAT_ARROW_UP, .FLAT_ARROW_DOWN, .FLAT_ARROW_BOTH, .NATURAL_ARROW_UP, .NATURAL_ARROW_DOWN, .NATURAL_ARROW_BOTH, .SORI, .KORON) (read only)
 //   @P hasBracket  bool
+//   @P role        enum  (???.AUTO, .USER) (read only)
 //   @P small       bool
-//   @P acctype     enum  (NONE, SHARP, FLAT, SHARP2, FLAT2, NATURAL, ...) (read only)
-//   @P role        enum  (AUTO, USER) (read only)
 //---------------------------------------------------------
 
 class Accidental : public Element {
 
 #ifdef SCRIPT_INTERFACE
       Q_OBJECT
-      Q_PROPERTY(bool hasBracket  READ hasBracket  WRITE undoSetHasBracket)
-      Q_PROPERTY(bool small       READ small       WRITE undoSetSmall)
       Q_PROPERTY(int  accType     READ qmlAccidentalType)
+      Q_PROPERTY(bool hasBracket  READ hasBracket  WRITE undoSetHasBracket)
       Q_PROPERTY(int  role        READ qmlRole)
+      Q_PROPERTY(bool small       READ small       WRITE undoSetSmall)
 
    public:
       enum QmlAccidentalRole { AUTO, USER };

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -50,13 +50,13 @@ enum class PlayEventType : char    {
 ///    Graphic representation of a chord.
 ///    Single notes are handled as degenerated chords.
 //
-//   @P notes       array[Ms::Note]    the list of notes (read only)
-//   @P lyrics      array[Ms::Lyrics]  the list of lyrics (read only)
-//   @P graceNotes  array[Ms::Chord]   the list of grace note chords (read only)
-//   @P stem        Ms::Stem           the stem of the chord if any (read only)
-//   @P hook        Ms::Hook           the hook of the chord if any (read only)
-//   @P beam        Ms::Beam           the beam of the chord if any (read only)
-//   @P stemSlash   Ms::StemSlash      the stem slash of the chord (acciacatura) if any (read only)
+//   @P beam        Beam            the beam of the chord if any (read only)
+//   @P graceNotes  array[Chord]    the list of grace note chords (read only)
+//   @P hook        Hook            the hook of the chord if any (read only)
+//   @P lyrics      array[Lyrics]   the list of lyrics (read only)
+//   @P notes       array[Note]     the list of notes (read only)
+//   @P stem        Stem            the stem of the chord if any (read only)
+//   @P stemSlash   StemSlash       the stem slash of the chord (acciaccatura) if any (read only)
 //---------------------------------------------------------
 
 class Chord : public ChordRest {
@@ -69,12 +69,12 @@ class Chord : public ChordRest {
             bool  accidental;
             };
 
-      Q_PROPERTY(QQmlListProperty<Ms::Note> notes READ qmlNotes)
-      Q_PROPERTY(QQmlListProperty<Ms::Lyrics> lyrics READ qmlLyrics)
+      Q_PROPERTY(Ms::Beam* beam              READ beam)
       Q_PROPERTY(QQmlListProperty<Ms::Chord> graceNotes READ qmlGraceNotes)
       Q_PROPERTY(Ms::Hook* hook              READ hook)
+      Q_PROPERTY(QQmlListProperty<Ms::Lyrics> lyrics READ qmlLyrics)
+      Q_PROPERTY(QQmlListProperty<Ms::Note> notes READ qmlNotes)
       Q_PROPERTY(Ms::Stem* stem              READ stem)
-      Q_PROPERTY(Ms::Beam* beam              READ beam)
       Q_PROPERTY(Ms::StemSlash* stemSlash    READ stemSlash)
 
       QList<Note*>         _notes;       // sorted to decreasing line step
@@ -178,7 +178,9 @@ class Chord : public ChordRest {
       bool underBeam() const;
       Hook* hook() const                     { return _hook; }
 
+      //@ add an element to the Chord
       Q_INVOKABLE virtual void add(Ms::Element*);
+      //@ remove the element from the Chord
       Q_INVOKABLE virtual void remove(Ms::Element*);
 
       Note* selectedNote() const;

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -41,15 +41,15 @@ class Spanner;
 //   @@ ChordRest
 ///    Virtual base class. Chords and rests can be part of a beam
 //
+//   @P beamMode      enum (Beam.AUTO, .BEGIN, .MID, .END, .NONE, .BEGIN32, .BEGIN64, .INVALID)
 //   @P durationType  int
-//   @P beamMode      Ms::Beam::Mode (AUTO, BEGIN, MID, END, NONE, BEGIN32, BEGIN64, INVALID)
 //   @P small         bool           small chord/rest
 //-------------------------------------------------------------------
 
 class ChordRest : public DurationElement {
       Q_OBJECT
-      Q_PROPERTY(int            durationType  READ durationTypeTicks  WRITE setDurationType)
       Q_PROPERTY(Ms::Beam::Mode beamMode      READ beamMode           WRITE undoSetBeamMode)
+      Q_PROPERTY(int            durationType  READ durationTypeTicks  WRITE setDurationType)
       Q_PROPERTY(bool           small         READ small              WRITE undoSetSmall)
 
       TDuration _durationType;

--- a/libmscore/clef.h
+++ b/libmscore/clef.h
@@ -111,8 +111,8 @@ class ClefInfo {
 //   @@ Clef
 ///    Graphic representation of a clef.
 //
-//   @P showCourtesy  bool
-//   @P small         bool  set by layout (read only)
+//   @P showCourtesy  bool    show/hide courtesy clef when applicable
+//   @P small         bool    small, mid-staff clef (read only, set by layout)
 //---------------------------------------------------------
 
 class Clef : public Element {

--- a/libmscore/dynamic.h
+++ b/libmscore/dynamic.h
@@ -25,7 +25,7 @@ class Segment;
 //   @@ Dynamic
 ///    dynamics marker; determines midi velocity
 //
-//   @P range  Ms::Dynamic::Range (STAFF, PART, SYSTEM)
+//   @P range  enum (Dynamic.STAFF, .PART, .SYSTEM)
 //-----------------------------------------------------------------------------
 
 class Dynamic : public Text {


### PR DESCRIPTION
Updates the documentation for classes named from A to D to proposal A) in http://dev-list.musescore.org/Plugin-documentation-generated-manual-td7579164.html

Properties are also sorted in alphabetical order for easier identification.

No attempt made to evaluate what to include and what to exclude from documentation: anything which is currently documented is retained. Case by case decisions can always be made.

Note that `enum`s for `Accidental` are not final, as current situation does not seem to work in plug-ins.