### PR TITLE
Fix wrong track order in respect to MIDI channels

### DIFF
--- a/midi/midifile.cpp
+++ b/midi/midifile.cpp
@@ -857,8 +857,8 @@ void MidiFile::separateChannel()
                         // create a list of channels used in current track
             QList<int> channel;
             MidiTrack &mt = _tracks[i];      // current track
-            for (auto i : mt.events()) {
-                  const MidiEvent& e = i.second;
+            for (const auto& ie : mt.events()) {
+                  const MidiEvent& e = ie.second;
                   if (e.isChannelEvent() && !channel.contains(e.channel()))
                         channel.append(e.channel());
                   }

--- a/midi/midifile.cpp
+++ b/midi/midifile.cpp
@@ -872,7 +872,7 @@ void MidiFile::separateChannel()
             for (int ii = 1; ii < nn; ++ii) {
                   MidiTrack t;
                   t.setOutChannel(channel[ii]);
-                  _tracks.insert(i + 1, t);
+                  _tracks.insert(i + ii, t);
                   }
                         // extract all different channel events from current track to inserted tracks
             for (auto ie = mt.events().begin(); ie != mt.events().end(); ) {


### PR DESCRIPTION
During channel separation tracks were created in reverse order, and here
https://musescore.org/en/node/46331#comment-217151
it was resulted in appearance of percussion track instead of Grand Piano.