### PR TITLE
Fix #70996 : Copy lyrics to clipboard

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -689,7 +689,7 @@ MuseScore::MuseScore()
       menuEdit->addMenu(menuMeasure);
 
       QMenu* menuTools = new QMenu(tr("&Tools"));
-      for (auto i : { "add-remove-breaks", "explode", "implode", "slash-fill", "slash-rhythm", "resequence-rehearsal-marks" })
+      for (auto i : { "add-remove-breaks", "explode", "implode", "slash-fill", "slash-rhythm", "resequence-rehearsal-marks", "copy-lyrics-to-clipboard" })
             menuTools->addAction(getAction(i));
       menuEdit->addMenu(menuTools);
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3047,6 +3047,9 @@ void ScoreView::cmd(const QAction* a)
       else if (cmd == "add-remove-breaks") {
             cmdAddRemoveBreaks();
             }
+      else if (cmd == "copy-lyrics-to-clipboard") {
+            cmdCopyLyricsToClipboard();
+            }
 
       // STATE_HARMONY_FIGBASS_EDIT actions
 
@@ -5948,6 +5951,15 @@ void ScoreView::cmdAddRemoveBreaks()
 
       if (noSelection)
              _score->deselectAll();
+      }
+//---------------------------------------------------------
+//   cmdCopyLyricsToClipboard
+///   Copy the score lyrics into clipboard
+//---------------------------------------------------------
+
+void ScoreView::cmdCopyLyricsToClipboard()
+      {
+      QApplication::clipboard()->setText(_score->extractLyrics());
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -413,6 +413,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void cmdInsertMeasures(int, Element::Type);
 
       void cmdAddRemoveBreaks();
+      void cmdCopyLyricsToClipboard();
 
       ScoreState mscoreState() const;
       void setCursorVisible(bool v);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3274,6 +3274,17 @@ Shortcut Shortcut::_sc[] = {
          ShortcutFlags::A_CMD
          },
       {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL,
+         "copy-lyrics-to-clipboard",
+         QT_TRANSLATE_NOOP("action","Copy Lyrics to Clipboard"),
+         QT_TRANSLATE_NOOP("action","Copy lyrics to clipboard"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CMD
+         },
+      {
          MsWidget::MAIN_WINDOW,
          STATE_DISABLED | STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
          "startcenter",


### PR DESCRIPTION
This is a PR is related to https://musescore.org/en/node/70996. It will require some translation work.

I stuck to the proposition in the issue tracker to put the command inside "Edit > Tool > Copy lyrics to clipboard" since it certainly makes sense.