### PR TITLE
windows makefile set default number of jobs to %NUMBER_OF_PROCESSORS%

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -22,7 +22,7 @@
 REVISION  = $(shell type mscore\revision.h)
 VERSION   = 2.1b-${REVISION}
 #VERSION = 2.1.0
-CPUS = 1
+CPUS = %NUMBER_OF_PROCESSORS%
 
 release:
 	if not exist build.release\nul mkdir build.release


### PR DESCRIPTION
%NUMBER_OF_PROCESSORS% is a standard windows environment variable which is set according to number of CPUs installed and their Hyper-Threading setting.  It should be used by default.