### PR TITLE
more navigation fixes

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1990,7 +1990,7 @@ Element* Score::move(const QString& cmd)
                         select(el, SelectType::SINGLE, 0);
                   else
                         _playNote = false;
-                  foreach (MuseScoreView* view ,viewer)
+                  for (MuseScoreView* view : viewer)
                         view->moveCursor();
                   }
             else {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1461,10 +1461,19 @@ void ScoreView::moveCursor()
             Segment*    seg   = is.segment();
             int         minTrack = (is.track() / VOICES) * VOICES;
             int         maxTrack = minTrack + VOICES;
+            // get selected chordrest, if one exists and is in this segment
+            ChordRest* scr = _score->selection().cr();
+            if (scr && scr->segment() != seg)
+                  scr = nullptr;
             // get the physical string corresponding to current visual string
             for (int t = minTrack; t < maxTrack; t++) {
                   Element* e = seg->element(t);
-                  if (e != nullptr && e->type() == Element::Type::CHORD)
+                  if (e != nullptr && e->type() == Element::Type::CHORD) {
+                        // if there is a selected chordrest in this segment on this track but it is not e
+                        // then the selected chordrest must be a grace note chord, and we should use it
+                        if (scr && scr->track() == t && scr != e)
+                              e = scr;
+                        // search notes looking for one on current string
                         for (Note* n : static_cast<Chord*>(e)->notes())
                               // if note found on this string, make it current
                               if (n->string() == strg) {
@@ -1484,6 +1493,7 @@ void ScoreView::moveCursor()
                                     done = true;
                                     break;
                                     }
+                        }
                   if (done)
                         break;
                   }


### PR DESCRIPTION
Still finding a few glitches in navigation for voice > 1 in note input mode:

- cursor right into an empty measure is possible (good) unless there is a subsequent measure with notes in that voice (bad)

- same for cursor left, but here there is also a glitch where if there is no previous measure with notes in that voice, the first cursor left action would appear to not work

I tested this as well as I could think to.  I'm attaching the file I did most of my testing with to the issue report https://musescore.org/en/node/69866.  Try clicking a note in voice 2 then cursoring right to end of score, left to beginning, and back to starting place, to cover all the cases I am trying to be sure to handle.  They all work.  it is of course possible I am still missing something, but this much at least works smoothly.