### PR TITLE
fix #81456: timesig paste fails

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -840,8 +840,11 @@ Element* ChordRest::drop(const DropData& data)
 
             case Element::Type::TIMESIG:
                   if (measure()->system()) {
-                        // convert page-relative pos to score-relative
                         DropData ndd = data;
+                        // adding from palette sets pos, but normal paste does not
+                        if (!fromPalette)
+                              ndd.pos = pagePos();
+                        // convert page-relative pos to score-relative
                         ndd.pos += measure()->system()->page()->pos();
                         return measure()->drop(ndd);
                         }


### PR DESCRIPTION
The "pos" parameter in the drop fucntions is set differently depending on how the drop was invoked, and I'm kind of figuring this out as I go along.  Code I added a while ago to allow adding time signatures by double click was working well enough, but the same code is used to handle copy/paste of time signature.  This copy/paste formerly happened to work soemtimes, depending on the value of an uninitiatized variable, but would crash in other situations in 2.0.2.  Turns out my PR #2207 - already merged - fixed that crash, but also prevented the paste from working in the cases where it otherwiuse might have happened to.

My change here should fix this case to allow paste to work, and should also be safe for any other code paths that result in ChordRest::drop() being called to add a time signature.