### PR TITLE
MusicXML export: enhanced using of attributes of <midi-device> tag

### DIFF
--- a/mtest/musicxml/io/testAccidentals1.xml
+++ b/mtest/musicxml/io/testAccidentals1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testAccidentals2.xml
+++ b/mtest/musicxml/io/testAccidentals2.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testAccidentals3.xml
+++ b/mtest/musicxml/io/testAccidentals3.xml
@@ -21,7 +21,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testArpGliss1.xml
+++ b/mtest/musicxml/io/testArpGliss1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testArpGliss2.xml
+++ b/mtest/musicxml/io/testArpGliss2.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testArpGliss3.xml
+++ b/mtest/musicxml/io/testArpGliss3.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testBarStyles.xml
+++ b/mtest/musicxml/io/testBarStyles.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testChordDiagrams1.xml
+++ b/mtest/musicxml/io/testChordDiagrams1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testChordNoVoice_ref.xml
+++ b/mtest/musicxml/io/testChordNoVoice_ref.xml
@@ -22,7 +22,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testClefs1.xml
+++ b/mtest/musicxml/io/testClefs1.xml
@@ -22,7 +22,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testCompleteMeasureRests.xml
+++ b/mtest/musicxml/io/testCompleteMeasureRests.xml
@@ -22,7 +22,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testCueNotes.xml
+++ b/mtest/musicxml/io/testCueNotes.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testDCalCoda.xml
+++ b/mtest/musicxml/io/testDCalCoda.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testDCalFine.xml
+++ b/mtest/musicxml/io/testDCalFine.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testDalSegno.xml
+++ b/mtest/musicxml/io/testDalSegno.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testDirections1.xml
+++ b/mtest/musicxml/io/testDirections1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testDurationRoundingError_ref.xml
+++ b/mtest/musicxml/io/testDurationRoundingError_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>25</midi-program>

--- a/mtest/musicxml/io/testDynamics1.xml
+++ b/mtest/musicxml/io/testDynamics1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testDynamics2.xml
+++ b/mtest/musicxml/io/testDynamics2.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>
@@ -36,7 +36,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testDynamics3_ref.xml
+++ b/mtest/musicxml/io/testDynamics3_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>
@@ -36,7 +36,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testEmptyMeasure_ref.xml
+++ b/mtest/musicxml/io/testEmptyMeasure_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testEmptyVoice1_ref.xml
+++ b/mtest/musicxml/io/testEmptyVoice1_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>
@@ -36,7 +36,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testFiguredBass1.xml
+++ b/mtest/musicxml/io/testFiguredBass1.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Bass Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>35</midi-program>

--- a/mtest/musicxml/io/testFiguredBass2.xml
+++ b/mtest/musicxml/io/testFiguredBass2.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>
@@ -38,7 +38,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Harpsichord</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>7</midi-program>

--- a/mtest/musicxml/io/testFiguredBass3.xml
+++ b/mtest/musicxml/io/testFiguredBass3.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testFormattedThings.xml
+++ b/mtest/musicxml/io/testFormattedThings.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testGrace1.xml
+++ b/mtest/musicxml/io/testGrace1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testGrace2.xml
+++ b/mtest/musicxml/io/testGrace2.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testHarmony1.xml
+++ b/mtest/musicxml/io/testHarmony1.xml
@@ -22,7 +22,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Music</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testHarmony2.xml
+++ b/mtest/musicxml/io/testHarmony2.xml
@@ -22,7 +22,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Music</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testHarmony3.xml
+++ b/mtest/musicxml/io/testHarmony3.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testHarmony4.xml
+++ b/mtest/musicxml/io/testHarmony4.xml
@@ -22,7 +22,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testHarmony5.xml
+++ b/mtest/musicxml/io/testHarmony5.xml
@@ -18,7 +18,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testHello.xml
+++ b/mtest/musicxml/io/testHello.xml
@@ -18,7 +18,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Music</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testImplicitMeasure1.xml
+++ b/mtest/musicxml/io/testImplicitMeasure1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Music</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testIncorrectStaffNumber_ref.xml
+++ b/mtest/musicxml/io/testIncorrectStaffNumber_ref.xml
@@ -22,7 +22,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>
@@ -36,7 +36,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testInstrumentChangeMIDIportExport_ref.xml
+++ b/mtest/musicxml/io/testInstrumentChangeMIDIportExport_ref.xml
@@ -19,7 +19,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>
@@ -33,7 +33,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>1</midi-program>
@@ -47,7 +47,7 @@
       <score-instrument id="P3-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P3-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P3-I1">
         <midi-channel>3</midi-channel>
         <midi-program>1</midi-program>
