### PR TITLE
fix #74961: initial octave guess on note input wrong after mmrests

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5062,11 +5062,11 @@ void ScoreView::cmdAddPitch(int note, bool addFlag)
                         octave++;
                   }
             else {
-                  int curPitch = -1;
+                  int curPitch = 60;
                   if (is.segment()) {
                         Staff* staff = score()->staff(is.track() / VOICES);
                         Segment* seg = is.segment()->prev1(Segment::Type::ChordRest | Segment::Type::Clef);
-                        while(seg) {
+                        while (seg) {
                               if (seg->segmentType() == Segment::Type::ChordRest) {
                                     Element* p = seg->element(is.track());
                                     if (p && p->type() == Element::Type::CHORD) {
@@ -5077,9 +5077,9 @@ void ScoreView::cmdAddPitch(int note, bool addFlag)
                                     }
                               else if (seg->segmentType() == Segment::Type::Clef) {
                                     Element* p = seg->element( (is.track() / VOICES) * VOICES); // clef on voice 1
-                                    if(p && p->type() == Element::Type::CLEF) {
+                                    if (p && p->type() == Element::Type::CLEF) {
                                           Clef* clef = static_cast<Clef*>(p);
-                                          // check if it's an actual key change or just a courtesy
+                                          // check if it's an actual change or just a courtesy
                                           ClefType ctb = staff->clef(clef->tick() - 1);
                                           if (ctb != clef->clefType() || clef->tick() == 0) {
                                                 curPitch = line2pitch(4, clef->clefType(), Key::C); // C 72 for treble clef
@@ -5087,7 +5087,7 @@ void ScoreView::cmdAddPitch(int note, bool addFlag)
                                                 }
                                           }
                                     }
-                              seg = seg->prev1(Segment::Type::ChordRest | Segment::Type::Clef);
+                              seg = seg->prev1MM(Segment::Type::ChordRest | Segment::Type::Clef);
                               }
                         octave = curPitch / 12;
                         }


### PR DESCRIPTION
Apparently this broke when we stopped writing generated clef to the score for the measures within mmrests - the search backwards for a clef to use found nothing.

I made two changes: searching backwards using prev1MM() rather than prev1(), and defaulting to 60 for curPitch rather than -1 (just in case we still do not find a clef).