### PR TITLE
Export/Import Settings (#100571)

### DIFF
--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -186,7 +186,11 @@ struct Preferences {
 
       Preferences();
       void write();
+      void write(QString filename);
+      void write(QSettings& s, bool prefsOnly);
       void read();
+      void read(QString filename);
+      void read(QSettings& s);
       void init();
       bool readDefaultStyle();
       };

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -61,6 +61,8 @@ class PreferenceDialog : public QDialog, private Ui::PrefsDialogBase {
       void defineShortcutClicked();
       void portaudioApiActivated(int idx);
       void resetAllValues();
+      void importPrefsClicked();
+      void exportPrefsClicked();
       void styleFileButtonClicked();
       void recordButtonClicked(int);
       void midiRemoteControlClearClicked();

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -51,6 +51,26 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="importPrefs">
+       <property name="accessibleName">
+        <string>Import preferences</string>
+       </property>
+       <property name="text">
+        <string>Import...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="exportPrefs">
+       <property name="accessibleName">
+        <string>Export preferences</string>
+       </property>
+       <property name="text">
+        <string>Export...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
This adds the possibility to import or export preferences from/to a file. It doesn't include shortcuts as I am currently working on feature to import/export them independently.
