### PR TITLE
Fix -j parameter on 'make' when cpuinfo returns processor=0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@
 
 REVISION  = `cat mscore/revision.h`
 CPUS      = `grep -c processor /proc/cpuinfo`
+# Avoid build errors when processor=0 (as in m68k)
+ifeq ($(CPUS), 0)
+  CPUS=1
+endif
 
 PREFIX    = "/usr/local"
 VERSION   = "2.1b-${REVISION}"


### PR DESCRIPTION
Build error example in Debian: http://buildd.debian-ports.org/status/fetch.php?pkg=musescore&arch=m68k&ver=2.0.1%2Bdfsg-1&stamp=1434857325