### PR TITLE
fix #63231: crash shortening a spanner

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2779,7 +2779,8 @@ MeasureBase* Score::insertMeasure(Element::Type type, MeasureBase* measure, bool
 
 void Score::checkSpanner(int startTick, int endTick)
       {
-      QList<Spanner*> sl;
+      QList<Spanner*> sl;     // spanners to remove
+      QList<Spanner*> sl2;    // spanners to shorten
       auto spanners = _spanner.findOverlapping(startTick, endTick);
 // printf("checkSpanner %d %d\n", startTick, endTick);
 //      for (auto i = spanners.begin(); i < spanners.end(); i++) {
@@ -2816,13 +2817,19 @@ void Score::checkSpanner(int startTick, int endTick)
                         }
                   else {
                         if (s->tick2() > lastTick)
-                              s->undoChangeProperty(P_ID::SPANNER_TICKS, lastTick - s->tick());
+                              sl2.append(s);    //s->undoChangeProperty(P_ID::SPANNER_TICKS, lastTick - s->tick());
+                        else
+                              s->computeEndElement();
                         }
-                  s->computeEndElement();
                   }
             }
       for (auto s : sl)       // actually remove scheduled spanners
             undo(new RemoveElement(s));
+      for (auto s : sl2) {    // shorten spanners that extended past end of score
+            undo(new ChangeProperty(s, P_ID::SPANNER_TICKS, lastTick - s->tick()));
+            s->computeEndElement();
+            }
       }
+
 }
 


### PR DESCRIPTION
See also https://musescore.org/en/node/66396.  In both cases, there was a crash on an operation that normally invovles spanners being shortened in checkSpanner(), although the crash was OS-dependent.  @AntonioBL tracked it down in that case to the undoChangeProperty() call, and I am 99% sure this will also explain https://musescore.org/en/node/63231.

My fix is to simply the shortening of the spanner outside the loop just as is done when removing them.  I also restructured things a little to avoid calling computeEndElement() for spanners we are about to delete or shorten.

I also changed the call to undoChangeProperty() to undo(new ChangeProperty()).  The main difference is that the former goes through links to make the same adjustment, but I don't think that is necessary or advisable here.  For linked parts, we are going to call checkSpanner() on the linked parts separately.  And for linked staves within the same score, we are going to add both spanners to this list separately, so I don't see any reason not to just shorten them separately too.

In the case of https://musescore.org/en/node/66396, it is still not known how this situation arose in the first place.  This was not a case of shortening a score; it happened on read.  Apparently there is a stray haipin in some of the mmrests in the parts for that score, and that probably suggests another bug somewhere that led to those being created.  But we don't (yet) have steps to reproduce.  My fix here simply allows those hairpins - which are not linked - to extend to the end of the relevant parts.