### PR TITLE
fix loop final repeat marks ignored - #75566

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5849,7 +5849,7 @@ void ScoreView::loopToggled(bool val)
       if (_score->lastMeasure() == 0)
             return;
       if (_score->pos(POS::LEFT) == 0 && _score->pos(POS::RIGHT) == 0)
-            _score->setPos(POS::RIGHT, _score->lastMeasure()->endTick()-1);
+            _score->setPos(POS::RIGHT, _score->lastMeasure()->endTick());
       _curLoopIn->move(_score->loopInTick());
       _curLoopOut->move(_score->loopOutTick());
       _curLoopIn->setVisible(val);

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -733,7 +733,7 @@ void Seq::process(unsigned n, float* buffer)
             //
             unsigned framePos = 0;
             int endTime = *pPlayTime + frames;
-            int utickEnd = cs->repeatList()->tick2utick(cs->lastMeasure()->endTick()) - 1;
+            int utickEnd = cs->repeatList()->tick2utick(cs->lastMeasure()->endTick());
             for ( ; *pPlayPos != pEvents->cend(); ) {
                   int n;
                   if (inCountIn) {
@@ -1505,7 +1505,7 @@ void Seq::setLoopIn()
       else
             tick = cs->pos();             // Otherwise, use the selected note.
       if (tick >= cs->loopOutTick())   // If In pos >= Out pos, reset Out pos to end of score
-            cs->setPos(POS::RIGHT, cs->lastMeasure()->endTick() - 1);
+            cs->setPos(POS::RIGHT, cs->lastMeasure()->endTick());
       cs->setPos(POS::LEFT, tick);
       }
 
@@ -1524,8 +1524,8 @@ void Seq::setLoopOut()
       if (tick <= cs->loopInTick())   // If Out pos <= In pos, reset In pos to beginning of score
             cs->setPos(POS::LEFT, 0);
       else
-          if (tick > cs->lastMeasure()->endTick() - 1)
-              tick = cs->lastMeasure()->endTick() - 1;
+          if (tick > cs->lastMeasure()->endTick())
+              tick = cs->lastMeasure()->endTick();
       cs->setPos(POS::RIGHT, tick);
       if (state == Transport::PLAY)
             guiToSeq(SeqMsg(SeqMsgId::SEEK, tick));

--- a/mscore/textcursor.cpp
+++ b/mscore/textcursor.cpp
@@ -133,6 +133,8 @@ void PositionCursor::move(int tick)
       //
       // set mark height for whole system
       //
+      if (_type == CursorType::LOOP_OUT)
+        tick --;
       Score* score = _sv->score();
       Measure* measure = score->tick2measureMM(tick);
       if (measure == 0)


### PR DESCRIPTION
Fix issue #75566 -Loop Playback ignores final repeat marks
At the same time, this fix improves the position of the loopOut marker.