### PR TITLE
fix #53081: click in repitch mode

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1189,7 +1189,10 @@ void Score::putNote(const QPointF& pos, bool replace)
             qDebug("cannot put note here, get position failed");
             return;
             }
-      putNote(p, replace);
+      if (inputState().repitchMode())
+            repitchNote(p, replace);
+      else
+            putNote(p, replace);
       }
 
 void Score::putNote(const Position& p, bool replace)


### PR DESCRIPTION
Makes click in repitch mode work to replace chord, or add to  chord if shift+click.  Previously, clicking in repitch mode did not act like repitch at all; it was just a normal click.