### PR TITLE
Fix compile errors with Qt5.5

### DIFF
--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -85,7 +85,6 @@ void lengthenTooShortNotes(std::multimap<int, MTrack> &tracks)
       }
 
 
-#ifdef QT_DEBUG
 
 bool doNotesOverlap(const MTrack &track)
       {
@@ -137,7 +136,6 @@ bool noTooShortNotes(const std::multimap<int, MTrack> &tracks)
       return true;
       }
 
-#endif
 
 std::vector<std::multimap<ReducedFraction, MidiChord> >
 separateDrumChordsTo2Voices(const std::multimap<ReducedFraction, MidiChord> &chords)

--- a/mscore/importmidi/importmidi_chord.cpp
+++ b/mscore/importmidi/importmidi_chord.cpp
@@ -197,7 +197,6 @@ void removeOverlappingNotes(std::multimap<int, MTrack> &tracks)
       }
 
 
-#ifdef QT_DEBUG
 
 // check for equal on time values with the same voice that is invalid
 bool areOnTimeValuesDifferent(const std::multimap<ReducedFraction, MidiChord> &chords)
@@ -265,7 +264,6 @@ bool areBarIndexesSet(const std::multimap<ReducedFraction, MidiChord> &chords)
       return true;
       }
 
-#endif
 
 void setToNegative(ReducedFraction &v1, ReducedFraction &v2, ReducedFraction &v3)
       {
@@ -598,11 +596,9 @@ void setBarIndexes(
                   continue;
             for (; it != chords.end(); ++it) {
                   const auto onTime = Quantize::findQuantizedChordOnTime(*it, basicQuant);
-#ifdef QT_DEBUG
                   const auto barStart = ReducedFraction::fromTicks(sigmap->bar2tick(barIndex, 0));
                   Q_ASSERT_X(!(it->first >= barStart && onTime < barStart),
                              "MChord::setBarIndexes", "quantized on time cannot be in previous bar");
-#endif
                   if (onTime < endBarTick) {
                         it->second.barIndex = barIndex;
                         continue;

--- a/mscore/importmidi/importmidi_chord.h
+++ b/mscore/importmidi/importmidi_chord.h
@@ -135,7 +135,6 @@ void setBarIndexes(
             const ReducedFraction &basicQuant,
             const ReducedFraction &lastTick, const TimeSigMap *sigmap);
 
-#ifdef QT_DEBUG
 
 bool areOnTimeValuesDifferent(const std::multimap<ReducedFraction, MidiChord> &chords);
 bool areBarIndexesSuccessive(const std::multimap<ReducedFraction, MidiChord> &chords);
@@ -146,7 +145,6 @@ bool isLastTickValid(const ReducedFraction &lastTick,
                      const std::multimap<int, MTrack> &tracks);
 bool areBarIndexesSet(const std::multimap<ReducedFraction, MidiChord> &chords);
 
-#endif
 
 } // namespace MChord
 } // namespace Ms

--- a/mscore/importmidi/importmidi_clef.cpp
+++ b/mscore/importmidi/importmidi_clef.cpp
@@ -141,7 +141,6 @@ MinMaxPitch findMinMaxSegPitch(const Segment *seg, int strack)
       }
 
 
-#ifdef QT_DEBUG
 
 bool doesClefBreakTie(const Staff *staff)
       {
@@ -169,7 +168,6 @@ bool doesClefBreakTie(const Staff *staff)
       return false;
       }
 
-#endif
 
 
 // clef index: 0 - treble, 1 - bass

--- a/mscore/importmidi/importmidi_drum.cpp
+++ b/mscore/importmidi/importmidi_drum.cpp
@@ -18,7 +18,6 @@ extern Preferences preferences;
 namespace MidiDrum {
 
 
-#ifdef QT_DEBUG
 
 bool haveNonZeroVoices(const std::multimap<ReducedFraction, MidiChord> &chords)
       {
@@ -29,7 +28,6 @@ bool haveNonZeroVoices(const std::multimap<ReducedFraction, MidiChord> &chords)
       return true;
       }
 
-#endif
 
 
 void splitChord(

--- a/mscore/importmidi/importmidi_fraction.cpp
+++ b/mscore/importmidi/importmidi_fraction.cpp
@@ -7,8 +7,6 @@
 namespace Ms {
 
 
-#ifdef QT_DEBUG
-
 //---------------------------------------------------------------------------------------
 // https://www.securecoding.cert.org/confluence/display/seccode/
 // INT32-C.+Ensure+that+operations+on+signed+integers+do+not+result+in+overflow?showComments=false
@@ -70,7 +68,6 @@ bool isUnaryNegationOverflow(int a)             // -a
       return (a == std::numeric_limits<int>::min());
       }
 
-#endif
 
 //---------------------------------------------------------------------------------------
 

--- a/mscore/importmidi/importmidi_lrhand.cpp
+++ b/mscore/importmidi/importmidi_lrhand.cpp
@@ -38,7 +38,6 @@ bool needToSplit(const std::multimap<ReducedFraction, MidiChord> &chords,
       }
 
 
-#ifdef QT_DEBUG
 
 bool areNotesSortedByPitchInAscOrder(const QList<MidiNote>& notes)
       {
@@ -48,8 +47,6 @@ bool areNotesSortedByPitchInAscOrder(const QList<MidiNote>& notes)
             }
       return true;
       }
-
-#endif
 
 
 struct SplitTry {

--- a/mscore/importmidi/importmidi_lyrics.cpp
+++ b/mscore/importmidi/importmidi_lyrics.cpp
@@ -62,7 +62,6 @@ extractLyricsFromTrack(const MidiTrack &track, int division, bool isDivisionInTp
       }
 
 
-#ifdef QT_DEBUG
 
 bool areEqualIndexesSuccessive(const QList<MTrack> &tracks)
       {
@@ -84,7 +83,6 @@ bool areEqualIndexesSuccessive(const QList<MTrack> &tracks)
       return true;
       }
 
-#endif
 
 
 struct BestTrack

--- a/mscore/importmidi/importmidi_quant.cpp
+++ b/mscore/importmidi/importmidi_quant.cpp
@@ -558,8 +558,6 @@ struct QuantData
       };
 
 
-#ifdef QT_DEBUG
-
 bool areAllVoicesSame(
             const std::deque<std::multimap<ReducedFraction, MidiChord>::const_iterator> &chords)
       {
@@ -743,8 +741,6 @@ bool areChordsSortedByOnTime(
             }
       return true;
       }
-
-#endif
 
 
 ReducedFraction quantizeToLarge(
@@ -1179,9 +1175,7 @@ void quantizeOffTimes(
                                                             quantizedChords, basicQuant);
                   note.offTime = result.first;
                   note.offTimeQuant = result.second;
-#ifdef QT_DEBUG
                   checkOffTime(note, chordIt, quantizedChords);
-#endif
                   }
             }
       }
