### PR TITLE
Fix Erhu channel.

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -9113,7 +9113,7 @@
                   <aPitchRange>62-93</aPitchRange>
                   <pPitchRange>62-105</pPitchRange>
                   <Channel>
-                        <program value="40"/>
+                        <program value="110"/>
                   </Channel>
                   <Channel name="pizzicato">
                         <program value="45"/>


### PR DESCRIPTION
According to the Roland GS and Yamaha XG, the Erhu belongs to channel 111 (1-128) or 110 (0-127).

Yamaha XG specifications v2.00: 
http://www.jososoft.dk/yamaha/pdf/XGspec2-00e.pdf

Roland GS: 
http://www.voidaudio.net/gsinstrument.html

![qq20150805-1 2x](https://cloud.githubusercontent.com/assets/2240638/9083837/2ae21610-3ba0-11e5-948b-858404d7dd64.png)
