### PR TITLE
fix #19871: no swing on tuplets

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1470,7 +1470,7 @@ void Score::createPlayEvents(Chord* chord)
       int unit = st.swingUnit;
       int ratio = st.swingRatio;
       // Check if swing needs to be applied
-      if (unit) {
+      if (unit && !chord->tuplet()) {
             swingAdjustParams(chord, gateTime, ontime, unit, ratio);
             }
       //

--- a/mtest/libmscore/midi/testSwing8thTriplets-ref.txt
+++ b/mtest/libmscore/midi/testSwing8thTriplets-ref.txt
@@ -1,6 +1,8 @@
 Tick  =      0   Type  =   144   Pitch  =    72   Velocity  =    80   Channel  =     0    
 Tick  =      0   Type  =     3   Pitch  =     0   Velocity  =     0   Channel  =     0    
-Tick  =    455   Type  =   144   Pitch  =    72   Velocity  =     0   Channel  =     0    
+Tick  =    323   Type  =   144   Pitch  =    72   Velocity  =     0   Channel  =     0    
+Tick  =    336   Type  =   144   Pitch  =    76   Velocity  =    80   Channel  =     0    
+Tick  =    471   Type  =   144   Pitch  =    76   Velocity  =     0   Channel  =     0    
 Tick  =    480   Type  =   144   Pitch  =    77   Velocity  =    80   Channel  =     0    
 Tick  =    480   Type  =     4   Pitch  =     0   Velocity  =     0   Channel  =     0    
 Tick  =    631   Type  =   144   Pitch  =    77   Velocity  =     0   Channel  =     0    
@@ -10,7 +12,9 @@ Tick  =    800   Type  =   144   Pitch  =    74   Velocity  =    80   Channel  =
 Tick  =    951   Type  =   144   Pitch  =    74   Velocity  =     0   Channel  =     0    
 Tick  =    960   Type  =   144   Pitch  =    72   Velocity  =    80   Channel  =     0    
 Tick  =    960   Type  =     4   Pitch  =     0   Velocity  =     0   Channel  =     0    
-Tick  =   1415   Type  =   144   Pitch  =    72   Velocity  =     0   Channel  =     0    
+Tick  =   1187   Type  =   144   Pitch  =    72   Velocity  =     0   Channel  =     0    
+Tick  =   1200   Type  =   144   Pitch  =    67   Velocity  =    80   Channel  =     0    
+Tick  =   1427   Type  =   144   Pitch  =    67   Velocity  =     0   Channel  =     0    
 Tick  =   1440   Type  =   144   Pitch  =    62   Velocity  =    80   Channel  =     0    
 Tick  =   1440   Type  =     4   Pitch  =     0   Velocity  =     0   Channel  =     0    
 Tick  =   1895   Type  =   144   Pitch  =    62   Velocity  =     0   Channel  =     0    

--- a/mtest/libmscore/midi/testSwing8thTriplets.mscx
+++ b/mtest/libmscore/midi/testSwing8thTriplets.mscx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <museScore version="2.00">
   <programVersion>2.0.0</programVersion>
-  <programRevision>3543170</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
@@ -9,12 +8,6 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <figuredBassFontFamily>MScoreBC</figuredBassFontFamily>
-      <beamMinLen>1.32</beamMinLen>
-      <beamNoSlope>0</beamNoSlope>
-      <smallNoteMag>0.7</smallNoteMag>
-      <graceNoteMag>0.7</graceNoteMag>
-      <smallStaffMag>0.7</smallStaffMag>
       <swingRatio>70</swingRatio>
       <page-layout>
         <page-height>1683.36</page-height>
@@ -68,8 +61,8 @@
         </Staff>
       <trackName>Flute</trackName>
       <Instrument>
-        <longName pos="0">Flute</longName>
-        <shortName pos="0">Fl.</shortName>
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
         <minPitchP>59</minPitchP>
         <maxPitchP>98</maxPitchP>
@@ -110,9 +103,6 @@
           <concertClefType>G</concertClefType>
           <transposingClefType>G</transposingClefType>
           </Clef>
-        <KeySig>
-          <accidental>0</accidental>
-          </KeySig>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>
@@ -124,10 +114,17 @@
           <text>system-text</text>
           </StaffText>
         <Chord>
-          <durationType>quarter</durationType>
+          <durationType>eighth</durationType>
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>eighth</durationType>
+          <Note>
+            <pitch>76</pitch>
+            <tpc>18</tpc>
             </Note>
           </Chord>
         <Tuplet id="1">
@@ -163,11 +160,29 @@
             <tpc>16</tpc>
             </Note>
           </Chord>
+        <Tuplet id="2">
+          <normalNotes>2</normalNotes>
+          <actualNotes>2</actualNotes>
+          <baseNote>eighth</baseNote>
+          <Number>
+            <style>Tuplet</style>
+            <text>2</text>
+            </Number>
+          </Tuplet>
         <Chord>
-          <durationType>quarter</durationType>
+          <Tuplet>2</Tuplet>
+          <durationType>eighth</durationType>
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>2</Tuplet>
+          <durationType>eighth</durationType>
+          <Note>
+            <pitch>67</pitch>
+            <tpc>15</tpc>
             </Note>
           </Chord>
         <Chord>


### PR DESCRIPTION
Disables swing processing for chords within tuplets, which should be more to people's liking.  Updated the triplet test to check this.