### PR TITLE
fix #73051: editing spanner length with multiple voices and/or tuplets

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3584,36 +3584,39 @@ ChordRest* Score::findCR(int tick, int track) const
 
 //---------------------------------------------------------
 //   findCRinStaff
-//    find chord/rest <= tick in staff
-//    prefer shortest duration (so it does not overlap next chordrest segment)
+//    find last chord/rest on staff that ends before tick
 //---------------------------------------------------------
 
-ChordRest* Score::findCRinStaff(int tick, int track) const
+ChordRest* Score::findCRinStaff(int tick, int staffIdx) const
       {
-      Measure* m = tick2measureMM(tick);
+      int ptick = tick - 1;
+      Measure* m = tick2measureMM(ptick);
       if (!m) {
-            qDebug("findCRinStaff: no measure for tick %d", tick);
+            qDebug("findCRinStaff: no measure for tick %d", ptick);
             return nullptr;
             }
       // attach to first rest all spanner when mmRest
       if (m->isMMRest())
-            tick = m->tick();
+            ptick = m->tick();
       Segment* s = m->first(Segment::Type::ChordRest);
-      int strack = (track / VOICES) * VOICES;
+      int strack = staffIdx * VOICES;
       int etrack = strack + VOICES;
       int actualTrack = strack;
 
+      int lastTick = -1;
       for (Segment* ns = s; ; ns = ns->next(Segment::Type::ChordRest)) {
-            if (ns == 0 || ns->tick() > tick)
+            if (ns == 0 || ns->tick() > ptick)
                   break;
-            // found a segment; now find shortest chordrest on this staff (if any)
-            ChordRest* shortestCR = 0;
+            // found a segment; now find longest cr on this staff that does not overlap tick
             for (int t = strack; t < etrack; ++t) {
                   ChordRest* cr = static_cast<ChordRest*>(ns->element(t));
-                  if (cr && (!shortestCR || cr->actualTicks() < shortestCR->actualTicks())) {
-                        shortestCR = cr;
-                        s = ns;
-                        actualTrack = t;
+                  if (cr) {
+                        int endTick = cr->tick() + cr->actualTicks();
+                        if (endTick >= lastTick && endTick <= tick) {
+                              s = ns;
+                              actualTrack = t;
+                              lastTick = endTick;
+                              }
                         }
                   }
             }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3612,7 +3612,10 @@ ChordRest* Score::findCRinStaff(int tick, int staffIdx) const
                   ChordRest* cr = static_cast<ChordRest*>(ns->element(t));
                   if (cr) {
                         int endTick = cr->tick() + cr->actualTicks();
-                        if (endTick >= lastTick && endTick <= tick) {
+                        // allow fudge factor for tuplets
+                        // TODO: replace with fraction-based calculation
+                        int fudge = cr->tuplet() ? 5 : 0;
+                        if (endTick + fudge >= lastTick && endTick - fudge <= tick) {
                               s = ns;
                               actualTrack = t;
                               lastTick = endTick;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1039,7 +1039,7 @@ class Score : public QObject {
       Hairpin* addHairpin(bool crescendo, int tickStart, int tickEnd, int track);
 
       ChordRest* findCR(int tick, int track) const;
-      ChordRest* findCRinStaff(int tick, int track) const;
+      ChordRest* findCRinStaff(int tick, int staffIdx) const;
       void layoutSpanner();
       void insertTime(int tickPos, int tickLen);
 

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -534,13 +534,15 @@ void Spanner::computeEndElement()
       {
       switch (_anchor) {
             case Anchor::SEGMENT: {
-                  _endElement = score()->findCRinStaff(tick2() - 1, track2());
+                  // find last cr on this staff that ends before tick2
+                  _endElement = score()->findCRinStaff(tick2(), track2() / VOICES);
                   if (!_endElement) {
                         qDebug("%s no end element for tick %d", name(), tick2());
                         return;
                         }
                   if (!endCR()->measure()->isMMRest()) {
-                        int nticks = endCR()->tick() + endCR()->actualTicks() - _tick;
+                        ChordRest* cr = endCR();
+                        int nticks = cr->tick() + cr->actualTicks() - _tick;
                         if (_ticks != nticks) {
                               qDebug("%s ticks changed, %d -> %d", name(), _ticks, nticks);
                               setTicks(nticks);

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -543,7 +543,10 @@ void Spanner::computeEndElement()
                   if (!endCR()->measure()->isMMRest()) {
                         ChordRest* cr = endCR();
                         int nticks = cr->tick() + cr->actualTicks() - _tick;
-                        if (_ticks != nticks) {
+                        // allow fudge factor for tuplets
+                        // TODO: replace with fraction-based calculation
+                        int fudge = cr->tuplet() ? 5 : 0;
+                        if (qAbs(_ticks - nticks) > fudge) {
                               qDebug("%s ticks changed, %d -> %d", name(), _ticks, nticks);
                               setTicks(nticks);
                               if (type() == Element::Type::OTTAVA)


### PR DESCRIPTION
When computeEndElement() tries to find the CR to use, it calls findCRinStaff() to find the last CR before the end tick.  findCRinStaff() assumes the CR to use will be found in the last segment before the specified end tick (the last segment that contains notes for this staff, anyhow).  But this isn't necessarily true in the presence of multiple voices.  We don't just want a CR that *starts* before the specified end tick; we want one that *ends* before the end tick.  This might be earlier in the measure.

I had improved the logic somewhat with #1753, so at least in the cases where we found the right segment, we would pick an appropriate note.  But this still didn't consider the possibility that the we might need a note that started earlier in the measure.

This PR here fixes the loigic of findCRinStaff() to be clear that it is trying to find the last CR that *ends* before the specified tick.  As part of this logic, I also included a fudge factor for tuplets, which fixes https://musescore.org/en/node/63041 and partially addresses https://musescore.org/en/node/69646 (the initial span of lines is still set badly in some cases when applying to a tuplet, but at least it is easily corrected now).

I have tested the fix against the scores/steps that originally reproduced all of the issue that were connected to this, including https://musescore.org/en/node/28446, and all cases work as expected.