### PR TITLE
fix #57646: corruption on paste with segment annotation in voice > 0

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -324,9 +324,10 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
 
                               // be sure to paste the element in the destination track;
                               // setting track needs to be repeated, as it might have been overwritten by el->read()
-                              el->setTrack(e.track());
+                              // preserve *voice* from source, though
+                              el->setTrack(e.track() + el->voice());
 
-                              undoChangeElement(seg->element(e.track()), el);
+                              undoAddElement(el);
                               }
                         else if (tag == "Clef") {
                               Clef* clef = new Clef(this);


### PR DESCRIPTION
This definitely fixes the bug, as well as another where the pasted annotation moves to voice 1.  I don't think this breaks anything else, but it would be good to have someone else think through this (see my notes in the issue report) to be sure I am not missing something. 