### PR TITLE
fix #100626: crash on copy that removes slur

### DIFF
--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -505,9 +505,12 @@ void Selection::updateSelectedElements()
             if (sp->type() == Element::Type::VOLTA)
                   continue;
             if (sp->type() == Element::Type::SLUR) {
-                if ((sp->tick() >= stick && sp->tick() < etick) || (sp->tick2() >= stick && sp->tick2() < etick))
-                      if (canSelect(sp->startCR()) && canSelect(sp->endCR()))
-                        appendFiltered(sp); // slur with start or end in range selection
+                  // ignore if start & end elements not calculated yet
+                  if (!sp->startElement() || !sp->endElement())
+                        continue;
+                  if ((sp->tick() >= stick && sp->tick() < etick) || (sp->tick2() >= stick && sp->tick2() < etick))
+                        if (canSelect(sp->startCR()) && canSelect(sp->endCR()))
+                              appendFiltered(sp);     // slur with start or end in range selection
             }
             else if ((sp->tick() >= stick && sp->tick() < etick) && (sp->tick2() >= stick && sp->tick2() <= etick))
                   appendFiltered(sp); // spanner with start and end in range selection


### PR DESCRIPTION
updateSelectedElements() is called within pasteStaff() at a point when slurs attached to the pasdsage haven't been updated yet.  Formerly, this wasn't a problem because the slurs remained attached to the original notes even though they were deleted, which was the cause of https://musescore.org/en/node/93316, but my fix for that issue means that the new start & end elements haven't necessarily been calculated yet (and indeed, the slur may well end up being deleted).

While it's possible we could revisit the call to updateSelectedElements() within pasteStaff() - couldn't we do this at the very end of the pasting process, during or after endCmd()? - the safer fix is just to be sure updateSelectedElements() can handle slurs that have null start or end points.  So that's what I've done here.

BTW, the only actual change is the two lines that skip the slurs with null start or endpoints.  The next few lines I just fixed the indenting.