### PR TITLE
fix #66076: tie not linked when adding note too long for measure

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -525,6 +525,7 @@ Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction 
 
                   ChordRest* ncr;
                   Note* note = 0;
+                  Tie* addTie = 0;
                   if (nval.pitch == -1) {
                         nr = ncr = new Rest(this);
                         nr->setTrack(track);
@@ -537,6 +538,7 @@ Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction 
                         if (tie) {
                               tie->setEndNote(note);
                               note->setTieBack(tie);
+                              addTie = tie;
                               }
                         Chord* chord = new Chord(this);
                         chord->setTrack(track);
@@ -555,6 +557,8 @@ Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction 
                         }
                   ncr->setTuplet(cr ? cr->tuplet() : 0);
                   undoAddCR(ncr, measure, tick);
+                  if (addTie)
+                        undoAddElement(addTie);
                   _playNote = true;
                   segment = ncr->segment();
                   tick += ncr->actualTicks();


### PR DESCRIPTION
I won't guarantee this is *always* the right answer, but it works in the basic case.  It mimics what happens when adding ties directly: first the tie is created, its endpoints and track set, then undoAddElement does the rest of the linking.  That last step was missing for ties created by entering a note too long for the measure.