### PR TITLE
Fix metronome bug #87266

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1542,6 +1542,7 @@ int Score::renderMetronome(EventMap* events, Measure* m, int playPos, int tickOf
       int numOfClicks = numerator;                          // default to a full measure of 'clicks'
       int lastPause   = clickTicks;                         // the number of ticks to wait after the last 'click'
       int initialPause = 0;
+      int anacrusisClickOffset = 0;
       // if not at the beginning of a measure, add clicks for the initial measure part
       if (msrTick < playPos) {
             numOfClicks = msrTicks / clickTicks;
@@ -1550,6 +1551,7 @@ int Score::renderMetronome(EventMap* events, Measure* m, int playPos, int tickOf
       // or if measure not complete (anacrusis), add clicks for the missing measure part
       else if (msrTicks < clickTicks * numerator) {
             numOfClicks = msrTicks / clickTicks;
+            anacrusisClickOffset = denominator - numOfClicks;
             initialPause = msrTicks - numOfClicks * clickTicks;
             lastPause   = clickTicks;
             }
@@ -1563,10 +1565,11 @@ int Score::renderMetronome(EventMap* events, Measure* m, int playPos, int tickOf
             int missingTicks = (clickTicks * numerator) - msrTicks;
             numOfClicks = (missingTicks / clickTicks) + 1;
             lastPause = missingTicks - ((numOfClicks - 1) * clickTicks);
+            anacrusisClickOffset = 0;
             }
       for (int i = 0; i < numOfClicks; i++) {
             tick = (countIn ? 0 : m->tick()) + initialPause + i * clickTicks + tickOffset;
-            event.setType((i % numerator) == 0 ? ME_TICK1 : ME_TICK2);
+            event.setType(((i + anacrusisClickOffset) % numerator) == 0 ? ME_TICK1 : ME_TICK2);
             events->insert(std::pair<int,NPlayEvent>(tick, event));
             }
       return tick + lastPause;

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1553,11 +1553,7 @@ int Score::renderMetronome(EventMap* events, Measure* m, int playPos, int tickOf
             initialPause = msrTicks - numOfClicks * clickTicks;
             lastPause   = clickTicks;
             }
-/*
-      // MIN_CLICKS: be sure to have at least MIN_CLICKS clicks: if less, add full measures
-      while (numOfClicks < MIN_CLICKS)
-            numOfClicks += numerator;
-*/
+
       // click-clack-clack triplets
       if (triplets)
             numerator = 3;


### PR DESCRIPTION
This is my attempt to fix the issue in #87266.

It seems to work fine with the example provided, with regular measures and with loops started at 
arbitrary points.

Odd time signatures and count-ins seem to work similarly well.

However, I don't completely understand what the original author was trying to do by adding clicks to an incomplete measure, so perhaps it would be best if somebody familiar would review it.

4e2eadf7 is about using a "Tock" only on the first beat, so that an incomplete measure does not start with a "clack" - i.e. in "Happy Birthday To You", as notated here (https://upload.wikimedia.org/score/d/x/dxdw8ddy3oga5r3rj0yo587ct6cxceq/dxdw8ddy.png), the metronome goes "click CLACK click click CLACK click click" instead of "CLACK CLACK click click CLACK click click".

I think the original behaviour ("CLACK CLACK click click") was a bug, but feel free to disregard the extra commit if it was intended behaviour.