### PR TITLE
fix #101386: crash on undo of add with inspector not shown

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -69,11 +69,10 @@ void MuseScore::showInspector(bool visible)
             connect(_inspector, SIGNAL(visibilityChanged(bool)), a, SLOT(setChecked(bool)));
             addDockWidget(Qt::RightDockWidgetArea, _inspector);
             }
-      if (visible) {
-            updateInspector();
-            }
       if (_inspector)
             _inspector->setVisible(visible);
+      if (visible)
+            updateInspector();
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1195,7 +1195,7 @@ void MuseScore::selectionChanged(SelState selectionState)
             pianorollEditor->changeSelection(selectionState);
       if (drumrollEditor)
             drumrollEditor->changeSelection(selectionState);
-      if (_inspector && _inspector->isVisible())
+      if (_inspector)
             updateInspector();
       }
 
@@ -1207,7 +1207,7 @@ void MuseScore::updateInspector()
       {
       if (!_inspector)
             return;
-      if (cs) {
+      if (_inspector->isVisible() && cs) {
             if (state() == STATE_EDIT)
                   _inspector->setElement(cv->getEditObject());
             else if (state() == STATE_FOTO)


### PR DESCRIPTION
I believe what is happening is that when the Inspector is not visible, it continues to maintain a notion of the current element, but this is no longer being updated on change of selection due to #2258, which performed an optimization by not updating the Inspector on each change of selection.  After cetain combinations of operations involving add and undo of elements, this leads to a stale reference to the "currently" selected element that in fact no longer exists, and this is what ultimately leads to the crash.

Probably there are lots of ways of solving this, but here's my proposal:

1) Amend the code introduced in #2258 to still call updateInspector() even if not visible, but have updateInspector() clear its record of currently selected element if the Inspector is not visible (just as it does if there is no current score).

2) Because this means the Inspector will now think nothing is selected even when something is, go ahead and update the Inspector upon showing the Inspector.  We were actually doing this already, but in the wrong order - first calling updateInspector, *then* setting it visible.  Which has worked fine thus far, but breaks if we have updateInspector() not do anything when the inspector is not visible.
