### PR TITLE
fix #81371: crash/hang with frames at end of score

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2815,7 +2815,7 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
                   if (curMeasure)
                         curMeasure = curMeasure->prev();
                   else
-                        curMeasure = lastMeasure();
+                        curMeasure = last();
                   }
             firstInRow = false;
             }


### PR DESCRIPTION
As cadiz1 points out, the problem was caused by my change in #2068.  Looking at my code, and seeing that the trigger for the bug has to do with a frame at the end of the score, it seems pretty clear: I should have used last() instead of lastMeasure() to get the last MeasureBase.  I have verified that making this change fixes all the variations listed in the bug report, and also allows loading of the files from the forum posting that led to this bug report (https://musescore.org/en/node/81356).