### PR TITLE
fix #93316: slur still lays out to deleted note

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -1507,8 +1507,7 @@ QString BarLine::accessibleExtraInfo()
             int tick = seg->tick();
 
             auto spanners = score()->spannerMap().findOverlapping(tick, tick);
-            for (auto i = spanners.begin(); i < spanners.end(); i++) {
-                  ::Interval<Spanner*> interval = *i;
+            for (auto interval : spanners) {
                   Spanner* s = interval.value;
                   if (!score()->selectionFilter().canSelect(s)) continue;
                   if (s->type() == Element::Type::VOLTA) {

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2843,8 +2843,8 @@ QPointF Chord::layoutArticulation(Articulation* a)
       bool botGap = false;
       bool topGap = false;
 
-      const std::vector< ::Interval<Spanner*> >& si = score()->spannerMap().findOverlapping(tick(), tick());
-      for (::Interval<Spanner*> is : si) {
+      auto si = score()->spannerMap().findOverlapping(tick(), tick());
+      for (auto is : si) {
             Spanner* sp = is.value;
             if ((sp->type() != Element::Type::SLUR) || (sp->tick() != tick() && sp->tick2() != tick()))
                  continue;

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1420,8 +1420,7 @@ QString ChordRest::accessibleExtraInfo()
 
             SpannerMap& smap = score()->spannerMap();
             auto spanners = smap.findOverlapping(tick(), tick());
-            for (auto i = spanners.begin(); i < spanners.end(); i++) {
-                  const ::Interval<Spanner*> interval = *i;
+            for (auto interval : spanners) {
                   Spanner* s = interval.value;
                   if (!score()->selectionFilter().canSelect(s)) continue;
                   if (s->type() == Element::Type::VOLTA || //voltas are added for barlines

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -446,7 +446,8 @@ bool Score::rewriteMeasures(Measure* fm, Measure* lm, const Fraction& ns, int st
 
             int tick1 = m1->tick();
             int tick2 = m2->endTick();
-            for (auto i : s->spannerMap().findContained(tick1, tick2))
+            auto spanners = s->spannerMap().findContained(tick1, tick2);
+            for (auto i : spanners)
                   undo(new RemoveElement(i.value));
             s->undoRemoveMeasures(m1, m2);
 
@@ -2126,7 +2127,8 @@ void Score::cmdDeleteSelection()
             int tick2   = s2 ? s2->tick() : INT_MAX;
             int track1  = selection().staffStart() * VOICES;
             int track2  = selection().staffEnd() * VOICES;
-            for (auto i : _spanner.findOverlapping(stick1, stick2 - 1)) {
+            auto spanners = _spanner.findOverlapping(stick1, stick2 - 1);
+            for (auto i : spanners) {
                   Spanner* sp = i.value;
                   if (sp->type() == Element::Type::VOLTA)
                         continue;

--- a/libmscore/joinMeasure.cpp
+++ b/libmscore/joinMeasure.cpp
@@ -33,7 +33,8 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
 
       int tick1 = m1->tick();
       int tick2 = m2->endTick();
-      for (auto i : _spanner.findContained(tick1, tick2))
+      auto spanners = _spanner.findContained(tick1, tick2);
+      for (auto i : spanners)
             undo(new RemoveElement(i.value));
       undoRemoveMeasures(m1, m2);
       Measure* m = new Measure(this);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1779,7 +1779,7 @@ static bool validMMRestMeasure(Measure* m)
 
 #if 0
       auto l = m->score()->spannerMap().findOverlapping(m->tick(), m->endTick());
-      for (::Interval<Spanner*> isp : l) {
+      for (auto isp : l) {
             Spanner* s = isp.value;
             if (s->type() == Element::Type::VOLTA && (s->tick() == m->tick() || s->tick2() == m->endTick()))
                   return false;
@@ -1809,7 +1809,7 @@ static bool breakMultiMeasureRest(Measure* m)
       if (m->breakMultiMeasureRest())
             return true;
       auto sl = m->score()->spannerMap().findOverlapping(m->tick(), m->endTick());
-      foreach (auto i, sl) {
+      for (auto i : sl) {
             Spanner* s = i.value;
             if (s->type() == Element::Type::VOLTA && (s->tick() == m->tick() || s->tick2() == m->tick()))
                   return true;
@@ -1841,7 +1841,7 @@ static bool breakMultiMeasureRest(Measure* m)
 
       // break for end of volta
       auto l = m->score()->spannerMap().findOverlapping(m->tick(), m->endTick());
-      for (::Interval<Spanner*> isp : l) {
+      for (auto isp : l) {
             Spanner* s = isp.value;
             if (s->type() == Element::Type::VOLTA && (s->tick2() == m->endTick()))
                   return false;

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1300,7 +1300,8 @@ void renderGlissando(NoteEventList* events, Note *notestart)
 //---------------------------------------------------------
 
 Trill* findFirstTrill(Chord *chord) {
-      for (auto i : chord->score()->spannerMap().findOverlapping(1+chord->tick(), chord->tick() + chord->actualTicks() - 1)) {
+      auto spanners = chord->score()->spannerMap().findOverlapping(1+chord->tick(), chord->tick() + chord->actualTicks() - 1);
+      for (auto i : spanners) {
             if (i.value->type() != Element::Type::TRILL)
                   continue;
             if (i.value->track() != chord->track())

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2477,7 +2477,6 @@ void Score::splitStaff(int staffIdx, int splitPoint)
                         undoRemoveElement(note);
                         Chord* chord = note->chord();
                         if (chord->notes().isEmpty()) {
-                              undoRemoveElement(chord);
                               for (auto sp : spanner()) {
                                     Slur* slur = static_cast<Slur*>(sp.second);
                                     if (slur->type() != Element::Type::SLUR)
@@ -2497,6 +2496,7 @@ void Score::splitStaff(int staffIdx, int splitPoint)
                                                 }
                                           }
                                     }
+                              undoRemoveElement(chord);
                               }
                         }
                   }

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -565,6 +565,16 @@ void Segment::remove(Element* el)
                   _elist[track] = 0;
                   int staffIdx = el->staffIdx();
                   measure()->checkMultiVoices(staffIdx);
+                  // spanners with this cr as start or end element will need relayout
+                  SpannerMap& smap = score()->spannerMap();
+                  auto spanners = smap.findOverlapping(tick(), tick());
+                  for (auto interval : spanners) {
+                        Spanner* s = interval.value;
+                        if (s->startElement() == el)
+                              s->setStartElement(nullptr);
+                        if (s->endElement() == el)
+                              s->setEndElement(nullptr);
+                        }
                   }
                   break;
 
@@ -1226,9 +1236,8 @@ QString Segment::accessibleExtraInfo()
       QString startSpanners = "";
       QString endSpanners = "";
 
-      std::vector< ::Interval<Spanner*> > spanners = score()->spannerMap().findOverlapping(this->tick(), this->tick());
-      for (std::vector< ::Interval<Spanner*> >::iterator i = spanners.begin(); i < spanners.end(); i++) {
-            ::Interval<Spanner*> interval = *i;
+      auto spanners = score()->spannerMap().findOverlapping(this->tick(), this->tick());
+      for (auto interval : spanners) {
             Spanner* s = interval.value;
             if (!score()->selectionFilter().canSelect(s)) continue;
             if (this->segmentType() == Segment::Type::EndBarLine       ||

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1368,7 +1368,8 @@ static Volta* findVolta(Measure* m, bool left)
       {
       int stick = m->tick();
       int etick = m->tick() + m->ticks();
-      for (auto i : m->score()->spannerMap().findOverlapping(stick, etick)) {
+      auto spanners = m->score()->spannerMap().findOverlapping(stick, etick);
+      for (auto i : spanners) {
             Spanner* el = i.value;
             if (el->type() != Element::Type::VOLTA)
                   continue;


### PR DESCRIPTION
This code works and should be safe to the extent I understand the spanner map implementation, which is not very well.  Main question to me is if there is a better / more direct way to find the spanners attached to this chordrest.  I borrowed this code from ChordRest::accessibleExtraInfo().