### PR TITLE
fix #57461: translate instruments' channel

### DIFF
--- a/mscore/articulationprop.cpp
+++ b/mscore/articulationprop.cpp
@@ -59,16 +59,16 @@ ArticulationProperties::ArticulationProperties(Articulation* na, QWidget* parent
                   if (a->name.isEmpty() || a->name == "normal")
                         channelList->addItem(tr("normal"));
                   else
-                        channelList->addItem(a->name);
+                        channelList->addItem(qApp->translate("InstrumentsXML", a->name.toUtf8().data()));
                   }
             foreach(const NamedEventList& el, instrument->midiActions()) {
-                  midiActionList->addItem(el.name);
+                  midiActionList->addItem(qApp->translate("InstrumentsXML", el.name.toUtf8().data()));
                   }
             }
 
 #if 0
       foreach(const NamedEventList& e, instrument->midiActions)
-            midiActionList->addItem(e.name);
+            midiActionList->addItem(qApp->translate("InstrumentsXML", e.name.toUtf8().data()));
       articulationChange->setChecked(!articulation->articulationName().isEmpty());
       midiAction->setChecked(!articulation->midiActionName().isEmpty());
 

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -59,8 +59,13 @@ void PartEdit::setPart(Part* p, Channel* a)
       channel = a;
       part    = p;
       QString s = part->partName();
-      if (!a->name.isEmpty() && a->name != "normal")
-            s += "-" + a->name;
+      if (!a->name.isEmpty()) {
+            s += "-";
+            if (a->name != "normal")
+                  s += tr("normal");
+            else
+                  s += qApp->translate("InstrumentsXML", a->name.toUtf8().data());
+            }
       partName->setText(s);
       mute->setChecked(a->mute);
       solo->setChecked(a->solo);

--- a/mscore/stafftextproperties.cpp
+++ b/mscore/stafftextproperties.cpp
@@ -59,7 +59,10 @@ StaffTextProperties::StaffTextProperties(const StaffText* st, QWidget* parent)
       _staffText = static_cast<StaffText*>(st->clone());
 
 #ifndef AEOLUS
-	tabWidget->removeTab(2);
+      tabWidget->removeTab(2);
+#endif
+#ifndef MIDIACTIONS // ToDo: not yet implemented
+      tabWidget->removeTab(1);
 #endif
 
       const char* vbsh { "QToolButton:checked, QToolButton:pressed { color: white; background:%1;}" };

--- a/mscore/stafftextproperties.cpp
+++ b/mscore/stafftextproperties.cpp
@@ -39,7 +39,7 @@ static void initChannelCombo(QComboBox* cb, StaffText* st)
             if (a->name.isEmpty() || a->name == "normal")
                   cb->addItem(QObject::tr("normal"));
             else
-                  cb->addItem(a->name);
+                  cb->addItem(qApp->translate("InstrumentsXML", a->name.toUtf8().data()));
             }
       }
 
@@ -186,8 +186,8 @@ StaffTextProperties::StaffTextProperties(const StaffText* st, QWidget* parent)
             if (a->name.isEmpty() || a->name == "normal")
                   item->setText(0, tr("normal"));
             else
-                  item->setText(0, a->name);
-            item->setText(1, a->descr);
+                  item->setText(0, qApp->translate("InstrumentsXML", a->name.toUtf8().data()));
+            item->setText(1, qApp->translate("InstrumentsXML", a->descr.toUtf8().data()));
             if (i == 0)
                   selectedItem = item;
             }
@@ -388,16 +388,16 @@ void StaffTextProperties::channelItemChanged(QTreeWidgetItem* item, QTreeWidgetI
             if (e.name.isEmpty() || e.name == "normal")
                   item->setText(0, tr("normal"));
             else
-                  item->setText(0, e.name);
-            item->setText(1, e.descr);
+                  item->setText(0, qApp->translate("InstrumentsXML", e.name.toUtf8().data()));
+            item->setText(1, qApp->translate("InstrumentsXML", e.descr.toUtf8().data()));
             }
       foreach(const NamedEventList& e, channel->midiActions) {
             QTreeWidgetItem* item = new QTreeWidgetItem(actionList);
             if (e.name.isEmpty() || e.name == "normal")
                   item->setText(0, tr("normal"));
             else
-                  item->setText(0, e.name);
-            item->setText(1, e.descr);
+                  item->setText(0, qApp->translate("InstrumentsXML", e.name.toUtf8().data()));
+            item->setText(1, qApp->translate("InstrumentsXML", e.descr.toUtf8().data()));
             }
       foreach(const ChannelActions& ca, *_staffText->channelActions()) {
             if (ca.channel == channelIdx) {


### PR DESCRIPTION
Needs a change in the Python script that extracts strings from instruments.xml, @lasconic is having that ready, as per IRC.

While at it also make the channel description translatable, even it that currently isn't used in instruments.xml. This needs a futher change in the afore mentioned Python script...