### PR TITLE
fix #67026: link articulations between score and part also when applied via keyboard shortcuts.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1548,6 +1548,7 @@ bool Score::addArticulation(Element* el, Articulation* a)
             return false;
             }
       a->setParent(cr);
+      a->setTrack(cr->track()); // make sure it propagates between score and parts
       undoAddElement(a);
       return true;
       }


### PR DESCRIPTION
Shamelessly stole the idea from @MarcSabatella, but don't quite understand why the same mechanism doesn't seem to be needed a few lines up for the undoRemoveElement() too?