### PR TITLE
Bends playback

### DIFF
--- a/fluid/chan.cpp
+++ b/fluid/chan.cpp
@@ -69,7 +69,7 @@ void Channel::initCtrl()
       key_pressure     = 0;
       channel_pressure = 0;
       pitch_bend       = 0x2000; // Range is 0x4000, pitch bend wheel starts in centered position
-      pitch_wheel_sensitivity = 2; /* two semi-tones */
+      pitch_wheel_sensitivity = 12; /* twelve semi-tones */
       bank_msb         = 0;
 
       for (int i = 0; i < GEN_LAST; i++) {

--- a/fluid/fluid.cpp
+++ b/fluid/fluid.cpp
@@ -179,7 +179,7 @@ void Fluid::play(const PlayEvent& event)
                   err = !cp->preset()->noteon(this, noteid++, ch, key, vel, event.tuning());
                   }
             }
-      else if (type == ME_CONTROLLER)  {
+      else if (type == ME_CONTROLLER) {
             switch(event.dataA()) {
                   case CTRL_PROGRAM:
                         program_change(ch, event.dataB());
@@ -193,6 +193,10 @@ void Fluid::play(const PlayEvent& event)
                         cp->setcc(event.dataA(), event.dataB());
                         break;
                   }
+            }
+      else if (type == ME_PITCHBEND){
+            int midiPitch = event.dataB() * 128 + event.dataA();  // msb * 128 + lsb
+            cp->pitchBend(midiPitch);
             }
       if (err)
             qWarning("FluidSynth error: event 0x%2x channel %d: %s",

--- a/fluid/fluid.cpp
+++ b/fluid/fluid.cpp
@@ -184,9 +184,6 @@ void Fluid::play(const PlayEvent& event)
                   case CTRL_PROGRAM:
                         program_change(ch, event.dataB());
                         break;
-                  case CTRL_PITCH:
-                        cp->pitchBend(event.dataB());
-                        break;
                   case CTRL_PRESS:
                         break;
                   default:

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -258,7 +258,6 @@ static void collectNote(EventMap* events, int channel, const Note* note, int vel
 
                   if (pitchIndex == 0 && (pitch == nextPitch.pitch)) {
                         int midiPitch = (pitch * 16384) / 1200 + 8192;
-                        qDebug()<<"p: "<<midiPitch;
                         int msb = midiPitch / 128;
                         int lsb = midiPitch % 128;
                         NPlayEvent ev(ME_PITCHBEND, channel, lsb, msb);
@@ -285,7 +284,6 @@ static void collectNote(EventMap* events, int channel, const Note* note, int vel
 
                         // We don't support negative pitch, but Midi does. Let's center by adding 8192.
                         int midiPitch = (p * 16384) / 1200 + 8192;
-                        qDebug()<<"p: "<<midiPitch;
                         // Representing pitch as two bytes
                         int msb = midiPitch / 128;
                         int lsb = midiPitch % 128;
@@ -297,59 +295,6 @@ static void collectNote(EventMap* events, int channel, const Note* note, int vel
             NPlayEvent ev(ME_PITCHBEND, channel, 0, 64); // 0:64 is 8192 - no pitch bend
             events->insert(std::pair<int, NPlayEvent>(tick1+noteLen, ev));
             }
-#if 0
-      if (note->bend()) {
-            Bend* bend = note->bend();
-            int ticks = note->playTicks();
-            const QList<PitchValue>& points = bend->points();
-
-            // transform into midi values
-            //    pitch is in 1/100 semitones
-            //    midi pitch is 12/16384 semitones
-            //
-            //    time is in noteDuration/60
-
-            int n = points.size();
-            int tick1 = 0;
-            for (int pt = 0; pt < n; ++pt) {
-                  int pitch = points[pt].pitch;
-
-                  if ((pt == 0) && (pitch == points[pt+1].pitch)) {
-                        Event ev(ME_CONTROLLER);
-                        ev.setChannel(channel);
-                        ev.setController(CTRL_PITCH);
-                        int midiPitch = (pitch * 16384) / 300;
-                        ev.setValue(midiPitch);
-                        events->insertMulti(tick, ev);
-                        }
-                  if (pitch != points[pt+1].pitch) {
-                        int pitchDelta = points[pt+1].pitch - pitch;
-                        int tick2      = (points[pt+1].time * ticks) / 60;
-                        int dt = points[pt+1].time - points[pt].time;
-                        for (int tick3 = tick1; tick3 < tick2; tick3 += 16) {
-                              Event ev(ME_CONTROLLER);
-                              ev.setChannel(channel);
-                              ev.setController(CTRL_PITCH);
-
-                              int dx = ((tick3-tick1) * 60) / ticks;
-                              int p  = pitch + dx * pitchDelta / dt;
-
-                              int midiPitch = (p * 16384) / 1200;
-                              ev.setValue(midiPitch);
-                              events->insertMulti(tick + tick3, ev);
-                              }
-                        tick1 = tick2;
-                        }
-                  if (pt == (n-2))
-                        break;
-                  }
-            Event ev(ME_CONTROLLER);
-            ev.setChannel(channel);
-            ev.setController(CTRL_PITCH);
-            ev.setValue(0);
-            events->insertMulti(tick + ticks, ev);
-            }
-#endif
       }
 
 //---------------------------------------------------------

--- a/midi/midifile.cpp
+++ b/midi/midifile.cpp
@@ -102,19 +102,17 @@ void MidiFile::writeEvent(const MidiEvent& event)
                   put(event.velo());
                   break;
 
+            case ME_PITCHBEND:
+                  writeStatus(ME_PITCHBEND, event.channel());
+                  put(event.dataA());
+                  put(event.dataB());
+                  break;
+
             case ME_CONTROLLER:
                   switch(event.controller()) {
                         case CTRL_PROGRAM:
                               writeStatus(ME_PROGRAM, event.channel());
                               put(event.value() & 0x7f);
-                              break;
-                        case CTRL_PITCH:
-                              {
-                              writeStatus(ME_PITCHBEND, event.channel());
-                              int v = event.value() + 8192;
-                              put(v & 0x7f);
-                              put((v >> 7) & 0x7f);
-                              }
                               break;
                         case CTRL_PRESS:
                               writeStatus(ME_AFTERTOUCH, event.channel());
@@ -599,9 +597,8 @@ bool MidiFile::readEvent(MidiEvent* event)
                   event->setValue(b & 0x7f);
                   break;
             case ME_PITCHBEND:        // pitch bend
-                  event->setType(ME_CONTROLLER);
-                  event->setController(CTRL_PITCH);
-                  event->setValue(((((b & 0x80) ? 0 : b) << 7) + a) - 8192);
+                  event->setDataA(a & 0x7f);
+                  event->setDataB(b & 0x7f);
                   break;
             case ME_PROGRAM:
                   event->setValue(a & 0x7f);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -152,6 +152,7 @@ void Preferences::init()
             midiRemote[i].type = MIDI_REMOTE_TYPE_INACTIVE;
 
       midiExpandRepeats        = true;
+      midiExportRPNs           = false;
       MScore::playRepeats      = true;
       MScore::panPlayback      = true;
       instrumentList1          = ":/data/instruments.xml";
@@ -284,6 +285,7 @@ void Preferences::write()
       s.setValue("defaultStyle",       defaultStyleFile);
 
       s.setValue("midiExpandRepeats",  midiExpandRepeats);
+      s.setValue("midiExportRPNs",     midiExportRPNs);
       s.setValue("playRepeats",        MScore::playRepeats);
       s.setValue("panPlayback",        MScore::panPlayback);
       s.setValue("instrumentList",     instrumentList1);
@@ -426,6 +428,7 @@ void Preferences::read()
       defaultStyleFile         = s.value("defaultStyle", defaultStyleFile).toString();
 
       midiExpandRepeats        = s.value("midiExpandRepeats", midiExpandRepeats).toBool();
+      midiExportRPNs           = s.value("midiExportRPNs", midiExportRPNs).toBool();
       MScore::playRepeats      = s.value("playRepeats", MScore::playRepeats).toBool();
       MScore::panPlayback      = s.value("panPlayback", MScore::panPlayback).toBool();
       alternateNoteEntryMethod = s.value("alternateNoteEntry", alternateNoteEntryMethod).toBool();
@@ -830,6 +833,7 @@ void PreferenceDialog::updateValues()
             }
       sessionScore->setText(prefs.startScore);
       expandRepeats->setChecked(prefs.midiExpandRepeats);
+      exportRPNs->setChecked(prefs.midiExportRPNs);
       instrumentList1->setText(prefs.instrumentList1);
       instrumentList2->setText(prefs.instrumentList2);
 
@@ -1374,6 +1378,7 @@ void PreferenceDialog::apply()
       prefs.exportAudioSampleRate = exportAudioSampleRates[idx];
 
       prefs.midiExpandRepeats  = expandRepeats->isChecked();
+      prefs.midiExportRPNs     = exportRPNs->isChecked();
       prefs.instrumentList1    = instrumentList1->text();
       prefs.instrumentList2    = instrumentList2->text();
 

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -122,6 +122,7 @@ struct Preferences {
       MidiRemote midiRemote[MIDI_REMOTES];
 
       bool midiExpandRepeats;
+      bool midiExportRPNs;
       QString instrumentList1; // file path of instrument templates
       QString instrumentList2;
 

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -23,6 +23,64 @@
    <string>MuseScore Preferences</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_10">
+   <item row="1" column="0">
+    <layout class="QHBoxLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QPushButton" name="resetToDefault">
+       <property name="accessibleName">
+        <string>Reset All Preferences to Default</string>
+       </property>
+       <property name="text">
+        <string>Reset All Preferences to Default</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>131</width>
+         <height>31</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+       <property name="accessibleName">
+        <string>Apply</string>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="0" column="0">
     <widget class="QTabWidget" name="General">
      <property name="sizePolicy">
@@ -3063,6 +3121,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="exportRPNs">
+            <property name="text">
+             <string>Export RPNs</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -3461,64 +3526,6 @@
      </widget>
     </widget>
    </item>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QPushButton" name="resetToDefault">
-       <property name="accessibleName">
-        <string>Reset All Preferences to Default</string>
-       </property>
-       <property name="text">
-        <string>Reset All Preferences to Default</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>131</width>
-         <height>31</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="focusPolicy">
-        <enum>Qt::StrongFocus</enum>
-       </property>
-       <property name="accessibleName">
-        <string>Apply</string>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
   </layout>
  </widget>
  <pixmapfunction>getPixmap</pixmapfunction>
@@ -3661,7 +3668,6 @@
   <tabstop>shortestNote</tabstop>
   <tabstop>pngResolution</tabstop>
   <tabstop>pngTransparent</tabstop>
-  <tabstop>expandRepeats</tabstop>
   <tabstop>exportAudioSampleRate</tabstop>
   <tabstop>exportLayout</tabstop>
   <tabstop>exportAllBreaks</tabstop>

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -513,7 +513,7 @@ void Seq::playEvent(const NPlayEvent& event, unsigned framePos)
             if (!mute)
                   putEvent(event, framePos);
             }
-      else if (type == ME_CONTROLLER)
+      else if (type == ME_CONTROLLER || type == ME_PITCHBEND)
             putEvent(event, framePos);
       }
 

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -977,6 +977,23 @@ void Seq::initInstruments(bool realTime)
                   else
                         sendEvent(event);
                   }
+            // Setting pitch bend sensitivity to 12 semitones for external synthesizers
+            if ((preferences.useJackMidi || preferences.useAlsaAudio) && mm.channel != 9) {
+                  if (realTime) {
+                        putEvent(NPlayEvent(ME_CONTROLLER, channel->channel, CTRL_LRPN, 0));
+                        putEvent(NPlayEvent(ME_CONTROLLER, channel->channel, CTRL_HRPN, 0));
+                        putEvent(NPlayEvent(ME_CONTROLLER, channel->channel, CTRL_HDATA,12));
+                        putEvent(NPlayEvent(ME_CONTROLLER, channel->channel, CTRL_LRPN, 127));
+                        putEvent(NPlayEvent(ME_CONTROLLER, channel->channel, CTRL_HRPN, 127));
+                        }
+                  else {
+                        sendEvent(NPlayEvent(ME_CONTROLLER, channel->channel, CTRL_LRPN, 0));
+                        sendEvent(NPlayEvent(ME_CONTROLLER, channel->channel, CTRL_HRPN, 0));
+                        sendEvent(NPlayEvent(ME_CONTROLLER, channel->channel, CTRL_HDATA,12));
+                        sendEvent(NPlayEvent(ME_CONTROLLER, channel->channel, CTRL_LRPN, 127));
+                        sendEvent(NPlayEvent(ME_CONTROLLER, channel->channel, CTRL_HRPN, 127));
+                        }
+                  }
             }
       }
 
