### PR TITLE
fix #78531 prevent Album memory leak by deleting scores when print/join

### DIFF
--- a/mscore/album.h
+++ b/mscore/album.h
@@ -37,7 +37,7 @@ struct AlbumItem {
       Score* score;
 
       AlbumItem();
-      AlbumItem(QString path);
+      AlbumItem(const QString& path);
       };
 
 //---------------------------------------------------------
@@ -53,6 +53,7 @@ class Album {
       void load(XmlReader&);
       void save(Xml&);
       void loadScores();
+      void unloadScores();
 
    public:
       Album();


### PR DESCRIPTION
Previously, both Album::print() and Album::createScore() created new Score objects when calling Album::loadScores(), but never deleted those created score objects.

I've added an Album::unloadScores() function which corresponds to Album::loadScores() to iterate over list of album items and delete any already-loaded scores.  I've called this whenever Album::print() or Album::createScore() return.