### PR TITLE
fix #96971 suppress benign make release warnings

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -518,7 +518,7 @@ QPointF Element::pagePos() const
             else if (parent()->type() == Element::Type::SYSTEM)
                   system = static_cast<System*>(parent());
             else
-                  Q_ASSERT(false);
+                  {Q_ASSERT(false);}
             if (system) {
                   int si = staffIdx();
                   if (type() == Element::Type::CHORD || type() == Element::Type::REST)
@@ -553,7 +553,7 @@ QPointF Element::canvasPos() const
             else if (parent()->type() == Element::Type::SYSTEM)
                   system = static_cast<System*>(parent());
             else
-                  Q_ASSERT(false);
+                  {Q_ASSERT(false);}
             if (system) {
                   int si = staffIdx();
                   if (type() == Element::Type::CHORD || type() == Element::Type::REST)

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -792,7 +792,7 @@ void LyricsLineSegment::layout()
       bool        endOfSystem       = false;
       bool        isEndMelisma      = lyricsLine()->lyrics()->ticks() > 0;
       Lyrics*     lyr, *nextLyr     = nullptr;
-      qreal       fromX, toX;             // start and end point of intra-lyrics room
+      qreal       fromX = 0, toX = 0;             // start and end point of intra-lyrics room
       qreal       sp                = spatium();
       System*     sys;
 

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2617,8 +2617,8 @@ bool Measure::createEndBarLines()
       bool mensur = false;    // keep note of Mensurstrich case
       int spanTot;            // to keep track of the target span as we count down
       int lastIdx;
-      int spanFrom;
-      int spanTo;
+      int spanFrom = 0;
+      int spanTo = 0;
       static const int unknownSpanFrom = 9999;
 
       for (int staffIdx = 0; staffIdx < nstaves; ++staffIdx) {

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -80,7 +80,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
       int dstTick = dst->tick();
       bool done = false;
       bool pasted = false;
-      int tickLen, staves = 0;
+      int tickLen = 0, staves = 0;
       while (e.readNextStartElement()) {
             if (done)
                   break;

--- a/mscore/importmidi/importmidi_voice.cpp
+++ b/mscore/importmidi/importmidi_voice.cpp
@@ -705,22 +705,22 @@ int findMaxOccupiedVoiceInBar(
             const std::multimap<ReducedFraction, MidiChord>::iterator &chordIt,
             const std::multimap<ReducedFraction, MidiChord> &chords)
       {
-      const int barIndex = chordIt->second.barIndex;
+      const unsigned int barIndex = chordIt->second.barIndex;
       int maxVoice = 0;
                   // look forward
       for (auto it = chordIt; it != chords.end(); ++it) {
             const MidiChord &chord = it->second;
-            if (chord.barIndex > barIndex + 1)
+            if ((unsigned int) chord.barIndex > barIndex + 1)
                   break;
-            if (chord.barIndex == barIndex && chord.voice > maxVoice)
+            if ((unsigned int) chord.barIndex == barIndex && chord.voice > maxVoice)
                   maxVoice = chord.voice;
             }
                   // look backward
       for (auto it = chordIt; ; ) {
             const MidiChord &chord = it->second;
-            if (chord.barIndex < barIndex - 1)
+            if ((unsigned int) chord.barIndex + 1 < barIndex)
                   break;
-            if (chord.barIndex == barIndex && chord.voice > maxVoice)
+            if ((unsigned int) chord.barIndex == barIndex && chord.voice > maxVoice)
                   maxVoice = chord.voice;
             if (it == chords.begin())
                   break;

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -3429,7 +3429,6 @@ void MusicXMLParserPass2::clef(const QString& partId, Measure* measure, const in
 
       Part* part = _pass1.getPart(partId);
       Q_ASSERT(part);
-      int staves = part->nstaves();
 
       // TODO: check error handling for
       // - single staff

--- a/mscore/magbox.cpp
+++ b/mscore/magbox.cpp
@@ -187,6 +187,7 @@ double MagBox::getMag(ScoreView* canvas) const
                   break;
 
             default:
+                  nmag = 0.0;
                   break;
             }
       if (nmag < 0.0001)

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1488,6 +1488,9 @@ void MuseScore::updateViewModeCombo()
             case LayoutMode::SYSTEM:
                   idx = 2;
                   break;
+            default:
+                  idx = 0;
+                  break;
             }
       viewModeCombo->setCurrentIndex(idx);
       }

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -53,29 +53,6 @@ extern bool externalStyle;
 static int exportAudioSampleRates[2] = { 44100, 48000 };
 
 //---------------------------------------------------------
-//   PeriodItem
-//---------------------------------------------------------
-
-struct PeriodItem {
-       int time;
-       const char* text;
-       PeriodItem(const int t, const  char* txt) {
-             time = t;
-             text = txt;
-             }
-       };
-
-static PeriodItem updatePeriods[] = {
-      PeriodItem(24,      QT_TRANSLATE_NOOP("preferences","Every Day")),
-      PeriodItem(72,      QT_TRANSLATE_NOOP("preferences","Every 3 Days")),
-      PeriodItem(7*24,    QT_TRANSLATE_NOOP("preferences","Every Week")),
-      PeriodItem(2*7*24,  QT_TRANSLATE_NOOP("preferences","Every 2 Weeks")),
-      PeriodItem(30*24,   QT_TRANSLATE_NOOP("preferences","Every Month")),
-      PeriodItem(2*30*24, QT_TRANSLATE_NOOP("preferences","Every 2 Months")),
-      PeriodItem(-1,      QT_TRANSLATE_NOOP("preferences","Never")),
-      };
-
-//---------------------------------------------------------
 //   Preferences
 //---------------------------------------------------------
 


### PR DESCRIPTION
This commit cleans some -Wempty-body, -Wmaybe-uninitialized, -Wunused-variable, and -Wstrict-overflow compiler warnings that arise on my x86-64 and ARMv7-A arch linux machines when compiling release (not debug).
These compiler messages all don't seem to cause any bugs, but since they pollute the build output, they make it harder to spot potentially important warnings that might arise, so I'm making these small changes to remove or suppress them.
The "empty-body" warnings occur because Q_ASSERT statements are removed when QT_NO_DEBUG is defined, causing the else blocks to have nothing.  Surrounding the Q_ASSERT with brackets will suppress this warning.
The "maybe-uninitialized" warnings are all suppressed by assigning the variables to 0 either at initialization or in a switch default block.
The "unused-variable" warning is due to PeriodItem updatePeriods[] in preferences.cpp being defined but never used, and so I've commented out with #if 0 / #endif, so it is atleast still in the code.
The "strict-overflow" warning is due to compiler wanting to perform an optimization which would cause signed overflow.  However since I don't think any reasonable human use would be able to cause an overflow in findMaxOccupiedVoiceInBar(), I've surround the function with GCC pragmas which will suppress the warning.