### PR TITLE
add text for legacy hairpins

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -408,6 +408,13 @@ void Hairpin::read(XmlReader& e)
             else if (!TextLine::readProperties(e))
                   e.unknown();
             }
+
+      // add default text to legacy hairpins
+      if (score()->mscVersion() <= 206) {
+            bool cresc = _hairpinType == Hairpin::Type::CRESCENDO;
+            setBeginText(cresc ? "cresc." : "dim.");
+            setContinueText(cresc ? "(cresc.)" : "(dim.)");
+            }
       }
 
 //---------------------------------------------------------

--- a/mtest/libmscore/compat/hairpin-ref.mscx
+++ b/mtest/libmscore/compat/hairpin-ref.mscx
@@ -159,6 +159,12 @@
           </Chord>
         <HairPin id="2">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/join/join03-ref.mscx
+++ b/mtest/libmscore/join/join03-ref.mscx
@@ -105,6 +105,12 @@
         <HairPin id="2">
           <subtype>0</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/join/join07-ref.mscx
+++ b/mtest/libmscore/join/join07-ref.mscx
@@ -126,6 +126,12 @@
         <HairPin id="2">
           <subtype>0</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/measure/measure-4-ref.mscx
+++ b/mtest/libmscore/measure/measure-4-ref.mscx
@@ -100,6 +100,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/measure/measure-5-ref.mscx
+++ b/mtest/libmscore/measure/measure-5-ref.mscx
@@ -106,6 +106,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/measure/measure-6-ref.mscx
+++ b/mtest/libmscore/measure/measure-6-ref.mscx
@@ -96,6 +96,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/measure/measure-7-ref.mscx
+++ b/mtest/libmscore/measure/measure-7-ref.mscx
@@ -100,6 +100,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/measure/measure-9-ref.mscx
+++ b/mtest/libmscore/measure/measure-9-ref.mscx
@@ -99,6 +99,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/parts/part-all-appendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-appendmeasures.mscx
@@ -196,6 +196,12 @@
             <off2 x="0" y="0"/>
             <pos x="34.0159" y="6.60645"/>
             </Segment>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <lid>14</lid>
@@ -1087,6 +1093,12 @@
             <subtype>0</subtype>
             <veloChange>10</veloChange>
             <lid>115</lid>
+            <beginText>
+              <text>cresc.</text>
+              </beginText>
+            <continueText>
+              <text>(cresc.)</text>
+              </continueText>
             </HairPin>
           <Chord>
             <lid>14</lid>

--- a/mtest/libmscore/parts/part-all-parts.mscx
+++ b/mtest/libmscore/parts/part-all-parts.mscx
@@ -196,6 +196,12 @@
             <off2 x="0" y="0"/>
             <pos x="34.0159" y="6.60645"/>
             </Segment>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <lid>14</lid>
@@ -1075,6 +1081,12 @@
             <subtype>0</subtype>
             <veloChange>10</veloChange>
             <lid>115</lid>
+            <beginText>
+              <text>cresc.</text>
+              </beginText>
+            <continueText>
+              <text>(cresc.)</text>
+              </continueText>
             </HairPin>
           <Chord>
             <lid>14</lid>

--- a/mtest/libmscore/parts/part-all-uappendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uappendmeasures.mscx
@@ -196,6 +196,12 @@
             <off2 x="0" y="0"/>
             <pos x="34.0159" y="6.60645"/>
             </Segment>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <lid>14</lid>
@@ -1075,6 +1081,12 @@
             <subtype>0</subtype>
             <veloChange>10</veloChange>
             <lid>115</lid>
+            <beginText>
+              <text>cresc.</text>
+              </beginText>
+            <continueText>
+              <text>(cresc.)</text>
+              </continueText>
             </HairPin>
           <Chord>
             <lid>14</lid>

--- a/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
@@ -196,6 +196,12 @@
             <off2 x="0" y="0"/>
             <pos x="34.0159" y="6.60645"/>
             </Segment>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <lid>14</lid>
@@ -1075,6 +1081,12 @@
             <subtype>0</subtype>
             <veloChange>10</veloChange>
             <lid>115</lid>
+            <beginText>
+              <text>cresc.</text>
+              </beginText>
+            <continueText>
+              <text>(cresc.)</text>
+              </continueText>
             </HairPin>
           <Chord>
             <lid>14</lid>

--- a/mtest/libmscore/parts/part-all.mscx
+++ b/mtest/libmscore/parts/part-all.mscx
@@ -182,6 +182,12 @@
             <off2 x="0" y="0"/>
             <pos x="34.0159" y="6.60645"/>
             </Segment>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/selectionfilter/selectionfilter1-base-ref.xml
+++ b/mtest/libmscore/selectionfilter/selectionfilter1-base-ref.xml
@@ -21,6 +21,12 @@
       <subtype>0</subtype>
       <veloChange>10</veloChange>
       <track>0</track>
+      <beginText>
+        <text>cresc.</text>
+        </beginText>
+      <continueText>
+        <text>(cresc.)</text>
+        </continueText>
       </HairPin>
     <Chord>
       <track>0</track>

--- a/mtest/libmscore/split/split03-ref.mscx
+++ b/mtest/libmscore/split/split03-ref.mscx
@@ -109,6 +109,12 @@
         <HairPin id="2">
           <subtype>0</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/split/split07-ref.mscx
+++ b/mtest/libmscore/split/split07-ref.mscx
@@ -132,6 +132,12 @@
         <HairPin id="2">
           <subtype>0</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/timesig/timesig-03-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-03-ref.mscx
@@ -187,6 +187,12 @@
         <HairPin id="2">
           <subtype>1</subtype>
           <veloChange>10</veloChange>
+          <beginText>
+            <text>dim.</text>
+            </beginText>
+          <continueText>
+            <text>(dim.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <durationType>quarter</durationType>

--- a/mtest/libmscore/tools/undoExplode01-ref.mscx
+++ b/mtest/libmscore/tools/undoExplode01-ref.mscx
@@ -316,6 +316,12 @@
       <Measure number="3">
         <HairPin id="2">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <dots>1</dots>
@@ -464,6 +470,12 @@
       <Measure number="3">
         <HairPin id="4">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <dots>1</dots>
@@ -612,6 +624,12 @@
       <Measure number="3">
         <HairPin id="6">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <dots>1</dots>
@@ -760,6 +778,12 @@
       <Measure number="3">
         <HairPin id="8">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <dots>1</dots>

--- a/mtest/libmscore/tools/undoExplode02-ref.mscx
+++ b/mtest/libmscore/tools/undoExplode02-ref.mscx
@@ -371,6 +371,12 @@
       <Measure number="3">
         <HairPin id="2">
           <subtype>0</subtype>
+          <beginText>
+            <text>cresc.</text>
+            </beginText>
+          <continueText>
+            <text>(cresc.)</text>
+            </continueText>
           </HairPin>
         <Chord>
           <dots>1</dots>


### PR DESCRIPTION
Adds begin/continue text for hairpins in 2.0.2 scores (and earlier).  Thanks to @Jojo-Schmitz for heloing with the tests.