### PR TITLE
fix #64251: crash on playback of ornament on tab staff

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -935,10 +935,16 @@ int articulationExcursion(Note *noteL, Note *noteR, int deltastep)
                         }
                   }
             if (!done) {
-                  AccidentalVal acciv2 = measureR->findAccidental(chordR->segment(), chordR->staff()->idx(), lineR2);
-                  int acci2 = int(acciv2);
-                  // we have to add ( note->ppitch() - noteL->epitch() ) which is the delta for transposing instruments.
-                  halfsteps = line2pitch(lineL-deltastep, clefL, Key::C) + noteL->ppitch() - noteL->epitch() + acci2 - pitchL;
+                  if (staffL->isPitchedStaff()) {
+                        AccidentalVal acciv2 = measureR->findAccidental(chordR->segment(), chordR->staff()->idx(), lineR2);
+                        int acci2 = int(acciv2);
+                        // we have to add ( note->ppitch() - noteL->epitch() ) which is the delta for transposing instruments.
+                        halfsteps = line2pitch(lineL-deltastep, clefL, Key::C) + noteL->ppitch() - noteL->epitch() + acci2 - pitchL;
+                        }
+                  else {
+                        // cannot rely on accidentals or key signatures
+                        halfsteps = deltastep;
+                        }
                   }
             }
       return halfsteps;


### PR DESCRIPTION
The crash was from trying to calculate an appropriate accidental so we can decide whether to go a half step or whole step (or something else potentially).  Neither accidental nor key calculations make sense on tab staves, however.  I'm not sure what makes sense to do instead, so I'm preventing the crash by always going with half steps for tab.

@jimka2001 : feel free to try to come up with something more clever.