### PR TITLE
fix #65961: dotted line when dragging text

### DIFF
--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -332,21 +332,6 @@ void Dynamic::reset()
       }
 
 //---------------------------------------------------------
-//   dragAnchor
-//---------------------------------------------------------
-
-QLineF Dynamic::dragAnchor() const
-      {
-      qreal xp = 0.0;
-      for (Element* e = parent(); e; e = e->parent())
-            xp += e->x();
-      qreal yp = measure()->system()->staffYpage(staffIdx());
-      QPointF p(xp, yp);
-
-      return QLineF(p, canvasPos());
-      }
-
-//---------------------------------------------------------
 //   drag
 //---------------------------------------------------------
 

--- a/libmscore/dynamic.h
+++ b/libmscore/dynamic.h
@@ -108,8 +108,6 @@ class Dynamic : public Text {
       void setDynRange(Range t) { _dynRange = t;    }
       void undoSetDynRange(Range t);
 
-      virtual QLineF dragAnchor() const override;
-
       virtual QVariant getProperty(P_ID propertyId) const override;
       virtual bool     setProperty(P_ID propertyId, const QVariant&) override;
       virtual QVariant propertyDefault(P_ID id) const override;

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1468,24 +1468,6 @@ void Harmony::textStyleChanged()
       }
 
 //---------------------------------------------------------
-//   dragAnchor
-//---------------------------------------------------------
-
-QLineF Harmony::dragAnchor() const
-      {
-      qreal xp = 0.0;
-      for (Element* e = parent(); e; e = e->parent())
-            xp += e->x();
-      qreal yp;
-      if (parent()->type() == Element::Type::SEGMENT)
-            yp = static_cast<Segment*>(parent())->measure()->system()->staffYpage(staffIdx());
-      else
-            yp = parent()->canvasPos().y();
-      QPointF p(xp, yp);
-      return QLineF(p, canvasPos());
-      }
-
-//---------------------------------------------------------
 //   extensionName
 //---------------------------------------------------------
 

--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -177,7 +177,6 @@ class Harmony : public Text {
       virtual void spatiumChanged(qreal oldValue, qreal newValue) override;
       virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
       virtual void textStyleChanged() override;
-      virtual QLineF dragAnchor() const override;
       void setHarmony(const QString& s);
       virtual QPainterPath shape() const override;
       void calculateBoundingRect();

--- a/libmscore/instrchange.cpp
+++ b/libmscore/instrchange.cpp
@@ -127,21 +127,6 @@ bool InstrumentChange::setProperty(P_ID propertyId, const QVariant& v)
       }
 
 //---------------------------------------------------------
-//   dragAnchor
-//---------------------------------------------------------
-
-QLineF InstrumentChange::dragAnchor() const
-      {
-      qreal xp = 0.0;
-      for (Element* e = parent(); e; e = e->parent())
-            xp += e->x();
-      qreal yp = segment()->measure()->system()->staffYpage(staffIdx());
-      QPointF p(xp, yp);
-
-      return QLineF(p, canvasPos());
-      }
-
-//---------------------------------------------------------
 //   drag
 //---------------------------------------------------------
 

--- a/libmscore/instrchange.h
+++ b/libmscore/instrchange.h
@@ -45,7 +45,6 @@ class InstrumentChange : public Text  {
 
       Segment* segment() const                { return (Segment*)parent(); }
 
-      virtual QLineF dragAnchor() const override;
       virtual QRectF drag(EditData*) override;
 
       virtual QVariant getProperty(P_ID propertyId) const override;

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2429,6 +2429,27 @@ void Text::dragTo(const QPointF& p)
       }
 
 //---------------------------------------------------------
+//   dragAnchor
+//---------------------------------------------------------
+
+QLineF Text::dragAnchor() const
+      {
+      qreal xp = 0.0;
+      for (Element* e = parent(); e; e = e->parent())
+            xp += e->x();
+      qreal yp;
+      if (parent()->type() == Element::Type::SEGMENT)
+            yp = static_cast<Segment*>(parent())->measure()->system()->staffYpage(staffIdx());
+      else
+            yp = parent()->canvasPos().y();
+      QPointF p1(xp, yp);
+      QPointF p2 = canvasPos();
+      if (layoutToParentWidth())
+            p2 += bbox().topLeft();
+      return QLineF(p1, p2);
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -308,6 +308,8 @@ class Text : public Element {
       void setAbove(bool val) {  textStyle().setYoff(val ? -2.0 : 7.0); }
       void dragTo(const QPointF&);
 
+      virtual QLineF dragAnchor() const override;
+
       QVariant getProperty(P_ID propertyId) const;
       bool setProperty(P_ID propertyId, const QVariant& v);
       virtual QVariant propertyDefault(P_ID id) const;


### PR DESCRIPTION
I don't know if there is some reason this was removed - it was present for text in 1.3, and it is still present in 2.0 for many other elements (articulations, etc) and even *some* types of text (dynamics, instrument change, chord symbols).  So it seems it might have been a deliberate change to remove it for other text, but I can't see a reason for it.  So this PR adds Text::dragAnchor(), which works for text whether attached to segments (eg, staff text) or notes (fingering) or measures (measure numbers) or frames (titles).  Meaning we no longer need the overrides for the dynamics, instrument change, or chord symbols.