### PR TITLE
fix #89401: delete first measure removes timesig from parts

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2061,22 +2061,22 @@ void Score::cmdDeleteSelectedMeasures()
             Measure* is = score->tick2measure(startTick);
             Measure* ie = score->tick2measure(endTick);
 
-            undoRemoveMeasures(is, ie);
+            score->undoRemoveMeasures(is, ie);
 
             // adjust views
-            Measure* focusOn = is->prevMeasure() ? is->prevMeasure() : firstMeasure();
-            foreach(MuseScoreView* v, score->viewer)
+            Measure* focusOn = is->prevMeasure() ? is->prevMeasure() : score->firstMeasure();
+            for (MuseScoreView* v : score->viewer)
                   v->adjustCanvasPosition(focusOn, false);
 
             if (createEndBar) {
                   Measure* lastMeasure = score->lastMeasure();
                   if (lastMeasure && lastMeasure->endBarLineType() == BarLineType::NORMAL)
-                        undoChangeEndBarLineType(lastMeasure, BarLineType::END);
+                        score->undoChangeEndBarLineType(lastMeasure, BarLineType::END);
                   }
 
             // insert correct timesig after deletion
             Measure* mBeforeSel = is->prevMeasure();
-            Measure* mAfterSel  = mBeforeSel ? mBeforeSel->nextMeasure() : firstMeasure();
+            Measure* mAfterSel  = mBeforeSel ? mBeforeSel->nextMeasure() : score->firstMeasure();
             if (mAfterSel && lastDeletedSig) {
                   bool changed = true;
                   if (mBeforeSel) {


### PR DESCRIPTION
In this code, we are looping through the scores using "score" as the iterator, but there are a few places where we fail to preface an operation with "score->", so the operation actually takes place on "this" score.  The one that actually caused the problem is the call to firstMeasure() when initializing mAfterSel, but I kind of think the other calls I modified were just problems waiting to happen.