### PR TITLE
fix #96246: crash removing null lyric

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3079,8 +3079,10 @@ void Chord::removeMarkings(bool keepTremolo)
             remove(e);
       for (Element* e : articulations())
             remove(e);
-      for (Element* e : lyricsList())
-            remove(e);
+      for (Element* e : lyricsList()) {
+            if (e)
+                  remove(e);
+            }
       for (Element* e : graceNotes())
             remove(e);
       for (Note* n : notes()) {


### PR DESCRIPTION
This avoids the crashes.  It doesn't do anything special with the null lyric - I guess it is left in the lyric list for now.  But so far I can't make anything bad happen as a result, and when I check with the object debugger I don't see anything unusual.