### PR TITLE
cheap partial fix for #51626: disallow copy/paste with local time sig…

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -156,6 +156,11 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                               tuplet->setTrack(e.track());
                               tuplet->read(e);
                               int tick = e.tick();
+                              // no paste into local time signature
+                              if (staff(dstStaffIdx)->timeStretch(tick) != Fraction(1, 1)) {
+                                    qDebug("paste into local time signature");
+                                    return false;
+                                    }
                               Measure* measure = tick2measure(tick);
                               tuplet->setParent(measure);
                               tuplet->setTick(tick);
@@ -174,6 +179,11 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                               cr->read(e);
                               cr->setSelected(false);
                               int tick = e.tick();
+                              // no paste into local time signature
+                              if (staff(dstStaffIdx)->timeStretch(tick) != Fraction(1, 1)) {
+                                    qDebug("paste into local time signature");
+                                    return false;
+                                    }
                               if (cr->isGrace())
                                     graceNotes.push_back(static_cast<Chord*>(cr));
                               else {

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -1041,7 +1041,7 @@ static bool checkEnd(Element* e, int endTick)
 //---------------------------------------------------------
 //   canCopy
 //    return false if range selection intersects a tuplet
-//    or a tremolo
+//    or a tremolo, or a local timne signature
 //---------------------------------------------------------
 
 bool Selection::canCopy() const
@@ -1051,7 +1051,8 @@ bool Selection::canCopy() const
 
       int endTick = _endSegment ? _endSegment->tick() : score()->lastSegment()->tick();
 
-      for (int staffIdx = _staffStart; staffIdx != _staffEnd; ++staffIdx)
+      for (int staffIdx = _staffStart; staffIdx != _staffEnd; ++staffIdx) {
+
             for (int voice = 0; voice < VOICES; ++voice) {
                   int track = staffIdx * VOICES + voice;
                   if (!canSelectVoice(track))
@@ -1076,6 +1077,14 @@ bool Selection::canCopy() const
                   if (checkEnd(endSegmentSelection->element(track), endTick))
                         return false;
                   }
+
+            // loop through measures on this staff checking for local time signatures
+            for (Measure* m = _startSegment->measure(); m && m->tick() < endTick; m = m->nextMeasure()) {
+                  if (_score->staff(staffIdx)->timeStretch(m->tick()) != Fraction(1, 1))
+                        return false;
+                  }
+
+            }
       return true;
       }
 


### PR DESCRIPTION
…natures

I have added code to detect local time signatures during both copy and paste operations, and I disallow the oepration if a local time signature is encountered.  Ultimately, we should consider supporting this, but I think it important we at least prevent this corruption for 2.0.3.

The error message you get on trying to copy/paste in a local time signature passage, for now, refers to tuplets.  Shortly before the release of 2.0 when I went in and fixed a bunch of bugs involving local time signatures, a number were fixed by disallowing the operation and piggybacking on existing error messages because we had already passed string freeze for the release.  We should probably go back and revisit all of these - and/or see which are worth actually fixing rather than disallowing.

Even just producing better error messages will in some cases - like this one - require a bit of code refactoring, because right now the functions involved return simple bool values, and the error messages is generated further upstream where it is assumed that any falure must be on account of tuplets.  We'd need to change some of these functions to return meaningful error codes.  I think that's a change that should be looked at in "big picture" terms, coming up with a meaningful set of error codes across all of these operations.