### PR TITLE
fix #69271: arpeggio manual adjustments not saved for tab

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2338,6 +2338,7 @@ void Chord::layoutTablature()
             qreal h = downNote()->pos().y() + downNote()->headHeight() - y;
             _arpeggio->setHeight(h);
             _arpeggio->setPos(-lll, y);
+            _arpeggio->adjustReadPos();
 
             // handle the special case of _arpeggio->span() > 1
             // in layoutArpeggio2() after page layout has done so we


### PR DESCRIPTION
The adjustreadPos() call is present in layoutPitched(), seems needed here as well.