### PR TITLE
fix #75826: barline offset not saved

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -1325,6 +1325,7 @@ void BarLine::updateGenerated(bool canBeTrue)
                   && _visible       == true
                   && generatedType  == true
                   && _customSpan    == false
+                  && !isNudged()
                   );
             }
       }


### PR DESCRIPTION
For some reason, it never really occured to me we even supported user offsets on barlines.  But it does work, other than being lost on save / reload.  And I think the only reason it gets lost on save/reload is because the generated flag never gets set.  I added a check to the place we check the other properties that can affect generated status, and it works for the cases I tried.  I know management of barlines is complex and delicate, but I'm pretty sure this change should be safe.