@@ -61,7 +61,7 @@
       <score-instrument id="P4-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P4-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P4-I1">
         <midi-channel>4</midi-channel>
         <midi-program>1</midi-program>
@@ -75,7 +75,7 @@
       <score-instrument id="P5-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P5-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P5-I1">
         <midi-channel>5</midi-channel>
         <midi-program>1</midi-program>
@@ -89,7 +89,7 @@
       <score-instrument id="P6-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P6-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P6-I1">
         <midi-channel>6</midi-channel>
         <midi-program>1</midi-program>
@@ -103,7 +103,7 @@
       <score-instrument id="P7-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P7-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P7-I1">
         <midi-channel>7</midi-channel>
         <midi-program>1</midi-program>
@@ -117,7 +117,7 @@
       <score-instrument id="P8-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P8-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P8-I1">
         <midi-channel>8</midi-channel>
         <midi-program>1</midi-program>
@@ -131,7 +131,7 @@
       <score-instrument id="P9-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P9-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P9-I1">
         <midi-channel>9</midi-channel>
         <midi-program>1</midi-program>
@@ -145,7 +145,7 @@
       <score-instrument id="P10-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P10-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P10-I1">
         <midi-channel>11</midi-channel>
         <midi-program>1</midi-program>
@@ -159,7 +159,7 @@
       <score-instrument id="P11-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P11-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P11-I1">
         <midi-channel>12</midi-channel>
         <midi-program>1</midi-program>
@@ -173,7 +173,7 @@
       <score-instrument id="P12-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P12-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P12-I1">
         <midi-channel>13</midi-channel>
         <midi-program>1</midi-program>
@@ -187,7 +187,7 @@
       <score-instrument id="P13-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P13-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P13-I1">
         <midi-channel>14</midi-channel>
         <midi-program>1</midi-program>
@@ -201,7 +201,7 @@
       <score-instrument id="P14-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P14-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P14-I1">
         <midi-channel>15</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testInvisibleElements.xml
+++ b/mtest/musicxml/io/testInvisibleElements.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testKeysig1.xml
+++ b/mtest/musicxml/io/testKeysig1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testKeysig2.xml
+++ b/mtest/musicxml/io/testKeysig2.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>B♭ Clarinet</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>72</midi-program>

