### PR TITLE
fix #73821: toggle rhythmic slash notation does not follow links

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2836,7 +2836,7 @@ void Score::cmdSlashFill()
                   s = setNoteRest(s, track + voice, nv, f);
                   Chord* c = static_cast<Chord*>(s->element(track + voice));
                   if (c->links()) {
-                        foreach (ScoreElement* e, *c->links()) {
+                        for (ScoreElement* e : *c->links()) {
                               Chord* lc = static_cast<Chord*>(e);
                               lc->setSlash(true, true);
                               }
@@ -2870,7 +2870,14 @@ void Score::cmdSlashRhythm()
       foreach (Element* e, selection().elements()) {
             if (e->voice() >= 2 && e->type() == Element::Type::REST) {
                   Rest* r = static_cast<Rest*>(e);
-                  r->setAccent(!r->accent());
+                  if (r->links()) {
+                        for (ScoreElement* e : *r->links()) {
+                              Rest* lr = static_cast<Rest*>(e);
+                              lr->setAccent(!lr->accent());
+                              }
+                        }
+                  else
+                        r->setAccent(!r->accent());
                   continue;
                   }
             else if (e->type() == Element::Type::NOTE) {
@@ -2883,7 +2890,14 @@ void Score::cmdSlashRhythm()
                         continue;
                   chords.append(c);
                   // toggle slash setting
-                  c->setSlash(!c->slash(), false);
+                  if (c->links()) {
+                        for (ScoreElement* e : *c->links()) {
+                              Chord* lc = static_cast<Chord*>(e);
+                              lc->setSlash(!lc->slash(), false);
+                              }
+                        }
+                  else
+                        c->setSlash(!c->slash(), false);
                   }
             }
       setLayoutAll(true);


### PR DESCRIPTION
For some reason, I had made the "fill with slashes" tool follow links, but not "toggle rhythmic slash notation".  This PR fixes that.

I was originally thinking I'd knock off a few more "changes to X are not linked between score and parts" issues while I was at it, but I've come to realize that most of them are wrapped up in a question of policy on what properties *should* be linked.  See https://musescore.org/en/node/73841.

But even though slash notation is in some sense just a collection of properties set together (fixed, line, head group, play, no_stem, small, and/or visible), it still seems a given to me that using Edit / Toggle Rhythmic Slash Notation should follow links, even if there is room for discussion regarding what happens when setting individual properties via Inspector.