### PR TITLE
Allow any dev to auto-upload to personal bintray.

### DIFF
--- a/build/travis/job2_AppImage/bintray.sh
+++ b/build/travis/job2_AppImage/bintray.sh
@@ -43,7 +43,9 @@ fi
 BINTRAY_USER=$BINTRAY_USER # env
 BINTRAY_API_KEY=$BINTRAY_API_KEY # env
 
-BINTRAY_REPO_OWNER="musescore"
+BINTRAY_REPO_OWNER=$BINTRAY_REPO_OWNER #env
+[ "$BINTRAY_REPO_OWNER" ] || BINTRAY_REPO_OWNER="musescore"
+
 WEBSITE_URL="http://musescore.org"
 ISSUE_TRACKER_URL="https://musescore.org/project/issues"
 VCS_URL="https://github.com/musescore/MuseScore.git" # Mandatory for packages in free Bintray repos


### PR DESCRIPTION
if $BINTRAY_REPO_OWNER is set in the environment then use it, otherwise default to using the string "musescore".