### PR TITLE
fix #72491: text properties in lines added by double click

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -290,6 +290,37 @@ void Score::cmdAddSpanner(Spanner* spanner, int staffIdx, Segment* startSegment,
       else
             tick2 = endSegment->tick();
       spanner->setTick2(tick2);
+      if (spanner->type() == Element::Type::TEXTLINE
+          || spanner->type() == Element::Type::NOTELINE
+          || spanner->type() == Element::Type::OTTAVA
+          || spanner->type() == Element::Type::PEDAL
+          || spanner->type() == Element::Type::VOLTA) {
+            // rebase text elements to score style
+            TextLine* tl = static_cast<TextLine*>(spanner);
+            TextStyleType st;
+            Text* t;
+            // begin
+            t = tl->beginTextElement();
+            if (t) {
+                  st = t->textStyleType();
+                  if (st >= TextStyleType::DEFAULT)
+                        t->textStyle().restyle(MScore::baseStyle()->textStyle(st), textStyle(st));
+                  }
+            // continue
+            t = tl->continueTextElement();
+            if (t) {
+                  st = t->textStyleType();
+                  if (st >= TextStyleType::DEFAULT)
+                        t->textStyle().restyle(MScore::baseStyle()->textStyle(st), textStyle(st));
+                  }
+            // end
+            t = tl->endTextElement();
+            if (t) {
+                  st = t->textStyleType();
+                  if (st >= TextStyleType::DEFAULT)
+                        t->textStyle().restyle(MScore::baseStyle()->textStyle(st), textStyle(st));
+                  }
+            }
       undoAddElement(spanner);
       }
 

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -446,6 +446,21 @@ TextLine::~TextLine()
       }
 
 //---------------------------------------------------------
+//   setScore
+//---------------------------------------------------------
+
+void TextLine::setScore(Score* s)
+      {
+      Spanner::setScore(s);
+      if (_beginText)
+            _beginText->setScore(s);
+      if (_continueText)
+            _continueText->setScore(s);
+      if (_endText)
+            _endText->setScore(s);
+      }
+
+//---------------------------------------------------------
 //   createBeginTextElement
 //---------------------------------------------------------
 

--- a/libmscore/textline.h
+++ b/libmscore/textline.h
@@ -84,6 +84,7 @@ class TextLine : public SLine {
 
       virtual TextLine* clone() const override            { return new TextLine(*this); }
       virtual Element::Type type() const override         { return Element::Type::TEXTLINE; }
+      virtual void setScore(Score* s) override;
       virtual LineSegment* createLineSegment() override;
 
       virtual void write(Xml& xml) const override;


### PR DESCRIPTION
Two separate issues:

1) Cloning a textline from the palette copies the text properties as is, rather than applying the score text style.  Thus the initial style when applying a textline by double click was not honoring the score style.  Fixed by rebasing the style in the same manner that is done when adding text elements (staff text, etc) directly.

2) setScore() on a textline was not setting the score for the text elements, so the text elements within the textline have their _score still set to gscore, which is why reset to style was not working either.  Fixed by defining TextLine::setScore() override.
