### PR TITLE
Build 32 bit AppImages (fix #95541 improvement)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,15 @@ env:
     - "ARTIFACTS_S3_BUCKET=vtest.musescore.org"
     - secure: "lVj+9BBtJIjW3CwfXstvNyYVn0AkXEwTyiPmp4BprcheP78WIqZNC0uG2RjG9MgyHbZkprE7zRdqR9YPWTitg+XYkkD6+jPHRO+PQFLARuiTAX9yhUO53yQQZC2wMkQ#+bFuZsFmz1rfAsPHx3bXeZAMsz+Qnh8D2yIqqV7qxwWw="
     - secure: "L+66yQZIZJTyIAfrG89ncKIkMAr4+UvaOZMsd420OSdnEH9kpdm5Kws8rG0VVLAtqhfQfi3K9DuC8Ub7IiXqil//h+I9WJ2LHKirWK0m/MkhTFC6hfi0uSnQCX/jud3Keewxf3ovgiKQvIw6VR37UC50YJM9+KhZKtsNYhGAdos="
+    # Branches for uploads of Linux nightly builds & stable release AppImages
+    - "APPIMAGE_UPLOAD_BRANCHES=\"master 2.0.3\""
+    # AppImages are built on all branches, but only uploaded on those listed
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: "JOB=AppImage"
+    - env: "JOB=AppImage_64bit"
+    - env: "JOB=AppImage_32bit"
   include:
     # 1st parallel build job - debug build on Ubuntu
     - env: "JOB=Tests"
@@ -53,8 +57,8 @@ matrix:
         - "./build/travis/job1_Tests/run_tests.sh"
       after_script:
         - 'ARTIFACTS_PATHS="$(ls vtest/html | tr "\n" ":")" artifacts upload'
-    # 2nd parallel build job - portable Linux AppImage build on CentOS
-    - env: "JOB=AppImage"
+    # 2nd parallel build job - portable Linux AppImage 64-bit build on CentOS
+    - env: "JOB=AppImage_64bit"
       addons:
         apt:
           packages:
@@ -64,8 +68,19 @@ matrix:
       services:
         - docker
       script:
-        - "./build/travis/job2_AppImage/build.sh --upload-branches master 2.0.3"
-        # AppImages are built on all branches, but only uploaded on those listed
+        - "./build/travis/job2_AppImage/build.sh --upload-branches $APPIMAGE_UPLOAD_BRANCHES"
+    # 3rd parallel build job - portable Linux AppImage 32-bit build on CentOS
+    - env: "JOB=AppImage_32bit"
+      addons:
+        apt:
+          packages:
+          - bsdtar
+          - curl
+          - zsync
+      services:
+        - docker
+      script:
+        - "./build/travis/job2_AppImage/build.sh --32bit --upload-branches $APPIMAGE_UPLOAD_BRANCHES"
 
 notifications:
   recipients:

--- a/build/Linux+BSD/portable/Recipe
+++ b/build/Linux+BSD/portable/Recipe
@@ -54,20 +54,20 @@ cd "$(dirname "$(readlink -f "${0}")")/../../../.."
 
 yum -y install epel-release
 
-# basic dependencies (present on CentOS LiveCD ISO but needed by Docker image)
-yum -y install wget which automake
+# basic dependencies (needed by Docker image)
+yum -y install git wget which automake
 
 if [ "${OS}" == "CentOS 6" ]; then
-  # Get newer version of git than available by default
+  # Get newer compiler than available by default
   wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
-  yum install -y devtoolset-2-git
-  source /opt/rh/devtoolset-2/enable # enable the new version
+  yum -y install devtoolset-2-gcc devtoolset-2-gcc-c++ devtoolset-2-binutils
+  source /opt/rh/devtoolset-2/enable # enable new compiler
 else
-  yum -y install git
+  yum -y install gcc gcc-c++ binutils
 fi
 
 # Build AppImageKit now to avoid conflicts with MuseScore's dependencies (LAME)
-[ -d "AppImageKit" ] || git clone -b master --single-branch --depth 1 https://github.com/probonopd/AppImageKit.git
+[ -d "AppImageKit" ] || git clone --depth 1 https://github.com/probonopd/AppImageKit.git
 cd AppImageKit
 ./build.sh
 
@@ -78,18 +78,9 @@ cd ..
 #wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
 yum -y install cmake mesa-libGL-devel pulseaudio-libs-devel alsa-lib-devel jack-audio-connection-kit-devel portaudio-devel libsndfile-devel libvorbis-devel qt5-qtbase-devel qt5-qttools-libs-designercomponents qt5-qttools-devel qt5-qtdeclarative-devel qt5-qtscript-devel qt5-qtwebkit-devel qt5-qtxmlpatterns-devel qt5-qtquick1-devel qt5-qtsvg-devel qt5-qttools-devel qt5-qttools-static qt5-qtmultimedia-devel qt5-qtwebchannel-devel qt5-qtimageformats qt5-qtquickcontrols
 
-if [ "${OS}" == "CentOS 6" ]; then
-  # Get newer compiler than available by default
-  # wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
-  yum -y install devtoolset-2-gcc devtoolset-2-gcc-c++ devtoolset-2-binutils
-  source /opt/rh/devtoolset-2/enable # enable new compiler
-else
-  yum -y install gcc gcc-c++ binutils
-fi
-
 # Install LAME (get this dependency last because rpmforge and epel-release conflict)
-wget http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm
-rpm -ivh rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm || true # don't fail if already installed
+wget http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el6.rf.$(arch).rpm
+rpm -ivh rpmforge-release-0.5.3-1.el6.rf.$(arch).rpm || true # don't fail if already installed
 yum -y install lame-devel
 
 ##########################################################################
@@ -97,7 +88,7 @@ yum -y install lame-devel
 ##########################################################################
 
 # If not building on Travis then might need to fetch MuseScore
-[ -d "MuseScore" ] || git clone -b portable-linux-build-on-travis --single-branch --depth 1 https://github.com/shoogle/MuseScore.git
+[ -d "MuseScore" ] || git clone --depth 1 https://github.com/musescore/MuseScore.git
 
 cd MuseScore
 make revision

--- a/build/Linux+BSD/portable/copy-libs
+++ b/build/Linux+BSD/portable/copy-libs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Usage:   copy-libs  $share_path
 
@@ -18,7 +18,15 @@ main() {
 
   num_failures=0 # store number of libraries that couldn't be copied
   getCrossPlatformDependencies
-  getLinuxOnlyDependencies
+
+  # get linux-specific dependencies, based on which distro is making the AppImage
+  if [ "$(grep "CentOS release 6" /etc/*release*)" ]; then
+    building_on_CentOS_6
+  else
+    echo "${0}: Warning: Not running on a supported build system!" >&2
+    # Try to fetch all dependencies, just in case
+    building_on_CentOS_6
+  fi
 
   if [ "$num_failures" != "0" ]; then
     echo "Error: $num_failures libraries couldn't be copied."
@@ -96,9 +104,10 @@ getCrossPlatformDependencies() {
 
 ##########################################################################
 # LINUX-ONLY DEPENDENCIES (no equivalents in "mscore/CMakeLists.txt")
-# Note: always check the oldest distribution first
+# These differ depending on the distribution used to build the AppImage.
+# Note: always check the oldest supported distribution first
 ##########################################################################
-getLinuxOnlyDependencies() {
+building_on_CentOS_6() {
   # Needed by Centos 6.7:
   dest_dir="$lib_dest"
   copyLib libjack.so.0
@@ -128,7 +137,17 @@ getLinuxOnlyDependencies() {
 }
 
 locateLib() {
-  local path="$(ldconfig -p | grep "$1" | awk '{print $4}')"
+  # First search $LD_LIBRARY_PATH
+  declare -a dir_array
+  IFS=':' read -ra dir_array <<< "${LD_LIBRARY_PATH}"
+  for d in "${dir_array[@]}"; do
+    if [ -e "$d/$1" ]; then
+      echo "$d/$1"
+      return
+    fi
+  done
+  # If it wasn't found then search library cache
+  local path="$(ldconfig -p | awk '{print $4}' | grep "$1" | head -n1)"
   [ "$path" ] || echo "$1 not found." >&2
   echo "$path"
 }

--- a/build/travis/job2_AppImage/bintray.sh
+++ b/build/travis/job2_AppImage/bintray.sh
@@ -60,13 +60,13 @@ FILE="$1"
 # MUSESCORE NAMING SCHEME:
 # File:    MuseScore-X.Y.Z-<arch>.AppImage (e.g. MuseScore-2.0.3-x86_64)
 # Version: X.Y.Z
-# Package: MuseScore-Linux
+# Package: MuseScore-Linux-<arch>
 #
 # NIGHTLY NAMING SCHEME:
 # File:    MuseScoreNightly-<datetime>-<branch>-<commit>-<arch>.AppImage
 #    (e.g. MuseScoreNightly-201601151332-master-f53w6dg-x86_64.AppImage)
 # Version: <datetime>-<branch>-<commit> (e.g. 201601151332-master-f53w6dg)
-# Package: MuseScoreNightly-<branch> (e.g. MuseScoreNightly-master)
+# Package: MuseScoreNightly-<branch>-<arch> (e.g. MuseScoreNightly-master-x86_64)
 
 # Read app name from file name (get characters before first dash)
 APPNAME="$(basename "$FILE" | sed -r 's|^([^-]*)-.*$|\1|')"
@@ -93,12 +93,12 @@ case "${ARCH}" in
     ;;
 esac
 
-FILE_UPLOAD_PATH="$ARCH/$(basename "${FILE}")"
+FILE_UPLOAD_PATH="$(basename "${FILE}")"
 
 if [ "${APPNAME}" == "MuseScore" ]; then
   # Upload a new version but don't publish it (invisible until published)
   url_query="" # Don't publish, don't overwrite existing files with same name
-  PCK_NAME="$APPNAME-Linux"
+  PCK_NAME="$APPNAME-Linux-$ARCH"
   BINTRAY_REPO="MuseScore"
   LABELS="[\"music\", \"audio\", \"MIDI\", \"AppImage\"]"
 elif  [ "${APPNAME}" == "MuseScoreNightly" ]; then
@@ -108,7 +108,7 @@ elif  [ "${APPNAME}" == "MuseScoreNightly" ]; then
   # Get Git branch from $VERSION (get characters between first and last dash)
   BRANCH="$(echo $VERSION | sed -r 's|^[^-]*-(.*)-[^-]*$|\1|')"
 
-  PCK_NAME="$APPNAME-$BRANCH"
+  PCK_NAME="$APPNAME-$BRANCH-$ARCH"
   BINTRAY_REPO="nightlies-linux"
   LABELS="[\"nightly\", \"unstable\", \"testing\"]"
 else
@@ -150,7 +150,7 @@ if [ "${APPNAME}" == "MuseScore" ]; then
   DESCRIPTION=$(bsdtar -f "${FILE}" -O -x ./"${DESKTOP}" | grep -e "^Comment=" | sed s/Comment=//g)
 elif [ "${APPNAME}" == "MuseScoreNightly" ]; then
   # Use custom description for nightly builds
-  DESCRIPTION="Automated builds of the $BRANCH development branch for Linux systems. FOR TESTING PURPOSES ONLY!"
+  DESCRIPTION="Automated builds of the $BRANCH development branch for $SYSTEM Linux systems. FOR TESTING PURPOSES ONLY!"
 fi
 
 ICONNAME=$(bsdtar -f "${FILE}" -O -x "${DESKTOP}" | grep -e "^Icon=" | sed s/Icon=//g)

--- a/build/travis/job2_AppImage/build.sh
+++ b/build/travis/job2_AppImage/build.sh
@@ -4,6 +4,8 @@
 # Build portable Linux AppImages and upload them to Bintray. AppImages will
 # always be uploaded unless a list of specific branches is passed in. e.g.:
 #    $   build.sh  --upload-branches  master  my-branch-1  my-branch-2
+# Builds will be for the native architecture (64 bit) unless another is
+# specified for cross-compiling. (e.g. build.sh --32bit)
 
 set -e # exit on error
 set -x # echo commands
@@ -27,17 +29,31 @@ else
   makefile_overrides="" # use Makefile defaults
 fi
 
-# Build MuseScore AppImage inside Docker image
-docker run -i -v "${PWD}:/MuseScore" library/centos:6 \
-   /bin/bash -c "/MuseScore/build/Linux+BSD/portable/Recipe $makefile_overrides"
+# Build AppImage. Are we cross-compiling?
+case "$1" in
+  --32bit )
+    shift
+    # Build MuseScore AppImage inside 32-bit Docker image
+    docker run -i -v "${PWD}:/MuseScore" toopher/centos-i386:centos6 /bin/bash -c \
+      "linux32 --32bit i386 /MuseScore/build/Linux+BSD/portable/Recipe $makefile_overrides"
+    ;;
+  * )
+    [ "$1" == "--64bit" ] && shift || true
+    # Build MuseScore AppImage inside native (64-bit) Docker image
+    docker run -i -v "${PWD}:/MuseScore" library/centos:6 /bin/bash -c \
+      "/MuseScore/build/Linux+BSD/portable/Recipe $makefile_overrides"
+    ;;
+esac
 
 # Should the AppImage be uploaded?
 if [ "$1" == "--upload-branches" ]; then
+  # User passed in list of branchs so only upload those listed
   shift
   for upload_branch in "$@" ; do
     [ "$branch" == "$upload_branch" ] && upload=true || true # bypass `set -e`
   done
 else
+  # No list passed in so upload on every branch
   upload=true
 fi
 


### PR DESCRIPTION
So it turns out that enabling 32 bit builds wasn't *too* difficult after all. This builds on i686 rather than i386 but that shouldn't matter; I get the impression that anything reporting itself as i386 is really i686 these days.

Successful Bintray upload [confirmed](https://bintray.com/shoogle/test/). I had to switch to including the architecture in the Bintray package names. I don't have a 32 bit system to test the AppImages on but I tested inside a 32 bit chroot on my 64 bit system with no problems.