### PR TITLE
Fix #74561 - TAB: slurs attached to note heads with stems beside staff

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -818,10 +818,13 @@ void Slur::slurPos(SlurPos* sp)
             return;
             }
 
-      bool useTablature = staff() != nullptr && staff()->isTabStaff();
-      StaffType* stt = nullptr;
-      if (useTablature)
-            stt = staff()->staffType();
+      bool        useTablature      = staff() != nullptr && staff()->isTabStaff();
+      bool        staffHasStems     = true;     // assume staff uses stems
+      StaffType*  stt               = nullptr;
+      if (useTablature) {
+            stt               = staff()->staffType();
+            staffHasStems     = stt->stemThrough();   // if tab with stems beside, stems do not count for slur pos
+            }
 
       ChordRest* scr = startCR();
       ChordRest* ecr = endCR();
@@ -853,8 +856,8 @@ void Slur::slurPos(SlurPos* sp)
 
       qreal xo, yo;
 
-      Stem* stem1 = sc?sc->stem():0;
-      Stem* stem2 = ec?ec->stem():0;
+      Stem* stem1 = sc && staffHasStems ? sc->stem() : 0;
+      Stem* stem2 = ec && staffHasStems ? ec->stem() : 0;
 
       enum class SlurAnchor : char {
             NONE, STEM


### PR DESCRIPTION
Fix #74561 - TAB: slurs attached to note heads with stems beside staff

__References__:
- Original issue: https://musescore.org/en/node/74561
- Discussion: https://musescore.org/en/node/69846 and in particular https://musescore.org/en/node/69846#comment-324076

__The issue__:
In tabs with the "stems beside staves" option and several voices, slurs are currently drawn at the end of the staff, which is not customary.

__The fix__:
This fix draws the slurs always attached to note heads, both with a single voice and with multiple voices.