### PR TITLE
fix #85956: drum note altered by arrow changes pitch on reload

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1223,8 +1223,11 @@ void Score::upDown(bool up, UpDownMode mode)
                   case StaffGroup::PERCUSSION:
                         {
                         const Drumset* ds = part->instrument()->drumset();
-                        if (ds)
+                        if (ds) {
                               newPitch = up ? ds->prevPitch(pitch) : ds->nextPitch(pitch);
+                              newTpc1 = pitch2tpc(newPitch, Key::C, Prefer::NEAREST);
+                              newTpc2 = newTpc1;
+                              }
                         }
                         break;
                   case StaffGroup::TAB:

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1184,7 +1184,7 @@ void Note::read(XmlReader& e)
       // but since there are other causes of tpc corruption (eg, https://musescore.org/en/node/74746)
       // including perhaps some we don't know about yet,
       // we will attempt to fix some problems here regardless of version
-      if (!e.pasteMode() && !MScore::testMode) {
+      if (staff() && !staff()->isDrumStaff() && !e.pasteMode() && !MScore::testMode) {
             int tpc1Pitch = (tpc2pitch(_tpc[0]) + 12) % 12;
             int tpc2Pitch = (tpc2pitch(_tpc[1]) + 12) % 12;
             int concertPitch = _pitch % 12;
@@ -1192,18 +1192,16 @@ void Note::read(XmlReader& e)
                   qDebug("bad tpc1 - concertPitch = %d, tpc1 = %d", concertPitch, tpc1Pitch);
                   _pitch += tpc1Pitch - concertPitch;
                   }
-            if (staff()) {
-                  Interval v = staff()->part()->instrument(e.tick())->transpose();
-                  int transposedPitch = (_pitch - v.chromatic) % 12;
-                  if (tpc2Pitch != transposedPitch) {
-                        qDebug("bad tpc2 - transposedPitch = %d, tpc2 = %d", transposedPitch, tpc2Pitch);
-                        // just in case the staff transposition info is not reliable here,
-                        // do not attempt to correct tpc
-                        // except for older scores where we know there are tpc problems
-                        if (score()->mscVersion() <= 206) {
-                              v.flip();
-                              _tpc[1] = Ms::transposeTpc(_tpc[0], v, true);
-                              }
+            Interval v = staff()->part()->instrument(e.tick())->transpose();
+            int transposedPitch = (_pitch - v.chromatic) % 12;
+            if (tpc2Pitch != transposedPitch) {
+                  qDebug("bad tpc2 - transposedPitch = %d, tpc2 = %d", transposedPitch, tpc2Pitch);
+                  // just in case the staff transposition info is not reliable here,
+                  // do not attempt to correct tpc
+                  // except for older scores where we know there are tpc problems
+                  if (score()->mscVersion() <= 206) {
+                        v.flip();
+                        _tpc[1] = Ms::transposeTpc(_tpc[0], v, true);
                         }
                   }
             }


### PR DESCRIPTION
When I added code to correct tpc/pitch mismatches on load (relevant to https://musescore.org/en/node/81091 and https://musescore.org/en/node/9352), I neglected to exclude drum staves from consideration.  tpc isn't relevant for drum staves, and we don't always manage it "correctly", so my code was "fixing" pitch of some drum notes on load unnecessaily.

This PR changes the fixup-on-load code to ignore drum staves.  It also manages the tpc for drum notes in upDown, which is what was causing the specific problem in the issue report.  It's quite possible there are other places where operations on drum staves will allow "bad" tpc info, but it's normally irrelevant, so I'm not bothering to make an exhaustive investigation.  Even if the tpc goes bad, the first part of my change here means it will be harmless as it always was before.