### PR TITLE
fix #96986 : allowed disabling of SHIFT+SPACE

### DIFF
--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -80,9 +80,9 @@ bool ScoreView::editKeyLyrics(QKeyEvent* ev)
 
       switch(key) {
             case Qt::Key_Space:
-                  if (!(modifiers & CONTROL_MODIFIER)) {
+                  if (!(modifiers & (CONTROL_MODIFIER | Qt::ShiftModifier))) {
                         // TODO: shift+tab events are filtered by qt
-                        lyricsTab(modifiers & Qt::ShiftModifier, true, false);
+                        lyricsTab(false , true, false);
                         }
                   else
                         return false;


### PR DESCRIPTION
Behaviour after changes,
If,
a) User did not change the shortcut for previous syllable: SHIFT+SPACE takes you to the previous word.
b) User cleared the shortcut for previous syllable but did not introduce a new one : SHIFT+SPACE gives a space in word.
c) User changed the shortcut to some other key combination : SHIFT+SPACE gives a space in word while the new key combination takes you to previous word.
