### PR TITLE
Fix #69846, #69821, #63561 - multi-voice TAB's: stem and slur positions

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -811,12 +811,13 @@ void Chord::computeUp()
             // if no stems or stem beside staves
             if (tab->slashStyle() || !tab->stemThrough()) {
                   // if measure has voices, set stem direction according to voice
-                  // reverse the logic if stemsDown (#63561)
                   if (measure()->mstaff(staffIdx())->hasVoices)
-                        _up = !tab->stemsDown() ? !(track() % 2) : (track() % 2);
+                        _up = !(track() % 2);
                   else                          // if only voice 1,
-                        _up = !tab->stemsDown();// unconditionally set _up according to TAB stem direction
-                  return;                       // (if no stems, _up does not really matter!)
+                        // uncondtionally set to down if not stems or according to TAB stem direction otherwise
+                        // (even with no stems, stem direction controls position of slurs and ties)
+                        _up = tab->slashStyle() ? false : !tab->stemsDown();
+                  return;
                   }
             // if TAB has stems through staves, chain into standard processing
             }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3544,10 +3544,16 @@ void Measure::layoutX(qreal stretch)
                   if (stt->slashStyle())        // if no stems
                         distAbove = stt->genDurations() ? -stt->durationBoxY() : 0.0;
                   else {                        // if stems
-                        if (stt->stemsDown() && !mstaff(staffIdx)->hasVoices)
+                        if (mstaff(staffIdx)->hasVoices) {  // reserve space both above and below
                               distBelow = (STAFFTYPE_TAB_DEFAULTSTEMLEN_UP + STAFFTYPE_TAB_DEFAULTSTEMDIST_UP)*_spatium;
-                        else
                               distAbove = (STAFFTYPE_TAB_DEFAULTSTEMLEN_DN + STAFFTYPE_TAB_DEFAULTSTEMDIST_DN)*_spatium;
+                              }
+                        else {                              // if no voices, reserve space on stem side
+                              if (stt->stemsDown())
+                                    distBelow = (STAFFTYPE_TAB_DEFAULTSTEMLEN_UP + STAFFTYPE_TAB_DEFAULTSTEMDIST_UP)*_spatium;
+                              else
+                                    distAbove = (STAFFTYPE_TAB_DEFAULTSTEMLEN_DN + STAFFTYPE_TAB_DEFAULTSTEMDIST_DN)*_spatium;
+                              }
                         }
                   if (distAbove > staves[staffIdx]->distanceUp)
                      staves[staffIdx]->distanceUp = distAbove;

--- a/mtest/guitarpro/volta.gp5-ref.mscx
+++ b/mtest/guitarpro/volta.gp5-ref.mscx
@@ -2638,8 +2638,8 @@
             <accidental>0</accidental>
             </KeySig>
           <Beam id="37">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="37">
             <lid>10</lid>
@@ -2691,8 +2691,8 @@
               </Note>
             </Chord>
           <Beam id="38">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="38">
             <lid>17</lid>
@@ -2744,8 +2744,8 @@
               </Note>
             </Chord>
           <Beam id="39">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="39">
             <lid>24</lid>
@@ -2814,8 +2814,8 @@
           </Measure>
         <Measure number="2">
           <Beam id="40">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="40">
             <lid>34</lid>
@@ -2867,8 +2867,8 @@
               </Note>
             </Chord>
           <Beam id="41">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="41">
             <lid>41</lid>
@@ -2920,8 +2920,8 @@
               </Note>
             </Chord>
           <Beam id="42">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="42">
             <lid>48</lid>
@@ -2990,8 +2990,8 @@
           </Measure>
         <Measure number="3">
           <Beam id="43">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="43">
             <lid>58</lid>
@@ -3043,8 +3043,8 @@
               </Note>
             </Chord>
           <Beam id="44">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="44">
             <lid>65</lid>
@@ -3096,8 +3096,8 @@
               </Note>
             </Chord>
           <Beam id="45">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="45">
             <lid>72</lid>
@@ -3166,8 +3166,8 @@
           </Measure>
         <Measure number="4">
           <Beam id="46">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="46">
             <lid>82</lid>
@@ -3219,8 +3219,8 @@
               </Note>
             </Chord>
           <Beam id="47">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="47">
             <lid>89</lid>
@@ -3272,8 +3272,8 @@
               </Note>
             </Chord>
           <Beam id="48">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="48">
             <lid>96</lid>
@@ -3342,8 +3342,8 @@
           </Measure>
         <Measure number="5">
           <Beam id="49">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="49">
             <lid>106</lid>
@@ -3395,8 +3395,8 @@
               </Note>
             </Chord>
           <Beam id="50">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="50">
             <lid>113</lid>
@@ -3448,8 +3448,8 @@
               </Note>
             </Chord>
           <Beam id="51">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="51">
             <lid>120</lid>
@@ -3518,8 +3518,8 @@
           </Measure>
         <Measure number="6">
           <Beam id="52">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="52">
             <lid>130</lid>
@@ -3571,8 +3571,8 @@
               </Note>
             </Chord>
           <Beam id="53">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="53">
             <lid>137</lid>
@@ -3624,8 +3624,8 @@
               </Note>
             </Chord>
           <Beam id="54">
-            <l1>46</l1>
-            <l2>46</l2>
+            <l1>-16</l1>
+            <l2>-16</l2>
             </Beam>
           <Tuplet id="54">
             <lid>144</lid>


### PR DESCRIPTION
__Background__:

In the original TAB implementation, the "Stems above / below" setting was followed when there was only one voice, while with multiple voices, voice 1 stems were always above and voice 2 stems always below.

In issue https://musescore.org/en/node/63561 the OP reported that:
- with multiple voices, stems in TAB did not follow the "Stems above / below" setting;
- extra space was allocated for voice 2 stems.

Both issues were more apparent than real, because the example provided casually had no stems in voice 2 (all whole notes). With the commit https://github.com/musescore/MuseScore/commit/33797cd6c55490cd67a3267e5e7e09f409e61dbf :
- voice 1 stems are forced to be below or down according to the setting even for multi-voice cases and voice 2 stems on the opposite side;
- additional distance is allocated above the TAB staff (but not below) if stems are above or there are multiple voices or below (but not above) if stems are below and there is only voice 1.

__Issues__:

1a) The original stem directions were __by design__, assuming that with multiple voices notes of voice 1 tend to be above and notes of voice 2 tend to be below; then it is more sensible to put voice 1 stems above and voice 2 stems below, limiting the "Stems above / below" setting to the single voice case only.

1b) Stem direction controls slurs and tie placement and users are complaining that, with multiple voices, stems, slurs and ties are placed unexpectedly. See issue https://musescore.org/en/node/69846 and forum post https://musescore.org/en/node/69821 .

2) About additional staff distance allocation, with multiple voices it has to be allocated __both__ above and below, as stems may appear both above and below.

__Fix__:

1) This patch fixes 1) by restoring the original stem direction computation (single voice: follow "Stems above / below" setting | multiple voices: voice 1 unconditionally above and voice 2 below) when tab is configured to have stems beside the staff and also when it is configured to have __no stems at all__ (so that slurs and ties occur in expected positions).

2) It corrects additional staff distance allocation for the multiple voice case. No resources are spent to check the odd case when one voice casually has no stems over the entire system (in which case, additional distance on that side could in theory be spared).