### PR TITLE
sketch for fix #94911 and fix #99796

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2756,6 +2756,7 @@ void Score::cmdRemoveStaff(int staffIdx)
             undo(new RemoveElement(i));
             }
 
+      int srstaff = s->rstaff();
       undoRemoveStaff(s);
 
       // remove linked staff and measures in linked staves in excerpts
@@ -2765,9 +2766,9 @@ void Score::cmdRemoveStaff(int staffIdx)
                   if (staff == s)
                         continue;
                   Score* lscore = staff->score();
-                  if (lscore != this) {
+                  if ((lscore != this) && (srstaff == staff->rstaff())) {
                         lscore->undoRemoveStaff(staff);
-                        s->score()->undo(new UnlinkStaff(staff, s));
+                        s->score()->undo(new UnlinkStaff(s, staff));
                         if (staff->part()->nstaves() == 0) {
                               int pIndex    = lscore->staffIdx(staff->part());
                               lscore->undoRemovePart(staff->part(), pIndex);

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -844,11 +844,11 @@ void Staff::unlink(Staff* staff)
       if (!_linkedStaves->staves().contains(staff))
             return;
       _linkedStaves->remove(staff);
-      if (_linkedStaves->staves().size() <= 1) {
-            delete _linkedStaves;
-            _linkedStaves = 0;
-            }
-      staff->_linkedStaves = 0;
+      //if (_linkedStaves->staves().size() <= 1) {
+      //      delete _linkedStaves;
+      //      _linkedStaves = 0;
+      //      }
+      //staff->_linkedStaves = 0;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Most probably, a **proof of concept**.

These changes ensures that:
- only the corresponding staff in the excerpt is deleted, while the other linked staves still present in the root score are kept in the excerpt as well.
- the staves in the excerpt being deleted are deleted from the _linkedStaves list.
- the _linkedStaves list is not put to 0 prematurely

I am not sure about the deletion of _linkedStaves and putting it to 0: as it is in this PR I think we could possibly have a memory leak (?); however maybe losing memory of _linkedStaves could possibly create problems in the undo/redo chain of linking.

Hope this helps in further progress with this bug.