### PR TITLE
fix #73531 final measure has both repeat and DS/DC

### DIFF
--- a/libmscore/repeatlist.cpp
+++ b/libmscore/repeatlist.cpp
@@ -277,8 +277,13 @@ void RepeatList::unwind()
             Repeat flags = m->repeatFlags();
             bool doJump = false; // process jump after endrepeat
 
-// qDebug("repeat m%d(%d) lc%d loop %d repeatCount %d isGoto %d endRepeat %p flags 0x%x",
-//               m->no(), m->tick(), m->playbackCount(), loop, repeatCount, isGoto, endRepeat, int(flags));
+            // during any DC or DS, will take last time through repeat
+            if (isGoto && (flags & Repeat::END))
+                  loop = m->repeatCount() - 1;
+
+//            qDebug("m%d(tick %7d) %p: playbackCount %d loop %d repeatCount %d isGoto %d endRepeat %p continueAt %p flags 0x%x",
+//                   m->no()+1, m->tick(), m, m->playbackCount(), loop, repeatCount, isGoto, endRepeat, continueAt, int(flags));
+
 
             if (endRepeat) {
                   Volta* volta = _score->searchVolta(m->tick());

--- a/mtest/libmscore/repeat/repeat28.mscx
+++ b/mtest/libmscore/repeat/repeat28.mscx
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="2.06">
-  <programVersion>2.0.2</programVersion>
-  <programRevision>3543170</programRevision>
+<museScore version="2.00">
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
-    <Synthesizer>
-      </Synthesizer>
     <Division>480</Division>
     <Style>
       <lastSystemFillLimit>0</lastSystemFillLimit>
@@ -35,11 +31,9 @@
     <metaTag name="arranger"></metaTag>
     <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
-    <metaTag name="creationDate">2015-08-15</metaTag>
     <metaTag name="lyricist"></metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
-    <metaTag name="platform">Linux</metaTag>
     <metaTag name="poet"></metaTag>
     <metaTag name="source"></metaTag>
     <metaTag name="translator"></metaTag>
@@ -102,7 +96,6 @@
           </Articulation>
         <Channel>
           <program value="0"/>
-          <synti>Fluid</synti>
           </Channel>
         </Instrument>
       </Part>
@@ -120,6 +113,9 @@
           <sigD>4</sigD>
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
+        <StaffText>
+          <text>1,2,2,1,2, then new section 1</text>
+          </StaffText>
         <Rest>
           <durationType>measure</durationType>
           <duration z="4" n="4"/>

--- a/mtest/libmscore/repeat/repeat29.mscx
+++ b/mtest/libmscore/repeat/repeat29.mscx
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="2.06">
-  <programVersion>2.0.2</programVersion>
-  <programRevision>3543170</programRevision>
+<museScore version="2.00">
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
-    <Synthesizer>
-      </Synthesizer>
     <Division>480</Division>
     <Style>
       <lastSystemFillLimit>0</lastSystemFillLimit>
@@ -35,11 +31,9 @@
     <metaTag name="arranger"></metaTag>
     <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
-    <metaTag name="creationDate">2015-08-15</metaTag>
     <metaTag name="lyricist"></metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
-    <metaTag name="platform">Linux</metaTag>
     <metaTag name="poet"></metaTag>
     <metaTag name="source"></metaTag>
     <metaTag name="translator"></metaTag>
@@ -102,7 +96,6 @@
           </Articulation>
         <Channel>
           <program value="0"/>
-          <synti>Fluid</synti>
           </Channel>
         </Instrument>
       </Part>
@@ -120,6 +113,9 @@
           <sigD>4</sigD>
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
+        <StaffText>
+          <text>1,2,3,3,2,3, then new section 1</text>
+          </StaffText>
         <Rest>
           <durationType>measure</durationType>
           <duration z="4" n="4"/>

--- a/mtest/libmscore/repeat/repeat30.mscx
+++ b/mtest/libmscore/repeat/repeat30.mscx
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="2.06">
-  <programVersion>2.0.2</programVersion>
-  <programRevision>3543170</programRevision>
+<museScore version="2.00">
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
-    <Synthesizer>
-      </Synthesizer>
     <Division>480</Division>
     <Style>
       <lastSystemFillLimit>0</lastSystemFillLimit>
+      <measureNumberInterval>1</measureNumberInterval>
+      <measureNumberSystem>0</measureNumberSystem>
       <page-layout>
         <page-height>1683.36</page-height>
         <page-width>1190.88</page-width>
@@ -35,11 +33,9 @@
     <metaTag name="arranger"></metaTag>
     <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
-    <metaTag name="creationDate">2015-08-15</metaTag>
     <metaTag name="lyricist"></metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
-    <metaTag name="platform">Linux</metaTag>
     <metaTag name="poet"></metaTag>
     <metaTag name="source"></metaTag>
     <metaTag name="translator"></metaTag>
@@ -102,7 +98,6 @@
           </Articulation>
         <Channel>
           <program value="0"/>
-          <synti>Fluid</synti>
           </Channel>
         </Instrument>
       </Part>
@@ -124,23 +119,35 @@ then section with end repeat</text>
           <sigD>4</sigD>
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <StaffText>
+          <text>1, then new section 1,2,1,2</text>
+          </StaffText>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="1">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="2">
         <endRepeat>2</endRepeat>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>74</pitch>
+            <tpc>16</tpc>
+            </Note>
+          </Chord>
         </Measure>
       </Staff>
     </Score>

--- a/mtest/libmscore/repeat/repeat31.mscx
+++ b/mtest/libmscore/repeat/repeat31.mscx
@@ -7,8 +7,8 @@
     <Style>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <page-layout>
-        <page-height>1683.36</page-height>
-        <page-width>1190.88</page-width>
+        <page-height>1584</page-height>
+        <page-width>1224</page-width>
         <page-margins type="even">
           <left-margin>56.6929</left-margin>
           <right-margin>56.6929</right-margin>
@@ -38,11 +38,9 @@
     <metaTag name="source"></metaTag>
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
-    <metaTag name="workTitle">repeat28 single-measure repeat at end of section</metaTag>
+    <metaTag name="workTitle">repeat test score ends on :| and Jump</metaTag>
     <PageList>
       <Page>
-        <System>
-          </System>
         <System>
           </System>
         <System>
@@ -104,7 +102,7 @@
         <height>10</height>
         <Text>
           <style>Title</style>
-          <text>repeat27 single-measure repeat at end of section</text>
+          <text>m1 |: m2 D.C. :|</text>
           </Text>
         </VBox>
       <Measure number="1">
@@ -114,31 +112,35 @@
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <StaffText>
-          <text>1,2,2, then new section 1</text>
+          <text>1,2,2,1,2</text>
           </StaffText>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="2">
         <startRepeat/>
         <endRepeat>2</endRepeat>
-        <LayoutBreak>
-          <subtype>section</subtype>
-          </LayoutBreak>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
-        </Measure>
-      <Measure number="1">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Jump>
+          <style>Repeat Text Right</style>
+          <text>D.C.</text>
+          <jumpTo>start</jumpTo>
+          <playUntil>end</playUntil>
+          <continueAt></continueAt>
+          </Jump>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>74</pitch>
+            <tpc>16</tpc>
+            </Note>
+          </Chord>
         <BarLine>
-          <subtype>end</subtype>
+          <subtype>end-repeat</subtype>
           <span>1</span>
           </BarLine>
         </Measure>

--- a/mtest/libmscore/repeat/repeat32.mscx
+++ b/mtest/libmscore/repeat/repeat32.mscx
@@ -7,8 +7,8 @@
     <Style>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <page-layout>
-        <page-height>1683.36</page-height>
-        <page-width>1190.88</page-width>
+        <page-height>1584</page-height>
+        <page-width>1224</page-width>
         <page-margins type="even">
           <left-margin>56.6929</left-margin>
           <right-margin>56.6929</right-margin>
@@ -38,11 +38,9 @@
     <metaTag name="source"></metaTag>
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
-    <metaTag name="workTitle">repeat28 single-measure repeat at end of section</metaTag>
+    <metaTag name="workTitle">repeat test score ends on :| and Jump</metaTag>
     <PageList>
       <Page>
-        <System>
-          </System>
         <System>
           </System>
         <System>
@@ -104,7 +102,7 @@
         <height>10</height>
         <Text>
           <style>Title</style>
-          <text>repeat27 single-measure repeat at end of section</text>
+          <text>m1 S m2 |: m3 DS :|</text>
           </Text>
         </VBox>
       <Measure number="1">
@@ -114,31 +112,52 @@
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <StaffText>
-          <text>1,2,2, then new section 1</text>
+          <text>1,2,3,3,2,3</text>
           </StaffText>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="2">
+        <Marker>
+          <style>Repeat Text Left</style>
+          <text><sym>segno</sym></text>
+          <label>segno</label>
+          </Marker>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
+            <pitch>73</pitch>
+            <tpc>21</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="3">
         <startRepeat/>
         <endRepeat>2</endRepeat>
-        <LayoutBreak>
-          <subtype>section</subtype>
-          </LayoutBreak>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
-        </Measure>
-      <Measure number="1">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Jump>
+          <style>Repeat Text Right</style>
+          <text>D.S.</text>
+          <jumpTo>segno</jumpTo>
+          <playUntil>end</playUntil>
+          <continueAt></continueAt>
+          </Jump>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>74</pitch>
+            <tpc>16</tpc>
+            </Note>
+          </Chord>
         <BarLine>
-          <subtype>end</subtype>
+          <subtype>end-repeat</subtype>
           <span>1</span>
           </BarLine>
         </Measure>

--- a/mtest/libmscore/repeat/repeat33.mscx
+++ b/mtest/libmscore/repeat/repeat33.mscx
@@ -7,8 +7,8 @@
     <Style>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <page-layout>
-        <page-height>1683.36</page-height>
-        <page-width>1190.88</page-width>
+        <page-height>1584</page-height>
+        <page-width>1224</page-width>
         <page-margins type="even">
           <left-margin>56.6929</left-margin>
           <right-margin>56.6929</right-margin>
@@ -38,11 +38,9 @@
     <metaTag name="source"></metaTag>
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
-    <metaTag name="workTitle">repeat28 single-measure repeat at end of section</metaTag>
+    <metaTag name="workTitle">repeat test score ends on :| and Jump</metaTag>
     <PageList>
       <Page>
-        <System>
-          </System>
         <System>
           </System>
         <System>
@@ -104,7 +102,7 @@
         <height>10</height>
         <Text>
           <style>Title</style>
-          <text>repeat27 single-measure repeat at end of section</text>
+          <text>m1 |: m2 m3 DC :|</text>
           </Text>
         </VBox>
       <Measure number="1">
@@ -114,31 +112,47 @@
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <StaffText>
-          <text>1,2,2, then new section 1</text>
+          <text>1,2,3,2,3,1,2,3</text>
           </StaffText>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="2">
         <startRepeat/>
-        <endRepeat>2</endRepeat>
-        <LayoutBreak>
-          <subtype>section</subtype>
-          </LayoutBreak>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
+            <pitch>73</pitch>
+            <tpc>21</tpc>
+            </Note>
+          </Chord>
         </Measure>
-      <Measure number="1">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+      <Measure number="3">
+        <endRepeat>2</endRepeat>
+        <Jump>
+          <style>Repeat Text Right</style>
+          <text>D.C.</text>
+          <jumpTo>start</jumpTo>
+          <playUntil>end</playUntil>
+          <continueAt></continueAt>
+          </Jump>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>74</pitch>
+            <tpc>16</tpc>
+            </Note>
+          </Chord>
         <BarLine>
-          <subtype>end</subtype>
+          <subtype>end-repeat</subtype>
           <span>1</span>
           </BarLine>
         </Measure>

--- a/mtest/libmscore/repeat/repeat34.mscx
+++ b/mtest/libmscore/repeat/repeat34.mscx
@@ -7,8 +7,8 @@
     <Style>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <page-layout>
-        <page-height>1683.36</page-height>
-        <page-width>1190.88</page-width>
+        <page-height>1584</page-height>
+        <page-width>1224</page-width>
         <page-margins type="even">
           <left-margin>56.6929</left-margin>
           <right-margin>56.6929</right-margin>
@@ -38,11 +38,9 @@
     <metaTag name="source"></metaTag>
     <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
-    <metaTag name="workTitle">repeat28 single-measure repeat at end of section</metaTag>
+    <metaTag name="workTitle">repeat test score ends on :| and Jump</metaTag>
     <PageList>
       <Page>
-        <System>
-          </System>
         <System>
           </System>
         <System>
@@ -104,7 +102,7 @@
         <height>10</height>
         <Text>
           <style>Title</style>
-          <text>repeat27 single-measure repeat at end of section</text>
+          <text>m1 |: m2 1e m3 :| 2e m4 |: m5 DC :|</text>
           </Text>
         </VBox>
       <Measure number="1">
@@ -114,31 +112,80 @@
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <StaffText>
-          <text>1,2,2, then new section 1</text>
+          <text>1,2,3,2,4,5,5,1,2,4,5</text>
           </StaffText>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
         </Measure>
       <Measure number="2">
         <startRepeat/>
-        <endRepeat>2</endRepeat>
-        <LayoutBreak>
-          <subtype>section</subtype>
-          </LayoutBreak>
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>74</pitch>
+            <tpc>16</tpc>
+            </Note>
+          </Chord>
         </Measure>
-      <Measure number="1">
-        <Rest>
-          <durationType>measure</durationType>
-          <duration z="4" n="4"/>
-          </Rest>
+      <Measure number="3">
+        <endRepeat>2</endRepeat>
+        <Volta id="2">
+          <endHook>1</endHook>
+          <beginText>
+            <text>1.</text>
+            </beginText>
+          <endings>1</endings>
+          </Volta>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>76</pitch>
+            <tpc>18</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="4">
+        <endSpanner id="2"/>
+        <Volta id="3">
+          <endHook>1</endHook>
+          <beginText>
+            <text>2.</text>
+            </beginText>
+          <endings>2</endings>
+          </Volta>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>77</pitch>
+            <tpc>13</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="5">
+        <startRepeat/>
+        <endRepeat>2</endRepeat>
+        <Jump>
+          <style>Repeat Text Right</style>
+          <text>D.C.</text>
+          <jumpTo>start</jumpTo>
+          <playUntil>end</playUntil>
+          <continueAt></continueAt>
+          </Jump>
+        <endSpanner id="3"/>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>79</pitch>
+            <tpc>15</tpc>
+            </Note>
+          </Chord>
         <BarLine>
-          <subtype>end</subtype>
+          <subtype>end-repeat</subtype>
           <span>1</span>
           </BarLine>
         </Measure>

--- a/mtest/libmscore/repeat/tst_repeat.cpp
+++ b/mtest/libmscore/repeat/tst_repeat.cpp
@@ -73,6 +73,11 @@ class TestRepeat : public QObject, public MTest
 
       void repeat30() { repeat("repeat30.mscx", "1;1;2;1;2"); }     // #73496 single measure section at beginning of score followed by a section with end repeat (without beginning repeat)
 
+      void repeat31() { repeat("repeat31.mscx", "1;2;2;1;2"); }               // #73531 ending measure has jump and repeat m1 |: m2 DC :|
+      void repeat32() { repeat("repeat32.mscx", "1;2;3;3;2;3"); }             // #73531 ending measure has jump and repeat m1 |S m2 |: m3 DS :|
+      void repeat33() { repeat("repeat33.mscx", "1;2;3;2;3;1;2;3"); }         // #73531 ending measure has jump and repeat m1 |: m2 | m3 DC :|
+      void repeat34() { repeat("repeat34.mscx", "1;2;3;2;4;5;5;1;2;4;5"); }   // #73531 ending measure has jump and repeat m1 |: m2 |1e m3 :| 2e m4 |: m5 | DC :|
+
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
This fixes bug where if final measure has both a repeat and a DS/DC, then during the DC that final measure is taken but shouldn't (since repeats take last time during DC/DS). I fixed by setting the loop count variable to the repeat count of the measure if on a DC/DS.  Note, I'm submitting this fix because it is the minimal amount of change to RepeatList::unwind(), and since I need this fix in the code before I can fix #65161 "repeatlist unwind section by section".  (What I would like to do later, is maybe rewrite some of the unwind, so it is a little cleaner)