### PR TITLE
fix #57756: crash on delete of time sig with frames

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -601,6 +601,8 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
                   // we may use this to reinstate time signatures
                   if (m && m->prevMeasure())
                         nm = m->prevMeasure()->nextMeasure();
+                  else
+                        nm = nullptr;
 
                   if (sectionBreak) {
                         // reinstate section break, then stop rewriting
@@ -660,13 +662,16 @@ bool Score::rewriteMeasures(Measure* fm, const Fraction& ns, int staffIdx)
       Segment* s = nm->undoGetSegment(Segment::Type::TimeSig, nm->tick());
       for (int i = 0; i < nstaves(); ++i) {
             if (!s->element(i * VOICES)) {
-                  TimeSig* nts = new TimeSig(*staff(i)->timeSig(nm->tick()));
-                  nts->setParent(s);
-                  if (sectionBreak) {
-                        nts->setGenerated(false);
-                        nts->setShowCourtesySig(false);
+                  TimeSig* ots = staff(i)->timeSig(nm->tick());
+                  if (ots) {
+                        TimeSig* nts = new TimeSig(*ots);
+                        nts->setParent(s);
+                        if (sectionBreak) {
+                              nts->setGenerated(false);
+                              nts->setShowCourtesySig(false);
+                              }
+                        undoAddElement(nts);
                         }
-                  undoAddElement(nts);
                   }
             }
 


### PR DESCRIPTION
Crash was caused by my change here:

https://github.com/musescore/MuseScore/commit/9b14b402f6e02fccb212e8a2fc64510db5cdedc3

The intent was to make sure if we are only rewriting up to a section break or a local time sig in some staff, and there was not already a time signature on some staves at the point where we stopped, we need to add an explicit time sig there (based on whatever time signature was previously in effect for that measure).

The issue here is the result of two flaws in my original code:

1) not checking to see if there was in fact a time signature in effect (there isn't if we just deleted the initial/only time signature) - fixed by adding a check for null pointer before trying to clone it

2) inappropriately performing this check for the first measure after a frame, even though we don't actually stop rewriting at that point - fixed by making sure "nm" is explicitly set to null if we reach the end of the score (it had been set to the bar after the frame during a previous  pass through the loop)
