### PR TITLE
fix #74171: cresc. and dim. lines

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -188,7 +188,6 @@ void HairpinSegment::draw(QPainter* painter) const
             QVector<qreal> pattern;
             pattern << 5.0 << 20.0;
             pen.setDashPattern(pattern);
-            pen.setDashOffset(15.0);
             }
 
       painter->setPen(pen);
@@ -208,6 +207,7 @@ void HairpinSegment::draw(QPainter* painter) const
 QVariant HairpinSegment::getProperty(P_ID id) const
       {
       switch (id) {
+            case P_ID::HAIRPIN_TEXTLINE:
             case P_ID::HAIRPIN_CIRCLEDTIP:
             case P_ID::HAIRPIN_TYPE:
             case P_ID::VELO_CHANGE:
@@ -217,7 +217,7 @@ QVariant HairpinSegment::getProperty(P_ID id) const
             case P_ID::HAIRPIN_CONT_HEIGHT:
                   return hairpin()->getProperty(id);
             default:
-                  return LineSegment::getProperty(id);
+                  return TextLineSegment::getProperty(id);
             }
       }
 
@@ -228,6 +228,7 @@ QVariant HairpinSegment::getProperty(P_ID id) const
 bool HairpinSegment::setProperty(P_ID id, const QVariant& v)
       {
       switch (id) {
+            case P_ID::HAIRPIN_TEXTLINE:
             case P_ID::HAIRPIN_CIRCLEDTIP:
             case P_ID::HAIRPIN_TYPE:
             case P_ID::VELO_CHANGE:
@@ -238,7 +239,7 @@ bool HairpinSegment::setProperty(P_ID id, const QVariant& v)
             case P_ID::HAIRPIN_CONT_HEIGHT:
                   return hairpin()->setProperty(id, v);
             default:
-                  return LineSegment::setProperty(id, v);
+                  return TextLineSegment::setProperty(id, v);
             }
       }
 
@@ -249,6 +250,8 @@ bool HairpinSegment::setProperty(P_ID id, const QVariant& v)
 QVariant HairpinSegment::propertyDefault(P_ID id) const
       {
       switch (id) {
+            case P_ID::HAIRPIN_TEXTLINE:
+            case P_ID::TEXT_STYLE_TYPE:
             case P_ID::HAIRPIN_CIRCLEDTIP:
             case P_ID::HAIRPIN_TYPE:
             case P_ID::VELO_CHANGE:
@@ -258,7 +261,7 @@ QVariant HairpinSegment::propertyDefault(P_ID id) const
             case P_ID::HAIRPIN_CONT_HEIGHT:
                   return hairpin()->propertyDefault(id);
             default:
-                  return LineSegment::propertyDefault(id);
+                  return TextLineSegment::propertyDefault(id);
             }
       }
 
@@ -275,7 +278,7 @@ PropertyStyle HairpinSegment::propertyStyle(P_ID id) const
                   return hairpin()->propertyStyle(id);
 
             default:
-                  return LineSegment::propertyStyle(id);
+                  return TextLineSegment::propertyStyle(id);
             }
       }
 
@@ -292,7 +295,7 @@ void HairpinSegment::resetProperty(P_ID id)
                   return hairpin()->resetProperty(id);
 
             default:
-                  return LineSegment::resetProperty(id);
+                  return TextLineSegment::resetProperty(id);
             }
       }
 