--- a/mtest/musicxml/io/testLines1.xml
+++ b/mtest/musicxml/io/testLines1.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testLines2.xml
+++ b/mtest/musicxml/io/testLines2.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testLyricsVoice2a.xml
+++ b/mtest/musicxml/io/testLyricsVoice2a.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Alto</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>
@@ -38,7 +38,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Tenor</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testLyricsVoice2b_ref.xml
+++ b/mtest/musicxml/io/testLyricsVoice2b_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Alto</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>
@@ -38,7 +38,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Tenor</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testManualBreaks.xml
+++ b/mtest/musicxml/io/testManualBreaks.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testMeasureLength_ref.xml
+++ b/mtest/musicxml/io/testMeasureLength_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>
@@ -38,7 +38,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Alto Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testMidiDeviceExport.mscx
+++ b/mtest/musicxml/io/testMidiDeviceExport.mscx
@@ -1,0 +1,1382 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.06">
+  <programVersion>2.1.0</programVersion>
+  <programRevision>5e1fdab</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Synthesizer>
+      </Synthesizer>
+    <Division>480</Division>
+    <Style>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <page-layout>
+        <page-height>1683.36</page-height>
+        <page-width>1190.88</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2015-06-21</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Linux</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="-1" span="0"/>
+        </Staff>
+      <trackName>Voice</trackName>
+      <Instrument>
+        <longName>Voice</longName>
+        <shortName>Vo.</shortName>
+        <trackName>Voice</trackName>
+        <minPitchP>36</minPitchP>
+        <maxPitchP>94</maxPitchP>
+        <minPitchA>40</minPitchA>
+        <maxPitchA>79</maxPitchA>
+        <instrumentId>voice.vocals</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="52"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="2">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="3">
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Bagpipe</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="4">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="5">
+        <InstrumentChange>
+          <Instrument>
+            <longName>Harpsichord</longName>
+            <shortName>Hch.</shortName>
+            <trackName>Harpsichord</trackName>
+            <minPitchP>29</minPitchP>
+            <maxPitchP>89</maxPitchP>
+            <minPitchA>29</minPitchA>
+            <maxPitchA>89</maxPitchA>
+            <instrumentId>keyboard.harpsichord</instrumentId>
+            <clef staff="2">F</clef>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="6"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Harp</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="6">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="7">
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Bagpipe</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="8">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="9">
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="10">
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>67</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>67</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>67</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>67</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="11">
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>67</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>67</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>67</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <InstrumentChange>
+          <Instrument>
+            <longName>Bagpipe</longName>
+            <shortName>Bagp.</shortName>
+            <trackName>Bagpipe</trackName>
+            <minPitchP>67</minPitchP>
+            <maxPitchP>81</maxPitchP>
+            <minPitchA>67</minPitchA>
+            <maxPitchA>81</maxPitchA>
+            <transposeDiatonic>-1</transposeDiatonic>
+            <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>wind.pipes.bagpipes</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="109"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Instr</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>67</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="2">
+        <InstrumentChange>
+          <Instrument>
+            <longName>Classical Guitar</longName>
+            <shortName>Guit.</shortName>
+            <trackName>Classical Guitar</trackName>
+            <minPitchP>40</minPitchP>
+            <maxPitchP>83</maxPitchP>
+            <minPitchA>40</minPitchA>
+            <maxPitchA>83</maxPitchA>
+            <instrumentId>pluck.guitar.nylon-string</instrumentId>
+            <clef>G8vb</clef>
+            <StringData>
+              <frets>19</frets>
+              <string>40</string>
+              <string>45</string>
+              <string>50</string>
+              <string>55</string>
+              <string>59</string>
+              <string>64</string>
+              </StringData>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="24"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <pos x="0.531483" y="-2.32155"/>
+          <text>Guitar</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="3">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="4">
+        <InstrumentChange>
+          <Instrument>
+            <longName>Flute</longName>
+            <shortName>Fl.</shortName>
+            <trackName>Flute</trackName>
+            <minPitchP>59</minPitchP>
+            <maxPitchP>98</maxPitchP>
+            <minPitchA>60</minPitchA>
+            <maxPitchA>93</maxPitchA>
+            <instrumentId>wind.flutes.flute</instrumentId>
+            <Articulation>
+              <velocity>100</velocity>
+              <gateTime>95</gateTime>
+              </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
+            <Articulation name="staccato">
+              <velocity>100</velocity>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="tenuto">
+              <velocity>100</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
+              </Articulation>
+            <Articulation name="sforzato">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+              </Articulation>
+            <Channel>
+              <program value="73"/>
+              <synti>Fluid</synti>
+              </Channel>
+            </Instrument>
+          <text>Flute</text>
+          </InstrumentChange>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="5">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="6">
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="7">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="8">
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>69</pitch>
+            <tpc>17</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="9">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="10">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="11">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/musicxml/io/testMidiDeviceExport_ref.xml
+++ b/mtest/musicxml/io/testMidiDeviceExport_ref.xml
@@ -1,0 +1,921 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <identification>
+    <encoding>
+      <software>MuseScore 0.7.0</software>
+      <encoding-date>2007-09-10</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="no"/>
+      <supports element="print" attribute="new-system" type="no"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I2">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I3">
+        <instrument-name>Harpsichord</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I4">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I5">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I6">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I7">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I8">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I9">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I10">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I11">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I12">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I13">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I14">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I15">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <score-instrument id="P1-I16">
+        <instrument-name>Bagpipe</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I2" port="1"></midi-device>
+      <midi-instrument id="P1-I2">
+        <midi-channel>2</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I3" port="1"></midi-device>
+      <midi-instrument id="P1-I3">
+        <midi-channel>3</midi-channel>
+        <midi-program>7</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I4" port="1"></midi-device>
+      <midi-instrument id="P1-I4">
+        <midi-channel>4</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I5" port="1"></midi-device>
+      <midi-instrument id="P1-I5">
+        <midi-channel>5</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I6" port="1"></midi-device>
+      <midi-instrument id="P1-I6">
+        <midi-channel>6</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I7" port="1"></midi-device>
+      <midi-instrument id="P1-I7">
+        <midi-channel>7</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I8" port="1"></midi-device>
+      <midi-instrument id="P1-I8">
+        <midi-channel>8</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I9" port="1"></midi-device>
+      <midi-instrument id="P1-I9">
+        <midi-channel>9</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I10" port="1"></midi-device>
+      <midi-instrument id="P1-I10">
+        <midi-channel>11</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I11" port="1"></midi-device>
+      <midi-instrument id="P1-I11">
+        <midi-channel>12</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I12" port="1"></midi-device>
+      <midi-instrument id="P1-I12">
+        <midi-channel>13</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I13" port="1"></midi-device>
+      <midi-instrument id="P1-I13">
+        <midi-channel>14</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I14" port="1"></midi-device>
+      <midi-instrument id="P1-I14">
+        <midi-channel>15</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I15" port="1"></midi-device>
+      <midi-instrument id="P1-I15">
+        <midi-channel>16</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-device id="P1-I16" port="2"></midi-device>
+      <midi-instrument id="P1-I16">
+        <midi-channel>1</midi-channel>
+        <midi-program>110</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P2">
+      <part-name>Voice</part-name>
+      <part-abbreviation>Vo.</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Voice</instrument-name>
+        </score-instrument>
+      <score-instrument id="P2-I2">
+        <instrument-name>Classical Guitar</instrument-name>
+        </score-instrument>
+      <score-instrument id="P2-I3">
+        <instrument-name>Flute</instrument-name>
+        </score-instrument>
+      <midi-device port="2"></midi-device>
+      <midi-instrument id="P2-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>53</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P2-I2">
+        <midi-channel>3</midi-channel>
+        <midi-program>25</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      <midi-instrument id="P2-I3">
+        <midi-channel>4</midi-channel>
+        <midi-program>74</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <instruments>16</instruments>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I1"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I1"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I1"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I1"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="2">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="3">
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Bagpipe</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I2"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I2"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I2"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I2"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="4">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="5">
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Harp</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="6">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="7">
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Bagpipe</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I4"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I4"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I4"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I4"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="8">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="9">
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I5"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I6"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I7"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I8"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="10">
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I9"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I10"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I11"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I12"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="11">
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I13"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I14"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I15"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Instr</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P1-I16"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <instruments>3</instruments>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="2">
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Guitar</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I2"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I2"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I2"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I2"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="3">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="4">
+      <direction placement="above">
+        <direction-type>
+          <words font-weight="bold" font-size="12">Flute</words>
+          </direction-type>
+        </direction>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="5">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="6">
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="7">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="8">
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <instrument id="P2-I3"/>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="9">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="10">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      </measure>
+    <measure number="11">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/mtest/musicxml/io/testMultiInstrumentPart1.xml
+++ b/mtest/musicxml/io/testMultiInstrumentPart1.xml
@@ -26,14 +26,13 @@
       <score-instrument id="P1-I2">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>
         <volume>78.7402</volume>
         <pan>0</pan>
         </midi-instrument>
