### PR TITLE
fix #92521: make pulseaudio support optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ addons:
     - libegl1-mesa-dev
     - libegl1-mesa
     - ccache
+    - libpulse-dev
 
 sudo: false
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,25 @@ set(MSCORE_UNSTABLE  TRUE)          # mark as unstable
 set(USE_SSE           TRUE)
 set(SCRIPT_INTERFACE  TRUE)
 
+# Disable components not supported on Windows
+if (MINGW)
+      set(WIN_NOT_AVAIL "not available on Windows")
+      option(BUILD_PULSEAUDIO ${WIN_NOT_AVAIL} OFF)
+      option(BUILD_ALSA ${WIN_NOT_AVAIL} OFF)
+endif (MINGW)
+
+# Disable components not supported on Mac
+if (APPLE)
+      set(MAC_NOT_AVAIL "not available on Mac")
+      option(BUILD_PULSEAUDIO ${MAC_NOT_AVAIL} OFF)
+      option(BUILD_ALSA ${MAC_NOT_AVAIL} OFF)
+endif (APPLE)
+
+# Disable components not supported on Linux/BSD
+if (NOT APPLE AND NOT MINGW)
+      set(NIX_NOT_AVAIL "not available on Linux/BSD")
+endif (NOT APPLE AND NOT MINGW)
+
 option(AEOLUS        "enable pipe organ synthesizer"      OFF)
 option(ZERBERUS      "enable experimental sfz sampler"    ON)
 option(OSC           "enable OSC remote control protocol" ON)
@@ -76,7 +95,10 @@ option(BUILD_LAME    "enable mp3 export" ON)                   # requires libmp3
 
 SET(JACK_LONGNAME "jack (jack audio connection kit)")
 SET(JACK_MIN_VERSION "0.98.0")
-option(BUILD_JACK    "Build with support for ${JACK_LONGNAME}. jack >= ${JACK_MIN_VERSION} will be needed." ON)
+option(BUILD_JACK    "Build with support for ${JACK_LONGNAME} audio backend. jack >= ${JACK_MIN_VERSION} will be needed." ON)
+option(BUILD_PULSEAUDIO "Build with support for Pulseaudio audio backend." ON)
+option(BUILD_ALSA "Build with support for ALSA audio backend." ON)
+option(BUILD_PORTAUDIO "Build with support for Portaudio audio backend." ON)
 
 if (APPLE)
       set (CMAKE_CXX_COMPILER   clang++)
@@ -203,36 +225,44 @@ SET(QT_USE_QTHELP        TRUE)
 ## alsa >= 1.0.0
 ##
 
-if (APPLE OR MINGW)
-      message("Disabling ALSA support due to OS X or MINGW build.")
-      set (USE_ALSA 0)
-      set (HAS_MIDI 1)
-else (APPLE OR MINGW)
+if (BUILD_ALSA)
       PKGCONFIG (alsa 1.0.0 ALSA_INCDIR ALSA_LIBDIR ALSA_LIB ALSA_CPP )
       if (NOT ALSA_INCDIR)
-            message(FATAL_ERROR "Fatal error: ALSA >= 1.0.0 required")
+            message(SEND_ERROR "Error: ALSA support requested (BUILD_ALSA=${BUILD_ALSA}), but ALSA >= 1.0.0 was not found.")
       else (NOT ALSA_INCDIR)
-            message("Alsa found.")
+            message("ALSA >= 1.0.0 found. ALSA support enabled.")
             set (USE_ALSA 1)
-            set (HAS_MIDI 1)
       endif (NOT ALSA_INCDIR)
+else (BUILD_ALSA)
+     message(STATUS "ALSA support disabled")
+endif (BUILD_ALSA)
+
+##
+## MIDI
+##
+
+if (APPLE OR MINGW)
+      set (HAS_MIDI 1)
+else (APPLE OR MINGW)
+      if (USE_ALSA)
+            set (HAS_MIDI 1)
+      endif (USE_ALSA)
 endif (APPLE OR MINGW)
 
 ##
 ## pulseaudio
 ##
 
-if (APPLE OR MINGW)
-      set (USE_PULSEAUDIO 0)
-else (APPLE OR MINGW)
+if (BUILD_PULSEAUDIO)
       if (PULSEAUDIO_FOUND)
             set(USE_PULSEAUDIO 1)
-            message("Pulseaudio found.")
+            message("Pulseaudio found. Pulseaudio support enabled.")
       else (PULSEAUDIO_FOUND)
-            set(USE_PULSEAUDIO 0)
-            message("Pulseaudio not found.")
+            message(SEND_ERROR "Error: Pulseaudio support requested (BUILD_PULSEAUDIO=${BUILD_PULSEAUDIO}), but Pulseaudio was not found.")
       endif (PULSEAUDIO_FOUND)
-endif (APPLE OR MINGW)
+else (BUILD_PULSEAUDIO)
+      message(STATUS "Pulseaudio support disabled")
+endif (BUILD_PULSEAUDIO)
 
 ##
 ## lame
