### PR TITLE
fix #5098: tpc corruption on copy of note

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1531,9 +1531,15 @@ Element* Note::drop(const DropData& data)
                         delete e;
                         return 0;
                         }
-                  e->setParent(ch);
+                  // calculate correct transposed tpc
+                  Note* n = static_cast<Note*>(e);
+                  Interval v = part()->instrument(ch->tick())->transpose();
+                  v.flip();
+                  n->setTpc2(Ms::transposeTpc(n->tpc1(), v, true));
+                  // replace this note with new note
+                  n->setParent(ch);
                   score()->undoRemoveElement(this);
-                  score()->undoAddElement(e);
+                  score()->undoAddElement(n);
                   }
                   break;
 


### PR DESCRIPTION
When copying a single note onto another note, the source tpc values were being copied verbatim rsather than being adjusted for the transposition of the destination staff.

I have fixed this in Note::drop(), which seemed logical.  It is possible this same code is hit in different situations as well, but even if so, most likely the same bug exists there.  And in any case, if the other cases were already setting the tpc's appropriately, my code here should still be harmless - it will just set tpc2 to what it presumably already was.