### PR TITLE
fix #101171 portable copy-lib xcbglintegrations

### DIFF
--- a/build/Linux+BSD/portable/copy-libs
+++ b/build/Linux+BSD/portable/copy-libs
@@ -121,6 +121,7 @@ building_on_CentOS_6() {
   copyLib libQt5QuickWidgets.so.5
   copyLib libQt5Test.so.5
   copyLib libQt5XcbQpa.so.5
+  copyQt plugins/xcbglintegrations/libqxcb-glx-integration.so # Needed by plugins which open a window
 
   # Needed by Ubuntu 12.04:
   dest_dir="$lib_dest"


### PR DESCRIPTION
This fixes a crash with AppImages when trying to run any plugin that opens up a window.  Since copy-libs didn't copy any library for xcbglintegrations, that caused QXcbIntegration to panic "Cannot create platform OpenGL context, neither GLX nor EGL are enabled" and halt execution with a SIGABORT.