### PR TITLE
fix some texts for translation

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -215,6 +215,13 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
             articulationTable->setCellWidget(i, 1, cb);
             }
 
+      dividerLeftSym->addItem( tr("System Divider"),            Sym::symNames[int(SymId::systemDivider)]);
+      dividerLeftSym->addItem( tr("Long System Divider"),       Sym::symNames[int(SymId::systemDividerLong)]);
+      dividerLeftSym->addItem( tr("Extra Long System Divider"), Sym::symNames[int(SymId::systemDividerExtraLong)]);
+      dividerRightSym->addItem(tr("System Divider"),            Sym::symNames[int(SymId::systemDivider)]);
+      dividerRightSym->addItem(tr("Long System Divider"),       Sym::symNames[int(SymId::systemDividerLong)]);
+      dividerRightSym->addItem(tr("Extra Long System Divider"), Sym::symNames[int(SymId::systemDividerExtraLong)]);
+
       // figured bass init
       QList<QString> fbFontNames = FiguredBass::fontNames();
       for (const QString& family: fbFontNames)
@@ -424,8 +431,8 @@ void EditStyle::getValues()
       lstyle.set(StyleIdx::repeatBarTips,           showRepeatBarTips->isChecked());
       lstyle.set(StyleIdx::startBarlineSingle,      showStartBarlineSingle->isChecked());
       lstyle.set(StyleIdx::startBarlineMultiple,    showStartBarlineMultiple->isChecked());
-      lstyle.set(StyleIdx::dividerLeftSym,          dividerLeftSym->currentText());
-      lstyle.set(StyleIdx::dividerRightSym,         dividerRightSym->currentText());
+      lstyle.set(StyleIdx::dividerLeftSym,          dividerLeftSym->currentData());
+      lstyle.set(StyleIdx::dividerRightSym,         dividerRightSym->currentData());
 
       lstyle.set(StyleIdx::measureSpacing,          measureSpacing->value());
       lstyle.set(StyleIdx::showMeasureNumber,       showMeasureNumber->isChecked());
@@ -642,8 +649,8 @@ void EditStyle::setValues()
       showRepeatBarTips->setChecked(lstyle.value(StyleIdx::repeatBarTips).toBool());
       showStartBarlineSingle->setChecked(lstyle.value(StyleIdx::startBarlineSingle).toBool());
       showStartBarlineMultiple->setChecked(lstyle.value(StyleIdx::startBarlineMultiple).toBool());
-      dividerLeftSym->setCurrentText(lstyle.value(StyleIdx::dividerLeftSym).toString());
-      dividerRightSym->setCurrentText(lstyle.value(StyleIdx::dividerRightSym).toString());
+      dividerLeftSym->setCurrentIndex(dividerLeftSym->findData(lstyle.value(StyleIdx::dividerLeftSym).toString()));
+      dividerRightSym->setCurrentIndex(dividerRightSym->findData(lstyle.value(StyleIdx::dividerRightSym).toString()));
 
       measureSpacing->setValue(lstyle.value(StyleIdx::measureSpacing).toDouble());
       noteBarDistance->setValue(lstyle.value(StyleIdx::noteBarDistance).toDouble());
@@ -686,7 +693,7 @@ void EditStyle::setValues()
       else if (unit == TDuration(TDuration::DurationType::V_ZERO).name()) {
             SwingOff->setChecked(true);
             swingBox->setEnabled(false);
-      }
+            }
       QString s(lstyle.value(StyleIdx::chordDescriptionFile).toString());
       chordDescriptionFile->setText(s);
       chordsXmlFile->setChecked(lstyle.value(StyleIdx::chordsXmlFile).toBool());

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -89,11 +89,11 @@
             </item>
             <item row="1" column="1">
              <widget class="QComboBox" name="musicalTextFont">
-            <item>
-                <property name="text">
-                    <string>Bravura Text</string>
-                </property>
-            </item>
+              <item>
+               <property name="text">
+                <string>Bravura Text</string>
+               </property>
+              </item>
               <item>
                <property name="text">
                 <string>Emmentaler Text</string>
@@ -1629,23 +1629,7 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QComboBox" name="dividerLeftSym">
-                    <item>
-                     <property name="text">
-                      <string>systemDivider</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>systemDividerLong</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>systemDividerExtraLong</string>
-                     </property>
-                    </item>
-                   </widget>
+                   <widget class="QComboBox" name="dividerLeftSym"/>
                   </item>
                   <item>
                    <spacer name="horizontalSpacer_18">
