### PR TITLE
fix crash in Score::appendPart(name)

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3369,7 +3369,7 @@ void Score::appendPart(const QString& name)
                   staff->setBracket(0, t->bracket[0]);
                   staff->setBracketSpan(0, t->nstaves());
                   }
-            undoInsertStaff(staff, n + i);
+            undoInsertStaff(staff, i);
             }
 
       part->staves()->front()->setBarLineSpan(part->nstaves());


### PR DESCRIPTION
Fixes <a href="https://musescore.org/en/node/58056">crash in a plugin</a>.

The problem is the call to undoInsertStaff(staff, n+i ) in Sore::appendPart(name) with an absolute staff index (n+i) where n is the number of staves the score already has. 
However undoInsertStaff(staff, ridx) will consider ridx a relative staff index in the newly created part. This will lead to cmdAddStaves be called with a non-existing index, that finally crashes when trying to call invisible() on a staff null pointer.
I replaced (n+i) with i making the index relative to the first staff of the newly created part.