### PR TITLE
fix #95826: avoid crash when switching scores while in edit mode

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1338,8 +1338,8 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
       cv = view;
       if (cv) {
             if (cv->score() && (cs != cv->score())) {
-                  // exit note entry mode
-                  if (cv->noteEntryMode()) {
+                  // exit note entry or edit mode
+                  if (cv->noteEntryMode() || cv->editMode()) {
                         cv->cmd(getAction("escape"));
                         qApp->processEvents();
                         }


### PR DESCRIPTION
This fixes the crash and seems like it should be safe.  There is still a fun glitch where the text from the first score gets used as the "undo" text in the other score.  Probably we should investigate removing the "static" declarations from some of these variables in the Text class.  But that seems potentially more dangerous to me.