### PR TITLE
Fix #69616: Added shortcut for toggle sforzato (default Shift+V)

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2258,6 +2258,8 @@ void Score::cmd(const QAction* a)
             addArticulation(ArticulationType::Tenuto);
       else if (cmd == "add-marcato")
             addArticulation(ArticulationType::Marcato);
+      else if (cmd == "add-sforzato")
+            addArticulation(ArticulationType::Sforzatoaccent);
       else if (cmd == "add-trill")
             addArticulation(ArticulationType::Trill);
       else if (cmd == "add-8va")

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -197,6 +197,10 @@
     <seq>Ctrl+Alt+O</seq>
     </SC>
   <SC>
+    <key>add-sforzato</key>
+    <seq>Shift+V</seq>
+    </SC>
+  <SC>
     <key>stretch+</key>
     <seq>}</seq>
     </SC>

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -561,6 +561,17 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "add-sforzato",
+         QT_TRANSLATE_NOOP("action","Sforzato"),
+         QT_TRANSLATE_NOOP("action","Toggle sforzato"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CMD
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "stretch+",
          QT_TRANSLATE_NOOP("action","Increase Stretch"),
          QT_TRANSLATE_NOOP("action","Increase stretch"),


### PR DESCRIPTION
Shift+V kind of looks like an accent, but sideways. It's easily pressed with a single hand, which is important for how often I can see myself and others using it.

Other shortcuts I considered:

Shift+A (as in Accent) - conflicts with *Add A*
Ctrl+Alt+A - okay but would prefer something simpler
^ (looks like an accent) - conflicts with *Add 6th Below* on US keyboards
Shift+Z (as in sforZato) - on the one hand it's adjacent to Shift+S, so it's easy to create a series of sforzato/staccato notes, but a wrong press of this while pressing Ctrl+Shift+Z can erase the undo history

Using the name "sforzato", but perhaps "accent" may be better for the UI?