### PR TITLE
fix #78196 no courtesy clef if section ends on non-measure

### DIFF
--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -190,7 +190,7 @@ void Clef::layout()
                         // if courtesy clef: show if score has courtesy clefs on
                         || ( score()->styleB(StyleIdx::genCourtesyClef)
                               // AND measure is not at the end of a repeat or of a section
-                              && !( (meas->repeatFlags() & Repeat::END) || meas->sectionBreak() )
+                              && !( (meas->repeatFlags() & Repeat::END) || meas->isFinalMeasureOfSection() )
                               // AND this clef has courtesy clef turned on
                               && showCourtesy() );
                   bHide |= !showClef;

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2417,6 +2417,26 @@ bool Measure::slashStyle(int staffIdx) const
       }
 
 //---------------------------------------------------------
+//   isFinalMeasureOfSection
+//    returns true if this measure is final actual measure of a section
+//    takes into consideration fact that subsequent measures base objects may have section break before encountering next actual measure
+//---------------------------------------------------------
+
+bool Measure::isFinalMeasureOfSection() const
+      {
+      const MeasureBase* mb = static_cast<const MeasureBase*>(this);
+
+      do {
+            if (mb->sectionBreak())
+                  return true;
+
+            mb = mb->next();
+            } while (mb && !mb->isMeasure());   // loop until reach next actual measure or end of score
+
+      return false;
+      }
+
+//---------------------------------------------------------
 //   scanElements
 //---------------------------------------------------------
 

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -293,6 +293,7 @@ class Measure : public MeasureBase {
       bool isRepeatMeasure(Staff* staff);
       bool visible(int staffIdx) const;
       bool slashStyle(int staffIdx) const;
+      bool isFinalMeasureOfSection() const;
 
       bool breakMultiMeasureRest() const        { return _breakMultiMeasureRest | _breakMMRest; }
       bool breakMMRest() const                  { return _breakMMRest; }

--- a/mtest/libmscore/clef_courtesy/clef_courtesy_78196.mscx
+++ b/mtest/libmscore/clef_courtesy/clef_courtesy_78196.mscx
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <page-layout>
+        <page-height>1683.36</page-height>
+        <page-width>1190.88</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Title</metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="2">
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        <StaffText>
+          <text>should not display courtesy clef at end of this measure:</text>
+          </StaffText>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        <Clef>
+          <concertClefType>C3</concertClefType>
+          <transposingClefType>C3</transposingClefType>
+          </Clef>
+        </Measure>
+      <Measure number="1">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="2">
+        <StaffText>
+          <text>should not display courtesy clef at end of this measure:</text>
+          </StaffText>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        <Clef>
+          <concertClefType>F</concertClefType>
+          <transposingClefType>F</transposingClefType>
+          </Clef>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        <Text>
+          <style>Frame</style>
+          <text>(vertical frame with section break)</text>
+          </Text>
+        </TBox>
+      <Measure number="1">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <Measure number="2">
+        <StaffText>
+          <text>should not display courtesy clef at end of this measure:</text>
+          </StaffText>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        <Clef>
+          <concertClefType>C3</concertClefType>
+          <transposingClefType>C3</transposingClefType>
+          </Clef>
+        </Measure>
+      <HBox>
+        <width>26.262</width>
+        <Text>
+          <style>Frame</style>
+          <text>h_frame w/ section break</text>
+          </Text>
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        </HBox>
+      <Measure number="1">
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/clef_courtesy/tst_clef_courtesy.cpp
+++ b/mtest/libmscore/clef_courtesy/tst_clef_courtesy.cpp
@@ -33,6 +33,7 @@ class TestClefCourtesy : public QObject, public MTest
       void initTestCase();
       void clef_courtesy01();
       void clef_courtesy02();
+      void clef_courtesy_78196();
       };
 
 //---------------------------------------------------------
@@ -155,6 +156,51 @@ void TestClefCourtesy::clef_courtesy02()
 
       QVERIFY(saveCompareScore(score, "clef_courtesy02.mscx", DIR + "clef_courtesy02-ref.mscx"));
       delete score;
+      }
+
+//---------------------------------------------------------
+//   clef_courtesy_78196
+//    input score has section breaks on non-measure MeasureBase objects.
+//    should not display courtesy clefs at the end of final measure of each section (meas 2, 4, & 6), even if section break occurs on subsequent non-measure frame.
+//---------------------------------------------------------
+
+void TestClefCourtesy::clef_courtesy_78196()
+      {
+      Score* score = readScore(DIR + "clef_courtesy_78196.mscx");
+      score->doLayout();
+
+      Measure* m1 = score->firstMeasure();
+      Measure* m2 = m1->nextMeasure();
+      Measure* m3 = m2->nextMeasure();
+      Measure* m4 = m3->nextMeasure();
+      Measure* m5 = m4->nextMeasure();
+      Measure* m6 = m5->nextMeasure();
+      Measure* m7 = m6->nextMeasure();
+
+      // check both clef elements are there, but none is shown
+      Clef*    clefCourt = nullptr;
+      Segment* seg = nullptr;
+
+      // verify clef exists in segment of final tick of m2, but that it is not visible
+      seg = m2->findSegment(Segment::Type::Clef, m3->tick());
+      QVERIFY2(seg != nullptr, "No SegClef at end of measure 2.");
+      clefCourt = static_cast<Clef*>(seg->element(0));
+      QVERIFY2(clefCourt != nullptr, "No courtesy clef at end of measure 2.");
+      QVERIFY2(clefCourt->bbox().width() == 0, "Courtesy clef at end of measure 2 is NOT hidden.");
+
+      // verify clef exists in segment of final tick of m4, but that it is not visible
+      seg = m4->findSegment(Segment::Type::Clef, m5->tick());
+      QVERIFY2(seg != nullptr, "No SegClef at end of measure 4.");
+      clefCourt = static_cast<Clef*>(seg->element(0));
+      QVERIFY2(clefCourt != nullptr, "No courtesy clef at end of measure 4.");
+      QVERIFY2(clefCourt->bbox().width() == 0, "Courtesy clef at end of measure 4 is NOT hidden.");
+
+      // verify clef exists in segment of final tick of m6, but that it is not visible
+      seg = m6->findSegment(Segment::Type::Clef, m7->tick());
+      QVERIFY2(seg != nullptr, "No SegClef at end of measure 6.");
+      clefCourt = static_cast<Clef*>(seg->element(0));
+      QVERIFY2(clefCourt != nullptr, "No courtesy clef at end of measure 6.");
+      QVERIFY2(clefCourt->bbox().width() == 0, "Courtesy clef at end of measure 6 is NOT hidden.");
       }
 
 QTEST_MAIN(TestClefCourtesy)


### PR DESCRIPTION
if section break occurs on subsequent non-measure MeasureBase frames, then the final actual Measure of that section should not get courtesy clef.