### PR TITLE
fix #68806: bad barline span with hidden/invisible staves

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -844,8 +844,13 @@ void BarLine::endEdit()
                   int idx1 = staffIdx() + _span;
                   int idx2 = staffIdx() + staff()->barLineSpan();
                   // set standard span for each no-longer-spanned staff
-                  for (int idx = idx1; idx < idx2; ++idx)
-                        score()->undoChangeBarLineSpan(score()->staff(idx), 1, 0, (score()->staff(idx)->lines()-1)*2);
+                  for (int idx = idx1; idx < idx2; ++idx) {
+                        Staff* staff = score()->staff(idx);
+                        int lines = staff->lines();
+                        int spanFrom = lines == 1 ? BARLINE_SPAN_1LINESTAFF_FROM : 0;
+                        int spanTo = lines == 1 ? BARLINE_SPAN_1LINESTAFF_TO : (lines - 1) * 2;
+                        score()->undoChangeBarLineSpan(staff, 1, spanFrom, spanTo);
+                        }
                   }
             }
 

--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -1237,7 +1237,10 @@ void BarLine::updateCustomSpan()
       // span is custom if barline belongs to a staff and any of the staff span params is different from barline's
       // if no staff or same span params as staff, span is not custom
       Staff* stf = staff();
-      _customSpan = stf && (stf->barLineSpan() != _span || stf->barLineFrom() != _spanFrom || stf->barLineTo() != _spanTo);
+      if (!stf)
+            _customSpan = false;
+      else
+            _customSpan = stf->barLineSpan() != _span || stf->barLineFrom() != _spanFrom || stf->barLineTo() != _spanTo;
       updateGenerated(!_customSpan);
       }
 
@@ -1281,7 +1284,7 @@ void BarLine::updateCustomType()
                   }
             }
       _customSubtype = (_barLineType != refType);
-      updateGenerated(!_customSubtype);         // if _customSubType, _genereated is surely false
+      updateGenerated(!_customSubtype);         // if _customSubType, _generated is surely false
       }
 
 //---------------------------------------------------------

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2594,7 +2594,7 @@ bool Measure::createEndBarLines()
                         // but if staff is set to no span, a multi-staff spanning bar line
                         // has been shortened to span less staves and following staves left without bars;
                         // set bar line span values to default
-                        else {
+                        else if (show) {
                               span        = 1;
                               spanFrom    = staffLines == 1 ? BARLINE_SPAN_1LINESTAFF_FROM : 0;
                               spanTo      = staffLines == 1 ? BARLINE_SPAN_1LINESTAFF_TO : (staff->lines() - 1) * 2;

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2585,7 +2585,7 @@ bool Measure::createEndBarLines()
                         }
                   else {                              // otherwise, get from staff
                         span = staff->barLineSpan();
-                        // if some span OR last staff (span0) of a Mensurstrich case, get From/To from staff
+                        // if some span OR last staff (span==0) of a Mensurstrich case, get From/To from staff
                         if (span || mensur) {
                               spanFrom    = staff->barLineFrom();
                               spanTo      = staff->barLineTo();
@@ -2614,8 +2614,6 @@ bool Measure::createEndBarLines()
             else if (spanFrom == unknownSpanFrom && show) {
                   // we started a span earlier, but had not found a visible staff yet
                   spanFrom = staffLines == 1 ? BARLINE_SPAN_1LINESTAFF_FROM : 0;
-                  if (bl)
-                        bl->setCustomSpan(true);
                   }
             if (staff->show() && span) {
                   //

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -427,12 +427,12 @@ void MuseScore::editInstrList()
                         // span to last staff
                         setSpan = n - i;
                         }
-                  else if (span > 1) {
+                  else if (span > 1 && staff->barLineTo() > 0) {
                         // TODO: check if spanTo is still valid
                         // the code here fixes https://musescore.org/en/node/41786
                         // but by forcing an update,
                         // we lose custom modifications to staff barLineTo
-                        // at least this happens only for span > 1
+                        // at least this happens only for span > 1, and not for Mensurstrich
                         setSpan = span;   // force update to pick up new barLineTo value
                         }
                   else {


### PR DESCRIPTION
This replaces #2119 , which I closed as I didn't like a few things about the implementation.  The current version is a bit more well-thought out, but still pretty inelegant, as the problem being solved is multi-faceted and the existing code was pretty complex.

Even though it does seem to work, I judge this to likely be too risky to want to try for 2.0.2, unless someone else wants to do a some thorough review and testing.  But it could be worth trying on the master.  It still suffers from some undo issues on the hide empty staves side especially (barliens marked custom during the process are not restored on undo).  And there are other odd effects present in the current code as well (ie, before this PR) that aren't fixed.  Like: try extending barlines through two staves, then use Edit / Instruments to reverse the order of the two staves.  All barlines become marked "custom" at that point.