### PR TITLE
change "bar line" to "barline"

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -55,7 +55,7 @@ static const BarLineTableItem barLineTable[] {
         { BarLineType::NORMAL,           QT_TRANSLATE_NOOP("Palette", "Normal barline") },
         { BarLineType::BROKEN,           QT_TRANSLATE_NOOP("Palette", "Dashed barline") },
         { BarLineType::DOTTED,           QT_TRANSLATE_NOOP("Palette", "Dotted barline") },
-        { BarLineType::END,              QT_TRANSLATE_NOOP("Palette", "End bar barline") },
+        { BarLineType::END,              QT_TRANSLATE_NOOP("Palette", "Final barline") },
         { BarLineType::DOUBLE,           QT_TRANSLATE_NOOP("Palette", "Double barline") },
         { BarLineType::START_REPEAT,     QT_TRANSLATE_NOOP("Palette", "Start repeat") },
         { BarLineType::END_REPEAT,       QT_TRANSLATE_NOOP("Palette", "End repeat") },
@@ -1035,7 +1035,7 @@ qreal BarLine::layoutWidth(Score* score, BarLineType type, qreal mag)
             case BarLineType::DOTTED:
                   break;
             default:
-                  qDebug("illegal bar line type");
+                  qDebug("illegal barline type");
                   break;
             }
       return dw;

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -98,7 +98,7 @@ static const ElementName elementNames[] = {
       ElementName("InstrumentName",       QT_TRANSLATE_NOOP("elementName", "Instrument Name")),
       ElementName("SlurSegment",          QT_TRANSLATE_NOOP("elementName", "Slur Segment")),
       ElementName("StaffLines",           QT_TRANSLATE_NOOP("elementName", "Staff Lines")),
-      ElementName("BarLine",              QT_TRANSLATE_NOOP("elementName", "Bar Line")),
+      ElementName("BarLine",              QT_TRANSLATE_NOOP("elementName", "Barline")),
       ElementName("SystemDivider",        QT_TRANSLATE_NOOP("elementName", "System Divider")),
       ElementName("StemSlash",            QT_TRANSLATE_NOOP("elementName", "Stem Slash")),
       ElementName("Line",                 QT_TRANSLATE_NOOP("elementName", "Line")),

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -545,7 +545,7 @@ Score::FileError Score::read114(XmlReader& e)
 
             // check barLineSpan
             if (s->barLineSpan() > (n - idx)) {
-                  qDebug("read114: invalid bar line span %d (max %d)",
+                  qDebug("read114: invalid barline span %d (max %d)",
                      s->barLineSpan(), n - idx);
                   s->setBarLineSpan(n - idx);
                   }

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -2547,7 +2547,7 @@
             <item row="1" column="0">
              <widget class="QLabel" name="label_83">
               <property name="text">
-               <string>End barline thickness:</string>
+               <string>Final barline thickness:</string>
               </property>
               <property name="buddy">
                <cstring>endBarWidth</cstring>
@@ -2567,7 +2567,7 @@
             <item row="2" column="0">
              <widget class="QLabel" name="label_84">
               <property name="text">
-               <string>End barline distance:</string>
+               <string>Final barline distance:</string>
               </property>
               <property name="buddy">
                <cstring>endBarDistance</cstring>

--- a/mtest/libmscore/barline/tst_barline.cpp
+++ b/mtest/libmscore/barline/tst_barline.cpp
@@ -111,11 +111,11 @@ void TestBarline::barline01()
                   QVERIFY2(seg != nullptr, msg);
 
                   bar = static_cast<BarLine*>(seg->element(0));
-                  sprintf(msg, "No bar line in measure %d of system %d.", msrNo+1, sysNo+1);
+                  sprintf(msg, "No barline in measure %d of system %d.", msrNo+1, sysNo+1);
                   QVERIFY2(bar != nullptr, msg);
 
                   height      = bar->bbox().height() / spatium;
-                  sprintf(msg, "Wrong bar line height in measure %d of system %d.", msrNo+1, sysNo+1);
+                  sprintf(msg, "Wrong barline height in measure %d of system %d.", msrNo+1, sysNo+1);
                   QVERIFY2(height > heightMin && height < heightMax, msg);
             }
             sysNo++;
@@ -153,11 +153,11 @@ void TestBarline::barline02()
             QVERIFY2(seg != nullptr, msg);
 
             BarLine* bar = static_cast<BarLine*>(seg->element(0));
-            sprintf(msg, "No bar line in measure %d.", msrNo);
+            sprintf(msg, "No barline in measure %d.", msrNo);
             QVERIFY2(bar != nullptr, msg);
 
             // bar line should be generated if NORMAL, except the END one at the end
-            sprintf(msg, "Bar line in measure %d changed into 'non-generated'.", msrNo);
+            sprintf(msg, "Barline in measure %d changed into 'non-generated'.", msrNo);
             bool test = (bar->barLineType() == BarLineType::NORMAL)
                         ? bar->generated() : !bar->generated();
             QVERIFY2(test, msg);
@@ -191,13 +191,13 @@ void TestBarline::barline03()
       QVERIFY2(seg != nullptr, "No SegStartRepeatBarLine segment in measure 5.");
 
       BarLine* bar = static_cast<BarLine*>(seg->element(0));
-      QVERIFY2(bar != nullptr, "No start-repeat bar line in measure 5.");
+      QVERIFY2(bar != nullptr, "No start-repeat barline in measure 5.");
 
       QVERIFY2(bar->span() == 2 && bar->spanFrom() == 2 && bar->spanTo() == 6,
-            "Wrong span data in start-repeat bar line of measure 5.");
+            "Wrong span data in start-repeat barline of measure 5.");
 
       // check start-repeat bar ine in second staff is gone
