### PR TITLE
fix #101916: undetected conflict with standard keys

### DIFF
--- a/mscore/shortcutcapturedialog.cpp
+++ b/mscore/shortcutcapturedialog.cpp
@@ -134,12 +134,23 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
       bool conflict = false;
       QString msgString;
 
-      foreach (Shortcut* ss, localShortcuts) {
+      for (Shortcut* ss : localShortcuts) {
             if (s == ss)
                   continue;
             if (!(s->state() & ss->state()))    // no conflict if states do not overlap
                   continue;
-            foreach(const QKeySequence& ks, ss->keys()) {
+
+            QList<QKeySequence> skeys = QKeySequence::keyBindings(ss->standardKey());
+
+            for (const QKeySequence& ks : skeys) {
+                  if (ks == key) {
+                        msgString = tr("Shortcut conflicts with ") + ss->descr();
+                        conflict = true;
+                        break;
+                        }
+                  }
+
+            for (const QKeySequence& ks : ss->keys()) {
                   if (ks == key) {
                         msgString = tr("Shortcut conflicts with ") + ss->descr();
                         conflict = true;


### PR DESCRIPTION
Fix for https://musescore.org/en/node/101916 . Setting keys like Ctrl+S or Ctrl+O as shortcuts was possible despite the conflict with the standard shortcuts (save, open, ...) . 