### PR TITLE
fix #93006: layout shift due to overestimating size of courtesy keysig

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2161,12 +2161,12 @@ qreal Score::cautionaryWidth(Measure* m, bool& hasCourtesy)
                         Segment* s  = m->findSegment(Segment::Type::KeySigAnnounce, tick);
 
                         if (s && s->element(track)) {
-                              wwMax = qMax(wwMax, s->element(track)->width()) + leftMargin;
+                              wwMax = qMax(wwMax, s->element(track)->width() + leftMargin);
                               hasCourtesy = true;
                               }
                         else {
                               nks->layout();
-                              wwMax = qMax(wwMax, nks->width()) + leftMargin;
+                              wwMax = qMax(wwMax, nks->width() + leftMargin);
                               //hasCourtesy = false;
                               }
                         }


### PR DESCRIPTION
Last year we (mostly @mgavioli ) fixed a number of issues that were causing inconsistencies in layout, with a typical symptom being that each time you pressed Ctrl+A, one measure would move back and forth from one system to the next, with a correspond ripple effect on layout from that point on.  These issues all had to do with how we accounted for the width of courtesy elements - clefs, key and time signatures.

In the process of fixing these, I introduced some code that almost but not quite worked:

https://github.com/musescore/MuseScore/commit/25e43f2f1b97340027c6c8768158c8a543bbe49b

It works well if there is only one staff, but the more staves, the more the code overestimates the width of courtesy key signatures, because I keep adding leftMargin to the accumulated max width on every iteration of the loop rather than only adding it to the current width.  So the more staves a piece has, the more we overestimate the width of courtesy elements, leading us to think a measure will fit that won't or vice versa.