### PR TITLE
fix #65861: paste of single chord symbol does not transpose

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -41,6 +41,7 @@
 #include "harmony.h"
 #include "figuredbass.h"
 #include "icon.h"
+#include "utils.h"
 
 namespace Ms {
 
@@ -882,7 +883,19 @@ Element* ChordRest::drop(const DropData& data)
                   break;
 
             case Element::Type::HARMONY:
-                  static_cast<Harmony*>(e)->render();
+                  {
+                  // transpose
+                  Harmony* harmony = static_cast<Harmony*>(e);
+                  Interval interval = staff()->part()->instrument()->transpose();
+                  if (!score()->styleB(StyleIdx::concertPitch) && !interval.isZero()) {
+                        interval.flip();
+                        int rootTpc = transposeTpc(harmony->rootTpc(), interval, true);
+                        int baseTpc = transposeTpc(harmony->baseTpc(), interval, true);
+                        score()->undoTransposeHarmony(harmony, rootTpc, baseTpc);
+                        }
+                  // render
+                  harmony->render();
+                  }
                   // fall through
             case Element::Type::TEXT:
             case Element::Type::STAFF_TEXT:

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -796,7 +796,7 @@ PasteStatus Score::cmdPaste(const QMimeData* ms, MuseScoreView* view)
             qDebug("no application mime data");
             return PasteStatus::NO_MIME;
             }
-      if ((_selection.isSingle()|| _selection.isList()) && ms->hasFormat(mimeSymbolFormat)) {
+      if ((_selection.isSingle() || _selection.isList()) && ms->hasFormat(mimeSymbolFormat)) {
             QByteArray data(ms->data(mimeSymbolFormat));
             XmlReader e(data);
             QPointF dragOffset;


### PR DESCRIPTION
As far as I know or could discover, we don't use "drop" for anything else that could be adversely affected by doing the transposition there.  I was a little concerned that somewhere we might have a case where the chord is already transposed.  But it seems this is used just for single copy/paste.  It was presumably used for  the palette when we had a chord symbol on the palette, and it would have made perfect sense to transpose these.