### PR TITLE
Fix #100551 : [Piano Roll] Unable to select a note that contains some events when it is sandwiched between normal notes.

### DIFF
--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -331,7 +331,6 @@ void PianorollEditor::updateSelection()
 
 void PianorollEditor::selectionChanged()
       {
-      updateSelection();
       QList<QGraphicsItem*> items = gv->scene()->selectedItems();
       if (items.size() == 1) {
             QGraphicsItem* item = items[0];
@@ -347,23 +346,21 @@ void PianorollEditor::selectionChanged()
             for (QGraphicsItem* item : items) {
                   if (item->type() == PianoItemType) {
                         Note* note = static_cast<PianoItem*>(item)->note();
-                        _score->select(note, SelectType::ADD, 0);
+                        if (!note->selected())
+                              _score->select(note, SelectType::ADD, 0);
                         }
                   }
             }
       for (MuseScoreView* view : score()->getViewer())
             view->updateAll();
-      startTimer(0);    // delayed update
-      }
 
-//---------------------------------------------------------
-//   timerEvent
-//---------------------------------------------------------
+      gv->scene()->blockSignals(true);
+      for (QGraphicsItem* item : gv->scene()->items())
+            if (item->type() == PianoItemType)
+                item->setSelected(static_cast<PianoItem*>(item)->note()->selected());
+      gv->scene()->blockSignals(false);
 
-void PianorollEditor::timerEvent(QTimerEvent* event)
-      {
-      killTimer(event->timerId());
-      gv->updateNotes();
+      gv->scene()->update();
       updateSelection();
       }
 

--- a/mscore/pianoroll.h
+++ b/mscore/pianoroll.h
@@ -76,7 +76,6 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       void tickLenChanged(int);
       void onTimeChanged(int val);
       void playlistChanged();
-      virtual void timerEvent(QTimerEvent*) override;
 
    public slots:
       void changeSelection(SelState);


### PR DESCRIPTION
https://musescore.org/en/node/100551