### PR TITLE
fix #50921: disallow measure stretch <= 0

### DIFF
--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -220,7 +220,7 @@ class Measure : public MeasureBase {
       SegmentList* segments()                   { return &_segments; }
 
       qreal userStretch() const;
-      void setUserStretch(qreal v)              { _userStretch = (v < 0 ? 0 : v); }
+      void setUserStretch(qreal v)              { _userStretch = (v < 0.001 ? 0.001 : v); }
 
       void layoutX(qreal stretch);
       void layoutWidth(qreal width);


### PR DESCRIPTION
disalow it to be smaller than 0.001, so you can still set it to 0 in the dialog (and it will be shown as that), but prevent bad effects from happening if set to 0 for all measures of a system