### PR TITLE
Fluid: Multiply attenuation by 0.4 to preserve sf2 compatibility and equivalence to FluidSynth.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ CMakeLists.txt.user.*
 vtest/html
 thirdparty/mupdf-qt
 
+/build

--- a/fluid/voice.cpp
+++ b/fluid/voice.cpp
@@ -774,7 +774,7 @@ void Voice::update_param(int _gen)
                   break;
 
             case GEN_ATTENUATION:
-                  attenuation = GEN(GEN_ATTENUATION);
+                  attenuation = GEN_04(GEN_ATTENUATION);
 
                   /* Range: SF2.01 section 8.1.3 # 48
                    * Motivation for range checking:

--- a/fluid/voice.h
+++ b/fluid/voice.h
@@ -208,6 +208,7 @@ class Voice
       void update_param(int gen);
 
       double GEN(int n) { return gen[n].val + gen[n].mod + gen[n].nrpn; }
+      double GEN_04(int n) { return gen[n].val*0.4 + gen[n].mod + gen[n].nrpn; }
 
       void modulate_all();
       void modulate(bool _cc, int _ctrl);


### PR DESCRIPTION
This fixes compatibility with virtually all softsynths, including Polyphone, Viena, FluidSynth, and BASSMIDI, and also soundfonts including SGM.

Technically, all of the above violate the SF2 standard. However, this is de-facto correct behavoir.