### PR TITLE
fix for #63961: save/restore mid-measure barline span correctly

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -203,6 +203,9 @@ void BarLine::getY(qreal* y1, qreal* y2) const
             int staffIdx1    = staffIdx();
             int staffIdx2    = staffIdx1 + _span - 1;
             if (staffIdx2 >= score()->nstaves()) {
+                  // this can happen on read
+                  // as we may be laying out a barline that spans multiple staves
+                  // before we have read the staves it spans
                   qDebug("BarLine: bad _span %d", _span);
                   staffIdx2 = score()->nstaves() - 1;
                   }
@@ -557,7 +560,7 @@ void BarLine::read(XmlReader& e)
                   _span     = e.readInt();
 
                   if (_spanTo == UNKNOWN_BARLINE_TO)
-                        _spanTo = staff() ? (staff()->lines() -1) * _span : 4 * _span;
+                        _spanTo = staff() ? (staff()->lines() - 1) * 2 : 8;
 
                   // WARNING: following statements assume staff and staff bar line spans are correctly set
                   // ws: _spanTo can be UNKNOWN_BARLINE_TO

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -807,6 +807,7 @@ Element* ChordRest::drop(const DropData& data)
                   {
                   BarLine* bl = static_cast<BarLine*>(e);
                   bl->setTrack(staffIdx() * VOICES);
+                  bl->setGenerated(false);
 
                   if (tick() == m->tick())
                         return m->drop(data);


### PR DESCRIPTION
So far I have only a partial fix - the issue with the modified barline not saving / restoring correctly.  It seems actually this didn't work at all until a few months ago - see https://github.com/musescore/MuseScore/commit/729a788b44240947fd83fbed7dc678d10fb6f73a.  Now it works only if adding the barline via drap & drop as opposed to click note / double click palette icon - the latter sets the barline to generated, so it isn't written.  Furthermore, if extending the mid-measure barline across multiple staves, it fails on save / reload if extending the barline across more than two staves - this is because the span is set incorrectly (according to my understanding of how it should be set).

These changes don't address the problem of the span not affecting linked parts.  That's more complicated, as it will require creating new linked barlines.  I'm not sure we can make all possible combinations work, but I'm trying to get the basic case described in the issue report to work.  Those changes will be elsewhere in the code.