### PR TITLE
fix #78521 prevent segfault when append scores without any measures

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2066,7 +2066,7 @@ bool Score::appendScore(Score* score)
       MeasureBase* lastMeasure = last();
       if (!lastMeasure)
             return false;
-      int tickLen = lastMeasure->endTick();
+      int tickOfAppend = lastMeasure->endTick();
 
       if (!lastMeasure->lineBreak() && !lastMeasure->pageBreak()) {
             lastMeasure->undoSetBreak(true, LayoutBreak::Type::LINE);
@@ -2094,10 +2094,11 @@ bool Score::appendScore(Score* score)
             _measures.add(nmb);
             }
       fixTicks();
+      Measure* firstAppendedMeasure = tick2measure(tickOfAppend);
 
       // if the appended score has less staves,
       // make sure the measures have full measure rest
-      for (Measure* m = tick2measure(tickLen); m; m = m->nextMeasure()) {
+      for (Measure* m = firstAppendedMeasure; m; m = m->nextMeasure()) {
             for (int staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
                   Fraction f;
                   for (Segment* s = m->first(Segment::Type::ChordRest); s; s = s->next(Segment::Type::ChordRest)) {
@@ -2114,29 +2115,30 @@ bool Score::appendScore(Score* score)
             }
 
       // adjust key signatures
-      for (Staff* st : score->staves()) {
-            int staffIdx = score->staffIdx(st);
-            Staff* joinedStaff = staff(staffIdx);
-            // special case for initial "C" key signature - these have no explicit element
-            Measure* m = tick2measure(tickLen);
-            Segment* seg = m->getSegment(Segment::Type::KeySig, tickLen);
-            if (!seg->element(staffIdx * VOICES)) {
-                  // no need to create new initial "C" key sig
-                  // if staff already ends in that key
-                  if (joinedStaff->key(tickLen - 1) == Key::C)
-                        continue;
-                  Key key = Key::C;
-                  KeySig* ks = new KeySig(this);
-                  ks->setTrack(staffIdx * VOICES);
-                  ks->setKey(key);
-                  ks->setParent(seg);
-                  addElement(ks);
-                  }
-            // other key signatures (initial other than "C", non-initial)
-            for (auto k : *(st->keyList())) {
-                  int tick = k.first;
-                  KeySigEvent key = k.second;
-                  joinedStaff->setKey(tick + tickLen, key);
+      if (firstAppendedMeasure) {
+            Segment* seg = firstAppendedMeasure->getSegment(Segment::Type::KeySig, tickOfAppend);
+            for (Staff* st : score->staves()) {
+                  int staffIdx = score->staffIdx(st);
+                  Staff* joinedStaff = staff(staffIdx);
+                  // special case for initial "C" key signature - these have no explicit element
+                  if (!seg->element(staffIdx * VOICES)) {
+                        // no need to create new initial "C" key sig
+                        // if staff already ends in that key
+                        if (joinedStaff->key(tickOfAppend - 1) == Key::C)
+                              continue;
+                        Key key = Key::C;
+                        KeySig* ks = new KeySig(this);
+                        ks->setTrack(staffIdx * VOICES);
+                        ks->setKey(key);
+                        ks->setParent(seg);
+                        addElement(ks);
+                        }
+                  // other key signatures (initial other than "C", non-initial)
+                  for (auto k : *(st->keyList())) {
+                        int tick = k.first;
+                        KeySigEvent key = k.second;
+                        joinedStaff->setKey(tick + tickOfAppend, key);
+                        }
                   }
             }
 
@@ -2146,8 +2148,8 @@ bool Score::appendScore(Score* score)
             Spanner* ns = static_cast<Spanner*>(spanner->clone());
             ns->setScore(this);
             ns->setParent(0);
-            ns->setTick(spanner->tick() + tickLen);
-            ns->setTick2(spanner->tick2() + tickLen);
+            ns->setTick(spanner->tick() + tickOfAppend);
+            ns->setTick2(spanner->tick2() + tickOfAppend);
             if (ns->type() == Element::Type::SLUR) {
                   // set start/end element for slur
                   ns->setStartElement(0);

--- a/mscore/album.cpp
+++ b/mscore/album.cpp
@@ -30,6 +30,20 @@
 namespace Ms {
 
 //---------------------------------------------------------
+//   AlbumItem
+//---------------------------------------------------------
+AlbumItem::AlbumItem()
+      {
+      this->score = nullptr;
+      }
+
+AlbumItem::AlbumItem(QString path)
+      {
+      this->path = path;
+      this->score = nullptr;
+      }
+
+//---------------------------------------------------------
 //   Album
 //---------------------------------------------------------
 
@@ -259,7 +273,6 @@ void Album::load(XmlReader& e)
             const QStringRef& tag(e.name());
             if (tag == "Score") {
                   AlbumItem* i = new AlbumItem;
-                  i->score = 0;
                   while (e.readNextStartElement()) {
                         const QStringRef& tag(e.name());
                         if (tag == "name")

--- a/mscore/album.h
+++ b/mscore/album.h
@@ -35,6 +35,9 @@ struct AlbumItem {
       QString name;
       QString path;
       Score* score;
+
+      AlbumItem();
+      AlbumItem(QString path);
       };
 
 //---------------------------------------------------------

--- a/mscore/albummanager.cpp
+++ b/mscore/albummanager.cpp
@@ -75,9 +75,7 @@ void AlbumManager::addClicked()
             if (fn.isEmpty())
                   continue;
             if(fn.endsWith (".mscz") || fn.endsWith (".mscx")) {
-                  AlbumItem* item = new AlbumItem;
-                  item->path = fn;
-                  album->append(item);
+                  album->append(new AlbumItem(fn));
                   QFileInfo fi(fn);
 
                   QListWidgetItem* li = new QListWidgetItem(fi.completeBaseName(), scoreList);

--- a/mtest/libmscore/album/album_78521-empty.mscx
+++ b/mtest/libmscore/album/album_78521-empty.mscx
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <page-layout>
+        <page-height>1683.36</page-height>
+        <page-width>1190.88</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Title</metaTag>
+    <PageList>
+      <Page>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/album/album_78521-vbox-vbox-empty-ref.mscx
+++ b/mtest/libmscore/album/album_78521-vbox-vbox-empty-ref.mscx
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <page-layout>
+        <page-height>1683.36</page-height>
+        <page-width>1190.88</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Title</metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        </VBox>
+      <VBox>
+        <height>10</height>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
+        <LayoutBreak>
+          <subtype>section</subtype>
+          </LayoutBreak>
+        </VBox>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/album/album_78521-vbox.mscx
+++ b/mtest/libmscore/album/album_78521-vbox.mscx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <page-layout>
+        <page-height>1683.36</page-height>
+        <page-width>1190.88</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer">Composer</metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Title</metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        </VBox>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/album/tst_album.cpp
+++ b/mtest/libmscore/album/tst_album.cpp
@@ -29,6 +29,7 @@ class TestAlbum : public QObject, public MTest
    private slots:
       void initTestCase();
       void album01();
+      void album_78521();
 
       };
 
@@ -47,20 +48,30 @@ void TestAlbum::initTestCase()
 
 void TestAlbum::album01()
       {
-      Album* album = new Album();
-      album->setName("test");
-      
-      AlbumItem* item = new AlbumItem;
-      item->path = root + "/" + DIR + "album01-01.mscx";
-      album->append(item);
-      
-      item = new AlbumItem;
-      item->path = root + "/" + DIR + "album01-02.mscx";
-      album->append(item);
-      
-      album->createScore("album01.mscx");
-      
+      Album album;
+      album.setName("test");
+      album.append(new AlbumItem(root + "/" + DIR + "album01-01.mscx"));
+      album.append(new AlbumItem(root + "/" + DIR + "album01-02.mscx"));
+      album.createScore("album01.mscx");
       QVERIFY(compareFiles("album01.mscx", DIR + "album01-ref.mscx"));
+      }
+
+//---------------------------------------------------------
+///  album_78521
+///   test cases for input scores that contain no actual measures:
+///   -album_78521-vbox contains only a VBox (but no measures)
+///   -album_78521-empty contains no MeasureBase objects
+//--------------------------------------------------------
+
+void TestAlbum::album_78521()
+      {
+      Album album;
+      album.setName("test");
+      album.append(new AlbumItem(root + "/" + DIR + "album_78521-vbox.mscx"));
+      album.append(new AlbumItem(root + "/" + DIR + "album_78521-vbox.mscx"));
+      album.append(new AlbumItem(root + "/" + DIR + "album_78521-empty.mscx"));
+      album.createScore("album_78521-vbox-vbox-empty.mscx");
+      QVERIFY(compareFiles("album_78521-vbox-vbox-empty.mscx", DIR + "album_78521-vbox-vbox-empty-ref.mscx"));
       }
 
 QTEST_MAIN(TestAlbum)


### PR DESCRIPTION
in Score::appendScore, before trying to adjust key signatures at first appended measure, this fix makes sure that the measure actually exists first.  This prevents the mscore crash due to null pointer dereference.

In addition, I've changed the variable name 'tickLen' into 'tickOfAppend' so the variable name makes sense before and after the append occurs.

In addition, I've added two constructors to AlbumItem.  This allows album test functions to use fewer lines of code, since can append a new albumitem with a path in one line.

The test case I added creates an ablum from two scores of a vbox only and an empty score to exercise ability to append scores with no actual measures.