### PR TITLE
fix #87331: crash on full measure rest command with mmrest

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2322,6 +2322,13 @@ void Score::cmdFullMeasureRest()
             Segment* s2 = selection().endSegment();
             int stick1 = selection().tickStart();
             int stick2 = selection().tickEnd();
+            if (styleB(StyleIdx::createMultiMeasureRests)) {
+                  // use underlying measures
+                  if (s1 && s1->measure()->isMMRest())
+                        s1 = tick2segment(stick1);
+                  if (s2 && s2->measure()->isMMRest())
+                        s2 = tick2segment(stick2, true);
+                  }
 
             Segment* ss1 = s1;
             if (ss1->segmentType() != Segment::Type::ChordRest)
@@ -2363,8 +2370,12 @@ void Score::cmdFullMeasureRest()
                               break;
                         }
                   }
-            s1 = tick2segment(stick1);
-            s2 = tick2segment(stick2);
+            // selected range is probably empty now and possibly subsumed by an mmrest
+            // so updating selection requires forcing mmrests to be updated first
+            if (styleB(StyleIdx::createMultiMeasureRests))
+                  createMMRests();
+            s1 = tick2segmentMM(stick1);
+            s2 = tick2segmentMM(stick2, true);
             if (s1 == 0 || s2 == 0)
                   deselectAll();
             else {


### PR DESCRIPTION
We were looping on regular measures even though the selection ended on an mmrest.  I first tried fixing this by changing the loops to us next1MM() and nextMeasureMM(), but there were trickier problems to solve where you could get corruption (completely empty measure) if the selection ever included a mesasure covered by an mmrest.  In the end, I think the solution I went with makes more sense and is more robust.

The code at the end of the function to update the selection wasn't working either in the presence of mmrests, which is what triggered the corruption issue I discovered.  Fixing this requires me to force an update of mmrests while still in the command.  I've gotten away with this before, so hopefully it's OK.  But FWIW, we might consider having createMMRests() (normally called in doLayout, after a command has completed) automatically update the selection.  This would probably solve other issues we mnight have where a selection becomes invalid in the presence of mmrests.