@@ -1177,11 +1194,15 @@ void Seq::stopNotes(int channel, bool realTime)
             for(int ch = 0; ch < cs->midiMapping()->size(); ch++) {
                   send(NPlayEvent(ME_CONTROLLER, ch, CTRL_SUSTAIN, 0));
                   send(NPlayEvent(ME_CONTROLLER, ch, CTRL_ALL_NOTES_OFF, 0));
+                  if (cs->midiChannel(ch) != 9)
+                        send(NPlayEvent(ME_PITCHBEND,  ch, 0, 64));
                   }
             }
       else {
             send(NPlayEvent(ME_CONTROLLER, channel, CTRL_SUSTAIN, 0));
             send(NPlayEvent(ME_CONTROLLER, channel, CTRL_ALL_NOTES_OFF, 0));
+            if (cs->midiChannel(channel) != 9)
+                  send(NPlayEvent(ME_PITCHBEND,  channel, 0, 64));
             }
       if (preferences.useAlsaAudio || preferences.useJackAudio || preferences.usePulseAudio || preferences.usePortaudioAudio)
             _synti->allNotesOff(channel);

--- a/synthesizer/event.h
+++ b/synthesizer/event.h
@@ -124,7 +124,7 @@ enum {
       // controller
       //
       CTRL_PROGRAM   = 0x81,
-      CTRL_PITCH     = 0x82,
+      /*             = 0x82,*/
       CTRL_PRESS     = 0x83,
       CTRL_POLYAFTER = 0x84
       };


### PR DESCRIPTION
* Added bend playback via internal and external synthesisers.
* Added "Export RPNs" checkbox in Preferences to (dis)allow export of RPN messages ([some software](https://musescore.org/en/node/37431) crashes while getting RPN events). Unchecked by default.
* Removed CTRL_PITCH internal MIDI event. Using ME_PITCHBEND is enough.
* Default pitch wheel sensitivity changed to 12 semi-tones for compatibility with GuitarPro and TuxGuitar.

We support importing bends from Gp* files as well as reading/writing to msc* files.
We don't support importing bends from MIDI and MusicXML files.

Here's video demo of bend playback: a solo from Guns N' Roses - Sweet Child O' Mine.
https://www.youtube.com/watch?v=5cSO1Hgr8lw

More information: http://igevorse.lited.net/p21.html