### PR TITLE
fix #74911: disable system dividers when generating parts

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -375,14 +375,18 @@ Score::Score(Score* parent)
       else {
             // inherit most style settings from parent
             _style = *parent->style();
+
             // but borrow defaultStyle page layout settings
             const PageFormat* pf = MScore::defaultStyle()->pageFormat();
             qreal sp = MScore::defaultStyle()->spatium();
             _style.setPageFormat(*pf);
             _style.setSpatium(sp);
 
-            //concert pitch is off for parts
+            // and force some style settings that just make sense for parts
             _style.set(StyleIdx::concertPitch, false);
+            _style.set(StyleIdx::createMultiMeasureRests, true);
+            _style.set(StyleIdx::dividerLeft, false);
+            _style.set(StyleIdx::dividerRight, false);
             }
 
       _synthesizerState = parent->_synthesizerState;

--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -276,7 +276,6 @@ void ExcerptsDialog::createExcerptClicked(QListWidgetItem* cur)
       e->setPartScore(nscore);
 
       nscore->setName(e->title()); // needed before AddExcerpt
-      nscore->style()->set(StyleIdx::createMultiMeasureRests, true);
 
       score->startCmd();
       score->undo(new AddExcerpt(nscore));

--- a/mtest/libmscore/parts/part-all-parts.mscx
+++ b/mtest/libmscore/parts/part-all-parts.mscx
@@ -963,10 +963,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1263,6 +1259,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="6" len="104/4">
+          <multiMeasureRest>26</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="104" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>11520</tick>
         <Measure number="7">
           <Rest>
             <lid>56</lid>
@@ -1514,8 +1522,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1680,6 +1686,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="4" len="112/4">
+          <multiMeasureRest>28</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="112" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>7680</tick>
         <Measure number="5">
           <Rest>
             <lid>137</lid>

--- a/mtest/libmscore/parts/part-breath-parts.mscx
+++ b/mtest/libmscore/parts/part-breath-parts.mscx
@@ -723,8 +723,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -843,6 +841,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>17</lid>
@@ -1096,8 +1106,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1221,6 +1229,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>90</lid>

--- a/mtest/libmscore/parts/part-chordline-parts.mscx
+++ b/mtest/libmscore/parts/part-chordline-parts.mscx
@@ -709,8 +709,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -819,6 +817,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>15</lid>
@@ -1072,8 +1082,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1183,6 +1191,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>87</lid>

--- a/mtest/libmscore/parts/part-empty-parts.mscx
+++ b/mtest/libmscore/parts/part-empty-parts.mscx
@@ -710,8 +710,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -821,6 +819,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>15</lid>
@@ -1074,8 +1084,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1190,6 +1198,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>87</lid>

--- a/mtest/libmscore/parts/part-fingering-parts.mscx
+++ b/mtest/libmscore/parts/part-fingering-parts.mscx
@@ -720,8 +720,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -841,6 +839,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>17</lid>
@@ -1094,8 +1104,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1215,6 +1223,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>89</lid>

--- a/mtest/libmscore/parts/part-symbol-parts.mscx
+++ b/mtest/libmscore/parts/part-symbol-parts.mscx
@@ -714,8 +714,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -829,6 +827,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>16</lid>
@@ -1082,8 +1092,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1198,6 +1206,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>88</lid>

--- a/mtest/libmscore/parts/partStyle-score-ref.mscx
+++ b/mtest/libmscore/parts/partStyle-score-ref.mscx
@@ -624,6 +624,23 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="1" len="32/4">
+          <multiMeasureRest>8</multiMeasureRest>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            <showCourtesySig>1</showCourtesySig>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="32" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>1920</tick>
         <Measure number="2">
           <Rest>
             <lid>32</lid>

--- a/mtest/libmscore/parts/tst_parts.cpp
+++ b/mtest/libmscore/parts/tst_parts.cpp
@@ -149,7 +149,6 @@ void TestParts::createParts(Score* score)
 
       nscore->setName(parts.front()->partName());
       score->undo(new AddExcerpt(nscore));
-      nscore->style()->set(StyleIdx::createMultiMeasureRests, true);
 
       //
       // create second part
@@ -165,7 +164,6 @@ void TestParts::createParts(Score* score)
 
       nscore->setName(parts.front()->partName());
       score->undo(new AddExcerpt(nscore));
-      nscore->style()->set(StyleIdx::createMultiMeasureRests, true);
       }
 
 //---------------------------------------------------------

--- a/mtest/libmscore/spanners/glissando-cloning02-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning02-ref.mscx
@@ -165,6 +165,7 @@
       <currentLayer>0</currentLayer>
       <Division>480</Division>
       <Style>
+        <createMultiMeasureRests>1</createMultiMeasureRests>
         <TextStyle>
           <halign>left</halign>
           <valign>top</valign>


### PR DESCRIPTION
Just as parts should have concert pitch default to "off" and mmrests to "on" regardless of the setting in the score, dividers should default to "off".

It's a one-line change, but in implementing it, I noticed we set the concert pitch status and mmrest status in totally different places.  While it's possible there is a good reason for this, I'm included to think it was an oversight because these were added at very different times.

The code for to disable concert pitch for parts was added relatively recently.  Apparently the score setting for concert pitch was inherited by the part all the way back to before 1.0 (!) and it continued to be the case through most of 2.0 development.  This was finally fixed not long before beta 1, by forcing concert pitch off in the Score copy constructor:

https://github.com/musescore/MuseScore/commit/7c720790f1a0d769222f93a9f9013233d0ed5e37

Whereas the code for mmrests goes back to the beginning of the current history; this is done in the handler for the File / Parts dialog.  However, it seems there was a problem with this that I fixed (also around the time of the beta 1) by moving the code to a spot earlier in the same function - basically to a point where it is effectively the same as if it had been done in the constructor:

https://github.com/musescore/MuseScore/commit/6e66e12d2322228c106a94f106d3019e37a36c2a

I like having this done in the constructor rather than the dialog; that way it gets hit no matter how parts are generated (eg, if this can be triggered via command line, plugins, osc, etc).  So for this PR I went ahead moved the mmrest setting there too for consistency.  No ill effects I can see.