### PR TITLE
fix #49246: elements duplicated when note tied over barline

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2901,6 +2901,34 @@ void Chord::setSlash(bool flag, bool stemless)
       }
 
 //---------------------------------------------------------
+//   removeMarkings
+//    - this is normally called after cloning a chord to tie a note over the barline
+//    - there is no special undo handling; the assumption is that undo will simply remove the cloned chord
+//    - two note tremolos are converted into simple notes
+//    - single note tremolos are optionally retained
+//---------------------------------------------------------
+
+void Chord::removeMarkings(bool keepTremolo)
+      {
+      if (tremolo() && !keepTremolo)
+            remove(tremolo());
+      if (arpeggio())
+            remove(arpeggio());
+      for (Element* e : el())
+            remove(e);
+      for (Element* e : articulations())
+            remove(e);
+      for (Element* e : lyricsList())
+            remove(e);
+      for (Element* e : graceNotes())
+            remove(e);
+      for (Note* n : notes()) {
+            for (Element* e : n->el())
+                  n->remove(e);
+            }
+      }
+
+//---------------------------------------------------------
 //   mag
 //---------------------------------------------------------
 

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -160,6 +160,7 @@ class Chord : public ChordRest {
       StemSlash* stemSlash() const           { return _stemSlash; }
       bool slash();
       void setSlash(bool flag, bool stemless);
+      void removeMarkings(bool keepTremolo = false);
 
       const QList<Chord*>& graceNotes() const { return _graceNotes; }
       QList<Chord*>& graceNotes()             { return _graceNotes; }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2693,6 +2693,11 @@ void Score::connectTies(bool silent)
                               else {
                                     nc->setTremolo(tremolo);
                                     tremolo->setChords(c, nc);
+                                    // cross-measure tremolos are not supported
+                                    // but can accidentally result from copy & paste
+                                    // remove them now
+                                    if (c->measure() != nc->measure())
+                                          c->remove(tremolo);
                                     }
                               break;
                               }

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -180,6 +180,18 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                                     e.incTick(cr->actualTicks());
                                     if (cr->type() == Element::Type::CHORD) {
                                           Chord* chord = static_cast<Chord*>(cr);
+                                          // disallow tie across barline within two-note tremolo
+                                          // tremolos can potentially still straddle the barline if no tie is required
+                                          // but these will be removed later
+                                          if (chord->tremolo() && chord->tremolo()->twoNotes()) {
+                                                Measure* m = tick2measure(tick);
+                                                int ticks = cr->actualTicks();
+                                                int rticks = m->endTick() - tick;
+                                                if (rticks < ticks || (rticks != ticks && rticks < ticks * 2)) {
+                                                      qDebug("tremolo does not fit in measure");
+                                                      return false;
+                                                      }
+                                                }
                                           for (int i = 0; i < graceNotes.size(); ++i) {
                                                 Chord* gc = graceNotes[i];
                                                 gc->setGraceIndex(i);
@@ -201,7 +213,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                                                       }
                                                 }
                                           }
-                                    //shorten last cr to fit in the space made by makeGap
+                                    // shorten last cr to fit in the space made by makeGap
                                     if ((tick - dstTick) + cr->actualTicks() > tickLen) {
                                           int newLength = tickLen - (tick - dstTick);
                                           // check previous CR on same track, if it has tremolo, delete the tremolo
@@ -461,6 +473,8 @@ void Score::pasteChordRest(ChordRest* cr, int tick, const Interval& srcTranspose
                   while (rest) {
                         measure = tick2measure(tick);
                         Chord* c2 = firstpart ? c : static_cast<Chord*>(c->clone());
+                        if (!firstpart)
+                              c2->removeMarkings(true);
                         int mlen = measure->tick() + measure->ticks() - tick;
                         int len = mlen > rest ? rest : mlen;
                         QList<TDuration> dl = toDurationList(Fraction::fromTicks(len), true);

--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -333,6 +333,7 @@ bool TrackList::write(Measure* measure) const
                   // split note/rest
                   //
 
+                  bool firstpart = true;
                   while (duration.numerator() > 0) {
                         if ((e->type() == Element::Type::REST || e->type() == Element::Type::REPEAT_MEASURE)
                            && (duration >= rest || e == back())
@@ -375,6 +376,8 @@ bool TrackList::write(Measure* measure) const
                               else if (e->type() == Element::Type::CHORD) {
                                     segment = m->getSegment(e, m->tick() + pos.ticks());
                                     Chord* c = static_cast<Chord*>(e)->clone();
+                                    if (!firstpart)
+                                          c->removeMarkings(true);
                                     c->setScore(score);
                                     c->setTrack(_track);
                                     c->setDuration(d);
@@ -428,6 +431,7 @@ bool TrackList::write(Measure* measure) const
                                           }
                                     }
                               }
+                        firstpart = false;
                         }
                   }
             else if (e->type() == Element::Type::BAR_LINE) {


### PR DESCRIPTION
I do the same thing - stripping away unneeded markings when tying over the barline - for both paste and for rewrite due to time signature change.  This code should probably be factored out.  Not sure if there are other places where it would be useful.  I could see it being something like a standalone Chord::removeMarkings() we call, or maybe another parameter passed to Chord::clone() to decide if we should copy the markings.