### PR TITLE
fix compile tests on ARM compiler warnings

### DIFF
--- a/mscore/capella.cpp
+++ b/mscore/capella.cpp
@@ -1992,7 +1992,7 @@ unsigned Capella::readUnsigned()
 
 int Capella::readInt()
       {
-      char c;
+      signed char c;
       read(&c, 1);
       if (c == -128) {
             short s;

--- a/mscore/capella.h
+++ b/mscore/capella.h
@@ -570,7 +570,7 @@ class ChordObj : public BasicDurationalObj, public NoteObj {
    public:
       enum class StemDir : signed char { DOWN = -1, AUTO = 0, UP = 1, NONE = 3 };
       BeamMode beamMode;
-      char notationStave;
+      signed char notationStave;
       char dStemLength;
       unsigned char nTremoloBars;
       unsigned articulation;

--- a/mscore/importgtp-gp4.cpp
+++ b/mscore/importgtp-gp4.cpp
@@ -60,12 +60,12 @@ namespace Ms {
 bool GuitarPro4::readMixChange(Measure* measure)
       {
       /*char patch   =*/ readChar();
-      char volume  = readChar();
-      char pan     = readChar();
-      char chorus  = readChar();
-      char reverb  = readChar();
-      char phase   = readChar();
-      char tremolo = readChar();
+      signed char volume  = readChar();
+      signed char pan     = readChar();
+      signed char chorus  = readChar();
+      signed char reverb  = readChar();
+      signed char phase   = readChar();
+      signed char tremolo = readChar();
       int tempo    = readInt();
 
       bool tempoEdited = false;

--- a/mscore/importgtp-gp5.cpp
+++ b/mscore/importgtp-gp5.cpp
@@ -323,12 +323,12 @@ bool GuitarPro5::readMixChange(Measure* measure)
       {
       /*char patch   =*/ readChar();
       skip(16);
-      char volume  = readChar();
-      char pan     = readChar();
-      char chorus  = readChar();
-      char reverb  = readChar();
-      char phase   = readChar();
-      char tremolo = readChar();
+      signed char volume  = readChar();
+      signed char pan     = readChar();
+      signed char chorus  = readChar();
+      signed char reverb  = readChar();
+      signed char phase   = readChar();
+      signed char tremolo = readChar();
       readDelphiString();                 // tempo name
 
       int tempo = readInt();

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -687,12 +687,12 @@ Fraction GuitarPro::len2fraction(int len)
 bool GuitarPro::readMixChange(Measure* measure)
       {
       /*char patch   =*/ readChar();
-      char volume  = readChar();
-      char pan     = readChar();
-      char chorus  = readChar();
-      char reverb  = readChar();
-      char phase   = readChar();
-      char tremolo = readChar();
+      signed char volume  = readChar();
+      signed char pan     = readChar();
+      signed char chorus  = readChar();
+      signed char reverb  = readChar();
+      signed char phase   = readChar();
+      signed char tremolo = readChar();
       int tempo    = readInt();
 
       if (volume >= 0)

--- a/mtest/libmscore/midi/tst_midi.cpp
+++ b/mtest/libmscore/midi/tst_midi.cpp
@@ -133,7 +133,7 @@ bool compareElements(Element* e1, Element* e2)
             KeySig* ks1 = static_cast<KeySig*>(e1);
             KeySig* ks2 = static_cast<KeySig*>(e2);
             if (ks1->key() != ks2->key()) {
-                  qDebug("      key signature %d  !=  %d", ks1->key(), ks2->key());
+                  qDebug("      key signature %d  !=  %d", int(ks1->key()), int(ks2->key()));
                   return false;
                   }
             }


### PR DESCRIPTION
fix a couple complains -Wtype-limits in capella & importgtp, due to same unspecified char issue with ARM.  These occur when making tests, which I didn't notice before because this is the first time I've ran the tests on arm.  Note, these are the only chars that compiler complained about, since it know that the later if statements are always taken.  But I suspect that most other chars in importgtp* need to be set to explicitly signed as well...but I haven't had time now to look into that.

Also fixed a compiler complaint -Wformat= in tst_midi in a qDebug statement.