### PR TITLE
fix #94856: some palettes too small on high DPI displays

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -83,7 +83,7 @@ static bool needsStaff(Element* e)
 Palette::Palette(QWidget* parent)
    : QWidget(parent)
       {
-      extraMag      = 1.0;
+      extraMag      = 1.0 * guiScaling;
       currentIdx    = -1;
       dragIdx       = -1;
       selectedIdx   = -1;


### PR DESCRIPTION
Palettes that set an explicit mag were being sized correctly - which is to say, consistently on all systems regardless of display resolution.  But palettes that were using the default magnification and not setting it explicitly were rendering smaller on high resolution displays, because the Palette constructor was initializing extraMag to 1.0 and not taking guiScaling into account, whereas an explicit setMag() call does use guiScaling.

Systems with standard 96 DPI displays won't see a difference, but systems with high DPI displays were seeing certain palettes - like Articulations & Ornaments - render too small.  This change fixes that, so palette sizes should be more consistent across systems.  Sorry I missed this last time around, but thanks to Zack for noticing something wasn't right.