### PR TITLE
Album::createScore now tries to append all excerpts (parts) for each score.

### DIFF
--- a/mscore/album.cpp
+++ b/mscore/album.cpp
@@ -22,6 +22,7 @@
 #include "globals.h"
 #include "libmscore/score.h"
 #include "libmscore/page.h"
+#include "libmscore/excerpt.h"
 #include "preferences.h"
 #include "libmscore/mscore.h"
 #include "libmscore/xml.h"
@@ -127,16 +128,61 @@ bool Album::createScore(const QString& fn)
       loadScores();
 
       Score* firstScore = _scores[0]->score;
-      if (!firstScore)
+      if (!firstScore) {
+            qDebug("First score is NULL. Will not attempt to join scores.");
             return false;
+            }
+
+      // do layout for first score's root and excerpt scores
       firstScore->doLayout();
+      for (int i=0; i<firstScore->excerpts().count(); i++) {
+            if (firstScore->excerpts().at(i)->partScore()) {
+                  firstScore->excerpts().at(i)->partScore()->doLayout();
+                  }
+            else {
+                  qDebug("First score has excerpts, but excerpt %d is NULL.  Will not attempt to join scores.", i);
+                  return false;
+                  }
+            }
+
       Score* score = firstScore->clone();
+
       foreach (AlbumItem* item, _scores) {
+
             if (item->score == 0 || item->score == firstScore)
                   continue;
+
+            // try to append root score
             item->score->doLayout();
             if (!score->appendScore(item->score)) {
-                  qDebug("cannot append score");
+                  qDebug("Cannot append root score of album item \"%s\".", qPrintable(item->name));
+                  delete score;
+                  return false;
+                  }
+
+            // try to append each excerpt
+            if (item->score->excerpts().count() == score->excerpts().count() ) {
+                  for (int i=0; i<score->excerpts().count(); i++) {
+                        Score* currentScoreExcerpt = item->score->excerpts().at(i)->partScore();
+                        if (currentScoreExcerpt) {
+                              currentScoreExcerpt->doLayout();
+                              if (!score->excerpts().at(i)->partScore()->appendScore(currentScoreExcerpt)) {
+                                    qDebug("Cannot append excerpt %d of album item \"%s\".", i, qPrintable(item->name));
+                                    delete score;
+                                    return false;
+                                    }
+                              }
+                        else {
+                              qDebug("First score has excerpts, but excerpt %d of album item \"%s\" is NULL.  Will not attempt to join scores.",
+                                          i, qPrintable(item->name));
+                              delete score;
+                              return false;
+                              }
+                        }
+                  }
+            else {
+                  qDebug("Will not append album item \"%s\".  Mismatch between number of excerpts with first album item \"%s\"",
+                              qPrintable( item->name ), qPrintable( _scores[0]->name ) );
                   delete score;
                   return false;
                   }

--- a/mscore/album.cpp
+++ b/mscore/album.cpp
@@ -161,7 +161,7 @@ bool Album::createScore(const QString& fn)
                   }
 
             // try to append each excerpt
-            if (item->score->excerpts().count() == score->excerpts().count() ) {
+            if (item->score->excerpts().count() == score->excerpts().count()) {
                   for (int i = 0; i < score->excerpts().count(); i++) {
                         Score* currentScoreExcerpt = item->score->excerpts().at(i)->partScore();
                         if (currentScoreExcerpt) {

--- a/mscore/album.cpp
+++ b/mscore/album.cpp
@@ -135,7 +135,7 @@ bool Album::createScore(const QString& fn)
 
       // do layout for first score's root and excerpt scores
       firstScore->doLayout();
-      for (int i=0; i<firstScore->excerpts().count(); i++) {
+      for (int i = 0; i < firstScore->excerpts().count(); i++) {
             if (firstScore->excerpts().at(i)->partScore()) {
                   firstScore->excerpts().at(i)->partScore()->doLayout();
                   }
@@ -162,7 +162,7 @@ bool Album::createScore(const QString& fn)
 
             // try to append each excerpt
             if (item->score->excerpts().count() == score->excerpts().count() ) {
-                  for (int i=0; i<score->excerpts().count(); i++) {
+                  for (int i = 0; i < score->excerpts().count(); i++) {
                         Score* currentScoreExcerpt = item->score->excerpts().at(i)->partScore();
                         if (currentScoreExcerpt) {
                               currentScoreExcerpt->doLayout();
@@ -182,7 +182,7 @@ bool Album::createScore(const QString& fn)
                   }
             else {
                   qDebug("Will not append album item \"%s\".  Mismatch between number of excerpts with first album item \"%s\"",
-                              qPrintable( item->name ), qPrintable( _scores[0]->name ) );
+                              qPrintable(item->name), qPrintable(_scores[0]->name));
                   delete score;
                   return false;
                   }


### PR DESCRIPTION
If want to create joined mscz of an album of scores that all already contain pregenerated parts (called "excerpts" interally), then this fixes bug #70836 where only part excerpts from the first score are copied to joined score.  Album::createScore now iterates over every part excerpt for every album item and appends it to the corresponding part excerpt of the joined score.  That means that any part specific edits (e.g. part-specific spacings) are now copied over to the joined score.  Note: for simplicity sake, I am assuming user has identical ordering of parts in each score.  I am only testing to make sure that there are an equal *number* of part excerpts in each score and am testing that each part excerpt actually *exists* before trying to append, or else I display a meaningful qDebug message, and return failure so that the user gets presented with error popup.  Any more testing (e.g. that the parts are named the same, use the same instruments, and have the same number of staves, etc.) I think is beyond of the scope of this bug as it would have made this fix much more complicated.