### PR TITLE
fix #88221: crash on create tuplet with hyphenated lyric

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4652,6 +4652,7 @@ void ScoreView::cmdCreateTuplet( ChordRest* cr, Tuplet* tuplet)
       if (el) {
             _score->select(el, SelectType::SINGLE, 0);
             if (!noteEntryMode()) {
+                  _score->doLayout();
                   sm->postEvent(new CommandEvent("note-input"));
                   qApp->processEvents();
                   }


### PR DESCRIPTION
See analysis in https://musescore.org/en/node/88221#comment-389091 and following.  We need to force a relayout before forcing note input mode.  I tried just doing a rebuildBspTree(), but it didn't work - the niote input cursor wasn't correct.  doLayout() seems to do the job better.

It's possible there is another solution involving rebuilding the tree in Score::removeUnmanaged() or something else, but forcing a layout here in cmdCreateTuplet() seems relatively safe and nicely contained.