### PR TITLE
select rest or other note after deleting note

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2108,6 +2108,8 @@ void Score::cmdDeleteSelectedMeasures()
 
 void Score::cmdDeleteSelection()
       {
+      ChordRest* cr = nullptr;      // select something after deleting notes
+
       if (selection().isRange()) {
             Segment* s1 = selection().startSegment();
             Segment* s2 = selection().endSegment();
@@ -2230,18 +2232,22 @@ void Score::cmdDeleteSelection()
                                     Staff* staff = Score::staff(track / VOICES);
                                     int tick = m->tick();
                                     Fraction f = staff->timeSig(tick)->sig();
-                                    setRest(tick, track, f, false, 0);
+                                    Rest* r = setRest(tick, track, f, false, 0);
+                                    if (!cr)
+                                          cr = r;
                                     if (s2 && (m == s2->measure()))
                                           break;
                                     }
                               }
                         else {
-                              setRest(tick, track, f, false, tuplet);
+                              Rest* r = setRest(tick, track, f, false, tuplet);
+                              if (!cr)
+                                    cr = r;
                               }
                         }
                   }
             s1 = tick2segment(stick1);
-            s2 = tick2segment(stick2,true);
+            s2 = tick2segment(stick2, true);
             if (s1 == 0 || s2 == 0)
                   deselectAll();
             else {
@@ -2261,15 +2267,28 @@ void Score::cmdDeleteSelection()
             // so we don't try to delete them twice if they are also in selection
             QList<ScoreElement*> deletedElements;
 
+
             for (Element* e : el) {
                   // these are the linked elements we are about to delete
                   QList<ScoreElement*> links;
                   if (e->links())
                         links = *e->links();
 
+                  // find location of element to select after deleting notes
+                  int tick = -1;
+                  int track = -1;
+                  if (!cr && e->type() == Element::Type::NOTE) {
+                        tick = static_cast<Note*>(e)->chord()->tick();
+                        track = e->track();
+                        }
+
                   // delete element if we have not done so already
                   if (!deletedElements.contains(e))
                         deleteItem(e);
+
+                  // find element to select
+                  if (!cr && tick >= 0 && track >= 0)
+                        cr = findCR(tick, track);
 
                   // add these linked elements to list of already-deleted elements
                   for (ScoreElement* se : links)
@@ -2277,16 +2296,18 @@ void Score::cmdDeleteSelection()
                   }
 
             }
+
       deselectAll();
-      if (_is.noteEntryMode()) {
-            ChordRest* cr = _is.cr();
-            if (cr) {
-                  if (cr->type() == Element::Type::CHORD)
-                        select(static_cast<Chord*>(cr)->upNote(), SelectType::SINGLE);
-                  else
-                        select(cr, SelectType::SINGLE);
-                  }
+      // make new selection if appropriate
+      if (_is.noteEntryMode())
+            cr = _is.cr();
+      if (cr) {
+            if (cr->type() == Element::Type::CHORD)
+                  select(static_cast<Chord*>(cr)->upNote(), SelectType::SINGLE);
+            else
+                  select(cr, SelectType::SINGLE);
             }
+
       _layoutAll = true;
       }
 


### PR DESCRIPTION
As requested in https://musescore.org/en/node/81841.  Upon deleting a selection that includes a note, this change will attempt to select something reasonable - either the rest that replaces the note if the note was in a single-note chord, or another note in the chord.  For range selections, the top left note is used; for list selections, the first note in the list.

Comments welcome.  Seems there is widespread agreement this is a good thing to do in principle.