### PR TITLE
Fix #79466 - TAB: vert. pos. of value symbols does not follow score scale

### DIFF
--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -874,7 +874,7 @@ void TabDurationSymbol::layout()
             ypos += TAB_RESTSYMBDISPL * spatium();
             }
       bbox().setRect(0.0, ybb * mags, wbb * mags, _tab->durationBoxH() * mags);
-      setPos(0.0, ypos);
+      setPos(0.0, ypos*mags);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fix #79466 - TAB: vertical position of value symbols does not follow score scale

__Reference__: details, screen-shots and sample at https://musescore.org/en/node/79466

The vertical position of value symbols in TAB set for "Note values | Shown as"  at "Note symbols" does not change proportionally when the global score scale changes, but remains approx. the same.