### PR TITLE
fix #83286: unable to tie with grace note in higher numbered track of…

### DIFF
--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -760,9 +760,9 @@ Note* searchTieNote(Note* note)
                   QList<Chord*> gnb = c->graceNotesBefore();
                   if (!gnb.isEmpty()) {
                         Chord* gc = gnb[0];
-                        note2 = gc->findNote(note->pitch());
-                        if (note2)
-                              return note2;
+                        Note* gn2 = gc->findNote(note->pitch());
+                        if (gn2)
+                              return gn2;
                         }
                   int staffIdx = c->staffIdx() + c->staffMove();
                   if (staffIdx != chord->staffIdx() + chord->staffMove())  // cannot happen?


### PR DESCRIPTION
… instrument

BTW, the code when adding a tie will favor a grace note in another voice over a normal note in the same voice.  This seems deliberate and not a bad algorithm, so I didn't change it.  I just fixed it to not fail in the case shown in the bug report.