### PR TITLE
Fix note_groups.ui for high DPI screens

### DIFF
--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -336,7 +336,9 @@ void ExampleView::mousePressEvent(QMouseEvent* event)
 
 QSize ExampleView::sizeHint() const
       {
-      return QSize(1000 * guiScaling, 80 * guiScaling);
+      return QSize(
+            1000 * guiScaling * (MScore::DPI / 90),
+              80 * guiScaling * (MScore::DPI / 90));
       }
 
 

--- a/mscore/note_groups.ui
+++ b/mscore/note_groups.ui
@@ -47,7 +47,7 @@
      <item row="1" column="2">
       <widget class="Ms::ExampleView" name="view16">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -152,7 +152,7 @@
      <item row="2" column="2">
       <widget class="Ms::ExampleView" name="view32">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -238,7 +238,7 @@
      <item row="0" column="2">
       <widget class="Ms::ExampleView" name="view8">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>


### PR DESCRIPTION
This is a quick fix for an issue which occurs only on high DPI screens (on Ubuntu) while creating a custom time signature in the palette:

![note_groups](https://cloud.githubusercontent.com/assets/11692818/8986369/2829cd46-36dc-11e5-883b-b61da4602219.png)

The noteheads are outside the `ExampleView`'s bounds so you cannot customize the beamings. I have changed the `sizepolicy` to `Expanding`.