### PR TITLE
fix #78216 no courtesy key or time sig if section ends on non-measure

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2833,7 +2833,7 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
 
       bool needRelayout = false;
 
-      foreach (System* system, sl) {
+      for (System* system : sl) {
             // set system initial bar line type here, as in System::layout...() methods
             // it is either too early (in System::layout() measures are not added to the system yet)
             // or too late (in System::layout2(), horizontal spacing has already been done
@@ -2856,12 +2856,13 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
 
             if (m && nm) {
                   int tick = m->tick() + m->ticks();
+                  bool isFinalMeasureOfSection = m->isFinalMeasureOfSection();
 
                   // locate a time sig. in the next measure and, if found,
                   // check if it has cout. sig. turned off
                   TimeSig* ts;
                   Segment* tss         = nm->findSegment(Segment::Type::TimeSig, tick);
-                  bool showCourtesySig = tss && styleB(StyleIdx::genCourtesyTimesig) && !(m->sectionBreak() && _layoutMode != LayoutMode::FLOAT);
+                  bool showCourtesySig = tss && styleB(StyleIdx::genCourtesyTimesig) && !(isFinalMeasureOfSection && _layoutMode != LayoutMode::FLOAT);
                   if (showCourtesySig) {
                         ts = static_cast<TimeSig*>(tss->element(0));
                         if (ts && !ts->showCourtesySig())
@@ -2900,7 +2901,7 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
                   for (int staffIdx = 0; staffIdx < n; ++staffIdx) {
                         int track = staffIdx * VOICES;
                         Staff* staff = _staves[staffIdx];
-                        showCourtesySig = styleB(StyleIdx::genCourtesyKeysig) && !(m->sectionBreak() && _layoutMode != LayoutMode::FLOAT);
+                        showCourtesySig = styleB(StyleIdx::genCourtesyKeysig) && !(isFinalMeasureOfSection && _layoutMode != LayoutMode::FLOAT);
 
                         KeySigEvent key1 = staff->keySigEvent(tick - 1);
                         KeySigEvent key2 = staff->keySigEvent(tick);

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2417,6 +2417,26 @@ bool Measure::slashStyle(int staffIdx) const
       }
 
 //---------------------------------------------------------
+//   isFinalMeasureOfSection
+//    returns true if this measure is final actual measure of a section
+//    takes into consideration fact that subsequent measures base objects may have section break before encountering next actual measure
+//---------------------------------------------------------
+
+bool Measure::isFinalMeasureOfSection() const
+      {
+      const MeasureBase* mb = static_cast<const MeasureBase*>(this);
+
+      do {
+            if (mb->sectionBreak())
+                  return true;
+
+            mb = mb->next();
+            } while (mb && !mb->isMeasure());   // loop until reach next actual measure or end of score
+
+      return false;
+      }
+
+//---------------------------------------------------------
 //   scanElements
 //---------------------------------------------------------
 

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -293,6 +293,7 @@ class Measure : public MeasureBase {
       bool isRepeatMeasure(Staff* staff);
       bool visible(int staffIdx) const;
       bool slashStyle(int staffIdx) const;
+      bool isFinalMeasureOfSection() const;
 
       bool breakMultiMeasureRest() const        { return _breakMultiMeasureRest | _breakMMRest; }
       bool breakMMRest() const                  { return _breakMMRest; }

--- a/mtest/libmscore/keysig/keysig_78216.mscx
+++ b/mtest/libmscore/keysig/keysig_78216.mscx
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <page-layout>
+        <page-height>1584</page-height>
+        <page-width>1224</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Title</metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <HBox>
+        <width>5</width>
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        </HBox>
+      <Measure number="1">
+        <KeySig>
+          <accidental>1</accidental>
+          </KeySig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        <Text>
+          <style>Frame</style>
+          <text></text>
+          </Text>
+        </TBox>
+      <Measure number="1">
+        <KeySig>
+          <accidental>2</accidental>
+          </KeySig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text></text>
+          </Text>
+        </TBox>
+      <HBox>
+        <width>5</width>
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        </HBox>
+      <Measure number="1">
+        <KeySig>
+          <accidental>3</accidental>
+          </KeySig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/keysig/tst_keysig.cpp
+++ b/mtest/libmscore/keysig/tst_keysig.cpp
@@ -34,6 +34,7 @@ class TestKeySig : public QObject, public MTest
       void initTestCase();
       void keysig();
       void concertPitch();
+      void keysig_78216();
       };
 
 //---------------------------------------------------------
@@ -107,6 +108,27 @@ void TestKeySig::keysig()
       QVERIFY(saveCompareScore(score, writeFile6, reference6));
 
       delete score;
+      }
+
+//---------------------------------------------------------
+//   keysig_78216
+//    input score has section breaks on non-measure MeasureBase objects.
+//    should not display courtesy keysig at the end of final measure of each section (meas 1, 2, & 3), even if section break occurs on subsequent non-measure frame.
+//---------------------------------------------------------
+
+void TestKeySig::keysig_78216()
+      {
+      Score* score = readScore(DIR + "keysig_78216.mscx");
+      score->doLayout();
+
+      Measure* m1 = score->firstMeasure();
+      Measure* m2 = m1->nextMeasure();
+      Measure* m3 = m2->nextMeasure();
+
+      // verify no keysig exists in segment of final tick of m1, m2, m3
+      QVERIFY2(m1->findSegment(Segment::Type::KeySig, m1->endTick()) == nullptr, "Should be no keysig at end of measure 1.");
+      QVERIFY2(m2->findSegment(Segment::Type::KeySig, m2->endTick()) == nullptr, "Should be no keysig at end of measure 2.");
+      QVERIFY2(m3->findSegment(Segment::Type::KeySig, m3->endTick()) == nullptr, "Should be no keysig at end of measure 3.");
       }
 
 void TestKeySig::concertPitch()

--- a/mtest/libmscore/timesig/timesig_78216.mscx
+++ b/mtest/libmscore/timesig/timesig_78216.mscx
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <page-layout>
+        <page-height>1584</page-height>
+        <page-width>1224</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Title</metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="4" n="4"/>
+          </Rest>
+        </Measure>
+      <HBox>
+        <width>5</width>
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        </HBox>
+      <Measure number="1">
+        <TimeSig>
+          <sigN>5</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="5" n="4"/>
+          </Rest>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        <Text>
+          <style>Frame</style>
+          <text></text>
+          </Text>
+        </TBox>
+      <Measure number="1">
+        <TimeSig>
+          <sigN>6</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="6" n="4"/>
+          </Rest>
+        </Measure>
+      <TBox>
+        <height>1</height>
+        <Text>
+          <style>Frame</style>
+          <text></text>
+          </Text>
+        </TBox>
+      <HBox>
+        <width>5</width>
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        </HBox>
+      <Measure number="1">
+        <TimeSig>
+          <sigN>3</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Rest>
+          <durationType>measure</durationType>
+          <duration z="3" n="4"/>
+          </Rest>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/timesig/tst_timesig.cpp
+++ b/mtest/libmscore/timesig/tst_timesig.cpp
@@ -35,6 +35,7 @@ class TestTimesig : public QObject, public MTest
       void timesig02();
       void timesig03();
       void timesig04();
+      void timesig_78216();
       };
 
 //---------------------------------------------------------
@@ -124,6 +125,28 @@ void TestTimesig::timesig04()
 
       QVERIFY(saveCompareScore(score, "timesig-04.mscx", DIR + "timesig-04-ref.mscx"));
       delete score;
+      }
+
+
+//---------------------------------------------------------
+//   timesig_78216
+//    input score has section breaks on non-measure MeasureBase objects.
+//    should not display courtesy timesig at the end of final measure of each section (meas 1, 2, & 3), even if section break occurs on subsequent non-measure frame.
+//---------------------------------------------------------
+
+void TestTimesig::timesig_78216()
+      {
+      Score* score = readScore(DIR + "timesig_78216.mscx");
+      score->doLayout();
+
+      Measure* m1 = score->firstMeasure();
+      Measure* m2 = m1->nextMeasure();
+      Measure* m3 = m2->nextMeasure();
+
+      // verify no timesig exists in segment of final tick of m1, m2, m3
+      QVERIFY2(m1->findSegment(Segment::Type::TimeSig, m1->endTick()) == nullptr, "Should be no timesig at end of measure 1.");
+      QVERIFY2(m2->findSegment(Segment::Type::TimeSig, m2->endTick()) == nullptr, "Should be no timesig at end of measure 2.");
+      QVERIFY2(m3->findSegment(Segment::Type::TimeSig, m3->endTick()) == nullptr, "Should be no timesig at end of measure 3.");
       }
 
 QTEST_MAIN(TestTimesig)


### PR DESCRIPTION
If a section break occurs on a non-measure MeasureBase object such as a vertical or horizontal frame, then the courtesy key or time signature should still not be displayed in the final actual measure of the section.

Note, that this PR and #2223 share the same added function Measure::isFinalMeasureOfSection() so there shouldn't be any merge conflicts if you accept both of these PRs.