### PR TITLE
fix #68271: ottava added differently for double click than drag & drop

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -290,7 +290,13 @@ void Score::cmdAddSpanner(Spanner* spanner, int staffIdx, Segment* startSegment,
       else
             tick2 = endSegment->tick();
       spanner->setTick2(tick2);
-      undoAddElement(spanner);
+      // original spanner may have been cloned from palette
+      // this results in different behavior from drag & drop for ottava
+      // we can simulate drag & drop by cloning the clone
+      // see https://musescore.org/en/node/68271
+      Spanner* nsp = static_cast<Spanner*>(spanner->clone());
+      delete spanner;
+      undoAddElement(nsp);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
When adding an element via drag & drop, the element to be added is created by reading the XML for the original element.  When adding via double click, we access the element more directlly and clone it as needed.  This resulted in the subtly different behavior for ottavas seen in this issue.  Because drag & drop creates a new score element and then reads it, the code here kicks in:

https://github.com/musescore/MuseScore/blob/9e4f00207980e910297efc61b8c8e3685f783c58/libmscore/ottava.cpp#L415-L418

If the score uses Emmentaler, this strips out out the symbol and replaces it with plain text.  But simply cloning the palette item does not do this, since the palette item belongs to gscore and gscore uses Bravura.

I can't say I'm crazy about that automatic replacement of the ottava symbols with plain text - the fallback system would have allowed this to work even for fonts that lack the symbol.  But I'd like to fix this inconsistency for 2.0.2, so my change here accomplishes that by performing a second clone operation after setting the score on the first clone.