### PR TITLE
fix #58821: glitch  extending selection left before mmrest

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2897,7 +2897,7 @@ void Score::selectRange(Element* e, int staffIdx)
                               oe = oe->parent();
                         ChordRest* ocr = static_cast<ChordRest*>(oe);
 
-                        Segment* endSeg = tick2segment(ocr->segment()->tick() + ocr->actualTicks());
+                        Segment* endSeg = tick2segmentMM(ocr->segment()->tick() + ocr->actualTicks());
                         if (!endSeg)
                               endSeg = ocr->segment()->next();
 


### PR DESCRIPTION
This fixes the case at hand, also the similar case where you click a note or rest before an mmrest then shift+click one further to the left.  There may be other places where this same sort of adjustment is needed, but everything else I tried works correctly.