### PR TITLE
Fix #100636 : [Piano Roll] The score view doesn't paint correctly when selection in the piano roll changes.

### DIFF
--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -351,6 +351,8 @@ void PianorollEditor::selectionChanged()
                         }
                   }
             }
+      for (MuseScoreView* view : score()->getViewer())
+            view->updateAll();
       startTimer(0);    // delayed update
       }
 


### PR DESCRIPTION
https://musescore.org/en/node/100636