### PR TITLE
fix #102071: sym not processed in line properties

### DIFF
--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2893,6 +2893,46 @@ QString Text::convertToHtml(const QString& s, const TextStyle& st)
       }
 
 //---------------------------------------------------------
+//   tagEscape
+//---------------------------------------------------------
+
+QString Text::tagEscape(QString s)
+      {
+      QStringList tags = { "sym", "b", "i", "u", "sub", "sup" };
+      for (QString tag : tags) {
+            QString openTag = "<" + tag + ">";
+            QString openProxy = "!!" + tag + "!!";
+            QString closeTag = "</" + tag + ">";
+            QString closeProxy = "!!/" + tag + "!!";
+            s.replace(openTag, openProxy);
+            s.replace(closeTag, closeProxy);
+            }
+      s = Xml::xmlString(s);
+      for (QString tag : tags) {
+            QString openTag = "<" + tag + ">";
+            QString openProxy = "!!" + tag + "!!";
+            QString closeTag = "</" + tag + ">";
+            QString closeProxy = "!!/" + tag + "!!";
+            s.replace(openProxy, openTag);
+            s.replace(closeProxy, closeTag);
+            }
+      return s;
+      }
+
+//---------------------------------------------------------
+//   unEscape
+//---------------------------------------------------------
+
+QString Text::unEscape(QString s)
+      {
+      s.replace("&lt;", "<");
+      s.replace("&gt;", ">");
+      s.replace("&amp;", "&");
+      s.replace("&quot;", "\"");
+      return s;
+      }
+
+//---------------------------------------------------------
 //   accessibleInfo
 //---------------------------------------------------------
 

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -322,6 +322,8 @@ class Text : public Element {
       virtual void textChanged() {}
       QString convertFromHtml(const QString& ss) const;
       static QString convertToHtml(const QString&, const TextStyle&);
+      static QString tagEscape(QString s);
+      static QString unEscape(QString s);
 
       void undoSetText(const QString& s) { undoChangeProperty(P_ID::TEXT, s); }
       virtual QString accessibleInfo() override;

--- a/mscore/lineproperties.cpp
+++ b/mscore/lineproperties.cpp
@@ -54,9 +54,9 @@ LineProperties::LineProperties(TextLine* l, QWidget* parent)
       otl = l;
       tl  = l->clone();
 
-      beginText->setText(otl->beginText());
-      continueText->setText(otl->continueText());
-      endText->setText(otl->endText());
+      beginText->setText(Text::unEscape(otl->beginText()));
+      continueText->setText(Text::unEscape(otl->continueText()));
+      endText->setText(Text::unEscape(otl->endText()));
 
       setTextPlace(otl->beginTextPlace(),    beginTextPlace);
       setTextPlace(otl->continueTextPlace(), continueTextPlace);
@@ -138,15 +138,15 @@ void LineProperties::accept()
             otl->undoChangeProperty(P_ID::END_TEXT_PLACE, int(pt));
 
       if (beginText->text() != otl->beginText())
-            otl->undoChangeProperty(P_ID::BEGIN_TEXT, Xml::xmlString(beginText->text()));
+            otl->undoChangeProperty(P_ID::BEGIN_TEXT, Text::tagEscape(beginText->text()));
       else if (otl->beginText().isEmpty())
             otl->setBeginText("");
       if (continueText->text() != otl->continueText())
-            otl->undoChangeProperty(P_ID::CONTINUE_TEXT, Xml::xmlString(continueText->text()));
+            otl->undoChangeProperty(P_ID::CONTINUE_TEXT, Text::tagEscape(continueText->text()));
       else if (otl->continueText().isEmpty())
             otl->setContinueText("");
       if (endText->text() != otl->endText())
-            otl->undoChangeProperty(P_ID::END_TEXT, Xml::xmlString(endText->text()));
+            otl->undoChangeProperty(P_ID::END_TEXT, Text::tagEscape(endText->text()));
       else if (otl->endText().isEmpty())
             otl->setEndText("");
 

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -414,14 +414,14 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
       else if (cmd == "v-props") {
             VoltaSegment* vs = static_cast<VoltaSegment*>(e);
             VoltaProperties vp;
-            vp.setText(vs->volta()->text());
+            vp.setText(Text::unEscape(vs->volta()->text()));
             vp.setEndings(vs->volta()->endings());
             int rv = vp.exec();
             if (rv) {
                   QString txt  = vp.getText();
                   QList<int> l = vp.getEndings();
                   if (txt != vs->volta()->text())
-                        vs->volta()->undoChangeProperty(P_ID::BEGIN_TEXT, Xml::xmlString(txt));
+                        vs->volta()->undoChangeProperty(P_ID::BEGIN_TEXT, Text::tagEscape(txt));
                   if (l != vs->volta()->endings())
                         vs->volta()->undoChangeProperty(P_ID::VOLTA_ENDING, QVariant::fromValue(l));
                   }


### PR DESCRIPTION
See issue report for analysis.

I feel like I am probably reinventing the wheel here and that there should already be code like this somewhere, but I couldn't find anything quite right.  So I added functions tagEscape() and unEscape() that we can use to escape <, >, and & characters *except* within a <sym> tag (optionally we can protect other tags), and then to unescape these characters again.

I don't do anything special regarding multibyte or Unicode handling.  I see the xmlString() does, but I don't think I need to do anything special given how I implemented this.  We should test this with Chinese or some such if possible.

Or maybe there is a better way to solve the problem.  I'm not especially attached to the way I did it.