### PR TITLE
Fix #71931 - TAB: Option to show or hide back-tied notes

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -702,7 +702,7 @@ void Note::draw(QPainter* painter) const
 
       if (tablature) {
             StaffType* tab = staff()->staffType();
-            if (tieBack() && tab->slashStyle())       // skip back-tied notes on tabs without stems
+            if (tieBack() && !tab->showBackTied())    // skip back-tied notes if not shown
                   return;
             QString s;
             if (fixed())

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -64,7 +64,7 @@ StaffType::StaffType(StaffGroup sg, const QString& xml, const QString& name, int
    const QString& durFontName, qreal durFontSize, qreal durFontUserY, qreal genDur,
    const QString& fretFontName, qreal fretFontSize, qreal fretFontUserY,
    TablatureSymbolRepeat symRepeat, bool linesThrough, TablatureMinimStyle minimStyle, bool onLines,
-   bool showRests, bool stemsDown, bool stemThrough, bool upsideDown, bool useNumbers)
+   bool showRests, bool stemsDown, bool stemThrough, bool upsideDown, bool useNumbers, bool showBackTied)
       {
       _group   = sg;
       _xmlName = xml;
@@ -91,6 +91,7 @@ StaffType::StaffType(StaffGroup sg, const QString& xml, const QString& name, int
       setStemsThrough(stemThrough);
       setUpsideDown(upsideDown);
       setUseNumbers(useNumbers);
+      setShowBackTied(showBackTied);
       }
 
 
@@ -161,6 +162,7 @@ bool StaffType::isSameStructure(const StaffType& st) const
                && st._linesThrough  == _linesThrough
                && st._minimStyle    == _minimStyle
                && st._onLines       == _onLines
+               && st._showBackTied  == _showBackTied
                && st._showRests     == _showRests
                && st._stemsDown     == _stemsDown
                && st._stemsThrough  == _stemsThrough
@@ -231,7 +233,7 @@ void StaffType::write(Xml& xml) const
             xml.tag("fretFontSize",     _fretFontSize);
             xml.tag("fretFontY",        _fretFontUserY);
             if (_symRepeat != TablatureSymbolRepeat::NEVER)
-                  xml.tag("symbolRepeat",     int(_symRepeat));
+                  xml.tag("symbolRepeat", int(_symRepeat));
             xml.tag("linesThrough",     _linesThrough);
             xml.tag("minimStyle",       int(_minimStyle));
             xml.tag("onLines",          _onLines);
@@ -240,6 +242,10 @@ void StaffType::write(Xml& xml) const
             xml.tag("stemsThrough",     _stemsThrough);
             xml.tag("upsideDown",       _upsideDown);
             xml.tag("useNumbers",       _useNumbers);
+            // only output "showBackTied" if different from !"slashStyle"
+            // to match the behaviour in 2.0.2 scores (or older)
+            if (_showBackTied != !_slashStyle)
+                  xml.tag("showBackTied",  _showBackTied);
             }
       xml.etag();
       }
@@ -272,8 +278,11 @@ void StaffType::read(XmlReader& e)
                   setLineDistance(Spatium(e.readDouble()));
             else if (tag == "clef")
                   setGenClef(e.readInt());
-            else if (tag == "slashStyle")
-                  setSlashStyle(e.readInt());
+            else if (tag == "slashStyle") {
+                  bool val = e.readInt() != 0;
+                  setSlashStyle(val);
+                  setShowBackTied(!val);  // for compatibility with 2.0.2 scores where this prop
+                  }                       // was lacking and controlled by "slashStyle" instead
             else if (tag == "barlines")
                   setShowBarlines(e.readInt());
             else if (tag == "timesig")
@@ -314,6 +323,8 @@ void StaffType::read(XmlReader& e)
                   setUpsideDown(e.readBool());
             else if (tag == "useNumbers")
                   setUseNumbers(e.readBool());
+            else if (tag == "showBackTied")           // must be after reading "slashStyle" prop, as in older
+                  setShowBackTied(e.readBool());      // scores, this prop was lacking and controlled by "slashStyle"
             else
                   e.unknown();
             }
@@ -1178,20 +1189,20 @@ void StaffType::initStaffTypes()
          StaffType(StaffGroup::PERCUSSION, "perc1Line", QObject::tr("Perc. 1 line"),  1, 1, true, true, false, true, false, true),
          StaffType(StaffGroup::PERCUSSION, "perc3Line", QObject::tr("Perc. 3 lines"), 3, 2, true, true, false, true, false, true),
          StaffType(StaffGroup::PERCUSSION, "perc5Line", QObject::tr("Perc. 5 lines"), 5, 1, true, true, false, true, false, true),
