### PR TITLE
fix #89576: reset spanner segments in range selection on Ctrl+R

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2972,8 +2972,14 @@ void ScoreView::cmd(const QAction* a)
                   }
             else {
                   _score->startCmd();
-                  foreach(Element* e, _score->selection().elements())
+                  for (Element* e : _score->selection().elements()) {
                         e->reset();
+                        if (e->isSpanner()) {
+                              Spanner* sp = static_cast<Spanner*>(e);
+                              for (SpannerSegment* ss : sp->spannerSegments())
+                                    ss->reset();
+                              }
+                        }
                   _score->endCmd();
                   }
             _score->setLayoutAll(true);


### PR DESCRIPTION
There might be a reason we don't fully reset spanners on Ctrl+R of a range selection, but for now I'm assuming it's just a accident.  The Spanner is selected, not the SpannerSegment, and we call reset() on the Spanner but not the SpannerSegments, when it's really the latter that we probably *want* reset - that's where the common properties (eg, offset, shape, etc) are applied.

It would also be possible to define Spanner::reset() and have it loop through the segments.  Interestingly, SpannerSegment::reset() calls Spanner::reset() but not vice versa.  Making me wonder if there is some reason for this I am not seeing.  Still, as a user, I do think it feels wrong for Ctrl+R to not seem to work on spanners within range selections.