### PR TITLE
Include separator before full screen command on OS X

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -823,9 +823,9 @@ MuseScore::MuseScore()
       menuView->addAction(getAction("show-unprintable"));
       menuView->addAction(getAction("show-frames"));
       menuView->addAction(getAction("show-pageborders"));
-     
-#ifndef Q_OS_MAC
       menuView->addSeparator();
+      
+#ifndef Q_OS_MAC
       a = getAction("fullscreen");
       a->setCheckable(true);
       a->setChecked(false);


### PR DESCRIPTION
If this doesn't work, let me know. I'm just guessing that it would work.