@@ -1738,23 +1722,7 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QComboBox" name="dividerRightSym">
-                    <item>
-                     <property name="text">
-                      <string>systemDivider</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>systemDividerLong</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>systemDividerExtraLong</string>
-                     </property>
-                    </item>
-                   </widget>
+                   <widget class="QComboBox" name="dividerRightSym"/>
                   </item>
                   <item>
                    <spacer name="horizontalSpacer_20">

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -294,8 +294,8 @@ void GuitarPro::initGuitarProDrumset()
       gpDrumset->drum(70) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Maracas"), NoteHead::Group::HEAD_NORMAL, 3, MScore::Direction::UP);
       gpDrumset->drum(71) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Short Whistle"), NoteHead::Group::HEAD_NORMAL, 3, MScore::Direction::UP);
       gpDrumset->drum(72) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Long Whistle"), NoteHead::Group::HEAD_NORMAL, 3, MScore::Direction::UP);
-      gpDrumset->drum(73) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Short G\u00fciro"), NoteHead::Group::HEAD_NORMAL, 3, MScore::Direction::UP);
-      gpDrumset->drum(74) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Long G\u00fciro"), NoteHead::Group::HEAD_NORMAL, 3, MScore::Direction::UP);
+      gpDrumset->drum(73) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Short Guiro"), NoteHead::Group::HEAD_NORMAL, 3, MScore::Direction::UP);
+      gpDrumset->drum(74) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Long Guiro"), NoteHead::Group::HEAD_NORMAL, 3, MScore::Direction::UP);
       gpDrumset->drum(75) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Claves"), NoteHead::Group::HEAD_NORMAL, 3, MScore::Direction::UP);
       gpDrumset->drum(76) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Hi Wood Block"), NoteHead::Group::HEAD_NORMAL, 3, MScore::Direction::UP);
       gpDrumset->drum(77) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Low Wood Block"), NoteHead::Group::HEAD_NORMAL, 3, MScore::Direction::UP);

--- a/mscore/inspector/inspector_tremolo.ui
+++ b/mscore/inspector/inspector_tremolo.ui
@@ -50,7 +50,7 @@
       </font>
      </property>
      <property name="text">
-      <string>TremoloBar</string>
+      <string>Tremolo Bar</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -131,8 +131,6 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../musescore.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2792,7 +2792,7 @@ Shortcut Shortcut::_sc[] = {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "add-noteline",
-         QT_TRANSLATE_NOOP("action","Note Anchored line"),
+         QT_TRANSLATE_NOOP("action","Note Anchored Line"),
          QT_TRANSLATE_NOOP("action","Note anchored line")
          },
       {

--- a/mtest/guitarpro/all-percussion.gp5-ref.mscx
+++ b/mtest/guitarpro/all-percussion.gp5-ref.mscx
@@ -388,14 +388,14 @@
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Short Güiro</name>
+          <name>Short Guiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="74">
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Long Güiro</name>
+          <name>Long Guiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="75">
@@ -1678,14 +1678,14 @@
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Short Güiro</name>
+            <name>Short Guiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="74">
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Long Güiro</name>
+            <name>Long Guiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="75">

--- a/mtest/libmscore/midimapping/test14-ref.mscx
+++ b/mtest/libmscore/midimapping/test14-ref.mscx
@@ -500,14 +500,14 @@
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Short Güiro</name>
+          <name>Short Guiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="74">
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Long Güiro</name>
+          <name>Long Guiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="75">
@@ -1757,14 +1757,14 @@
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Short Güiro</name>
+            <name>Short Guiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="74">
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Long Güiro</name>
+            <name>Long Guiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="75">

--- a/mtest/libmscore/midimapping/test15-ref.mscx
+++ b/mtest/libmscore/midimapping/test15-ref.mscx
@@ -492,14 +492,14 @@
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Short Güiro</name>
+          <name>Short Guiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="74">
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Long Güiro</name>
+          <name>Long Guiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="75">
@@ -1916,14 +1916,14 @@
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Short Güiro</name>
+            <name>Short Guiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="74">
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Long Güiro</name>
+            <name>Long Guiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="75">

--- a/mtest/libmscore/midimapping/test16-ref.mscx
+++ b/mtest/libmscore/midimapping/test16-ref.mscx
@@ -492,14 +492,14 @@
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Short Güiro</name>
+          <name>Short Guiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="74">
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Long Güiro</name>
+          <name>Long Guiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="75">
@@ -1791,14 +1791,14 @@
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Short Güiro</name>
+            <name>Short Guiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="74">
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Long Güiro</name>
+            <name>Long Guiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="75">


### PR DESCRIPTION
the fix for Güiro vs. Guiro seems needed due to a suspected bug in
lupdate, it seems to drop the \ and so screws up on Transifex.

Also included is a fix for #94081, System Dividers don't work when translated  