### PR TITLE
increased min & max range for custom note tuning from +/-200.0 to +/-2000.0

### DIFF
--- a/mscore/inspector/inspector_note.ui
+++ b/mscore/inspector/inspector_note.ui
@@ -313,10 +313,10 @@
         <string>Tuning</string>
        </property>
        <property name="minimum">
-        <double>-200.000000000000000</double>
+        <double>-2000.000000000000000</double>
        </property>
        <property name="maximum">
-        <double>200.000000000000000</double>
+        <double>2000.000000000000000</double>
        </property>
        <property name="singleStep">
         <double>10.000000000000000</double>


### PR DESCRIPTION
I'm currently writing a plugin for MuseScore that allows to write tablature notes for the styrian harmonica, you can find the github page there ... https://github.com/stoneMcClane/MuseScore-Styrian-Harmonica-Plugin

The plugin is already working to a point where I can write pretty good tab-note sheets with it, but for the plugin to work with correct MIDI playback it needs to assign different tunings to the notes in MuseScore. The tuning for some notes needs to go below or above the currently implemented limit of [-200.0, +200.0] ... for the plugin development I forked the MuseScore repository and produced a dev-build where I increased the custom tuning range to [-2000.0, +2000.0] so that my plugin can set note tunings accordingly.

I hope this change can make it into the master repository, the change should not have any side effects from what I can tell.