### PR TITLE
Note input nagivation in gaps

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1939,10 +1939,19 @@ Element* Score::move(const QString& cmd)
             if (el->type() == Element::Type::CHORD)
                   el = static_cast<Chord*>(el)->upNote();       // originally downNote
             _playNote = true;
-            select(el, SelectType::SINGLE, 0);
             if (noteEntryMode()) {
+                  // if cursor moved into a gap, selection cannot follow
+                  // only select & play el if it was not already selected (does not normally happen)
+                  ChordRest* cr = _is.cr();
+                  if (cr || !el->selected())
+                        select(el, SelectType::SINGLE, 0);
+                  else
+                        _playNote = false;
                   foreach (MuseScoreView* view ,viewer)
                         view->moveCursor();
+                  }
+            else {
+                  select(el, SelectType::SINGLE, 0);
                   }
             }
       return el;

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2238,6 +2238,15 @@ void Score::cmdDeleteSelection()
 
             }
       deselectAll();
+      if (_is.noteEntryMode()) {
+            ChordRest* cr = _is.cr();
+            if (cr) {
+                  if (cr->type() == Element::Type::CHORD)
+                        select(static_cast<Chord*>(cr)->upNote(), SelectType::SINGLE);
+                  else
+                        select(cr, SelectType::SINGLE);
+                  }
+            }
       _layoutAll = true;
       }
 


### PR DESCRIPTION
This primarily fixes https://musescore.org/en/node/69866, which was introduced with an earlier fix for https://musescore.org/en/node/63176.  The behavior introduced with that fix is logical and works well enough, but one aspect of it is seen as a regression: it is currently impossible to navigate into a gap at all.  Previously, one could at least navigate into a measure that contained no notes for a given voice, if one pressed the cursor right key while on the last note of the previous measure.

The original fix made sure a valid element was selected if you tried to navigate into a gap, but by then explicitly selecting that element even though it was already selected, this broke the navigation into the gap.  The input cursor follows the selection, so the cursor never actually enters the gap.

My fix here simply disables the re-selecting of the already-selected element in cases where you have navigated itno a gap.  So the original bug is still fixed (we keep the current selection even though there is no chordrest at the input cursor position), but it is now possible to navigate into a gap if you start from a valid selection.

There was discussion in the threads for the original bug & my proposed PR that we should select the rest that remains behind after deleting a note.  That was part of the original bug report.  My second commit here goes ahead and explicitly selects the rest (or top note of chord if there are still notes left) after deleting a note, thus completing the fix for the original bug.