### PR TITLE
fix #58231: crash changing text style of empty lyric

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3861,8 +3861,8 @@ qreal Score::computeMinWidth(Segment* fs, bool firstMeasureInSystem)
                               foreach (Lyrics* l, cr->lyricsList()) {
                                     if (!l)
                                           continue;
+                                    l->layout();      // need to create layout even if empty
                                     if (!l->isEmpty()) {
-                                          l->layout();
                                           lyrics = l;
                                           QRectF b(l->bbox().translated(l->pos()));
                                           llw = qMax(llw, -(b.left()+lx+cx));


### PR DESCRIPTION
Crash was caused by trying to draw a lyric that was not laid out yet.  I first tried working around this by just avoiding the crash in the draw, but it would still crash later if you tried editing the lyric further.  So I decided I needed to make sure the empty lyric is laid out.

With the change in this PR, there is no more crash.  But if you try to enter text after the text style change (you have to press Esc or click in the text box to return focus to score), the text is still in the old font.  Not sure why that works for other types of text but not for lyrics, but it seems a much more minor issue I am not going to worry about right now.