### PR TITLE
Fix #88171 - Lyrics dash max distance as a parameter

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -872,6 +872,7 @@ void LyricsLineSegment::layout()
 #endif
             qreal len         = pos2().x();
             qreal minDashLen  = score()->styleS(StyleIdx::lyricsDashMinLength).val() * sp;
+            qreal maxDashDist = score()->styleS(StyleIdx::lyricsDashMaxDistance).val() * sp;
             if (len < minDashLen) {                                           // if no room for a dash
                   // if at end of system or dash is forced
                   if (endOfSystem || score()->styleB(StyleIdx::lyricsDashForce)) {
@@ -882,13 +883,13 @@ void LyricsLineSegment::layout()
                   else                                                        //   if within system or dash not forced
                         _numOfDashes = 0;                                     //     draw no dash
                   }
-            else if (len < (Lyrics::LYRICS_DASH_DEFAULT_STEP * TWICE * sp)) { // if no room for two dashes
+            else if (len < (maxDashDist * TWICE)) {                           // if no room for two dashes
                   _numOfDashes = 1;                                           //    draw one dash
                   if (_dashLength > len)                                      // if no room for a full dash
                         _dashLength = len;                                    //    shorten it
                   }
             else
-                  _numOfDashes = len / (Lyrics::LYRICS_DASH_DEFAULT_STEP * sp);// draw several dashes
+                  _numOfDashes = len / maxDashDist;                           // draw several dashes
 
             // adjust next lyrics horiz. position if too little a space forced to skip the dash
             if (_numOfDashes == 0 && nextLyr != nullptr && len > 0)

--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -60,7 +60,6 @@ class Lyrics : public Text {
       // metrics for dashes and melisma; all in sp. units:
       static constexpr qreal  MELISMA_DEFAULT_LINE_THICKNESS      = 0.10;     // for melisma line only;
       static constexpr qreal  MELISMA_DEFAULT_PAD                 = 0.10;     // the empty space before a melisma line
-      static constexpr qreal  LYRICS_DASH_DEFAULT_STEP            = 16.0;     // the max. distance between dashes
       static constexpr qreal  LYRICS_DASH_DEFAULT_PAD             = 0.05;     // the min. empty space before and after a dash
 // WORD_MIN_DISTANCE has never been implemented
 //      static constexpr qreal  LYRICS_WORD_MIN_DISTANCE            = 0.33;     // min. distance between lyrics from different words

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -237,7 +237,8 @@ static const StyleTypes2 styleTypes2[] = {
       { StyleIdx::barGraceDistance,            StyleType("barGraceDistance",        StyleValueType::SPATIUM) },
       { StyleIdx::lyricsDashMinLength,         StyleType("lyricsDashMinLength",     StyleValueType::SPATIUM) },
       { StyleIdx::lyricsDashMaxLength,         StyleType("lyricsDashMaxLegth",      StyleValueType::SPATIUM) },
-      { StyleIdx::lyricsDashForce,             StyleType("lyricsDashForce",         StyleValueType::BOOL)    }
+      { StyleIdx::lyricsDashForce,             StyleType("lyricsDashForce",         StyleValueType::BOOL)    },
+      { StyleIdx::lyricsDashMaxDistance,       StyleType("lyricsDashMaxDistance",   StyleValueType::SPATIUM) }
       };
 
 class StyleTypes {
@@ -603,7 +604,8 @@ StyleData::StyleData()
             { StyleIdx::barGraceDistance,            QVariant(.6) },
             { StyleIdx::lyricsDashMinLength,         QVariant(0.4) },
             { StyleIdx::lyricsDashMaxLength,         QVariant(0.8) },
-            { StyleIdx::lyricsDashForce,             QVariant(true) }
+            { StyleIdx::lyricsDashForce,             QVariant(true) },
+            { StyleIdx::lyricsDashMaxDistance,       QVariant(16.0) }
             };
       for (unsigned i = 0; i < sizeof(values2)/sizeof(*values2); ++i)
             _values[int(values2[i].idx)] = values2[i].val;

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -149,6 +149,10 @@ class StyleType {
 
 //---------------------------------------------------------
 //   StyleIdx
+//
+//    Keep in sync with:
+//    *) styleTypes2[] in style.cpp
+//    *) StyleVal2 values2[] in style.cpp
 //---------------------------------------------------------
 
 enum class StyleIdx : unsigned char {
@@ -376,6 +380,7 @@ enum class StyleIdx : unsigned char {
       lyricsDashMinLength,
       lyricsDashMaxLength,
       lyricsDashForce,
+      lyricsDashMaxDistance,
 
       STYLES
       };

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -444,6 +444,7 @@ void EditStyle::getValues()
       lstyle.set(StyleIdx::lyricsDashMinLength,     lyricsDashMinLength->value());
       lstyle.set(StyleIdx::lyricsDashMaxLength,     lyricsDashMaxLength->value());
       lstyle.set(StyleIdx::lyricsDashForce,         lyricsDashForce->isChecked());
+      lstyle.set(StyleIdx::lyricsDashMaxDistance,   lyricsDashMaxDistance->value());
       lstyle.set(StyleIdx::lastSystemFillLimit,     lastSystemFillThreshold->value() / 100.0);
       lstyle.set(StyleIdx::genClef,                 genClef->isChecked());
       lstyle.set(StyleIdx::genKeysig,               genKeysig->isChecked());
@@ -666,6 +667,7 @@ void EditStyle::setValues()
       lyricsDashMinLength->setValue(lstyle.value(StyleIdx::lyricsDashMinLength).toDouble());
       lyricsDashMaxLength->setValue(lstyle.value(StyleIdx::lyricsDashMaxLength).toDouble());
       lyricsDashForce->setChecked(lstyle.value(StyleIdx::lyricsDashForce).toBool());
+      lyricsDashMaxDistance->setValue(lstyle.value(StyleIdx::lyricsDashMaxDistance).toDouble());
       lastSystemFillThreshold->setValue(lstyle.value(StyleIdx::lastSystemFillLimit).toDouble() * 100.0);
 
       genClef->setChecked(lstyle.value(StyleIdx::genClef).toBool());

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -85,6 +85,9 @@
               <property name="text">
                <string>Musical text font:</string>
               </property>
+              <property name="buddy">
+               <cstring>musicalTextFont</cstring>
+              </property>
              </widget>
             </item>
             <item row="1" column="1">
@@ -2320,6 +2323,9 @@
               <property name="indent">
                <number>5</number>
               </property>
+              <property name="buddy">
+               <cstring>barAccidentalDistance</cstring>
+              </property>
              </widget>
             </item>
             <item row="13" column="1">
@@ -2358,6 +2364,9 @@
               </property>
               <property name="indent">
                <number>5</number>
+              </property>
+              <property name="buddy">
+               <cstring>multiMeasureRestMargin</cstring>
               </property>
              </widget>
             </item>
@@ -2414,7 +2423,7 @@
                <number>5</number>
               </property>
               <property name="buddy">
-               <cstring>barNoteDistance</cstring>
+               <cstring>barGraceDistance</cstring>
               </property>
              </widget>
             </item>
@@ -3587,9 +3596,12 @@
             <property name="text">
              <string>Max. dash length:</string>
             </property>
+            <property name="buddy">
+             <cstring>lyricsDashMaxLength</cstring>
+            </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QCheckBox" name="lyricsDashForce">
             <property name="text">
              <string>Always force dash</string>
@@ -3611,6 +3623,9 @@
           </item>
           <item row="1" column="1">
            <widget class="QDoubleSpinBox" name="lyricsDashMaxLength">
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
             <property name="suffix">
              <string>sp</string>
             </property>
@@ -3630,6 +3645,9 @@
           </item>
           <item row="0" column="1">
            <widget class="QDoubleSpinBox" name="lyricsDashMinLength">
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
             <property name="suffix">
              <string>sp</string>
             </property>
@@ -3648,6 +3666,38 @@
            <widget class="QLabel" name="label_93">
             <property name="text">
              <string>Min. dash length:</string>
+            </property>
+            <property name="buddy">
+             <cstring>lyricsDashMinLength</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_94">
+            <property name="text">
+             <string>Max dash distance:</string>
+            </property>
+            <property name="buddy">
+             <cstring>lyricsDashMaxDistance</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="lyricsDashMaxDistance">
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="suffix">
+             <string>sp</string>
+            </property>
+            <property name="decimals">
+             <number>0</number>
+            </property>
+            <property name="minimum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>16.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -4983,6 +5033,9 @@
             <property name="text">
              <string>Position:</string>
             </property>
+            <property name="buddy">
+             <cstring>radioFretNumLeft</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="3">
@@ -5017,6 +5070,9 @@
             <property name="text">
              <string>Barré line thickness:</string>
             </property>
+            <property name="buddy">
+             <cstring>barreLineWidth</cstring>
+            </property>
            </widget>
           </item>
           <item row="2" column="1">
@@ -5039,6 +5095,9 @@
            <widget class="QLabel" name="label_5">
             <property name="text">
              <string>Scale:</string>
+            </property>
+            <property name="buddy">
+             <cstring>fretMag</cstring>
             </property>
            </widget>
           </item>
@@ -5814,6 +5873,9 @@
                <property name="text">
                 <string>Tuplet bracket thickness:</string>
                </property>
+               <property name="buddy">
+                <cstring>tupletBracketWidth</cstring>
+               </property>
               </widget>
              </item>
              <item row="0" column="1">
@@ -6044,6 +6106,10 @@
   <tabstop>frameSystemDistance</tabstop>
   <tabstop>lastSystemFillThreshold</tabstop>
   <tabstop>genClef</tabstop>
+  <tabstop>genCourtesyTimesig</tabstop>
+  <tabstop>genKeysig</tabstop>
+  <tabstop>genCourtesyKeysig</tabstop>
+  <tabstop>genCourtesyClef</tabstop>
   <tabstop>showHeader</tabstop>
   <tabstop>showHeaderFirstPage</tabstop>
   <tabstop>headerOddEven</tabstop>
@@ -6083,6 +6149,7 @@
   <tabstop>minMeasureWidth_2</tabstop>
   <tabstop>measureSpacing</tabstop>
   <tabstop>barNoteDistance</tabstop>
+  <tabstop>barGraceDistance</tabstop>
   <tabstop>barAccidentalDistance</tabstop>
   <tabstop>noteBarDistance</tabstop>
   <tabstop>minNoteDistance</tabstop>
@@ -6096,6 +6163,7 @@
   <tabstop>showRepeatBarTips</tabstop>
   <tabstop>showStartBarlineSingle</tabstop>
   <tabstop>showStartBarlineMultiple</tabstop>
+  <tabstop>scaleBarlines</tabstop>
   <tabstop>barWidth</tabstop>
   <tabstop>endBarWidth</tabstop>
   <tabstop>endBarDistance</tabstop>
@@ -6129,6 +6197,10 @@
   <tabstop>smallNoteSize</tabstop>
   <tabstop>graceNoteSize</tabstop>
   <tabstop>smallClefSize</tabstop>
+  <tabstop>lyricsDashMinLength</tabstop>
+  <tabstop>lyricsDashMaxLength</tabstop>
+  <tabstop>lyricsDashMaxDistance</tabstop>
+  <tabstop>lyricsDashForce</tabstop>
   <tabstop>hairpinY</tabstop>
   <tabstop>resetHairpinY</tabstop>
   <tabstop>hairpinLineWidth</tabstop>
@@ -6147,14 +6219,14 @@
   <tabstop>resetVoltaLineStyle</tabstop>
   <tabstop>ottavaY</tabstop>
   <tabstop>resetOttavaY</tabstop>
-  <tabstop>ottavaNumbersOnly</tabstop>
-  <tabstop>resetOttavaNumbersOnly</tabstop>
   <tabstop>ottavaHook</tabstop>
   <tabstop>resetOttavaHook</tabstop>
   <tabstop>ottavaLineWidth</tabstop>
   <tabstop>resetOttavaLineWidth</tabstop>
   <tabstop>ottavaLineStyle</tabstop>
   <tabstop>resetOttavaLineStyle</tabstop>
+  <tabstop>ottavaNumbersOnly</tabstop>
+  <tabstop>resetOttavaNumbersOnly</tabstop>
   <tabstop>pedalY</tabstop>
   <tabstop>pedalLineWidth</tabstop>
   <tabstop>pedalLineStyle</tabstop>
@@ -6194,9 +6266,9 @@
   <tabstop>radioFBModern</tabstop>
   <tabstop>radioFBHistoric</tabstop>
   <tabstop>propertyDistanceHead</tabstop>
-  <tabstop>articulationMag</tabstop>
   <tabstop>propertyDistanceStem</tabstop>
   <tabstop>propertyDistance</tabstop>
+  <tabstop>articulationMag</tabstop>
   <tabstop>articulationTable</tabstop>
   <tabstop>accidentalTable</tabstop>
   <tabstop>radioKeySigNatNone</tabstop>


### PR DESCRIPTION
Fix #88171 - Lyrics dash max distance as a parameter

Turns the previously hard-code max. distance between multiple dashes into a user configurable score style.

__References__:
- Issue: https://musescore.org/en/node/88171
- Original request with discussion and screen-shots: https://musescore.org/en/node/87841