### PR TITLE
fix #37346: pan button ineffective in pianoroll editor

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -558,7 +558,9 @@ MuseScore::MuseScore()
       transportTools->addWidget(_playButton);
       transportTools->addWidget(new AccessibleToolButton(transportTools, getAction("loop")));
       transportTools->addSeparator();
-      transportTools->addWidget(new AccessibleToolButton(transportTools, getAction("repeat")));
+      QAction* repeatAction = getAction("repeat");
+      repeatAction->setChecked(MScore::playRepeats);
+      transportTools->addWidget(new AccessibleToolButton(transportTools, repeatAction));
       transportTools->addWidget(new AccessibleToolButton(transportTools, getAction("pan")));
       transportTools->addWidget(new AccessibleToolButton(transportTools, metronomeAction));
 
@@ -4238,9 +4240,11 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
       else if (cmd == "print")
             printFile();
       else if (cmd == "repeat") {
-            MScore::playRepeats = !MScore::playRepeats;
-            cs->updateRepeatList(MScore::playRepeats);
-            emit cs->playlistChanged();
+            MScore::playRepeats = a->isChecked();
+            if (cs) {
+                  cs->updateRepeatList(MScore::playRepeats);
+                  emit cs->playlistChanged();
+                  }
             }
       else if (cmd == "pan")
             MScore::panPlayback = !MScore::panPlayback;

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -18,6 +18,7 @@
 #include "libmscore/staff.h"
 #include "libmscore/measure.h"
 #include "libmscore/note.h"
+#include "libmscore/repeatlist.h"
 #include "awl/pitchlabel.h"
 #include "awl/pitchedit.h"
 #include "awl/poslabel.h"
@@ -484,6 +485,8 @@ void PianorollEditor::keyReleased(int /*pitch*/)
 void PianorollEditor::heartBeat(Seq* seq)
       {
       unsigned tick = seq->getCurTick();
+      if (score()->repeatList())
+            tick = score()->repeatList()->utick2tick(tick);
       if (locator[0].tick() != tick) {
             posChanged(POS::CURRENT, tick);
             if (preferences.followSong)

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -64,7 +64,9 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       tb->addAction(getAction("loop"));
       tb->addSeparator();
       tb->addAction(getAction("repeat"));
-      tb->addAction(getAction("follow"));
+      QAction* followAction = getAction("follow");
+      followAction->setChecked(preferences.followSong);
+      tb->addAction(followAction);
       tb->addSeparator();
       tb->addAction(getAction("metronome"));
 

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2372,10 +2372,12 @@ Shortcut Shortcut::_sc[] = {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
          "follow",
-         QT_TRANSLATE_NOOP("action","Pan piano roll"),
+         QT_TRANSLATE_NOOP("action","Pan Piano Roll"),
          QT_TRANSLATE_NOOP("action","Toggle pan piano roll"),
          QT_TRANSLATE_NOOP("action","Pan roll during playback"),
-         Icons::pan_ICON
+         Icons::pan_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_SCORE | ShortcutFlags::A_CHECKABLE | ShortcutFlags::A_CHECKED
          },
       {
          MsWidget::MAIN_WINDOW,


### PR DESCRIPTION
Original problem was mostly just a matter of the button not indicating it was checkable.  However, after fixing that, I discovered its state was not being initialized properly according to the current preference setting.  I then realized the same same was true for the "play repeats" button (both on main window and in pianoroll), and this probably explains a couple of reports I have seen on the forums.  This PR should fix all three problems.

I see also the "play repeats" option does not work correctly with the pianoroll - it does not follow the repeats correctly when turned on.  Not sure what's up with that, but it seems unrelated to the other issues.