### PR TITLE
Mark corrupted measures with a red outline in debug mode

### DIFF
--- a/libmscore/check.cpp
+++ b/libmscore/check.cpp
@@ -178,6 +178,7 @@ bool Score::sanityCheck(const QString& name)
             int endStaff = staves().size();
             for (int staffIdx = 0; staffIdx < endStaff; ++staffIdx) {
                   Fraction voices[VOICES] = {};
+                  m->mstaff(staffIdx)->setCorrupted(false);
                   for (Segment* s = m->first(Segment::Type::ChordRest); s; s = s->next(Segment::Type::ChordRest)) {
                         for (int v = 0; v < VOICES; ++v) {
                               ChordRest* cr = static_cast<ChordRest*>(s->element(staffIdx* VOICES + v));
@@ -190,6 +191,7 @@ bool Score::sanityCheck(const QString& name)
                         QString msg = tr("Measure %1 Staff %2 incomplete. Expected: %3; Found: %4").arg(mNumber).arg( staffIdx+1).arg(mLen.print()).arg(voices[0].print());
                         qDebug() << msg;
                         error += QString("%1\n").arg(msg);
+                        m->mstaff(staffIdx)->setCorrupted(true);
                         result = false;
                         }
                   for (int v = 1; v < VOICES; ++v) {
@@ -197,6 +199,7 @@ bool Score::sanityCheck(const QString& name)
                               QString msg = tr("Measure %1, staff %2, voice %3 too long. Expected: %4; Found: %5").arg( mNumber).arg(staffIdx + 1).arg(v+1).arg(mLen.print()).arg(voices[v].print());
                               qDebug() << msg;
                               error += QString("%1\n").arg(msg);
+                              m->mstaff(staffIdx)->setCorrupted(true);
                               result = false;
                               }
                         }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1575,6 +1575,8 @@ void Score::doLayout()
       // but then it's used for drag and drop and should be set to new version
       if (_mscVersion <= 114)
             _mscVersion = MSCVERSION;     // for later drag & drop usage
+      if (MScore::debugMode)
+            sanityCheck();
       }
 
 //---------------------------------------------------------

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -93,6 +93,7 @@ MStaff::MStaff()
       _vspacerDown = 0;
       _visible     = true;
       _slashStyle  = false;
+      _corrupted = false;
       }
 
 MStaff::~MStaff()
@@ -114,6 +115,7 @@ MStaff::MStaff(const MStaff& m)
       _vspacerDown = 0;
       _visible     = m._visible;
       _slashStyle  = m._slashStyle;
+      _corrupted = m._corrupted;
       }
 
 //---------------------------------------------------------

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -59,6 +59,8 @@ struct MStaff {
       bool _visible;
       bool _slashStyle;
 
+      bool _corrupted;
+
       MStaff();
       ~MStaff();
       MStaff(const MStaff&);
@@ -71,6 +73,8 @@ struct MStaff {
       void setTrack(int);
       Text* noText() const         { return _noText;     }
       void setNoText(Text* t)      { _noText = t;        }
+      void setCorrupted(bool c)    { _corrupted = c; }
+      bool corrupted()             { return _corrupted; }
       };
 
 //---------------------------------------------------------

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1915,6 +1915,7 @@ void ScoreView::paint(const QRect& r, QPainter& p)
             p.setBrush(QBrush(Qt::NoBrush));
             p.drawRect(r);
             }
+      double _spatium = score()->spatium();
       const Selection& sel = _score->selection();
       if (sel.isRange()) {
             Segment* ss = sel.startSegment();
@@ -1931,7 +1932,6 @@ void ScoreView::paint(const QRect& r, QPainter& p)
             pen.setStyle(Qt::SolidLine);
 
             p.setPen(pen);
-            double _spatium = score()->spatium();
             double x2      = ss->pagePos().x() - _spatium;
             int staffStart = sel.staffStart();
             int staffEnd   = sel.staffEnd();
@@ -1999,6 +1999,21 @@ void ScoreView::paint(const QRect& r, QPainter& p)
             //
             p.drawLine(QLineF(x2, y1, x2, y2).translated(system2->page()->pos()));
             }
+      if (!_score->printing() && MScore::debugMode) {
+            QPen pen;
+            pen.setColor(Qt::red);
+            pen.setWidthF(1);
+            pen.setStyle(Qt::SolidLine);
+            p.setPen(pen);
+            for (Measure* m = _score->firstMeasure(); m; m = m->nextMeasure()) {
+                  for (int staffIdx = 0; staffIdx < _score->nstaves(); staffIdx++) {
+                        if (m->mstaff(staffIdx)->corrupted()) {
+                              p.drawRect(m->staffabbox(staffIdx).translated(m->system()->page()->pos()).adjusted(0, -_spatium, 0, _spatium));
+                              }
+                        }
+                  }
+            }
+
       p.setMatrixEnabled(false);
       if ((_score->layoutMode() != LayoutMode::LINE) && !r1.isEmpty()) {
             p.setClipRegion(r1);  // only background


### PR DESCRIPTION
The goal would be to detect as soon as possible the creation of a timewise corrupted measure.
Of course, we are doing the sanityCheck for each and every call to layout so it's far from optimal for large scores. Also, we know that corruption can happen on save/read and this will help less to detect these types of time corruption.