@@ -1361,13 +1355,11 @@ findQuantizedChords(
                               fc.isInTuplet = true;
                               fc.tuplet = chord.tuplet;
                               }
-#ifdef QT_DEBUG
                         else {
                               Q_ASSERT_X(fc.tuplet == chord.tuplet,
                                          "Quantize::findQuantizedChords",
                                          "Tuplets of merged chords are different");
                               }
-#endif
                         }
                   }
             else {

--- a/mscore/importmidi/importmidi_simplify.cpp
+++ b/mscore/importmidi/importmidi_simplify.cpp
@@ -30,7 +30,6 @@ bool hasComplexBeamedDurations(const QList<std::pair<ReducedFraction, TDuration>
       }
 
 
-#ifdef QT_DEBUG
 
 bool areDurationsEqual(
             const QList<std::pair<ReducedFraction, TDuration> > &durations,
@@ -42,8 +41,6 @@ bool areDurationsEqual(
 
       return desiredLen == desiredLen;
       }
-
-#endif
 
 
 void lengthenNote(

--- a/mscore/importmidi/importmidi_tie.cpp
+++ b/mscore/importmidi/importmidi_tie.cpp
@@ -17,11 +17,9 @@
 #include "libmscore/chord.h"
 #include "libmscore/note.h"
 
-#ifdef QT_DEBUG
 #include "libmscore/staff.h"
 #include "libmscore/score.h"
 #include "libmscore/measure.h"
-#endif
 
 
 namespace Ms {
@@ -92,7 +90,6 @@ void TieStateMachine::addSeg(const Segment *seg, int strack)
       }
 
 
-#ifdef QT_DEBUG
 
 void printInconsistentTieLocation(int measureIndex, int staffIndex)
       {
@@ -137,7 +134,6 @@ bool areTiesConsistent(const Staff *staff)
       return true;
       }
 
-#endif
 
 
 } // namespace MidiTie

--- a/mscore/importmidi/importmidi_tie.h
+++ b/mscore/importmidi/importmidi_tie.h
@@ -34,9 +34,7 @@ class TieStateMachine
       };
 
 
-#ifdef QT_DEBUG
 bool areTiesConsistent(const Staff *staff);
-#endif
 
 
 } // namespace MidiTie

