### PR TITLE
fix #90766: bad layout with hbox at end of system followed by mmrest

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2827,6 +2827,14 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
                         curMeasure = curMeasure->prev();
                   else
                         curMeasure = last();
+                  // skip to beginning of mmrest
+                  if (curMeasure && curMeasure->isMeasure() && styleB(StyleIdx::createMultiMeasureRests)) {
+                        Measure* m = static_cast<Measure*>(curMeasure);
+                        while (m && m->mmRestCount() < 0)
+                              m = m->prevMeasure();
+                        if (m && m->hasMMRest())
+                              curMeasure = m->mmRest();
+                        }
                   }
             firstInRow = false;
             }


### PR DESCRIPTION
Related to my previous fix for [#54221], I didn't handle the mmrest case correctly.  This fixes that.

BTW, while we have MeasureBase::nextMM(), we don't have MeasureBase::prevMM().  We also don't have Score::lastMM().  If they existed, I could have simply replaced my calls here to those.  I considered adding these functions, but I guess we've gone this long without them and it wasn't difficult to do the mm adjustment myself here.

Note that in the process of testing this I discovered another bug, https://musescore.org/en/node/91471.  But it seems unrelated enough to want to submit this PR as is.  I'd like someone else who was more involved in the code change responsible to look at that one ( @ericfont ?) but can try my hand if no one else wants.