### PR TITLE
Improve pattern detection in beamed notes (zero slope)

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -577,6 +577,38 @@ bool Beam::slopeZero(const QList<ChordRest*>& cl)
       int l1 = cl.front()->line();
       int le = cl.back()->line();
 
+
+      // look for a repeating pattern
+      int period = cl.size() - 1;
+      bool found = false;
+      while (period > 0 && !found) {
+            found = true;
+            while (period > 0) {
+                  if (cl[0]->line() == cl[period]->line()) {
+                        break;
+                        }
+                  --period;
+                  }
+            
+            if (period == 0) {
+                  found = false;
+                  break;
+                  }
+            
+            for (int i = period; i < cl.size(); i++) {
+                  if (cl[i]->line() != cl[i % period]->line()) {
+                        --period;
+                        found = false;
+                        break;
+                        }
+                  }
+            }
+      
+      if (found) {
+            return true;
+            }
+
+
       // look for some pattern
       if (cl.size() == 4) {
             int l2 = cl[1]->line();
@@ -596,9 +628,9 @@ bool Beam::slopeZero(const QList<ChordRest*>& cl)
             if ((l2 > l1) && (l3 > l2) && (l1 == l4) && (l2 == l5) && (l3 == le))
                   return true;
             }
-      //
-      //    concave beams have a slope of 0.0
-      //
+      
+      
+      // concave beams have a slope of 0.0
       bool sameLine = true;
 
       slope = 0.0;

--- a/mtest/libmscore/copypaste/copypaste20-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste20-ref.mscx
@@ -135,8 +135,8 @@
             </Note>
           </Chord>
         <Beam id="2">
-          <l1>-15</l1>
-          <l2>-16</l2>
+          <l1>-12</l1>
+          <l2>-12</l2>
           </Beam>
         <Chord>
           <durationType>eighth</durationType>


### PR DESCRIPTION
This improves the behavior of the Beam::slopeZero method.

If there is a repeated pattern of pitches in the beamed notes, the beam will have zero slope (ref. Behind Bars, pg. 22):

Before:
![beamslope1](https://cloud.githubusercontent.com/assets/11692818/12986529/0dfe7ef6-d0f8-11e5-8c5d-a278af417063.png)
After:
![beamslope2](https://cloud.githubusercontent.com/assets/11692818/12986533/10002510-d0f8-11e5-8b60-a77729664187.png)

The slope will also be zero if the pattern of pitches is "truncated", e.g.: a b c d a b c
