### PR TITLE
More mmrest / copy/paste fixes

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -404,8 +404,10 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
             s->connectTies();
 
       if (pasted) {                       //select only if we pasted something
-            Segment* s1 = tick2segment(dstTick);
-            Segment* s2 = tick2segment(dstTick + tickLen);
+            if (styleB(StyleIdx::createMultiMeasureRests))
+                  doLayout();
+            Segment* s1 = tick2segmentMM(dstTick);
+            Segment* s2 = tick2segmentMM(dstTick + tickLen);
             int endStaff = dstStaff + staves;
             if (endStaff > nstaves())
                   endStaff = nstaves();

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -405,7 +405,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
 
       if (pasted) {                       //select only if we pasted something
             if (styleB(StyleIdx::createMultiMeasureRests))
-                  doLayout();
+                  createMMRests();
             Segment* s1 = tick2segmentMM(dstTick);
             Segment* s2 = tick2segmentMM(dstTick + tickLen);
             int endStaff = dstStaff + staves;

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1367,6 +1367,18 @@ void Score::writeSegments(Xml& xml, int strack, int etrack,
    Segment* fs, Segment* ls, bool writeSystemElements, bool clip, bool needFirstTick)
       {
       int endTick = ls == 0 ? lastMeasure()->endTick() : ls->tick();
+      // in clipboard mode, ls might be in an mmrest
+      // since we are traversing regular measures,
+      // force ls to last segment of the corresponding regular measure
+      // if it is not in same measure as fs
+      Measure* lm = ls ? ls->measure() : 0;
+      if (clip && lm && lm->isMMRest() && lm != fs->measure()) {
+            lm = tick2measure(ls->measure()->tick());
+            if (lm)
+                  ls = lm->last();
+            else
+                  qDebug("writeSegments: no measure for end segment in mmrest");
+            }
       for (int track = strack; track < etrack; ++track) {
             if (!xml.canWriteVoice(track))
                   continue;
@@ -1394,7 +1406,7 @@ void Score::writeSegments(Xml& xml, int strack, int etrack,
                                     }
                               }
                         }
-                  foreach (Element* e, segment->annotations()) {
+                  for (Element* e : segment->annotations()) {
                         if (e->track() != track || e->generated()
                            || (e->systemFlag() && !writeSystemElements)) {
                               continue;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1938,12 +1938,12 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                   // this can happen in mmrests
                   // first chordrest segment of mmrest instead
                   const Measure* mmr = ss->measure()->mmRest1();
-                  if (mmr)
+                  if (mmr && mmr->system())
                         ss = mmr->first(Segment::Type::ChordRest);
                   else
-                        return;                 // not an mmrest?
+                        return;                 // still no system?
                   if (!ss)
-                        return;                 // mmrest has no chordrest segment?
+                        return;                 // no chordrest segment?
                   }
 
             p.setBrush(Qt::NoBrush);
@@ -1984,11 +1984,22 @@ void ScoreView::paint(const QRect& r, QPainter& p)
             System* system1 = system2;
             double x1;
 
-            for (Segment* s = ss; s && (s != es);) {
+            for (Segment* s = ss; s && (s != es); ) {
                   Segment* ns = s->next1MM();
                   system1  = system2;
                   system2  = s->measure()->system();
-                  pt       = s->pagePos();
+                  if (!system2) {
+                        // as before, use mmrest if necessary
+                        const Measure* mmr = s->measure()->mmRest1();
+                        if (mmr)
+                              system2 = mmr->system();
+                        if (!system2)
+                              break;
+                        // extend rectangle to end of mmrest
+                        pt = mmr->last()->pagePos();
+                        }
+                  else
+                        pt = s->pagePos();
                   x1  = x2;
                   x2  = pt.x() + _spatium * 2;
 


### PR DESCRIPTION
(I was already doing further work on this branch when the original PR was merged; if I need to repeat this work on a new branch, that's fine, it won't be hard)

The original bug in https://musescore.org/en/node/74881 had to do with drawing the selection rectangle after a paste into an mmrest.  My initial fix addressed the symptom and successfully avoided the crash in that particular case but did not address the underlying cause and in testing I found other related issues, so I filed https://musescore.org/en/node/74946.

The first new commit here - the changes to Score::writeSegments() - fixes the most serious problems in 74946.  If a selection ends in an mmrest and we do a "copy", we were  actually copying the data all the way to the end of the score.  Apparently we manage to get away with this sometimes, but the issue report shows how to get corruption or a crash.  My fix detects these cases where we would have run past the end of the selection and accounts for them, hopefully without disturbing anything else.

The second commit addresses the less serious problem in 74946 (the selection after the paste going to the end of the score), which it turns out provides what might be considered a better fix for the original issue.  The relevant changes are the ones in Score::pasteStaff().  If mmrests are enabled, I force a relayout before trying to establish the new selection, and I use tick2segmentMM() to establish the start and end segments.  This should guarantee the start segment and end segment will not be within "hidden" (beneath mmrests) measures that have not been laid out yet, and would in theory mean my original fix is no longer required.

However, there may be other cases where the selection can get into that state, so better safe than sorry.  And while I was at it, I found other corner cases of crashes on pastes involving mmrests in this same place in the code that my original fix did not cover, so I improved that as well with the changes to ScoreView::paint().

So, basically, the first commit addresses the "copy" problem that led to the corruptions and crashes in 74946.  The changes to paste.cpp in the second commit addresses the root cause of the "paste" problem that led to the bad selection noted in 74946 as well as the original crash.  The changes to scoreview.cpp in that second commit are theoretically not needed with the changes to paste.cpp, but since there might be other ways to get into that situation, they seem good to keep.

Again, I am happy to repackage this as a separate branch, or squash the commits, or separate out the two changes in the second commit.