--- a/mscore/importmidi/importmidi_tuplet.cpp
+++ b/mscore/importmidi/importmidi_tuplet.cpp
@@ -531,7 +531,6 @@ void addChordsBetweenTupletNotes(
       }
 
 
-#ifdef QT_DEBUG
 
 bool doTupletsHaveCommonChords(const std::vector<TupletInfo> &tuplets)
       {
@@ -806,7 +805,6 @@ bool areAllTupletsDifferent(const std::multimap<ReducedFraction, TupletData> &tu
       return true;
       }
 
-#endif
 
 
 void addTupletEvents(std::multimap<ReducedFraction, TupletData> &tupletEvents,
@@ -839,13 +837,11 @@ void addTupletEvents(std::multimap<ReducedFraction, TupletData> &tupletEvents,
                   if (tiedTuplet.tupletId == tupletInfo.id) {
                         MidiChord &midiChord = tiedTuplet.chord->second;
 
-#ifdef QT_DEBUG
                         QString message = "Tied tuplet and tied chord have different voices, "
                                           "tuplet voice = ";
                         message += QString::number(tiedTuplet.voice) + ", chord voice = ";
                         message += QString::number(midiChord.voice) + ", bar number (from 1) = ";
                         message += QString::number(midiChord.barIndex + 1);
-#endif
                         Q_ASSERT_X(tiedTuplet.voice == midiChord.voice,
                                    "MidiTuplet::addTupletEvents", message.toAscii().data());
 
@@ -1141,9 +1137,7 @@ void findAllTuplets(
                               // chords at the end of the current bar
                               // may have changed bar index - from next bar to the current bar
                               // because they were included in tuplets
-#ifdef QT_DEBUG
                         bool nextBarFound = false;
-#endif
                         const auto endBarTick = ReducedFraction::fromTicks(
                                                 sigmap->bar2tick(currentBarIndex + 1, 0));
                         for (auto it = endBarIt; it != chords.end() && it->first < endBarTick; ++it) {
@@ -1156,10 +1150,8 @@ void findAllTuplets(
 
                                     ++endBarIt;
                                     }
-#ifdef QT_DEBUG
                               if (it->second.barIndex > currentBarIndex)
                                     nextBarFound = true;
-#endif
                               }
                         }
 

--- a/mscore/importmidi/importmidi_tuplet.h
+++ b/mscore/importmidi/importmidi_tuplet.h
@@ -112,8 +112,6 @@ ReducedFraction findOnTimeBetweenChords(
             const ReducedFraction &basicQuant,
             const ReducedFraction &barStart);
 
-#ifdef QT_DEBUG
-
 bool areAllTupletsReferenced(
             const std::multimap<ReducedFraction, MidiChord> &chords,
             const std::multimap<ReducedFraction, TupletData> &tupletEvents);
@@ -129,8 +127,6 @@ bool areTupletRangesOk(
             const std::multimap<ReducedFraction, TupletData> &tuplets);
 
 bool areAllTupletsDifferent(const std::multimap<ReducedFraction, TupletData> &tuplets);
-
-#endif
 
 } // namespace MidiTuplet
 } // namespace Ms

--- a/mscore/importmidi/importmidi_tuplet_filter.cpp
+++ b/mscore/importmidi/importmidi_tuplet_filter.cpp
@@ -276,7 +276,6 @@ TupletErrorResult findTupletError(
       }
 
 
-#ifdef QT_DEBUG
 
 bool areCommonsDifferent(const std::vector<int> &selectedCommons)
       {
@@ -304,7 +303,6 @@ bool areCommonsUncommon(const std::vector<int> &selectedCommons,
       return true;
       }
 
-#endif
 
 
 int findAvailableVoice(
@@ -387,7 +385,6 @@ bool canUseIndex(
       }
 
 
-#ifdef QT_DEBUG
 
 bool areTupletChordsEmpty(const std::vector<TupletInfo> &tuplets)
       {
@@ -426,7 +423,6 @@ bool validateSelectedTuplets(Iter beginIt,
       return true;
       }
 
-#endif
 
 
 void tryUpdateBestIndexes(

--- a/mscore/importmidi/importmidi_tuplet_tonotes.cpp
+++ b/mscore/importmidi/importmidi_tuplet_tonotes.cpp
@@ -23,7 +23,6 @@ void addElementToTuplet(int voice,
       {
       const auto foundTuplets = findTupletsForTimeRange(voice, onTime, len, tuplets, true);
 
-#ifdef QT_DEBUG
       if (foundTuplets.size() > 1) {
             qDebug() << "Measure number (from 1):" << el->measure()->no() + 1
                      << ", staff index (from 0):" << el->staff()->idx();
@@ -31,7 +30,6 @@ void addElementToTuplet(int voice,
             Q_ASSERT_X(false, "MidiTuplet::addElementToTuplet",
                        "More than one tuplet contains specified duration");
             }
-#endif
 
       if (!foundTuplets.empty()) {
             auto &tuplet = const_cast<TupletData &>(foundTuplets.front()->second);
@@ -73,7 +71,6 @@ void createTupletNotes(
       }
 
 
-#ifdef QT_DEBUG
 
 void printInvalidTupletLocation(int measureIndex, int staffIndex)
       {
@@ -115,7 +112,6 @@ bool haveTupletsEnoughElements(const Staff *staff)
       return true;
       }
 
-#endif
 
 } // namespace MidiTuplet
 } // namespace Ms

--- a/mscore/importmidi/importmidi_tuplet_tonotes.h
+++ b/mscore/importmidi/importmidi_tuplet_tonotes.h
@@ -21,9 +21,7 @@ void addElementToTuplet(int voice,
 void createTupletNotes(Staff *staff,
                        const std::multimap<ReducedFraction, TupletData> &tuplets);
 
-#ifdef QT_DEBUG
 bool haveTupletsEnoughElements(const Staff *staff);
-#endif
 
 } // namespace MidiTuplet
 } // namespace Ms

--- a/mscore/importmidi/importmidi_tuplet_voice.cpp
+++ b/mscore/importmidi/importmidi_tuplet_voice.cpp
@@ -182,7 +182,6 @@ void setNonTupletVoices(
       }
 
 
-#ifdef QT_DEBUG
 
 bool areAllElementsUnique(
             const std::list<std::multimap<ReducedFraction, MidiChord>::iterator> &nonTuplets)
@@ -293,7 +292,6 @@ bool voiceDontExceedLimit(
       return false;
       }
 
-#endif
 
 
 void eraseBackTiedTuplet(

--- a/mscore/importmidi/importmidi_tuplet_voice.h
+++ b/mscore/importmidi/importmidi_tuplet_voice.h
@@ -54,8 +54,6 @@ chordInterval(const std::pair<const ReducedFraction, MidiChord> &chord,
               const ReducedFraction &basicQuant,
               const ReducedFraction &barStart);
 
-#ifdef QT_DEBUG
-
 bool haveOverlappingVoices(
             const std::list<std::multimap<ReducedFraction, MidiChord>::iterator> &nonTuplets,
             const std::vector<TupletInfo> &tuplets,
@@ -63,8 +61,6 @@ bool haveOverlappingVoices(
             const std::multimap<ReducedFraction, MidiChord> &chords,
             const ReducedFraction &basicQuant,
             const ReducedFraction &barStart);
-
-#endif
 
 } // namespace MidiTuplet
 } // namespace Ms

--- a/mscore/importmidi/importmidi_voice.cpp
+++ b/mscore/importmidi/importmidi_voice.cpp
@@ -45,7 +45,6 @@ int voiceLimit()
       }
 
 
-#ifdef QT_DEBUG
 
 bool areNotesSortedByOffTimeInAscOrder(
             const QList<MidiNote>& notes,
@@ -97,7 +96,6 @@ bool areVoicesSame(const std::multimap<ReducedFraction, MidiChord> &chords)
       return true;
       }
 
-#endif
 
 
 bool allNotesHaveEqualLength(const QList<MidiNote> &notes)

--- a/mscore/importmidi/importmidi_voice.h
+++ b/mscore/importmidi/importmidi_voice.h
@@ -31,11 +31,9 @@ bool splitChordToVoice(
       const ReducedFraction &maxChordLength,
       bool allowParallelTuplets = false);
 
-#ifdef QT_DEBUG
 
 bool areVoicesSame(const std::multimap<ReducedFraction, MidiChord> &chords);
 
-#endif
 
 } // namespace MidiVoice
 } // namespace Ms


### PR DESCRIPTION
define debug methods even if QT_DEBUG is not set,
because the new implementation of Q_ASSERT_X in Qt5.5
always requires all symbols to be defined.

importmidi defines some debug helper methods only when compiled with QT_DEBUG, which was fine up to Qt5.4. With Qt5.5, however,  'make' leads to compile errors. (See <a href="https://musescore.org/en/node/68051">https://musescore.org/en/node/68051</a>)

If it's OK to have the debug helpers included in the release version, this does fix the compilation problems with Qt5.5