### PR TITLE
Fix #81876: add old Tenor clef and alternate Percussion clef

### DIFF
--- a/fonts/gootville/glyphnames.json
+++ b/fonts/gootville/glyphnames.json
@@ -4001,7 +4001,7 @@
         "description": "G clef ottava bassa with C clef"
     }, 
     "gClef8vbOld": {
-        "codepoint": "U+E055", 
+        "codepoint": "U+E053", 
         "description": "G clef ottava bassa (old style)"
     }, 
     "gClef8vbParens": {
@@ -9387,8 +9387,8 @@
         "description": "Unpitched percussion clef 1"
     }, 
     "unpitchedPercussionClef2": {
-        "alternateCodepoint": "U+1D126", 
-        "codepoint": "U+E06A", 
+        "alternateCodepoint": "U+1D125", 
+        "codepoint": "U+E069", 
         "description": "Unpitched percussion clef 2"
     }, 
     "ventiduesima": {

--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -52,9 +52,10 @@ const ClefInfo ClefInfo::clefTable[] = {
 { "G1",   "G",         1,  0, 47, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, QT_TRANSLATE_NOOP("clefTable", "French violin clef"),     StaffGroup::STANDARD  }, // G4
 { "F8va", "F",         4,  1, 40, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, QT_TRANSLATE_NOOP("clefTable", "Bass clef 8va"),          StaffGroup::STANDARD  }, // F_8VA
 { "F15ma","F",         4,  2, 47, { 2, 5, 1, 4, 7, 3, 6, 6, 3, 7, 4, 8, 5, 9 }, QT_TRANSLATE_NOOP("clefTable", "Bass clef 15ma"),         StaffGroup::STANDARD  }, // F_15MA
-{ "PERC2","percussion",2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, QT_TRANSLATE_NOOP("clefTable", "Percussion"),             StaffGroup::PERCUSSION}, // PERC2 placeholder
+{ "PERC2","percussion",2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, QT_TRANSLATE_NOOP("clefTable", "Percussion2"),            StaffGroup::PERCUSSION}, // PERC2
 { "TAB2", "TAB",       5,  0,  0, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, QT_TRANSLATE_NOOP("clefTable", "Tablature2"),             StaffGroup::TAB       },
 { "G8vbp","G",         2,  0, 45, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, QT_TRANSLATE_NOOP("clefTable", "Treble clef optional 8vb"),StaffGroup::STANDARD }, // G5
+{ "G8vbo","G",         2, -1, 38, { 0, 3,-1, 2, 5, 1, 4, 4, 1, 5, 2, 6, 3, 7 }, QT_TRANSLATE_NOOP("clefTable", "Treble clef 8vb Old"),    StaffGroup::STANDARD  },
       };
 
 
@@ -250,6 +251,10 @@ void Clef::layout1()
                   symbol->setSym(SymId::gClef8vb);
                   yoff = 3.0 * curLineDist;
                   break;
+            case ClefType::G3_O:                            // double G clef 8vb on 2nd line
+                  symbol->setSym(SymId::gClef8vbOld);
+                  yoff = 3.0 * curLineDist;
+                  break;
             case ClefType::F:                              // F clef on penultimate line
                   symbol->setSym(SymId::fClef);
                   yoff = 1.0 * curLineDist;
@@ -301,8 +306,11 @@ void Clef::layout1()
                   yoff = curLineDist * (curLines - 1) * .5;
                   break;
             case ClefType::PERC:                           // percussion clefs
-            case ClefType::PERC2:         // no longer supported: fall back to same glyph as PERC
                   symbol->setSym(SymId::unpitchedPercussionClef1);
+                  yoff = curLineDist * (curLines - 1) * 0.5;
+                  break;
+            case ClefType::PERC2:
+                  symbol->setSym(SymId::unpitchedPercussionClef2);
                   yoff = curLineDist * (curLines - 1) * 0.5;
                   break;
             case ClefType::G4:                             // G clef in 1st line

--- a/libmscore/clef.h
+++ b/libmscore/clef.h
@@ -57,9 +57,10 @@ enum class ClefType : signed char {
       G4,
       F_8VA,
       F_15MA,
-      PERC2,            // no longer supported, but kept for compat. with old scores; rendered as PERC
+      PERC2,
       TAB2,
       G5,
+      G3_O,
       MAX
       };
 

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -696,15 +696,15 @@ Palette* MuseScore::newClefsPalette(bool basic)
       sp->setMag(0.8);
       sp->setGrid(33, 60);
       sp->setYOffset(1.0);
-      // Up to ClefType::MAX-1, because ClefType::PERC2 is no longer supported
       static std::vector<ClefType> clefs1  {
             ClefType::G,   ClefType::F, ClefType::C3, ClefType::C4
             };
       static std::vector<ClefType> clefs2  {
-            ClefType::G,   ClefType::G1,    ClefType::G2,     ClefType::G3,  ClefType::G5,  ClefType::G4,
-            ClefType::C1,  ClefType::C2,    ClefType::C3,     ClefType::C4,  ClefType::C5,
-            ClefType::F,   ClefType::F_8VA, ClefType::F_15MA, ClefType::F8,  ClefType::F15,
-            ClefType::F_B, ClefType::F_C,   ClefType::PERC,   ClefType::TAB, ClefType::TAB2
+            ClefType::G,     ClefType::G1,  ClefType::G2,  ClefType::G3,    ClefType::G3_O,
+            ClefType::G5,    ClefType::G4,  ClefType::C1,  ClefType::C2,    ClefType::C3,
+            ClefType::C4,    ClefType::C5,  ClefType::F,   ClefType::F_8VA, ClefType::F_15MA,
+            ClefType::F8,    ClefType::F15, ClefType::F_B, ClefType::F_C,   ClefType::PERC,
+            ClefType::PERC2, ClefType::TAB, ClefType::TAB2
             };
       for (ClefType j : basic ? clefs1 : clefs2) {
             Clef* k = new Ms::Clef(gscore);


### PR DESCRIPTION
The glyphs are in Bravura and get added on PR #2242 for Emmentaler, but are missing in Gonville, so more work is needed to fully suport them.
Another commit to fake these clefs for Gonville, separate commit so it can easily get reverted once these glyphs got added to that font for real there too