### PR TITLE
fix #9352: instrument change transposition

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -900,7 +900,7 @@ Element* ChordRest::drop(const DropData& data)
                   {
                   // transpose
                   Harmony* harmony = static_cast<Harmony*>(e);
-                  Interval interval = staff()->part()->instrument()->transpose();
+                  Interval interval = staff()->part()->instrument(tick())->transpose();
                   if (!score()->styleB(StyleIdx::concertPitch) && !interval.isZero()) {
                         interval.flip();
                         int rootTpc = transposeTpc(harmony->rootTpc(), interval, true);

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -421,7 +421,7 @@ void Score::cmdAddInterval(int val, const QList<Note*>& nl)
                   npitch        = line2pitch(line, clef, key);
 
                   int ntpc   = pitch2tpc(npitch, key, Prefer::NEAREST);
-                  Interval v = on->part()->instrument()->transpose();
+                  Interval v = on->part()->instrument(tick)->transpose();
                   if (v.isZero())
                         ntpc1 = ntpc2 = ntpc;
                   else {

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1020,7 +1020,7 @@ NoteVal Score::noteValForPosition(Position pos, bool &error)
                   else {
                         nval.pitch += instr->transpose().chromatic;
                         nval.tpc2 = step2tpc(step % 7, acci);
-                        Interval v = st->part()->instrument()->transpose();
+                        Interval v = st->part()->instrument(tick)->transpose();
                         if (v.isZero())
                               nval.tpc1 = nval.tpc2;
                         else

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -199,7 +199,9 @@ void Harmony::write(Xml& xml) const
             int rRootTpc = _rootTpc;
             int rBaseTpc = _baseTpc;
             if (staff()) {
-                  const Interval& interval = part()->instrument()->transpose();
+                  Segment* segment = static_cast<Segment*>(parent());
+                  int tick = segment ? segment->tick() : -1;
+                  const Interval& interval = part()->instrument(tick)->transpose();
                   if (xml.clipboardmode && !score()->styleB(StyleIdx::concertPitch) && interval.chromatic) {
                         rRootTpc = transposeTpc(_rootTpc, interval, true);
                         rBaseTpc = transposeTpc(_baseTpc, interval, true);
@@ -743,7 +745,9 @@ void Harmony::endEdit()
                   // we may now need to change the TPC's and the text, and re-render
                   if (score()->styleB(StyleIdx::concertPitch) != h->score()->styleB(StyleIdx::concertPitch)) {
                         Part* partDest = h->part();
-                        Interval interval = partDest->instrument()->transpose();
+                        Segment* segment = static_cast<Segment*>(parent());
+                        int tick = segment ? segment->tick() : -1;
+                        Interval interval = partDest->instrument(tick)->transpose();
                         if (!interval.isZero()) {
                               if (!h->score()->styleB(StyleIdx::concertPitch))
                                     interval.flip();

--- a/libmscore/instrchange.cpp
+++ b/libmscore/instrchange.cpp
@@ -58,6 +58,7 @@ InstrumentChange::~InstrumentChange()
 
 void InstrumentChange::setInstrument(const Instrument& i)
       {
+      //*_instrument = i;
       delete _instrument;
       _instrument = new Instrument(i);
       }
@@ -86,6 +87,17 @@ void InstrumentChange::read(XmlReader& e)
                   _instrument->read(e);
             else if (!Text::readProperties(e))
                   e.unknown();
+            }
+      if (score()->mscVersion() <= 206) {
+            // previous versions did not honor transposition of instrument change
+            // except in ways that it should not have
+            // notes entered before the instrument change was added would not be altered,
+            // so original transposition remained in effect
+            // notes added afterwards would be transposed by both intervals, resulting in tpc corruption
+            // here we set the instrument change to inherit the staff transposition to emulate previous versions
+            // in Note::read(), we attempt to fix the tpc corruption
+            Interval v = staff() ? staff()->part()->instrument()->transpose() : 0;
+            _instrument->setTranspose(v);
             }
       }
 

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -304,9 +304,10 @@ int Note::tpc1default(int p) const
       {
       Key key = Key::C;
       if (staff() && chord()) {
-            key = staff()->key(chord()->tick());
+            int tick = chord()->tick();
+            key = staff()->key(tick);
             if (!concertPitch()) {
-                  Interval interval = part()->instrument()->transpose();
+                  Interval interval = part()->instrument(tick)->transpose();
                   if (!interval.isZero()) {
                         interval.flip();
                         key = transposeKey(key, interval);
@@ -324,9 +325,10 @@ int Note::tpc2default(int p) const
       {
       Key key = Key::C;
       if (staff() && chord()) {
-            key = staff()->key(chord()->tick());
+            int tick = chord()->tick();
+            key = staff()->key(tick);
             if (concertPitch()) {
-                  Interval interval = part()->instrument()->transpose();
+                  Interval interval = part()->instrument(tick)->transpose();
                   if (!interval.isZero())
                         key = transposeKey(key, interval);
                   }
@@ -341,7 +343,8 @@ int Note::tpc2default(int p) const
 void Note::setTpcFromPitch()
       {
       // works best if note is already added to score, otherwise we can't determine transposition or key
-      Interval v = staff() ? part()->instrument()->transpose() : Interval();
+      int tick = chord() ? chord()->tick() : -1;
+      Interval v = staff() ? part()->instrument(tick)->transpose() : Interval();
       Key key = (staff() && chord()) ? staff()->key(chord()->tick()) : Key::C;
       // convert key to concert pitch
       if (!concertPitch() && !v.isZero())
@@ -416,7 +419,8 @@ QString Note::tpcUserName(bool explicitAccidental)
 
 int Note::transposeTpc(int tpc)
       {
-      Interval v = part()->instrument()->transpose();
+      int tick = chord() ? chord()->tick() : -1;
+      Interval v = part()->instrument(tick)->transpose();
       if (v.isZero())
             return tpc;
       if (concertPitch()) {
@@ -748,7 +752,7 @@ void Note::draw(QPainter* painter) const
             //
             if (chord() && chord()->segment() && staff() && !selected()
                && !score()->printing() && MScore::warnPitchRange) {
-                  const Instrument* in = part()->instrument();
+                  const Instrument* in = part()->instrument(chord()->tick());
                   int i = ppitch();
                   if (i < in->minPitchP() || i > in->maxPitchP())
                         painter->setPen(Qt::red);
@@ -1159,7 +1163,8 @@ void Note::read(XmlReader& e)
                   _tpc[1] = tpc;
             }
       if (!(tpcIsValid(_tpc[0]) && tpcIsValid(_tpc[1]))) {
-            Interval v = staff() ? part()->instrument()->transpose() : Interval();
+            int tick = chord() ? chord()->tick() : -1;
+            Interval v = staff() ? part()->instrument(tick)->transpose() : Interval();
             if (tpcIsValid(_tpc[0])) {
                   v.flip();
                   if (v.isZero())
@@ -1174,6 +1179,35 @@ void Note::read(XmlReader& e)
                         _tpc[0] = Ms::transposeTpc(_tpc[1], v, true);
                   }
             }
+      // check consistency of pitch, tpc1, tpc2, and transposition
+      // see note in InstrumentChange::read() about a known case of tpc corruption produced in 2.0.x
+      // but since there are other causes of tpc corruption (eg, https://musescore.org/en/node/74746)
+      // including perhaps some we don't know about yet,
+      // we will attempt to fix some problems here regardless of version
+      if (!e.pasteMode() && !MScore::testMode) {
+            int tpc1Pitch = (tpc2pitch(_tpc[0]) + 12) % 12;
+            int tpc2Pitch = (tpc2pitch(_tpc[1]) + 12) % 12;
+            int concertPitch = _pitch % 12;
+            if (tpc1Pitch != concertPitch) {
+                  qDebug("bad tpc1 - concertPitch = %d, tpc1 = %d", concertPitch, tpc1Pitch);
+                  _pitch += tpc1Pitch - concertPitch;
+                  }
+            if (staff()) {
+                  Interval v = staff()->part()->instrument(e.tick())->transpose();
+                  int transposedPitch = (_pitch - v.chromatic) % 12;
+                  if (tpc2Pitch != transposedPitch) {
+                        qDebug("bad tpc2 - transposedPitch = %d, tpc2 = %d", transposedPitch, tpc2Pitch);
+                        // just in case the staff transposition info is not reliable here,
+                        // do not attempt to correct tpc
+                        // except for older scores where we know there are tpc problems
+                        if (score()->mscVersion() <= 206) {
+                              v.flip();
+                              _tpc[1] = Ms::transposeTpc(_tpc[0], v, true);
+                              }
+                        }
+                  }
+            }
+      return;
       }
 
 //---------------------------------------------------------
@@ -1201,7 +1235,8 @@ QRectF Note::drag(EditData* data)
 
 int Note::transposition() const
       {
-      return staff() ? part()->instrument()->transpose().chromatic : 0;
+      int tick = chord() ? chord()->tick() : -1;
+      return staff() ? part()->instrument(tick)->transpose().chromatic : 0;
       }
 
 //---------------------------------------------------------
@@ -1251,7 +1286,7 @@ void Note::endDrag()
             // determine new pitch of dragged note
             int nPitch = line2pitch(nLine, clef, key);
             if (!concertPitch()) {
-                  Interval interval = staff->part()->instrument()->transpose();
+                  Interval interval = staff->part()->instrument(tick)->transpose();
                   nPitch += interval.chromatic;
                   }
             int tpc1 = pitch2tpc(nPitch, key, Prefer::NEAREST);
@@ -2130,10 +2165,10 @@ void Note::setNval(const NoteVal& nval, int tick)
       _tpc[0] = nval.tpc1;
       _tpc[1] = nval.tpc2;
 
-      Interval v = part()->instrument()->transpose();
+      if (tick == -1 && chord())
+            tick = chord()->tick();
+      Interval v = part()->instrument(tick)->transpose();
       if (nval.tpc1 == Tpc::TPC_INVALID) {
-            if (tick == -1)
-                  tick = chord()->tick();
             Key key = staff()->key(tick);
             if (!concertPitch() && !v.isZero())
                   key = transposeKey(key, v);

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -38,7 +38,7 @@ namespace Ms {
 //   transposeChord
 //---------------------------------------------------------
 
-static void transposeChord(Chord* c, Interval srcTranspose)
+static void transposeChord(Chord* c, Interval srcTranspose, int tick)
       {
       // set note track
       // check if staffMove moves a note to a
@@ -49,7 +49,7 @@ static void transposeChord(Chord* c, Interval srcTranspose)
       if (nn < 0 || nn >= c->score()->nstaves())
             c->setStaffMove(0);
       Part* part = c->part();
-      Interval dstTranspose = part->instrument()->transpose();
+      Interval dstTranspose = part->instrument(tick)->transpose();
 
       if (srcTranspose != dstTranspose) {
             if (!dstTranspose.isZero()) {
@@ -195,7 +195,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                                           for (int i = 0; i < graceNotes.size(); ++i) {
                                                 Chord* gc = graceNotes[i];
                                                 gc->setGraceIndex(i);
-                                                transposeChord(gc, e.transpose());
+                                                transposeChord(gc, e.transpose(), tick);
                                                 chord->add(gc);
                                                 }
                                           graceNotes.clear();
@@ -294,7 +294,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                               harmony->setTrack(e.track());
                               // transpose
                               Part* partDest = staff(e.track() / VOICES)->part();
-                              Interval interval = partDest->instrument()->transpose();
+                              Interval interval = partDest->instrument(e.tick())->transpose();
                               if (!styleB(StyleIdx::concertPitch) && !interval.isZero()) {
                                     interval.flip();
                                     int rootTpc = transposeTpc(harmony->rootTpc(), interval, true);
@@ -446,7 +446,7 @@ void Score::pasteChordRest(ChordRest* cr, int tick, const Interval& srcTranspose
       {
 // qDebug("pasteChordRest %s at %d, len %d/%d", cr->name(), tick, cr->duration().numerator(), cr->duration().denominator() );
       if (cr->type() == Element::Type::CHORD)
-            transposeChord(static_cast<Chord*>(cr), srcTranspose);
+            transposeChord(static_cast<Chord*>(cr), srcTranspose, tick);
 
       Measure* measure = tick2measure(tick);
       if (!measure)
@@ -636,7 +636,7 @@ void Score::pasteSymbols(XmlReader& e, ChordRest* dst)
                               el->setTrack(trackZeroVoice(destTrack));
                               // transpose
                               Part* partDest = staff(track2staff(destTrack))->part();
-                              Interval interval = partDest->instrument()->transpose();
+                              Interval interval = partDest->instrument(destTick)->transpose();
                               if (!styleB(StyleIdx::concertPitch) && !interval.isZero()) {
                                     interval.flip();
                                     int rootTpc = transposeTpc(el->rootTpc(), interval, true);

--- a/libmscore/pitchspelling.cpp
+++ b/libmscore/pitchspelling.cpp
@@ -746,8 +746,9 @@ void spell(QList<Event>& notes, int key)
 void changeAllTpcs(Note* n, int tpc1)
       {
       Interval v;
+      int tick = n && n->chord() ? n->chord()->tick() : -1;
       if (n && n->part() && n->part()->instrument()) {
-            v = n->part()->instrument()->transpose();
+            v = n->part()->instrument(tick)->transpose();
             v.flip();
             }
       int tpc2 = Ms::transposeTpc(tpc1, v, true);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1441,7 +1441,16 @@ void Score::addElement(Element* element)
 
             case Element::Type::INSTRUMENT_CHANGE: {
                   InstrumentChange* ic = static_cast<InstrumentChange*>(element);
-                  ic->part()->setInstrument(ic->instrument(), ic->segment()->tick());
+                  int tickStart = ic->segment()->tick();
+                  auto i = ic->part()->instruments()->upper_bound(tickStart);
+                  int tickEnd;
+                  if (i == ic->part()->instruments()->end())
+                        tickEnd = -1;
+                  else
+                        tickEnd = i->first;
+                  Interval oldV = ic->part()->instrument(tickStart)->transpose();
+                  ic->part()->setInstrument(ic->instrument(), tickStart);
+                  transpositionChanged(ic->part(), oldV, tickStart, tickEnd);
                   rebuildMidiMapping();
                   _instrumentsChanged = true;
                   }
@@ -1591,7 +1600,16 @@ void Score::removeElement(Element* element)
                   break;
             case Element::Type::INSTRUMENT_CHANGE: {
                   InstrumentChange* ic = static_cast<InstrumentChange*>(element);
-                  ic->part()->removeInstrument(ic->segment()->tick());
+                  int tickStart = ic->segment()->tick();
+                  auto i = ic->part()->instruments()->upper_bound(tickStart);
+                  int tickEnd;
+                  if (i == ic->part()->instruments()->end())
+                        tickEnd = -1;
+                  else
+                        tickEnd = i->first;
+                  Interval oldV = ic->part()->instrument(tickStart)->transpose();
+                  ic->part()->removeInstrument(tickStart);
+                  transpositionChanged(ic->part(), oldV, tickStart, tickEnd);
                   rebuildMidiMapping();
                   _instrumentsChanged = true;
                   }
@@ -2476,7 +2494,7 @@ void Score::adjustKeySigs(int sidx, int eidx, KeyList km)
                         continue;
                   KeySigEvent oKey = i->second;
                   KeySigEvent nKey = oKey;
-                  int diff = -staff->part()->instrument()->transpose().chromatic;
+                  int diff = -staff->part()->instrument(tick)->transpose().chromatic;
                   if (diff != 0 && !styleB(StyleIdx::concertPitch) && !oKey.custom() && !oKey.isAtonal())
                         nKey.setKey(transposeKey(nKey.key(), diff));
                   staff->setKey(tick, nKey);
@@ -2584,8 +2602,9 @@ void Score::cmdConcertPitchChanged(bool flag, bool /*useDoubleSharpsFlats*/)
       for (Staff* staff : _staves) {
             if (staff->staffType()->group() == StaffGroup::PERCUSSION)
                   continue;
+            // if this staff has no transposition, and no instrument changes, we can skip it
             Interval interval = staff->part()->instrument()->transpose();
-            if (interval.isZero())
+            if (interval.isZero() && staff->part()->instruments()->size() == 1)
                   continue;
             if (!flag)
                   interval.flip();
@@ -2594,9 +2613,12 @@ void Score::cmdConcertPitchChanged(bool flag, bool /*useDoubleSharpsFlats*/)
             int startTrack = staffIdx * VOICES;
             int endTrack   = startTrack + VOICES;
 
-            transposeKeys(staffIdx, staffIdx+1, 0, lastSegment()->tick(), interval);
+            transposeKeys(staffIdx, staffIdx + 1, 0, lastSegment()->tick(), interval, true, !flag);
 
             for (Segment* segment = firstSegment(Segment::Type::ChordRest); segment; segment = segment->next1(Segment::Type::ChordRest)) {
+                  interval = staff->part()->instrument(segment->tick())->transpose();
+                  if (!flag)
+                        interval.flip();
                   for (Element* e : segment->annotations()) {
                         if ((e->type() != Element::Type::HARMONY) || (e->track() < startTrack) || (e->track() >= endTrack))
                               continue;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -526,7 +526,7 @@ class Score : public QObject {
       void addRemoveBreaks(int interval, bool lock);
 
       bool transpose(Note* n, Interval, bool useSharpsFlats);
-      void transposeKeys(int staffStart, int staffEnd, int tickStart, int tickEnd, const Interval&);
+      void transposeKeys(int staffStart, int staffEnd, int tickStart, int tickEnd, const Interval&, bool useInstrument = false, bool flip = false);
       bool transpose(TransposeMode mode, TransposeDirection, Key transposeKey, int transposeInterval,
          bool trKeys, bool transposeChordNames, bool useDoubleSharpsFlats);
 
@@ -1051,7 +1051,7 @@ class Score : public QObject {
       void setNoteHeadWidth( qreal n) { _noteHeadWidth = n; }
 
       QList<int> uniqueStaves() const;
-      void transpositionChanged(Part*, Interval);
+      void transpositionChanged(Part*, Interval, int tickStart = 0, int tickEnd = -1);
 
       void moveUp(ChordRest*);
       void moveDown(ChordRest*);

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -460,7 +460,7 @@ void Staff::write(Xml& xml) const
 
       // for copy/paste we need to know the actual transposition
       if (xml.clipboardmode) {
-            Interval v = part()->instrument()->transpose();
+            Interval v = part()->instrument()->transpose(); // TODO: tick?
             if (v.diatonic)
                   xml.tag("transposeDiatonic", v.diatonic);
             if (v.chromatic)

--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -157,7 +157,7 @@ void StringData::fretChords(Chord * chord) const
       int   count = 0;
       // store staff pitch offset at this tick, to speed up actual note pitch calculations
       // (ottavas not implemented yet)
-      int transp = chord->staff() ? chord->part()->instrument()->transpose().chromatic : 0;
+      int transp = chord->staff() ? chord->part()->instrument()->transpose().chromatic : 0;     // TODO: tick?
       int pitchOffset = /*chord->staff()->pitchOffset(chord->segment()->tick())*/ - transp;
       // if chord parent is not a segment, the chord is special (usually a grace chord):
       // fret it by itself, ignoring the segment
@@ -257,7 +257,7 @@ void StringData::fretChords(Chord * chord) const
 
 int StringData::pitchOffsetAt(Staff* staff, int /*tick*/)
       {
-      int transp = staff ? staff->part()->instrument()->transpose().chromatic : 0;
+      int transp = staff ? staff->part()->instrument()->transpose().chromatic : 0;  // TODO: tick?
       return (/*staff->pitchOffset(tick)*/ - transp);
       }
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -569,6 +569,8 @@ void System::setInstrumentNames(bool longName)
             return;
             }
 
+      // TODO: ml is normally empty here, so we are unable to retrieve tick
+      // thus, staff name does not reflect current instrument
       int tick = ml.isEmpty() ? 0 : ml.front()->tick();
       for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
             SysStaff* staff = _staves[staffIdx];

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -480,8 +480,10 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
 //    key -   -7(Cb) - +7(C#)
 //---------------------------------------------------------
 
-void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickEnd, const Interval& interval)
+void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickEnd, const Interval& interval, bool useInstrument, bool flip)
       {
+      Interval firstInterval = interval;
+      Interval segmentInterval = interval;
       for (int staffIdx = staffStart; staffIdx < staffEnd; ++staffIdx) {
             Staff* st = staff(staffIdx);
             if (st->staffType()->group() == StaffGroup::PERCUSSION)
@@ -491,8 +493,13 @@ void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickE
             for (Segment* s = firstSegment(Segment::Type::KeySig); s; s = s->next1(Segment::Type::KeySig)) {
                   if (s->tick() < tickStart)
                         continue;
-                  if (s->tick() >= tickEnd)
+                  if (tickEnd != -1 && s->tick() >= tickEnd)
                         break;
+                  if (useInstrument) {
+                        segmentInterval = st->part()->instrument(s->tick())->transpose();
+                        if (flip)
+                              segmentInterval.flip();
+                        }
                   KeySig* ks = static_cast<KeySig*>(s->element(staffIdx * VOICES));
                   if (!ks)
                         continue;
@@ -502,7 +509,7 @@ void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickE
                         createKey = false;
                   if (!ks->isCustom() && !ks->isAtonal()) {
                         Key key  = st->key(s->tick());
-                        Key nKey = transposeKey(key, interval);
+                        Key nKey = transposeKey(key, segmentInterval);
                         // remove initial C major key signatures
                         if (nKey == Key::C && s->tick() == 0) {
                               undo(new RemoveElement(ks));
@@ -518,7 +525,7 @@ void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickE
                   }
             if (createKey && firstMeasure()) {
                   Key key  = Key::C;
-                  Key nKey = transposeKey(key, interval);
+                  Key nKey = transposeKey(key, firstInterval);
                   KeySigEvent ke;
                   ke.setKey(nKey);
                   KeySig* ks = new KeySig(this);
@@ -643,20 +650,24 @@ void Note::transposeDiatonic(int interval, bool keepAlterations, bool useDoubleA
 //   transpositionChanged
 //---------------------------------------------------------
 
-void Score::transpositionChanged(Part* part, Interval oldV)
+void Score::transpositionChanged(Part* part, Interval oldV, int tickStart, int tickEnd)
       {
-      Interval v = part->instrument()->transpose();
+      Interval v = part->instrument(tickStart)->transpose();
       v.flip();
 
       // transpose keys first
       if (!styleB(StyleIdx::concertPitch)) {
             Interval diffV(oldV.chromatic + v.chromatic);
-            int tickEnd = lastSegment() ? lastSegment()->tick() : 0;
-            transposeKeys(part->startTrack() / VOICES, part->endTrack() / VOICES, 0, tickEnd, diffV);
+            //int tickEnd = lastSegment() ? lastSegment()->tick() : 0;
+            transposeKeys(part->startTrack() / VOICES, part->endTrack() / VOICES, tickStart, tickEnd, diffV);
             }
 
       // now transpose notes
       for (Segment* s = firstSegment(Segment::Type::ChordRest); s; s = s->next1(Segment::Type::ChordRest)) {
+            if (s->tick() < tickStart)
+                  continue;
+            if (tickEnd != -1 && s->tick() >= tickEnd)
+                  break;
             for (Staff* st : *part->staves()) {
                   if (st->staffType()->group() == StaffGroup::PERCUSSION)
                         continue;

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -47,7 +47,7 @@ extern bool useFactorySettings;
 //   EditStaff
 //---------------------------------------------------------
 
-EditStaff::EditStaff(Staff* s, QWidget* parent)
+EditStaff::EditStaff(Staff* s, int /*tick*/, QWidget* parent)
    : QDialog(parent)
       {
       orgStaff = s;
@@ -62,7 +62,7 @@ EditStaff::EditStaff(Staff* s, QWidget* parent)
       maxPitchPSelect->setIcon(editIcon);
 
       Part* part        = orgStaff->part();
-      instrument        = *part->instrument();
+      instrument        = *part->instrument(/*tick*/);
       Score* score      = part->score();
       staff             = new Staff(score);
       staff->setSmall(orgStaff->small());
@@ -75,6 +75,22 @@ EditStaff::EditStaff(Staff* s, QWidget* parent)
       staff->setShowIfEmpty(orgStaff->showIfEmpty());
       staff->setUserMag(orgStaff->userMag());
       staff->setHideSystemBarLine(orgStaff->hideSystemBarLine());
+
+      // get tick range for instrument
+      auto i = part->instruments()->upper_bound(0);   // tick
+      if (i == part->instruments()->end())
+            _tickEnd = -1;
+      else
+            _tickEnd = i->first;
+#if 1
+      _tickStart = -1;
+#else
+      --i;
+      if (i == part->instruments()->begin())
+            _tickStart = 0;
+      else
+            _tickStart = i->first;
+#endif
 
       // hide string data controls if instrument has no strings
       stringDataFrame->setVisible(instrument.stringData() && instrument.stringData()->strings() > 0);
@@ -287,6 +303,7 @@ void EditStaff::apply()
 
       QString newPartName = partName->text().simplified();
       if (!(instrument == *part->instrument()) || part->partName() != newPartName) {
+            // instrument has changed
             Interval v1 = instrument.transpose();
             Interval v2 = part->instrument()->transpose();
 
@@ -294,7 +311,7 @@ void EditStaff::apply()
             emit instrumentChanged();
 
             if (v1 != v2)
-                  score->transpositionChanged(part, v2);
+                  score->transpositionChanged(part, v2, _tickStart, _tickEnd);
             }
       orgStaff->undoChangeProperty(P_ID::MAG, mag->value() / 100.0);
       orgStaff->undoChangeProperty(P_ID::COLOR, color->color());

--- a/mscore/editstaff.h
+++ b/mscore/editstaff.h
@@ -43,6 +43,7 @@ class EditStaff : public QDialog, private Ui::EditStaffBase {
       Staff*      orgStaff;
       Instrument  instrument;
       int         _minPitchA, _maxPitchA, _minPitchP, _maxPitchP;
+      int         _tickStart, _tickEnd;
 
       virtual void closeEvent(QCloseEvent*);
       void apply();
@@ -72,7 +73,7 @@ class EditStaff : public QDialog, private Ui::EditStaffBase {
       void instrumentChanged();
 
    public:
-      EditStaff(Staff*, QWidget* parent = 0);
+      EditStaff(Staff*, int tick, QWidget* parent = 0);
       };
 
 

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1269,7 +1269,7 @@ static void pitch2xml(const Note* note, QString& s, int& alter, int& octave)
       {
 
       const Staff* st = note->staff();
-      const Instrument* instr = st->part()->instrument();
+      const Instrument* instr = st->part()->instrument();   // TODO: tick
       const Interval intval = instr->transpose();
 
       s      = tpc2stepName(note->tpc());
@@ -4785,7 +4785,7 @@ void ExportMusicXml::write(QIODevice* dev)
                                     }
                               }
                         // instrument details
-                        if (instrument->transpose().chromatic) {
+                        if (instrument->transpose().chromatic) {  // TODO: tick
                               xml.stag("transpose");
                               xml.tag("diatonic",  instrument->transpose().diatonic % 7);
                               xml.tag("chromatic", instrument->transpose().chromatic % 12);

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -275,7 +275,7 @@ static void xmlSetPitch(Note* n, int step, int alter, int octave, const int octa
       //const Staff* staff = n->score()->staff(track / VOICES);
       //const Instrument* instr = staff->part()->instr();
 
-      const Interval intval = instr->transpose();
+      const Interval intval = instr->transpose();     // TODO: tick
 
       //qDebug("  staff=%p instr=%p dia=%d chro=%d",
       //       staff, instr, (int) intval.diatonic, (int) intval.chromatic);

--- a/mscore/importxml.cpp
+++ b/mscore/importxml.cpp
@@ -170,7 +170,7 @@ static void xmlSetPitch(Note* n, char step, int alter, int octave, Ottava* (&ott
 
       const Staff* staff = n->score()->staff(track / VOICES);
       const Instrument* instr = staff->part()->instrument();
-      const Interval intval = instr->transpose();
+      const Interval intval = instr->transpose();     // TODO: tick
       //qDebug("  staff=%p instr=%p dia=%d chro=%d",
       //       staff, instr, (int) intval.diatonic, (int) intval.chromatic);
 

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -459,7 +459,7 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
                                           KeySig* okeysig = new KeySig(score);
                                           okeysig->setKeySigEvent(staff->keySigEvent(tick1));
                                           if (!score->styleB(StyleIdx::concertPitch) && !okeysig->isCustom() && !okeysig->isAtonal()) {
-                                                Interval v = staff->part()->instrument()->transpose();
+                                                Interval v = staff->part()->instrument(tick1)->transpose();
                                                 if (!v.isZero()) {
                                                       Key k = okeysig->key();
                                                       okeysig->setKey(transposeKey(k, v));

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -563,6 +563,7 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
             if (si.exec()) {
                   const InstrumentTemplate* it = si.instrTemplate();
                   if (it) {
+                        //Instrument* instrument = new Instrument(Instrument::fromTemplate(it));
                         ic->setInstrument(Instrument::fromTemplate(it));
                         score()->undo(new ChangeInstrument(ic, ic->instrument()));
                         score()->updateChannel();
@@ -593,7 +594,14 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
             vp.exec();
             }
       else if (cmd == "staff-props") {
-            EditStaff editStaff(e->staff(), 0);
+            int tick = -1;
+            if (e->isChordRest())
+                  tick = static_cast<ChordRest*>(e)->tick();
+            else if (e->type() == Element::Type::NOTE)
+                  tick = static_cast<Note*>(e)->chord()->tick();
+            else if (e->type() == Element::Type::MEASURE)
+                  tick = static_cast<Measure*>(e)->tick();
+            EditStaff editStaff(e->staff(), tick, 0);
             connect(&editStaff, SIGNAL(instrumentChanged()), mscore, SLOT(instrumentChanged()));
             editStaff.exec();
             }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1176,7 +1176,8 @@ void ScoreView::measurePopup(const QPoint& gpos, Measure* obj)
             mscore->editInPianoroll(staff);
             }
       else if (cmd == "staff-properties") {
-            EditStaff editStaff(staff, this);
+            int tick = obj ? obj->tick() : -1;
+            EditStaff editStaff(staff, tick, this);
             connect(&editStaff, SIGNAL(instrumentChanged()), mscore, SLOT(instrumentChanged()));
             editStaff.exec();
             }
@@ -4487,7 +4488,7 @@ void ScoreView::cmdChangeEnharmonic(bool up)
                         }
                   else {
                         n->undoSetTpc(tpc);
-                        if (up || staff->part()->instrument()->transpose().isZero()) {
+                        if (up || staff->part()->instrument(n->chord()->tick())->transpose().isZero()) {
                               // change both spellings
                               int t = n->transposeTpc(tpc);
                               if (n->concertPitch())

--- a/mtest/libmscore/instrumentchange/copy-ref.mscx
+++ b/mtest/libmscore/instrumentchange/copy-ref.mscx
@@ -165,17 +165,30 @@
             <maxPitchA>80</maxPitchA>
             <transposeDiatonic>-1</transposeDiatonic>
             <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>brass.trumpet.bflat</instrumentId>
             <Articulation>
               <velocity>100</velocity>
               <gateTime>100</gateTime>
               </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
             <Articulation name="staccato">
               <velocity>100</velocity>
-              <gateTime>85</gateTime>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="tenuto">
               <velocity>100</velocity>
               <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="sforzato">
               <velocity>120</velocity>
@@ -195,6 +208,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -202,6 +216,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -211,6 +226,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -218,6 +234,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -227,6 +244,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -234,6 +252,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -243,6 +262,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -250,6 +270,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -259,6 +280,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -266,6 +288,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -275,6 +298,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -282,6 +306,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -291,6 +316,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -298,6 +324,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <BarLine>
@@ -360,17 +387,30 @@
             <maxPitchA>80</maxPitchA>
             <transposeDiatonic>-1</transposeDiatonic>
             <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>brass.trumpet.bflat</instrumentId>
             <Articulation>
               <velocity>100</velocity>
               <gateTime>100</gateTime>
               </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
             <Articulation name="staccato">
               <velocity>100</velocity>
-              <gateTime>85</gateTime>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="tenuto">
               <velocity>100</velocity>
               <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="sforzato">
               <velocity>120</velocity>
@@ -390,6 +430,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -397,6 +438,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -406,6 +448,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -413,6 +456,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -422,6 +466,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -429,6 +474,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -438,6 +484,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -445,6 +492,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -454,6 +502,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -461,6 +510,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -470,6 +520,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -477,6 +528,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <BarLine>

--- a/mtest/libmscore/instrumentchange/copy.mscx
+++ b/mtest/libmscore/instrumentchange/copy.mscx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="2.00">
+<museScore version="2.07">
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
@@ -27,10 +27,15 @@
     <showUnprintable>1</showUnprintable>
     <showFrames>1</showFrames>
     <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
     <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">Instrument Change</metaTag>
     <PageList>
@@ -43,13 +48,15 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <type>0</type>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
         <bracket type="-1" span="0"/>
         </Staff>
       <trackName>Flute</trackName>
       <Instrument>
-        <longName pos="0">Flute</longName>
-        <shortName pos="0">Fl.</shortName>
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
         <minPitchP>59</minPitchP>
         <maxPitchP>98</maxPitchP>
@@ -78,13 +85,15 @@
       </Part>
     <Part>
       <Staff id="2">
-        <type>0</type>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
         <bracket type="-1" span="0"/>
         </Staff>
       <trackName>Oboe</trackName>
       <Instrument>
-        <longName pos="0">Oboe</longName>
-        <shortName pos="0">Ob.</shortName>
+        <longName>Oboe</longName>
+        <shortName>Ob.</shortName>
         <trackName>Oboe</trackName>
         <minPitchP>58</minPitchP>
         <maxPitchP>93</maxPitchP>
@@ -124,9 +133,6 @@
           <concertClefType>G</concertClefType>
           <transposingClefType>G</transposingClefType>
           </Clef>
-        <KeySig>
-          <accidental>0</accidental>
-          </KeySig>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>
@@ -146,16 +152,12 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="2">
         <InstrumentChange>
           <Instrument>
-            <longName pos="0">B♭ Trumpet</longName>
-            <shortName pos="0">B♭ Tpt.</shortName>
+            <longName>B♭ Trumpet</longName>
+            <shortName>B♭ Tpt.</shortName>
             <trackName>B♭ Trumpet</trackName>
             <minPitchP>52</minPitchP>
             <maxPitchP>85</maxPitchP>
@@ -163,17 +165,30 @@
             <maxPitchA>80</maxPitchA>
             <transposeDiatonic>-1</transposeDiatonic>
             <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>brass.trumpet.bflat</instrumentId>
             <Articulation>
               <velocity>100</velocity>
               <gateTime>100</gateTime>
               </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
             <Articulation name="staccato">
               <velocity>100</velocity>
-              <gateTime>85</gateTime>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="tenuto">
               <velocity>100</velocity>
               <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="sforzato">
               <velocity>120</velocity>
@@ -186,7 +201,6 @@
               <program value="59"/>
               </Channel>
             </Instrument>
-          <style>Instrument Change</style>
           <text>Trumpet</text>
           </InstrumentChange>
         <Chord>
@@ -194,6 +208,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -201,12 +216,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="3">
         <Chord>
@@ -214,6 +226,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -221,12 +234,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="4">
         <Chord>
@@ -234,6 +244,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -241,12 +252,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="5">
         <Chord>
@@ -254,6 +262,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -261,12 +270,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="6">
         <Chord>
@@ -274,6 +280,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -281,12 +288,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="7">
         <Chord>
@@ -294,6 +298,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -301,12 +306,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="8">
         <Chord>
@@ -314,6 +316,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -321,6 +324,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <BarLine>
@@ -335,9 +339,6 @@
           <concertClefType>G</concertClefType>
           <transposingClefType>G</transposingClefType>
           </Clef>
-        <KeySig>
-          <accidental>0</accidental>
-          </KeySig>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>
@@ -357,10 +358,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="2">
         <Chord>
@@ -377,10 +374,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="3">
         <Chord>
@@ -397,10 +390,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="4">
         <Chord>
@@ -417,10 +406,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="5">
         <Chord>
@@ -437,10 +422,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="6">
         <Chord>
@@ -457,10 +438,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="7">
         <Chord>
@@ -477,10 +454,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="8">
         <Chord>


### PR DESCRIPTION
NOTE: I think this is now ready to merge.

It turns out most of the necessary framework was already in place to get Instrument change text to affect transposition.  After all, we already can retrieving the current instrument for a staff by tick, for playback purposes.  Mostly this PR is just a matter of adding the tick parameter when retrieving the current instrument for transposition purposes as well - and actually, more than a few places we were already doing this (leading to bugs, because it wasn't done consistently).

Basiclly two things left to do:

1) come up with a better solution for Score::transposeKeys() than my current hack of using a zero or octave interval to signify transposition into or out of concert pitch rather than by a fixed interval).  Should be just a matter of adding a nw parameter or two.

2) In my current code, the Staff Properties dialog will show the correct instrument settings according to where you clicked when invoking the dialog.  However, any instrument changes you make end up affecting the entire duration of the score.  We will need to detect the proper range and limit the Score::transpositionChanged() to just that range.  In principle, it shouldn't be hard; I'm just not sure how I want to go about this.

Meanwhile, though, everything else should work well enough to start testing, if anyone is so inclined.