### PR TITLE
fix #68466: spanner changes to length of mmrest

### DIFF
--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -539,12 +539,14 @@ void Spanner::computeEndElement()
                         qDebug("%s no end element for tick %d", name(), tick2());
                         return;
                         }
-                  int nticks = endCR()->tick() + endCR()->actualTicks() - _tick;
-                  if (_ticks != nticks) {
-                        qDebug("%s ticks changed, %d -> %d", name(), _ticks, nticks);
-                        setTicks(nticks);
-                        if (type() == Element::Type::OTTAVA)
-                              staff()->updateOttava();
+                  if (!endCR()->measure()->isMMRest()) {
+                        int nticks = endCR()->tick() + endCR()->actualTicks() - _tick;
+                        if (_ticks != nticks) {
+                              qDebug("%s ticks changed, %d -> %d", name(), _ticks, nticks);
+                              setTicks(nticks);
+                              if (type() == Element::Type::OTTAVA)
+                                    staff()->updateOttava();
+                              }
                         }
                   }
                   break;


### PR DESCRIPTION
Code was added not too long ago to adjust the length of a spanner if something happens to remove its end element:

https://github.com/musescore/MuseScore/commit/cbaf46d2137f8c224969f9810b077c8da68c9087

However, this code also made it so that a spanner that ends within an empty measure would be lengthened to the end of an mmrest when mmrests are turned on.

There's probably a better solution that just disabling the code for mmrests, but this does seem to work for the case, and I couldn't actually come up with any cases that it didn't handle.  I tried variations like generating parts and deleting measures within the mmrest in the score to see if the part would adjust, and it did.  I kind of suspect that any problem that is caused by this is likely not worse than the current situation.  But I would also say, the current bug is enough of a corner case that I'm not all that concerned about rushing a fix in.