### PR TITLE
fix #99626 Preferences obey nativeDialogs setting in .ini

### DIFF
--- a/mscore/pathlistdialog.cpp
+++ b/mscore/pathlistdialog.cpp
@@ -18,6 +18,7 @@
 //=============================================================================
 
 #include "pathlistdialog.h"
+#include "preferences.h"
 
 namespace Ms {
 
@@ -41,8 +42,12 @@ PathListDialog::PathListDialog(QWidget* parent)
 
 void PathListDialog::addClicked()
       {
-      QString newPath = QFileDialog::getExistingDirectory (this, tr("Choose a directory"),
-         QString("%1/%2").arg(QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation)).arg(QCoreApplication::applicationName()));
+      QString newPath = QFileDialog::getExistingDirectory(
+         this,
+         tr("Choose a directory"),
+         QString("%1/%2").arg(QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation)).arg(QCoreApplication::applicationName()),
+         QFileDialog::ShowDirsOnly | (preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog)
+         );
       if (!newPath.isEmpty()) {
             newPath = QDir(newPath).absolutePath();
             if(files->findItems(newPath, Qt::MatchExactly).size() == 0)

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -1144,7 +1144,9 @@ void PreferenceDialog::selectInstrumentList1()
          this,
          tr("Choose Instrument List"),
          instrumentList1->text(),
-         tr("Instrument List (*.xml)")
+         tr("Instrument List (*.xml)"),
+         0,
+         preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog
          );
       if (!s.isNull())
             instrumentList1->setText(s);
@@ -1160,7 +1162,9 @@ void PreferenceDialog::selectInstrumentList2()
          this,
          tr("Choose Instrument List"),
          instrumentList2->text(),
-         tr("Instrument List (*.xml)")
+         tr("Instrument List (*.xml)"),
+         0,
+         preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog
          );
       if (!s.isNull())
             instrumentList2->setText(s);
@@ -1176,7 +1180,9 @@ void PreferenceDialog::selectStartWith()
          this,
          tr("Choose Starting Score"),
          sessionScore->text(),
-         tr("MuseScore Files (*.mscz *.mscx);;All (*)")
+         tr("MuseScore Files (*.mscz *.mscx);;All (*)"),
+         0,
+         preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog
          );
       if (!s.isNull())
             sessionScore->setText(s);
@@ -1604,7 +1610,8 @@ void PreferenceDialog::selectScoresDirectory()
       QString s = QFileDialog::getExistingDirectory(
          this,
          tr("Choose Score Folder"),
-         myScores->text()
+         myScores->text(),
+         QFileDialog::ShowDirsOnly | (preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog)
          );
       if (!s.isNull())
             myScores->setText(s);
@@ -1619,7 +1626,8 @@ void PreferenceDialog::selectStylesDirectory()
       QString s = QFileDialog::getExistingDirectory(
          this,
          tr("Choose Style Folder"),
-         myStyles->text()
+         myStyles->text(),
+         QFileDialog::ShowDirsOnly | (preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog)
          );
       if (!s.isNull())
             myStyles->setText(s);
@@ -1634,7 +1642,8 @@ void PreferenceDialog::selectTemplatesDirectory()
       QString s = QFileDialog::getExistingDirectory(
          this,
          tr("Choose Template Folder"),
-         myTemplates->text()
+         myTemplates->text(),
+         QFileDialog::ShowDirsOnly | (preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog)
          );
       if (!s.isNull())
             myTemplates->setText(s);
@@ -1649,7 +1658,8 @@ void PreferenceDialog::selectPluginsDirectory()
       QString s = QFileDialog::getExistingDirectory(
          this,
          tr("Choose Plugin Folder"),
-         myPlugins->text()
+         myPlugins->text(),
+         QFileDialog::ShowDirsOnly | (preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog)
          );
       if (!s.isNull())
             myPlugins->setText(s);
@@ -1664,7 +1674,8 @@ void PreferenceDialog::selectImagesDirectory()
       QString s = QFileDialog::getExistingDirectory(
          this,
          tr("Choose Image Folder"),
-         myImages->text()
+         myImages->text(),
+         QFileDialog::ShowDirsOnly | (preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog)
          );
       if (!s.isNull())
             myImages->setText(s);


### PR DESCRIPTION
If on linux, Preferences dialogs for setting folders and files will now obey nativeDialog boolean setting from ini.

Note: this commit doesn't change behavior for Windows and OS X, since Qt says getExistingDirectory() and getOpenFileName() do not obey the QFileDialog::DontUseNativeDialog option.