### PR TITLE
Shadownotes during note entry

### DIFF
--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -65,7 +65,7 @@ add_library (
       bsymbol.cpp marker.cpp jump.cpp stemslash.cpp ledgerline.cpp
       synthesizerstate.cpp mcursor.cpp groups.cpp mscoreview.cpp
       noteline.cpp spannermap.cpp
-      bagpembell.cpp ambitus.cpp keylist.cpp scoreElement.cpp
+      bagpembell.cpp ambitus.cpp keylist.cpp scoreElement.cpp shadownotesymbol.cpp
       shape.cpp systemdivider.cpp midimapping.cpp
       )
 

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1746,6 +1746,11 @@ void Element::drawSymbols(const std::vector<SymId>& s, QPainter* p, const QPoint
       score()->scoreFont()->draw(s, p, magS(), o);
       }
 
+void Element::drawShadowSymbols(const QList<SymId>& s, QPainter* p, const QPointF& o) const
+      {
+      score()->scoreFont()->drawShadow(s, p, magS(), o);
+      }
+
 //---------------------------------------------------------
 //   symHeight
 //---------------------------------------------------------

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -576,6 +576,7 @@ class Element : public QObject, public ScoreElement {
       void drawSymbol(SymId id, QPainter* p, const QPointF& o = QPointF()) const;
       void drawSymbol(SymId id, QPainter* p, const QPointF& o, int n) const;
       void drawSymbols(const std::vector<SymId>&, QPainter* p, const QPointF& o = QPointF()) const;
+      void drawShadowSymbols(const QList<SymId>&, QPainter* p, const QPointF& o = QPointF()) const;
       qreal symHeight(SymId id) const;
       qreal symWidth(SymId id) const;
       qreal symWidth(const std::vector<SymId>&) const;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -513,6 +513,7 @@ class Score : public QObject, public ScoreElement {
    signals:
       void posChanged(POS, unsigned);
       void playlistChanged();
+      void updateShadow();
 
    public:
       Score();

--- a/libmscore/shadownote.h
+++ b/libmscore/shadownote.h
@@ -14,6 +14,7 @@
 #define __SHADOWNOTE_H__
 
 #include "element.h"
+#include "shadownotesymbol.h"
 
 class QPainter;
 
@@ -32,7 +33,7 @@ class ShadowNote : public Element {
       Q_OBJECT
 
       int _line;
-      SymId sym;
+      ShadowNoteSymbol symbols;
 
    public:
       ShadowNote(Score*);
@@ -42,7 +43,8 @@ class ShadowNote : public Element {
       int line() const                   { return _line;   }
       void setLine(int n)                { _line = n;      }
       virtual void draw(QPainter*) const;
-      void setSym(SymId id)              { sym = id;     }
+      void setSym(SymId id);
+      void setSymbols(TDuration::DurationType type, SymId noteSymbol);
       };
 
 

--- a/libmscore/shadownotesymbol.cpp
+++ b/libmscore/shadownotesymbol.cpp
@@ -1,0 +1,88 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2002-2012 Werner Schweer
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "shadownotesymbol.h"
+#include "sym.h"
+
+namespace Ms {
+
+
+void ShadowNoteSymbol::setSymbols(TDuration::DurationType type, SymId noteSymbol)
+    {
+
+    clearSymbols();
+    symNotehead=noteSymbol;
+    if(symNotehead != SymId::noSym)
+    {
+        bNoteSymSet = true;
+    }
+
+
+
+
+    switch(type) {
+          case TDuration::DurationType::V_LONG:
+                symFlag=SymId::flagInternalUp;
+                break;
+          case TDuration::DurationType::V_BREVE:
+                symFlag = SymId::noSym;
+                break;
+          case TDuration::DurationType::V_WHOLE:
+                symFlag = SymId::noSym;
+                break;
+          case TDuration::DurationType::V_HALF:
+                symFlag=SymId::flagInternalUp;
+                break;
+          case TDuration::DurationType::V_QUARTER:
+                symFlag= SymId::flagInternalUp;
+                break;
+          case TDuration::DurationType::V_EIGHTH:
+                symFlag=SymId::flag8thUp;
+                break;
+          case TDuration::DurationType::V_16TH:
+                symFlag=SymId::flag16thUp;
+                break;
+          case TDuration::DurationType::V_32ND:
+                symFlag=SymId::flag32ndUp;
+                break;
+          case TDuration::DurationType::V_64TH:
+                symFlag=SymId::flag64thUp;
+                break;
+          case TDuration::DurationType::V_128TH:
+                symFlag=SymId::flag128thUp;
+                break;
+          default:
+                symFlag = SymId::noSym;
+          }
+
+        if(symFlag != SymId::noSym)
+        {
+            bFlagSymSet = true;
+        }
+    }
+
+void ShadowNoteSymbol::clearSymbols()
+{
+    symNotehead=SymId::noSym;
+    symFlag=SymId::noSym;
+    bNoteSymSet = false;
+    bFlagSymSet = false;
+}
+
+
+
+ShadowNoteSymbol::~ShadowNoteSymbol()
+      {
+
+      }
+
+}

--- a/libmscore/shadownotesymbol.h
+++ b/libmscore/shadownotesymbol.h
@@ -1,0 +1,52 @@
+#ifndef __SHADOWNOTESYMBOL_H__
+#define __SHADOWNOTESYMBOL_H__
+
+#include "duration.h"
+#include "durationtype.h"
+#include "sym.h"
+
+namespace Ms {
+
+class TDuration;
+
+//---------------------------------------------------------
+//    @@ NoteSymbol
+///     This class implements a note symbol which can be used for placing notes
+//    @P isFullMeasure  bool  (read only)
+//---------------------------------------------------------
+
+class ShadowNoteSymbol {
+
+
+    public:
+    ShadowNoteSymbol():
+        symNotehead(SymId::noSym),
+        symFlag(SymId::noSym),
+        bNoteSymSet(false),
+        bFlagSymSet(false)
+    {
+
+    }
+
+   public:
+      ~ShadowNoteSymbol();
+      void setSymbols(TDuration::DurationType type, SymId noteSymbol);
+      SymId getNoteId() const { return symNotehead; }
+      SymId getFlagId() const { return symFlag; }
+      void clearSymbols();
+      bool isValid() const { return bNoteSymSet; }
+      bool noFlag() const { return bFlagSymSet ? false:true ; }
+
+  private:
+      SymId symNotehead;
+      SymId symFlag;
+      bool bNoteSymSet;
+      bool bFlagSymSet;
+
+
+      };
+
+}     // namespace Ms
+
+#endif // __SHADOWNOTESYMBOL_H__
+

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -5390,18 +5390,58 @@ void ScoreFont::draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos,
       draw(d, painter, mag, pos);
       }
 
-void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, qreal mag, const QPointF& _pos, qreal scale) const
+
+
+void ScoreFont::drawShadow(const QList<SymId>& ids, QPainter* p, qreal mag, const QPointF& _pos, qreal scale) const
       {
       QPointF pos(_pos);
-      for (SymId id : ids) {
-            draw(id, p, mag, pos, scale);
-            pos.rx() += (sym(id).advance() * mag);
+      qreal penWidth=p->pen().width();
+      draw(ids[0], p, mag, pos, scale);
+      pos.rx() += ((sym(ids[0]).advance() - penWidth/3) * mag);
+      qreal yOffset = -((sym(ids[0]).bbox().height())/4);
+
+      if(ids[1]!=SymId::noSym) {
+            if(ids[1]!=SymId::flagInternalUp) {
+                  pos.ry() -= (sym(ids[1]).bbox().height());
+                  p->drawLine(QLineF(pos.rx(), yOffset, pos.rx(), pos.ry()-yOffset));
+                  pos.rx() -= penWidth/3;
+                  draw(ids[1], p, mag, pos, scale);
+                  }
+            else {
+                  p->drawLine(QLineF(pos.rx(), yOffset, pos.rx(), -18));
+                  }
             }
+
       }
+
 void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, qreal mag, const QPointF& _pos) const
       {
       qreal scale = p->worldTransform().m11();
       draw(ids, p, mag, _pos, scale);
+      }
+
+void ScoreFont::draw(const std::vector<SymId>& ids, QPainter* p, qreal mag, const QPointF& _pos, qreal scale) const
+      {
+      QPointF pos(_pos);
+      int x=0;
+      for (SymId id : ids) {
+            if(x!=0)
+                  pos.ry() -= (sym(id).bbox().height());
+
+            draw(id, p, mag, pos, scale);
+
+            if(x==0)
+                  pos.rx() += (sym(id).advance() * mag);
+
+            x++;
+            }
+
+      }
+
+void ScoreFont::drawShadow(const QList<SymId>& ids, QPainter* p, qreal mag, const QPointF& _pos) const
+      {
+      qreal scale = p->worldTransform().m11();
+      drawShadow(ids, p, mag, _pos, scale);
       }
 
 //---------------------------------------------------------

--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -2649,6 +2649,8 @@ class ScoreFont {
       void draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos) const;
       void draw(const std::vector<SymId>&, QPainter*, qreal mag, const QPointF& pos) const;
       void draw(const std::vector<SymId>&, QPainter*, qreal mag, const QPointF& pos, qreal scale) const;
+      void drawShadow(const QList<SymId>&, QPainter*, qreal mag, const QPointF& pos) const;
+      void drawShadow(const QList<SymId>&, QPainter*, qreal mag, const QPointF& pos, qreal scale) const;
       void draw(SymId id, QPainter* painter, qreal mag, const QPointF& pos, int n) const;
 
       qreal height(SymId id, qreal mag) const         { return sym(id).bbox().height() * mag; }

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -367,6 +367,9 @@ void MuseScore::updateInputState(Score* score)
       getAction("beam32")->setChecked(is.beamMode()     == Beam::Mode::BEGIN32);
       getAction("auto-beam")->setChecked(is.beamMode()  == Beam::Mode::AUTO);
       getAction("repitch")->setChecked(is.repitchMode());
+
+      if(is.noteEntryMode() && !is.rest())
+            emit score->updateShadow();
       }
 }
 

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -312,6 +312,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void doFotoDragEdit(QMouseEvent* ev);
 
       void updateContinuousPanel();
