### PR TITLE
more conservative handling of legacy hairpins

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -410,10 +410,13 @@ void Hairpin::read(XmlReader& e)
             }
 
       // add default text to legacy hairpins
-      if (score()->mscVersion() <= 206) {
+      if (score()->mscVersion() <= 206 && !_useTextLine) {
             bool cresc = _hairpinType == Hairpin::Type::CRESCENDO;
-            setBeginText(cresc ? "cresc." : "dim.");
-            setContinueText(cresc ? "(cresc.)" : "(dim.)");
+            if (!_beginText)
+                  setBeginText(cresc ? "cresc." : "dim.");
+
+            if (!_continueText)
+                  setContinueText(cresc ? "(cresc.)" : "(dim.)");
             }
       }
 


### PR DESCRIPTION
Updated to only override hairpin text if empty and not currently in "textline" mode.  Thus, if there is a 2.0.3, things should be OK.  The only glitch would be if user creates a textline hairpin, explicitly removes the text, then changes to regular hairpin, then saves, then reoads, then changes *back* to textline.  The default text will reappear.  But I don't really see that as a problem.