### PR TITLE
fix #76006 append first measure before perform minWidth2() calculation

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2213,6 +2213,7 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
             bool hasCourtesy;
             qreal cautionaryW = 0.0;
             qreal ww          = 0.0;
+            bool systemWasNotEmpty = !system->measures().isEmpty();
 
             if (curMeasure->type() == Element::Type::HBOX) {
                   ww = point(static_cast<Box*>(curMeasure)->boxWidth());
@@ -2238,6 +2239,7 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
                   if (isFirstMeasure) {
                         firstMeasure = m;
                         addSystemHeader(m, isFirstSystem);
+                        system->measures().append(curMeasure);    // append measure to system before minWidth2() performs courtesy clef layout calculation
                         ww = m->minWidth2();
                         }
                   else
@@ -2276,21 +2278,23 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
 
                   if (ww < minMeasureWidth)
                         ww = minMeasureWidth;
-                  isFirstMeasure = false;
                   }
 
             // collect at least one measure
-            bool empty = system->measures().isEmpty();
-
-            if (!empty && (minWidth + ww > systemWidth)) {
+            if (systemWasNotEmpty && (minWidth + ww > systemWidth)) {
                   curMeasure->setSystem(oldSystem);
                   continueFlag = false;
                   break;
                   }
+
             if (curMeasure->type() == Element::Type::MEASURE)
                   lastMeasure = static_cast<Measure*>(curMeasure);
 
-            system->measures().append(curMeasure);
+            // append measure if did not already append measure
+            if (curMeasure->type() == Element::Type::MEASURE && isFirstMeasure)
+                  isFirstMeasure = false;
+            else
+                  system->measures().append(curMeasure);
 
             Element::Type nt;
             if (_showVBox)

--- a/mtest/libmscore/clef_courtesy/clef_courtesy03-ref.mscx
+++ b/mtest/libmscore/clef_courtesy/clef_courtesy03-ref.mscx
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <maxSystemDistance>20</maxSystemDistance>
+      <lyricsDistance>0</lyricsDistance>
+      <lyricsMinBottomDistance>0</lyricsMinBottomDistance>
+      <frameSystemDistance>0</frameSystemDistance>
+      <barWidth>0.2</barWidth>
+      <endBarWidth>0.4</endBarWidth>
+      <bracketDistance>0.4</bracketDistance>
+      <stemWidth>0.2</stemWidth>
+      <staffLineWidth>0.15</staffLineWidth>
+      <genCourtesyTimesig>0</genCourtesyTimesig>
+      <sectionPause>2</sectionPause>
+      <showHeader>1</showHeader>
+      <evenHeaderL>$p</evenHeaderL>
+      <evenHeaderR>$:workTitle:</evenHeaderR>
+      <oddHeaderL>$:workTitle:</oddHeaderL>
+      <oddHeaderR>$p</oddHeaderR>
+      <footerOddEven>0</footerOddEven>
+      <evenFooterL>$:copyright:</evenFooterL>
+      <evenFooterC>$:plate:</evenFooterC>
+      <evenFooterR>Version $:version:</evenFooterR>
+      <page-layout>
+        <page-height>1627.09</page-height>
+        <page-width>1133.86</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>85.0394</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>85.0394</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="-1" span="0"/>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>85</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="73"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Clef>
+          <concertClefType>G8va</concertClefType>
+          <transposingClefType>G8va</transposingClefType>
+          </Clef>
+        </Measure>
+      <Measure number="1">
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/clef_courtesy/clef_courtesy03.mscx
+++ b/mtest/libmscore/clef_courtesy/clef_courtesy03.mscx
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <maxSystemDistance>20</maxSystemDistance>
+      <lyricsDistance>0</lyricsDistance>
+      <lyricsMinBottomDistance>0</lyricsMinBottomDistance>
+      <frameSystemDistance>0</frameSystemDistance>
+      <barWidth>0.2</barWidth>
+      <endBarWidth>0.4</endBarWidth>
+      <bracketDistance>0.4</bracketDistance>
+      <stemWidth>0.2</stemWidth>
+      <staffLineWidth>0.15</staffLineWidth>
+      <genCourtesyTimesig>0</genCourtesyTimesig>
+      <sectionPause>2</sectionPause>
+      <showHeader>1</showHeader>
+      <evenHeaderL>$p</evenHeaderL>
+      <evenHeaderR>$:workTitle:</evenHeaderR>
+      <oddHeaderL>$:workTitle:</oddHeaderL>
+      <oddHeaderR>$p</oddHeaderR>
+      <footerOddEven>0</footerOddEven>
+      <evenFooterL>$:copyright:</evenFooterL>
+      <evenFooterC>$:plate:</evenFooterC>
+      <evenFooterR>Version $:version:</evenFooterR>
+      <page-layout>
+        <page-height>1627.09</page-height>
+        <page-width>1133.86</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>85.0394</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>85.0394</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <bracket type="-1" span="0"/>
+        </Staff>
+      <trackName>Flute</trackName>
+      <Instrument>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>85</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="73"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="1">
+        <Chord>
+          <durationType>whole</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/clef_courtesy/tst_clef_courtesy.cpp
+++ b/mtest/libmscore/clef_courtesy/tst_clef_courtesy.cpp
@@ -33,6 +33,7 @@ class TestClefCourtesy : public QObject, public MTest
       void initTestCase();
       void clef_courtesy01();
       void clef_courtesy02();
+      void clef_courtesy03();
       };
 
 //---------------------------------------------------------
