### PR TITLE
Fix #81501 : copy/paste containing HTML name issue

### DIFF
--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2596,10 +2596,20 @@ void Text::paste()
                         else
                               insertSym(Sym::name2id(token));
                         }
+                  else if (!c.isLetter()) {
+                        state = 0;
+                        insertText("&");
+                        insertText(token);
+                        insertText(c);
+                        }
                   else
                         token += c;
                   }
             }
+      if (state == 2) {
+          insertText("&");
+          insertText(token);
+          }
       layoutEdit();
       bool lo = type() == Element::Type::INSTRUMENT_NAME;
       score()->setLayoutAll(lo);

--- a/mtest/libmscore/text/tst_text.cpp
+++ b/mtest/libmscore/text/tst_text.cpp
@@ -32,6 +32,7 @@ class TestText : public QObject, public MTest
       void initTestCase();
       void testText();
       void testSpecialSymbols();
+      void testPaste();
       void testTextProperties();
       void testCompatibility();
       void testDelete();
@@ -185,6 +186,54 @@ void TestText::testSpecialSymbols()
       QCOMPARE(text->xmlText(), QString("&amp;gt;"));
       }
 
+//---------------------------------------------------------
+///   testPaste
+//---------------------------------------------------------
+
+void TestText::testPaste()
+      {
+      Text* text = new Text(score);
+      text->setTextStyle(score->textStyle(TextStyleType::DYNAMICS));
+
+      text->startEdit(0, QPoint());
+      text->layout();
+      text->moveCursorToEnd();
+
+      QApplication::clipboard()->setText("copy & paste");
+      text->paste();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("copy &amp; paste"));
+
+      text->selectAll();
+      text->deleteSelectedText();
+      text->startEdit(0, QPoint());
+      text->layout();
+      text->moveCursorToEnd();
+      QApplication::clipboard()->setText("copy &aa paste");
+      text->paste();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("copy &amp;aa paste"));
+
+      text->selectAll();
+      text->deleteSelectedText();
+      text->startEdit(0, QPoint());
+      text->layout();
+      text->moveCursorToEnd();
+      QApplication::clipboard()->setText("&");
+      text->paste();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("&amp;"));
+
+      text->selectAll();
+      text->deleteSelectedText();
+      text->startEdit(0, QPoint());
+      text->layout();
+      text->moveCursorToEnd();
+      QApplication::clipboard()->setText("&sometext");
+      text->paste();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("&amp;sometext"));
+      }
 //---------------------------------------------------------
 ///   testTextProperties
 //---------------------------------------------------------


### PR DESCRIPTION
This is a PR is related to https://musescore.org/en/node/81501.

The text being pasted is parsed for HTML code. This is done using a "state" integer that takes the value "2" when it first encounters an ampersand, then concatenate the remaining part of the string as the "token", until it hits a semicolon.

Since any HTML name is made of letters (upper and lower case), I suggest to add a simple test for stopping the parsing when a character is something else than a letter, and add the "failed to parse" part of the string.