### PR TITLE
UI: Move symbol-based fingerings to fingering palette

### DIFF
--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -128,11 +128,12 @@ enum class ArticulationType : char {
       LinePrall,
       Schleifer,
       Snappizzicato,
+      ARTICULATIONS_PROPER,
 //      Tapping,
 //      Slapping,
 //      Popping,
       // Fingerings
-      ThumbPosition,
+      ThumbPosition = ARTICULATIONS_PROPER,
       LuteFingThumb,
       LuteFingFirst,
       LuteFingSecond,

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -464,6 +464,12 @@ Palette* MuseScore::newFingeringPalette()
             f->setXmlText(QString(stringnumber[i]));
             sp->append(f, tr("String number %1").arg(stringnumber[i]));
             }
+      // include additional symbol-based fingerings (temporarily?) implemented as articulations
+      for (int i = int(ArticulationType::ARTICULATIONS_PROPER); i < int(ArticulationType::ARTICULATIONS); ++i) {
+            Articulation* s = new Articulation(gscore);
+            s->setArticulationType(ArticulationType(i));
+            sp->append(s, qApp->translate("Fingering", s->subtypeUserName().toUtf8().constData()));
+            }
       return sp;
       }
 
@@ -545,7 +551,8 @@ Palette* MuseScore::newArticulationsPalette(bool basic)
                   }
             }
       else {
-            for (int i = 0; i < int(ArticulationType::ARTICULATIONS); ++i) {
+            // do not include additional symbol-based fingerings (temporarily?) implemented as articulations
+            for (int i = 0; i < int(ArticulationType::ARTICULATIONS_PROPER); ++i) {
                   Articulation* s = new Articulation(gscore);
                   s->setArticulationType(ArticulationType(i));
                   sp->append(s, qApp->translate("articulation", s->subtypeUserName().toUtf8().constData()));


### PR DESCRIPTION
__Background__: Five fingering signs (cello thumb position and 4 lute fingerings) are not text-based, like all other fingerings, but symbol-based, like articulations and can use practically all the articulation code. For this reason, they have been implemented as articulations.

As a temporary measure which has never been addressed after the fact, they were initially placed in the Articulations palette, together with other articulations.

__Fix__: This fix moves those 5 signs to the fingering palette. The involved palettes in the Advanced Workspace then look like this:
![extrafingerings](https://cloud.githubusercontent.com/assets/1420743/11059953/4f9b1440-879d-11e5-9e77-89bc92e76d16.png)

__Note__: No change to the actual implementation of those signs, which remain as articulations.

There is work in progress to see if some new (and possibly some older) signs, belonging to the Articulation class and which are (or should) be attached to notes, can be implemented in a more appropriate way. It is well possible this w.i.p. will affect these 5 sign too.

However, as the outcome of this other change is unclear yet (whether it will be successful at all and, in case, how it will be implemented); this fix has been provided to solve this oddity in a potentially definitive way.