### PR TITLE
fix #66826: always display key change at start of system

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1676,7 +1676,7 @@ void Score::addSystemHeader(Measure* m, bool isFirstSystem)
                   keysig->layout();
                   undo(new AddElement(keysig));
                   }
-            else if (!needKeysig && keysig)
+            else if (!needKeysig && keysig && keysig->generated())
                   undoRemoveElement(keysig);
             else if (keysig && !(keysig->keySigEvent() == keyIdx))
                   undo(new ChangeKeySig(keysig, keyIdx, keysig->showCourtesy()));


### PR DESCRIPTION
(even when turning off "Create key signature for all systems")

As far as I am concerned, this should be the correct behavior: turning off the "Create key signature for all systems" option should affect only *generated* key signatures, not actual key changes.

This change should be safe for most scores - needKeySig will always be true unless you explicitly turn off that option, which hardly anyone will do.  And I am pretty sure people who turn that option off would still expect to see key changes.  See also https://musescore.org/node/16726