### PR TITLE
Listening to MIDI Machine Control messages [welcome for testing]

### DIFF
--- a/mscore/driver.h
+++ b/mscore/driver.h
@@ -54,6 +54,7 @@ class Driver {
       virtual void checkTransportSeek(int, int, bool) {}
       virtual int bufferSize() {return 0;}
       virtual void updateOutPortCount(int) {}
+      void readMMC(int type, int len, int* data);
       };
 
 

--- a/mscore/jackaudio.cpp
+++ b/mscore/jackaudio.cpp
@@ -377,6 +377,15 @@ int JackAudio::processAudio(jack_nframes_t frames, void* p)
                               int type = event.buffer[0];
                               if (nn && (type == ME_CLOCK || type == ME_SENSE))
                                     continue;
+
+                              if (type >= ME_SYSEX) {
+                                    int* data = new int[nn-1];
+                                    for (int y = 0; y < nn-1; y++)
+                                          data[y] = event.buffer[y+1];
+                                    audio->readMMC(type, nn-1, data);
+                                    delete[] data;
+                                    continue;
+                                    }
                               Event e;
                               e.setChannel(type & 0xf);
                               type &= 0xf0;

--- a/mscore/pm.cpp
+++ b/mscore/pm.cpp
@@ -213,6 +213,25 @@ void PortMidiDriver::read()
             int n = Pm_Read(inputStream, buffer, 1);
             if (n > 0) {
                   int status  = Pm_MessageStatus(buffer[0].message);
+                  if (status >= ME_SYSEX) {
+                        int len = 0;
+                        int* data = nullptr;
+                        if (status == ME_SONGPOS) {
+                              data = new int[2];
+                              data[0] = Pm_MessageData1(buffer[0].message);
+                              data[1] = Pm_MessageData2(buffer[0].message);
+                              len = 2;
+                              seq->driver()->readMMC(status, len, data);
+                              }
+                        else if (status == ME_SYSEX) {
+                              // TODO
+                              }
+                        else
+                              seq->driver()->readMMC(status, len, data);
+
+                         if (data)
+                               delete[] data;
+                        }
                   int type    = status & 0xF0;
                   int channel = status & 0x0F;
                   if (type == ME_NOTEON) {

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -103,6 +103,8 @@ void Preferences::init()
       iconWidth          = 28;
 
       enableMidiInput    = true;
+      acceptMMCmessages  = false;
+      mmcDeviceId        = 127;
       playNotes          = true;
       playChordOnAddNote = true;
 
@@ -247,6 +249,8 @@ void Preferences::write()
       s.setValue("dropColor",          MScore::dropColor);
       s.setValue("defaultColor",       MScore::defaultColor);
       s.setValue("enableMidiInput",    enableMidiInput);
+      s.setValue("acceptMMCmessages",  acceptMMCmessages);
+      s.setValue("mmcDeviceId",        mmcDeviceId);
       s.setValue("playNotes",          playNotes);
       s.setValue("playChordOnAddNote", playChordOnAddNote);
 
@@ -400,6 +404,8 @@ void Preferences::read()
       MScore::dropColor       = s.value("dropColor",    MScore::dropColor).value<QColor>();
 
       enableMidiInput         = s.value("enableMidiInput", enableMidiInput).toBool();
+      acceptMMCmessages       = s.value("acceptMMCmessages", acceptMMCmessages).toBool();
+      mmcDeviceId             = s.value("mmcDeviceId", mmcDeviceId).toInt();
       playNotes               = s.value("playNotes", playNotes).toBool();
       playChordOnAddNote      = s.value("playChordOnAddNote", playChordOnAddNote).toBool();
 
@@ -680,6 +686,11 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       connect(jackDriver, SIGNAL(toggled(bool)), SLOT(exclusiveAudioDriver(bool)));
       connect(useJackAudio, SIGNAL(toggled(bool)), SLOT(nonExclusiveJackDriver(bool)));
       connect(useJackMidi,  SIGNAL(toggled(bool)), SLOT(nonExclusiveJackDriver(bool)));
+
+      QStringList sl;
+      for (int i = 0; i < 127; i++)
+            sl.append(QString().setNum(i));
+      mmcDevice->insertItems(0, sl);
       updateRemote();
       }
 
@@ -803,6 +814,8 @@ void PreferenceDialog::updateValues()
       iconHeight->setValue(prefs.iconHeight);
 
       enableMidiInput->setChecked(prefs.enableMidiInput);
+      mmcDevice->setCurrentIndex(prefs.mmcDeviceId);
+      acceptMMC->setChecked(prefs.acceptMMCmessages);
       playNotes->setChecked(prefs.playNotes);
       playChordOnAddNote->setChecked(prefs.playChordOnAddNote);
 
@@ -1289,6 +1302,8 @@ void PreferenceDialog::apply()
       prefs.enableMidiInput = enableMidiInput->isChecked();
       prefs.playNotes      = playNotes->isChecked();
       prefs.playChordOnAddNote = playChordOnAddNote->isChecked();
+      prefs.acceptMMCmessages  = acceptMMC->isChecked();
+      prefs.mmcDeviceId        = mmcDevice->currentIndex();
 
       prefs.showNavigator      = navigatorShow->isChecked();
       prefs.showPlayPanel      = playPanelShow->isChecked();

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -89,6 +89,8 @@ struct Preferences {
       int iconHeight, iconWidth;
       QColor dropColor;
       bool enableMidiInput;
+      bool acceptMMCmessages;
+      int mmcDeviceId;
       bool playNotes;         // play notes on click
       bool playChordOnAddNote;
       bool showNavigator;

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -1265,6 +1265,19 @@
         </widget>
        </item>
        <item>
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
         <widget class="QGroupBox" name="rcGroup">
          <property name="toolTip">
           <string>Enable MIDI remote control</string>
@@ -1297,6 +1310,19 @@
           <property name="spacing">
            <number>6</number>
           </property>
+          <item row="2" column="5">
+           <widget class="Ms::GreendotButton" name="rca4">
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="accessibleName">
+             <string>Quarter note is active</string>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_15">
             <property name="text">
@@ -1506,19 +1532,6 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="5">
-           <widget class="Ms::GreendotButton" name="rca4">
-            <property name="focusPolicy">
-             <enum>Qt::StrongFocus</enum>
-            </property>
-            <property name="accessibleName">
-             <string>Quarter note is active</string>
-            </property>
-            <property name="text">
-             <string notr="true">...</string>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="6">
            <widget class="Ms::RecordButton" name="rcr4">
             <property name="focusPolicy">
@@ -1558,6 +1571,13 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="12">
+           <widget class="QLabel" name="label_46">
+            <property name="text">
+             <string>Double augmentation dot</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="12">
            <widget class="QLabel" name="label_45">
             <property name="text">
@@ -1565,13 +1585,6 @@
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="12">
-           <widget class="QLabel" name="label_46">
-            <property name="text">
-             <string>Double augmentation dot</string>
             </property>
            </widget>
           </item>
@@ -1751,22 +1764,6 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="Ms::GreendotButton" name="stopActive">
-            <property name="focusPolicy">
-             <enum>Qt::StrongFocus</enum>
-            </property>
-            <property name="toolTip">
-             <string>Is active</string>
-            </property>
-            <property name="accessibleName">
-             <string>Stop is active</string>
-            </property>
-            <property name="text">
-             <string notr="true">...</string>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="2">
            <widget class="Ms::RecordButton" name="recordPlay">
             <property name="focusPolicy">
@@ -1777,6 +1774,22 @@
             </property>
             <property name="accessibleName">
              <string>Play record</string>
+            </property>
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Ms::GreendotButton" name="stopActive">
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
+            <property name="toolTip">
+             <string>Is active</string>
+            </property>
+            <property name="accessibleName">
+             <string>Stop is active</string>
             </property>
             <property name="text">
              <string notr="true">...</string>
@@ -1825,6 +1838,16 @@
             </property>
            </widget>
           </item>
+          <item row="4" column="4">
+           <widget class="QLabel" name="label_41">
+            <property name="text">
+             <string>16th note</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
           <item row="4" column="2">
            <widget class="Ms::RecordButton" name="recordEditMode">
             <property name="focusPolicy">
@@ -1838,16 +1861,6 @@
             </property>
             <property name="text">
              <string notr="true">...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="4">
-           <widget class="QLabel" name="label_41">
-            <property name="text">
-             <string>16th note</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
@@ -1975,16 +1988,6 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="8">
-           <widget class="QLabel" name="label_53">
-            <property name="text">
-             <string>Undo</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
           <item row="4" column="12" colspan="3">
            <widget class="QPushButton" name="midiRemoteControlClear">
             <property name="accessibleName">
@@ -1992,6 +1995,16 @@
             </property>
             <property name="text">
              <string>Clear</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="8">
+           <widget class="QLabel" name="label_53">
+            <property name="text">
+             <string>Undo</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
@@ -2645,51 +2658,6 @@
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout71">
-          <item row="1" column="2">
-           <widget class="QCheckBox" name="becomeTimebaseMaster">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="accessibleName">
-             <string>Timebase Master</string>
-            </property>
-            <property name="text">
-             <string>Timebase Master</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="useJackTransport">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="accessibleName">
-             <string>Use JACK Transport</string>
-            </property>
-            <property name="text">
-             <string>Use JACK Transport</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0" colspan="2">
-           <widget class="QCheckBox" name="useJackAudio">
-            <property name="accessibleName">
-             <string>Use JACK Audio</string>
-            </property>
-            <property name="text">
-             <string>Use JACK Audio</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="3">
            <widget class="QCheckBox" name="rememberLastMidiConnections">
             <property name="sizePolicy">
@@ -2703,6 +2671,19 @@
             </property>
             <property name="text">
              <string>Remember last connection(s)</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QCheckBox" name="useJackAudio">
+            <property name="accessibleName">
+             <string>Use JACK Audio</string>
+            </property>
+            <property name="text">
+             <string>Use JACK Audio</string>
             </property>
             <property name="checked">
              <bool>false</bool>
@@ -2737,6 +2718,102 @@
              <string>Use JACK MIDI</string>
             </property>
            </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="useJackTransport">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="accessibleName">
+             <string>Use JACK Transport</string>
+            </property>
+            <property name="text">
+             <string>Use JACK Transport</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QCheckBox" name="becomeTimebaseMaster">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="accessibleName">
+             <string>Timebase Master</string>
+            </property>
+            <property name="text">
+             <string>Timebase Master</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="mmcGroupBox">
+         <property name="title">
+          <string>MIDI Machine Control</string>
+         </property>
+         <property name="flat">
+          <bool>true</bool>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
+           <widget class="QCheckBox" name="acceptMMC">
+            <property name="text">
+             <string>Accept MMC messages</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_21">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_19">
+            <property name="text">
+             <string>Device ID:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="mmcDevice">
+            <item>
+             <property name="text">
+              <string>Any</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_22">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>316</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1555,4 +1555,26 @@ void Seq::handleTimeSigTempoChanged()
       {
       _driver->handleTimeSigTempoChanged();
       }
+
+//---------------------------------------------------------
+//   accurateSeek
+//   used to seek when receiving an external
+//   MIDI Machine Control GOTO or Song Position Pointer message.
+//   Called from RT thread.
+//---------------------------------------------------------
+
+void Seq::accurateSeek(int utick)
+      {
+      EventMap::const_iterator it = events.lower_bound(utick);
+      if (it->first != utick) {
+            // There is no event at the given utick.
+            // In order to seek accurate we have to create new event.
+            // Note: this event is temporal and will be deleted
+            // on the next collectEvents() call.
+            if (playlistChanged)
+                  collectEvents();
+            seq->events.insert(std::pair<int, NPlayEvent>(utick, NPlayEvent(ME_INVALID, 0 , 0, 0)));
+            }
+      seekRT(utick);
+      }
 }

--- a/mscore/seq.h
+++ b/mscore/seq.h
@@ -173,6 +173,7 @@ class Seq : public QObject, public Sequencer {
       void setRelTempo(double);
       void seek(int utick);
       void seekRT(int utick);
+      void accurateSeek(int utick);
       void stopNotes(int channel = -1, bool realTime = false);
       void start();
       void stop();


### PR DESCRIPTION
MIDI Machine Control (MMC) is a feature that helps to control playback of MuseScore via MIDI by sending special MIDI messages.
For now MuseScore is able to listen to this messages, not send them.
#### New opportunities unlocked:
- Synchronize MuseScore with software that doesn't support JACK Transport
- Control playback of MuseScore even without JACK
#### Supported events:
- System realtime messages:
  - Start (0xFA)
  - Stop (0XFC)
  - Continue (0xFB)
  - Song Position Pointer (SPP) (0xF2)
- System exclusive (SysEx) messages: (0xF0 0x7F <deviceID&gt; 0x06 <command&gt; 0xF7)
  - Stop (command: 1)
  - Pause (9)
  - Play (2)
  - Deferred play (3)
  - Rewind (5)
  - Goto/Locate (0xF0 0x7F &lt;deviceID&gt; 0x06 0x44 0x06 0x01 <hr&gt; <mn&gt; <sc&gt; <fr&gt; <ff&gt; 0xF7) 
#### It works with:
- JACK MIDI
- ALSA MIDI
- PortMidi (partially)
#### Events that are not supported for PortMidi:

System exclusive messages
#### UI changes:
- "Accept MMC messages" checkbox in Preferences->I/O
- Combo box for selecting Device ID
#### Tips
- Since MuseScore is a note editor/engraver, it's better to use SPP message instead of Goto/Locate. SPP operates with MIDI beats while Goto/Locate with time in seconds/frames.
-  Use small MIDI buffer to minimize the delay between applications. For JACK it is 64/128 samples. Using "ALSA Raw-MIDI" MIDI driver instead of "ALSA Sequencer" reduces the delay twice.
- Not all sequencers can handle MIDI realtime messages in real time, so if you want to seek/locate while playing it's better to stop playback, seek and play again.
- There is no restriction on using MMC with JACK Transport, but you can get a delay or other surprises.

Welcome for testing!
