### PR TITLE
fix #66241: note offset not preserved for tab

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1673,9 +1673,10 @@ void Note::layout()
 
 void Note::layout2()
       {
-      // this is now done in Score::layoutChords3()
+      // for standard staves this is done in Score::layoutChords3()
       // so that the results are available there
-      // adjustReadPos();
+      if (staff()->isTabStaff())
+            adjustReadPos();
 
       int dots = chord()->dots();
       if (dots) {


### PR DESCRIPTION
I believe I broke this here: 

https://github.com/musescore/MuseScore/commit/fbc676111d3274cbc0ba6a57b73eef6aacbbf8e1

Formerly, Note::layout2() called adjustReadPos().  I needed to move that earlier for pitched staff calculations, but in doing so, I neglected to handle the tab case.  For all I know it could benefit from being moved earlier for tab as well, but simply restoring that call here for tab fixes the issue at hand.

@mgavioli : does this make sense to you?  Sorry for once again failing to consider tab in one of my layout changes, even if it was over a year ago when I was young and naive :-)