### PR TITLE
Musicxml fixes

### DIFF
--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -5106,16 +5106,11 @@ void MusicXMLParserPass2::notations(Note* note, ChordRest* cr, const int tick,
                         if (_slur[slurNo].isStart()) {
                               // slur stop when slur already started: wrap up
                               Slur* newSlur = _slur[slurNo].slur();
-                              if (cr->isGrace()) {
-                                    newSlur->setAnchor(Spanner::Anchor::CHORD);
-                                    newSlur->setEndElement(newSlur->startElement());
-                                    newSlur->setStartElement(cr);
-                                    }
-                              else {
+                              if(!(cr->isGrace())){
                                     newSlur->setTick2(tick);
                                     newSlur->setTrack2(track);
-                                    newSlur->setEndElement(cr);
                                     }
+                              newSlur->setEndElement(cr);
                               _slur[slurNo] = SlurDesc();
                               }
                         else if (_slur[slurNo].isStop())
@@ -5124,8 +5119,10 @@ void MusicXMLParserPass2::notations(Note* note, ChordRest* cr, const int tick,
                         else {
                               // slur stop for new slur: init
                               Slur* newSlur = new Slur(_score);
-                              newSlur->setTick2(tick);
-                              newSlur->setTrack2(track);
+                              if(!(cr->isGrace())){
+                                    newSlur->setTick2(tick);
+                                    newSlur->setTrack2(track);
+                                    }
                               newSlur->setEndElement(cr);
                               _slur[slurNo].stop(newSlur);
                               }

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -4840,16 +4840,11 @@ void MusicXml::xmlNotations(Note* note, ChordRest* cr, int trk, int tick, int ti
                         if (slur[slurNo].isStart()) {
                               // slur stop when slur already started: wrap up
                               Slur* newSlur = slur[slurNo].slur();
-                              if(cr->isGrace()){
-                                    newSlur->setAnchor(Spanner::Anchor::CHORD);
-                                    newSlur->setEndElement(newSlur->startElement());
-                                    newSlur->setStartElement(cr);
-                                    }
-                              else {
+                              if(!(cr->isGrace())){
                                     newSlur->setTick2(tick);
                                     newSlur->setTrack2(track);
-                                    newSlur->setEndElement(cr);
                                     }
+                              newSlur->setEndElement(cr);
                               slur[slurNo] = SlurDesc();
                               }
                         else if (slur[slurNo].isStop())
@@ -4858,8 +4853,10 @@ void MusicXml::xmlNotations(Note* note, ChordRest* cr, int trk, int tick, int ti
                         else {
                               // slur stop for new slur: init
                               Slur* newSlur = new Slur(score);
-                              newSlur->setTick2(tick);
-                              newSlur->setTrack2(track);
+                              if(!(cr->isGrace())){
+                                    newSlur->setTick2(tick);
+                                    newSlur->setTrack2(track);
+                                    }
                               newSlur->setEndElement(cr);
                               slur[slurNo].stop(newSlur);
                               }


### PR DESCRIPTION
Fix #58596 incorrect layout slur to grace note. Once again, IMHO, useful to cherry pick for 2.0.1, as the only workarounds I am aware of are tedious (drag the affected slur to the correct position or enter it again).