### PR TITLE
fix #58971: corruption on moving grace note to another voice

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3903,6 +3903,10 @@ void Score::changeVoice(int voice)
                   if (note->tieFor() || note->tieBack())
                         continue;
 
+                  // move grace notes with main chord only
+                  if (chord->isGrace())
+                        continue;
+
                   if (chord->voice() != voice) {
                         Segment* s       = chord->segment();
                         Measure* m       = s->measure();
@@ -3990,6 +3994,14 @@ void Score::changeVoice(int voice)
                                     r->setDuration(chord->duration());
                                     r->setTuplet(chord->tuplet());
                                     r->setParent(s);
+                                    // if there were grace notes, move them
+                                    for (Chord* gc : chord->graceNotes()) {
+                                          Chord* ngc = new Chord(*gc);
+                                          undoRemoveElement(gc);
+                                          ngc->setParent(dstChord);
+                                          ngc->setTrack(dstChord->track());
+                                          undoAddElement(ngc);
+                                          }
                                     // remove chord, replace with rest
                                     undoRemoveElement(chord);
                                     undoAddCR(r, m, s->tick());


### PR DESCRIPTION
In this PR, grace notes cannot be moved individually, but are moved automatically if all notes in the chord to which they are attached are moved.  It would be possible of course to implement something where the grace notes were moved if a destination chord exists, but I'm not sure that's necessary, and this fixes the corruption.