### PR TITLE
Plugin framework: add requiresScore flag

### DIFF
--- a/mscore/mscorePlugins.cpp
+++ b/mscore/mscorePlugins.cpp
@@ -413,6 +413,15 @@ void MuseScore::pluginTriggered(int idx)
             }
 
       QmlPlugin* p = qobject_cast<QmlPlugin*>(obj);
+      if(MuseScoreCore::mscoreCore->currentScore() == nullptr && p->requiresScore() == true) {
+            QMessageBox::information(0,
+                  QMessageBox::tr("MuseScore"),
+                  QMessageBox::tr("No score open.\n"
+                  "This plugin requires an open score to run.\n"),
+                  QMessageBox::Ok, QMessageBox::NoButton);
+            delete obj;
+            return;
+            }
       p->setFilePath(pp.section('/', 0, -2));
 
       if (p->pluginType() == "dock" || p->pluginType() == "dialog") {

--- a/mscore/pluginCreator.cpp
+++ b/mscore/pluginCreator.cpp
@@ -300,6 +300,17 @@ void PluginCreator::runClicked()
       run->setEnabled(false);
 
       item = qobject_cast<QmlPlugin*>(obj);
+      if(MuseScoreCore::mscoreCore->currentScore() == nullptr && item->requiresScore() == true) {
+            QMessageBox::information(0,
+                  QMessageBox::tr("MuseScore"),
+                  QMessageBox::tr("No score open.\n"
+                  "This plugin requires an open score to run.\n"),
+                  QMessageBox::Ok, QMessageBox::NoButton);
+            delete obj;
+            item = nullptr;
+            closePlugin();
+            return;
+            }
       item->setFilePath(path.isEmpty() ? QString() : path.section('/', 0, -2));
 
       if (item->pluginType() == "dock" || item->pluginType() == "dialog") {

--- a/mscore/qmlplugin.cpp
+++ b/mscore/qmlplugin.cpp
@@ -30,6 +30,7 @@ QmlPlugin::QmlPlugin(QQuickItem* parent)
    : QQuickItem(parent)
       {
       msc = MuseScoreCore::mscoreCore;
+      _requiresScore = true;              // by default plugins require a score to work
       }
 
 QmlPlugin::~QmlPlugin()

--- a/mscore/qmlplugin.h
+++ b/mscore/qmlplugin.h
@@ -40,6 +40,7 @@ extern int updateVersion();
 //   @P description          QString
 //   @P pluginType           QString
 //   @P dockArea             QString
+//   @P requiresScore        bool              whether the plugin requires an existing score to run
 //   @P division             int               number of MIDI ticks for 1/4 note (read only)
 //   @P mscoreVersion        int               complete version number of MuseScore in the form: MMmmuu (read only)
 //   @P mscoreMajorVersion   int               1st part of the MuseScore version (read only)
@@ -59,6 +60,7 @@ class QmlPlugin : public QQuickItem {
       Q_PROPERTY(QString pluginType      READ pluginType WRITE setPluginType)
 
       Q_PROPERTY(QString dockArea        READ dockArea WRITE setDockArea)
+      Q_PROPERTY(bool requiresScore      READ requiresScore WRITE setRequiresScore)
       Q_PROPERTY(int division            READ division)
       Q_PROPERTY(int mscoreVersion       READ mscoreVersion)
       Q_PROPERTY(int mscoreMajorVersion  READ mscoreMajorVersion)
@@ -72,6 +74,7 @@ class QmlPlugin : public QQuickItem {
       QString _menuPath;
       QString _pluginType;
       QString _dockArea;
+      bool    _requiresScore;
       QString _version;
       QString _description;
       QFile logFile;
@@ -99,6 +102,8 @@ class QmlPlugin : public QQuickItem {
       void setDockArea(const QString& s)   { _dockArea = s;    }
       QString dockArea() const             { return _dockArea; }
       void runPlugin()                     { emit run();       }
+      void setRequiresScore(bool b)        { _requiresScore = b;    }
+      bool requiresScore() const           { return _requiresScore; }
 
       int division() const                { return MScore::division; }
       int mscoreVersion() const           { return Ms::version();      }


### PR DESCRIPTION
A built-in property is added to plug-ins called `requiresScore` which controls whether the plug-in requires a score to run or can run without any score open (for instance because it creates the target score itself).

If the property is `true` and the plug-in is launched when no score is open, a message box display a warning message and the launch is aborted.

This happens when launching the plug-in both directly from the `Plugins` menu and from within the Plugin Creator.

By default this property is `true` (so that all existing QML plug-ins are assumed to require an open score); the property can be set to `false` by adding a line like

`requiresScore: false`

in the property definitions of the plug-in `MuseScore` object.