### PR TITLE
Fixed Doxyfiles & README.md, so make doxy builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,43 +81,52 @@ Kept as an example of how to integrate with a complex synthesizer.
     used in MIDI import for beat detection. (http://code.soundsoftware.ac.uk/projects/beatroot-vamp/repository)
 
 
-## Installation
+## Building
 **Read the developer handbook for a [complete build walkthrough](http://musescore.org/en/developers-handbook/compilation) and a list of dependencies.**
 
-* unpack source distribution
+### Getting sources
+If using git to download repo of entire code history, type:
 
-        tar xvofj mscore-x.x.x.tar.bz2
+    git clone https://github.com/musescore/MuseScore.git
+    cd MuseScore
 
-* make
+Else can just download the latest source release tarball from https://github.com/musescore/MuseScore/releases, and then from your download directory type:
 
-        cd mscore-x.x.x
-        make release
+    tar xzf MuseScore-x.x.x.tar.gz
+    cd MuseScore-x.x.x
 
-if something goes wrong, then remove the whole build subdirectory with `make clean` and start new with `make release`
+### Release Build
+To compile MuseScore, type:
 
-* install as root user
+    make release
 
-        sudo make install
+If something goes wrong, then remove the whole build subdirectory with `make clean` and start new with `make release`.
+
+### Running
+To start MuseScore, type:
+
+    ./build.release/mscore/mscore
+
+The Start Center window will appear on every invocation, until you disable that setting via the "Preferences" dialog.
+
+### Installing 
+To install to default prefix using root user, type:
+
+    sudo make install
+
+### Debug Build
+A debug version can be built by doing `make debug` instead of `make release`.
+
+To run the debug version, type:
+
+    ./build.debug/mscore/mscore
+
+### Testing
+See mtest/README.md or https://musescore.org/en/developers-handbook/testing for instructions on how to run the test suite.
 
 ### Program Documentation
-To generate the program documentation with DoxyGen, type
+To generate program documentation using DoxyGen, first do `make debug`, then type:
 
-    cd build
     make doxy
 
-Browse the documentation with your favourite html browser at build/Doc/html/index.html
-
-### Run
-
-    cd build.release/mscore
-    ./mscore
-
-to start MuseScore. On first invocation a demofile is shown. You probably want to change that in the "Preferences" dialog.
-
-### Debug
-A debug version can be built by doing `make debug` above, instead of `make release`.
-
-To test the debug version, type
-
-    cd build.debug/mscore
-    ./mscore
+Browse the documentation in subdirectory Doc/html/index.html using any html browser.

--- a/build/Doxyfile-LibMscore.in
+++ b/build/Doxyfile-LibMscore.in
@@ -812,7 +812,7 @@ HTML_FOOTER            = @CMAKE_CURRENT_SOURCE_DIR@/build/doxygen/footer.html
 # the style sheet file to the HTML output directory, so don't put your own
 # stylesheet in the HTML output directory as well, or it will be erased!
 
-HTML_STYLESHEET        = @CMAKE_CURRENT_SOURCE_DIR@/doxygen/customdoxygen.css
+HTML_STYLESHEET        = @CMAKE_CURRENT_SOURCE_DIR@/build/doxygen/customdoxygen.css
 
 # If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes,
 # files or namespaces will be aligned in HTML using tables. If set to

--- a/build/Doxyfile.in
+++ b/build/Doxyfile.in
@@ -810,7 +810,7 @@ HTML_FOOTER            = @CMAKE_CURRENT_SOURCE_DIR@/build/doxygen/footer.html
 # the style sheet file to the HTML output directory, so don't put your own
 # stylesheet in the HTML output directory as well, or it will be erased!
 
-HTML_STYLESHEET        = @CMAKE_CURRENT_SOURCE_DIR@/doxygen/customdoxygen.css
+HTML_STYLESHEET        = @CMAKE_CURRENT_SOURCE_DIR@/build/doxygen/customdoxygen.css
 
 # If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes,
 # files or namespaces will be aligned in HTML using tables. If set to


### PR DESCRIPTION
Also updated/cleaned-up README.md build instructions.

The old README instructions did not build doxy, because (1) <del>the Makefile that builds doxy is located in root directory (not in build.debug)</del>, and because (2) the Doxyfiles pointed to incorrect location for HTML_STYLESHEET.

EDIT: well (1) was not a problem.  In actuality, doxy will build from both root directory and from build.debug directory.