### PR TITLE
fix #32696 pauseBefore RepeatSegments after SECTION_BREAK

### DIFF
--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -175,7 +175,6 @@ void MeasureBase::remove(Element* el)
                         break;
                   case LayoutBreak::Type::SECTION:
                         _sectionBreak = 0;
-                        score()->setPause(endTick(), 0);
                         score()->addLayoutFlags(LayoutFlag::FIX_TICKS);
                         score()->setLayoutAll(true);
                         break;

--- a/libmscore/repeatlist.h
+++ b/libmscore/repeatlist.h
@@ -28,7 +28,8 @@ class RepeatSegment {
       int len;
       int utick;
       qreal utime;
-      qreal timeOffset;
+      qreal timeOffset;      
+      qreal pauseBefore;
 
       RepeatSegment();
       };
@@ -45,7 +46,7 @@ class RepeatList: public QList<RepeatSegment*>
       RepeatSegment* rs;            // tmp value during unwind()
 
       Measure* jumpToStartRepeat(Measure*);
-      void unwindSection(Measure* fm, Measure* em);
+      void unwindSection(Measure* fm, Measure* em, qreal pauseBefore);
 
    public:
       RepeatList(Score* s);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -499,11 +499,6 @@ void Score::fixTicks()
                   m->mmRest()->moveTicks(diff);
 
 //            if (!parentScore()) {
-                  //
-                  //  implement section break rest
-                  //
-                  if (m->sectionBreak() && m->pause() != 0.0)
-                        setPause(m->tick() + m->ticks(), m->pause());
 
                   //
                   // implement fermata as a tempo change


### PR DESCRIPTION
Section break pauses now only delay playback when start sections that occur after a section break.  For cases when a section ends with a DC/S al Fine, then the pause will only be incurred after DC/S when playback reaches fine.  Pauses no longer happen every single time that playback encounters a measure with section break.