-      <midi-device id="P1-I2" port="1"></midi-device>
       <midi-instrument id="P1-I2">
         <midi-channel>2</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testMultiMeasureRest1_ref.xml
+++ b/mtest/musicxml/io/testMultiMeasureRest1_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testMultiMeasureRest3_ref.xml
+++ b/mtest/musicxml/io/testMultiMeasureRest3_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testMultipleNotations_ref.xml
+++ b/mtest/musicxml/io/testMultipleNotations_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testNonStandardKeySig1.xml
+++ b/mtest/musicxml/io/testNonStandardKeySig1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testNonStandardKeySig2.xml
+++ b/mtest/musicxml/io/testNonStandardKeySig2.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testNonUniqueThings_ref.xml
+++ b/mtest/musicxml/io/testNonUniqueThings_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piccolo</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>73</midi-program>

--- a/mtest/musicxml/io/testNoteAttributes1.xml
+++ b/mtest/musicxml/io/testNoteAttributes1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testNoteAttributes2_ref.xml
+++ b/mtest/musicxml/io/testNoteAttributes2_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Violin</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testNoteAttributes3.xml
+++ b/mtest/musicxml/io/testNoteAttributes3.xml
@@ -18,7 +18,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>20</midi-program>

--- a/mtest/musicxml/io/testNoteheadParentheses.xml
+++ b/mtest/musicxml/io/testNoteheadParentheses.xml
@@ -18,7 +18,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testNoteheads.xml
+++ b/mtest/musicxml/io/testNoteheads.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Music</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testNotesRests1.xml
+++ b/mtest/musicxml/io/testNotesRests1.xml
@@ -25,7 +25,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testNotesRests2.xml
+++ b/mtest/musicxml/io/testNotesRests2.xml
@@ -25,7 +25,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testNumberedLyrics_ref.xml
+++ b/mtest/musicxml/io/testNumberedLyrics_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Alto</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testOverlappingSpanners.xml
+++ b/mtest/musicxml/io/testOverlappingSpanners.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testRepeatCounts.xml
+++ b/mtest/musicxml/io/testRepeatCounts.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testRestNotations_ref.xml
+++ b/mtest/musicxml/io/testRestNotations_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testRestsNoType_ref.xml
+++ b/mtest/musicxml/io/testRestsNoType_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testRestsTypeWhole_ref.xml
+++ b/mtest/musicxml/io/testRestsTypeWhole_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testSlurTieLineStyle.xml
+++ b/mtest/musicxml/io/testSlurTieLineStyle.xml
@@ -18,7 +18,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testSlurs.xml
+++ b/mtest/musicxml/io/testSlurs.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testSpecialCharacters.xml
+++ b/mtest/musicxml/io/testSpecialCharacters.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testStaffTwoKeySigs.xml
+++ b/mtest/musicxml/io/testStaffTwoKeySigs.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testStringVoiceName_ref.xml
+++ b/mtest/musicxml/io/testStringVoiceName_ref.xml
@@ -22,7 +22,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testSystemBrackets1.xml
+++ b/mtest/musicxml/io/testSystemBrackets1.xml
@@ -27,7 +27,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piccolo</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>73</midi-program>
@@ -41,7 +41,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>74</midi-program>
@@ -59,7 +59,7 @@
       <score-instrument id="P3-I1">
         <instrument-name>Treble Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P3-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P3-I1">
         <midi-channel>3</midi-channel>
         <midi-program>73</midi-program>
