### PR TITLE
fix #88741: selection lost after insert measure with mmrests enabled

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5352,11 +5352,18 @@ void ScoreView::cmdInsertMeasures(int n, Element::Type type)
       _score->startCmd();
       for (int i = 0; i < n; ++i)
             _score->insertMeasure(type, mb);
-
-      // measure may be part of mm rest:
-      if (!_score->styleB(StyleIdx::createMultiMeasureRests) && type == Element::Type::MEASURE)
-            _score->select(mb, SelectType::SINGLE, 0);
       _score->endCmd();
+
+      if (mb->type() == Element::Type::MEASURE) {
+            // re-select the original measure (which may now be covered by an mmrest)
+            // do this after the layout so mmrests are updated
+            Measure* m = _score->tick2measureMM(mb->tick());
+            _score->select(m, SelectType::SINGLE, 0);
+            }
+      else {
+            // original selection was not a measure, just re-select it
+            _score->select(mb, SelectType::SINGLE, 0);
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
We were deliberately not re-selecting the original measure after the insertion in the mmrest case, I guess because the mmrests may change after the operation.  But as far as I can tell, simply moving the selection to *after* the endCmd() works just fine.  The code I added does the right thing in all cases I could think to test.