### PR TITLE
fix #95051: bad melisma layout after hbox

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1547,8 +1547,6 @@ void Score::doLayout()
                         sp->layout();
                   }
             }
-      for (Spanner* s : _unmanagedSpanner)
-            s->layout();
 
       if (layoutMode() != LayoutMode::LINE) {
             layoutSystems2();
@@ -1556,6 +1554,9 @@ void Score::doLayout()
             }
       for (Measure* m = firstMeasureMM(); m; m = m->nextMeasureMM())
             m->layout2();
+
+      for (Spanner* s : _unmanagedSpanner)
+            s->layout();
 
       for (auto s : _spanner.map()) {           // DEBUG
             Spanner* sp = s.second;


### PR DESCRIPTION
The code for laying out the line seems fine to me, except that it is called before system layout is finalized.  Simply moving the unmanagedSpanner layout a little later fixes this.

I would not be surprised to find there is some reason it needs to happen before system layout so the change here would break something.  So far, though, I can't find anything that breaks.

@mgavioli : do you recall if in fact there is a reason we cannot simply do as I am doing here?