### PR TITLE
Fix #71076 - TABs: Make flag symbols unselectable

### DIFF
--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -821,7 +821,7 @@ qreal StaffType::physStringToYOffset(int strg) const
 TabDurationSymbol::TabDurationSymbol(Score* s)
    : Element(s)
       {
-      setFlags(ElementFlag::MOVABLE | ElementFlag::SELECTABLE);
+      setFlags(flags() & ~(ElementFlag::MOVABLE | ElementFlag::SELECTABLE) );
       setGenerated(true);
       _tab  = 0;
       _text = QString();
@@ -830,7 +830,7 @@ TabDurationSymbol::TabDurationSymbol(Score* s)
 TabDurationSymbol::TabDurationSymbol(Score* s, StaffType* tab, TDuration::DurationType type, int dots)
    : Element(s)
       {
-      setFlags(ElementFlag::MOVABLE | ElementFlag::SELECTABLE);
+      setFlags(flags() & ~(ElementFlag::MOVABLE | ElementFlag::SELECTABLE) );
       setGenerated(true);
       setDuration(type, dots, tab);
       }


### PR DESCRIPTION
Fix #71076 - TABs: Make flag symbols unselectable

The flag symbols used in historic tabs are not supposed to be selectable, but on some occasions, they happen to be, which causes a crash.

Issue report at: https://musescore.org/en/node/71076