### PR TITLE
fix #75071 proper removal of settings .ini using locks

### DIFF
--- a/all.h
+++ b/all.h
@@ -163,6 +163,7 @@
 #include <QHelpIndexModel>
 #include <QTextBrowser>
 
+#include <QLockFile>
 
 // change Q_ASSERT to NOP if not debugging
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4769,7 +4769,15 @@ int main(int argc, char* av[])
       if (deletePreferences) {
             QDir(dataPath).removeRecursively();
             QSettings settings;
-            QFile::remove(settings.fileName());
+            QFile::remove(settings.fileName() + ".lock");               // forcibly remove any stale lock
+            QLockFile settingsLockFile(settings.fileName() + ".lock");
+            if (settingsLockFile.lock()) {
+                  QFile::remove(settings.fileName());
+                  settingsLockFile.unlock();
+                  }
+            else {
+                  qWarning("Unable to lock %s, so can't delete preferences.", qPrintable(settings.fileName()));
+                  }
             }
 
       // create local plugin directory


### PR DESCRIPTION
This is a slightly more involved fix for handling presence of a stale lock file during a factory reset.
It implements what I believe is a more "proper" method utilizing Qt5's QLockFile class:
1. remove stale settings .lock via removeStaleLockFile()
2. try to lock
3. delete settings
4. unlock
and prints meaningful qDebug messages on failure

Please see my earlier PR #2200 for a much simpler solution.