### PR TITLE
fix #91536: crash adding figured bass to palette

### DIFF
--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -986,8 +986,11 @@ FiguredBass::FiguredBass(const FiguredBass& fb)
       {
       setOnNote(fb.onNote());
       setTicks(fb.ticks());
-      for (auto i : fb.items)       // deep copy is needed
-            items.push_back(new FiguredBassItem(*i));
+      for (auto i : fb.items) {     // deep copy is needed
+            FiguredBassItem* fbi = new FiguredBassItem(*i);
+            fbi->setParent(this);
+            items.push_back(fbi);
+            }
 //      items = fb.items;
       }
 

--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -1111,7 +1111,7 @@ void FiguredBass::layout()
 
 void FiguredBass::layoutLines()
       {
-      if(_ticks <= 0) {
+      if(_ticks <= 0 || segment() == nullptr) {
 NoLen:
             _lineLenghts.resize(1);                         // be sure to always have
             _lineLenghts[0] = 0;                            // at least 1 item in array

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1365,6 +1365,7 @@ bool Note::acceptDrop(const DropData& data) const
          || (type == Element::Type::BEND)
          || (type == Element::Type::TREMOLOBAR)
          || (type == Element::Type::FRET_DIAGRAM)
+         || (type == Element::Type::FIGURED_BASS)
          || (type == Element::Type::LYRICS));
       }
 

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -377,6 +377,8 @@ void ScoreView::dragMoveEvent(QDragMoveEvent* event)
                   case Element::Type::BAGPIPE_EMBELLISHMENT:
                   case Element::Type::AMBITUS:
                   case Element::Type::TREMOLOBAR:
+                  case Element::Type::FIGURED_BASS:
+                  case Element::Type::LYRICS:
                         {
                         QList<Element*> el = elementsAt(pos);
                         bool found = false;
@@ -566,6 +568,8 @@ void ScoreView::dropEvent(QDropEvent* event)
                   case Element::Type::BAGPIPE_EMBELLISHMENT:
                   case Element::Type::AMBITUS:
                   case Element::Type::TREMOLOBAR:
+                  case Element::Type::FIGURED_BASS:
+                  case Element::Type::LYRICS:
                         {
                         Element* el = 0;
                         for (const Element* e : elementsAt(pos)) {


### PR DESCRIPTION
This fixes the crash.  However, it does not actually enable the operation to succeed meaningfully - it seems we don't currently allow figured bass elements to be added from the palette, or copied from note to note via Ctrl+Shift+drag.