### PR TITLE
Do not update Inspector if not visible.

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1145,7 +1145,8 @@ void MuseScore::selectionChanged(SelState selectionState)
             pianorollEditor->changeSelection(selectionState);
       if (drumrollEditor)
             drumrollEditor->changeSelection(selectionState);
-      updateInspector();
+      if (_inspector && _inspector->isVisible())
+            updateInspector();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Reduces delay / lag of selecting an element.