### PR TITLE
fix #60791: timesig change deletes voices 2-4 in linked staves

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -812,7 +812,7 @@ void cloneStaff(Staff* srcStaff, Staff* dstStaff)
 
 //---------------------------------------------------------
 //   cloneStaff2
-//    staves are in different scores
+//    staves are potentially in different scores
 //---------------------------------------------------------
 
 void cloneStaff2(Staff* srcStaff, Staff* dstStaff, int stick, int etick)

--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -460,10 +460,11 @@ bool TrackList::write(Measure* measure) const
       //
 
       for (Segment* s = measure->first(); s; s = s->next1()) {
-            Chord* chord = static_cast<Chord*>(s->element(_track));
-            if (chord == 0 || chord->type() != Element::Type::CHORD)
+            Element* e = s->element(_track);
+            if (e == 0 || e->type() != Element::Type::CHORD)
                   continue;
-            foreach (Note* n, chord->notes()) {
+            Chord* chord = static_cast<Chord*>(e);
+            for (Note* n : chord->notes()) {
                   Tie* tie = n->tieFor();
                   if (!tie)
                         continue;
@@ -550,7 +551,8 @@ bool ScoreRange::write(Score* score, int tick) const
             int track = dl->track();
             if (!dl->write(score->tick2measure(tick)))
                   return false;
-            if ((track % VOICES) == 0) {
+            if ((track % VOICES) == VOICES - 1)  {
+                  // clone staff if appropriate after all voices have been copied
                   int staffIdx = track / VOICES;
                   Staff* ostaff = score->staff(staffIdx);
                   LinkedStaves* linkedStaves = ostaff->linkedStaves();


### PR DESCRIPTION
I'm pretty surprised this hasn't been reported more often!  A time signature change deletes the contents voices 2-4 in linked staves & parts.  See the issue report for my analysis (and  big thanks again to cadiz1 for his help pinpointing when things went awry).  The upshot is, when rewriting measures for a timesig change, we are only rewriting "unique" staves - the primary staff only for each set of linked staves - and then depending on cloneStaff2 to recreate the linked staff for us.  Unfortunately, we do the cloning too soon - after only the first track of the staff has been written.

My fix here is very simple: I wait until we write all four tracks before cloning the staff.  But I have reservations:

- Can we rely on all four tracks having entries in the track list for the ScoreRange?  So far, this seems true, and indeed, ScoreList::read() always creates all four.  So hopefully this is OK.

- Is this really a sound approach overall (not rewriting linked staves directly but instead recreating them on the fly)?  It has one pretty obvious downside: it means we lose all manual adjustments in linked staves if you make a time signature change.  Instead, the linked staves re-inherit manual adjustments from the "primary" staff.  I can live with this for now in order to fix this bug for 2.0.2, but I do think this will be worth revisting later.
