### PR TITLE
fix warning due to unused variable

### DIFF
--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -394,7 +394,7 @@ void ExcerptsDialog::accept()
 
                         deleteExcerpt(e);
                         // remove the excerpt
-                        score->undo(new RemoveExcerpt(e->partScore()));
+                        score->undo(new RemoveExcerpt(partScore));
                         }
                   }
             else


### PR DESCRIPTION
by actually using it.
The warning got introduced with ca474ecd, when a part of that method had been factored out.