### PR TITLE
improve double click behavior adding Lines from palette

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1512,24 +1512,45 @@ void Score::cmdAddTie()
 
 void Score::cmdAddOttava(Ottava::Type type)
       {
+      Selection sel = selection();
       ChordRest* cr1;
       ChordRest* cr2;
-      getSelectedChordRest2(&cr1, &cr2);
-      if (!cr1)
-            return;
-      if (cr2 == 0)
-            cr2 = cr1;
+      // add on each staff if possible
+      if (sel.isRange() && sel.staffStart() != sel.staffEnd() - 1) {
+            for (int staffIdx = sel.staffStart() ; staffIdx < sel.staffEnd(); ++staffIdx) {
+                  ChordRest* cr1 = sel.firstChordRest(staffIdx * VOICES);
+                  ChordRest* cr2 = sel.lastChordRest(staffIdx * VOICES);
+                  if (!cr1)
+                       continue;
+                  if (cr2 == 0)
+                       cr2 = cr1;
+                  Ottava* ottava = new Ottava(this);
+                  ottava->setOttavaType(type);
+                  ottava->setTrack(cr1->track());
+                  ottava->setTrack2(cr1->track());
+                  ottava->setTick(cr1->tick());
+                  ottava->setTick2(cr2->tick() + cr2->actualTicks());
+                  undoAddElement(ottava);
+                  }
+            }
+      else {
+            getSelectedChordRest2(&cr1, &cr2);
+            if (!cr1)
+                  return;
+            if (cr2 == 0)
+                  cr2 = cr1;
 
-      Ottava* ottava = new Ottava(this);
-      ottava->setOttavaType(type);
+            Ottava* ottava = new Ottava(this);
+            ottava->setOttavaType(type);
 
-      ottava->setTrack(cr1->track());
-      ottava->setTrack2(cr1->track());
-      ottava->setTick(cr1->tick());
-      ottava->setTick2(cr2->tick() + cr2->actualTicks());
-      undoAddElement(ottava);
-      if (!noteEntryMode())
-            select(ottava, SelectType::SINGLE, 0);
+            ottava->setTrack(cr1->track());
+            ottava->setTrack2(cr1->track());
+            ottava->setTick(cr1->tick());
+            ottava->setTick2(cr2->tick() + cr2->actualTicks());
+            undoAddElement(ottava);
+            if (!noteEntryMode())
+                  select(ottava, SelectType::SINGLE, 0);
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1012,7 +1012,8 @@ class Score : public QObject {
       bool isSpannerStartEnd(int tick, int track) const;
       void removeSpanner(Spanner*);
       void addSpanner(Spanner*);
-      void cmdAddSpanner(Spanner* e, const QPointF& pos);
+      void cmdAddSpanner(Spanner* spanner, const QPointF& pos);
+      void cmdAddSpanner(Spanner* spanner, int staffIdx, Segment* startSegment, Segment* endSegment);
       void checkSpanner(int startTick, int lastTick);
       const std::set<Spanner*>unmanagedSpanners() { return _unmanagedSpanner; }
       void addUnmanagedSpanner(Spanner*);

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -18,6 +18,7 @@
 #include "segment.h"
 #include "measure.h"
 #include "undo.h"
+#include "staff.h"
 
 namespace Ms {
 
@@ -542,6 +543,8 @@ void Spanner::computeEndElement()
                   if (_ticks != nticks) {
                         qDebug("%s ticks changed, %d -> %d", name(), _ticks, nticks);
                         setTicks(nticks);
+                        if (type() == Element::Type::OTTAVA)
+                              staff()->updateOttava();
                         }
                   }
                   break;


### PR DESCRIPTION
This is a trial implementation of an improvement in the usability / behavior when adding lines from the palette via double click.  It allows a line to be added either with a range selection or with exactly two chordrests selected, by double clicking the palette icon.  The line will be created with the initial span already set according to the selection.  This is tested to work for pedal, ottava, trill, text lines, and voltas, none of which could be added in this way previously.  It also works for hairpins, which previously worked only because there was explicit code to do so (and see #2042 for issues with that approach), and for slurs, which also worked in some cases but not others.

As discussion in the comments for #2042, there is still a regression in that selecting two notes then pressing a hairpin shortcut does not work.  This current PR at least fixes this for double click, and perhaps might make it easier to solve the problem for shortcut as well.

With this PR, there are some issues when selecting two notes on the same staff but in different voices before double clicking a line from the palette - lines may be added longer or shorter than intended.  But it's no worse than the current situation, and probably better.  I think these are the same issues we currently have with shift+left/right in edit mode when mutliple voices are involved - some cases where this does not work as expected.  I know this has been discussed before, but I can't find a current issue.

I do think my code here works well as far as I have tested, but more testing is needed, and I do want to look at those multiple-voice issues.