### PR TITLE
Fix mtest compilation on Windows (ambiguous Chord symbol)

### DIFF
--- a/mtest/libmscore/copypaste/tst_copypaste.cpp
+++ b/mtest/libmscore/copypaste/tst_copypaste.cpp
@@ -61,15 +61,15 @@ class TestCopyPaste : public QObject, public MTest
       void copyPasteOnlySecondVoice();
       void copypaste19() { copypaste("19"); }       // chord symbols
       void copyPasteShortTremolo() { copypastevoice("21", 1); } // remove tremolo on shorten note #30411
-      
+
 
       void copypastestaff50() { copypastestaff("50"); }       // staff & slurs
 
       void copyPastePartial();
-      
+
       void copyPasteTuplet01() { copypastetuplet("01"); }
       void copyPasteTuplet02() { copypastetuplet("02"); }
-      
+
       };
 
 //---------------------------------------------------------
@@ -204,7 +204,7 @@ void TestCopyPaste::copyPaste2Voice()
 
       // select 2 chord rests at the start of the first measure
       Segment* s = m1->first(Segment::Type::ChordRest);
-      score->select(static_cast<Chord*>(s->element(0))->notes().at(0));
+      score->select(static_cast<Ms::Chord*>(s->element(0))->notes().at(0));
       s = s->next(Segment::Type::ChordRest);
       score->select(s->element(0), SelectType::RANGE);
 
@@ -248,7 +248,7 @@ void TestCopyPaste::copypastevoice(const char* idx, int voice)
       // create a range selection on 2 and 3 beat of first measure
       Segment::Type segTypeCR = Segment::Type::ChordRest;
       Segment* s = m1->first(segTypeCR)->next1(segTypeCR);
-      score->select(static_cast<Chord*>(s->element(voice))->notes().at(0));
+      score->select(static_cast<Ms::Chord*>(s->element(voice))->notes().at(0));
       s = s->next(Segment::Type::ChordRest);
       score->select(s->element(voice), SelectType::RANGE);
 
@@ -284,7 +284,7 @@ void TestCopyPaste::copyPaste2Voice5()
       // create a range selection from 2 eighth note to the end of first measure
       Segment::Type segTypeCR = Segment::Type::ChordRest;
       Segment* s = m1->first(segTypeCR)->next1(segTypeCR);
-      score->select(static_cast<Chord*>(s->element(0))->notes().at(0));
+      score->select(static_cast<Ms::Chord*>(s->element(0))->notes().at(0));
 
       s = m1->last()->prev(Segment::Type::ChordRest);
       score->select(s->element(0), SelectType::RANGE);
@@ -365,7 +365,7 @@ void TestCopyPaste::copypaste2Voice6()
       // create a range selection from 2nd eighth note to the end of first measure
       Segment::Type segTypeCR = Segment::Type::ChordRest;
       Segment* s = m1->first(segTypeCR)->next1(segTypeCR);
-      score->select(static_cast<Chord*>(s->element(0))->notes().at(0));
+      score->select(static_cast<Ms::Chord*>(s->element(0))->notes().at(0));
 
       s = m1->last()->prev(Segment::Type::ChordRest);
       score->select(s->element(1), SelectType::RANGE);
@@ -403,7 +403,7 @@ void TestCopyPaste::copypastetuplet(const char* idx)
       Measure* m2 = m1->nextMeasure();
 
       Segment* s = m1->first(Segment::Type::ChordRest);
-      score->select(static_cast<Chord*>(s->element(0))->notes().at(0));
+      score->select(static_cast<Ms::Chord*>(s->element(0))->notes().at(0));
       s = s->next(Segment::Type::ChordRest);
       score->select(s->element(0), SelectType::RANGE);
       QVERIFY(score->selection().canCopy());

--- a/mtest/libmscore/earlymusic/tst_earlymusic.cpp
+++ b/mtest/libmscore/earlymusic/tst_earlymusic.cpp
@@ -61,7 +61,7 @@ void TestEarlymusic::earlymusic01()
       QVERIFY(msr);
       Segment*    seg   = msr->findSegment(Segment::Type::ChordRest, 0);
       QVERIFY(seg);
-      Chord*      chord = static_cast<Chord*>(seg->element(0));
+      Ms::Chord*      chord = static_cast<Ms::Chord*>(seg->element(0));
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       QVERIFY(chord->crossMeasure() == CrossMeasure::UNKNOWN);
       TDuration cmDur   = chord->crossMeasureDurationType();

