### PR TITLE
Fix #88756 - Disable unnecessary actions in text editing states

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -42,7 +42,7 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_DISABLED | STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT
-            | STATE_LYRICS_EDIT | STATE_PLAY,
+             | STATE_PLAY,
          "file-open",
          QT_TRANSLATE_NOOP("action","Open..."),
          QT_TRANSLATE_NOOP("action","File: Open"),
@@ -51,7 +51,8 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT| STATE_LYRICS_EDIT
+            | STATE_HARMONY_FIGBASS_EDIT | STATE_PLAY,
          "file-save",
          QT_TRANSLATE_NOOP("action","Save"),
          QT_TRANSLATE_NOOP("action","File: Save"),
@@ -60,7 +61,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "file-save-online",
          QT_TRANSLATE_NOOP("action","Save Online..."),
          QT_TRANSLATE_NOOP("action","File: Save online"),
@@ -71,7 +72,8 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT | STATE_LYRICS_EDIT
+            | STATE_HARMONY_FIGBASS_EDIT | STATE_PLAY,
          "file-save-as",
          QT_TRANSLATE_NOOP("action","Save As..."),
          QT_TRANSLATE_NOOP("action","File: Save as"),
@@ -82,7 +84,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "file-save-selection",
          QT_TRANSLATE_NOOP("action","Save Selection..."),
          QT_TRANSLATE_NOOP("action","Save selection"),
@@ -93,7 +95,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "file-save-a-copy",
          QT_TRANSLATE_NOOP("action","Save a Copy..."),
          QT_TRANSLATE_NOOP("action","File: Save a copy"),
@@ -104,7 +106,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
          "file-export",
          QT_TRANSLATE_NOOP("action","Export..."),
          QT_TRANSLATE_NOOP("action","Export score"),
@@ -115,7 +117,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "file-part-export",
          QT_TRANSLATE_NOOP("action","Export Parts..."),
          QT_TRANSLATE_NOOP("action","Export parts"),
@@ -126,8 +128,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_DISABLED | STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT
-            | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_DISABLED | STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
          "file-import-pdf",
          QT_TRANSLATE_NOOP("action","Import PDF..."),
          QT_TRANSLATE_NOOP("action","Import PDF"),
@@ -135,7 +136,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "file-close",
          QT_TRANSLATE_NOOP("action","Close"),
          QT_TRANSLATE_NOOP("action","File: Close"),
@@ -143,7 +144,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_DISABLED | STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_DISABLED | STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "file-new",
          QT_TRANSLATE_NOOP("action","New..."),
          QT_TRANSLATE_NOOP("action","File: New"),
@@ -153,7 +154,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          Ms::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY  | STATE_PLAY,
          "print",
          QT_TRANSLATE_NOOP("action","Print..."),
          QT_TRANSLATE_NOOP("action","Print"),
@@ -184,7 +185,8 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT | STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT | STATE_LYRICS_EDIT
+            | STATE_HARMONY_FIGBASS_EDIT,
          "cut",
          QT_TRANSLATE_NOOP("action","Cut"),
          0,
@@ -193,7 +195,8 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT |STATE_LYRICS_EDIT | STATE_FOTO,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT | STATE_LYRICS_EDIT
+            | STATE_HARMONY_FIGBASS_EDIT | STATE_FOTO,
          "copy",
          QT_TRANSLATE_NOOP("action","Copy"),
          0,
@@ -202,7 +205,8 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT |STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT |STATE_LYRICS_EDIT
+            | STATE_HARMONY_FIGBASS_EDIT,
          "paste",
          QT_TRANSLATE_NOOP("action","Paste"),
          0,
@@ -1633,7 +1637,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "toggle-palette",
          QT_TRANSLATE_NOOP("action","Palettes"),
          0,
@@ -1643,7 +1647,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "toggle-playpanel",
          QT_TRANSLATE_NOOP("action","Play Panel"),
          QT_TRANSLATE_NOOP("action","Play panel"),
@@ -1653,7 +1657,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "toggle-selection-window",
          QT_TRANSLATE_NOOP("action","Selection Filter"),
          QT_TRANSLATE_NOOP("action","Selection filter"),
@@ -1663,7 +1667,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "toggle-navigator",
          QT_TRANSLATE_NOOP("action","Navigator"),
          0,
@@ -1673,7 +1677,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "toggle-midiimportpanel",
          QT_TRANSLATE_NOOP("action","MIDI Import Panel"),
          QT_TRANSLATE_NOOP("action","MIDI import panel"),
