### PR TITLE
fix #84876: extend selection to left with last measure selected

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3084,6 +3084,8 @@ void Score::selectAdd(Element* e)
 void Score::selectRange(Element* e, int staffIdx)
       {
       int activeTrack = e->track();
+      // current selection is range extending to end of score?
+      bool endRangeSelected = selection().isRange() && selection().endSegment() == nullptr;
       if (e->type() == Element::Type::MEASURE) {
             Measure* m = static_cast<Measure*>(e);
             int tick  = m->tick();
@@ -3191,7 +3193,7 @@ void Score::selectRange(Element* e, int staffIdx)
                   qDebug("sel state %d", int(_selection.state()));
                   return;
                   }
-            if (!_selection.endSegment())
+            if (!endRangeSelected && !_selection.endSegment())
                   _selection.setEndSegment(cr->segment()->nextCR());
             if (!_selection.startSegment())
                   _selection.setStartSegment(cr->segment());


### PR DESCRIPTION
I suspect the call to setEndSegment() in the code I modified is not needed at all any more.  That is, I think all cases that might land here now result in endSegment() already being set correctly, so  endSegment() will probably never be null if it wasn't null when we started.  But I can't prove that, so I went with hopefully a safer solution: checking to see if endSegment() is null before we begin, and not messing with it here if so.