### PR TITLE
cheap fix #88291: disable shift+left/right in cases where it fails

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5935,7 +5935,8 @@ void ScoreView::cmdMoveCR(bool left)
                               break;
                         }
                   ChordRest* cr2 = left ? prevChordRest(cr1) : nextChordRest(cr1);
-                  if (cr2 && cr1->measure() == cr2->measure()) {
+                  if (cr2 && cr1->measure() == cr2->measure() && !cr1->tuplet() && !cr2->tuplet()
+                      && cr1->durationType() == cr2->durationType() && cr1->duration() == cr2->duration()) {
                         if (!cmdActive) {
                               _score->startCmd();
                               cmdActive = true;


### PR DESCRIPTION
The shift+left/right functions to swpa CR's is extremely limited - it only works correctly if the notes are int he same measure and have the same duration and there are no tuplets.  Unfortunately, in the cases where it fails to work correctly, it corrupts the score, creating gaps or overlapping durations.  Fixing these in the general case would be pretty involved - we'd need to be deleting and inserting segments, etc.  For now, I propose we simply disable the operation except in the cases where it works correctly, so that is what this PR does.