### PR TITLE
fix #96626 signed MidiMapping, StaffTypes chars

### DIFF
--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -273,7 +273,7 @@ const int STAFF_GROUP_MAX = int(StaffGroup::TAB) + 1;      // out of enum to avo
 //    Must be in sync with list in setDefaultStyle().
 //---------------------------------------------------------
 
-enum class TextStyleType : char {
+enum class TextStyleType : signed char {
       DEFAULT = 0,
       TITLE,
       SUBTITLE,

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -162,8 +162,8 @@ class MeasureBaseList {
 struct MidiMapping {
       Part* part;
       Channel* articulation;
-      char port;
-      char channel;
+      signed char port;
+      signed char channel;
       };
 
 //---------------------------------------------------------

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -149,7 +149,7 @@ struct TablatureDurationFont {
 
 // ready-made staff types:
 
-enum class StaffTypes : char {
+enum class StaffTypes : signed char {
       STANDARD,
       PERC_1LINE, PERC_3LINE, PERC_5LINE,
       TAB_6SIMPLE, TAB_6COMMON, TAB_6FULL,


### PR DESCRIPTION
ARM treats chars as unsigned by default, causing problems when comparing to chars to negative values.  Explicitly declaring these "chars" as "signed chars" fixes this.