### PR TITLE
Add feature #28376 - Drop the keysignature you want

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1010,6 +1010,15 @@ Element* ChordRest::drop(const DropData& data)
                   delete ks;
 
                   // apply only to this stave
+
+                  // Take consideration of transposed instrument if not in ConcertPitch
+                  if (!concertPitch()) {
+                        Interval interval = staff()->part()->instrument()->transpose();
+                        if (interval.chromatic && !k.custom() && !k.isAtonal()) {
+                              k.setKey(transposeKey(k.key(), interval));
+                              }
+                        }
+
                   score()->undoChangeKeySig(staff(), tick(), k);
                   }
                   break;

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -13,6 +13,7 @@
 #include "sym.h"
 #include "staff.h"
 #include "clef.h"
+#include "part.h"
 #include "keysig.h"
 #include "measure.h"
 #include "segment.h"
@@ -282,6 +283,15 @@ Element* KeySig::drop(const DropData& data)
             }
       KeySigEvent k = ks->keySigEvent();
       delete ks;
+
+      // Take consideration of transposed instrument if not in ConcertPitch
+      if (!concertPitch()) {
+            Interval interval = staff()->part()->instrument()->transpose();
+            if (interval.chromatic && !k.custom() && !k.isAtonal()) {
+                  k.setKey(transposeKey(k.key(), interval));
+                  }
+            }
+
       if (data.modifiers & Qt::ControlModifier) {
             // apply only to this stave
             if (!(k == keySigEvent()))

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1394,6 +1394,14 @@ qDebug("drop staffList");
                   KeySigEvent k = ks->keySigEvent();
                   delete ks;
 
+                  // Take consideration of transposed instrument if not in ConcertPitch
+                  if (!concertPitch()) {
+                        Interval interval = staff->part()->instrument()->transpose();
+                        if (interval.chromatic && !k.custom() && !k.isAtonal()) {
+                              k.setKey(transposeKey(k.key(), interval));
+                              }
+                        }
+
                   if (data.modifiers & Qt::ControlModifier) {
                         // apply only to this stave
                         score()->undoChangeKeySig(staff, tick(), k);

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1258,8 +1258,10 @@ bool Measure::acceptDrop(const DropData& data) const
             case Element::Type::TIMESIG:
                   if (data.modifiers & Qt::ControlModifier)
                         viewer->setDropRectangle(staffR);
-                  else
+                  else {
                         viewer->setDropRectangle(canvasBoundingRect());
+                        viewer->setDropStaffRectangle(staffR);
+                        }
                   return true;
 
             case Element::Type::BRACKET:

--- a/libmscore/mscoreview.h
+++ b/libmscore/mscoreview.h
@@ -55,6 +55,7 @@ class MuseScoreView {
       virtual int gripCount() const { return 0; }
       virtual const QRectF& getGrip(Grip) const = 0;
       virtual void setDropRectangle(const QRectF&) {};
+      virtual void setDropStaffRectangle(const QRectF&) {};
       virtual void cmdAddSlur(Note* /*firstNote*/, Note* /*lastNote*/) {};
       virtual void cmdAddHairpin(bool) {};
       virtual void startEdit() {};

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -72,6 +72,10 @@ void ScoreView::setDropTarget(const Element* el)
             _score->addRefresh(dropRectangle);
             dropRectangle = QRectF();
             }
+      if (dropStaffRectangle.isValid()) {
+            _score->addRefresh(dropStaffRectangle);
+            dropStaffRectangle = QRectF();
+            }
       }
 
 //---------------------------------------------------------
@@ -95,6 +99,19 @@ void ScoreView::setDropRectangle(const QRectF& r)
             _score->addRefresh(r.normalized());
             dropAnchor = QLineF();
             }
+      _score->addRefresh(r);
+      }
+
+//---------------------------------------------------------
+//   setDropStaffRectangle
+//      Used to highlight the staff where the key signature will be dropped
+//---------------------------------------------------------
+
+void ScoreView::setDropStaffRectangle(const QRectF& r)
+      {
+      if (dropStaffRectangle.isValid())
+            _score->addRefresh(dropStaffRectangle);
+      dropStaffRectangle = r;
       _score->addRefresh(r);
       }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1909,6 +1909,8 @@ void ScoreView::paint(const QRect& r, QPainter& p)
             }
       if (dropRectangle.isValid())
             p.fillRect(dropRectangle, QColor(80, 0, 0, 80));
+      if (dropStaffRectangle.isValid())
+            p.fillRect(dropStaffRectangle, QColor(40, 0, 0, 80));
 
       //
       // frame text in edit mode, except for text in a text frame

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -137,6 +137,7 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       const Element* dropTarget;    ///< current drop target during dragMove
       QRectF dropRectangle;         ///< current drop rectangle during dragMove
+      QRectF dropStaffRectangle;         ///< current drop rectangle during dragMove
       QLineF dropAnchor;            ///< line to current anchor point during dragMove
 
       QTransform _matrix, imatrix;
@@ -369,6 +370,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void onEditPasteTransition(QMouseEvent* ev);
 
       virtual void setDropRectangle(const QRectF&);
+      virtual void setDropStaffRectangle(const QRectF& r);
       virtual void setDropTarget(const Element*) override;
       void setDropAnchor(const QLineF&);
       const QTransform& matrix() const  { return _matrix; }


### PR DESCRIPTION
This commit adds the feature Issues #28376 - Request method to specify that key signature being added is already transposed (https://musescore.org/fr/node/28376)

This way, when not in Concert Pitch mode, the Key signature taken in the palette will be the one put on the staff where it is dropped. All other staves will adjust accordingly, unless Control key is hold. In that case, only the selected staff will be changed.
