### PR TITLE
fix #78636: insert before frame fails

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2668,8 +2668,12 @@ static MeasureBase* searchMeasureBase(Score* score, MeasureBase* mb)
                   }
             }
       else {
-            if (!mb->links())
-                  qDebug("searchMeasureBase: no links");
+            if (!mb->links()) {
+                  if (mb->score() == score)
+                        return mb;
+                  else
+                        qDebug("searchMeasureBase: no links");
+                  }
             else {
                   for (ScoreElement* m : *mb->links()) {
                         if (m->score() == score)
@@ -2737,7 +2741,7 @@ MeasureBase* Score::insertMeasure(Element::Type type, MeasureBase* measure, bool
                         }
 
                   Measure* m = static_cast<Measure*>(mb);
-                  Measure* mi = static_cast<Measure*>(im);
+                  Measure* mi = im ? score->tick2measure(im->tick()) : nullptr;
                   m->setTimesig(f);
                   m->setLen(f);
                   ticks = m->ticks();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5401,7 +5401,7 @@ MeasureBase* ScoreView::checkSelectionStateForInsertMeasure()
 
       Element* e = _score->selection().element();
       if (e) {
-            if (e->type() == Element::Type::VBOX || e->type() == Element::Type::TBOX)
+            if (e->type() == Element::Type::VBOX || e->type() == Element::Type::TBOX || e->type() == Element::Type::HBOX)
                   return static_cast<MeasureBase*>(e);
             }
       QMessageBox::warning(0, "MuseScore",


### PR DESCRIPTION
If you select a frame in a score that does not have linked parts, then try to insert either a measure or a frame before it, the measure/frame is actually appended to the end ather than being inserted before the selected frame.  That's because searchMeasureBase() was returning nullptr in this case.  Fixed to return the original frame.

BTW, in the case of inserting measures, this bug was also "corrupting" any spanners present after the insertion point, because undoInsertTime() was still inserting the time at the proper place even though the measures themselves were being appended to the end.