### PR TITLE
fix #85641: preserve fingering user offset on paste

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -943,7 +943,7 @@ void Score::undoAddElement(Element* element)
                   }
             if (links == 0) {
                   undo(new AddElement(element));
-                  if (element->type() == Element::Type::FINGERING && element->userOff().isNull())
+                  if (element->type() == Element::Type::FINGERING && !element->isNudged())
                         element->score()->layoutFingering(static_cast<Fingering*>(element));
                   else if (element->type() == Element::Type::CHORD) {
 #ifndef QT_NO_DEBUG


### PR DESCRIPTION
I thought I had fixed this last year as part of #1388, but the fix I put in place for this does not work and apparently never worked (!).  At the point I try to decide whetehr or not to apply the automatic fingering layout to a psted fingering, the fingering has not yet been laid out at all, and thus userOff() is not meaningful yet.  Checking isNudged() - which looks at both userOff() and readPos() - is the way to go.