### PR TITLE
fix #77366: crash adding cross-staff tie

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1250,7 +1250,7 @@ void Score::undoAddElement(Element* element)
                   // accounting for grace notes and cross-staff notation
                   int sm = 0;
                   if (cr1->staffIdx() != cr2->staffIdx())
-                        sm = cr1->staffMove() + cr2->staffMove();
+                        sm = cr2->staffIdx() - cr1->staffIdx();
                   Chord* c1 = findLinkedChord(cr1, score->staff(staffIdx));
                   Chord* c2 = findLinkedChord(cr2, score->staff(staffIdx + sm));
                   Note* nn1 = c1->findNote(n1->pitch());


### PR DESCRIPTION
I am not sure if there is a reaosn this caclulation was originally done using staffMove() rather than staffIdx().  In the case at hand for my simplified steps to reproduce, the value should have been 1 but was calculated as -1.  If I simply change the calculation to take the negative, it works here but fails in the opposite case.  The staffIdx() calcualtion in this PR works in the cases I have tried, but I admit it is hard for me to keep all the different possibilities in my head.