### PR TITLE
fix #64911: space before start repeat

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3929,8 +3929,8 @@ qreal Score::computeMinWidth(Segment* fs, bool firstMeasureInSystem)
                               }
                         if ((segType == Segment::Type::Clef) && (pt != Segment::Type::ChordRest))
                               minDistance = styleP(StyleIdx::clefLeftMargin);
-                        else if (segType == Segment::Type::StartRepeatBarLine)
-                              minDistance = .5 * _spatium;
+                        else if (segType == Segment::Type::StartRepeatBarLine && pSeg)
+                              minDistance = .5 * _spatium;  // TODO: make style parameter
                         else if (segType == Segment::Type::TimeSig && pt == Segment::Type::Clef) {
                               // missing key signature, but allocate default margin anyhow
                               minDistance = styleP(StyleIdx::keysigLeftMargin);
@@ -3974,12 +3974,12 @@ qreal Score::computeMinWidth(Segment* fs, bool firstMeasureInSystem)
                         qreal sp = 0.0;
 
                         // space chord symbols unless they miss each other vertically
-                        if (eFound || (hFound && hBbox.top() < hLastBbox[staffIdx].bottom() && hBbox.bottom() > hLastBbox[staffIdx].top()))
+                        if (hFound && hBbox.top() < hLastBbox[staffIdx].bottom() && hBbox.bottom() > hLastBbox[staffIdx].top())
                               sp = hRest[staffIdx] + minHarmonyDistance + hSpace.lw();
 
                         // barline: limit space to maxHarmonyBarDistance
-                        if (eFound && !hFound && spaceHarmony)
-                              sp = qMin(sp, maxHarmonyBarDistance);
+                        else if (eFound && !hFound && spaceHarmony)
+                              sp = qMin(hRest[staffIdx], maxHarmonyBarDistance);
 
                         hLastBbox[staffIdx] = hBbox;
                         hRest[staffIdx] = hSpace.rw();

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3371,7 +3371,7 @@ void Measure::layoutX(qreal stretch)
                               }
                         if ((segType == Segment::Type::Clef) && (pt != Segment::Type::ChordRest))
                               minDistance = score()->styleS(StyleIdx::clefLeftMargin).val() * _spatium;
-                        else if (segType == Segment::Type::StartRepeatBarLine)
+                        else if (segType == Segment::Type::StartRepeatBarLine && pSeg)
                               minDistance = .5 * _spatium;
                         else if (segType == Segment::Type::TimeSig && pt == Segment::Type::Clef) {
                               // missing key signature, but allocate default margin anyhow
@@ -3417,12 +3417,12 @@ void Measure::layoutX(qreal stretch)
                         qreal sp = 0.0;
 
                         // space chord symbols unless they miss each other vertically
-                        if (eFound || (hFound && hBbox.top() < hLastBbox[staffIdx].bottom() && hBbox.bottom() > hLastBbox[staffIdx].top()))
+                        if (hFound && hBbox.top() < hLastBbox[staffIdx].bottom() && hBbox.bottom() > hLastBbox[staffIdx].top())
                               sp = hRest[staffIdx] + minHarmonyDistance + hSpace.lw();
 
                         // barline: limit space to maxHarmonyBarDistance
-                        if (eFound && !hFound && spaceHarmony)
-                              sp = qMin(sp, maxHarmonyBarDistance);
+                        else if (eFound && spaceHarmony)
+                              sp = qMin(hRest[staffIdx], maxHarmonyBarDistance);
 
                         hLastBbox[staffIdx] = hBbox;
                         hRest[staffIdx] = hSpace.rw();


### PR DESCRIPTION
The bug report shows how start repeats at the beginning of a system with no clef / key / time signature are inappropriately indented.  It turns out there are two totally different reasons why.

First, there was 0.5sp space always added before start repeats.  I changed this only do this if there is a previous segment.

The trickier issue is that the algorithm for avoiding collisions betwene chord symbols was causing minHarmonyDistance space to be allocated in front of the first segment of a system.  Turn that setting up (in Style / General / Chord Symbols) to 10sp, and you'll set the first element of each system gets indented by that amount, even if there are no chord symbols anywhere.  And even at the default setting of 0.5sp, I think this may have been causing subtle problems with spacing.

I don't totally understand this aspect of the layout code, but I can see that the problem is that space is being allocated for almost every non-cr (if "efound" is true), whereas I *think* it is really supposed to be about the end barline only.  I simplified the code to clarify this, and so far I don't think I broke anything, but more review and/or testing would be nice.

BTW, I had a hand in some of this code a few months ago as I changed how chords at the end of a measure are handled, but I'm pretty sure this issue predated my changes.  