### PR TITLE
scripting: use undo when changing visible property

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1621,6 +1621,15 @@ void Element::undoSetColor(const QColor& c)
       }
 
 //---------------------------------------------------------
+//   undoSetVisible
+//---------------------------------------------------------
+
+void Element::undoSetVisible(bool v)
+      {
+      score()->undoChangeProperty(this, P_ID::VISIBLE, v);
+      }
+
+//---------------------------------------------------------
 //   bbox() function for scripts
 //
 //    use spatium units rather than raster units

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -175,7 +175,7 @@ class Element : public QObject, public ScoreElement {
       Q_PROPERTY(int                      track       READ track        WRITE setTrack)
       Q_PROPERTY(Ms::Element::Type        type        READ type)
       Q_PROPERTY(QPointF                  userOff     READ scriptUserOff WRITE scriptSetUserOff)
-      Q_PROPERTY(bool                     visible     READ visible      WRITE setVisible)
+      Q_PROPERTY(bool                     visible     READ visible      WRITE undoSetVisible)
 
       Element* _parent { 0 };
 
@@ -465,6 +465,7 @@ class Element : public QObject, public ScoreElement {
       QColor curColor(const Element* proxy) const;
       virtual void setColor(const QColor& c)     { _color = c;    }
       void undoSetColor(const QColor& c);
+      void undoSetVisible(bool v);
 
       static Element::Type readType(XmlReader& node, QPointF*, Fraction*);
 


### PR DESCRIPTION
Changing the visible property of elements didn't use the undo system.
Added Element::undoSetVisible(bool) following the model of Element::undoSetColor()

This problem was reported <a href="https://musescore.org/en/node/15025#comment-266861">here</a>.