### PR TITLE
fix #66276: shift from A4 to Letter on My First Score

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1992,11 +1992,16 @@ static void loadScores(const QStringList& argv)
                               Score* score = mscore->readScore(preferences.startScore);
                               if (preferences.startScore.startsWith(":/") && score) {
                                     score->setPageFormat(*MScore::defaultStyle()->pageFormat());
+                                    score->doLayout();
                                     score->setCreated(true);
                                     }
                               if (score == 0) {
                                     score = mscore->readScore(":/data/My_First_Score.mscz");
-                                    score->setCreated(true);
+                                    if (score) {
+                                          score->setPageFormat(*MScore::defaultStyle()->pageFormat());
+                                          score->doLayout();
+                                          score->setCreated(true);
+                                          }
                                     }
                               if (score)
                                     currentScoreView = mscore->appendScore(score);


### PR DESCRIPTION
We need to re-layout after setting the page format.

There was also the slimmest chance of a crash on startup, not checking for null after loading My First Score.