### PR TITLE
Plugin Manual - Documentation update for classes S-Z

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -229,55 +229,57 @@ enum class PasteStatus : char {
 
 //---------------------------------------------------------
 //   @@ Score
-//   @P firstMeasure    Ms::Measure       the first measure of the score (read only)
-//   @P firstMeasureMM  Ms::Measure       the first multi-measure rest measure of the score (read only)
-//   @P lastMeasure     Ms::Measure       the last measure of the score (read only)
-//   @P lastMeasureMM   Ms::Measure       the last multi-measure rest measure of the score (read only)
-//   @P lastSegment     Ms::Segment       the last score segment (read-only)
-//   @P name            QString           name of the score
+//   @P composer        string            composer of the score (read only)
+//   @P duration        int               duration of score in seconds (read only)
+//   @P excerpts        array[Excerpt]    the list of the excerpts (linked parts)
+//   @P firstMeasure    Measure           the first measure of the score (read only)
+//   @P firstMeasureMM  Measure           the first multi-measure rest measure of the score (read only)
+//   @P harmonyCount    int               number of harmony items (read only)
+//   @P hasHarmonies    bool              score has chord symbols (read only)
+//   @P hasLyrics       bool              score has lyrics (read only)
+//   @P keysig          int               key signature at the start of the score (read only)
+//   @P lastMeasure     Measure           the last measure of the score (read only)
+//   @P lastMeasureMM   Measure           the last multi-measure rest measure of the score (read only)
+//   @P lastSegment     Segment           the last score segment (read-only)
+//   @P lyricCount      int               number of lyric items (read only)
+//   @P name            string            name of the score
+//   @P nmeasures       int               number of measures (read only)
 //   @P npages          int               number of pages (read only)
 //   @P nstaves         int               number of staves (read only)
 //   @P ntracks         int               number of tracks (staves * 4) (read only)
-//   @P nmeasures       int               number of measures (read only)
-//   @P parts           array[Ms::Part]   the list of parts (read only)
-//   @P title           QString           title of the score (read only)
-//   @P subtitle        QString           subtitle of the score (read only)
-//   @P composer        QString           composer of the score (read only)
-//   @P poet            QString           poet of the score (read only)
-//   @P hasLyrics       bool              score has lyrics (read only)
-//   @P hasHarmonies    bool              score has chord symbols (read only)
-//   @P lyricCount      int               number of lyric item (read only)
-//   @P harmonyCount    int               number of harmony item (read only)
-//   @P keysig          int               key signature at the start of the score (read only)
-//   @P duration        int               duration of score in seconds (read only)
-//   @P excerpts        array[Ms::Excerpt] the list of the excerpts (linked parts)
+// not to be documented?
+//   @  pageFormat      PageFormat        the page format for the score
+//   @P parts           array[Part]       the list of parts (read only)
+//   @P poet            string            poet of the score (read only)
+//   @P subtitle        string            subtitle of the score (read only)
+//   @P title           string            title of the score (read only)
 //---------------------------------------------------------
 
 class Score : public QObject {
       Q_OBJECT
-      Q_PROPERTY(Ms::Measure*           firstMeasure      READ firstMeasure)
-      Q_PROPERTY(Ms::Measure*           firstMeasureMM    READ firstMeasureMM)
-      Q_PROPERTY(Ms::Measure*           lastMeasure       READ lastMeasure)
-      Q_PROPERTY(Ms::Measure*           lastMeasureMM     READ lastMeasureMM)
-      Q_PROPERTY(Ms::Segment*           lastSegment       READ lastSegment)
-      Q_PROPERTY(QString                name              READ name           WRITE setName)
-      Q_PROPERTY(int                    npages            READ npages)
-      Q_PROPERTY(int                    nstaves           READ nstaves)
-      Q_PROPERTY(int                    ntracks           READ ntracks)
-      Q_PROPERTY(int                    nmeasures         READ nmeasures)
-      Q_PROPERTY(QQmlListProperty<Ms::Part> parts     READ qmlParts)
-      Q_PROPERTY(QString                title             READ title)
-      Q_PROPERTY(QString                subtitle          READ subtitle)
-      Q_PROPERTY(QString                composer          READ composer)
-      Q_PROPERTY(QString                poet              READ poet)
-      Q_PROPERTY(bool                   hasLyrics         READ hasLyrics)
-      Q_PROPERTY(bool                   hasHarmonies      READ hasHarmonies)
-      Q_PROPERTY(int                    lyricCount        READ lyricCount)
-      Q_PROPERTY(int                    harmonyCount      READ harmonyCount)
-      Q_PROPERTY(int                    keysig            READ keysig)
-      Q_PROPERTY(int                    duration          READ duration)
-      Q_PROPERTY(QQmlListProperty<Ms::Excerpt> excerpts   READ qmlExcerpts)
-      Q_PROPERTY(Ms::PageFormat*        pageFormat        READ pageFormat     WRITE undoChangePageFormat)
+      Q_PROPERTY(QString                        composer          READ composer)
+      Q_PROPERTY(int                            duration          READ duration)
+      Q_PROPERTY(QQmlListProperty<Ms::Excerpt>  excerpts          READ qmlExcerpts)
+      Q_PROPERTY(Ms::Measure*                   firstMeasure      READ firstMeasure)
+      Q_PROPERTY(Ms::Measure*                   firstMeasureMM    READ firstMeasureMM)
+      Q_PROPERTY(int                            harmonyCount      READ harmonyCount)
+      Q_PROPERTY(bool                           hasHarmonies      READ hasHarmonies)
+      Q_PROPERTY(bool                           hasLyrics         READ hasLyrics)
+      Q_PROPERTY(int                            keysig            READ keysig)
+      Q_PROPERTY(Ms::Measure*                   lastMeasure       READ lastMeasure)
+      Q_PROPERTY(Ms::Measure*                   lastMeasureMM     READ lastMeasureMM)
+      Q_PROPERTY(Ms::Segment*                   lastSegment       READ lastSegment)
+      Q_PROPERTY(int                            lyricCount        READ lyricCount)
+      Q_PROPERTY(QString                        name              READ name           WRITE setName)
+      Q_PROPERTY(int                            nmeasures         READ nmeasures)
+      Q_PROPERTY(int                            npages            READ npages)
+      Q_PROPERTY(int                            nstaves           READ nstaves)
+      Q_PROPERTY(int                            ntracks           READ ntracks)
+      Q_PROPERTY(Ms::PageFormat*                pageFormat        READ pageFormat     WRITE undoChangePageFormat)
+      Q_PROPERTY(QQmlListProperty<Ms::Part>     parts             READ qmlParts)
+      Q_PROPERTY(QString                        poet              READ poet)
+      Q_PROPERTY(QString                        subtitle          READ subtitle)
+      Q_PROPERTY(QString                        title             READ title)
 
    public:
       enum class FileError : char {
@@ -632,7 +634,9 @@ class Score : public QObject {
       void repitchNote(const Position& pos, bool replace);
       void cmdAddPitch(int pitch, bool addFlag);
 
+      //@ to be used at least once by plugins of type "dialog" before score modifications to make them undoable
       Q_INVOKABLE void startCmd();        // start undoable command
+      //@ to be used at least once by plugins of type "dialog" after score modifications to make them undoable
       Q_INVOKABLE void endCmd(bool rollback = false);          // end undoable command
       void end();             // layout & update canvas
       void end1();
@@ -843,6 +847,7 @@ class Score : public QObject {
       RepeatList* repeatList() const;
       qreal utick2utime(int tick) const;
       int utime2utick(qreal utime) const;
+      //@ ??
       Q_INVOKABLE void updateRepeatList(bool expandRepeats);
 
       void nextInputPos(ChordRest* cr, bool);
@@ -870,6 +875,7 @@ class Score : public QObject {
       Ms::Measure* lastMeasureMM() const;
       MeasureBase* measure(int idx) const;
 
+      //@ returns the first segment of the score of the given type (use Segment.Clef, ... enum)
       Q_INVOKABLE Ms::Segment* firstSegment(Segment::Type s = Segment::Type::All) const;
       Ms::Segment* firstSegmentMM(Segment::Type s = Segment::Type::All) const;
       Ms::Segment* lastSegment() const;
@@ -904,6 +910,7 @@ class Score : public QObject {
       void removeAudio();
       void enqueueMidiEvent(MidiInputEvent ev) { midiInputQueue.enqueue(ev); }
 
+      //@ ??
       Q_INVOKABLE void doLayout();
       void layoutSystems();
       void layoutSystems2();
@@ -939,7 +946,9 @@ class Score : public QObject {
       QMap<QString, QString>& metaTags()               { return _metaTags; }
       void setMetaTags(const QMap<QString,QString>& t) { _metaTags = t; }
 
-      Q_INVOKABLE QString metaTag(const QString& s) const;
+      //@ returns as a string the metatag named 'tag'
+      Q_INVOKABLE QString metaTag(const QString& tag) const;
+      //@ sets the metatag named 'tag' to 'val'
       Q_INVOKABLE void setMetaTag(const QString& tag, const QString& val);
 
       QMap<int, LinkedElements*>& links();
@@ -1002,10 +1011,14 @@ class Score : public QObject {
       QList<Score*> scoreList();
       bool switchLayer(const QString& s);
       void layoutPage(const PageContext&,  qreal);
+      //@ appends to the score a named part as last part
       Q_INVOKABLE void appendPart(const QString&);
+      //@ appends to the score a number of measures
       Q_INVOKABLE void appendMeasures(int);
 #ifdef SCRIPT_INTERFACE
+      //@ ??
       Q_INVOKABLE void addText(const QString&, const QString&);
+      //@ creates and returns a cursor to be used to navigate the score
       Q_INVOKABLE Ms::Cursor* newCursor();
 #endif
       qreal computeMinWidth(Segment* fs, bool firstMeasureInSystem);
@@ -1077,6 +1090,7 @@ class Score : public QObject {
       QString createRehearsalMarkText(RehearsalMark* current) const;
       QString nextRehearsalMarkText(RehearsalMark* previous, RehearsalMark* current) const;
 
+      //@ ??
       Q_INVOKABLE void cropPage(qreal margins);
       bool sanityCheck(const QString& name = nullptr);
 

--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -36,13 +36,13 @@ class System;
 ///    A segment holds all vertical aligned staff elements.
 ///    Segments are typed and contain only Elements of the same type.
 //
-//   @P next            Ms::Segment       the next segment in the whole score; null at last score segment (read-only)
-//   @P nextInMeasure   Ms::Segment       the next segment in measure; null at last measure segment (read-only)
-//   @P prev            Ms::Segment       the previous segment in the whole score; null at first score segment (read-only)
-//   @P prevInMeasure   Ms::Segment       the previous segment in measure; null at first measure segment (read-only)
-//   @P segmentType     Ms::Segment::Type (Invalid, Clef, KeySig, Ambitus, TimeSig, StartRepeatBarLine, BarLine, ChordRest, Breath, EndBarLine TimeSigAnnounce, KeySigAnnounce, All)
+//   @P annotations     array[Element]    the list of annotations (read only)
+//   @P next            Segment           the next segment in the whole score; null at last score segment (read-only)
+//   @P nextInMeasure   Segment           the next segment in measure; null at last measure segment (read-only)
+//   @P prev            Segment           the previous segment in the whole score; null at first score segment (read-only)
+//   @P prevInMeasure   Segment           the previous segment in measure; null at first measure segment (read-only)
+//   @P segmentType     enum (Segment.All, .Ambitus, .BarLine, .Breath, .ChordRest, .Clef, .EndBarLine, .Invalid, .KeySig, .KeySigAnnounce, .StartRepeatBarLine, .TimeSig, .TimeSigAnnounce)
 //   @P tick            int               midi tick position (read only)
-//   @P annotations     array[Ms::Element] the list of annotations (read only)
 //------------------------------------------------------------------------
 
 /**
@@ -57,13 +57,13 @@ class System;
 
 class Segment : public Element {
       Q_OBJECT
+      Q_PROPERTY(QQmlListProperty<Ms::Element> annotations READ qmlAnnotations)
       Q_PROPERTY(Ms::Segment*       next              READ next1)
       Q_PROPERTY(Ms::Segment*       nextInMeasure     READ next)
       Q_PROPERTY(Ms::Segment*       prev              READ prev1)
       Q_PROPERTY(Ms::Segment*       prevInMeasure     READ prev)
       Q_PROPERTY(Ms::Segment::Type  segmentType       READ segmentType WRITE setSegmentType)
       Q_PROPERTY(int                tick              READ tick)
-      Q_PROPERTY(QQmlListProperty<Ms::Element> annotations READ qmlAnnotations)
       Q_ENUMS(Type)
 
 public:
@@ -139,6 +139,7 @@ public:
 
       Ms::Element* element(int track) const { return _elist.value(track);  }
       // a variant of the above function, specifically designed to be called from QML
+      //@ returns the element at track 'track' (null if none)
       Q_INVOKABLE Ms::Element* elementAt(int track) const;
       ChordRest* cr(int track) const                    {
             Q_ASSERT(_segmentType == Type::ChordRest);

--- a/libmscore/slur.h
+++ b/libmscore/slur.h
@@ -59,7 +59,7 @@ struct SlurOffsets {
 
 //---------------------------------------------------------
 //   @@ SlurSegment
-///    also used for Tie
+///    a single segment of slur; also used for Tie
 //---------------------------------------------------------
 
 class SlurSegment : public SpannerSegment {
@@ -124,8 +124,8 @@ class SlurSegment : public SpannerSegment {
 
 //-------------------------------------------------------------------
 //   @@ SlurTie
-//   @P lineType       int                    (0 - solid, 1 - dotted, 2 - dashed)
-//   @P slurDirection  Ms::MScore::Direction  (AUTO, UP, DOWN)
+//   @P lineType       int    (0 - solid, 1 - dotted, 2 - dashed)
+//   @P slurDirection  enum (Direction.AUTO, Direction.DOWN, Direction.UP)
 //-------------------------------------------------------------------
 
 class SlurTie : public Spanner {

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -93,11 +93,11 @@ class SpannerSegment : public Element {
 //   @@ Spanner
 ///   Virtual base class for slurs, ties, lines etc.
 //
-//    @P anchor         Ms::Spanner::Anchor     (SEGMENT, MEASURE, CHORD, NOTE)
-//    @P endElement     MS::Element             the element the spanner end is anchored to (read-only)
-//    @P startElement   MS::Element             the element the spanner start is anchored to (read-only)
-//    @P tick           int                     tick start position
-//    @P tick2          int                     tick end position
+//    @P anchor         enum (Spanner.CHORD, Spanner.MEASURE, Spanner.NOTE, Spanner.SEGMENT)
+//    @P endElement     Element           the element the spanner end is anchored to (read-only)
+//    @P startElement   Element           the element the spanner start is anchored to (read-only)
+//    @P tick           int               tick start position
+//    @P tick2          int               tick end position
 //----------------------------------------------------------------------------------
 
 class Spanner : public Element {

--- a/libmscore/tempotext.h
+++ b/libmscore/tempotext.h
@@ -22,8 +22,8 @@ namespace Ms {
 //   @@ TempoText
 ///    Tempo marker which determines the midi tempo.
 //
-//   @P tempo       qreal  tempo in beats per second (beat=1/4)
-//   @P followText  bool   determine tempo from text
+//   @P tempo       float     tempo in quarter notes (crochets) per second
+//   @P followText  bool      determine tempo from text
 //-------------------------------------------------------------------
 
 class TempoText : public Text  {

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -178,7 +178,7 @@ class TextBlock {
 //   @@ Text
 ///    Graphic representation of a text.
 //
-//   @P text  Qstring  the raw text
+//   @P text  string  the raw text
 //---------------------------------------------------------
 
 class Text : public Element {

--- a/libmscore/timesig.h
+++ b/libmscore/timesig.h
@@ -35,26 +35,26 @@ enum class TimeSigType : char {
 //   @@ TimeSig
 ///    This class represents a time signature.
 //
-//   @P numeratorString     QString    text of numerator
-//   @P denominatorString   QString    text of denominator
-//   @P showCourtesySig     bool       show courtesy time signature for this sig if appropriate
-//   @P numerator           int        (read only)
-//   @P denominator         int        (read only)
-//   @P numeratorStretch    int        (read only)
-//   @P denominatorStretch  int        (read only)
-//   @P groups              Ms::Groups
+//   @P denominator         int           (read only)
+//   @P denominatorStretch  int           (read only)
+//   @P denominatorString   string        text of denominator
+//   @P groups              Groups
+//   @P numerator           int           (read only)
+//   @P numeratorStretch    int           (read only)
+//   @P numeratorString     string        text of numerator
+//   @P showCourtesySig     bool          show courtesy time signature for this sig if appropriate
 //---------------------------------------------------------------------------------------
 
 class TimeSig : public Element {
       Q_OBJECT
-      Q_PROPERTY(QString numeratorString   READ numeratorString   WRITE undoSetNumeratorString)
-      Q_PROPERTY(QString denominatorString READ denominatorString WRITE undoSetDenominatorString)
-      Q_PROPERTY(bool showCourtesySig      READ showCourtesySig   WRITE undoSetShowCourtesySig)
-      Q_PROPERTY(int numerator             READ numerator)
       Q_PROPERTY(int denominator           READ denominator)
-      Q_PROPERTY(int numeratorStretch      READ numeratorStretch)
       Q_PROPERTY(int denominatorStretch    READ denominatorStretch)
+      Q_PROPERTY(QString denominatorString READ denominatorString WRITE undoSetDenominatorString)
       Q_PROPERTY(Ms::Groups groups         READ groups            WRITE undoSetGroups)
+      Q_PROPERTY(int numerator             READ numerator)
+      Q_PROPERTY(int numeratorStretch      READ numeratorStretch)
+      Q_PROPERTY(QString numeratorString   READ numeratorString   WRITE undoSetNumeratorString)
+      Q_PROPERTY(bool showCourtesySig      READ showCourtesySig   WRITE undoSetShowCourtesySig)
 
       TimeSigType _timeSigType;
       QString _numeratorString;     // calculated from actualSig() if !customText
@@ -92,6 +92,7 @@ class TimeSig : public Element {
 
       Fraction sig() const               { return _sig; }
       void setSig(const Fraction& f, TimeSigType st = TimeSigType::NORMAL);
+      //@ sets the time signature
       Q_INVOKABLE void setSig(int z, int n, TimeSigType st = TimeSigType::NORMAL) { setSig(Fraction(z, n), st); }
       int numerator() const              { return _sig.numerator(); }
       int denominator() const            { return _sig.denominator(); }

--- a/libmscore/trill.h
+++ b/libmscore/trill.h
@@ -57,7 +57,7 @@ class TrillSegment : public LineSegment {
 
 //---------------------------------------------------------
 //   @@ Trill
-//   @P trillType  Ms::Trill::Type  (TRILL_LINE, UPPRALL_LINE, DOWNPRALL_LINE, PRALLPRALL_LINE)
+//   @P trillType  enum (Trill.DOWNPRALL_LINE, .PRALLPRALL_LINE, .PURE_LINE, .TRILL_LINE, .UPPRALL_LINE)
 //---------------------------------------------------------
 
 class Trill : public SLine {

--- a/libmscore/volta.h
+++ b/libmscore/volta.h
@@ -48,7 +48,7 @@ class VoltaSegment : public TextLineSegment {
 
 //---------------------------------------------------------
 //   @@ Volta
-//   @P voltaType  Ms::Volta::Type  (OPEN, CLOSED)
+//   @P voltaType  enum (Volta.CLOSE, Volta.OPEN)
 //---------------------------------------------------------
 
 class Volta : public TextLine {


### PR DESCRIPTION
Updates the documentation for classes named from S to Z to proposal A) in http://dev-list.musescore.org/Plugin-documentation-generated-manual-td7579164.html

Properties are also sorted in alphabetical order for easier identification.

No attempt made to evaluate what to include and what to exclude from documentation: anything which is currently documented is retained. Case by case decisions can always be made.

Description of some methods for `Score` (in file libmscore/score.h) are stubs.