### PR TITLE
Typo fix

### DIFF
--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -641,7 +641,7 @@ class ChangePatch : public UndoCommand {
    public:
       ChangePatch(Score* s, Channel* c, const MidiPatch* pt)
          : score(s), channel(c), patch(*pt) {}
-      UNDO_NAME("ChangePitch")
+      UNDO_NAME("ChangePatch")
       };
 
 //---------------------------------------------------------
@@ -1286,7 +1286,7 @@ class LinkUnlink : public UndoCommand {
 class Unlink : public LinkUnlink {
 
    public:
-      Unlink(ScoreElement* e) : LinkUnlink(e, nullptr) {};
+      Unlink(ScoreElement* e) : LinkUnlink(e, nullptr) {}
       virtual void undo() override { doLink();   }
       virtual void redo() override { doUnlink(); }
       UNDO_NAME("Unlink")


### PR DESCRIPTION
Typo fix in Undo.h
I've checked other Undo classes for the same typos - they're ok.