### PR TITLE
Add reorder parts buttons in parts dialog

### DIFF
--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -80,6 +80,8 @@ ExcerptsDialog::ExcerptsDialog(Score* s, QWidget* parent)
       connect(newButton, SIGNAL(clicked()), SLOT(newClicked()));
       connect(newAllButton, SIGNAL(clicked()), SLOT(newAllClicked()));
       connect(deleteButton, SIGNAL(clicked()), SLOT(deleteClicked()));
+      connect(moveUpButton, SIGNAL(clicked()), SLOT(moveUpClicked()));
+      connect(moveDownButton, SIGNAL(clicked()), SLOT(moveDownClicked()));
       connect(excerptList, SIGNAL(currentItemChanged(QListWidgetItem*, QListWidgetItem*)),
          SLOT(excerptChanged(QListWidgetItem*, QListWidgetItem*)));
       connect(partList, SIGNAL(itemDoubleClicked(QListWidgetItem*)),
@@ -186,6 +188,47 @@ void ExcerptsDialog::newAllClicked()
             excerptList->selectionModel()->clearSelection();
             excerptList->setCurrentItem(ei, QItemSelectionModel::SelectCurrent);
             }
+      }
+
+//---------------------------------------------------------
+//   moveUpClicked
+//---------------------------------------------------------
+
+void ExcerptsDialog::moveUpClicked()
+      {
+      QListWidgetItem* cur = excerptList->currentItem();
+      if (cur == 0)
+            return;
+      int currentRow = excerptList->currentRow();
+      if (currentRow <= 0)
+            return;
+      QListWidgetItem* currentItem = excerptList->takeItem(currentRow);
+      excerptList->insertItem(currentRow - 1, currentItem);
+      excerptList->setCurrentRow(currentRow - 1);
+
+      score->excerpts().swap(currentRow, currentRow-1);
+      score->setExcerptsChanged(true);
+      }
+
+//---------------------------------------------------------
+//   moveDownClicked
+//---------------------------------------------------------
+
+void ExcerptsDialog::moveDownClicked()
+      {
+      QListWidgetItem* cur = excerptList->currentItem();
+      if (cur == 0)
+            return;
+      int currentRow = excerptList->currentRow();
+      int nbRows = excerptList->count();
+      if (currentRow >= nbRows - 1)
+            return;
+      QListWidgetItem* currentItem = excerptList->takeItem(currentRow);
+      excerptList->insertItem(currentRow + 1, currentItem);
+      excerptList->setCurrentRow(currentRow + 1);
+
+      score->excerpts().swap(currentRow, currentRow+1);
+      score->setExcerptsChanged(true);
       }
 
 //---------------------------------------------------------

--- a/mscore/excerptsdialog.h
+++ b/mscore/excerptsdialog.h
@@ -69,6 +69,8 @@ class ExcerptsDialog : public QDialog, private Ui::ExcerptsDialog {
       void deleteClicked();
       void newClicked();
       void newAllClicked();
+      void moveUpClicked();
+      void moveDownClicked();
       void excerptChanged(QListWidgetItem* cur, QListWidgetItem* prev);
       void partDoubleClicked(QListWidgetItem*);
       void partClicked(QListWidgetItem*);

--- a/mscore/excerptsdialog.ui
+++ b/mscore/excerptsdialog.ui
@@ -57,6 +57,9 @@
      <layout class="QVBoxLayout">
       <item>
        <widget class="QListWidget" name="excerptList">
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
+        </property>
         <property name="uniformItemSizes">
          <bool>true</bool>
         </property>
@@ -83,6 +86,20 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="moveUpButton">
+          <property name="text">
+           <string>Up</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="moveDownButton">
+          <property name="text">
+           <string>Down</string>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QPushButton" name="newAllButton">


### PR DESCRIPTION
Add the feature request (https://musescore.org/en/node/38871) to reorder parts in the parts dialog.