### PR TITLE
Fully fix #95116 for OS X non-Retina display

### DIFF
--- a/mscore/startcenter.cpp
+++ b/mscore/startcenter.cpp
@@ -154,7 +154,7 @@ void Startcenter::writeSettings(QSettings& settings)
 void Startcenter::readSettings(QSettings& settings)
       {
       settings.beginGroup("Startcenter");
-      resize(settings.value("size", QSize(700, 570)).toSize());
+      resize(settings.value("size", QSize(720, 570)).toSize());
       move(settings.value("pos", QPoint(200, 100)).toPoint());
       settings.endGroup();
       }


### PR DESCRIPTION
Allow three thumbnails in a row (plus scroll bar) to display in Start Center after scaling changes