### PR TITLE
74906 hairpin text

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -294,6 +294,7 @@ void Score::cmdAddSpanner(Spanner* spanner, int staffIdx, Segment* startSegment,
           || spanner->type() == Element::Type::NOTELINE
           || spanner->type() == Element::Type::OTTAVA
           || spanner->type() == Element::Type::PEDAL
+          || spanner->type() == Element::Type::HAIRPIN
           || spanner->type() == Element::Type::VOLTA) {
             // rebase text elements to score style
             TextLine* tl = static_cast<TextLine*>(spanner);

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2402,6 +2402,8 @@ Hairpin* Score::addHairpin(bool decrescendo, int tickStart, int tickEnd, int tra
       {
       Hairpin* pin = new Hairpin(this);
       pin->setHairpinType(decrescendo ? Hairpin::Type::DECRESCENDO : Hairpin::Type::CRESCENDO);
+      pin->setBeginText(decrescendo ? "dim." : "cresc.");
+      pin->setContinueText(decrescendo ? "(dim.)" : "(cresc.)");
       pin->setTrack(track);
       pin->setTrack2(track);
       pin->setTick(tickStart);

--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -33,8 +33,12 @@ Spatium Hairpin::editHairpinHeight;
 void HairpinSegment::layout()
       {
       if (hairpin()->useTextLine()) {
+            // layout as textline rather than true hairpin
+            // use dynamics text style for position, so the text aligns with dynamics
+            // TODO: new style setting specifically for vertical offset of textline hairpins?
+            // or, use hairpinY but adjust by 0.5sp, which currently yields same vertical position as dynamics
             if (parent())
-                  rypos() += score()->styleS(StyleIdx::hairpinY).val() * spatium();
+                  rypos() += score()->textStyle(TextStyleType::DYNAMICS).offset(spatium()).y();
             TextLineSegment::layout();
             return;
             }

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -786,11 +786,15 @@ Palette* MuseScore::newLinesPalette(bool basic)
       Hairpin* gabel0 = new Hairpin(gscore);
       gabel0->setHairpinType(Hairpin::Type::CRESCENDO);
       gabel0->setLen(w);
+      gabel0->setBeginText("cresc.");
+      gabel0->setContinueText("(cresc.)");
       sp->append(gabel0, qApp->translate("lines", "Crescendo hairpin"));
 
       Hairpin* gabel1 = new Hairpin(gscore);
       gabel1->setHairpinType(Hairpin::Type::DECRESCENDO);
       gabel1->setLen(w);
+      gabel1->setBeginText("dim.");
+      gabel1->setContinueText("(dim.)");
       sp->append(gabel1, QT_TRANSLATE_NOOP("Palette", "Diminuendo hairpin"));
 
       Hairpin* gabel2 = new Hairpin(gscore);
@@ -799,6 +803,7 @@ Palette* MuseScore::newLinesPalette(bool basic)
       gabel2->setUseTextLine(true);
       gabel2->setLineStyle(Qt::CustomDashLine);
       gabel2->setBeginText("cresc.");
+      gabel2->setContinueText("(cresc.)");
       sp->append(gabel2, qApp->translate("lines", "Crescendo line"));
 
       Hairpin* gabel3 = new Hairpin(gscore);
@@ -807,6 +812,7 @@ Palette* MuseScore::newLinesPalette(bool basic)
       gabel3->setUseTextLine(true);
       gabel3->setLineStyle(Qt::CustomDashLine);
       gabel3->setBeginText("dim.");
+      gabel3->setContinueText("(dim.)");
       sp->append(gabel3, QT_TRANSLATE_NOOP("Palette", "Diminuendo line"));
 
       Volta* volta = new Volta(gscore);


### PR DESCRIPTION
Two usability enhancements for the new textline hairpins:

1) prepopulate the begin text for ordinary (non-textline) hairpins (even though it won't be displayed by default) so it is all ready to go if you change it into a textline hairpin via the Inspector

2) adjust vertical position of the textline hairpin by 0.5sp to better align visually with the corresponding ordinary hairpin

The second of these is a bit of a hack, but one designed to correct for something done for 2.0 that was itself a bit of a hack.  The current default position of the ordinary hairpin (a general style setting) was chosen to make the vertical center of the hairpin align with a the vertical center of a dynamic marking at the default position (a text style setting).  These two defaults happen to differ by 0.5sp, because dynamics align to baseline but ordinary hairpins align to the vertical center (the tip) and moving the latter up by 0.5sp made it hit the vertical center of the dynamic with the default fonts.

We *could* add a new style parameter for the vertical position for the textline hairpin (also one to set the line style) and use this instead of the ordinary hairpin default position.  We could also revisit the default style settings and how we interpret the hairpin vertical position - making it specify the baseline position rather than the tip position, and adjust older scores accordingly.