### PR TITLE
Fixes #19155 Editable anchors for glissandi and other note-anchored spanners

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2985,6 +2985,25 @@ void Chord::setSlash(bool flag, bool stemless)
       }
 
 //---------------------------------------------------------
+//  updateEndsGlissando
+//    sets/resets the chord _endsGlissando according any glissando (or more)
+//    end into this chord or no.
+//---------------------------------------------------------
+
+void Chord::updateEndsGlissando()
+      {
+      _endsGlissando = false;       // assume no glissando ends here
+      // scan all chord notes for glissandi ending on this chord
+      for (Note* note : notes()) {
+            for (Spanner* sp : note->spannerBack())
+                  if (sp->type() == Element::Type::GLISSANDO) {
+                        _endsGlissando = true;
+                        return;
+                        }
+            }
+      }
+
+//---------------------------------------------------------
 //   removeMarkings
 //    - this is normally called after cloning a chord to tie a note over the barline
 //    - there is no special undo handling; the assumption is that undo will simply remove the cloned chord

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -86,7 +86,7 @@ class Chord : public ChordRest {
 
       Arpeggio*           _arpeggio;
       Tremolo*            _tremolo;
-      bool                _endsGlissando;///< true if this chord is the ending point of a glissando (nneeded for layout)
+      bool                _endsGlissando;///< true if this chord is the ending point of a glissando (needed for layout)
       ElementList         _el;           ///< chordline, slur
       QList<Chord*>       _graceNotes;
       int                 _graceIndex;   ///< if this is a grace note, index in parent list
@@ -156,9 +156,9 @@ class Chord : public ChordRest {
       Arpeggio* arpeggio() const             { return _arpeggio;  }
       Tremolo* tremolo() const               { return _tremolo;   }
       void setTremolo(Tremolo* t)            { _tremolo = t;      }
-//      Glissando* glissando() const           { return _glissando; }
       bool endsGlissando() const             { return _endsGlissando; }
       void setEndsGlissando (bool val)       { _endsGlissando = val; }
+      void updateEndsGlissando();
       StemSlash* stemSlash() const           { return _stemSlash; }
       bool slash();
       void setSlash(bool flag, bool stemless);

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -95,7 +95,7 @@ void GlissandoSegment::draw(QPainter* painter) const
             // this is very ugly but fix #68846 for now
             bool tmp = MScore::pdfPrinting;
             MScore::pdfPrinting = true;
-            score()->scoreFont()->draw(ids, painter, magS(), QPointF(x, b.height() * .7), scale *2.0);
+            score()->scoreFont()->draw(ids, painter, magS(), QPointF(x, -(b.y() + b.height()*0.5) ), scale /**2.0*/);
             MScore::pdfPrinting = tmp;
             }
       if (glissando()->showText()) {
@@ -106,7 +106,7 @@ void GlissandoSegment::draw(QPainter* painter) const
             if (r.width() < l) {
                   qreal yOffset = r.height() + r.y();       // find text descender height
                   // raise text slightly above line and slightly more with WAVY than with STRAIGHT
-                  yOffset += _spatium * (glissando()->glissandoType() == Glissando::Type::WAVY ? 0.8 : 0.1);
+                  yOffset += _spatium * (glissando()->glissandoType() == Glissando::Type::WAVY ? 0.4 : 0.1);
                   painter->setFont(f);
                   qreal x = (l - r.width()) * 0.5;
                   painter->drawText(QPointF(x, -yOffset), glissando()->text());

--- a/libmscore/glissando.h
+++ b/libmscore/glissando.h
@@ -32,9 +32,6 @@ class GlissandoSegment : public LineSegment {
       Q_OBJECT
 
    protected:
-      // make glissando segment non-editable, until proper support is added for
-      // anchor selection
-      virtual bool isEditable() const override              { return false; }
 
    public:
       GlissandoSegment(Score* s) : LineSegment(s)           {}
@@ -77,10 +74,6 @@ class Glissando : public SLine {
       bool _playGlissando;
 
    protected:
-      // make glissando non-editable, until proper support is added for anchor selection
-      // (in some occasions, trying to edit a single-segment glissando, redirects into
-      // editing the whole glissando)
-      virtual bool isEditable() const override              { return false; }
 
    public:
       Glissando(Score* s);

--- a/libmscore/line.h
+++ b/libmscore/line.h
@@ -50,7 +50,7 @@ class LineSegment : public SpannerSegment {
       Q_OBJECT
 
    protected:
-      virtual bool isEditable() const override { return true; }
+//      virtual bool isEditable() const override { return true; } // same as base class!
       virtual void editDrag(const EditData&) override;
       virtual bool edit(MuseScoreView*, Grip, int key, Qt::KeyboardModifiers, const QString& s) override;
       virtual void updateGrips(Grip*, QVector<QRectF>&) const override;

--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -226,7 +226,7 @@ Note* Score::upAltCtrl(Note* note) const
 //---------------------------------------------------------
 //   downAlt
 //    return next lower pitched note in chord
-//    move to previous track if at bottom of chord
+//    move to next track if at bottom of chord
 //---------------------------------------------------------
 
 Element* Score::downAlt(Element* element)

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -572,7 +572,7 @@ void Note::removeSpanner(Spanner* l)
                   // abort();
                   }
             if (l->type() == Element::Type::GLISSANDO)
-                 e->chord()->setEndsGlissando(false);
+                 e->chord()->updateEndsGlissando();
             }
       if (!removeSpannerFor(l)) {
             qDebug("Note(%p): cannot remove spannerFor %s %p", this, l->name(), l);

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -128,7 +128,10 @@ class Spanner : public Element {
 
    protected:
       QList<SpannerSegment*> segments;
+      // used to store spanner properties as they were at start of editing
+      // and detect edit changes when edit is over
       static int editTick, editTick2, editTrack2;
+      static Note * editEndNote, * editStartNote;
 
    public:
       Spanner(Score* = 0);

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -623,7 +623,11 @@ void TextLine::read(XmlReader& e)
 
 LineSegment* TextLine::createLineSegment()
       {
-      return new TextLineSegment(score());
+      TextLineSegment* seg = new TextLineSegment(score());
+      // note-anchored line segments are relative to system not to staff
+      if (anchor() == Spanner::Anchor::NOTE)
+            seg->setFlag(ElementFlag::ON_STAFF, false);
+      return seg;
       }
 
 //---------------------------------------------------------

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -3454,12 +3454,70 @@ void RemoveBracket::undo()
 
 void ChangeSpannerElements::flip()
       {
-      Element* se = spanner->startElement();
-      Element* ee = spanner->endElement();
-      spanner->setStartElement(startElement);
-      spanner->setEndElement(endElement);
-      startElement = se;
-      endElement   = ee;
+      Element*    oldStartElement   = spanner->startElement();
+      Element*    oldEndElement     = spanner->endElement();
+      if (spanner->anchor() == Spanner::Anchor::NOTE) {
+            // be sure new spanner elements are of the right type
+            if (startElement->type() != Element::Type::NOTE || endElement->type() != Element::Type::NOTE)
+                  return;
+            Note* newStartNote;
+            Note* newEndNote;
+            Note* oldStartNote;
+            Note* oldEndNote;
+            int   startDeltaTrack   = oldStartElement->track() - startElement->track();
+            int   endDeltaTrack     = oldEndElement->track() - endElement->track();
+            // scan all spanners linked to this one
+            for (ScoreElement* el : spanner->linkList()) {
+                  Spanner*    sp    = static_cast<Spanner*>(el);
+                  newStartNote      = newEndNote = nullptr;
+                  oldStartNote      = static_cast<Note*>(sp->startElement());
+                  oldEndNote        = static_cast<Note*>(sp->endElement());
+                  // if not the current spanner, but one linked to it, determine its new start and end notes
+                  // as modifications 'parallel' to the modifications of the current spanner's start and end notes
+                  if (sp != spanner) {
+                        // determine the track where to expect the 'parallel' start element
+                        int   newTrack    = sp->startElement()->track() + startDeltaTrack;
+                        // look in notes linked to new start note for a note with
+                        // same score as linked spanner and appropriate track
+                        for (ScoreElement* newEl : startElement->linkList())
+                              if (static_cast<Note*>(newEl)->score() == sp->score()
+                                          && static_cast<Note*>(newEl)->track() == newTrack) {
+                                    newStartNote = static_cast<Note*>(newEl);
+                                    break;
+                                    }
+                        // similarly to determine the 'parallel' end element
+                        newTrack    = sp->endElement()->track() + endDeltaTrack;
+                        for (ScoreElement* newEl : endElement->linkList())
+                              if (static_cast<Note*>(newEl)->score() == sp->score()
+                                          && static_cast<Note*>(newEl)->track() == newTrack) {
+                                    newEndNote = static_cast<Note*>(newEl);
+                                    break;
+                                    }
+                        }
+                  // if current spanner, just use stored start and end elements
+                  else {
+                        newStartNote      = static_cast<Note*>(startElement);
+                        newEndNote        = static_cast<Note*>(endElement);
+                        }
+                  // update spanner's start and end notes
+                  if (newStartNote != nullptr && newEndNote != nullptr) {
+                        oldStartNote->removeSpannerFor(sp);
+                        oldEndNote->removeSpannerBack(sp);
+                        sp->setNoteSpan(newStartNote, newEndNote);
+                        newStartNote->addSpannerFor(sp);
+                        newEndNote->addSpannerBack(sp);
+
+                        if (sp->type() == Element::Type::GLISSANDO)
+                              oldEndNote->chord()->updateEndsGlissando();
+                        }
+                  }
+            }
+      else {
+            spanner->setStartElement(startElement);
+            spanner->setEndElement(endElement);
+            }
+      startElement = oldStartElement;
+      endElement   = oldEndElement;
       if (spanner->type() == Element::Type::TIE) {
             Tie* tie = static_cast<Tie*>(spanner);
             static_cast<Note*>(endElement)->setTieBack(0);

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -290,6 +290,62 @@ Segment* prevSeg1(Segment* seg, int& track)
       }
 
 //---------------------------------------------------------
+// next/prevChordNote
+//
+//    returns the top note of the next/previous chord. If a chord exists in the same track as note,
+//    it is used. If not, the topmost existing chord is used.
+//    May return nullptr if there is no next/prev note
+//---------------------------------------------------------
+
+Note* nextChordNote(Note* note)
+      {
+      int         track       = note->track();
+      int         fromTrack   = (track / VOICES) * VOICES;
+      int         toTrack     = fromTrack + VOICES;
+      // TODO : limit to same instrument, not simply to same staff!
+      Segment*    seg   = note->chord()->segment()->nextCR(track, true);
+      while (seg) {
+            Element*    targetElement = seg->elementAt(track);
+            // if a chord exists in the same track, return its top note
+            if (targetElement != nullptr && targetElement->type() == Element::Type::CHORD)
+                  return static_cast<Chord*>(targetElement)->upNote();
+            // if not, return topmost chord in track range
+            for (int i = fromTrack ; i < toTrack; i++) {
+                  targetElement = seg->elementAt(i);
+                  if (targetElement != nullptr && targetElement->type() == Element::Type::CHORD)
+                        return static_cast<Chord*>(targetElement)->upNote();
+                  }
+            seg = seg->nextCR(track, true);
+            }
+      return nullptr;
+      }
+
+Note* prevChordNote(Note* note)
+      {
+      int         track       = note->track();
+      int         fromTrack   = (track / VOICES) * VOICES;
+      int         toTrack     = fromTrack + VOICES;
+      // TODO : limit to same instrument, not simply to same staff!
+      Segment*    seg   = note->chord()->segment()->prev1();
+      while (seg) {
+            if (seg->segmentType() == Segment::Type::ChordRest) {
+                  Element*    targetElement = seg->elementAt(track);
+                  // if a chord exists in the same track, return its top note
+                  if (targetElement != nullptr && targetElement->type() == Element::Type::CHORD)
+                        return static_cast<Chord*>(targetElement)->upNote();
+                  // if not, return topmost chord in track range
+                  for (int i = fromTrack ; i < toTrack; i++) {
+                        targetElement = seg->elementAt(i);
+                        if (targetElement != nullptr && targetElement->type() == Element::Type::CHORD)
+                              return static_cast<Chord*>(targetElement)->upNote();
+                        }
+                  }
+            seg = seg->prev1();
+            }
+      return nullptr;
+      }
+
+//---------------------------------------------------------
 //   pitchKeyAdjust
 //    change entered note to sounding pitch dependend
 //    on key.

--- a/libmscore/utils.h
+++ b/libmscore/utils.h
@@ -66,6 +66,8 @@ extern int majorVersion();
 extern int minorVersion();
 extern int updateVersion();
 
+extern Note* nextChordNote(Note* note);
+extern Note* prevChordNote(Note* note);
 extern Segment* nextSeg1(Segment* s, int& track);
 extern Segment* prevSeg1(Segment* seg, int& track);
 


### PR DESCRIPTION
Fixes #19155, #22861 (duplicate of the former) and #23100.

__References__:
Issues:	https://musescore.org/en/node/19155 https://musescore.org/en/node/22861 https://musescore.org/en/node/23100

__Description__:
Allows to change the start and end note to which a glissando is anchored after it has been entered. Either anchor can be changed independently.

The user interface follows the current working of other 'snappable' lines. Once either the start or end grip is selected:
- `[Shift]+[Left]` snaps the anchor to the previous chord, defaulting to its top note.
- `[Shift]+[Right]` snaps to the next chord, defaulting to its top note.
- `[Shift]+[Up]` snaps to the note above (possibly in a chord, voice or staff above the current one).
- `[Shift]+[Down]` snaps to the note below (possibly in a chord, voice or staff below the current one).

This permits to set the anchor points of a glissando to any note in the score, allowing several glissandi between the notes of the same two chords and other complex configurations (glissandi skipping intermediate chords, start and end notes in different voices or staves, and so on).

It is possible to move the anchor to a different staff of the same instrument, but not to a different instrument; also, it is not possible to 'cross' a change of instrument in the same staff.

__Known limitations__:
- The `[Shift]+[Up]` and `[Shift]+[Down]` use the same note-finding functions as the `[Alt]+[Up]` and `[Alt]+[Down]`actions which move the selection cursor to the above and below note, even across voices or staves (namely `Score::upAlt()` and `Score::downAlt()`). Occasionally, in particular if the note immediately above or below is not time-aligned, the algorithm has little expected results; however, the behaviour is already known to the user. Improving the algorithm would benefit both uses.

__Notes__:
- Most of the added infrastructure is not specific to glissando but to any spanner anchored to notes, then it should also add after-the-fact "snap to" note support to note-anchored text line.
- When moving an anchor, the algorithm usually prefers a note in the same voice/staff of the old note if it exists; if there is none, it tries other voices of the same staff.
- The change of anchor is undoable.
- The fix corrects the management of the `Chord::_endsGlissando` flag, taking into account that a chord can be the ending point of several glissandi and removing one of them not necessarily means the chord no longer ends a glissando (another glissando may still exists).
- The fix also improved the rendering of the glissando wavy line, with better alignment with anchor notes and, with glissando text, better text-line spacing.