### PR TITLE
fix #84806: crash adding note that creates tie in tab staff

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1461,16 +1461,16 @@ void ScoreView::moveCursor()
             Segment*    seg   = is.segment();
             int         minTrack = (is.track() / VOICES) * VOICES;
             int         maxTrack = minTrack + VOICES;
-            // get selected chordrest, if one exists and is in this segment
+            // get selected chord, if one exists and is in this segment
             ChordRest* scr = _score->selection().cr();
-            if (scr && scr->segment() != seg)
+            if (scr && (scr->type() != Element::Type::CHORD || scr->segment() != seg))
                   scr = nullptr;
             // get the physical string corresponding to current visual string
             for (int t = minTrack; t < maxTrack; t++) {
                   Element* e = seg->element(t);
                   if (e != nullptr && e->type() == Element::Type::CHORD) {
-                        // if there is a selected chordrest in this segment on this track but it is not e
-                        // then the selected chordrest must be a grace note chord, and we should use it
+                        // if there is a selected chord in this segment on this track but it is not e
+                        // then the selected chord must be a grace note chord, and we should use it
                         if (scr && scr->track() == t && scr != e)
                               e = scr;
                         // search notes looking for one on current string


### PR DESCRIPTION
Looks like a previous change of mine assumed a little too much - I need to check that the selected chord rest is actually a chord treating it as such.  I suspect there might be other ways to trigger this crash other than creating a tie, but the same fix should apply to other cases as well.