-      QVERIFY2(seg->element(1) == nullptr, "Extra start-repeat bar line in 2nd staff of measure 5.");
+      QVERIFY2(seg->element(1) == nullptr, "Extra start-repeat barline in 2nd staff of measure 5.");
 
 //      QVERIFY(saveCompareScore(score, "barline03.mscx", DIR + "barline03-ref.mscx"));
       delete score;
@@ -226,15 +226,15 @@ void TestBarline::barline04()
       QVERIFY2(seg != nullptr, "No SegStartRepeatBarLine segment in measure 5.");
 
       BarLine* bar = static_cast<BarLine*>(seg->element(0));
-      QVERIFY2(bar != nullptr, "No start-repeat bar line in measure 5.");
+      QVERIFY2(bar != nullptr, "No start-repeat barline in measure 5.");
 
       score->undoChangeSingleBarLineSpan(bar, 2, 2, 6);
       score->doLayout();
       QVERIFY2(bar->span() == 2 && bar->spanFrom() == 2 && bar->spanTo() == 6,
-            "Wrong span data in start-repeat bar line of measure 5.");
+            "Wrong span data in start-repeat barline of measure 5.");
 
       // check start-repeat bar ine in second staff is gone
-      QVERIFY2(seg->element(1) == nullptr, "Extra start-repeat bar line in 2nd staff of measure 5.");
+      QVERIFY2(seg->element(1) == nullptr, "Extra start-repeat barline in 2nd staff of measure 5.");
 
 //      QVERIFY(saveCompareScore(score, "barline04.mscx", DIR + "barline04-ref.mscx"));
       delete score;
@@ -270,17 +270,17 @@ void TestBarline::barline05()
       Segment* seg = msr->findSegment(Segment::Type::EndBarLine, msr->tick()+msr->ticks());
       QVERIFY2(seg != nullptr, "No SegEndBarLine segment in measure 4.");
       BarLine* bar = static_cast<BarLine*>(seg->element(0));
-      QVERIFY2(bar != nullptr, "No end-repeat bar line in measure 4.");
-      QVERIFY2(bar->barLineType() == BarLineType::END_REPEAT, "Bar line at measure 4 is not END-REPEAT");
-      QVERIFY2(bar->generated(), "End-repeat bar line in measure 4 is non-generated.");
+      QVERIFY2(bar != nullptr, "No end-repeat barline in measure 4.");
+      QVERIFY2(bar->barLineType() == BarLineType::END_REPEAT, "Barline at measure 4 is not END-REPEAT");
+      QVERIFY2(bar->generated(), "End-repeat barline in measure 4 is non-generated.");
 
       // check an end-repeat bar line has been created at the beginning of the next measure and it is not generated
       msr = msr->nextMeasure();
       seg = msr->findSegment(Segment::Type::StartRepeatBarLine, msr->tick());
       QVERIFY2(seg != nullptr, "No SegStartRepeatBarLine segment in measure 5.");
       bar = static_cast<BarLine*>(seg->element(0));
-      QVERIFY2(bar != nullptr, "No start-repeat bar line in measure 5.");
-      QVERIFY2(!bar->generated(), "Start-reapeat bar line in measure 5 is generated.");
+      QVERIFY2(bar != nullptr, "No start-repeat barline in measure 5.");
+      QVERIFY2(!bar->generated(), "Start-reapeat barline in measure 5 is generated.");
 
 //      QVERIFY(saveCompareScore(score, "barline05.mscx", DIR + "barline05-ref.mscx"));
       delete score;
@@ -319,15 +319,15 @@ void TestBarline::barline06()
                   BarLine* bar = static_cast<BarLine*>(seg->element(j*VOICES));
                   // if not the i-th staff, bar should be normal and not custom
                   if (j != i) {
-                        sprintf(msg, "bar line type NOT NORMAL or CUSTOM TYPE in staff %d of measure %d.", j+1, msrNo);
+                        sprintf(msg, "barline type NOT NORMAL or CUSTOM TYPE in staff %d of measure %d.", j+1, msrNo);
                         QVERIFY2(bar->barLineType() == BarLineType::NORMAL, msg);
                         QVERIFY2(bar->customSubtype() == false, msg);
                         }
                   // in the i-th staff, the bar line should be of type DOUBLE and custom type should be true
                   else {
-                        sprintf(msg, "No bar line for staff %d in measure %d", j+1, msrNo);
+                        sprintf(msg, "No barline for staff %d in measure %d", j+1, msrNo);
                         QVERIFY2(bar != nullptr, msg);
-                        sprintf(msg, "bar line type NOT DOUBLE or NOT CUSTOM TYPE in staff %d of measure %d.", j+1, msrNo);
+                        sprintf(msg, "barline type NOT DOUBLE or NOT CUSTOM TYPE in staff %d of measure %d.", j+1, msrNo);
                         QVERIFY2(bar->barLineType() == BarLineType::DOUBLE, msg);
                         QVERIFY2(bar->customSubtype() == true, msg);
                         }


### PR DESCRIPTION
While both seems correct, we should be consistent about it.
See also https://musescore.org/en/node/77186, Marc had settled for
"barline" in his book and except for some debug statements we're pretty
consistently using 'barline' in MuseScore source too, just one user
visible deviation in libmscore/element.cpp.
While at it, also change "End bar barline" to "Final barline".