### PR TITLE
Fix #71441 add cancel button to zerberus sfz loading

### DIFF
--- a/zerberus/sfz.cpp
+++ b/zerberus/sfz.cpp
@@ -340,6 +340,8 @@ bool ZInstrument::loadSfz(const QString& s)
                   continue;
             QList<QByteArray> bal = ba.split(' ');
             foreach(const QByteArray& bb, bal) {
+                  if (zerberus->loadWasCanceled())
+                        return false;
                   if (bb == "<group>") {
                         if (!groupMode && !r.isEmpty())
                               addRegion(r);

--- a/zerberus/zerberus.cpp
+++ b/zerberus/zerberus.cpp
@@ -448,6 +448,9 @@ bool Zerberus::loadInstrument(const QString& s)
                   return true;
                   }
             }
+      catch (std::bad_alloc& a) {
+            qDebug("Unable to allocate memory when loading Zerberus soundfont %s", qPrintable(s));
+            }
       catch (...) {
             }
       qDebug("Zerberus::loadInstrument failed");

--- a/zerberus/zerberus.h
+++ b/zerberus/zerberus.h
@@ -77,6 +77,7 @@ class Zerberus : public Ms::Synthesizer {
       VoiceFifo freeVoices;
       Voice* activeVoices = 0;
       int _loadProgress = 0;
+      bool _loadWasCanceled = false;
 
       void programChange(int channel, int program);
       void trigger(Channel*, int key, int velo, Trigger);
@@ -97,6 +98,8 @@ class Zerberus : public Ms::Synthesizer {
       Channel* channel(int n)       { return _channel[n]; }
       int loadProgress()            { return _loadProgress; }
       void setLoadProgress(int val) { _loadProgress = val; }
+      bool loadWasCanceled()        { return _loadWasCanceled; }
+      void setLoadWasCanceled(bool status)     { _loadWasCanceled = status; }
 
       virtual void setMasterTuning(double val) { _masterTuning = val;  }
       virtual double masterTuning() const      { return _masterTuning; }

--- a/zerberus/zerberusgui.cpp
+++ b/zerberus/zerberusgui.cpp
@@ -96,9 +96,9 @@ ZerberusGui::ZerberusGui(Ms::Synthesizer* s)
       connect(add, SIGNAL(clicked()), SLOT(addClicked()));
       connect(remove, SIGNAL(clicked()), SLOT(removeClicked()));
       connect(&_futureWatcher, SIGNAL(finished()), this, SLOT(onSoundFontLoaded()));
-      _progressDialog = new QProgressDialog(tr("Loading..."), "", 0, 100, 0, Qt::FramelessWindowHint);
+      _progressDialog = new QProgressDialog(tr("Loading..."), tr("Cancel"), 0, 100, 0, Qt::FramelessWindowHint);
       _progressDialog->reset(); // required for Qt 5.5, see QTBUG-47042
-      _progressDialog->setCancelButton(0);
+      connect(_progressDialog, SIGNAL(canceled()), this, SLOT(cancelLoadClicked()));
       _progressTimer = new QTimer(this);
       connect(_progressTimer, SIGNAL(timeout()), this, SLOT(updateProgress()));
       connect(files, SIGNAL(itemSelectionChanged()), this, SLOT(updateButtons()));
@@ -152,6 +152,8 @@ QFileInfoList Zerberus::sfzFiles()
 
 void ZerberusGui::addClicked()
       {
+      zerberus()->setLoadWasCanceled(false);
+
       QFileInfoList l = Zerberus::sfzFiles();
 
       SfzListDialog ld(this);
@@ -185,6 +187,15 @@ void ZerberusGui::addClicked()
       }
 
 //---------------------------------------------------------
+//   cancelLoad
+//---------------------------------------------------------
+
+void ZerberusGui::cancelLoadClicked()
+      {
+      zerberus()->setLoadWasCanceled(true);
+      }
+
+//---------------------------------------------------------
 //   updateProgress
 //---------------------------------------------------------
 
@@ -210,21 +221,22 @@ void ZerberusGui::updateButtons()
 void ZerberusGui::onSoundFontLoaded()
       {
       bool loaded = _futureWatcher.result();
+      bool wasNotCanceled = !_progressDialog->wasCanceled();
       _progressTimer->stop();
       _progressDialog->reset();
-      if (!loaded) {
-            QMessageBox::warning(this,
-            tr("MuseScore"),
-            tr("Cannot load SoundFont %1").arg(_loadedSfPath));
-            }
-      else {
+      if (loaded) {
             QListWidgetItem* item = new QListWidgetItem;
             item->setText(_loadedSfName);
             item->setData(Qt::UserRole, _loadedSfPath);
             files->insertItem(0, item);
+            emit valueChanged();
+            emit sfChanged();
             }
-      emit valueChanged();
-      emit sfChanged();
+      else if (wasNotCanceled) {
+            QMessageBox::warning(this,
+            tr("MuseScore"),
+            tr("Cannot load SoundFont %1").arg(_loadedSfPath));
+            }
       }
 
 //---------------------------------------------------------

--- a/zerberus/zerberusgui.h
+++ b/zerberus/zerberusgui.h
@@ -53,6 +53,7 @@ class ZerberusGui : public Ms::SynthesizerGui, Ui::ZerberusGui {
 
    private slots:
       void addClicked();
+      void cancelLoadClicked();
       void removeClicked();
       void onSoundFontLoaded();
       void updateProgress();


### PR DESCRIPTION
User can now cancel sfz loading.  This is useful to prevent a full system crash in case user's computer is low on memory, since loading the sfz might cause thrashing.