### PR TITLE
fix #75071 remove settings .lock file when factory reset

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4769,6 +4769,7 @@ int main(int argc, char* av[])
       if (deletePreferences) {
             QDir(dataPath).removeRecursively();
             QSettings settings;
+            QFile::remove(settings.fileName() + ".lock"); //forcibly remove lock
             QFile::remove(settings.fileName());
             }
 


### PR DESCRIPTION
This is a simple fix for handling presence of a stale lock file.
Simply removes the settings .lock file before removing the settings file.