+      void updateShadowNotes();
 
    signals:
       void viewRectChanged();
@@ -392,9 +393,10 @@ class ScoreView : public QWidget, public MuseScoreView {
       void pagePrev();
       void pageTop();
       void pageEnd();
-      QPointF toLogical(const QPoint& p) const { return imatrix.map(QPointF(p)); }
-      QRectF toLogical(const QRectF& r) const  { return imatrix.mapRect(r); }
-      QRect toPhysical(const QRectF& r) const  { return _matrix.mapRect(r).toRect(); }
+      QPointF toLogical(const QPoint& p) const   { return imatrix.map(QPointF(p)); }
+      QPointF toPhysical(const QPointF& p) const {return _matrix.map(p); }
+      QRectF toLogical(const QRectF& r) const    { return imatrix.mapRect(r); }
+      QRect toPhysical(const QRectF& r) const    { return _matrix.mapRect(r).toRect(); }
 
       bool searchMeasure(int i);
       bool searchPage(int i);


### PR DESCRIPTION
When I first used Musescore, I was a bit confused by the display of the notes during note entry. I expected them to be the note I was entering, and not just a filled or unfilled notehead. I also found it awkward, that after klicking the left mouse button in oder to enter a note, the entry cursor moved, but the mousecursor did not.

In this pull request I changed the behaviour to adress these issues. The changes are:

During note entry, shadow notes now also show duration of note
During drum note, entry shadow notes show the distinct noteheads
During note entry, the mouse cursor now follows the input cursor