### PR TITLE
fix #100656: C key signature not transposed on change instrument

### DIFF
--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -489,7 +489,7 @@ void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickE
             if (st->staffType()->group() == StaffGroup::PERCUSSION)
                   continue;
 
-            bool createKey = tickStart == 0;
+            bool createKey = tickStart <= 0;    // 0 and -1 are both valid values to indicate start of score
             for (Segment* s = firstSegment(Segment::Type::KeySig); s; s = s->next1(Segment::Type::KeySig)) {
                   if (s->tick() < tickStart)
                         continue;


### PR DESCRIPTION
A change I made in #2228 had an unintended side effect.  I added code to transpositionChanged() to optionally only transpose a given range (for use with the instrument change text), but since we support both tick == 0 and tick == -1 to indicate start of score with respect to instrument definitions (the actual instrument defined for the part has a tick of -1, whereas an instrument change on the first chord has a tick of 0), I needed to make transposeKeys() aware of this.

Since #9352 was only merged for master, this issue only affects the master, so this current PR is needed only for master (but would actually be harmless in 2.0.3, FWIW).