### PR TITLE
fix #89866: piano keyboard reflects ottava now

### DIFF
--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -327,7 +327,7 @@ void PianoTools::heartBeat(QList<const Ms::Note *> notes)
       {
       QSet<int> pitches;
       for (const Note* note : notes) {
-          pitches.insert(note->pitch());
+          pitches.insert(note->ppitch());
           }
       _piano->pressKeys(pitches);
       }


### PR DESCRIPTION
The pianotools code has to include the pitch offset as well, hence it has to consider the playback pitch. 