### PR TITLE
fix #65786: crashes and loss of work with paste in text frames

### DIFF
--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -522,9 +522,9 @@ bool Box::acceptDrop(const DropData& data) const
 Element* Box::drop(const DropData& data)
       {
       Element* e = data.element;
-      if(e->flag(ElementFlag::ON_STAFF))
+      if (e->flag(ElementFlag::ON_STAFF))
             return 0;
-      switch(e->type()) {
+      switch (e->type()) {
             case Element::Type::LAYOUT_BREAK:
                   {
                   LayoutBreak* lb = static_cast<LayoutBreak*>(e);
@@ -540,7 +540,7 @@ Element* Box::drop(const DropData& data)
                               delete lb;
                               break;
                               }
-                        foreach(Element* elem, _el) {
+                        foreach (Element* elem, _el) {
                               if (elem->type() == Element::Type::LAYOUT_BREAK) {
                                     score()->undoChangeElement(elem, e);
                                     break;
@@ -548,11 +548,12 @@ Element* Box::drop(const DropData& data)
                               }
                         break;
                         }
-                  lb->setTrack(-1);       // this are system elements
+                  lb->setTrack(-1);       // these are system elements
                   lb->setParent(this);
                   score()->undoAddElement(lb);
                   return lb;
                   }
+
             case Element::Type::STAFF_TEXT:
                   {
                   Text* text = new Text(score());
@@ -583,10 +584,15 @@ Element* Box::drop(const DropData& data)
                         }
                   break;
 
-            default:
+            case Element::Type::TEXT:
+            case Element::Type::IMAGE:
+            case Element::Type::SYMBOL:
                   e->setParent(this);
                   score()->undoAddElement(e);
                   return e;
+
+            default:
+                  return 0;
             }
       return 0;
       }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1930,6 +1930,13 @@ void Score::deleteItem(Element* el)
                   qDebug("cannot remove %s", el->name());
                   break;
 
+            case Element::Type::TEXT:
+                  if (el->parent()->type() == Element::Type::TBOX)
+                        undoChangeProperty(el, P_ID::TEXT, QString());
+                  else
+                        undoRemoveElement(el);
+                  break;
+
             default:
                   undoRemoveElement(el);
                   break;

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -821,9 +821,11 @@ PasteStatus Score::cmdPaste(const QMimeData* ms, MuseScoreView* view)
                                     ddata.view       = view;
                                     ddata.element    = nel;
                                     ddata.duration   = duration;
-                                    target->drop(ddata);
-                                    if (_selection.element())
-                                          addRefresh(_selection.element()->abbox());
+                                    if (target->acceptDrop(ddata)) {
+                                          target->drop(ddata);
+                                          if (_selection.element())
+                                                addRefresh(_selection.element()->abbox());
+                                          }
                                     }
                               }
                               delete el;

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -1556,8 +1556,9 @@ void Text::endEdit()
                   // when we called it for the linked elements
                   // by also checking for empty old text, we avoid creating an unnecessary element on undo stack
                   // that returns us to the initial empty text created upon startEdit()
+                  // (except this is needed for empty text frames to ensure that adding text marks score dity)
 
-                  if (!oldText.isEmpty()) {
+                  if (!oldText.isEmpty() || (parent() && parent()->type() == Element::Type::TBOX)) {
                         // oldText is good for original element
                         // but use original text for each linked element
                         // these can differ (eg, for chord symbols in transposing parts)

--- a/libmscore/textframe.h
+++ b/libmscore/textframe.h
@@ -33,10 +33,12 @@ class TBox : public VBox {
       virtual Element::Type type() const { return Element::Type::TBOX;       }
       virtual void write(Xml&) const override;
       virtual void read(XmlReader&) override;
+      virtual Element* drop(const DropData&) override;
+      virtual void add(Element* e) override;
+      virtual void remove(Element* el) override;
 
       virtual void layout();
       virtual void scanElements(void* data, void (*func)(void*, Element*), bool all=true);
-      virtual void remove(Element* el);
       Text* text()                        { return _text; }
       };
 


### PR DESCRIPTION
The "_text" field in text frames was not being managed well enough.  Drop (paste) operations were trying to add new elements to the _el list rather than re-using _text, and trying to delete the _text was not undo-safe and led to a crash on close.
e
Also, paste of arbitrary objects into frames was causing crashes for objects that normally require segments - articulations and tempo text are cases I found.  I fixed this within Box::drop() by handling all cases explicitly and doing nothing for default.  The second commit in this PR contains a pre-emptive fix for any other elements (aside from frames) that might not handle pasting of arbitrary elements: I check acceptDrop() before doing the drop().  If this is seen to be problematic for some reason, I could resubmit without that commit.