### PR TITLE
fix #75861: crash adding timesig to note or rest on page >1

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -43,6 +43,7 @@
 #include "icon.h"
 #include "utils.h"
 #include "keysig.h"
+#include "page.h"
 
 namespace Ms {
 
@@ -838,7 +839,16 @@ Element* ChordRest::drop(const DropData& data)
                   break;
 
             case Element::Type::TIMESIG:
-                  return measure()->drop(data);
+                  if (measure()->system()) {
+                        // convert page-relative pos to score-relative
+                        DropData ndd = data;
+                        ndd.pos += measure()->system()->page()->pos();
+                        return measure()->drop(ndd);
+                        }
+                  else {
+                        delete e;
+                        return 0;
+                        }
 
             case Element::Type::TEMPO_TEXT:
                   {

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1303,12 +1303,14 @@ bool Measure::acceptDrop(const DropData& data) const
 Element* Measure::drop(const DropData& data)
       {
       Element* e = data.element;
-      int staffIdx;
+      int staffIdx = -1;
       Segment* seg;
       _score->pos2measure(data.pos, &staffIdx, 0, &seg, 0);
 
       if (e->systemFlag())
             staffIdx = 0;
+      if (staffIdx < 0)
+            return 0;
 #if 0 // yet(?) unused
       QPointF mrp(data.pos - pagePos());
 #endif


### PR DESCRIPTION
The problem comes from a piece of code I never fully understood when I made PR #2104.  It has to do with the interpretation of the "pos" parameter in the drop data.  Here are some of my comments from the PR:

https://github.com/musescore/MuseScore/pull/2104#discussion-diff-33716992
https://github.com/musescore/MuseScore/pull/2104#discussion-diff-33717097

What I had determined was that for some reason the "pos" parameter needs to be set relative to the page for drops onto most elements, but relative to the beginning of score for drops onto measures.  This never really made sense to me, but I went with it and made my code conform.

Unfortunately, when I added code in another commit to allow time and key signatures to be added by selecting a note or rest before double-clicking rather than selecting a measure, I should have converted the "pos" from page-relative to score-relative when falling back from ChordRest::drop to Measure::drop.  So that is what this current PR does, also adds an additional check at the point where this was actually causing a crash.

I still don't claim to understand why we are treating "pos" totally differently for drops onto measures versus other elements, and maybe that should be revisted at some point.  But this fixes the crash.

BTW, we would have the same problems with keysigs, except that adding a keysig to a cr is now supported directly - mid-measure key signature changes were added just after 2.0.2.  I can't actually make 2.0.2 crash, but that's because the behavior depends on the value of an uninitialized variable (staffIdx in Measure::drop).  If we get lucky and it is 0, there is no crash.