### PR TITLE
fix #62091: crash on change voice

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3913,7 +3913,8 @@ void Score::changeVoice(int voice)
       {
       startCmd();
       QList<Element*> el;
-      foreach(Element* e, selection().elements()) {
+      QList<Element*> oel = selection().elements();     // make copy
+      for (Element* e : oel) {
             if (e->type() == Element::Type::NOTE) {
                   Note* note   = static_cast<Note*>(e);
                   Chord* chord = note->chord();
@@ -3962,6 +3963,8 @@ void Score::changeVoice(int voice)
                               ChordRest* pcr = nullptr;
                               ChordRest* ncr = nullptr;
                               for (Segment* s2 = m->first(Segment::Type::ChordRest); s2; s2 = s2->next()) {
+                                    if (s2->segmentType() != Segment::Type::ChordRest)
+                                          continue;
                                     ChordRest* cr2 = static_cast<ChordRest*>(s2->element(dstTrack));
                                     if (!cr2 || cr2->type() == Element::Type::REST)
                                           continue;
@@ -4032,7 +4035,7 @@ void Score::changeVoice(int voice)
 
       if (!el.isEmpty())
             selection().clear();
-      foreach(Element* e, el)
+      for (Element* e : el)
             select(e, SelectType::ADD, -1);
       setLayoutAll(true);
       endCmd();


### PR DESCRIPTION
Even though I don't see the same symptoms on my system that others do on theirs, I did manage to find two different issues that could both explain system-dependent failures.  One is a potential case of deleting items from a list while iterating over it, the other is casting a barline to a chordrest (!) and trying to call a member function.  This PR fixes both.