### PR TITLE
fix #91471: layout issues and crash on system with hbox only

### DIFF
--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -185,10 +185,12 @@ void Clef::layout()
             // only if there is a clef change
             if (!bHide && tick > 0 ) {
                   Measure* meas = clefSeg->measure();
+                  // courtesy clef: end of last measure measure of system
+                  bool courtesy = clefSeg->tick() == meas->endTick() && meas->system() && (meas == meas->system()->lastMeasure() || meas->system()->measures().indexOf(meas) == -1);
                   showClef =                    // show this clef if:
-                        // it is not a courtesy clef (not at the end of the last measure of the system)
-                        ((meas->system() && meas != meas->system()->lastMeasure())) || (clefSeg->tick() != meas->endTick())
-                        // if courtesy clef: show if score has courtesy clefs on
+                        // it is not a courtesy clef
+                        !courtesy
+                        // or, if courtesy clef: show if score has courtesy clefs on
                         || ( score()->styleB(StyleIdx::genCourtesyClef)
                               // AND measure is not at the end of a repeat or of a section
                               && !( (meas->repeatFlags() & Repeat::END) || meas->isFinalMeasureOfSection() )

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2288,6 +2288,8 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
 
             // collect at least one measure
             if (systemWasNotEmpty && (minWidth + ww > systemWidth)) {
+                  // remove measure from current system if it had been prematurely added
+                  system->measures().removeOne(curMeasure);
                   curMeasure->setSystem(oldSystem);
                   continueFlag = false;
                   break;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2219,7 +2219,6 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
             bool hasCourtesy;
             qreal cautionaryW = 0.0;
             qreal ww          = 0.0;
-            bool systemWasNotEmpty = !system->measures().isEmpty();
 
             if (curMeasure->type() == Element::Type::HBOX) {
                   ww = point(static_cast<Box*>(curMeasure)->boxWidth());
@@ -2245,7 +2244,6 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
                   if (isFirstMeasure) {
                         firstMeasure = m;
                         addSystemHeader(m, isFirstSystem);
-                        system->measures().append(curMeasure);    // append measure to system before minWidth2() performs courtesy clef layout calculation
                         ww = m->minWidth2();
                         }
                   else
@@ -2284,12 +2282,12 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
 
                   if (ww < minMeasureWidth)
                         ww = minMeasureWidth;
+                  isFirstMeasure = false;
                   }
 
             // collect at least one measure
-            if (systemWasNotEmpty && (minWidth + ww > systemWidth)) {
-                  // remove measure from current system if it had been prematurely added
-                  system->measures().removeOne(curMeasure);
+            bool empty = system->measures().isEmpty();
+            if (!empty && (minWidth + ww > systemWidth)) {
                   curMeasure->setSystem(oldSystem);
                   continueFlag = false;
                   break;
@@ -2298,11 +2296,7 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
             if (curMeasure->type() == Element::Type::MEASURE)
                   lastMeasure = static_cast<Measure*>(curMeasure);
 
-            // append measure if did not already append measure
-            if (curMeasure->type() == Element::Type::MEASURE && isFirstMeasure)
-                  isFirstMeasure = false;
-            else
-                  system->measures().append(curMeasure);
+            system->measures().append(curMeasure);
 
             Element::Type nt;
             if (_showVBox)


### PR DESCRIPTION
As per discussion in issue thread, the change made in #2222 resulted in a measure being prematurely added to a system in the case where the system contains a horizontal frame only (because the first actual measure does not fit).  This leads to layout problems (https://musescore.org/en/node/90766#comment-403656) and an eventual crash (https://musescore.org/en/node/91471).

My fix here is to remove the prematurely-added measure from the system once we decide it does not fit.  There is no need to check whether the measure has in fact already been added, because removeOne will simply return failure if there was nothing to remove.

It could be worth revisiting the original fix to issue 76006 so that we aren't prematurely adding the measure - perhaps by adjusting the code in Clef::layout() that was incorrectly detemrining we needed to show the clef.  We might also want to look at updating layoutSystem1(), which is by now somewhat out of sync with layoutSystem() and thus layout is sometimes off immediately after an undo operation that results in measures being added to or removed from a system (see my comment in https://musescore.org/en/node/76006#comment-404101).  But for now, I thought it important to solve the basic layout problem and crash.