@@ -1687,7 +1691,7 @@ Shortcut Shortcut::_sc[] = {
          //Avoid conflict with M in text
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
 #else
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
 #endif
          "toggle-mixer",
          QT_TRANSLATE_NOOP("action","Mixer"),
@@ -1698,34 +1702,34 @@ Shortcut Shortcut::_sc[] = {
          },
 //      {
 //         MsWidget::MAIN_WINDOW,
-//         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT,
+//         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
 //         "toggle-transport",
 //         QT_TRANSLATE_NOOP("action","Transport"),
 //         QT_TRANSLATE_NOOP("action","Transport toolbar")
 //         },
 //      {
 //         MsWidget::MAIN_WINDOW,
-//         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT,
+//         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
 //         "toggle-noteinput",
 //         QT_TRANSLATE_NOOP("action","Note Input"),
 //         QT_TRANSLATE_NOOP("action","Note input toolbar")
 //         },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
          "toggle-statusbar",
          QT_TRANSLATE_NOOP("action","Status Bar"),
          QT_TRANSLATE_NOOP("action","Status bar")
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_DISABLED | STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY | STATE_FOTO,
+         STATE_DISABLED | STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY | STATE_FOTO,
          "quit",
          QT_TRANSLATE_NOOP("action","Quit")
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
          "mag",
          QT_TRANSLATE_NOOP("action","Zoom Canvas"),
          QT_TRANSLATE_NOOP("action","Zoom canvas")
@@ -1892,7 +1896,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "rewind",
          QT_TRANSLATE_NOOP("action","Rewind"),
          QT_TRANSLATE_NOOP("action","Player rewind"),
@@ -2255,7 +2259,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "zoomin",
          QT_TRANSLATE_NOOP("action","Zoom In"),
          QT_TRANSLATE_NOOP("action","Zoom in")
@@ -2263,8 +2267,6 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          // conflicts with Ctrl+- in edit mode to enter lyrics hyphen
-         // STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT,
-
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY,
          "zoomout",
          QT_TRANSLATE_NOOP("action","Zoom Out"),
@@ -2272,7 +2274,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "zoom100",
          QT_TRANSLATE_NOOP("action","Zoom to 100%"),
          QT_TRANSLATE_NOOP("action","Zoom to 100%")
@@ -2461,7 +2463,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
          "hraster",
          QT_TRANSLATE_NOOP("action","Enable Snap to Horizontal Grid"),
          QT_TRANSLATE_NOOP("action","Enable snap to horizontal grid"),
@@ -2472,7 +2474,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
          "vraster",
          QT_TRANSLATE_NOOP("action","Enable Snap to Vertical Grid"),
          QT_TRANSLATE_NOOP("action","Enable snap to vertical grid"),
@@ -2483,7 +2485,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
          "config-raster",
          QT_TRANSLATE_NOOP("action","Configure Grid"),
          QT_TRANSLATE_NOOP("action","Configure grid")
@@ -2508,7 +2510,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY | STATE_FOTO,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY | STATE_FOTO,
          "media",
          QT_TRANSLATE_NOOP("action","Additional Media..."),
          QT_TRANSLATE_NOOP("action","Show media dialog")
@@ -2529,7 +2531,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY | STATE_FOTO,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY | STATE_FOTO,
          "page-settings",
          QT_TRANSLATE_NOOP("action","Page Settings..."),
          QT_TRANSLATE_NOOP("action","Page settings")
@@ -2596,7 +2598,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_FOTO,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT  | STATE_FOTO,
          "inspector",
          QT_TRANSLATE_NOOP("action","Inspector"),
          QT_TRANSLATE_NOOP("action","Show inspector")
@@ -2614,7 +2616,7 @@ Shortcut Shortcut::_sc[] = {
 #ifdef OMR
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT | STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT ,
          "omr",
          QT_TRANSLATE_NOOP("action","OMR Panel"),
          QT_TRANSLATE_NOOP("action","Show OMR panel")
@@ -2655,7 +2657,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT | STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT ,
          "metronome",
          QT_TRANSLATE_NOOP("action","Metronome"),
          QT_TRANSLATE_NOOP("action","Toggle metronome playback"),
@@ -2666,7 +2668,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT | STATE_LYRICS_EDIT,
+         STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT ,
          "countin",
          QT_TRANSLATE_NOOP("action","Count-In"),
          QT_TRANSLATE_NOOP("action","Toggle count-in playback"),
@@ -3297,7 +3299,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
-         STATE_DISABLED | STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_LYRICS_EDIT | STATE_PLAY,
+         STATE_DISABLED | STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT  | STATE_PLAY,
          "startcenter",
          QT_TRANSLATE_NOOP("action","Start Center"),
          QT_TRANSLATE_NOOP("action","Start center"),


### PR DESCRIPTION
Fix #88756 - Disable unnecessary actions in text editing states

__References__ :
- Issue: https://musescore.org/en/node/88756
- Forum post: https://musescore.org/en/node/88521 (with discussion and examples)

__Issue__:
In text editing states, any enabled actions mapped (either by default or by customization) to an alphanumeric character short-cut makes impossible to enter that character in the text.

Default short-cuts are carefully crafted to avoid this, but a user customizing his short-cuts may unknowingly and unexpectedly trigger this issue. Reducing the number of enabled actions in text editing states to the really necessary ones greatly reduces this probability.

__Fix__:
The following actions are enabled for __all three text editing states__ (general text, lyrics, chord names/fig. bass):
- "file-save"
- "file-save-as"
- "cut"
- "copy"
- "paste"
- "escape"
- "show-keys"

In __generic text editing state__, the following 5 additional actions are enabled:
- "text-b"
- "text-i"
- "text-u"
- "text-word-left"
- "text-word-right"

In __lyrics editing state__, the following two additional actions are enabled:
- "next-lyric"
- "prev-lyric"

In __chord names/fig. bass editing state__, 13 additional actions are enabled which move the entry cursor to a next/previous time point, beat or measure.