### PR TITLE
fix #22994: cross-staff grace note layout

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -530,6 +530,19 @@ QPointF Element::pagePos() const
       else {
             if (parent()->parent())
                   p += parent()->pagePos();
+            // grace chord position is based on that of the main chord
+            // but on the assumption they are on the same staves
+            // adjust position here if this assumption is not true
+            if (type() == Element::Type::CHORD && parent()->type() == Element::Type::CHORD) {
+                  const Chord* c = static_cast<const Chord*>(this);
+                  const Chord* pc = static_cast<const Chord*>(parent());
+                  System* system = pc->segment()->system();
+                  if ((c->staffMove() != pc->staffMove()) && system) {
+                        int csi = c->staffIdx() + c->staffMove();
+                        int psi = pc->staffIdx() + pc->staffMove();
+                        p.ry() += system->staffYpage(csi) - system->staffYpage(psi);
+                        }
+                  }
             }
       return p;
       }


### PR DESCRIPTION
The problem here is easy enough to understand: when calculating pagePos for the grace note chord, we base this in part on that of its parent, but if they are on different staves, the offsets will not have been calculated correctly during layout.  I kind of doubt it is possible to get that right during layout as the difference in staff positions is probably not finalized at that point.  So I chose to fix it by calculating the offset during Element::pagePos().  There are probably other ways this could be done, including overriding Chord::pagePos() or probably other methods entirely.

There might, for example, be a fix that also takes care of https://musescore.org/en/node/22641.  That one has a similar basic problem - layout of ties is performed based on an assumption the notes tied are on the same staff, and we probably can't do otherwise since staff position is probably not set soon enough to be useful.