### PR TITLE
fix #99236 remove mscoreGlobalShare/sound from soundfont path

### DIFF
--- a/fluid/fluid.cpp
+++ b/fluid/fluid.cpp
@@ -29,7 +29,6 @@
 #include "voice.h"
 
 namespace FluidS {
-using namespace Ms;
 
 /***************************************************************
  *
@@ -892,8 +891,9 @@ QFileInfoList Fluid::sfFiles()
       {
       QFileInfoList l;
 
-      QString path = preferences.sfPath;
-      QStringList pl = path.split(";");
+      QStringList pl = preferences.mySoundfontsPath.split(";");
+      pl.prepend(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("sound")).absoluteFilePath());
+
       foreach (const QString& s, pl) {
             QString ss(s);
             if (!s.isEmpty() && s[0] == '~')

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1975,7 +1975,7 @@ void importSoundfont(QString name)
             QWidget::tr("Do you want to install the SoundFont %1?").arg(info.fileName()),
              QMessageBox::Yes|QMessageBox::No, QMessageBox::NoButton);
       if (ret == QMessageBox::Yes) {
-            QStringList pl = preferences.sfPath.split(";");
+            QStringList pl = preferences.mySoundfontsPath.split(";");
             QString destPath;
             for (QString s : pl) {
                   QFileInfo dest(s);

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -177,7 +177,7 @@ void Preferences::init()
       myImagesPath    = QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("images_directory",     "Images"))).absoluteFilePath();
       myTemplatesPath = QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("templates_directory",  "Templates"))).absoluteFilePath();
       myPluginsPath   = QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("plugins_directory",    "Plugins"))).absoluteFilePath();
-      sfPath          = QString("%1;%2").arg(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("sound")).absoluteFilePath()).arg(QFileInfo(QString("%2/%3").arg(wd).arg(QCoreApplication::translate("soundfonts_directory", "Soundfonts"))).absoluteFilePath());
+      mySoundfontsPath = QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("soundfonts_directory", "Soundfonts"))).absoluteFilePath();
 
       MScore::setNudgeStep(.1);         // cursor key (default 0.1)
       MScore::setNudgeStep10(1.0);      // Ctrl + cursor key (default 1.0)
@@ -313,7 +313,7 @@ void Preferences::write()
       s.setValue("myImagesPath", myImagesPath);
       s.setValue("myTemplatesPath", myTemplatesPath);
       s.setValue("myPluginsPath", myPluginsPath);
-      s.setValue("sfPath",  sfPath);
+      s.setValue("mySoundfontsPath", mySoundfontsPath);
 
       s.setValue("hraster", MScore::hRaster());
       s.setValue("vraster", MScore::vRaster());
@@ -456,7 +456,7 @@ void Preferences::read()
       myImagesPath     = s.value("myImagesPath",     myImagesPath).toString();
       myTemplatesPath  = s.value("myTemplatesPath",  myTemplatesPath).toString();
       myPluginsPath    = s.value("myPluginsPath",    myPluginsPath).toString();
-      sfPath           = s.value("sfPath",           sfPath).toString();
+      mySoundfontsPath = s.value("mySoundfontsPath", mySoundfontsPath).toString();
 
       //Create directories if they are missing
       QDir dir;
@@ -465,7 +465,7 @@ void Preferences::read()
       dir.mkpath(myImagesPath);
       dir.mkpath(myTemplatesPath);
       dir.mkpath(myPluginsPath);
-      foreach (QString path, sfPath.split(";"))
+      foreach (QString path, mySoundfontsPath.split(";"))
             dir.mkpath(path);
 
       MScore::setHRaster(s.value("hraster", MScore::hRaster()).toInt());
@@ -601,8 +601,8 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       connect(myTemplatesButton, SIGNAL(clicked()), SLOT(selectTemplatesDirectory()));
       connect(myPluginsButton, SIGNAL(clicked()), SLOT(selectPluginsDirectory()));
       connect(myImagesButton, SIGNAL(clicked()), SLOT(selectImagesDirectory()));
-
       connect(mySoundfontsButton, SIGNAL(clicked()), SLOT(changeSoundfontPaths()));
+
       connect(updateTranslation, SIGNAL(clicked()), SLOT(updateTranslationClicked()));
 
       connect(defaultStyleButton,     SIGNAL(clicked()), SLOT(selectDefaultStyle()));
@@ -958,7 +958,7 @@ void PreferenceDialog::updateValues()
       myImages->setText(prefs.myImagesPath);
       myTemplates->setText(prefs.myTemplatesPath);
       myPlugins->setText(prefs.myPluginsPath);
-      sfPath->setText(prefs.sfPath);
+      mySoundfonts->setText(prefs.mySoundfontsPath);
 
       idx = 0;
       int n = sizeof(exportAudioSampleRates)/sizeof(*exportAudioSampleRates);
@@ -971,8 +971,6 @@ void PreferenceDialog::updateValues()
       exportAudioSampleRate->setCurrentIndex(idx);
       exportPdfDpi->setValue(prefs.exportPdfDpi);
       pageVertical->setChecked(MScore::verticalOrientation());
-
-      sfChanged = false;
       }
 
 //---------------------------------------------------------
@@ -1357,7 +1355,7 @@ void PreferenceDialog::apply()
       prefs.myImagesPath       = myImages->text();
       prefs.myTemplatesPath    = myTemplates->text();
       prefs.myPluginsPath      = myPlugins->text();
-      prefs.sfPath             = sfPath->text();
+      prefs.mySoundfontsPath = mySoundfonts->text();
 
       int idx = exportAudioSampleRate->currentIndex();
       prefs.exportAudioSampleRate = exportAudioSampleRates[idx];
@@ -1678,9 +1676,9 @@ void PreferenceDialog::changeSoundfontPaths()
       {
       PathListDialog pld(this);
       pld.setWindowTitle(tr("SoundFont Folders"));
-      pld.setPath(sfPath->text());
+      pld.setPath(mySoundfonts->text());
       if(pld.exec())
-            sfPath->setText(pld.path());
+            mySoundfonts->setText(pld.path());
       }
 
 //---------------------------------------------------------

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -27,6 +27,8 @@
 
 namespace Ms {
 
+extern QString mscoreGlobalShare;
+
 enum class SessionStart : char {
       EMPTY, LAST, NEW, SCORE
       };
@@ -164,8 +166,7 @@ struct Preferences {
       QString myImagesPath;
       QString myTemplatesPath;
       QString myPluginsPath;
-
-      QString sfPath;
+      QString mySoundfontsPath;
 
       bool nativeDialogs;
 

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -41,7 +41,6 @@ class PreferenceDialog : public QDialog, private Ui::PrefsDialogBase {
       Preferences prefs;
 
       void apply();
-      bool sfChanged;
       void updateSCListView();
       void setUseMidiOutput(bool);
       void updateValues();

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -588,7 +588,7 @@
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="QLineEdit" name="sfPath">
+           <widget class="QLineEdit" name="mySoundfonts">
             <property name="accessibleName">
              <string>SoundFont folders</string>
             </property>
@@ -3613,7 +3613,7 @@
   <tabstop>myTemplatesButton</tabstop>
   <tabstop>myPlugins</tabstop>
   <tabstop>myPluginsButton</tabstop>
-  <tabstop>sfPath</tabstop>
+  <tabstop>mySoundfonts</tabstop>
   <tabstop>mySoundfontsButton</tabstop>
   <tabstop>myImages</tabstop>
   <tabstop>myImagesButton</tabstop>

--- a/zerberus/zerberusgui.cpp
+++ b/zerberus/zerberusgui.cpp
@@ -135,8 +135,9 @@ QFileInfoList Zerberus::sfzFiles()
       {
       QFileInfoList l;
 
-      QString path = Ms::preferences.sfPath;
-      QStringList pl = path.split(";");
+      QStringList pl = Ms::preferences.mySoundfontsPath.split(";");
+      pl.prepend(QFileInfo(QString("%1%2").arg(Ms::mscoreGlobalShare).arg("sound")).absoluteFilePath());
+
       foreach (const QString& s, pl) {
             QString ss(s);
             if (!s.isEmpty() && s[0] == '~')
@@ -272,5 +273,3 @@ void ZerberusGui::synthesizerChanged()
             files->addItem(item);
             }
       }
-
-


### PR DESCRIPTION
Preferences upgraded to a class, and Preferences::sfPath now is a function that returns concatenation of user-defined soundfont path mySoundfontsPath and the default mscoreGlobalShare/sounds.  This fixes a bug with portable AppImages, which uses a temporary directory for mscoreGlobalShare.