### PR TITLE
Make user home path accessible to plugins

### DIFF
--- a/libmscore/plugins.h
+++ b/libmscore/plugins.h
@@ -45,8 +45,10 @@ class FileIO : public QObject {
       Q_INVOKABLE bool write(const QString& data);
       //@ removes the file
       Q_INVOKABLE bool remove();
+      //@ returns user's home directory
+      Q_INVOKABLE QString homePath() {QDir dir; return dir.homePath();}
       //@ returns a path suitable for a temporary file
-      Q_INVOKABLE QString tempPath() {QDir dir; return dir.tempPath();};
+      Q_INVOKABLE QString tempPath() {QDir dir; return dir.tempPath();}
       //@ returns the file modification time
       Q_INVOKABLE int modifiedTime();
 


### PR DESCRIPTION
Writing plugins in MuseScore 1, I often found it useful to be able to write files to the user's home directory and if it's no issue would love to see this functionality restored in MuseScore 2. Thanks!