### PR TITLE
fix #67031: incomplete glissando copied

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2667,9 +2667,8 @@ void Score::connectTies(bool silent)
                                     }
                               }
                         // connect a glissando without initial note (old glissando format)
-                        for (Spanner* spanner : n->spannerBack())
-                              if (spanner->type() == Element::Type::GLISSANDO
-                                          && spanner->startElement() == nullptr) {
+                        for (Spanner* spanner : n->spannerBack()) {
+                              if (spanner->type() == Element::Type::GLISSANDO && spanner->startElement() == nullptr) {
                                     Note* initialNote = Glissando::guessInitialNote(n->chord());
                                     n->removeSpannerBack(spanner);
                                     if (initialNote != nullptr) {
@@ -2682,9 +2681,18 @@ void Score::connectTies(bool silent)
                                           spanner->setParent(initialNote);
                                           initialNote->add(spanner);
                                           }
-                                    else
+                                    else {
                                           delete spanner;
+                                          }
                                     }
+                              }
+                        // spanner with no end element can happen during copy/paste
+                        for (Spanner* spanner : n->spannerFor()) {
+                              if (spanner->endElement() == nullptr) {
+                                    n->removeSpannerFor(spanner);
+                                    delete spanner;
+                                    }
+                              }
                         }
                   // connect two note tremolos
                   Tremolo* tremolo = c->tremolo();


### PR DESCRIPTION
Copy/paste of an incomplete gliss - eg, if the start note was part of selection but end note was not - left you with an "orphaned" forward gliss that wouldn't render but also wouldn't allow a new gliss to be added.  See issue report https://musescore.org/en/node/67031 and original discussion in https://musescore.org/en/node/66881

My change here checks for and removes such one-ended glissandi.

@mgavioli : does this change look good to you?  It does seem to work for the case at hand, and ordinary copy/paste also still works.  Not sure if there is some other case where it would be harmful to delete a glissando with no end note here.  Also, I don't see any bad effects from copy and paste of the end note of a gliss without the start, so I didn't add code to deal with that.