### PR TITLE
fix #97931: system initial barline type lost on reload

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2273,14 +2273,7 @@ void Measure::read(XmlReader& e, int staffIdx)
             else if (tag == "breakMultiMeasureRest")
                   _breakMultiMeasureRest = e.readBool();
             else if (tag == "sysInitBarLineType") {
-                  const QString& val(e.readElementText());
-                  _systemInitialBarLineType = BarLineType::NORMAL;
-                  for (unsigned i = 0; i < BarLine::barLineTableSize(); ++i) {
-                        if (BarLine::barLineTypeName(BarLineType(i)) == val) {
-                              _systemInitialBarLineType = BarLineType(i);
-                              break;
-                              }
-                        }
+                  _systemInitialBarLineType = BarLineType(Ms::getProperty(P_ID::SYSTEM_INITIAL_BARLINE_TYPE, e).toInt());
                   }
             else if (tag == "Tuplet") {
                   Tuplet* tuplet = new Tuplet(score());

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -16,6 +16,7 @@
 #include "groups.h"
 #include "xml.h"
 #include "note.h"
+#include "barline.h"
 
 namespace Ms {
 
@@ -214,7 +215,7 @@ static const PropertyData propertyList[] = {
       { P_ID::VOLTA_ENDING,        true,  "endings",               P_TYPE::INT_LIST },
       { P_ID::LINE_VISIBLE,        true,  "lineVisible",           P_TYPE::BOOL },
 
-      { P_ID::SYSTEM_INITIAL_BARLINE_TYPE, false, "sysInitBarLineType", P_TYPE::INT },
+      { P_ID::SYSTEM_INITIAL_BARLINE_TYPE, false, "sysInitBarLineType", P_TYPE::BARLINE_TYPE },
       { P_ID::MAG,                 false, "mag",                   P_TYPE::REAL },
       { P_ID::USE_DRUMSET,         false, "useDrumset",            P_TYPE::BOOL },
       { P_ID::PART_VOLUME,         false, "volume",                P_TYPE::INT },
@@ -367,6 +368,23 @@ QVariant getProperty(P_ID id, XmlReader& e)
                         return QVariant(int(Element::Placement::ABOVE));
                   else if (value == "below")
                         return QVariant(int(Element::Placement::BELOW));
+                  }
+                  break;
+            case P_TYPE::BARLINE_TYPE: {
+                  bool ok;
+                  const QString& val(e.readElementText());
+                  int ct = val.toInt(&ok);
+                  if (ok)
+                        return QVariant(ct);
+                  else {
+                        for (unsigned i = 0; i < BarLine::barLineTableSize(); ++i) {
+                              if (BarLine::barLineTypeName(BarLineType(i)) == val) {
+                                    ct = i;
+                                    break;
+                                    }
+                              }
+                        return QVariant(ct);
+                        }
                   }
                   break;
             case P_TYPE::BEAM_MODE:             // TODO

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -263,6 +263,7 @@ enum class P_TYPE : char {
       TEXT_STYLE,
       INT_LIST,
       GLISSANDO_STYLE,
+      BARLINE_TYPE,
       };
 
 extern QVariant getProperty(P_ID type, XmlReader& e);

--- a/libmscore/xml.cpp
+++ b/libmscore/xml.cpp
@@ -17,6 +17,7 @@
 #include "tuplet.h"
 #include "sym.h"
 #include "note.h"
+#include "barline.h"
 
 namespace Ms {
 
@@ -413,7 +414,7 @@ void Xml::tag(P_ID id, QVariant data, QVariant defaultData)
                   tag(name, data);
                   break;
             case P_TYPE::ORNAMENT_STYLE:
-                  switch ( MScore::OrnamentStyle(data.toInt())) {
+                  switch (MScore::OrnamentStyle(data.toInt())) {
                         case MScore::OrnamentStyle::BAROQUE:
                               tag(name, QVariant("baroque"));
                               break;
@@ -423,7 +424,7 @@ void Xml::tag(P_ID id, QVariant data, QVariant defaultData)
                              }
                   break;
             case P_TYPE::GLISSANDO_STYLE:
-                  switch ( MScore::GlissandoStyle(data.toInt())) {
+                  switch (MScore::GlissandoStyle(data.toInt())) {
                         case MScore::GlissandoStyle::BLACK_KEYS:
                               tag(name, QVariant("blackkeys"));
                               break;
@@ -439,7 +440,7 @@ void Xml::tag(P_ID id, QVariant data, QVariant defaultData)
                              }
                   break;
             case P_TYPE::DIRECTION:
-                  switch(MScore::Direction(data.toInt())) {
+                  switch (MScore::Direction(data.toInt())) {
                         case MScore::Direction::UP:
                               tag(name, QVariant("up"));
                               break;
@@ -451,7 +452,7 @@ void Xml::tag(P_ID id, QVariant data, QVariant defaultData)
                         }
                   break;
             case P_TYPE::DIRECTION_H:
-                  switch(MScore::DirectionH(data.toInt())) {
+                  switch (MScore::DirectionH(data.toInt())) {
                         case MScore::DirectionH::LEFT:
                               tag(name, QVariant("left"));
                               break;
@@ -463,7 +464,7 @@ void Xml::tag(P_ID id, QVariant data, QVariant defaultData)
                         }
                   break;
             case P_TYPE::LAYOUT_BREAK:
-                  switch(LayoutBreak::Type(data.toInt())) {
+                  switch (LayoutBreak::Type(data.toInt())) {
                         case LayoutBreak::Type::LINE:
                               tag(name, QVariant("line"));
                               break;
@@ -476,7 +477,7 @@ void Xml::tag(P_ID id, QVariant data, QVariant defaultData)
                         }
                   break;
             case P_TYPE::VALUE_TYPE:
-                  switch(Note::ValueType(data.toInt())) {
+                  switch (Note::ValueType(data.toInt())) {
                         case Note::ValueType::OFFSET_VAL:
                               tag(name, QVariant("offset"));
                               break;
@@ -486,7 +487,7 @@ void Xml::tag(P_ID id, QVariant data, QVariant defaultData)
                         }
                   break;
             case P_TYPE::PLACEMENT:
-                  switch(Element::Placement(data.toInt())) {
+                  switch (Element::Placement(data.toInt())) {
                         case Element::Placement::ABOVE:
                               tag(name, QVariant("above"));
                               break;
@@ -497,6 +498,9 @@ void Xml::tag(P_ID id, QVariant data, QVariant defaultData)
                   break;
             case P_TYPE::SYMID:
                   tag(name, Sym::id2name(SymId(data.toInt())));
+                  break;
+            case P_TYPE::BARLINE_TYPE:
+                  tag(name, BarLine::barLineTypeName(BarLineType(data.toInt())));
                   break;
             default:
                   Q_ASSERT(false);


### PR DESCRIPTION
We were writing the value as an int but reading itexpecting a string.  Since regular barlines read and write the type as a string, I changed the code here to be consistent with that.