### PR TITLE
Fix #57651: Crash on paste of tuplet in imported MIDI file

### DIFF
--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -438,7 +438,7 @@ class Element : public QObject, public ScoreElement {
 
       int staffIdx() const                    { return _track >> 2;        }
       int voice() const                       { return _track & 3;         }
-      void setVoice(int v)                    { _track = (_track / VOICES) + v; }
+      void setVoice(int v)                    { _track = (_track / VOICES) * VOICES + v; }
       Staff* staff() const;
       Part* part() const;
 

--- a/mtest/importmidi/tuplet_5_5_tuplets_rests.mscx
+++ b/mtest/importmidi/tuplet_5_5_tuplets_rests.mscx
@@ -187,7 +187,6 @@
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <Tuplet id="2">
-          <track>1</track>
           <normalNotes>4</normalNotes>
           <actualNotes>5</actualNotes>
           <baseNote>16th</baseNote>

--- a/mtest/importmidi/tuplet_triplets_mixed.mscx
+++ b/mtest/importmidi/tuplet_triplets_mixed.mscx
@@ -391,7 +391,6 @@
         </Measure>
       <Measure number="3">
         <Tuplet id="5">
-          <track>1</track>
           <normalNotes>2</normalNotes>
           <actualNotes>3</actualNotes>
           <baseNote>eighth</baseNote>


### PR DESCRIPTION
Element::setVoice(v) function is used only in MIDI import by tuplets apparently, that's why the issue was not revealed earlier.

However, the question is: should this function be removed, and setTrack(idx*voices + v) always used instead?