### PR TITLE
fix #54221: bd layout with measure after horizontal frame

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2787,16 +2787,29 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
 
       qreal ww = rowWidth;
       qreal minWidth;
+      bool firstInRow = true;
       for (bool a = true; a;) {
             a = layoutSystem(minWidth, ww, isFirstSystem, useLongName);
-            sl.append(_systems[curSystem]);
-            ++curSystem;
-            ww -= minWidth;
+            if ((0.0 < minWidth && minWidth <= ww) || firstInRow) {
+                  // system fits on this row, or we need to take it anyhow
+                  sl.append(_systems[curSystem]);
+                  ++curSystem;
+                  ww -= minWidth;
+                  }
+            else {
+                  // system does not fit on this row, and we don't need it to
+                  // reset to add to next row
+                  if (curMeasure)
+                        curMeasure = curMeasure->prev();
+                  else
+                        curMeasure = lastMeasure();
+                  }
+            firstInRow = false;
             }
       //
-      // dont stretch last system row, if minWidth is <= lastSystemFillLimit
+      // dont stretch last system row, if accumulated minWidth is <= lastSystemFillLimit
       //
-      if (curMeasure == 0 && ((minWidth / rowWidth) <= styleD(StyleIdx::lastSystemFillLimit)))
+      if (curMeasure == 0 && (((rowWidth - ww) / rowWidth) <= styleD(StyleIdx::lastSystemFillLimit)))
             raggedRight = true;
 
       //-------------------------------------------------------


### PR DESCRIPTION
layoutSystem() always takes at least one measure, thus forcing at least one measure to always appear after a horizontal frame whether it fits or not.  This change checks the return value from layoutSystem() to be sure it really fits in the row.

I also fixed a glitch in the next line, where we are trying to decide if the last system row needs to be filled, but we actually check only the last system within the row, so we don't fill some systems we should.