### PR TITLE
fix #25763: allow full measure rests to be created in voices > 1

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2385,26 +2385,26 @@ void Score::cmdFullMeasureRest()
             int track1  = selection().staffStart() * VOICES;
             int track2  = selection().staffEnd() * VOICES;
             for (int track = track1; track < track2; ++track) {
-                  int tick  = -1;
+                  // first pass - remove non-initial rests from empty measures/voices
                   for (Segment* s = s1; s != s2; s = s->next1()) {
                         if (!(s->measure()->isOnlyRests(track))) // Don't remove anything from measures that contain notes
                               continue;
                         if (s->segmentType() != Segment::Type::ChordRest || !s->element(track))
                               continue;
                         ChordRest* cr = static_cast<ChordRest*>(s->element(track));
-
-                        if (tick == -1) {
-                              // first ChordRest found:
-                              tick = s->measure()->tick();
+                        // keep first rest of measure as placeholder (replaced in second pass)
+                        // but delete all others
+                        if (s->rtick())
                               removeChordRest(cr, true);
-                              }
-                        else {
-                              removeChordRest(cr, true);
-                              }
                         }
+                  // second pass - replace placeholders with full measure rests
                   for (Measure* m = s1->measure(); m; m = m->nextMeasure()) {
-                        if (!(track % VOICES) && m->isOnlyRests(track)) {
-                              addRest(m->tick(), track, TDuration(TDuration::DurationType::V_MEASURE), 0);
+                        if (m->isOnlyRests(track)) {
+                              ChordRest* cr = m->findChordRest(m->tick(), track);
+                              if (cr) {
+                                    removeChordRest(cr, true);
+                                    addRest(m->tick(), track, TDuration(TDuration::DurationType::V_MEASURE), 0);
+                                    }
                               }
                         if (s2 && (m == s2->measure()))
                               break;


### PR DESCRIPTION
The algorithm originally deleted all rests from empty measure / voices in one pass, then made a second pass and added full measure rests for voice 1.  Because we don't want to just add full measure rest for other voices unless the voice is actually present (and contains only rests), I altered the algorithm to leave the a rest at the beginning of each measure as a placeholder during the first pass.  Then during the second pass, I look for these and replace them with full measures rests.  This means full measure rests will be created in a measure for any voice if that voice was only rests and actually had a rest at the beginning of the measure.  If voice 2 starts out with a hole, then a rest, the rest is simply deleted just as before.