--- a/mtest/libmscore/join/tst_join.cpp
+++ b/mtest/libmscore/join/tst_join.cpp
@@ -113,7 +113,7 @@ void TestJoin::join1(const char* p1)
       Segment* s = score->firstSegment(Segment::Type::ChordRest);
 
       for (int i = 0; i < 8; ++i) {
-            Note* note = static_cast<Chord*>(s->element(0))->upNote();
+            Note* note = static_cast<Ms::Chord*>(s->element(0))->upNote();
             QVERIFY(note->line() == 6);
             s = s->next1(Segment::Type::ChordRest);
             }

--- a/mtest/libmscore/note/tst_note.cpp
+++ b/mtest/libmscore/note/tst_note.cpp
@@ -316,12 +316,12 @@ void TestNote::grace()
       {
       Score* score = readScore(DIR + "grace.mscx");
       score->doLayout();
-      Chord* chord = score->firstMeasure()->findChord(0, 0);
+      Ms::Chord* chord = score->firstMeasure()->findChord(0, 0);
       Note* note = chord->upNote();
 
       // create
       score->setGraceNote(chord, note->pitch(), NoteType::APPOGGIATURA, MScore::division/2);
-      Chord* gc = chord->graceNotes().first();
+      Ms::Chord* gc = chord->graceNotes().first();
       Note* gn = gc->notes().first();
 //      Note* n = static_cast<Note*>(writeReadElement(gn));
 //      QCOMPARE(n->noteType(), NoteType::APPOGGIATURA);
@@ -342,7 +342,7 @@ void TestNote::grace()
       tr->setTrack(gc->track());
       score->undoAddElement(tr);
       score->endCmd();
-//      Chord* c = static_cast<Chord*>(writeReadElement(gc));
+//      Ms::Chord* c = static_cast<Ms::Chord*>(writeReadElement(gc));
 //      QVERIFY(c->tremolo() != 0);
 //      delete c;
 
@@ -354,7 +354,7 @@ void TestNote::grace()
       ar->setTrack(gc->track());
       score->undoAddElement(ar);
       score->endCmd();
-//      c = static_cast<Chord*>(writeReadElement(gc));
+//      c = static_cast<Ms::Chord*>(writeReadElement(gc));
 //      QVERIFY(c->articulations().size() == 1);
 //      delete c;
 

--- a/mtest/libmscore/parts/tst_parts.cpp
+++ b/mtest/libmscore/parts/tst_parts.cpp
@@ -897,7 +897,7 @@ Score* TestParts::doAddImage()
 
       Measure* m   = score->firstMeasure();
       Segment* s   = m->tick2segment(MScore::division);
-      Chord* chord = static_cast<Chord*>(s->element(0));
+      Ms::Chord* chord = static_cast<Ms::Chord*>(s->element(0));
       Note* note   = chord->upNote();
       DropData dd;
       dd.view = 0;

--- a/mtest/libmscore/spanners/tst_spanners.cpp
+++ b/mtest/libmscore/spanners/tst_spanners.cpp
@@ -82,7 +82,7 @@ void TestSpanners::spanners01()
       QVERIFY(msr);
       Segment*    seg   = msr->findSegment(Segment::Type::ChordRest, 0);
       QVERIFY(seg);
-      Chord*      chord = static_cast<Chord*>(seg->element(0));
+      Ms::Chord*      chord = static_cast<Ms::Chord*>(seg->element(0));
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       Note*       note  = chord->upNote();
       QVERIFY(note);
@@ -98,7 +98,7 @@ void TestSpanners::spanners01()
       QVERIFY(msr);
       seg   = msr->first();
       QVERIFY(seg);
-      chord = static_cast<Chord*>(seg->element(0));   // voice 0 of staff 0
+      chord = static_cast<Ms::Chord*>(seg->element(0));   // voice 0 of staff 0
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       note  = chord->upNote();
       QVERIFY(note);
@@ -114,7 +114,7 @@ void TestSpanners::spanners01()
       QVERIFY(msr);
       seg   = msr->first();
       QVERIFY(seg);
-      chord = static_cast<Chord*>(seg->element(4));   // voice 0 of staff 1
+      chord = static_cast<Ms::Chord*>(seg->element(4));   // voice 0 of staff 1
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       note  = chord->upNote();
       QVERIFY(note);
@@ -130,7 +130,7 @@ void TestSpanners::spanners01()
       QVERIFY(msr);
       seg   = msr->first();
       QVERIFY(seg);
-      chord = static_cast<Chord*>(seg->element(0));   // voice 0 of staff 0
+      chord = static_cast<Ms::Chord*>(seg->element(0));   // voice 0 of staff 0
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       note  = chord->upNote();
       QVERIFY(note);
@@ -146,7 +146,7 @@ void TestSpanners::spanners01()
       QVERIFY(msr);
       seg   = msr->first();
       QVERIFY(seg);
-      chord = static_cast<Chord*>(seg->element(0));   // voice 0 of staff 0
+      chord = static_cast<Ms::Chord*>(seg->element(0));   // voice 0 of staff 0
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       note  = chord->upNote();
       QVERIFY(note);
@@ -199,7 +199,7 @@ void TestSpanners::spanners03()
       QVERIFY(msr);
       Segment*    seg   = msr->findSegment(Segment::Type::ChordRest, 0);
       QVERIFY(seg);
-      Chord*      chord = static_cast<Chord*>(seg->element(0));
+      Ms::Chord*      chord = static_cast<Ms::Chord*>(seg->element(0));
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       Note*       note  = chord->upNote();
       QVERIFY(note);
@@ -211,7 +211,7 @@ void TestSpanners::spanners03()
 
       // GLISSANDO FROM AFTER-GRACE TO BEFORE-GRACE OF NEXT CHORD
       // go to last after-grace of chord and drop a glissando on it
-      Chord*      grace = chord->graceNotesAfter().last();
+      Ms::Chord*      grace = chord->graceNotesAfter().last();
       QVERIFY(grace && grace->type() == Element::Type::CHORD);
       note              = grace->upNote();
       QVERIFY(note);
@@ -224,7 +224,7 @@ void TestSpanners::spanners03()
       // go to next chord
       seg               = seg->nextCR(0);
       QVERIFY(seg);
-      chord             = static_cast<Chord*>(seg->element(0));
+      chord             = static_cast<Ms::Chord*>(seg->element(0));
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       note              = chord->upNote();
       QVERIFY(note);
@@ -237,7 +237,7 @@ void TestSpanners::spanners03()
       // go to next chord
       seg               = seg->nextCR(0);
       QVERIFY(seg);
-      chord             = static_cast<Chord*>(seg->element(0));
+      chord             = static_cast<Ms::Chord*>(seg->element(0));
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       // go to its last before-grace note
       grace             = chord->graceNotesBefore().last();
@@ -335,7 +335,7 @@ void TestSpanners::spanners06()
       QVERIFY(msr);
       Segment*    seg   = msr->findSegment(Segment::Type::ChordRest, 0);
       QVERIFY(seg);
-      Chord*      chord = static_cast<Chord*>(seg->element(0));
+      Ms::Chord*      chord = static_cast<Ms::Chord*>(seg->element(0));
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       Note*       note  = chord->upNote();
       QVERIFY(note);
@@ -368,7 +368,7 @@ void TestSpanners::spanners07()
       QVERIFY(msr);
       Segment*    seg   = msr->findSegment(Segment::Type::ChordRest, 0);
       QVERIFY(seg);
-      Chord*      chord = static_cast<Chord*>(seg->element(0));
+      Ms::Chord*      chord = static_cast<Ms::Chord*>(seg->element(0));
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       Note*       note  = chord->upNote();
       QVERIFY(note);
@@ -403,7 +403,7 @@ void TestSpanners::spanners08()
       QVERIFY(msr);
       Segment*    seg   = msr->findSegment(Segment::Type::ChordRest, 0);
       QVERIFY(seg);
-      Chord*      chord = static_cast<Chord*>(seg->element(0));
+      Ms::Chord*      chord = static_cast<Ms::Chord*>(seg->element(0));
       QVERIFY(chord && chord->type() == Element::Type::CHORD);
       QVERIFY(chord->lyricsList().size() > 0);
       Lyrics*     lyr   = chord->lyrics(0);

--- a/mtest/libmscore/tools/tst_tools.cpp
+++ b/mtest/libmscore/tools/tst_tools.cpp
@@ -416,7 +416,7 @@ void TestTools::undoChangeVoice()
       for (Segment* s = score->firstSegment(Segment::Type::ChordRest); s; s = s->next1()) {
             ChordRest* cr = static_cast<ChordRest*>(s->element(0));
             if (cr && cr->type() == Element::Type::CHORD) {
-                  Chord* c = static_cast<Chord*>(cr);
+                  Ms::Chord* c = static_cast<Ms::Chord*>(cr);
                   score->select(c->downNote(), SelectType::ADD);
                   }
             }


### PR DESCRIPTION
Error message:
https://gist.github.com/trig-ger/e20e780f29c02544d100

Some time before similar error was fixed in a similar way.