### PR TITLE
fix #60746: bad symbol position on drag & drop

### DIFF
--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -504,8 +504,15 @@ void ScoreView::dropEvent(QDropEvent* event)
                               if (el && el->type() == Element::Type::MEASURE) {
                                     dragElement->setTrack(staffIdx * VOICES);
                                     dragElement->setParent(seg);
-                                    if (applyUserOffset)
+                                    if (applyUserOffset) {
                                           dragElement->setUserOff(pos - seg->canvasPos());
+                                          Measure* m = static_cast<Measure*>(el);
+                                          if (m->system()) {
+                                                SysStaff* staff = m->system()->staff(staffIdx);
+                                                qreal yoff = staff ? staff->y() : 0.0;
+                                                dragElement->rUserYoffset() -= yoff;
+                                                }
+                                          }
                                     score()->undoAddElement(dragElement);
                                     }
                               else {


### PR DESCRIPTION
Maybe there is a cleaner way to do this.  Seems we probably solve the same basic problem (needing to convert system-relative offset to staff-relative) elsewhere?  But this works.