-//                 group               xml-name,         human-readable-name         lin dist  clef   bars stemless time      duration font     size off genDur     fret font          size off  duration symbol repeat        thru  minim style                  onLin  rests  stmDn  stmThr upsDn  nums
-         StaffType(StaffGroup::TAB, "tab6StrSimple", QObject::tr("Tab. 6-str. simple"), 6, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab6StrCommon", QObject::tr("Tab. 6-str. common"), 6, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab6StrFull",   QObject::tr("Tab. 6-str. full"),   6, 1.5, true,  true, false, true,  "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true),
-         StaffType(StaffGroup::TAB, "tab4StrSimple", QObject::tr("Tab. 4-str. simple"), 4, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab4StrCommon", QObject::tr("Tab. 4-str. common"), 4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab4StrFull",   QObject::tr("Tab. 4-str. full"),   4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true),
-         StaffType(StaffGroup::TAB, "tab5StrSimple", QObject::tr("Tab. 5-str. simple"), 5, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab5StrCommon", QObject::tr("Tab. 5-str. common"), 5, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab5StrFull",   QObject::tr("Tab. 5-str. full"),   5, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true),
-         StaffType(StaffGroup::TAB, "tabUkulele",    QObject::tr("Tab. ukulele"),       4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  true,  true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tabBalajka",    QObject::tr("Tab. balalaika"),     3, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  true,  true,  false, false, true),
-         StaffType(StaffGroup::TAB, "tab6StrItalian",QObject::tr("Tab. 6-str. Italian"),6, 1.5, false, true, true,  true,  "MuseScore Tab Italian",15, 0, true,  "MuseScore Tab Renaiss",10, 0, TablatureSymbolRepeat::NEVER, true,  TablatureMinimStyle::NONE,   true,  true,  false, false, true,  true),
-         StaffType(StaffGroup::TAB, "tab6StrFrench", QObject::tr("Tab. 6-str. French"), 6, 1.5, false, true, true,  true,  "MuseScore Tab French", 15, 0, true,  "MuseScore Tab Renaiss",10, 0, TablatureSymbolRepeat::NEVER, true,  TablatureMinimStyle::NONE,   false, false, false, false, false, false)
+//                 group               xml-name,         human-readable-name         lin dist  clef   bars stemless time      duration font     size off genDur     fret font          size off  duration symbol repeat        thru  minim style                  onLin  rests  stmDn  stmThr upsDn  nums bkTied
+         StaffType(StaffGroup::TAB, "tab6StrSimple", QObject::tr("Tab. 6-str. simple"), 6, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true, false),
+         StaffType(StaffGroup::TAB, "tab6StrCommon", QObject::tr("Tab. 6-str. common"), 6, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true, true),
+         StaffType(StaffGroup::TAB, "tab6StrFull",   QObject::tr("Tab. 6-str. full"),   6, 1.5, true,  true, false, true,  "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true, true),
+         StaffType(StaffGroup::TAB, "tab4StrSimple", QObject::tr("Tab. 4-str. simple"), 4, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true, false),
+         StaffType(StaffGroup::TAB, "tab4StrCommon", QObject::tr("Tab. 4-str. common"), 4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true, true),
+         StaffType(StaffGroup::TAB, "tab4StrFull",   QObject::tr("Tab. 4-str. full"),   4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true, true),
+         StaffType(StaffGroup::TAB, "tab5StrSimple", QObject::tr("Tab. 5-str. simple"), 5, 1.5, true,  true, true,  false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Sans",    9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::NONE,   true,  false, true,  false, false, true, false),
+         StaffType(StaffGroup::TAB, "tab5StrCommon", QObject::tr("Tab. 5-str. common"), 5, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  false, true,  false, false, true, true),
+         StaffType(StaffGroup::TAB, "tab5StrFull",   QObject::tr("Tab. 5-str. full"),   5, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SLASHED,true,  true,  true,  true,  false, true, true),
+         StaffType(StaffGroup::TAB, "tabUkulele",    QObject::tr("Tab. ukulele"),       4, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  true,  true,  false, false, true, true),
+         StaffType(StaffGroup::TAB, "tabBalajka",    QObject::tr("Tab. balalaika"),     3, 1.5, true,  true, false, false, "MuseScore Tab Modern", 15, 0, false, "MuseScore Tab Serif",   9, 0, TablatureSymbolRepeat::NEVER, false, TablatureMinimStyle::SHORTER,true,  true,  true,  false, false, true, true),
+         StaffType(StaffGroup::TAB, "tab6StrItalian",QObject::tr("Tab. 6-str. Italian"),6, 1.5, false, true, true,  true,  "MuseScore Tab Italian",15, 0, true,  "MuseScore Tab Renaiss",10, 0, TablatureSymbolRepeat::NEVER, true,  TablatureMinimStyle::NONE,   true,  true,  false, false, true,  true, false),
+         StaffType(StaffGroup::TAB, "tab6StrFrench", QObject::tr("Tab. 6-str. French"), 6, 1.5, false, true, true,  true,  "MuseScore Tab French", 15, 0, true,  "MuseScore Tab Renaiss",10, 0, TablatureSymbolRepeat::NEVER, true,  TablatureMinimStyle::NONE,   false, false, false, false, false, false,false)
          };
       }
 }                 // namespace Ms

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -190,6 +190,7 @@ class StaffType {
       bool  _stemsThrough = true;         // stems are drawn through the staff rather than beside it (stem-and-beam durations only)
       bool  _upsideDown   = false;        // whether lines are drawn with highest string at top (false) or at bottom (true)
       bool  _useNumbers   = true;         // true: use numbers ('0' - ...) for frets | false: use letters ('a' - ...)
+      bool  _showBackTied = true;         // whether back-tied notes are shown or not
 
       // TAB: internally managed variables
       // Note: values in RASTER UNITS are independent from score scaling and
@@ -237,7 +238,7 @@ class StaffType {
                   const QString& durFontName, qreal durFontSize, qreal durFontUserY, qreal genDur,
                   const QString& fretFontName, qreal fretFontSize, qreal fretFontUserY, TablatureSymbolRepeat symRepeat,
                   bool linesThrough, TablatureMinimStyle minimStyle, bool onLines, bool showRests,
-                  bool stemsDown, bool stemThrough, bool upsideDown, bool useNumbers);
+                  bool stemsDown, bool stemThrough, bool upsideDown, bool useNumbers, bool showBackTied);
 
       virtual ~StaffType() {}
       bool operator==(const StaffType&) const;
@@ -324,6 +325,7 @@ class StaffType {
       bool  stemThrough() const           { return _stemsThrough;       }
       bool  upsideDown() const            { return _upsideDown;         }
       bool  useNumbers() const            { return _useNumbers;         }
+      bool  showBackTied() const          { return _showBackTied;       }
 
       // properties setters (setting some props invalidates metrics)
       void  setDurationFontName(const QString&);
@@ -342,6 +344,7 @@ class StaffType {
       void  setStemsThrough(bool val)     { _stemsThrough = val;        }
       void  setUpsideDown(bool val)       { _upsideDown = val;          }
       void  setUseNumbers(bool val)       { _useNumbers = val; _fretMetricsValid = false; }
+      void  setShowBackTied(bool val)     { _showBackTied = val;        }
 
       // utility functions for tab specially managed elements
       QPointF chordStemPos(const Chord*) const;

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -39,17 +39,6 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       setupUi(this);
 
-      // needed to have separate sets of radio buttons
-      QButtonGroup* bg1 = new QButtonGroup(this);
-      bg1->addButton(numbersRadio);
-      bg1->addButton(lettersRadio);
-      QButtonGroup* bg2 = new QButtonGroup(this);
-      bg2->addButton(onLinesRadio);
-      bg2->addButton(aboveLinesRadio);
-      QButtonGroup* bg3 = new QButtonGroup(this);
-      bg3->addButton(linesThroughRadio);
-      bg3->addButton(linesBrokenRadio);
-
       staff     = st;
       staffType = *staff->staffType();
       Instrument* instr = staff->part()->instrument();
@@ -102,34 +91,35 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
       connect(showLedgerLinesPercussion,  SIGNAL(toggled(bool)),  SLOT(updatePreview()));
       connect(stemlessPercussion,         SIGNAL(toggled(bool)),  SLOT(updatePreview()));
 
-      connect(noteValuesSymb, SIGNAL(toggled(bool)),              SLOT(tabStemsToggled(bool)));
-      connect(noteValuesStems,SIGNAL(toggled(bool)),              SLOT(tabStemsToggled(bool)));
-      connect(valuesRepeatNever,  SIGNAL(toggled(bool)),          SLOT(updatePreview()));
-      connect(valuesRepeatSystem, SIGNAL(toggled(bool)),          SLOT(updatePreview()));
-      connect(valuesRepeatMeasure,SIGNAL(toggled(bool)),          SLOT(updatePreview()));
-      connect(valuesRepeatAlways, SIGNAL(toggled(bool)),          SLOT(updatePreview()));
-      connect(stemBesideRadio,SIGNAL(toggled(bool)),              SLOT(updatePreview()));
-      connect(stemThroughRadio,SIGNAL(toggled(bool)),             SLOT(tabStemThroughToggled(bool)));
-      connect(stemAboveRadio, SIGNAL(toggled(bool)),              SLOT(updatePreview()));
-      connect(stemBelowRadio, SIGNAL(toggled(bool)),              SLOT(updatePreview()));
-      connect(minimShortRadio,    SIGNAL(toggled(bool)),          SLOT(tabMinimShortToggled(bool)));
-      connect(minimSlashedRadio,  SIGNAL(toggled(bool)),          SLOT(updatePreview()));
-      connect(showRests,      SIGNAL(toggled(bool)),              SLOT(updatePreview()));
-      connect(durFontName,    SIGNAL(currentIndexChanged(int)),   SLOT(durFontNameChanged(int)));
-      connect(durFontSize,    SIGNAL(valueChanged(double)),       SLOT(updatePreview()));
-      connect(durY,           SIGNAL(valueChanged(double)),       SLOT(updatePreview()));
-      connect(fretFontName,   SIGNAL(currentIndexChanged(int)),   SLOT(fretFontNameChanged(int)));
-      connect(fretFontSize,   SIGNAL(valueChanged(double)),       SLOT(updatePreview()));
-      connect(fretY,          SIGNAL(valueChanged(double)),       SLOT(updatePreview()));
+      connect(noteValuesSymb,       SIGNAL(toggled(bool)),              SLOT(tabStemsToggled(bool)));
+      connect(noteValuesStems,      SIGNAL(toggled(bool)),              SLOT(tabStemsToggled(bool)));
+      connect(valuesRepeatNever,    SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(valuesRepeatSystem,   SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(valuesRepeatMeasure,  SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(valuesRepeatAlways,   SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(stemBesideRadio,      SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(stemThroughRadio,     SIGNAL(toggled(bool)),              SLOT(tabStemThroughToggled(bool)));
+      connect(stemAboveRadio,       SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(stemBelowRadio,       SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(minimShortRadio,      SIGNAL(toggled(bool)),              SLOT(tabMinimShortToggled(bool)));
+      connect(minimSlashedRadio,    SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(showRests,            SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(durFontName,          SIGNAL(currentIndexChanged(int)),   SLOT(durFontNameChanged(int)));
+      connect(durFontSize,          SIGNAL(valueChanged(double)),       SLOT(updatePreview()));
+      connect(durY,                 SIGNAL(valueChanged(double)),       SLOT(updatePreview()));
+      connect(fretFontName,         SIGNAL(currentIndexChanged(int)),   SLOT(fretFontNameChanged(int)));
+      connect(fretFontSize,         SIGNAL(valueChanged(double)),       SLOT(updatePreview()));
+      connect(fretY,                SIGNAL(valueChanged(double)),       SLOT(updatePreview()));
 
-      connect(linesThroughRadio, SIGNAL(toggled(bool)),           SLOT(updatePreview()));
-      connect(onLinesRadio,   SIGNAL(toggled(bool)),              SLOT(updatePreview()));
-      connect(upsideDown,     SIGNAL(toggled(bool)),              SLOT(updatePreview()));
-      connect(numbersRadio,   SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(linesThroughRadio,    SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(onLinesRadio,         SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(upsideDown,           SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(numbersRadio,         SIGNAL(toggled(bool)),              SLOT(updatePreview()));
+      connect(showBackTied,         SIGNAL(toggled(bool)),              SLOT(updatePreview()));
 
-      connect(templateReset,  SIGNAL(clicked()),                  SLOT(resetToTemplateClicked()));
-      connect(addToTemplates,   SIGNAL(clicked()),                SLOT(addToTemplatesClicked()));
-//      connect(groupCombo,       SIGNAL(currentIndexChanged(int)), SLOT(staffGroupChanged(int)));
+      connect(templateReset,        SIGNAL(clicked()),                  SLOT(resetToTemplateClicked()));
+      connect(addToTemplates,       SIGNAL(clicked()),                  SLOT(addToTemplatesClicked()));
+//      connect(groupCombo,           SIGNAL(currentIndexChanged(int)),   SLOT(staffGroupChanged(int)));
       }
 
 //---------------------------------------------------------
@@ -188,6 +178,7 @@ void EditStaffType::setValues()
                   aboveLinesRadio->setChecked(!staffType.onLines());
                   linesThroughRadio->setChecked(staffType.linesThrough());
                   linesBrokenRadio->setChecked(!staffType.linesThrough());
+                  showBackTied->setChecked(staffType.showBackTied());
 
                   idx = durFontName->findText(staffType.durationFontName(), Qt::MatchFixedString);
                   if (idx == -1)
@@ -355,6 +346,7 @@ void EditStaffType::setFromDlg()
       staffType.setFretFontSize(fretFontSize->value());
       staffType.setFretFontUserY(fretY->value());
       staffType.setLinesThrough(linesThroughRadio->isChecked());
+      staffType.setShowBackTied(showBackTied->isChecked());
       staffType.setMinimStyle(minimNoneRadio->isChecked() ? TablatureMinimStyle::NONE :
             (minimShortRadio->isChecked() ? TablatureMinimStyle::SHORTER : TablatureMinimStyle::SLASHED));
       staffType.setSymbolRepeat(valuesRepeatNever->isChecked() ? TablatureSymbolRepeat::NEVER :
@@ -402,6 +394,7 @@ void EditStaffType::blockSignals(bool block)
       numbersRadio->blockSignals(block);
       linesThroughRadio->blockSignals(block);
       onLinesRadio->blockSignals(block);
+      showBackTied->blockSignals(block);
 
       upsideDown->blockSignals(block);
       valuesRepeatNever->blockSignals(block);

--- a/mscore/editstafftype.ui
+++ b/mscore/editstafftype.ui
@@ -224,7 +224,7 @@
         <number>0</number>
        </property>
        <property name="currentIndex">
-        <number>2</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="page">
         <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,0">
@@ -483,7 +483,7 @@
                 </item>
                 <item>
                  <layout class="QGridLayout" name="gridLayout">
-                  <item row="2" column="0">
+                  <item row="1" column="0">
                    <widget class="QLabel" name="onStringsLabel">
                     <property name="minimumSize">
                      <size>
@@ -499,7 +499,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="1">
+                  <item row="1" column="1">
                    <widget class="QRadioButton" name="onLinesRadio">
                     <property name="minimumSize">
                      <size>
@@ -516,9 +516,12 @@
                     <property name="autoExclusive">
                      <bool>true</bool>
                     </property>
+                    <attribute name="buttonGroup">
+                     <string notr="true">OnAboveLinesButtGroup</string>
+                    </attribute>
                    </widget>
                   </item>
-                  <item row="4" column="1">
+                  <item row="2" column="1">
                    <widget class="QRadioButton" name="linesThroughRadio">
                     <property name="minimumSize">
                      <size>
@@ -535,9 +538,12 @@
                     <property name="autoExclusive">
                      <bool>true</bool>
                     </property>
+                    <attribute name="buttonGroup">
+                     <string notr="true">ContinuousBrokenLinesbuttGroup</string>
+                    </attribute>
                    </widget>
                   </item>
-                  <item row="4" column="0">
+                  <item row="2" column="0">
                    <widget class="QLabel" name="linesThroughLabel">
                     <property name="minimumSize">
                      <size>
@@ -571,7 +577,7 @@
                      <bool>true</bool>
                     </property>
                     <attribute name="buttonGroup">
-                     <string notr="true">buttonGroup</string>
+                     <string notr="true">NumLettersButtGroup</string>
                     </attribute>
                    </widget>
                   </item>
@@ -600,11 +606,11 @@
                      <bool>true</bool>
                     </property>
                     <attribute name="buttonGroup">
-                     <string notr="true">buttonGroup</string>
+                     <string notr="true">NumLettersButtGroup</string>
                     </attribute>
                    </widget>
                   </item>
-                  <item row="2" column="2">
+                  <item row="1" column="2">
                    <widget class="QRadioButton" name="aboveLinesRadio">
                     <property name="text">
                      <string>Above lines</string>
@@ -612,9 +618,12 @@
                     <property name="autoExclusive">
                      <bool>true</bool>
                     </property>
+                    <attribute name="buttonGroup">
+                     <string notr="true">OnAboveLinesButtGroup</string>
+                    </attribute>
                    </widget>
                   </item>
-                  <item row="4" column="2">
+                  <item row="2" column="2">
                    <widget class="QRadioButton" name="linesBrokenRadio">
                     <property name="text">
                      <string>Broken</string>
@@ -625,7 +634,34 @@
                     <property name="autoExclusive">
                      <bool>true</bool>
                     </property>
+                    <attribute name="buttonGroup">
+                     <string notr="true">ContinuousBrokenLinesbuttGroup</string>
+                    </attribute>
                    </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_3">
+                  <item>
+                   <widget class="QCheckBox" name="showBackTied">
+                    <property name="text">
+                     <string>Show back-tied fret marks</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_6">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
                   </item>
                  </layout>
                 </item>
@@ -845,7 +881,7 @@
                       <enum>Qt::PlainText</enum>
                      </property>
                      <property name="buddy">
-                      <cstring>noteValuesNone</cstring>
+                      <cstring>valuesRepeatNever</cstring>
                      </property>
                     </widget>
                    </item>
@@ -1322,6 +1358,12 @@
   <tabstop>genClef</tabstop>
   <tabstop>genTimesig</tabstop>
   <tabstop>showBarlines</tabstop>
+  <tabstop>genKeysigPitched</tabstop>
+  <tabstop>showLedgerLinesPitched</tabstop>
+  <tabstop>stemlessPitched</tabstop>
+  <tabstop>genKeysigPercussion</tabstop>
+  <tabstop>showLedgerLinesPercussion</tabstop>
+  <tabstop>stemlessPercussion</tabstop>
   <tabstop>upsideDown</tabstop>
   <tabstop>tabWidget</tabstop>
   <tabstop>fretFontName</tabstop>
@@ -1333,12 +1375,17 @@
   <tabstop>aboveLinesRadio</tabstop>
   <tabstop>linesThroughRadio</tabstop>
   <tabstop>linesBrokenRadio</tabstop>
+  <tabstop>showBackTied</tabstop>
   <tabstop>durFontName</tabstop>
   <tabstop>durFontSize</tabstop>
   <tabstop>durY</tabstop>
   <tabstop>noteValuesNone</tabstop>
   <tabstop>noteValuesSymb</tabstop>
   <tabstop>noteValuesStems</tabstop>
+  <tabstop>valuesRepeatNever</tabstop>
+  <tabstop>valuesRepeatSystem</tabstop>
+  <tabstop>valuesRepeatMeasure</tabstop>
+  <tabstop>valuesRepeatAlways</tabstop>
   <tabstop>stemBesideRadio</tabstop>
   <tabstop>stemThroughRadio</tabstop>
   <tabstop>stemAboveRadio</tabstop>
@@ -1350,12 +1397,6 @@
   <tabstop>templateCombo</tabstop>
   <tabstop>templateReset</tabstop>
   <tabstop>addToTemplates</tabstop>
-  <tabstop>showLedgerLinesPercussion</tabstop>
-  <tabstop>stemlessPercussion</tabstop>
-  <tabstop>genKeysigPitched</tabstop>
-  <tabstop>showLedgerLinesPitched</tabstop>
-  <tabstop>stemlessPitched</tabstop>
-  <tabstop>genKeysigPercussion</tabstop>
  </tabstops>
  <resources/>
  <connections>
@@ -1393,6 +1434,8 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
+  <buttongroup name="OnAboveLinesButtGroup"/>
+  <buttongroup name="NumLettersButtGroup"/>
+  <buttongroup name="ContinuousBrokenLinesbuttGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Fix #71931 - TAB: Option to show or hide back-tied notes

__References__:
- issue https://musescore.org/en/node/71931#comment-341166
- forum thread https://musescore.org/en/node/71886

Adds an option to the TAB staff type config. dlg box controlling whether back-tied notes are shown or not.

Should maintain backward compatibility, as the value of this new staff type parameter is by default set to `~_slashStyle`, which was the original rule for this detail.

Should also support forward compatibility, as the new staff type tag in score files would be simply ignored by older versions.