### PR TITLE
Ambitus: Ignore non-played notes

### DIFF
--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -569,6 +569,8 @@ void Ambitus::updateRange()
                               && chord->type() == Element::Type::CHORD) {
                         // update pitch range (with associated tpc's)
                         foreach (Note* n, chord->notes()) {
+                              if (!n->play())         // skip notes which are not to be played
+                                    continue;
                               int pitch = n->ppitch();
                               if (pitch > pitchTop) {
                                     pitchTop = pitch;


### PR DESCRIPTION
While calculating (or updating) the range of an ambitus element, notes with the `play` flag turned off are now ignored.

For a specific request, see: https://musescore.org/en/node/69476

The request was about ignoring cue notes; as cue notes are not categorized as such in the programme and what really counts is the play/non-play flag, I decided to use it as a criterion.