@@ -436,6 +439,8 @@ void Hairpin::undoSetDynRange(Dynamic::Range val)
 QVariant Hairpin::getProperty(P_ID id) const
       {
       switch (id) {
+            case P_ID::HAIRPIN_TEXTLINE:
+                return _useTextLine;
             case P_ID::HAIRPIN_CIRCLEDTIP:
                 return _hairpinCircledTip;
             case P_ID::HAIRPIN_TYPE:
@@ -460,6 +465,9 @@ QVariant Hairpin::getProperty(P_ID id) const
 bool Hairpin::setProperty(P_ID id, const QVariant& v)
       {
       switch (id) {
+            case P_ID::HAIRPIN_TEXTLINE:
+                _useTextLine = v.toBool();
+                break;
             case P_ID::HAIRPIN_CIRCLEDTIP:
                 _hairpinCircledTip = v.toBool();
                 break;
@@ -499,6 +507,8 @@ bool Hairpin::setProperty(P_ID id, const QVariant& v)
 QVariant Hairpin::propertyDefault(P_ID id) const
       {
       switch (id) {
+            case P_ID::HAIRPIN_TEXTLINE:    return _useTextLine;  // HACK: treat current setting as default
+            case P_ID::TEXT_STYLE_TYPE:     return int(TextStyleType::HAIRPIN);
             case P_ID::HAIRPIN_CIRCLEDTIP:  return false;
             case P_ID::HAIRPIN_TYPE:        return int(Type::CRESCENDO);
             case P_ID::VELO_CHANGE:         return 0;

--- a/libmscore/hairpin.h
+++ b/libmscore/hairpin.h
@@ -16,6 +16,7 @@
 #include "element.h"
 #include "dynamic.h"
 #include "line.h"
+#include "textline.h"
 #include "mscore.h"
 
 class QPainter;
@@ -29,7 +30,7 @@ class Hairpin;
 //   @@ HairpinSegment
 //---------------------------------------------------------
 
-class HairpinSegment : public LineSegment {
+class HairpinSegment : public TextLineSegment {
       Q_OBJECT
 
       QLineF l1, l2;
@@ -39,7 +40,7 @@ class HairpinSegment : public LineSegment {
 
    protected:
    public:
-      HairpinSegment(Score* s) : LineSegment(s) {}
+      HairpinSegment(Score* s) : TextLineSegment(s) {}
       Hairpin* hairpin() const                       { return (Hairpin*)spanner(); }
       virtual HairpinSegment* clone() const override { return new HairpinSegment(*this); }
       virtual Element::Type type() const override    { return Element::Type::HAIRPIN_SEGMENT; }
@@ -62,7 +63,7 @@ class HairpinSegment : public LineSegment {
 //   @P veloChange   int
 //---------------------------------------------------------
 
-class Hairpin : public SLine {
+class Hairpin : public TextLine {
       Q_OBJECT
       Q_ENUMS(Type)
       Q_ENUMS(Ms::Dynamic::Range)
@@ -75,6 +76,7 @@ class Hairpin : public SLine {
       Q_PROPERTY(Ms::Hairpin::Type  hairpinType READ  hairpinType WRITE undoSetHairpinType)
       Q_PROPERTY(int                veloChange  READ  veloChange  WRITE undoSetVeloChange)
 
+      bool _useTextLine;
       bool  _hairpinCircledTip;
       Type _hairpinType;
       int _veloChange;
@@ -103,8 +105,10 @@ class Hairpin : public SLine {
       virtual void layout() override;
       virtual LineSegment* createLineSegment() override;
 
+      bool useTextLine() const                 { return _useTextLine; }
+      void setUseTextLine(bool val)            { _useTextLine = val; }
       bool hairpinCircledTip() const           { return _hairpinCircledTip; }
-      void setHairpinCircledTip( bool val )    { _hairpinCircledTip = val; }
+      void setHairpinCircledTip(bool val)      { _hairpinCircledTip = val; }
 
       int veloChange() const           { return _veloChange; }
       void setVeloChange(int v)        { _veloChange = v;    }

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -308,6 +308,7 @@ enum class TextStyleType : char {
       GLISSANDO,
       OTTAVA,
       PEDAL,
+      HAIRPIN,
       BENCH,
       HEADER,
       FOOTER,

--- a/libmscore/ottava.cpp
+++ b/libmscore/ottava.cpp
@@ -111,6 +111,7 @@ QVariant OttavaSegment::propertyDefault(P_ID id) const
             case P_ID::OTTAVA_TYPE:
             case P_ID::PLACEMENT:
             case P_ID::NUMBERS_ONLY:
+            case P_ID::TEXT_STYLE_TYPE:
                   return ottava()->propertyDefault(id);
             default:
                   return TextLineSegment::propertyDefault(id);

--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -58,6 +58,7 @@ QVariant PedalSegment::propertyDefault(P_ID id) const
       switch (id) {
             case P_ID::LINE_WIDTH:
             case P_ID::LINE_STYLE:
+            case P_ID::TEXT_STYLE_TYPE:
                   return pedal()->propertyDefault(id);
             default:
                   return TextLineSegment::propertyDefault(id);

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -135,6 +135,7 @@ static const PropertyData propertyList[] = {
       { P_ID::NUMBERS_ONLY,        false, "numbersOnly",   P_TYPE::BOOL   },
       { P_ID::TRILL_TYPE,          false, "",              P_TYPE::INT    },
 
+      { P_ID::HAIRPIN_TEXTLINE,    false, "useTextLine",   P_TYPE::BOOL   },
       { P_ID::HAIRPIN_CIRCLEDTIP,  false, "hairpinCircledTip", P_TYPE::BOOL     },
       { P_ID::HAIRPIN_TYPE,        true,  "",              P_TYPE::INT     },
       { P_ID::HAIRPIN_HEIGHT,      false, "hairpinHeight",     P_TYPE::SPATIUM },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -130,6 +130,7 @@ enum class P_ID : unsigned char {
       NUMBERS_ONLY,
       TRILL_TYPE,
 
+      HAIRPIN_TEXTLINE,
       HAIRPIN_CIRCLEDTIP,
       HAIRPIN_TYPE,
       HAIRPIN_HEIGHT,

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -368,6 +368,8 @@ void initStyle(MStyle* s)
          AlignmentFlags::LEFT | AlignmentFlags::VCENTER, QPointF(), OffsetType::SPATIUM, true));
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Pedal"),             ff, 12, false, false, false,
          AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0.0, 0.15), OffsetType::SPATIUM, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Hairpin"),           ff, 12, false, true, false,
+         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(), OffsetType::SPATIUM, true));
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Bend"),              ff, 8, false, false, false,
          AlignmentFlags::CENTER | AlignmentFlags::BOTTOM, QPointF(), OffsetType::SPATIUM, true));
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Header"),            ff, 8, false, false, false,

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -115,10 +115,15 @@ void TextLineSegment::draw(QPainter* painter) const
             if (!tl->lineVisible())
                   pen.setColor(Qt::gray);
             if (tl->lineStyle() == Qt::CustomDashLine) {
+                  bool palette = !(parent() && parent()->parent());     // hack for palette
                   QVector<qreal> pattern;
-                  pattern << 5.0 << 20.0;
+                  if (palette)
+                        pattern << 5.0 << 5.0;
+                  else
+                        pattern << 5.0 << 20.0;
                   pen.setDashPattern(pattern);
-                  pen.setDashOffset(15.0);
+                  if (!palette)
+                        pen.setDashOffset(15.0);
                   }
             painter->setPen(pen);
 

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -114,6 +114,12 @@ void TextLineSegment::draw(QPainter* painter) const
             QPen pen(normalColor ? tl->lineColor() : color, textlineLineWidth, tl->lineStyle());
             if (!tl->lineVisible())
                   pen.setColor(Qt::gray);
+            if (tl->lineStyle() == Qt::CustomDashLine) {
+                  QVector<qreal> pattern;
+                  pattern << 5.0 << 20.0;
+                  pen.setDashPattern(pattern);
+                  pen.setDashOffset(15.0);
+                  }
             painter->setPen(pen);
 
             QPointF pp1(l, 0.0);
@@ -202,6 +208,7 @@ void TextLineSegment::layout1()
       TextLine* tl = textLine();
       if (parent() && tl && tl->type() != Element::Type::OTTAVA
                   && tl->type() != Element::Type::PEDAL
+                  && tl->type() != Element::Type::HAIRPIN
                   && tl->type() != Element::Type::VOLTA)
             rypos() += -5.0 * spatium();
 

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -482,6 +482,7 @@ void InspectorBase::setupLineStyle(QComboBox* cb)
       cb->setItemData(2, int(Qt::DotLine));
       cb->setItemData(3, int(Qt::DashDotLine));
       cb->setItemData(4, int(Qt::DashDotDotLine));
+      cb->setItemData(5, int(Qt::CustomDashLine));
       }
 }
 

--- a/mscore/inspector/inspectorHairpin.cpp
+++ b/mscore/inspector/inspectorHairpin.cpp
@@ -36,9 +36,11 @@ InspectorHairpin::InspectorHairpin(QWidget* parent)
             { P_ID::USER_OFF,            0, 0, e.offsetX,           e.resetX                 },
             { P_ID::USER_OFF,            1, 0, e.offsetY,           e.resetY                 },
             { P_ID::DIAGONAL,            0, 0, l.diagonal,          l.resetDiagonal          },
+            { P_ID::LINE_VISIBLE,        0, 0, l.lineVisible,       l.resetLineVisible       },
             { P_ID::LINE_COLOR,          0, 0, l.lineColor,         l.resetLineColor         },
             { P_ID::LINE_WIDTH,          0, 0, l.lineWidth,         l.resetLineWidth         },
             { P_ID::LINE_STYLE,          0, 0, l.lineStyle,         l.resetLineStyle         },
+            { P_ID::HAIRPIN_TEXTLINE,    0, 0, h.useTextLine,       h.resetUseTextLine       },
             { P_ID::HAIRPIN_CIRCLEDTIP,  0, 0, h.hairpinCircledTip, h.resetHairpinCircledTip },
             { P_ID::HAIRPIN_TYPE,        0, 0, h.hairpinType,       h.resetHairpinType       },
             { P_ID::DYNAMIC_RANGE,       0, 0, h.dynRange,          h.resetDynRange          },
@@ -48,5 +50,19 @@ InspectorHairpin::InspectorHairpin(QWidget* parent)
             };
       mapSignals();
       }
+
+//---------------------------------------------------------
+//   postInit
+//---------------------------------------------------------
+
+void InspectorHairpin::postInit()
+      {
+      bool useTextLine = h.useTextLine->isChecked();
+      l.lineVisible->setEnabled(useTextLine);
+      h.hairpinCircledTip->setDisabled(useTextLine);
+      h.hairpinHeight->setDisabled(useTextLine);
+      h.hairpinContHeight->setDisabled(useTextLine);
+      }
+
 }
 

--- a/mscore/inspector/inspectorHairpin.h
+++ b/mscore/inspector/inspectorHairpin.h
@@ -34,6 +34,7 @@ class InspectorHairpin : public InspectorBase {
 
    public:
       InspectorHairpin(QWidget* parent);
+      virtual void postInit() override;
       };
 
 

--- a/mscore/inspector/inspector_hairpin.ui
+++ b/mscore/inspector/inspector_hairpin.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>292</width>
-    <height>169</height>
+    <height>252</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -78,14 +78,20 @@
      <property name="verticalSpacing">
       <number>0</number>
      </property>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label">
+     <item row="2" column="2">
+      <widget class="QToolButton" name="resetHairpinType">
+       <property name="toolTip">
+        <string>Reset value</string>
+       </property>
+       <property name="accessibleName">
+        <string>Reset Type value</string>
+       </property>
        <property name="text">
-        <string>Height</string>
+        <string notr="true">...</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="QComboBox" name="hairpinType">
        <property name="accessibleName">
         <string>Type</string>
@@ -102,21 +108,58 @@
        </item>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Type</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Dynamic range</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="2">
+     <item row="5" column="2">
+      <widget class="QToolButton" name="resetHairpinHeight">
+       <property name="toolTip">
+        <string>Reset value</string>
+       </property>
+       <property name="accessibleName">
+        <string>Reset Height value</string>
+       </property>
+       <property name="text">
+        <string notr="true">...</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Continue height</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Velocity change</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QSpinBox" name="veloChange">
+       <property name="accessibleName">
+        <string>Velocity change</string>
+       </property>
+       <property name="maximum">
+        <number>127</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="useTextLine">
+       <property name="text">
+        <string>Text line</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
       <widget class="QToolButton" name="resetVeloChange">
        <property name="toolTip">
         <string>Reset value</string>
@@ -129,20 +172,99 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="QToolButton" name="resetHairpinType">
+     <item row="5" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Height</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QDoubleSpinBox" name="hairpinHeight">
+       <property name="accessibleName">
+        <string>Height</string>
+       </property>
+       <property name="suffix">
+        <string>sp</string>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="QToolButton" name="resetHairpinContHeight">
        <property name="toolTip">
         <string>Reset value</string>
        </property>
        <property name="accessibleName">
-        <string>Reset Type value</string>
+        <string>Reset Continue height value</string>
        </property>
        <property name="text">
         <string notr="true">...</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="2">
+      <widget class="QToolButton" name="resetDynRange">
+       <property name="toolTip">
+        <string>Reset value</string>
+       </property>
+       <property name="accessibleName">
+        <string>Reset Dynamic range value</string>
+       </property>
+       <property name="text">
+        <string notr="true">...</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="hairpinCircledTip">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+       <property name="accessibleName">
+        <string>Circled tip</string>
+       </property>
+       <property name="text">
+        <string>Circled tip</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Type</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QToolButton" name="resetHairpinCircledTip">
+       <property name="toolTip">
+        <string>Reset value</string>
+       </property>
+       <property name="accessibleName">
+        <string>Reset Circled tip value</string>
+       </property>
+       <property name="text">
+        <string notr="true">...</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QDoubleSpinBox" name="hairpinContHeight">
+       <property name="accessibleName">
+        <string>Continue height</string>
+       </property>
+       <property name="suffix">
+        <string>sp</string>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
       <widget class="QComboBox" name="dynRange">
        <property name="accessibleName">
         <string>Dynamic range</string>
@@ -164,118 +286,10 @@
        </item>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QSpinBox" name="veloChange">
-       <property name="accessibleName">
-        <string>Velocity change</string>
-       </property>
-       <property name="maximum">
-        <number>127</number>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Velocity change</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QToolButton" name="resetDynRange">
-       <property name="toolTip">
-        <string>Reset value</string>
-       </property>
-       <property name="accessibleName">
-        <string>Reset Dynamic range value</string>
-       </property>
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Continue height</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="QToolButton" name="resetHairpinHeight">
-       <property name="toolTip">
-        <string>Reset value</string>
-       </property>
-       <property name="accessibleName">
-        <string>Reset Height value</string>
-       </property>
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="2">
-      <widget class="QToolButton" name="resetHairpinContHeight">
-       <property name="toolTip">
-        <string>Reset value</string>
-       </property>
-       <property name="accessibleName">
-        <string>Reset Continue height value</string>
-       </property>
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QDoubleSpinBox" name="hairpinHeight">
-       <property name="accessibleName">
-        <string>Height</string>
-       </property>
-       <property name="suffix">
-        <string>sp</string>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QDoubleSpinBox" name="hairpinContHeight">
-       <property name="accessibleName">
-        <string>Continue height</string>
-       </property>
-       <property name="suffix">
-        <string>sp</string>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="hairpinCircledTip">
-       <property name="focusPolicy">
-        <enum>Qt::TabFocus</enum>
-       </property>
-       <property name="accessibleName">
-        <string>Circled tip</string>
-       </property>
-       <property name="text">
-        <string>Circled tip</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="2">
-      <widget class="QToolButton" name="resetHairpinCircledTip">
-       <property name="toolTip">
-        <string>Reset value</string>
-       </property>
-       <property name="accessibleName">
-        <string>Reset Circled tip value</string>
-       </property>
+      <widget class="QToolButton" name="resetUseTextLine">
        <property name="text">
-        <string notr="true">...</string>
+        <string>...</string>
        </property>
       </widget>
      </item>
@@ -284,6 +298,8 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>useTextLine</tabstop>
+  <tabstop>resetUseTextLine</tabstop>
   <tabstop>hairpinCircledTip</tabstop>
   <tabstop>resetHairpinCircledTip</tabstop>
   <tabstop>hairpinType</tabstop>

--- a/mscore/inspector/inspector_line.ui
+++ b/mscore/inspector/inspector_line.ui
@@ -187,6 +187,11 @@
          <string>Dash-dot-dotted</string>
         </property>
        </item>
+       <item>
+        <property name="text">
+         <string>Wide dashed</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item row="4" column="2">

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -786,12 +786,28 @@ Palette* MuseScore::newLinesPalette(bool basic)
       Hairpin* gabel0 = new Hairpin(gscore);
       gabel0->setHairpinType(Hairpin::Type::CRESCENDO);
       gabel0->setLen(w);
-      sp->append(gabel0, qApp->translate("lines", "Crescendo"));
+      sp->append(gabel0, qApp->translate("lines", "Crescendo hairpin"));
 
       Hairpin* gabel1 = new Hairpin(gscore);
       gabel1->setHairpinType(Hairpin::Type::DECRESCENDO);
       gabel1->setLen(w);
-      sp->append(gabel1, QT_TRANSLATE_NOOP("Palette", "Diminuendo"));
+      sp->append(gabel1, QT_TRANSLATE_NOOP("Palette", "Diminuendo hairpin"));
+
+      Hairpin* gabel2 = new Hairpin(gscore);
+      gabel2->setHairpinType(Hairpin::Type::CRESCENDO);
+      gabel2->setLen(w);
+      gabel2->setUseTextLine(true);
+      gabel2->setLineStyle(Qt::CustomDashLine);
+      gabel2->setBeginText("<i>cresc.</i>");
+      sp->append(gabel2, qApp->translate("lines", "Crescendo line"));
+
+      Hairpin* gabel3 = new Hairpin(gscore);
+      gabel3->setHairpinType(Hairpin::Type::DECRESCENDO);
+      gabel3->setLen(w);
+      gabel3->setUseTextLine(true);
+      gabel3->setLineStyle(Qt::CustomDashLine);
+      gabel3->setBeginText("<i>dim.</i>");
+      sp->append(gabel3, QT_TRANSLATE_NOOP("Palette", "Diminuendo line"));
 
       Volta* volta = new Volta(gscore);
       volta->setVoltaType(Volta::Type::CLOSED);

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -798,7 +798,7 @@ Palette* MuseScore::newLinesPalette(bool basic)
       gabel2->setLen(w);
       gabel2->setUseTextLine(true);
       gabel2->setLineStyle(Qt::CustomDashLine);
-      gabel2->setBeginText("<i>cresc.</i>");
+      gabel2->setBeginText("cresc.");
       sp->append(gabel2, qApp->translate("lines", "Crescendo line"));
 
       Hairpin* gabel3 = new Hairpin(gscore);
@@ -806,7 +806,7 @@ Palette* MuseScore::newLinesPalette(bool basic)
       gabel3->setLen(w);
       gabel3->setUseTextLine(true);
       gabel3->setLineStyle(Qt::CustomDashLine);
-      gabel3->setBeginText("<i>dim.</i>");
+      gabel3->setBeginText("dim.");
       sp->append(gabel3, QT_TRANSLATE_NOOP("Palette", "Diminuendo line"));
 
       Volta* volta = new Volta(gscore);

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -211,7 +211,9 @@ void ScoreView::createElementPropertyMenu(Element* e, QMenu* popup)
             }
       else if (e->type() == Element::Type::TEXTLINE_SEGMENT
                   || e->type() == Element::Type::OTTAVA_SEGMENT
-                  || e->type() == Element::Type::PEDAL_SEGMENT) {
+                  || e->type() == Element::Type::PEDAL_SEGMENT
+                  || (e->type() == Element::Type::HAIRPIN_SEGMENT
+                      && static_cast<HairpinSegment*>(e)->hairpin()->useTextLine())) {
             popup->addAction(tr("Line Properties..."))->setData("l-props");
             }
       else if (e->type() == Element::Type::STAFF_TEXT) {


### PR DESCRIPTION
This is a very simple/cheap implementation of crescendo and diminuendo as text lines.  Basically, I keep the existing Hairpin class but change it to inherit from TextLine rather than SLine to make it possible to have text.  I added a _useTextLine flag that I check to control whether we do the normal HairpinSegment layout & drawing or just pass it down to TextLineSegment.  I also check this flag when displaying the property menu so we can display Line Properties for these.

I also added a new "Wide dashed" line style, which is made available to all lines.  Ultimately this could actually have style or property settings for dash length and gap between dashes, but I picked some defaults for now I thought looked good.  I check the _useTextLine flag in Hairpin::propertyDefault() for the LINE_STYLE property, so it defaults to "Wide dashed" or "Continuous" as appropriate.

I added cresc. and dim. lines to the palette; these set _useTextLine and use "Wide dashed" line style.  And that's about it.