### PR TITLE
add support for shape note stafftypes

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -446,12 +446,73 @@ SymId Note::noteHead() const
       if (_headType != NoteHead::Type::HEAD_AUTO)
             ht = _headType;
 
-      SymId t = noteHead(up, _headGroup, ht);
+      NoteHead::Group headGroup;
+      if (staff()->staffType()->shapeNoteStyle() != ShapeNoteStyle::NONE) {
+            headGroup = shapeNoteHeadGroup();
+            }
+      else {
+            headGroup = _headGroup;
+            }
+
+      SymId t = noteHead(up, headGroup, ht);
       if (t == SymId::noSym) {
             qDebug("invalid note head %hhd/%hhd", _headGroup, ht);
             t = noteHead(up, NoteHead::Group::HEAD_NORMAL, ht);
             }
       return t;
+      }
+      
+//---------------------------------------------------------
+//   shapeNoteHeadGroup
+//---------------------------------------------------------
+
+NoteHead::Group Note::shapeNoteHeadGroup() const
+      {
+      static const char tpcNames[7]  = {'F', 'C', 'G', 'D', 'A', 'E', 'B'};
+      static const char noteNames[7] = {'C', 'D', 'E', 'F', 'G', 'A', 'B'};
+      static const char scales[15]   = {'C', 'G', 'D', 'A', 'E', 'B', 'F', 'C', 'G', 'D', 'A', 'E', 'B', 'F', 'C'};
+      
+      static const NoteHead::Group degreesFourShapes[7]  = { NoteHead::Group::HEAD_FA,
+                                                             NoteHead::Group::HEAD_SOL,
+                                                             NoteHead::Group::HEAD_LA,
+                                                             NoteHead::Group::HEAD_FA,
+                                                             NoteHead::Group::HEAD_SOL,
+                                                             NoteHead::Group::HEAD_LA,
+                                                             NoteHead::Group::HEAD_MI };
+
+      static const NoteHead::Group degreesSevenShapes[7] = { NoteHead::Group::HEAD_DO,
+                                                             NoteHead::Group::HEAD_RE,
+                                                             NoteHead::Group::HEAD_MI,
+                                                             NoteHead::Group::HEAD_FA,
+                                                             NoteHead::Group::HEAD_SOL,
+                                                             NoteHead::Group::HEAD_LA,
+                                                             NoteHead::Group::HEAD_TI };
+      char name = tpcNames[(tpc() + 1) % 7];
+      Key curKey = staff()->key(chord()->tick());
+      char scale = scales[int(curKey) + 7];
+
+      int indexOfScale = 0;
+      for (int i = 0; i < 7; i++) {
+            if (noteNames[i] == scale) {
+                  indexOfScale = i;
+                  break;
+                  }
+            }
+
+      int indexOfName = 0;
+      for (int i = 0; i < 7; i++) {
+            if (noteNames[i] == name) {
+                  indexOfName = i;
+                  break;
+                  }
+            }
+      int degreeIndex = (indexOfName - indexOfScale + 28) % 7;
+
+      ShapeNoteStyle style = staff()->staffType()->shapeNoteStyle();
+      if (style == ShapeNoteStyle::FOUR)
+            return degreesFourShapes[degreeIndex];
+      else //style == ShapeNoteStyle::FOUR
+            return degreesSevenShapes[degreeIndex];
       }
 
 //---------------------------------------------------------

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -270,6 +270,7 @@ class Note : public Element {
       QPointF stemUpSE() const;
 
       SymId noteHead() const;
+      NoteHead::Group shapeNoteHeadGroup() const;
       NoteHead::Group headGroup() const   { return _headGroup; }
       NoteHead::Type headType() const     { return _headType;  }
       void setHeadGroup(NoteHead::Group val);

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -523,7 +523,7 @@ void Staff::read(XmlReader& e)
             if (tag == "type") {    // obsolete
                   int staffTypeIdx = e.readInt();
                   qDebug("obsolete: Staff::read staffTypeIdx %d", staffTypeIdx);
-                  _staffType = *StaffType::preset(StaffTypes(staffTypeIdx));
+                  _staffType = *StaffType::preset(staffTypeIdx);
                   // set default barLineFrom and barLineTo according to staff type num. of lines
                   // (1-line staff bar lines are special)
                   _barLineFrom = (lines() == 1 ? BARLINE_SPAN_1LINESTAFF_FROM : 0);

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -150,10 +150,15 @@ bool StaffType::isSameStructure(const StaffType& st) const
          || st._genTimesig   != _genTimesig)
             return false;
 
-      if (_group != StaffGroup::TAB) {                      // common to pitched and percussion
+      if (_group == StaffGroup::PERCUSSION) {                      // common to pitched and percussion
             return st._genKeysig      == _genKeysig
                && st._showLedgerLines == _showLedgerLines
                ;
+            }
+      else if (_group == StaffGroup::STANDARD) {
+            return st._genKeysig       == _genKeysig
+                && st._showLedgerLines == _showLedgerLines
+                && st._shapeNoteStyle  == _shapeNoteStyle;
             }
       else {                                                // TAB-specific
             return st._genDurations == _genDurations
@@ -221,6 +226,12 @@ void StaffType::write(Xml& xml) const
                   xml.tag("keysig", _genKeysig);
             if (!_showLedgerLines)
                   xml.tag("ledgerlines", _showLedgerLines);
+            if (_shapeNoteStyle != ShapeNoteStyle::NONE) {
+                  if (_shapeNoteStyle == ShapeNoteStyle::FOUR)
+                        xml.tag("shapenotestyle", "FOUR");
+                  else if (_shapeNoteStyle == ShapeNoteStyle::SEVEN)
+                        xml.tag("shapenotestyle", "SEVEN");
+                  }
             }
       else {
             xml.tag("durations",        _genDurations);
@@ -314,6 +325,13 @@ void StaffType::read(XmlReader& e)
                   setUpsideDown(e.readBool());
             else if (tag == "useNumbers")
                   setUseNumbers(e.readBool());
+            else if (tag == "shapenotestyle") {
+                  QString style = e.readElementText();
+                  if (style == "FOUR")
+                        setShapeNoteStyle(ShapeNoteStyle::FOUR);
+                  else if (style == "SEVEN")
+                        setShapeNoteStyle(ShapeNoteStyle::SEVEN);
+                  }
             else
                   e.unknown();
             }
@@ -976,7 +994,7 @@ bool StaffType::fontData(bool bDuration, int nIdx, QString* pFamily, QString* pD
 //
 //=========================================================
 
-static const int _defaultPreset[STAFF_GROUP_MAX] =
+const int StaffType::defaultPreset[] =
       { 0,              // default pitched preset is "stdNormal"
         3,              // default percussion preset is "perc5lines"
         5               // default tab preset is "tab6StrCommon"
@@ -988,11 +1006,11 @@ static const QString _emptyString = QString();
 //   Static functions for StaffType presets
 //---------------------------------------------------------
 
-const StaffType* StaffType::preset(StaffTypes idx)
+const StaffType* StaffType::preset(int idx)
       {
-      if (int(idx) < 0 || int(idx) >= int(_presets.size()))
+      if (idx < 0 || idx >= int(_presets.size()))
             return &_presets[0];
-      return &_presets[int(idx)];
+      return &_presets[idx];
       }
 
 const StaffType* StaffType::presetFromXmlName(QString& xmlName)
@@ -1015,7 +1033,7 @@ const StaffType* StaffType::presetFromName(QString& name)
 #endif
 const StaffType* StaffType::getDefaultPreset(StaffGroup grp)
       {
-      int _idx = _defaultPreset[int(grp)];
+      int _idx = defaultPreset[int(grp)];
       return &_presets[_idx];
       }
 
@@ -1050,6 +1068,15 @@ void StaffType::initStaffTypes()
          StaffType(StaffGroup::TAB, "tab6StrItalian",QObject::tr("Tab. 6-str. Italian"),6, 1.5, false, true, true,  true,  "MuseScore Tab Italian",15, 0, true,  "MuseScore Tab Renaiss",10, 0, TablatureSymbolRepeat::NEVER, true,  TablatureMinimStyle::NONE,   true,  true,  false, false, true,  true),
          StaffType(StaffGroup::TAB, "tab6StrFrench", QObject::tr("Tab. 6-str. French"), 6, 1.5, false, true, true,  true,  "MuseScore Tab French", 15, 0, true,  "MuseScore Tab Renaiss",10, 0, TablatureSymbolRepeat::NEVER, true,  TablatureMinimStyle::NONE,   false, false, false, false, false, false)
          };
+      
+      StaffType shapeNotesFour = StaffType(StaffGroup::STANDARD, "shapeNotesFour", QObject::tr("Shape Notes - Four"), 5, 1, true, true, false, true, true, true);
+      shapeNotesFour.setShapeNoteStyle(ShapeNoteStyle::FOUR);
+
+      StaffType shapeNotesSeven = StaffType(StaffGroup::STANDARD, "shapeNotesSeven", QObject::tr("Shape Notes - Seven"), 5, 1, true, true, false, true, true, true);
+      shapeNotesSeven.setShapeNoteStyle(ShapeNoteStyle::SEVEN);
+
+      _presets.push_back(shapeNotesFour);
+      _presets.push_back(shapeNotesSeven);
       }
 }                 // namespace Ms
 

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -117,19 +117,11 @@ struct TablatureDurationFont {
 
       bool read(XmlReader&);
       };
-
-// ready-made staff types:
-
-enum class StaffTypes : char {
-      STANDARD,
-      PERC_1LINE, PERC_3LINE, PERC_5LINE,
-      TAB_6SIMPLE, TAB_6COMMON, TAB_6FULL,
-            TAB_4SIMPLE, TAB_4COMMON, TAB_4FULL,
-            TAB_UKULELE, TAB_BALALAJKA, TAB_ITALIAN, TAB_FRENCH,
-      STAFF_TYPES,
-      // some usefull shorthands:
-            PERC_DEFAULT = StaffTypes::PERC_5LINE,
-            TAB_DEFAULT = StaffTypes::TAB_6COMMON
+      
+enum class ShapeNoteStyle : char {
+      NONE,
+      FOUR,
+      SEVEN
       };
 
 static const int  STAFF_GROUP_NAME_MAX_LENGTH   = 32;
@@ -197,6 +189,8 @@ class StaffType {
       bool  _fretMetricsValid = false;    // whether fret font metrics are valid or not
       qreal _refDPI = 0.0;                // reference value used to last computed metrics and to see if they are still valid
 
+      ShapeNoteStyle _shapeNoteStyle = ShapeNoteStyle::NONE; // For "shape note" systems like Sacred Harp & Aiken
+
       // the array of configured fonts
       static QList<TablatureFretFont> _fretFonts;
       static QList<TablatureDurationFont> _durationFonts;
@@ -256,8 +250,9 @@ class StaffType {
 
       // static function to deal with presets
       static const StaffType* getDefaultPreset(StaffGroup grp);
-      static const StaffType* preset(StaffTypes idx);
+      static const StaffType* preset(int idx);
       static const StaffType* presetFromXmlName(QString& xmlName);
+      static const int defaultPreset[STAFF_GROUP_MAX];
 
       void setGenKeysig(bool val)              { _genKeysig = val;          }
       bool genKeysig() const                   { return _genKeysig;         }
@@ -282,6 +277,8 @@ class StaffType {
       qreal durationFontYOffset()         { setDurationMetrics(); return _durationYOffset + _durationFontUserY * MScore::DPI*SPATIUM20; }
       qreal fretBoxH()                    { setFretMetrics(); return _fretBoxH; }
       qreal fretBoxY()                    { setFretMetrics(); return _fretBoxY + _fretFontUserY * MScore::DPI*SPATIUM20; }
+      
+      ShapeNoteStyle shapeNoteStyle() const {  return _shapeNoteStyle; }
 
       // 2 methods to return the size of a box masking lines under a fret mark
       qreal fretMaskH()                   { return _lineDistance.val() * MScore::DPI*SPATIUM20; }
@@ -320,6 +317,7 @@ class StaffType {
       void  setStemsThrough(bool val)     { _stemsThrough = val;        }
       void  setUpsideDown(bool val)       { _upsideDown = val;          }
       void  setUseNumbers(bool val)       { _useNumbers = val; _fretMetricsValid = false; }
+      void  setShapeNoteStyle(ShapeNoteStyle val) { _shapeNoteStyle = val; };
 
       // utility functions for tab specially managed elements
       QPointF chordStemPos(const Chord*) const;

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -570,7 +570,7 @@ void EditStaffType::resetToTemplateClicked()
       {
       int idx = templateCombo->itemData(templateCombo->currentIndex()).toInt();
       if (idx >= 0) {
-            staffType = *(StaffType::preset(StaffTypes(idx)));
+            staffType = *(StaffType::preset(idx));
             setValues();
             }
       }

--- a/mscore/importgtp-gp4.cpp
+++ b/mscore/importgtp-gp4.cpp
@@ -621,7 +621,7 @@ void GuitarPro4::read(QFile* fp)
                   clefId = ClefType::PERC;
                   // instr->setUseDrumset(DrumsetKind::GUITAR_PRO);
                   instr->setDrumset(gpDrumset);
-                  staff->setStaffType(StaffType::preset(StaffTypes::PERC_DEFAULT));
+                  staff->setStaffType(StaffType::getDefaultPreset(StaffGroup::PERCUSSION));
                   }
             else if (patch >= 24 && patch < 32)
                   clefId = ClefType::G3;

--- a/mscore/importgtp-gp5.cpp
+++ b/mscore/importgtp-gp5.cpp
@@ -427,7 +427,7 @@ void GuitarPro5::readTracks()
                   clefId = ClefType::PERC;
                   // instr->setUseDrumset(DrumsetKind::GUITAR_PRO);
                   instr->setDrumset(gpDrumset);
-                  staff->setStaffType(StaffType::preset(StaffTypes::PERC_DEFAULT));
+                  staff->setStaffType(StaffType::getDefaultPreset(StaffGroup::PERCUSSION));
                   }
             else if (patch >= 24 && patch < 32)
                   clefId = ClefType::G3;

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -1321,7 +1321,7 @@ void GuitarPro2::read(QFile* fp)
                   clefId = ClefType::PERC;
                   // instr->setUseDrumset(DrumsetKind::GUITAR_PRO);
                   instr->setDrumset(gpDrumset);
-                  staff->setStaffType(StaffType::preset(StaffTypes::PERC_DEFAULT));
+                  staff->setStaffType(StaffType::getDefaultPreset(StaffGroup::PERCUSSION));
                   }
             else if (patch >= 24 && patch < 32)
                   clefId = ClefType::G3;
@@ -1345,9 +1345,9 @@ void GuitarPro2::read(QFile* fp)
             }
 
             Channel* ch = instr->channel(0);
-            if (midiChannel == int(StaffTypes::PERC_DEFAULT)) {
-                  ch->program = 0;
-                  ch->bank    = 128;
+            if (midiChannel == StaffType::defaultPreset[int(StaffGroup::PERCUSSION)]) { // SG::Standard   => 0
+                  ch->program = 0;                                                      // SG::Percussion => 3
+                  ch->bank    = 128;                                                    // SG::Tab        => 5
                   }
             else {
                   ch->program = patch;
@@ -1937,7 +1937,7 @@ void GuitarPro3::read(QFile* fp)
                   clefId = ClefType::PERC;
                   // instr->setUseDrumset(DrumsetKind::GUITAR_PRO);
                   instr->setDrumset(gpDrumset);
-                  staff->setStaffType(StaffType::preset(StaffTypes::PERC_DEFAULT));
+                  staff->setStaffType(StaffType::getDefaultPreset(StaffGroup::PERCUSSION));
                   }
             else if (patch >= 24 && patch < 32)
                   clefId = ClefType::G3;
@@ -2393,8 +2393,7 @@ Score::FileError importGTP(Score* score, const QString& name)
             if (staff->part()->instrument()->stringData()->strings() > 0 && part->staves()->front()->staffType()->group() == StaffGroup::STANDARD) {
                   p->setStaves(2);
                   Staff* s1 = p->staff(1);
-
-                  StaffType st = *StaffType::preset(StaffTypes::TAB_DEFAULT);
+                  StaffType st = *StaffType::getDefaultPreset(StaffGroup::TAB);
                   st.setSlashStyle(true);
                   s1->setStaffType(&st);
                   s1->setLines(staff->part()->instrument()->stringData()->strings());
@@ -2412,7 +2411,7 @@ Score::FileError importGTP(Score* score, const QString& name)
 
             if (staff->part()->instrument()->stringData()->strings() > 0 && part->staves()->front()->staffType()->group() == StaffGroup::STANDARD) {
                   Staff* staff2 = pscore->staff(1);
-                  staff2->setStaffType(StaffType::preset(StaffTypes::TAB_DEFAULT));
+                  staff2->setStaffType(StaffType::getDefaultPreset(StaffGroup::TAB));
                   staff2->setLines(staff->part()->instrument()->stringData()->strings());
             }
 

--- a/mscore/importmidi/importmidi_instrument.cpp
+++ b/mscore/importmidi/importmidi_instrument.cpp
@@ -398,7 +398,7 @@ void createInstruments(Score *score, QList<MTrack> &tracks)
 
             if (part->nstaves() == 1) {
                   if (track.mtrack->drumTrack()) {
-                        part->staff(0)->setStaffType(StaffType::preset(StaffTypes::PERC_DEFAULT));
+                        part->staff(0)->setStaffType(StaffType::getDefaultPreset(StaffGroup::PERCUSSION));
                         if (!instr) {
                               part->instrument()->setDrumset(smDrumset);
                               }

--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -2084,15 +2084,15 @@ void MusicXMLParserPass1::clef(const QString& partId)
                   n--;              // make zero-based
             }
 
-      StaffTypes staffType = StaffTypes::STANDARD;
+      StaffGroup staffGroup = StaffGroup::STANDARD;
 
       while (_e.readNextStartElement()) {
             if (_e.name() == "sign") {
                   QString sign = _e.readElementText();
                   if (sign == "TAB")
-                        staffType = StaffTypes::TAB_DEFAULT;
+                        staffGroup = StaffGroup::TAB;
                   else if (sign == "percussion")
-                        staffType = StaffTypes::PERC_DEFAULT;
+                        staffGroup = StaffGroup::PERCUSSION;
                   }
             else
                   skipLogCurrElem();
@@ -2105,8 +2105,8 @@ void MusicXMLParserPass1::clef(const QString& partId)
 
       // TODO: changed for #55501, but now staff type init is shared between pass 1 and 2
       // old code: if (0 <= n && n < staves && staffType != StaffTypes::STANDARD)
-      if (0 <= n && n < staves && staffType == StaffTypes::TAB_DEFAULT)
-            _score->staff(staffIdx + n)->setStaffType(StaffType::preset(staffType));
+      if (0 <= n && n < staves && staffGroup == StaffGroup::TAB)
+            _score->staff(staffIdx + n)->setStaffType(StaffType::getDefaultPreset(staffGroup));
       }
 
 //---------------------------------------------------------

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -413,7 +413,7 @@ static void setStaffTypePercussion(Part* part, Drumset* drumset)
       {
       for (int j = 0; j < part->nstaves(); ++j)
             if (part->staff(j)->lines() == 5 && !part->staff(j)->isDrumStaff())
-                  part->staff(j)->setStaffType(StaffType::preset(StaffTypes::PERC_DEFAULT));
+                  part->staff(j)->setStaffType(StaffType::getDefaultPreset(StaffGroup::PERCUSSION));
       // set drumset for instrument
       part->instrument()->setDrumset(drumset);
       part->instrument()->channel(0)->bank = 128;
@@ -3328,7 +3328,7 @@ void MusicXMLParserPass2::clef(const QString& partId, Measure* measure, const in
       clefno--;
 
       ClefType clef   = ClefType::G;
-      StaffTypes st = StaffTypes::STANDARD;
+      StaffGroup st = StaffGroup::STANDARD;
 
       QString c;
       int i = 0;
@@ -3397,11 +3397,11 @@ void MusicXMLParserPass2::clef(const QString& partId, Measure* measure, const in
             }
       else if (c == "percussion") {
             clef = ClefType::PERC;
-            st = StaffTypes::PERC_DEFAULT;
+            st = StaffGroup::PERCUSSION;
             }
       else if (c == "TAB") {
             clef = ClefType::TAB;
-            st= StaffTypes::TAB_DEFAULT;
+            st= StaffGroup::TAB;
             }
       else
             qDebug("clef: unknown clef <sign=%s line=%d oct ch=%d>", qPrintable(c), line, i);  // TODO
@@ -3424,8 +3424,8 @@ void MusicXMLParserPass2::clef(const QString& partId, Measure* measure, const in
       // also note that clef handling should probably done in pass1
       int staffIdx = _score->staffIdx(part);
       int lines = _score->staff(staffIdx)->lines();
-      if (st == StaffTypes::TAB_DEFAULT || (_hasDrumset && st == StaffTypes::PERC_DEFAULT)) {
-            _score->staff(staffIdx)->setStaffType(StaffType::preset(st));
+      if (st == StaffGroup::TAB || (_hasDrumset && st == StaffGroup::PERCUSSION)) {
+            _score->staff(staffIdx)->setStaffType(StaffType::getDefaultPreset(st));
             _score->staff(staffIdx)->setLines(lines);
             _score->staff(staffIdx)->setBarLineTo((lines - 1) * 2);
             }

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -2221,7 +2221,7 @@ void MusicXml::xmlPart(QDomElement e, QString id)
             // but may be incorrect for a percussion staff that does not use a percussion clef
             for (int j = 0; j < part->nstaves(); ++j)
                   if (part->staff(j)->lines() == 5 && !part->staff(j)->isDrumStaff())
-                        part->staff(j)->setStaffType(StaffType::preset(StaffTypes::PERC_DEFAULT));
+                        part->staff(j)->setStaffType(StaffType::getDefaultPreset(StaffGroup::PERCUSSION));
             // set drumset for instrument
             part->instrument()->setDrumset(drumset);
             part->instrument()->channel(0)->bank = 128;
@@ -4000,15 +4000,15 @@ void MusicXml::xmlAttributes(Measure* measure, int staff, QDomElement e, KeySig*
                         }
                   }
             else if (e.tagName() == "clef") {
-                  StaffTypes st = xmlClef(e, staff, measure);
+                  StaffGroup st = xmlClef(e, staff, measure);
                   int number = e.attribute(QString("number"), "-1").toInt();
                   int staffIdx = staff;
                   if (number != -1)
                         staffIdx += number - 1;
                   // qDebug("xmlAttributes clef score->staff(0) %p staffIdx %d score->staff(%d) %p",
                   //       score->staff(0), staffIdx, staffIdx, score->staff(staffIdx));
-                  if (st == StaffTypes::TAB_DEFAULT || (hasDrumset && st == StaffTypes::PERC_DEFAULT))
-                        score->staff(staffIdx)->setStaffType(StaffType::preset(st));
+                  if (st == StaffGroup::TAB || (hasDrumset && st == StaffGroup::PERCUSSION))
+                        score->staff(staffIdx)->setStaffType(StaffType::getDefaultPreset(st));
                   }
             else if (e.tagName() == "staves")
                   ;  // ignore, already handled
@@ -6236,10 +6236,10 @@ void MusicXml::xmlHarmony(QDomElement e, int tick, Measure* measure, int staff)
 //   xmlClef
 //---------------------------------------------------------
 
-StaffTypes MusicXml::xmlClef(QDomElement e, int staffIdx, Measure* measure)
+StaffGroup MusicXml::xmlClef(QDomElement e, int staffIdx, Measure* measure)
       {
       ClefType clef   = ClefType::G;
-      StaffTypes res = StaffTypes::STANDARD;
+      StaffGroup res = StaffGroup::STANDARD;
       int clefno = e.attribute(QString("number"), "1").toInt() - 1;
       QString c;
       int i = 0;
@@ -6307,11 +6307,11 @@ StaffTypes MusicXml::xmlClef(QDomElement e, int staffIdx, Measure* measure)
             }
       else if (c == "percussion") {
             clef = ClefType::PERC;
-            res = StaffTypes::PERC_DEFAULT;
+            res = StaffGroup::PERCUSSION;
             }
       else if (c == "TAB") {
             clef = ClefType::TAB;
-            res = StaffTypes::TAB_DEFAULT;
+            res = StaffGroup::TAB;
             }
       else
             qDebug("ImportMusicXML: unknown clef <sign=%s line=%d oct ch=%d>", qPrintable(c), line, i);

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -175,7 +175,7 @@ void StaffListItem::setStaffType(const StaffType* st)
       else {
             // if staff type given, look into combo box item data for a preset equal to staff type
             for (int i = 0; i < _staffTypeCombo->count(); ++i) {
-                  const StaffType* _st = StaffType::preset(StaffTypes(_staffTypeCombo->itemData(i).toInt()));
+                  const StaffType* _st = StaffType::preset(_staffTypeCombo->itemData(i).toInt());
                   if (*_st == *st) {
                         _staffTypeCombo->setCurrentIndex(i);
                         return;
@@ -183,7 +183,7 @@ void StaffListItem::setStaffType(const StaffType* st)
                   }
             // try harder
             for (int i = 0; i < _staffTypeCombo->count(); ++i) {
-                  const StaffType* _st = StaffType::preset(StaffTypes(_staffTypeCombo->itemData(i).toInt()));
+                  const StaffType* _st = StaffType::preset(_staffTypeCombo->itemData(i).toInt());
                   if (_st->isSameStructure(*st)) {
                         _staffTypeCombo->setCurrentIndex(i);
                         return;
@@ -211,7 +211,7 @@ void StaffListItem::setStaffType(int idx)
 
 const StaffType* StaffListItem::staffType() const
       {
-      return StaffType::preset(StaffTypes((staffTypeIdx())));
+      return StaffType::preset((staffTypeIdx()));
       }
 
 //---------------------------------------------------------
@@ -231,12 +231,12 @@ void StaffListItem::staffTypeChanged(int idx)
       {
       // check current clef matches new staff type
       int staffTypeIdx = _staffTypeCombo->itemData(idx).toInt();
-      const StaffType* stfType = StaffType::preset(StaffTypes(staffTypeIdx));
+      const StaffType* stfType = StaffType::preset(staffTypeIdx);
 
       PartListItem* pli = static_cast<PartListItem*>(QTreeWidgetItem::parent());
       pli->updateClefs();
 
-      if (_staff && _staff->staffType()->name() != stfType->name()) {
+      if (_staff && !(*(_staff->staffType()) == *stfType)) {
             if (_op != ListItemOp::I_DELETE && _op != ListItemOp::ADD)
                   _op = ListItemOp::UPDATE;
             }
@@ -268,7 +268,7 @@ void PartListItem::updateClefs()
       {
       for (int i = 0; i < childCount(); ++i) {
             StaffListItem* sli = static_cast<StaffListItem*>(child(i));
-            const StaffType* stfType = StaffType::preset(StaffTypes(sli->staffTypeIdx()));
+            const StaffType* stfType = StaffType::preset(sli->staffTypeIdx());
 
             ClefTypeList clefType;
             switch (stfType->group()) {

--- a/mscore/musicxml.h
+++ b/mscore/musicxml.h
@@ -239,7 +239,7 @@ class MusicXml {
       void xmlNotations(Note* note, ChordRest* cr, int trk, int tick, int ticks, QDomElement node);
       Note* xmlNote(Measure*, int stave, const QString& partId, Beam*& beam, QString& currentVoice, QDomElement node, QList<Chord*>& graceNotes, int& alt);
       void xmlHarmony(QDomElement node, int tick, Measure* m, int staff);
-      StaffTypes xmlClef(QDomElement, int staffIdx, Measure*);
+      StaffGroup xmlClef(QDomElement, int staffIdx, Measure*);
       void readPageFormat(PageFormat* pf, QDomElement de, qreal conversion);
       QList<QDomElement> findSlurElements(QDomElement);
       void addGraceNoteAfter(Chord*, Segment*);


### PR DESCRIPTION
This work includes the removal of the "StaffTypes Enum".  My reasoning for this is as follows:

First, only three members of the StaffTypes enum were being explicitly used in the code (Traditional, Default Tab, Default Percussion).

Second, these three members could easily be replaced with the existing "Staffgroups" enum combined with the existing "default staffgroup" function.  (So StaffTypes was replicating existing code).

Third, the names of all hardcoded stafftypes all already documented through the "_presets" array.

Finally, the StaffTypes enum used to determine which stafftypes were available to the various spinners and other selection lists.  However, in my coming project (after this pull request), the user will be able to dynamically load new stafftypes, and this means that the available stafftypes must be able to change dynamically.  However, since enums cannot dynamically change, so it made sense to eliminate "StaffTypes" altogether.
