### PR TITLE
add text for legacy hairpins

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -408,6 +408,13 @@ void Hairpin::read(XmlReader& e)
             else if (!TextLine::readProperties(e))
                   e.unknown();
             }
+
+      // add default text to legacy hairpins
+      if (score()->mscVersion() <= 206) {
+            bool cresc = _hairpinType == Hairpin::Type::CRESCENDO;
+            setBeginText(cresc ? "cresc." : "dim.");
+            setContinueText(cresc ? "(cresc.)" : "(dim.)");
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -375,14 +375,18 @@ Score::Score(Score* parent)
       else {
             // inherit most style settings from parent
             _style = *parent->style();
+
             // but borrow defaultStyle page layout settings
             const PageFormat* pf = MScore::defaultStyle()->pageFormat();
             qreal sp = MScore::defaultStyle()->spatium();
             _style.setPageFormat(*pf);
             _style.setSpatium(sp);
 
-            //concert pitch is off for parts
+            // and force some style settings that just make sense for parts
             _style.set(StyleIdx::concertPitch, false);
+            _style.set(StyleIdx::createMultiMeasureRests, true);
+            _style.set(StyleIdx::dividerLeft, false);
+            _style.set(StyleIdx::dividerRight, false);
             }
 
       _synthesizerState = parent->_synthesizerState;

--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -276,7 +276,6 @@ void ExcerptsDialog::createExcerptClicked(QListWidgetItem* cur)
       e->setPartScore(nscore);
 
       nscore->setName(e->title()); // needed before AddExcerpt
-      nscore->style()->set(StyleIdx::createMultiMeasureRests, true);
 
       score->startCmd();
       score->undo(new AddExcerpt(nscore));

--- a/mtest/libmscore/compat/hairpin-ref.mscx
+++ b/mtest/libmscore/compat/hairpin-ref.mscx
@@ -159,6 +159,12 @@
           </Chord>
         <HairPin id="2">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/join/join03-ref.mscx
+++ b/mtest/libmscore/join/join03-ref.mscx
@@ -105,6 +105,12 @@
         <HairPin id="2">
           <subtype>0</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/join/join07-ref.mscx
+++ b/mtest/libmscore/join/join07-ref.mscx
@@ -126,6 +126,12 @@
         <HairPin id="2">
           <subtype>0</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/measure/measure-4-ref.mscx
+++ b/mtest/libmscore/measure/measure-4-ref.mscx
@@ -100,6 +100,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/measure/measure-5-ref.mscx
+++ b/mtest/libmscore/measure/measure-5-ref.mscx
@@ -106,6 +106,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/measure/measure-6-ref.mscx
+++ b/mtest/libmscore/measure/measure-6-ref.mscx
@@ -96,6 +96,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/measure/measure-7-ref.mscx
+++ b/mtest/libmscore/measure/measure-7-ref.mscx
@@ -100,6 +100,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/measure/measure-9-ref.mscx
+++ b/mtest/libmscore/measure/measure-9-ref.mscx
@@ -99,6 +99,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/parts/part-all-appendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-appendmeasures.mscx
@@ -196,6 +196,12 @@
             <off2 x="0" y="0"/>
             <pos x="34.0159" y="6.60645"/>
             </Segment>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <lid>14</lid>
@@ -1087,6 +1093,12 @@
             <subtype>0</subtype>
             <veloChange>10</veloChange>
             <lid>115</lid>
+            <beginText>
+              <text>cresc.</text>
+              </beginText>
+            <continueText>
+              <text>(cresc.)</text>
+              </continueText>
             </HairPin>
           <Chord>
             <lid>14</lid>

--- a/mtest/libmscore/parts/part-all-parts.mscx
+++ b/mtest/libmscore/parts/part-all-parts.mscx
@@ -963,10 +963,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1263,6 +1259,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="6" len="104/4">
+          <multiMeasureRest>26</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="104" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>11520</tick>
         <Measure number="7">
           <Rest>
             <lid>56</lid>
@@ -1514,8 +1522,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1680,6 +1686,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="4" len="112/4">
+          <multiMeasureRest>28</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="112" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>normal</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>7680</tick>
         <Measure number="5">
           <Rest>
             <lid>137</lid>

--- a/mtest/libmscore/parts/part-all-parts.mscx
+++ b/mtest/libmscore/parts/part-all-parts.mscx
@@ -196,6 +196,12 @@
             <off2 x="0" y="0"/>
             <pos x="34.0159" y="6.60645"/>
             </Segment>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <lid>14</lid>
@@ -1075,6 +1081,12 @@
             <subtype>0</subtype>
             <veloChange>10</veloChange>
             <lid>115</lid>
+            <beginText>
+              <text>cresc.</text>
+              </beginText>
+            <continueText>
+              <text>(cresc.)</text>
+              </continueText>
             </HairPin>
           <Chord>
             <lid>14</lid>

--- a/mtest/libmscore/parts/part-all-uappendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uappendmeasures.mscx
@@ -196,6 +196,12 @@
             <off2 x="0" y="0"/>
             <pos x="34.0159" y="6.60645"/>
             </Segment>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <lid>14</lid>
@@ -1075,6 +1081,12 @@
             <subtype>0</subtype>
             <veloChange>10</veloChange>
             <lid>115</lid>
+            <beginText>
+              <text>cresc.</text>
+              </beginText>
+            <continueText>
+              <text>(cresc.)</text>
+              </continueText>
             </HairPin>
           <Chord>
             <lid>14</lid>

--- a/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
@@ -196,6 +196,12 @@
             <off2 x="0" y="0"/>
             <pos x="34.0159" y="6.60645"/>
             </Segment>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <lid>14</lid>
@@ -1075,6 +1081,12 @@
             <subtype>0</subtype>
             <veloChange>10</veloChange>
             <lid>115</lid>
+            <beginText>
+              <text>cresc.</text>
+              </beginText>
+            <continueText>
+              <text>(cresc.)</text>
+              </continueText>
             </HairPin>
           <Chord>
             <lid>14</lid>

--- a/mtest/libmscore/parts/part-all.mscx
+++ b/mtest/libmscore/parts/part-all.mscx
@@ -182,6 +182,12 @@
             <off2 x="0" y="0"/>
             <pos x="34.0159" y="6.60645"/>
             </Segment>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/parts/part-breath-parts.mscx
+++ b/mtest/libmscore/parts/part-breath-parts.mscx
@@ -723,8 +723,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -843,6 +841,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>17</lid>
@@ -1096,8 +1106,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1221,6 +1229,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>90</lid>

--- a/mtest/libmscore/parts/part-chordline-parts.mscx
+++ b/mtest/libmscore/parts/part-chordline-parts.mscx
@@ -709,8 +709,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -819,6 +817,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>15</lid>
@@ -1072,8 +1082,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1183,6 +1191,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>87</lid>

--- a/mtest/libmscore/parts/part-empty-parts.mscx
+++ b/mtest/libmscore/parts/part-empty-parts.mscx
@@ -710,8 +710,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -821,6 +819,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>15</lid>
@@ -1074,8 +1084,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1190,6 +1198,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>87</lid>

--- a/mtest/libmscore/parts/part-fingering-parts.mscx
+++ b/mtest/libmscore/parts/part-fingering-parts.mscx
@@ -720,8 +720,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -841,6 +839,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>17</lid>
@@ -1094,8 +1104,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1215,6 +1223,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>89</lid>

--- a/mtest/libmscore/parts/part-symbol-parts.mscx
+++ b/mtest/libmscore/parts/part-symbol-parts.mscx
@@ -714,8 +714,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -829,6 +827,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>16</lid>
@@ -1082,8 +1092,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>
@@ -1198,6 +1206,18 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="2" len="124/4">
+          <multiMeasureRest>31</multiMeasureRest>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="124" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>3840</tick>
         <Measure number="3">
           <Rest>
             <lid>88</lid>

--- a/mtest/libmscore/parts/partStyle-score-ref.mscx
+++ b/mtest/libmscore/parts/partStyle-score-ref.mscx
@@ -624,6 +624,23 @@
             <duration z="4" n="4"/>
             </Rest>
           </Measure>
+        <Measure number="1" len="32/4">
+          <multiMeasureRest>8</multiMeasureRest>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            <showCourtesySig>1</showCourtesySig>
+            </TimeSig>
+          <Rest>
+            <durationType>measure</durationType>
+            <duration z="32" n="4"/>
+            </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
+          </Measure>
+        <tick>1920</tick>
         <Measure number="2">
           <Rest>
             <lid>32</lid>

--- a/mtest/libmscore/parts/tst_parts.cpp
+++ b/mtest/libmscore/parts/tst_parts.cpp
@@ -149,7 +149,6 @@ void TestParts::createParts(Score* score)
 
       nscore->setName(parts.front()->partName());
       score->undo(new AddExcerpt(nscore));
-      nscore->style()->set(StyleIdx::createMultiMeasureRests, true);
 
       //
       // create second part
@@ -165,7 +164,6 @@ void TestParts::createParts(Score* score)
 
       nscore->setName(parts.front()->partName());
       score->undo(new AddExcerpt(nscore));
-      nscore->style()->set(StyleIdx::createMultiMeasureRests, true);
       }
 
 //---------------------------------------------------------

