### PR TITLE
fix #76531: handling of spaces within chord symbols

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -653,7 +653,7 @@ const ChordDescription* Harmony::parseHarmony(const QString& ss, int* root, int*
       *base = Tpc::TPC_INVALID;
       int slash = s.lastIndexOf('/');
       if (slash != -1) {
-            QString bs = s.mid(slash+1);
+            QString bs = s.mid(slash + 1).simplified();
             s = s.mid(idx, slash - idx).simplified();
             int idx2;
             *base = convertNote(bs, _baseSpelling, _baseCase, idx2);
@@ -666,7 +666,7 @@ const ChordDescription* Harmony::parseHarmony(const QString& ss, int* root, int*
                   }
             }
       else
-            s = s.mid(idx).simplified();
+            s = s.mid(idx);   // don't simplify; keep leading space before extension if present
       _userName = s;
       const ChordList* cl = score()->style()->chordList();
       const ChordDescription* cd = 0;

--- a/share/styles/chords_jazz.xml
+++ b/share/styles/chords_jazz.xml
@@ -110,6 +110,8 @@
     <sym name="aug"/>
     <sym name="dim"/>
     <sym name="alt"/>
+    <sym name="bass"/>
+    <sym name="pedal"/>
 
     </font>
 


### PR DESCRIPTION
Spaces *within* the extension were handled well, but not a space between the root and the extension.  Also, a space before the bass note (eg, C / Eb) was not handled correctly either, leading the " Eb" to not be recognized as a valid TPC.  This fixes both, shouldn't affect chord symbols without embedded spaces at all.