### PR TITLE
use oversized stylistic alternates for noteheads

### DIFF
--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -5672,6 +5672,26 @@ void ScoreFont::load()
                         QString("6stringTabClefSerif"),
                         SymId::sixStringTabClefSerif
                   },
+                  {     QString("noteheadBlack"),
+                        QString("noteheadBlackOversized"),
+                        SymId::noteheadBlack
+                  },
+                  {     QString("noteheadHalf"),
+                        QString("noteheadHalfOversized"),
+                        SymId::noteheadHalf
+                  },
+                  {     QString("noteheadWhole"),
+                        QString("noteheadWholeOversized"),
+                        SymId::noteheadWhole
+                  },
+                  {     QString("noteheadDoubleWhole"),
+                        QString("noteheadDoubleWholeOversized"),
+                        SymId::noteheadDoubleWhole
+                  },
+                  {     QString("noteheadDoubleWholeSquare"),
+                        QString("noteheadDoubleWholeSquareOversized"),
+                        SymId::noteheadDoubleWholeSquare
+                  },
                   {     QString("noteheadDoubleWhole"),
                         QString("noteheadDoubleWholeAlt"),
                         SymId::noteheadDoubleWholeAlt


### PR DESCRIPTION
I am submitting this just to see how Travis performs on the tests.  But my intent would be to implement style options to scale noteheads as per https://musescore.org/en/node/60446, and potentially use this to solve the issue created when Bravura noteheads were downsized recently, as per https://musescore.org/en/node/68461.