### PR TITLE
fix #76001 fix #76006 insert clef to measure

### DIFF
--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -303,7 +303,6 @@ class Measure : public MeasureBase {
       bool isEmpty() const;
       bool isOnlyRests(int track) const;
 
-
       void layoutStage1();
       int playbackCount() const      { return _playbackCount; }
       void setPlaybackCount(int val) { _playbackCount = val; }

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -264,6 +264,31 @@ qreal MeasureBase::pause() const
       }
 
 //---------------------------------------------------------
+//   isStartOfSection
+//    returns true if start of score.
+//    returns true if start of a new section.
+//          (caveat: section breaks may occur on measure base objects that aren't actual measures.)
+//---------------------------------------------------------
+
+bool MeasureBase::isStartOfSection() const
+      {
+      MeasureBase* m = _prev;
+      while (m) {
+            // if first reach a section break, then is start of a new section
+            if (m->sectionBreak())
+                  return true;
+
+            // if encounter an actual measure before encountering a section break, then is not start of a section
+            if (m->isMeasure())
+                  return false;
+
+            m = m->prev();
+            }
+
+      return true;      // if reach start of score, then is start of a section
+      }
+
+//---------------------------------------------------------
 //   layout
 //---------------------------------------------------------
 

--- a/libmscore/measurebase.h
+++ b/libmscore/measurebase.h
@@ -121,6 +121,8 @@ class MeasureBase : public Element {
       int endTick() const                    { return tick() + ticks();  }
       void setTick(int t)                    { _tick = t;     }
 
+      bool isStartOfSection() const;
+
       qreal pause() const;
 
       virtual QVariant getProperty(P_ID propertyId) const override;

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -533,13 +533,22 @@ void Score::undoChangeClef(Staff* ostaff, Segment* seg, ClefType st)
                   continue;
                   }
 
+            int staffIdx = staff->idx();
+            int track    = staffIdx * VOICES;
             Segment* destSeg = measure->findSegment(Segment::Type::Clef, tick);
 
-            // move measure-initial clef to last segment of prev measure
-
             if (firstSeg                        // if at start of measure
-               && measure->prevMeasure()        // and there is a previous measure
+               && !measure->isStartOfSection()  // and not start of a section
                ) {
+                  // remove clef from this segment if one exists
+                  Segment* segmentToRemoveClef = measure->findSegment(Segment::Type::Clef, tick);
+                  if (segmentToRemoveClef) {
+                        Clef* clefToRemove = static_cast<Clef*>(segmentToRemoveClef->element(track));
+                        if (clefToRemove)
+                              segmentToRemoveClef->remove(clefToRemove);
+                        }
+
+                  // move measure-initial clef to last segment of prev measure
                   measure = measure->prevMeasure();
                   destSeg = measure->findSegment(Segment::Type::Clef, tick);
                   }
@@ -548,8 +557,6 @@ void Score::undoChangeClef(Staff* ostaff, Segment* seg, ClefType st)
                   destSeg = new Segment(measure, Segment::Type::Clef, seg->tick());
                   score->undoAddElement(destSeg);
                   }
-            int staffIdx = staff->idx();
-            int track    = staffIdx * VOICES;
             Clef* clef   = static_cast<Clef*>(destSeg->element(track));
 
             if (clef) {


### PR DESCRIPTION
fix #76001 delete clef at start of measure before adding new clef:
If user drags a clef onto a measure, then Score::undoChangeClef will be called.  The old behavior did not remove any clef at beginning of the measure if the segment to add to was at start of measure, before actually adding the clef to the end of the previous measure.  I've fixed this case by first checking for existing clef at start of measure and deleting it before proceeding with the rest of the function which adds the new clef to end of previous measure (or modifies current one if exists).  (Note: Segment::remove(Clef*) already check to make sure clef is not a "generated" clef, so unnecessary for me to add that test.)

fix #76006 insert clef to meas after section break will insert at meas start:
Previously, if insert clef to a measure, then clef will be inserted to end of previous measure, except for case that is start of score in which case the new clef is added to beginning of the measure.  This commit changes behavior so that if measure is at start of section, then the new clef will be inserted at beginning of measure, for same behavior as if was at beginning of score.