### PR TITLE
fix #99221: corrupt undo of delete range starting with mmrest

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2156,6 +2156,12 @@ void Score::cmdDeleteSelection()
             Segment* s1 = selection().startSegment();
             Segment* s2 = selection().endSegment();
 
+            // delete content from measures underlying mmrests
+            if (s1 && s1->measure() && s1->measure()->isMMRest())
+                  s1 = s1->measure()->mmRestFirst()->first();
+            if (s2 && s2->measure() && s2->measure()->isMMRest())
+                  s2 = s2->measure()->mmRestLast()->last();
+
             int stick1 = selection().tickStart();
             int stick2 = selection().tickEnd();
 


### PR DESCRIPTION
Lots of analysis in issue report.  In the end, the fix is quite simple and should not have an impact elsewhere.  When deleting a selected range, I simply check the start and end segments to see if they are within an mmrest and move them to the corresponding underlying measures instead.
