### PR TITLE
fix #50921: disallow measure stretch < 0

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2219,7 +2219,7 @@ void Measure::read(XmlReader& e, int staffIdx)
                   }
             //----------------------------------------------------
             else if (tag == "stretch")
-                  _userStretch = e.readDouble();
+                  _userStretch = e.readDouble(0.001, 99.99);
             else if (tag == "LayoutBreak") {
                   LayoutBreak* lb = new LayoutBreak(score());
                   lb->read(e);

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -220,7 +220,7 @@ class Measure : public MeasureBase {
       SegmentList* segments()                   { return &_segments; }
 
       qreal userStretch() const;
-      void setUserStretch(qreal v)              { _userStretch = v;    }
+      void setUserStretch(qreal v)              { _userStretch = (v < 0.001)? 0.001: v; }
 
       void layoutX(qreal stretch);
       void layoutWidth(qreal width);


### PR DESCRIPTION
actually disallow it to be smaller than 0.001, so you can still set it to 0 in the dialog