### PR TITLE
partial fix for #46861: musicxml export lyrics extend

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -3556,12 +3556,17 @@ void ExportMusicXml::lyrics(const QList<Lyrics*>* ll, const int trk)
                         // write formatted
                         MScoreTextToMXML mttm("text", attr, defFmt, mtf);
                         mttm.writeTextFragments(l->fragmentList(), xml);
+#if 0
                         /*
                          Temporarily disabled because it doesn't work yet (and thus breaks the regression test).
                          See MusicXml::xmlLyric: "// TODO-WS      l->setTick(tick);"
                         if((l)->endTick() > 0)
                               xml.tagE("extend");
                         */
+#else
+                        if (l->ticks())
+                              xml.tagE("extend");
+#endif
                         xml.etag();
                         }
                   }


### PR DESCRIPTION
I originally assumed we lost the MusicXML export for lyrics extenders (underscore) with the fairly recent overhaul from @mgavioli .  But actually, it seems this code was removed way back in 2011, here:

http://sourceforge.net/p/mscore/code/4587/

@lvinken , @wschweer : do either of you remember what this might be about?  As far as I can tell, in the current code, simply checking l->ticks() works just fine to give us the same export we had in 1.3: a single "extend" element on the lyric itself.  No support for the MusicXML 3.0 start/continue/stop tags, but apparently that isn't strictly necessary.  I think my PR here should restore 2.0 to the same level of functionality as 1.3, unless there is something I am missing.

Getting the import to work seems it might be more difficult, but at least one user is caring more about export than import and really misses this.