### PR TITLE
Fully fix make -j parameter (partially fixed in 7ab44cd)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #=============================================================================
 
 REVISION  = `cat mscore/revision.h`
-CPUS      = `grep -c processor /proc/cpuinfo`
+CPUS      = $(shell grep -c processor /proc/cpuinfo)
 # Avoid build errors when processor=0 (as in m68k)
 ifeq ($(CPUS), 0)
   CPUS=1


### PR DESCRIPTION
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=797259

$CPUS was being set to the literal string 'grep -c processor /proc/cpuinfo' so `ifeq ($(CPUS), 0)` was never true. The string was expanded later on in the shell, but too late for this test. The fix causes the expansion to occur immediately.