### PR TITLE
102096 xvfb concurrent tests

### DIFF
--- a/build/travis/job1_Tests/run_tests.sh
+++ b/build/travis/job1_Tests/run_tests.sh
@@ -3,13 +3,13 @@
 
 cd build.debug/mtest
 
-xvfb-run ctest -j2 --output-on-failure
+xvfb-run -a ctest -j2 --output-on-failure
 
 PROC_RET=$?
 
 if [ "$PROC_RET" -ne 0 ]; then
   killall Xvfb
-  xvfb-run ./mtest
+  xvfb-run -a ./mtest
 fi
 
 # Searching for merge conflicts, by searching for the begin/end markers.

--- a/mtest/README.md
+++ b/mtest/README.md
@@ -1,19 +1,17 @@
-Building the tests
+Building & running the tests
 ==================
 
-Adapt for your own platform
-    
-    make debug
-    make debug install
-    cd build.debug/mtest
-    make
-    (make install) on Windows
+To build all tests:
 
-running them all
+| Linux | OSX | Windows |
+| ----- | --- | ------- |
+| make debug<br>sudo make installdebug<br>cd build.debug/mtest<br>make</pre> | make -f Makefile.osx debug<br>make -f Makefile.osx installdebug<br>cd build.debug/mtest<br>make -f Makefile.osx | mingw32-make -f Makefile.mingw debug<br>mingw32-make -f Makefile.mingw installdebug<br>cd build.debug\mtest<br>mingw32-make -f Makefile.mingw |
+
+To run all tests:
 
     ctest
 
-running only one for debug purpose
+To run only one test (for debugging purposes):
 
     cd libmscore/join/
     ./tst_join


### PR DESCRIPTION
add "-a" to xvfb-run to remove an error, which travis says can be fixed with https://github.com/travis-ci/docs-travis-ci-com/commit/0bc92eabe46348c6fc0e06cdbda2d2dbd8f54180

cleaned the mtest/README.md build instructions, but I'm only on linux now, so please verify.