@@ -281,19 +311,18 @@ IF(BUILD_JACK)
                  set (JACK_LIB "$ENV{PROGRAMFILES(x86)}/Jack/lib/libjack.a")
               ELSE("$ENV{PROCESSOR_ARCHITECTURE}" STREQUAL "x86")
                  # theoretically impossible case...
+                 MESSAGE(SEND_ERROR "Error: Impossible program/environment bitness combination deduced: 64-bit program running in 32-bit environment. This is a programming error. PROCESSOR_ARCHITEW6432=$ENV{PROCESSOR_ARCHITEW6432}. PROCESSOR_ARCHITECTURE=$ENV{PROCESSOR_ARCHITECTURE}")
               ENDIF("$ENV{PROCESSOR_ARCHITECTURE}" STREQUAL "x86")
            ENDIF("$ENV{PROCESSOR_ARCHITEW6432}" STREQUAL "")
-
+           MESSAGE("jack support enabled.")
      ELSE(MINGW)
            PKGCONFIG(jack ${JACK_MIN_VERSION} JACK_INCDIR JACK_LIBDIR JACK_LIB JACK_CPP)
            IF(JACK_INCDIR)
-                 MESSAGE(STATUS "${JACK_LONGNAME} >= ${JACK_MIN_VERSION} found")
+                 MESSAGE(STATUS "${JACK_LONGNAME} >= ${JACK_MIN_VERSION} found. jack support enabled.")
                  SET(USE_JACK 1)
            ELSE(JACK_INCDIR)
                  MESSAGE(STATUS "${JACK_LONGNAME} >= ${JACK_MIN_VERSION} not found")
-                 IF(NOT BUILD_JACK STREQUAL AUTO)
-                       MESSAGE(SEND_ERROR "Error: jack support requested but not found (BUILD_JACK=${BUILD_JACK})")
-                 ENDIF()
+                 MESSAGE(SEND_ERROR "Error: jack support requested (BUILD_JACK=${BUILD_JACK}), but jack was not found")
            ENDIF(JACK_INCDIR)
      ENDIF(MINGW)
 ELSE(BUILD_JACK)
@@ -305,24 +334,27 @@ ENDIF(BUILD_JACK)
 ## portaudio
 ##
 
-if (MINGW)
-    set ( USE_PORTAUDIO 1 )
-    set ( USE_PORTMIDI  1 )
-else (MINGW)
-    PKGCONFIG (portaudio-2.0 19 PORTAUDIO_INCDIR PORTAUDIO_LIBDIR PORTAUDIO_LIB PORTAUDIO_CPP)
-    if (PORTAUDIO_INCDIR)
-        message("portaudio detected ${PORTAUDIO_INCDIR} ${PORTAUDIO_LIBDIR} ${PORTAUDIO_LIB}")
-          set ( USE_PORTAUDIO 1 )
-    else (PORTAUDIO_INCDIR)
-          message("optional package portaudio-2.0 Version 19 not found (package portaudio19-dev)\n")
-          set ( USE_PORTAUDIO 0 )
-    endif (PORTAUDIO_INCDIR)
-    if (APPLE)
-      set (USE_PORTMIDI   1)
-    else (APPLE)
-      set (USE_PORTMIDI   0)
-    endif (APPLE)
-endif (MINGW)
+if (BUILD_PORTAUDIO)
+    if (MINGW)
+        set ( USE_PORTAUDIO 1 )
+        set ( USE_PORTMIDI  1 )
+    else (MINGW)
+        PKGCONFIG (portaudio-2.0 19 PORTAUDIO_INCDIR PORTAUDIO_LIBDIR PORTAUDIO_LIB PORTAUDIO_CPP)
+        if (PORTAUDIO_INCDIR)
+              message(STATUS "Portaudio found. Portaudio support enabled. ${PORTAUDIO_INCDIR} ${PORTAUDIO_LIBDIR} ${PORTAUDIO_LIB}")
+              set ( USE_PORTAUDIO 1 )
+        else (PORTAUDIO_INCDIR)
+              message(SEND_ERROR "Error: Portaudio support requested (BUILD_PORTAUDIO=${BUILD_PORTAUDIO}), but portaudio-2.0 Version 19 was not found (package portaudio19-dev)")
+        endif (PORTAUDIO_INCDIR)
+        if (APPLE)
+          set (USE_PORTMIDI   1)
+        else (APPLE)
+          set (USE_PORTMIDI   0)
+        endif (APPLE)
+    endif (MINGW)
+else (BUILD_PORTAUDIO)
+     message(STATUS "Portaudio support disabled")
+endif (BUILD_PORTAUDIO)
 
 
 if (APPLE)


### PR DESCRIPTION
BUILD_PULSEAUDIO is default ON, but will silently exclude pulseaudio
support if pulseaudio is not found or not supported by the
platform. This is in line with the behavior of BUILD_LAME.