### PR TITLE
upload even if list of branches is empty

### DIFF
--- a/build/travis/job2_AppImage/build.sh
+++ b/build/travis/job2_AppImage/build.sh
@@ -46,14 +46,14 @@ case "$1" in
 esac
 
 # Should the AppImage be uploaded?
-if [ "$1" == "--upload-branches" ]; then
-  # User passed in list of branchs so only upload those listed
+if [ "$1" == "--upload-branches" ] && [ "$2" != "ALL" ]; then
+  # User passed in a list of zero or more branches so only upload those listed
   shift
   for upload_branch in "$@" ; do
     [ "$branch" == "$upload_branch" ] && upload=true || true # bypass `set -e`
   done
 else
-  # No list passed in so upload on every branch
+  # No list passed in (or specified "ALL"), so upload on every branch
   upload=true
 fi
 


### PR DESCRIPTION
I would like my personal travis to upload all my personal branches to my personal bintray.
If travis environment variable $APPIMAGE_UPLOAD_BRANCHES isn't defined, then "./build/travis/job2_AppImage/build.sh" will have the same default behavior as if did not even use the parameter "--upload-branches".