### PR TITLE
Allow any dev to auto-upload to personal bintray.

### DIFF
--- a/build/travis/job2_AppImage/bintray.sh
+++ b/build/travis/job2_AppImage/bintray.sh
@@ -41,9 +41,9 @@ if [ $(env | grep TRAVIS_PULL_REQUEST ) ] ; then
 fi
 
 BINTRAY_USER=$BINTRAY_USER # env
+BINTRAY_REPO_OWNER=$BINTRAY_USER # same as BINTRAY_USER, since uploading to repo owned by user
 BINTRAY_API_KEY=$BINTRAY_API_KEY # env
 
-BINTRAY_REPO_OWNER="musescore"
 WEBSITE_URL="http://musescore.org"
 ISSUE_TRACKER_URL="https://musescore.org/project/issues"
 VCS_URL="https://github.com/musescore/MuseScore.git" # Mandatory for packages in free Bintray repos


### PR DESCRIPTION
BINTRAY_REPO_OWNER will be set to same string defined for Travis environment variable BINTRAY_USER.

Previously, if I tried to push to my github, the build would run, but the bintray upload would fail with a message "forbidden" from bintray (since BINTRAY_REPO_OWNER was hardcoded to be "musescore").

Now, when I push this branch to my own github, it correctly uploads the AppImage to my bintray, here's proof: https://bintray.com/artifact/download/ericfont/nightlies-linux/MuseScoreNightly-201603100306-bintray-repo-owner-f3acc50-x86_64.AppImage