### PR TITLE
fix #64506: temporary corruption on add of measure repeat

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1741,7 +1741,7 @@ void Score::deleteItem(Element* el)
                   removeChordRest(rm, false);
                   Rest* rest = new Rest(this);
                   rest->setDurationType(TDuration::DurationType::V_MEASURE);
-                  rest->setDuration(rm->measure()->len());
+                  rest->setDuration(rm->measure()->stretchedLen(rm->staff()));
                   rest->setTrack(rm->track());
                   rest->setParent(rm->parent());
                   Segment* segment = rm->segment();

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1515,6 +1515,8 @@ RepeatMeasure* Measure::cmdInsertRepeatMeasure(int staffIdx)
       RepeatMeasure* rm = new RepeatMeasure(_score);
       rm->setTrack(staffIdx * VOICES);
       rm->setParent(seg);
+      rm->setDurationType(TDuration::DurationType::V_MEASURE);
+      rm->setDuration(stretchedLen(_score->staff(staffIdx)));
       _score->undoAddCR(rm, this, tick());
       foreach (Element* el, _el) {
             if (el->type() == Element::Type::SLUR && el->staffIdx() == staffIdx)

--- a/libmscore/repeat.cpp
+++ b/libmscore/repeat.cpp
@@ -77,7 +77,7 @@ void RepeatMeasure::layout()
 Fraction RepeatMeasure::duration() const
       {
       if (measure())
-            return measure()->len();
+            return measure()->stretchedLen(staff());
       return Fraction(0, 1);
       }
 

--- a/mscore/debugger/debugger.cpp
+++ b/mscore/debugger/debugger.cpp
@@ -591,6 +591,7 @@ void Debugger::updateElement(Element* el)
                   case Element::Type::MEASURE:          ew = new MeasureView;         break;
                   case Element::Type::CHORD:            ew = new ChordDebug;          break;
                   case Element::Type::NOTE:             ew = new ShowNoteWidget;      break;
+                  case Element::Type::REPEAT_MEASURE:
                   case Element::Type::REST:             ew = new RestView;            break;
                   case Element::Type::CLEF:             ew = new ClefView;            break;
                   case Element::Type::TIMESIG:          ew = new TimeSigView;         break;
@@ -1205,7 +1206,7 @@ void ShowNoteWidget::accidentalClicked()
 RestView::RestView()
    : ShowElementBase()
       {
-      // chort rest
+      // chord rest
       crb.setupUi(addWidget());
       crb.beamMode->addItem("auto");
       crb.beamMode->addItem("beam begin");

--- a/mtest/guitarpro/repeated-bars.gpx-ref.mscx
+++ b/mtest/guitarpro/repeated-bars.gpx-ref.mscx
@@ -183,9 +183,9 @@
       <Measure number="2">
         <RepeatMeasure>
           <lid>15</lid>
+          <durationType>measure</durationType>
           <duration z="4" n="4"/>
           </RepeatMeasure>
-        <tick>3840</tick>
         <BarLine>
           <subtype>end</subtype>
           <span>1</span>
@@ -396,9 +396,9 @@
         <Measure number="2">
           <RepeatMeasure>
             <lid>15</lid>
+            <durationType>measure</durationType>
             <duration z="4" n="4"/>
             </RepeatMeasure>
-          <tick>3840</tick>
           <BarLine>
             <subtype>end</subtype>
             <span>1</span>
@@ -459,9 +459,9 @@
         <Measure number="2">
           <RepeatMeasure>
             <lid>15</lid>
+            <durationType>measure</durationType>
             <duration z="4" n="4"/>
             </RepeatMeasure>
-          <tick>3840</tick>
           <BarLine>
             <subtype>end</subtype>
             <span>1</span>


### PR DESCRIPTION
Measure repeats were being added with a durationType of V_INVALID and a duration of 0, and hence measures were being reported as corrupt on save online.  The duration was being written to the score, so it fixed itself on save/reload, although the durationType still reported as V_INVALID.

I have changed this use V_MEASURE and set the correct duration from the beginning.  If we really want to keep V_INVALID, I suppose that will still work, but this makes more sense to me.  It does mean tests may need to be updated as we will now be writing the durationType.  I will let Travis tell me about this.

BTW, there were also corruption issues both in writing the score and after deleting a measure repeat symbol if local time signatures were involved.  I fixed these by changing a couple of len() calls to stretchedLen().