### PR TITLE
fix #74881: crash on copy of rest into mmrest

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1932,6 +1932,20 @@ void ScoreView::paint(const QRect& r, QPainter& p)
 
             if (!ss)
                   return;
+
+            if (!ss->measure()->system()) {
+                  // segment is in a measure that has not been laid out yet
+                  // this can happen in mmrests
+                  // first chordrest segment of mmrest instead
+                  const Measure* mmr = ss->measure()->mmRest1();
+                  if (mmr)
+                        ss = mmr->first(Segment::Type::ChordRest);
+                  else
+                        return;                 // not an mmrest?
+                  if (!ss)
+                        return;                 // mmrest has no chordrest segment?
+                  }
+
             p.setBrush(Qt::NoBrush);
 
             QPen pen;


### PR DESCRIPTION
Crash happens because the measure for the selection start segment is part of an mmrest and has not been laid out.  My proposed fix here checks for this condition and replaces the start segment with the first segment of the mmrest, at least for the purposes of the calculations in ScoreView::paint().  The actual selection is not changed.  I considered actually replacing the start segment for the selection itself, but I was concerned with changing that without good reason.

Note this fixes only the originally reported problem.  In testing the fix, I discovered another crash I don't totally understand yet, but it seems unrelated.  Something to do with deleting ties.