### PR TITLE
expose globalDuration to scripting

### DIFF
--- a/libmscore/duration.h
+++ b/libmscore/duration.h
@@ -27,7 +27,8 @@ class Spanner;
 //   @@ DurationElement
 ///    Virtual base class for Chord, Rest and Tuplet.
 //
-//   @P duration  int  duration in ticks
+//   @P duration       Fraction  duration (as written)
+//   @P globalDuration Fraction  played duration
 //---------------------------------------------------------
 
 class DurationElement : public Element {
@@ -37,9 +38,11 @@ class DurationElement : public Element {
 #ifdef SCRIPT_INTERFACE
       Q_OBJECT
       Q_PROPERTY(FractionWrapper* duration READ durationW WRITE setDurationW)
+      Q_PROPERTY(FractionWrapper* globalDuration READ globalDurW)
 
       void setDurationW(FractionWrapper* f)  { _duration = f->fraction(); }
       FractionWrapper* durationW() const     { return new FractionWrapper(_duration); }
+      FractionWrapper* globalDurW() const    { return new FractionWrapper(globalDuration()); }
 #endif
 
    public:


### PR DESCRIPTION
Expose globalDuration (i.e. with respect to tuplets) to plugins.
As of now, a plugin cannot know the real duration of a note.
Example:
![globaldur](https://cloud.githubusercontent.com/assets/2162327/7440733/b6825e3a-f0c5-11e4-9ad6-ec4d7e23f0be.png)
Demo plugin output:
<pre>
Debug: found note: pitch=72, duration=1/8, (ticks=240), globalDuration=1/8, (ticks=240)
Debug: found note: pitch=72, duration=1/8, (ticks=240), globalDuration=1/8, (ticks=240)
Debug: found note: pitch=72, duration=1/8, (ticks=240), globalDuration=2/24, (ticks=160)
Debug: found note: pitch=72, duration=1/8, (ticks=240), globalDuration=2/24, (ticks=160)
Debug: found note: pitch=72, duration=1/8, (ticks=240), globalDuration=2/24, (ticks=160)
</pre>
