### PR TITLE
fix bug #78416

### DIFF
--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -172,7 +172,7 @@ void TempoText::textChanged()
       {
       if (!_followText)
             return;
-      QString s = plainText();
+      QString s = xmlText();
       s.replace(",", ".");
       for (const TempoPattern& pa : tp) {
             QRegExp re(QString(pa.pattern)+"\\s*=\\s*(\\d+[.]{0,1}\\d*)\\s*");
@@ -180,12 +180,12 @@ void TempoText::textChanged()
                   QStringList sl = re.capturedTexts();
                   if (sl.size() == 2) {
                         qreal nt = qreal(sl[1].toDouble()) * pa.f;
-                        if (nt != _tempo) {
+                        //if (nt != _tempo) {
                               setTempo(qreal(sl[1].toDouble()) * pa.f);
                               if(segment())
                                     score()->setTempo(segment(), _tempo);
                               score()->setPlaylistDirty();
-                              }
+                         //     }
                         break;
                         }
                   }


### PR DESCRIPTION
This fixes the bug described here: https://musescore.org/en/node/78416

See this pull request more as a discussion base or a work around - since the real bug seems somewhere in the Text class. It seems for some reason _layout doesn't get updated for the subscores - so _text contains the "good" values but _layout contains an old value. (For example when setting the tempo to 120 as described in the URL above (point 5) _layout still contians 80 but _text has the real value of 120)

The if-query however doesn't make sense at all since it's updating the tempomap which has nothing to do with the value of the TempoText object. Probably it should be split into two if-querys: one for updating the tempomap and one for updating the TempoText object - even though I don't know why you shouldn't just update it, even if the value hasn't changed. (shouldn't hurt that much, should it?)

Feel free to enlighten me about the things written here. Maybe I'm going have a deeper look at internals of the Text Class tomorrow.