### PR TITLE
fix #100521: Do not offset voice 1 rests if voice 3 is accent notation

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2936,6 +2936,7 @@ void Score::cmdSlashRhythm()
                         }
                   else
                         r->setAccent(!r->accent());
+                  r->measure()->checkMultiVoices(r->staffIdx());
                   continue;
                   }
             else if (e->type() == Element::Type::NOTE) {
@@ -2956,6 +2957,7 @@ void Score::cmdSlashRhythm()
                         }
                   else
                         c->setSlash(!c->slash(), false);
+                  c->measure()->checkMultiVoices(c->staffIdx());
                   }
             }
       setLayoutAll(true);

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2847,15 +2847,21 @@ void Measure::checkMultiVoices(int staffIdx)
                         bool v;
                         if (e->type() == Element::Type::CHORD) {
                               v = false;
-                              // consider chord visible if any note is visible
                               Chord* c = static_cast<Chord*>(e);
-                              for (Note* n : c->notes()) {
-                                    if (n->visible()) {
-                                          v = true;
-                                          break;
+                              // voices 3/4 in slash notation don't count as visible
+                              if (!(c->voice() >= 2 && c->slash())) {
+                                    // consider chord visible if any note is visible
+                                    for (Note* n : c->notes()) {
+                                          if (n->visible()) {
+                                                v = true;
+                                                break;
+                                                }
                                           }
                                     }
                               }
+                        else if (e->type() == Element::Type::REST &&
+                                 static_cast<Rest*>(e)->accent())
+                              v = false;
                         else
                               v = e->visible();
                         if (v) {

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -445,6 +445,12 @@ int Rest::computeLineOffset()
       {
       Segment* s = segment();
       bool offsetVoices = s && measure() && measure()->mstaff(staffIdx())->hasVoices;
+
+      // always offset rests in accent notation
+      if (accent()) {
+            offsetVoices = true;
+      }
+
       if (offsetVoices && voice() == 0) {
             // do not offset voice 1 rest if there exists a matching invisible rest in voice 2;
             Element* e = s->element(track() + 1);


### PR DESCRIPTION
This avoids collisions between the rest and the accent slashes/rests.

Signed-off-by: Ben Shelton ben.shelton@gmail.com
