### PR TITLE
fix #54691: wrong octave when adding note

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4987,7 +4987,12 @@ void ScoreView::cmdAddPitch(int note, bool addFlag)
                   Chord* chord = static_cast<Note*>(el)->chord();
                   Note* n = chord->upNote();
                   octave = n->epitch() / 12;
-                  if (tab[note] <= n->epitch() % 12)
+                  int tpc = n->tpc();
+                  if (tpc == Tpc::TPC_C_BB || tpc == Tpc::TPC_C_B)
+                        ++octave;
+                  else if (tpc == Tpc::TPC_B_S || tpc == Tpc::TPC_B_SS)
+                        --octave;
+                  if (note <= tpc2step(tpc))
                         octave++;
                   }
             else {


### PR DESCRIPTION
The old algorithm was based on the *pitch* of the original note, which made comparisons difficult: we really don't know the pitch of the note we are trying to add, at least, not until we add it (since it depends on key, accidental state, etc).

It occured to me it would be simply to just replace the pitch-based comparison with a plain step-based comparison.  The code - including the special casing for Cb et al - is essentially the same as that used in pitchspelling.cpp for pitch2absStepByKey().  Basically, we compare letter names, so key doesn't matter.  D followed by Shift+D will always enter a note in the octave above, regardless of whether the original D was actually D natural, flat, or sharp according to the key.

It fixes the problem at hand, although it has a side effect I would be perfectly happy to call feature: accidentals don't matter either.  So even in the key of D, Shift+D on a D will enter a note in the octave above regardless of whether the original D was actually D naturtal, flat, or sharp according to accidental state.