### PR TITLE
Plugin Manual - Documentation update for classes M-P

### DIFF
--- a/libmscore/marker.h
+++ b/libmscore/marker.h
@@ -21,8 +21,8 @@ namespace Ms {
 //---------------------------------------------------------
 //   @@ Marker
 //
-//   @P label       QString
-//   @P markerType  Ms::Marker::Type  (SEGNO, VARSEGNO, CODA, VARCODA, CODETTA, FINE, TOCODA, USER)
+//   @P label       string
+//   @P markerType  enum (Marker.CODA, .CODETTA, .FINE, .SEGNO, .TOCODA, .USER, .VARCODA, .VARSEGNO)
 //---------------------------------------------------------
 
 class Marker : public Text {

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -106,8 +106,8 @@ enum class MeasureNumberMode : char {
 //   @@ Measure
 ///    one measure in a system
 //
-//   @P firstSegment    Ms::Segment       the first segment of the measure (read-only)
-//   @P lastSegment     Ms::Segment       the last segment of the measure (read-only)
+//   @P firstSegment    Segment       the first segment of the measure (read-only)
+//   @P lastSegment     Segment       the last segment of the measure (read-only)
 //---------------------------------------------------------
 
 class Measure : public MeasureBase {

--- a/libmscore/measurebase.h
+++ b/libmscore/measurebase.h
@@ -31,12 +31,12 @@ class Measure;
 //   @@ MeasureBase
 ///    Virtual base class for Measure, HBox and VBox
 //
-//   @P lineBreak       bool              true if a system break is positioned on this measure
-//   @P nextMeasure     Ms::Measure       the next Measure (read-only)
-//   @P nextMeasureMM   Ms::Measure       the next multi-measure rest Measure (read-only)
-//   @P pageBreak       bool              true if a page break is positioned on this measure
-//   @P prevMeasure     Ms::Measure       the previous Measure (read-only)
-//   @P prevMeasureMM   Ms::Measure       the previous multi-measure rest Measure (read-only)
+//   @P lineBreak       bool        true if a system break is positioned on this measure
+//   @P nextMeasure     Measure     the next Measure (read-only)
+//   @P nextMeasureMM   Measure     the next multi-measure rest Measure (read-only)
+//   @P pageBreak       bool        true if a page break is positioned on this measure
+//   @P prevMeasure     Measure     the previous Measure (read-only)
+//   @P prevMeasureMM   Measure     the previous multi-measure rest Measure (read-only)
 //---------------------------------------------------------
 
 class MeasureBase : public Element {

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -115,66 +115,67 @@ struct NoteVal {
 //   @@ Note
 ///    Graphic representation of a note.
 //
-//   @P subchannel       int                     midi subchannel (for midi articulation) (read only)
-//   @P line             int                     notehead position (read only)
-//   @P fret             int                     fret number in tablature
-//   @P string           int                     string number in tablature
-//   @P tpc              int                     tonal pitch class, as per concert pitch setting
-//   @P tpc1             int                     tonal pitch class, non transposed
-//   @P tpc2             int                     tonal pitch class, transposed
-//   @P pitch            int                     midi pitch
-//   @P ppitch           int                     actual played midi pitch (honoring ottavas) (read only)
-//   @P ghost            bool                    ghost note (guitar: death note)
-//   @P hidden           bool                    hidden, not played note (read only)
-//   @P mirror           bool                    mirror note head on x axis (read only)
-//   @P small            bool                    small note head
-//   @P play             bool                    play note
-//   @P tuning           qreal                   tuning offset in cent
-//   @P veloType         Ms::Note::ValueType     (OFFSET_VAL, USER_VAL)
+//   @P accidental       Accidental       note accidental (null if none)
+//   @P accidentalType   int              note accidental type
+//   @P dots             array[NoteDot]   list of note dots (some can be null, read only)
+//   @P dotsCount        int              number of note dots (read only)
+//   @P elements         array[Element]   list of elements attached to note head
+//   @P fret             int              fret number in tablature
+//   @P ghost            bool             ghost note (guitar: death note)
+//   @P headGroup        enum (NoteHead.HEAD_NORMAL, .HEAD_BREVIS_ALT, .HEAD_CROSS, .HEAD_DIAMOND, .HEAD_DO, .HEAD_FA, .HEAD_LA, .HEAD_MI, .HEAD_RE, .HEAD_SLASH, .HEAD_SOL, .HEAD_TI, .HEAD_XCIRCLE, .HEAD_TRIANGLE)
+//   @P headType         enum (NoteHead.HEAD_AUTO, .HEAD_BREVIS, .HEAD_HALF, .HEAD_QUARTER, .HEAD_WHOLE)
+//   @P hidden           bool             hidden, not played note (read only)
+//   @P line             int              notehead position (read only)
+//   @P mirror           bool             mirror note head on x axis (read only)
+//   @P pitch            int              midi pitch
+//   @P play             bool             play note
+//   @P ppitch           int              actual played midi pitch (honoring ottavas) (read only)
+//   @P small            bool             small note head
+//   @P string           int              string number in tablature
+//   @P subchannel       int              midi subchannel (for midi articulation) (read only)
+//   @P tieBack          Tie              note backward tie (null if none, read only)
+//   @P tieFor           Tie              note forward tie (null if none, read only)
+//   @P tpc              int              tonal pitch class, as per concert pitch setting
+//   @P tpc1             int              tonal pitch class, non transposed
+//   @P tpc2             int              tonal pitch class, transposed
+//   @P tuning           float            tuning offset in cent
+//   @P userDotPosition  enum (Direction.AUTO, Direction.DOWN, Direction.UP)
+//   @P userMirror       enum (DirectionH.AUTO, DirectionH.LEFT, DirectionH.RIGHT)
 //   @P veloOffset       int
-//   @P userMirror       MScore::DirectionH      (AUTO, LEFT, RIGHT)
-//   @P userDotPosition  MScore::Direction       (AUTO, UP, DOWN)
-//   @P headGroup        NoteHead::Group         (HEAD_NORMAL, HEAD_CROSS, HEAD_DIAMOND, HEAD_TRIANGLE, HEAD_MI, HEAD_SLASH, HEAD_XCIRCLE, HEAD_DO, HEAD_RE, HEAD_FA, HEAD_LA, HEAD_TI, HEAD_SOL, HEAD_BREVIS_ALT)
-//   @P headType         NoteHead::Type          (HEAD_AUTO, HEAD_WHOLE, HEAD_HALF, HEAD_QUARTER, HEAD_BREVIS)
-//   @P elements         array[Ms::Element]      list of elements attached to note head
-//   @P accidental       Accidental              note accidental (null if none)
-//   @P accidentalType   MScore::AccidentalType  note accidental type
-//   @P dots             array[Ms::NoteDot]      list of note dots (some can be null, read only)
-//   @P dotsCount        int                     number of note dots (read only)
-//   @P tieFor           Ms::Tie                 note forward tie (null if none, read only)
-//   @P tieBack          Ms::Tie                 note backward tie (null if none, read only)
+//   @P veloType         enum (Note.OFFSET_VAL, Note.USER_VAL)
 //---------------------------------------------------------------------------------------
 
 class Note : public Element {
       Q_OBJECT
-      Q_PROPERTY(int subchannel                          READ subchannel)
-      Q_PROPERTY(int line                                READ line)
-      Q_PROPERTY(int fret                                READ fret             WRITE undoSetFret)
-      Q_PROPERTY(int string                              READ string           WRITE undoSetString)
-      Q_PROPERTY(int tpc                                 READ tpc)
-      Q_PROPERTY(int tpc1                                READ tpc1             WRITE undoSetTpc1)
-      Q_PROPERTY(int tpc2                                READ tpc2             WRITE undoSetTpc2)
-      Q_PROPERTY(int pitch                               READ pitch            WRITE undoSetPitch)
-      Q_PROPERTY(int ppitch                              READ ppitch)
-      Q_PROPERTY(bool ghost                              READ ghost            WRITE undoSetGhost)
-      Q_PROPERTY(bool hidden                             READ hidden)
-      Q_PROPERTY(bool mirror                             READ mirror)
-      Q_PROPERTY(bool small                              READ small            WRITE undoSetSmall)
-      Q_PROPERTY(bool play                               READ play             WRITE undoSetPlay)
-      Q_PROPERTY(qreal tuning                            READ tuning           WRITE undoSetTuning)
-      Q_PROPERTY(Ms::Note::ValueType veloType            READ veloType         WRITE undoSetVeloType)
-      Q_PROPERTY(int veloOffset                          READ veloOffset       WRITE undoSetVeloOffset)
-      Q_PROPERTY(Ms::MScore::DirectionH userMirror       READ userMirror       WRITE undoSetUserMirror)
-      Q_PROPERTY(Ms::MScore::Direction userDotPosition   READ userDotPosition  WRITE undoSetUserDotPosition)
-      Q_PROPERTY(Ms::NoteHead::Group headGroup           READ headGroup        WRITE undoSetHeadGroup)
-      Q_PROPERTY(Ms::NoteHead::Type headType             READ headType         WRITE undoSetHeadType)
-      Q_PROPERTY(QQmlListProperty<Ms::Element> elements  READ qmlElements)
-      Q_PROPERTY(Ms::Accidental* accidental              READ accidental)
-      Q_PROPERTY(int accidentalType                      READ qmlAccidentalType WRITE qmlSetAccidentalType)
-      Q_PROPERTY(QQmlListProperty<Ms::NoteDot> dots      READ qmlDots)
-      Q_PROPERTY(int dotsCount                           READ qmlDotsCount)
-      Q_PROPERTY(Ms::Tie* tieFor                         READ tieFor)
-      Q_PROPERTY(Ms::Tie* tieBack                        READ tieBack)
+      Q_PROPERTY(Ms::Accidental*                accidental        READ accidental)
+      Q_PROPERTY(int                            accidentalType    READ qmlAccidentalType  WRITE qmlSetAccidentalType)
+      Q_PROPERTY(QQmlListProperty<Ms::NoteDot>  dots              READ qmlDots)
+      Q_PROPERTY(int                            dotsCount         READ qmlDotsCount)
+      Q_PROPERTY(QQmlListProperty<Ms::Element>  elements          READ qmlElements)
+      Q_PROPERTY(int                            fret              READ fret               WRITE undoSetFret)
+      Q_PROPERTY(bool                           ghost             READ ghost              WRITE undoSetGhost)
+      Q_PROPERTY(Ms::NoteHead::Group            headGroup         READ headGroup          WRITE undoSetHeadGroup)
+      Q_PROPERTY(Ms::NoteHead::Type             headType          READ headType           WRITE undoSetHeadType)
+      Q_PROPERTY(bool                           hidden            READ hidden)
+      Q_PROPERTY(int                            line              READ line)
+      Q_PROPERTY(bool                           mirror            READ mirror)
+      Q_PROPERTY(int                            pitch             READ pitch              WRITE undoSetPitch)
+      Q_PROPERTY(bool                           play              READ play               WRITE undoSetPlay)
+      Q_PROPERTY(int                            ppitch            READ ppitch)
+      Q_PROPERTY(bool                           small             READ small              WRITE undoSetSmall)
+      Q_PROPERTY(int                            string            READ string             WRITE undoSetString)
+      Q_PROPERTY(int                            subchannel        READ subchannel)
+      Q_PROPERTY(Ms::Tie*                       tieBack           READ tieBack)
+      Q_PROPERTY(Ms::Tie*                       tieFor            READ tieFor)
+      Q_PROPERTY(int                            tpc               READ tpc)
+      Q_PROPERTY(int                            tpc1              READ tpc1               WRITE undoSetTpc1)
+      Q_PROPERTY(int                            tpc2              READ tpc2               WRITE undoSetTpc2)
+      Q_PROPERTY(qreal                          tuning            READ tuning             WRITE undoSetTuning)
+      Q_PROPERTY(Ms::MScore::Direction          userDotPosition   READ userDotPosition    WRITE undoSetUserDotPosition)
+      Q_PROPERTY(Ms::MScore::DirectionH         userMirror        READ userMirror         WRITE undoSetUserMirror)
+      Q_PROPERTY(int                            veloOffset        READ veloOffset         WRITE undoSetVeloOffset)
+      Q_PROPERTY(Ms::Note::ValueType            veloType          READ veloType           WRITE undoSetVeloType)
+
       Q_ENUMS(ValueType)
       Q_ENUMS(Ms::MScore::Direction)
       Q_ENUMS(Ms::MScore::DirectionH)

--- a/libmscore/ottava.h
+++ b/libmscore/ottava.h
@@ -54,7 +54,7 @@ class OttavaSegment : public TextLineSegment {
 
 //---------------------------------------------------------
 //   @@ Ottava
-//   @P ottavaType  Ms::Ottava::Type  (OTTAVA_8VA, OTTAVA_15MA, OTTAVA_8VB, OTTAVA_15MB, OTTAVA_22MA, OTTAVA_22MB)
+//   @P ottavaType  enum (Ottava.OTTAVA_8VA, .OTTAVA_8VB, .OTTAVA_15MA, .OTTAVA_15MB, .OTTAVA_22MA, .OTTAVA_22MB)
 //---------------------------------------------------------
 
 class Ottava : public TextLine {

--- a/libmscore/page.h
+++ b/libmscore/page.h
@@ -42,28 +42,28 @@ extern const PaperSize* getPaperSize(const qreal wi, const qreal hi);
 
 //---------------------------------------------------------
 //   @@ PageFormat
-//   @P size              QSizeF  paper size in inch
-//   @P printableWidth    qreal
-//   @P evenLeftMargin    qreal
-//   @P oddLeftMargin     qreal
-//   @P eventTopMargin    qreal
-//   @P oddTopMargin      qreal
-//   @P evenBottomMargin  qreal
-//   @P oddBottomMargin   qreal
+//   @P evenBottomMargin  float
+//   @P evenLeftMargin    float
+//   @P eventTopMargin    float
+//   @P oddBottomMargin   float
+//   @P oddLeftMargin     float
+//   @P oddTopMargin      float
+//   @P printableWidth    float
+//   @P size              size  paper size in inch
 //   @P twosided          bool
 //---------------------------------------------------------
 
 #ifdef SCRIPT_INTERFACE
 class PageFormat : public QObject {
       Q_OBJECT
-      Q_PROPERTY(QSizeF size             READ size             WRITE setSize)
-      Q_PROPERTY(qreal  printableWidth   READ printableWidth   WRITE setPrintableWidth  )
-      Q_PROPERTY(qreal  evenLeftMargin   READ evenLeftMargin   WRITE setEvenLeftMargin  )
-      Q_PROPERTY(qreal  oddLeftMargin    READ oddLeftMargin    WRITE setOddLeftMargin   )
-      Q_PROPERTY(qreal  evenTopMargin    READ evenTopMargin    WRITE setEvenTopMargin  )
-      Q_PROPERTY(qreal  oddTopMargin     READ oddTopMargin     WRITE setOddTopMargin    )
       Q_PROPERTY(qreal  evenBottomMargin READ evenBottomMargin WRITE setEvenBottomMargin)
+      Q_PROPERTY(qreal  evenLeftMargin   READ evenLeftMargin   WRITE setEvenLeftMargin  )
+      Q_PROPERTY(qreal  evenTopMargin    READ evenTopMargin    WRITE setEvenTopMargin  )
       Q_PROPERTY(qreal  oddBottomMargin  READ oddBottomMargin  WRITE setOddBottomMargin )
+      Q_PROPERTY(qreal  oddLeftMargin    READ oddLeftMargin    WRITE setOddLeftMargin   )
+      Q_PROPERTY(qreal  oddTopMargin     READ oddTopMargin     WRITE setOddTopMargin    )
+      Q_PROPERTY(qreal  printableWidth   READ printableWidth   WRITE setPrintableWidth  )
+      Q_PROPERTY(QSizeF size             READ size             WRITE setSize)
       Q_PROPERTY(bool   twosided         READ twosided         WRITE setTwosided        )
 #else
 class PageFormat {

--- a/libmscore/part.h
+++ b/libmscore/part.h
@@ -26,38 +26,43 @@ class InstrumentTemplate;
 
 //---------------------------------------------------------
 //   @@ Part
-//   @P partName   QString  name of the part, used in the mixer
-//   @P show       bool     check/set whether or not a part is shown
-//   @P longName   QString
-//   @P shortName  QString
-//   @P volume     int
-//   @P mute       bool
-//   @P endTrack   int      (read only)
-//   @P startTrack int      (read only)
-//   @  midiProgram int     (read only)
-//   @  midiChannel int     (read only)
-//   @  instrumentId string (read only)
+//   @P endTrack        int         (read only)
+//   @P harmonyCount    int         (read only)
+//   @P hasDrumStaff    bool        (read only)
+//   @P hasPitchedStaff bool        (read only)
+//   @P hasTabStaff     bool        (read only)
+//   @P instrumentId    string      (read only)
+//   @P longName        string
+//   @P lyricCount      int         (read only)
+//   @P midiChannel     int         (read only)
+//   @P midiProgram     int         (read only)
+//   @P mute            bool
+//   @P partName        string      name of the part, used in the mixer
+//   @P shortName       string
+//   @P show            bool        check/set whether or not a part is shown
+//   @P startTrack      int         (read only)
+//   @P volume          int
 //---------------------------------------------------------
 
 class Part : public QObject, public ScoreElement {
       Q_OBJECT
 
-      Q_PROPERTY(QString partName READ partName WRITE setPartName)
-      Q_PROPERTY(bool show READ show WRITE setShow)
-      Q_PROPERTY(QString longName READ longName WRITE setLongName)
-      Q_PROPERTY(QString shortName READ shortName WRITE setShortName)
-      Q_PROPERTY(int volume READ volume WRITE setVolume)
-      Q_PROPERTY(bool mute READ mute WRITE setMute)
-      Q_PROPERTY(int endTrack READ endTrack)
-      Q_PROPERTY(int startTrack READ startTrack)
-      Q_PROPERTY(int midiProgram READ midiProgram)
-      Q_PROPERTY(int midiChannel READ midiChannel)
-      Q_PROPERTY(QString instrumentId READ instrumentId)
-      Q_PROPERTY(int lyricCount READ lyricCount)
-      Q_PROPERTY(int harmonyCount READ harmonyCount)
-      Q_PROPERTY(bool hasTabStaff READ hasTabStaff)
-      Q_PROPERTY(bool hasPitchedStaff READ hasPitchedStaff)
-      Q_PROPERTY(bool hasDrumStaff READ hasDrumStaff)
+      Q_PROPERTY(int          endTrack          READ endTrack)
+      Q_PROPERTY(int          harmonyCount      READ harmonyCount)
+      Q_PROPERTY(bool         hasDrumStaff      READ hasDrumStaff)
+      Q_PROPERTY(bool         hasPitchedStaff   READ hasPitchedStaff)
+      Q_PROPERTY(bool         hasTabStaff       READ hasTabStaff)
+      Q_PROPERTY(QString      instrumentId      READ instrumentId)
+      Q_PROPERTY(QString      longName          READ longName     WRITE setLongName)
+      Q_PROPERTY(int          lyricCount        READ lyricCount)
+      Q_PROPERTY(int          midiChannel       READ midiChannel)
+      Q_PROPERTY(int          midiProgram       READ midiProgram)
+      Q_PROPERTY(bool         mute              READ mute         WRITE setMute)
+      Q_PROPERTY(QString      partName          READ partName     WRITE setPartName)
+      Q_PROPERTY(QString      shortName         READ shortName    WRITE setShortName)
+      Q_PROPERTY(bool         show              READ show         WRITE setShow)
+      Q_PROPERTY(int          startTrack        READ startTrack)
+      Q_PROPERTY(int          volume            READ volume       WRITE setVolume)
 
       QString _partName;           ///< used in tracklist (mixer)
       InstrumentList _instruments;

--- a/libmscore/plugins.h
+++ b/libmscore/plugins.h
@@ -24,7 +24,7 @@ namespace Ms {
 
 //---------------------------------------------------------
 //   @@ FileIO
-//   @P source QString
+//   @P source string
 //---------------------------------------------------------
 
 class FileIO : public QObject {
@@ -37,11 +37,17 @@ class FileIO : public QObject {
                NOTIFY sourceChanged)
       explicit FileIO(QObject *parent = 0);
 
+      //@ reads file contents and returns a string
       Q_INVOKABLE QString read();
+      //@ return true if the file exists
       Q_INVOKABLE bool exists();
+      //@ write a string to the file
       Q_INVOKABLE bool write(const QString& data);
+      //@ removes the file
       Q_INVOKABLE bool remove();
+      //@ returns a path suitable for a temporary file
       Q_INVOKABLE QString tempPath() {QDir dir; return dir.tempPath();};
+      //@ returns the file modification time
       Q_INVOKABLE int modifiedTime();
 
       QString source() { return mSource; };
@@ -69,8 +75,11 @@ class MsProcess : public QProcess {
       MsProcess(QObject* parent = 0) : QProcess(parent) {}
 
    public slots:
+      //@ --
       Q_INVOKABLE void start(const QString& program)      { QProcess::start(program); }
+      //@ --
       Q_INVOKABLE bool waitForFinished(int msecs = 30000) { return QProcess::waitForFinished(msecs); }
+      //@ --
       Q_INVOKABLE QByteArray readAllStandardOutput()      { return QProcess::readAllStandardOutput(); }
       };
 
@@ -78,8 +87,8 @@ class MsProcess : public QProcess {
 //   @@ ScoreView
 ///    This is an GUI element to show a score.
 //
-//   @P color  QColor  background color
-//   @P scale  qreal   scaling factor
+//   @P color  color    background color
+//   @P scale  float    scaling factor
 //---------------------------------------------------------
 
 class MsScoreView : public QQuickPaintedItem, public MuseScoreView {
@@ -119,9 +128,13 @@ class MsScoreView : public QQuickPaintedItem, public MuseScoreView {
       virtual void drawBackground(QPainter*, const QRectF&) const {}
 
    public slots:
+      //@ --
       Q_INVOKABLE void setScore(Score*);
+      //@ --
       Q_INVOKABLE void setCurrentPage(int n);
+      //@ --
       Q_INVOKABLE void nextPage();
+      //@ --
       Q_INVOKABLE void prevPage();
 
    public:


### PR DESCRIPTION
Updates the documentation for classes named from M to P to proposal A) in http://dev-list.musescore.org/Plugin-documentation-generated-manual-td7579164.html

Properties are also sorted in alphabetical order for easier identification.

No attempt made to evaluate what to include and what to exclude from documentation: anything which is currently documented is retained. Case by case decisions can always be made.

Description of methods for `QProcess` and `ScoreView` (in file libmscore/plugins.h) are stubs.