### PR TITLE
fix #88746: unable to save files

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -385,6 +385,7 @@ bool Score::saveFile()
       temp.close();
 
       QString name(info.filePath());
+      QDir dir(info.path());
       if (!saved()) {
             // if file was already saved in this session
             // save but don't overwrite backup again
@@ -393,7 +394,6 @@ bool Score::saveFile()
             // step 2
             // remove old backup file if exists
             //
-            QDir dir(info.path());
             QString backupName = QString(".") + info.fileName() + QString(",");
             if (dir.exists(backupName)) {
                   if (!dir.remove(backupName)) {
@@ -421,6 +421,17 @@ bool Score::saveFile()
             SetFileAttributes((LPCTSTR)backupNativePath.toLocal8Bit(), FILE_ATTRIBUTE_HIDDEN);
 #endif
             }
+      else {
+            // file has previously been saved - remove the old file
+            if (dir.exists(name)) {
+                  if (!dir.remove(name)) {
+//                      if (!MScore::noGui)
+//                            QMessageBox::critical(0, tr("MuseScore: Save File"),
+//                               tr("Removing old file") + name + tr(" failed"));
+                        }
+                  }
+            }
+
       //
       // step 4
       // rename temp name into file name


### PR DESCRIPTION
On the first save, we were renaming the old file to the backup, thus allowing the later rename of the temp file to succeed.  On subsequent saves, the old file is still present, so renaming the temp file fails.  My fix here simply removes the old file on subsequent saves.

I'm still not really crazy about the idea that we don't just update the backup on *every* save - I think this is what most people expect.  But at least it is now going to be much less likely we'll ever leave the user with an imcompletely written file.

Since the bug prevents the nightlies from being usable at all, I'm going to merge this, hope that's OK.  We can always revisit this later.