### PR TITLE
fix #41786: barline span issues after edit / instrument

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -830,7 +830,7 @@ void BarLine::endEdit()
                   int idx2 = idx1 + _span;
                   // set span 0 to all additional staves
                   for (int idx = idx1 + 1; idx < idx2; ++idx)
-                        // mensurstrich special case:
+                        // Mensurstrich special case:
                         // if line spans to top line of a stave AND current staff is
                         //    the last spanned staff BUT NOT the last score staff
                         //          keep its bar lines
@@ -1286,7 +1286,7 @@ void BarLine::updateCustomType()
                   }
             }
       _customSubtype = (_barLineType != refType);
-      updateGenerated(!_customSubtype);         // if _customSubType, _genereated is surely false
+      updateGenerated(!_customSubtype);         // if _customSubType, _generated is surely false
       }
 
 //---------------------------------------------------------

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2554,7 +2554,7 @@ bool Measure::createEndBarLines()
       BarLine* bl = 0;
       int span    = 0;        // span counter
       int aspan   = 0;        // actual span
-      bool mensur = false;    // keep note of mensurstrich case
+      bool mensur = false;    // keep note of Mensurstrich case
       int spanTot;            // to keep track of the target span
       int spanFrom;
       int spanTo;
@@ -2581,7 +2581,7 @@ bool Measure::createEndBarLines()
                         }
                   else {                              // otherwise, get from staff
                         span        = staff->barLineSpan();
-                        // if some span OR last staff (span=0) of a mensurstrich case, get From/To from staff
+                        // if some span OR last staff (span=0) of a Mensurstrich case, get From/To from staff
                         if (span || mensur) {
                               spanFrom    = staff->barLineFrom();
                               spanTo      = staff->barLineTo();
@@ -2644,14 +2644,14 @@ bool Measure::createEndBarLines()
                         // and the bar line for this staff (cbl) is not needed:
                         // DELETE it
                         if (cbl && cbl != bl) {
-                              // mensurstrich special case:
+                              // Mensurstrich special case:
                               // if span arrives inside the end staff (spanTo>0) OR
                               //          span is not multi-staff (spanTot<=1) OR
                               //          current staff is not the last spanned staff (span!=1) OR
                               //          staff is the last score staff
                               //    remove bar line for this staff
                               // If NONE of the above conditions holds, the staff is the last staff of
-                              // a mensurstrich(-like) span: keep its bar line, as it may span to next staff
+                              // a Mensurstrich(-like) span: keep its bar line, as it may span to next staff
                               if (spanTo > 0 || spanTot <= 1 || span != 1 || staffIdx == nstaves-1) {
                                     score()->undoRemoveElement(cbl);
                                     changed = true;
@@ -2688,7 +2688,7 @@ bool Measure::createEndBarLines()
                   --span;
                   }
             // if just finished (span==0) a multi-staff span (spanTot>1) ending at the top of a staff (spanTo<=0)
-            // scan this staff again, as it may have its own bar lines (mensurstich(-like) span)
+            // scan this staff again, as it may have its own bar lines (Mensurstrich(-like) span)
             if (spanTot > 1 && spanTo <= 0 && span == 0) {
                   mensur = true;
                   staffIdx--;


### PR DESCRIPTION
This fixes both https://musescore.org/en/node/41786 and https://musescore.org/en/node/68921, as well as similar issues where barline spans are invalid in some way after edit / instruments (see, for instance, https://musescore.org/en/node/68996).

The code for this comes from my PR #2122 , which is at this point still has issues I don't know how to resolve.  However, this new PR stands on its own and is usable as is.

It comes with one small regression that to me is more than worth it.  I added a TODO in the code about it, and I'll add a line comment there with more info.