### PR TITLE
Fix #99811 Snap tempo slider

### DIFF
--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -94,7 +94,10 @@ void PlayPanel::relTempoChanged(double d, int)
       {
       double relTempo = d * .01;
       emit relTempoChanged(relTempo);
-
+      // Snap tempo slider to 100% when it gets close
+      if (relTempo < 1.01 && relTempo > 0.99) {
+            relTempo = 1.00;
+            }
       setTempo(seq->curTempo() * relTempo);
       setRelTempo(relTempo);
       }


### PR DESCRIPTION
Implements snapping of the tempo slider to 100% as it gets close. 