### PR TITLE
fix #70861: add (sp) and vertical spacers in page layout window

### DIFF
--- a/mscore/pagesettings.ui
+++ b/mscore/pagesettings.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
+    <width>686</width>
     <height>390</height>
    </rect>
   </property>
@@ -178,7 +178,7 @@
            <string>Distance between two lines on a standard 5-line staff</string>
           </property>
           <property name="text">
-           <string>Staff space:</string>
+           <string>Staff space (sp):</string>
           </property>
           <property name="textFormat">
            <enum>Qt::PlainText</enum>
@@ -221,7 +221,7 @@
        <item>
         <widget class="QLabel" name="label_12">
          <property name="text">
-          <string>First page number:</string>
+          <string>First page &amp;number:</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -263,7 +263,7 @@
        <item>
         <widget class="QRadioButton" name="mmButton">
          <property name="text">
-          <string>mm</string>
+          <string>&amp;mm</string>
          </property>
         </widget>
        </item>
@@ -273,6 +273,19 @@
           <string>inch</string>
          </property>
         </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </item>
@@ -496,6 +509,19 @@
         </item>
        </layout>
       </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
in Page Layout window:
- changed "Staff spacing:" into "Staff spacing (sp):"
- added a vertical spacer to bottom of 1st column
- added a vertical spacer to bottom of 2nd column