@@ -73,7 +73,7 @@
       <score-instrument id="P4-I1">
         <instrument-name>Recorder</instrument-name>
         </score-instrument>
-      <midi-device id="P4-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P4-I1">
         <midi-channel>4</midi-channel>
         <midi-program>75</midi-program>
@@ -91,7 +91,7 @@
       <score-instrument id="P5-I1">
         <instrument-name>Oboe</instrument-name>
         </score-instrument>
-      <midi-device id="P5-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P5-I1">
         <midi-channel>5</midi-channel>
         <midi-program>69</midi-program>
@@ -105,7 +105,7 @@
       <score-instrument id="P6-I1">
         <instrument-name>English Horn</instrument-name>
         </score-instrument>
-      <midi-device id="P6-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P6-I1">
         <midi-channel>6</midi-channel>
         <midi-program>70</midi-program>
@@ -123,7 +123,7 @@
       <score-instrument id="P7-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P7-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P7-I1">
         <midi-channel>7</midi-channel>
         <midi-program>1</midi-program>
@@ -141,7 +141,7 @@
       <score-instrument id="P8-I1">
         <instrument-name>Violin</instrument-name>
         </score-instrument>
-      <midi-device id="P8-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P8-I1">
         <midi-channel>8</midi-channel>
         <midi-program>41</midi-program>
@@ -155,7 +155,7 @@
       <score-instrument id="P9-I1">
         <instrument-name>Viola</instrument-name>
         </score-instrument>
-      <midi-device id="P9-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P9-I1">
         <midi-channel>9</midi-channel>
         <midi-program>42</midi-program>

--- a/mtest/musicxml/io/testSystemBrackets2.xml
+++ b/mtest/musicxml/io/testSystemBrackets2.xml
@@ -26,7 +26,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>
@@ -39,7 +39,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Piano 2</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testTablature1.xml
+++ b/mtest/musicxml/io/testTablature1.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>25</midi-program>

--- a/mtest/musicxml/io/testTablature2.xml
+++ b/mtest/musicxml/io/testTablature2.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>25</midi-program>

--- a/mtest/musicxml/io/testTablature3.xml
+++ b/mtest/musicxml/io/testTablature3.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>25</midi-program>

--- a/mtest/musicxml/io/testTempo1.xml
+++ b/mtest/musicxml/io/testTempo1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>

