### PR TITLE
Right click menu in note entry mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ vtest/html
 thirdparty/mupdf-qt
 vtest/LOG
 
+/BuildRelease.bat
+/BuildClean.bat
+/BuildInstall.bat

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1317,6 +1317,9 @@ QMenu* MuseScore::genCreateMenu(QWidget* parent)
       lines->addAction(getAction("add-8va"));
       lines->addAction(getAction("add-8vb"));
       lines->addAction(getAction("add-noteline"));
+
+      popup->addAction(getAction("note-input"));
+
       return popup;
       }
 

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -195,6 +195,7 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       void objectPopup(const QPoint&, Element*);
       void measurePopup(const QPoint&, Measure*);
+      void noteEntryPopup(const QPoint&);
 
       void saveChord(Xml&);
 
@@ -450,6 +451,10 @@ class ScoreView : public QWidget, public MuseScoreView {
       void editFretDiagram(FretDiagram*);
       void editBendProperties(Bend*);
       void editTremoloBarProperties(TremoloBar*);
+
+      QToolBar* entryContxtToolbar;
+      QMenu*    entryContxtMenu;
+
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR introduces a right-click menu in note entry mode. This right click context menu provides the note entry toolbar. This makes the useage of the mouse more comfortable and faster, because one can for example change the note duration at the place of the note input an doesn't need to move the mouse up to the toolbar. 

This PR also includes a new menuentry for the right click context menu im note edit mode. This entry enables the switching to note entry mode. Therefore it is now possible to switch between note entry and note edit mode via right click context menues.
