### PR TITLE
renaming of *Info* under File menu

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2088,8 +2088,13 @@ Shortcut Shortcut::_sc[] = {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "edit-info",
+<<<<<<< HEAD
          QT_TRANSLATE_NOOP("action","Info..."),
          QT_TRANSLATE_NOOP("action","Edit score info"),
+=======
+         QT_TRANSLATE_NOOP("action","Score Properties..."),
+         QT_TRANSLATE_NOOP("action","Edit score properties"),
+>>>>>>> dd99df5... fix #92166:renamed info to score properties
          0,
          Icons::Invalid_ICON,
          Qt::WindowShortcut,


### PR DESCRIPTION
The pull request is with respect to  https://musescore.org/en/node/92166 . The "info" under File menu has been changed to "Score Properties ". 