### PR TITLE
fix gui scaling regressions for high DPI displays

### DIFF
--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -31,9 +31,10 @@ ExampleView::ExampleView(QWidget* parent)
       _score = 0;
       setAcceptDrops(true);
       setFocusPolicy(Qt::StrongFocus);
-      double mag = guiScaling * (DPI_DISPLAY / DPI);  // default is same as scoreview
+      double mag = 0.9 * guiScaling * (DPI_DISPLAY / DPI);  // 90% of nominal
       qreal _spatium = SPATIUM20 * mag;
-      _matrix  = QTransform(mag, 0.0, 0.0, mag, _spatium, -_spatium * 6);
+      // example would normally be 10sp from top of page; this leaves 3sp margin above
+      _matrix  = QTransform(mag, 0.0, 0.0, mag, _spatium, -_spatium * 7.0);
       imatrix  = _matrix.inverted();
       }
 
@@ -336,8 +337,10 @@ void ExampleView::mousePressEvent(QMouseEvent* event)
 
 QSize ExampleView::sizeHint() const
       {
-      qreal mag = guiScaling * (DPI_DISPLAY / DPI);   // same as example itself
-      return QSize(1000 * mag, 80 * mag);
+      qreal mag = 0.9 * guiScaling * (DPI_DISPLAY / DPI);
+      qreal _spatium = SPATIUM20 * mag;
+      // staff is 4sp tall with 3sp margin above; this leaves 3sp margin below
+      return QSize(1000 * mag, _spatium * 10.0);
       }
 
 

--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -31,8 +31,8 @@ ExampleView::ExampleView(QWidget* parent)
       _score = 0;
       setAcceptDrops(true);
       setFocusPolicy(Qt::StrongFocus);
-      double mag = 1.0;
-      qreal _spatium = SPATIUM20;
+      double mag = guiScaling * (DPI_DISPLAY / DPI);  // default is same as scoreview
+      qreal _spatium = SPATIUM20 * mag;
       _matrix  = QTransform(mag, 0.0, 0.0, mag, _spatium, -_spatium * 6);
       imatrix  = _matrix.inverted();
       }
@@ -336,9 +336,8 @@ void ExampleView::mousePressEvent(QMouseEvent* event)
 
 QSize ExampleView::sizeHint() const
       {
-      return QSize(
-            1000 * guiScaling * (DPI / 90),
-              80 * guiScaling * (DPI / 90));
+      qreal mag = guiScaling * (DPI_DISPLAY / DPI);   // same as example itself
+      return QSize(1000 * mag, 80 * mag);
       }
 
 

--- a/mscore/globals.h
+++ b/mscore/globals.h
@@ -95,8 +95,9 @@ struct MidiRemote {
 
 extern const char* stateName(ScoreState);
 
-static constexpr qreal DPMM_DISPLAY    = 4;   // 100 DPI
-static constexpr qreal PALETTE_SPATIUM = 1.9 * DPMM_DISPLAY;
+static constexpr qreal DPI_DISPLAY     = 96.0;  // 96 DPI nominal resolution
+static constexpr qreal DPMM_DISPLAY    = DPI_DISPLAY / 25.4;
+static constexpr qreal PALETTE_SPATIUM = 1.764 * DPMM_DISPLAY;
 
 extern QPaintDevice* pdev;
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -130,7 +130,7 @@ bool externalIcons = false;
 bool pluginMode = false;
 static bool startWithNewScore = false;
 double converterDpi = 0;
-double guiScaling = 1.0;
+double guiScaling = 0.0;
 int trimMargin = -1;
 bool noWebView = false;
 bool exportScoreParts = false;
@@ -348,7 +348,14 @@ MuseScore::MuseScore()
       {
       QScreen* screen      = QGuiApplication::primaryScreen();
       _physicalDotsPerInch = screen->physicalDotsPerInch();        // physical resolution
-      _physicalDotsPerInch *= guiScaling;
+      if (guiScaling == 0.0) {
+            // set scale for icons, palette elements, window sizes, etc
+            // the default values are hard coded in pixel sizes and assume ~96 DPI
+            if (qAbs(_physicalDotsPerInch - DPI_DISPLAY) > 6.0)
+                  guiScaling = _physicalDotsPerInch / DPI_DISPLAY;
+            else
+                  guiScaling = 1.0;
+            }
 
       _sstate = STATE_INIT;
       setWindowTitle(QString(MUSESCORE_NAME_VERSION));

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -347,7 +347,14 @@ MuseScore::MuseScore()
    : QMainWindow()
       {
       QScreen* screen      = QGuiApplication::primaryScreen();
+#if defined(Q_OS_WIN)
+      if (QSysInfo::WindowsVersion <= QSysInfo::WV_WINDOWS7)
+            _physicalDotsPerInch = screen->logicalDotsPerInch() * screen->devicePixelRatio();
+      else
+            _physicalDotsPerInch = screen->physicalDotsPerInch();  // physical resolution
+#else
       _physicalDotsPerInch = screen->physicalDotsPerInch();        // physical resolution
+#endif
       if (guiScaling == 0.0) {
             // set scale for icons, palette elements, window sizes, etc
             // the default values are hard coded in pixel sizes and assume ~96 DPI

--- a/mscore/note_groups.ui
+++ b/mscore/note_groups.ui
@@ -47,7 +47,7 @@
      <item row="1" column="2">
       <widget class="Ms::ExampleView" name="view16">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -152,7 +152,7 @@
      <item row="2" column="2">
       <widget class="Ms::ExampleView" name="view32">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -238,7 +238,7 @@
      <item row="0" column="2">
       <widget class="Ms::ExampleView" name="view8">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>


### PR DESCRIPTION
See discussion in https://musescore.org/en/node/87861, specifically my comments at https://musescore.org/en/node/87861#comment-388486 and below.

Now that scores are being scaled to physical screen resolution, we don't need the "-x" option to perform that function, so I have removed guiScaling from the calculation of physicalDotsPerInch.  And now that we have a good value for physicalDotsPerInch, I have also added code to set a reasonable default value of guiScaling (still needed for icons, palette elements, and window sizes, since they continue to be recorded in physical pixel dimensions).

The bottom line is that things now scale correctly for me on my high DPI display on Ubuntu, and I believe my changes should be safe for standard resolution displays.  However, I am not sure what effect my changes will have on Macs with "retina" displays, since that OS apparently does some scaling magic that allows the hard coded pixel dimensions to work correctly in most places.  If someone with a retina Mac can test my changes I would greatly appreciate it.  If the result is that icons, palette elements, and example views are now too large, we can ifdef the code in musescore.cpp that sets the default value for guiScaling, so it is always set to 1.0 for Mac rather than being scaled to physicalDotsPerInch.  Or maybe there is a different value thaty is more appropriate to use for Mac, like maybe screen->logicalDotsPerInch().

One other thing my code does not get right: while the *scaling* of example views is correct - so the note groups in Time Signature Properties are sized properly - the initial size of the widget is not.  The changes I made to ExampleView::sizeHint() seem like they should be correct, but it seems sizeHint() is being ignored here unelss I change the size policy.  Not sure what changed exactly here, since I think this was working earlier.  But in any case, it seems we should look at this in conjunction with #2288.  My changes here should be good in any case.