### PR TITLE
fix #78231: crash pasting chord symbol onto fret diagram

### DIFF
--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -502,9 +502,9 @@ Element* FretDiagram::drop(const DropData& data)
       {
       Element* e = data.element;
       if (e->type() == Element::Type::HARMONY) {
-            // TODO: make undoable
             Harmony* h = static_cast<Harmony*>(e);
-            h->setParent(this);
+            h->setParent(parent());
+            h->setTrack((track() / VOICES) * VOICES);
             score()->undoAddElement(h);
             }
       else {


### PR DESCRIPTION
I guess the previous code here was a holdover from when chord symbols really could be attached to frtet diagrams, but now they are independent, attached to segments.