@@ -154,6 +155,42 @@ void TestClefCourtesy::clef_courtesy02()
       QVERIFY2(clefCourt->bbox().width() == 0, "Courtesy clef in measure 3 is NOT hidden.");
 
       QVERIFY(saveCompareScore(score, "clef_courtesy02.mscx", DIR + "clef_courtesy02-ref.mscx"));
+      delete score;
+      }
+
+//---------------------------------------------------------
+//   clef_courtesy03
+//    tests issue #76006 "if insert clef to measure after single-measure system with section break, then should not display courtesy clef"
+//    adds a clef on meas 2, which occurs after a single-measure section
+//    the added clef should not be visible, since it is after a section break
+//---------------------------------------------------------
+
+void TestClefCourtesy::clef_courtesy03()
+      {
+      Score* score = readScore(DIR + "clef_courtesy03.mscx");
+      score->doLayout();
+
+      Measure* m1 = score->firstMeasure();
+      Measure* m2 = m1->nextMeasure();
+
+      // make a clef-drop object and drop it to the 2nd measure
+      Clef* clef = new Clef(score); // create a new element, as Measure::drop() will eventually delete it
+      clef->setClefType(ClefType::G1);
+      DropData dropData;
+      dropData.pos = m2->pagePos();
+      dropData.element = clef;
+      m2->drop(dropData);
+      score->doLayout();
+
+      // verify the not required courtesy clef element is on end of m1 but is not shown
+      Clef *clefCourt = nullptr;
+      Segment *seg = m1->findSegment(Segment::Type::Clef, m2->tick());
+      QVERIFY2(seg != nullptr, "No SegClef in measure 1.");
+      clefCourt = static_cast<Clef*>(seg->element(0));
+      QVERIFY2(clefCourt != nullptr, "No courtesy clef element in measure 1.");
+      QVERIFY2(clefCourt->bbox().width() == 0, "Courtesy clef in measure 1 is NOT hidden.");
+
+      QVERIFY(saveCompareScore(score, "clef_courtesy03.mscx", DIR + "clef_courtesy03-ref.mscx"));
       delete score;
       }
 

--- a/mtest/libmscore/clef_courtesy/updateReference
+++ b/mtest/libmscore/clef_courtesy/updateReference
@@ -2,5 +2,6 @@
 
 cp ../../../build.debug/mtest/libmscore/clef_courtesy/clef_courtesy01.mscx clef_courtesy01-ref.mscx
 cp ../../../build.debug/mtest/libmscore/clef_courtesy/clef_courtesy02.mscx clef_courtesy02-ref.mscx
+cp ../../../build.debug/mtest/libmscore/clef_courtesy/clef_courtesy03.mscx clef_courtesy03-ref.mscx
 
 


### PR DESCRIPTION
Previously, during Score::layoutSystem() the very first measure was not actually added to the system until after minWidth2() performed its calculation, resulting in Clef::layout() incorrectly determining that a courtesy clef should be added to all single-measure systems ending with a section break.  This is because teh showClef calculation in Clef::layout would evaluate (meas->system() && meas != meas->system()->lastMeasure()) to be true since meas->system()->lastMeasure() would be null at the time of executing minWidth2() for the first measure to be added to the system.

This fix first appends the initial measure of a system during Score::layoutSystem() before performing the minWidth2() calculation.  This ensures that Clef::layout() doesn't have an empty meas->system().

In order to accommodate the appending of the first measure earlier in the code, I first make sure to grab the state of system->measures().isEmpty() at the top of the loop, before possibly appending the first measure.  This ensures that will not break out of loop when performing calculation if (systemWasNotEmpty && (minWidth + ww > systemWidth)).

Also need to keep track of the value of isFirstMeasure until lower in the loop so can only append measure if did not already append measure