### PR TITLE
fix #71256: Updating Bagpipe Embellishment pitches ...

### DIFF
--- a/libmscore/bagpembell.cpp
+++ b/libmscore/bagpembell.cpp
@@ -304,17 +304,16 @@ BagpipeEmbellishmentInfo BagpipeEmbellishment::BagpipeEmbellishmentList[] = {
       };
 
 // Staff line and pitch for every bagpipe note
-
 BagpipeNoteInfo BagpipeEmbellishment::BagpipeNoteInfoList[] = {
-      { "LG",  6,  67},
-      { "LA",  5,  69},
-      { "B",   4,  71},
-      { "C",   3,  73}, // actually C#
-      { "D",   2,  74},
-      { "E",   1,  76},
-      { "F",   0,  78}, // actually F#
-      { "HG", -1,  79},
-      { "HA", -2,  81}
+      { "LG",  6,  65},
+      { "LA",  5,  67},
+      { "B",   4,  69},
+      { "C",   3,  71}, // actually C#
+      { "D",   2,  72},
+      { "E",   1,  74},
+      { "F",   0,  76}, // actually F#
+      { "HG", -1,  77},
+      { "HA", -2,  79}
 };
 
 //---------------------------------------------------------

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -2281,8 +2281,8 @@
                   <musicXMLid>wind.pipes.bagpipes</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>67-81</aPitchRange>
-                  <pPitchRange>67-81</pPitchRange>
+                  <aPitchRange>65-79</aPitchRange>
+                  <pPitchRange>65-79</pPitchRange>
                   <transposeDiatonic>-1</transposeDiatonic>
                   <transposeChromatic>-2</transposeChromatic>
                   <Channel>


### PR DESCRIPTION
and instrument range for correct displaying

When adding embellishments they are added with Score::setGraceNote() which sets the pitch through note->setTpcFromPitch();

I found that adjusting the pitches of the gracenotes in bagpembell.cpp fixed the display. Also, range was inaccurate (low G was highlighted as too low). Adjusted those in instruments.xml