--- a/mtest/libmscore/selectionfilter/selectionfilter1-base-ref.xml
+++ b/mtest/libmscore/selectionfilter/selectionfilter1-base-ref.xml
@@ -21,6 +21,12 @@
       <subtype>0</subtype>
       <veloChange>10</veloChange>
       <track>0</track>
+      <beginText>
+        <text>cresc.</text>
+        </beginText>
+      <continueText>
+        <text>(cresc.)</text>
+        </continueText>
       </HairPin>
     <Chord>
       <track>0</track>

--- a/mtest/libmscore/spanners/glissando-cloning02-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning02-ref.mscx
@@ -165,6 +165,7 @@
       <currentLayer>0</currentLayer>
       <Division>480</Division>
       <Style>
+        <createMultiMeasureRests>1</createMultiMeasureRests>
         <TextStyle>
           <halign>left</halign>
           <valign>top</valign>

--- a/mtest/libmscore/split/split03-ref.mscx
+++ b/mtest/libmscore/split/split03-ref.mscx
@@ -109,6 +109,12 @@
         <HairPin id="2">
           <subtype>0</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/split/split07-ref.mscx
+++ b/mtest/libmscore/split/split07-ref.mscx
@@ -132,6 +132,12 @@
         <HairPin id="2">
           <subtype>0</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/timesig/timesig-03-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-03-ref.mscx
@@ -187,6 +187,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/tools/undoExplode01-ref.mscx
+++ b/mtest/libmscore/tools/undoExplode01-ref.mscx
@@ -316,6 +316,12 @@
       <Measure number="3">
         <HairPin id="2">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <dots>1</dots>
@@ -464,6 +470,12 @@
       <Measure number="3">
         <HairPin id="4">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <dots>1</dots>
@@ -612,6 +624,12 @@
       <Measure number="3">
         <HairPin id="6">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <dots>1</dots>
@@ -760,6 +778,12 @@
       <Measure number="3">
         <HairPin id="8">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <dots>1</dots>

--- a/mtest/libmscore/tools/undoExplode02-ref.mscx
+++ b/mtest/libmscore/tools/undoExplode02-ref.mscx
@@ -371,6 +371,12 @@
       <Measure number="3">
         <HairPin id="2">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <dots>1</dots>


### PR DESCRIPTION
Forgot that I was also going to add the default text on read for hairpins in 2.0.2 and earlier scores.  Here it is.