### PR TITLE
Add G clef with optional vb8

### DIFF
--- a/fonts/gootville/glyphnames.json
+++ b/fonts/gootville/glyphnames.json
@@ -4005,8 +4005,8 @@
         "description": "G clef ottava bassa (old style)"
     }, 
     "gClef8vbParens": {
-        "codepoint": "U+E057", 
-        "description": "G clef, optionally ottava bassa"
+        "codepoint": "U+E050", 
+        "description": "fake G clef, optionally ottava bassa"
     }, 
     "gClefArrowDown": {
         "codepoint": "U+E05B", 

--- a/fonts/mscore/glyphnames.json
+++ b/fonts/mscore/glyphnames.json
@@ -284,6 +284,10 @@
     "gClef8vb": {
         "codepoint": "U+e1d7"
     },
+    "gClef8vbParens": {
+        "codepoint": "U+e19e",
+        "description": "fake G clef, optionally ottava bassa"
+    },
     "graceNoteSlashStemDown": {
         "codepoint": "U+e196"
     },

--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -54,6 +54,7 @@ const ClefInfo ClefInfo::clefTable[] = {
 { "F15ma","F",         4,  2, 47, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, QT_TRANSLATE_NOOP("clefTable", "Bass clef 15ma"),         StaffGroup::STANDARD  }, // F_15MA
 { "PERC2","percussion",2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, QT_TRANSLATE_NOOP("clefTable", "Percussion"),             StaffGroup::PERCUSSION}, // PERC2 placeholder
 { "TAB2", "TAB",       5,  0,  0, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, QT_TRANSLATE_NOOP("clefTable", "Tablature2"),             StaffGroup::TAB       },
+{ "G8vbp","G",         2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, QT_TRANSLATE_NOOP("clefTable", "Treble clef optional 8vb"),StaffGroup::STANDARD }, // G5
       };
 
 
@@ -315,6 +316,10 @@ void Clef::layout1()
             case ClefType::F_15MA:                         // F clef 15ma on penultimate line
                   symbol->setSym(SymId::fClef15ma);
                   yoff = 1.0 * curLineDist;
+                  break;
+            case ClefType::G5:                              // G clef on 2nd line
+                  symbol->setSym(SymId::gClef8vbParens);
+                  yoff = 3.0 * curLineDist;
                   break;
             case ClefType::INVALID:
             case ClefType::MAX:

--- a/libmscore/clef.h
+++ b/libmscore/clef.h
@@ -59,6 +59,7 @@ enum class ClefType : signed char {
       F_15MA,
       PERC2,            // no longer supported, but kept for compat. with old scores; rendered as PERC
       TAB2,
+      G5,
       MAX
       };
 

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -699,7 +699,7 @@ Palette* MuseScore::newClefsPalette(bool basic)
             ClefType::G,   ClefType::F, ClefType::C3, ClefType::C4
             };
       static std::vector<ClefType> clefs2  {
-            ClefType::G,   ClefType::G1,    ClefType::G2,     ClefType::G3,  ClefType::G4,
+            ClefType::G,   ClefType::G1,    ClefType::G2,     ClefType::G3,  ClefType::G5,  ClefType::G4,
             ClefType::C1,  ClefType::C2,    ClefType::C3,     ClefType::C4,  ClefType::C5,
             ClefType::F,   ClefType::F_8VA, ClefType::F_15MA, ClefType::F8,  ClefType::F15,
             ClefType::F_B, ClefType::F_C,   ClefType::PERC,   ClefType::TAB, ClefType::TAB2


### PR DESCRIPTION
Unfortunatly Emmentaler and Gonville are lacking the glyph, and I don't feel like messing around with fonts, so here it gets faked by using a standard G clef instead...

Playback wise it behaves just like a standard G clef.

This had been discussed in the forum a while ago, but I can't find it anymore.