### PR TITLE
fix #97826: extra distance scaled incorrectly on reload

### DIFF
--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -515,7 +515,7 @@ void Staff::write(Xml& xml) const
                   xml.tag("barLineSpan", _barLineSpan);
             }
       if (_userDist != 0.0)
-            xml.tag("distOffset", _userDist / spatium());
+            xml.tag("distOffset", _userDist / score()->spatium());
 
       writeProperty(xml, P_ID::MAG);
       writeProperty(xml, P_ID::COLOR);
@@ -607,7 +607,7 @@ void Staff::read(XmlReader& e)
                         _barLineTo = lines() == 1 ? BARLINE_SPAN_1LINESTAFF_TO : (lines() - 1) * 2;
                   }
             else if (tag == "distOffset")
-                  _userDist = e.readDouble() * spatium();
+                  _userDist = e.readDouble() * score()->spatium();
             else if (tag == "mag")
                   _userMag = e.readDouble(0.1, 10.0);
             else if (tag == "linkedTo") {


### PR DESCRIPTION
When saving a score that has a staff with both scaling and extra distance applied, the extra distance keeps changing on each save/reload.  Eg, the extra distance might start as 6sp and with a scaling of 50%, but after a save / reload, you end up with an extra distance of 12sp.  Clearly, the scaling was being applied to the extra distance incorrectly.

It turns out we were basing the units for the "distOff" tag on the staff spatium rather than the score spatium when reading and writing.  Meaning, in my example, we would actually be writing 12 as the value of "distOff".  In theory this might work, as on read, we'd convert this back to 6sp.  But unfortunately, the "mag" tag has not been seen yet, so we arent getting the correct staff spatium, so we end up with 12sp as our extra distance.

I don't see any reason we can't base the "distOff" tag on the score spatium and thus simply write "6" - the same value as shown in the dialog - rather than 12.  So that's what my PR does, and it appears to work just fine.  Existing scores are basically already messed up, so there shouldn't be a compatibility issue to worry about.