### PR TITLE
fix #84296: bad import of certain chord symbols

### DIFF
--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -1182,8 +1182,10 @@ QString ParsedChord::fromXml(const QString& rawKind, const QString& rawKindText,
             _quality = "augmented";
       else if (kind == "half-diminished") {
             _quality = "half-diminished";
-            extension = 7;
-            extend = true;
+            if (symbols) {
+                  extension = 7;
+                  extend = true;
+                  }
             }
       else if (kind == "diminished-seventh") {
             _quality = "diminished";
@@ -1304,7 +1306,7 @@ QString ParsedChord::fromXml(const QString& rawKind, const QString& rawKindText,
             _extension = QString("%1").arg(extension);
 
       // validate kindText
-      if (kindText != "" && kind != "none") {
+      if (kindText != "" && kind != "none" && kind != "other") {
             ParsedChord validate;
             validate.parse(kindText, cl, false);
             // kindText should parse to produce same kind, no degrees


### PR DESCRIPTION
Fixes for two specific chord symbols: kind=other with non-null text should obey the text, and kind=half-diminished with null text and no use-symbols" should not include duplicate 7's.