### PR TITLE
fix #62961: multiple hairpins added on list selection

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4329,7 +4329,9 @@ void ScoreView::cmdAddHairpin(bool decrescendo)
             _score->endCmd();
             _score->startCmd();
             }
-      else {
+      else if (selection.isRange() || selection.isSingle()) {
+            // for single staff range selection, or single selection,
+            // find start & end elements elements
             ChordRest* cr1;
             ChordRest* cr2;
             _score->getSelectedChordRest2(&cr1, &cr2);
@@ -4356,6 +4358,11 @@ void ScoreView::cmdAddHairpin(bool decrescendo)
                   else
                         _score->endCmd();
                   }
+            }
+      else {
+            // do not attempt for list selection
+            // or we will keep adding hairpins to the same chordrests
+            return;
             }
       }
 


### PR DESCRIPTION
Turns out it isn't straightforeard to just add a single hairpin to each note.  cmdAddHairpin tries to find appropriate notes within the selection; it isn't actually passed the current note.  We could add that as a parameter, but then it still wouldn't be clear when to use the current method and when to use the passed note.  It might be nice to support a single note selected on each staff, but since we support ranges across staves, that should be good enough most of the time.