--- a/mtest/musicxml/io/testTempo2_ref.xml
+++ b/mtest/musicxml/io/testTempo2_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testTimesig1.xml
+++ b/mtest/musicxml/io/testTimesig1.xml
@@ -25,7 +25,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testTimesig3.xml
+++ b/mtest/musicxml/io/testTimesig3.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Violine</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testTremolo.xml
+++ b/mtest/musicxml/io/testTremolo.xml
@@ -25,7 +25,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testTuplets1_ref.xml
+++ b/mtest/musicxml/io/testTuplets1_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testTuplets2_ref.xml
+++ b/mtest/musicxml/io/testTuplets2_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testTuplets3_ref.xml
+++ b/mtest/musicxml/io/testTuplets3_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>
@@ -38,7 +38,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testTuplets4.xml
+++ b/mtest/musicxml/io/testTuplets4.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Oboe</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>69</midi-program>

--- a/mtest/musicxml/io/testUnusualDurations_ref.xml
+++ b/mtest/musicxml/io/testUnusualDurations_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testVirtualInstruments_ref.xml
+++ b/mtest/musicxml/io/testVirtualInstruments_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Electric Guitar (2)</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <volume>78.7402</volume>
@@ -36,7 +36,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Bass Guitar (2)</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <volume>78.7402</volume>
@@ -49,7 +49,7 @@
       <score-instrument id="P3-I1">
         <instrument-name>Drum Set</instrument-name>
         </score-instrument>
-      <midi-device id="P3-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P3-I1">
         <midi-channel>3</midi-channel>
         <volume>78.7402</volume>

--- a/mtest/musicxml/io/testVoiceMapper1_ref.xml
+++ b/mtest/musicxml/io/testVoiceMapper1_ref.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Flute</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/testVoiceMapper2_ref.xml
+++ b/mtest/musicxml/io/testVoiceMapper2_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testVoiceMapper3_ref.xml
+++ b/mtest/musicxml/io/testVoiceMapper3_ref.xml
@@ -24,7 +24,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testVoicePiano1.xml
+++ b/mtest/musicxml/io/testVoicePiano1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Voice</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>53</midi-program>
@@ -36,7 +36,7 @@
       <score-instrument id="P2-I1">
         <instrument-name>Piano</instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testVolta1.xml
+++ b/mtest/musicxml/io/testVolta1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Guitar</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testWedge1.xml
+++ b/mtest/musicxml/io/testWedge1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testWords1.xml
+++ b/mtest/musicxml/io/testWords1.xml
@@ -23,7 +23,7 @@
       <score-instrument id="P1-I1">
         <instrument-name>Staff 1</instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>1</midi-program>

--- a/mtest/musicxml/io/testWords2.xml
+++ b/mtest/musicxml/io/testWords2.xml
@@ -22,7 +22,7 @@
       <score-instrument id="P1-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
         <midi-program>74</midi-program>
@@ -35,7 +35,7 @@
       <score-instrument id="P2-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P2-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P2-I1">
         <midi-channel>2</midi-channel>
         <midi-program>74</midi-program>
@@ -48,7 +48,7 @@
       <score-instrument id="P3-I1">
         <instrument-name></instrument-name>
         </score-instrument>
-      <midi-device id="P3-I1" port="1"></midi-device>
+      <midi-device port="1"></midi-device>
       <midi-instrument id="P3-I1">
         <midi-channel>3</midi-channel>
         <midi-program>74</midi-program>

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -103,6 +103,7 @@ private slots:
       void lyricsVoice2b() { mxmlIoTestRef("testLyricsVoice2b"); }
       void manualBreaks() { mxmlIoTest("testManualBreaks"); }
       void measureLength() { mxmlIoTestRef("testMeasureLength"); }
+      void midiDeviceExport() { mxmlMscxExportTestRef("testMidiDeviceExport"); }
       void midiPortExport() { mxmlMscxExportTestRef("testMidiPortExport"); }
       void multiInstrumentPart1() { mxmlIoTest("testMultiInstrumentPart1"); }
       //void multiInstrumentPart2() { mxmlIoTest("testMultiInstrumentPart2"); } must also fix exportxml.cpp


### PR DESCRIPTION
Attributes _id_ and _port_ are optional.
When _id_ tag is omitted, &lt;midi-device&gt; tag affects all instruments in a part, so if we have several instrumentChanges with the same MIDI port, we can get rid of extra lines in the resulting MusicXML file.
So, &lt;midi-device port="1"&gt; will affect all instrument in the part.
Also it saves a few bytes on simple scores without InstrumentChange.

Profit: smaller size of exported MusicXML file.
