### PR TITLE
fix #92626: corruption when removing all existing staves

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1135,11 +1135,18 @@ void Measure::cmdAddStaves(int sStaff, int eStaff, bool createRest)
             // replicate time signature
             if (ts) {
                   TimeSig* ots = 0;
+                  bool constructed = false;
                   for (int track = 0; track < staves.size() * VOICES; ++track) {
                         if (ts->element(track)) {
                               ots = static_cast<TimeSig*>(ts->element(track));
                               break;
                               }
+                        }
+                  if (!ots) {
+                        // no time signature found; use measure length to construct one
+                        ots = new TimeSig(score());
+                        ots->setSig(len());
+                        constructed = true;
                         }
                   // do no replicate local time signatures
                   if (ots && !ots->isLocal()) {
@@ -1149,6 +1156,8 @@ void Measure::cmdAddStaves(int sStaff, int eStaff, bool createRest)
                         timesig->setSig(ots->sig(), ots->timeSigType());
                         timesig->setNeedLayout(true);
                         score()->undoAddElement(timesig);
+                        if (constructed)
+                              delete ots;
                         }
                   }
             }


### PR DESCRIPTION
See issue report for details.  Corruption happens for non-4/4 scores because the measure length correctly reflects the time signature, but while the time signature segment still exists, there are no time signature elements.  My fix here constructs a newe time signature based on the measure length in these cases.