### PR TITLE
feature request 102796: keep selection when dragging score

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -856,7 +856,8 @@ ScoreView::ScoreView(QWidget* parent)
       cl = new QEventTransition(this, QEvent::MouseButtonRelease);
       cl->setTargetState(states[NORMAL]);
       s->addTransition(cl);
-      connect(s, SIGNAL(entered()), SLOT(deselectAll()));
+      connect(s, SIGNAL(entered()), SLOT(startScoreViewDrag()));
+      connect(s, SIGNAL(exited()), SLOT(endScoreViewDrag()));
       s->addTransition(new DragTransition(this));
 
       //----------------------setup play state
@@ -3451,6 +3452,9 @@ void ScoreView::dragScoreView(QMouseEvent* ev)
       if (dx == 0 && dy == 0)
             return;
 
+      // mouse was moved, so don't clear the selection
+      scoreViewDragging = true;
+
       constraintCanvas(&dx, &dy);
 
       _matrix.setMatrix(_matrix.m11(), _matrix.m12(), _matrix.m13(), _matrix.m21(),
@@ -3689,6 +3693,29 @@ void ScoreView::endLasso()
       _score->lassoSelectEnd();
       _score->end();
       mscore->endCmd();
+      }
+
+//---------------------------------------------------------
+//   startScoreViewDrag
+//
+//   reset flag
+//---------------------------------------------------------
+
+void ScoreView::startScoreViewDrag()
+      {
+      scoreViewDragging = false;
+      }
+
+//---------------------------------------------------------
+//   endScoreViewDrag
+//
+//   call deselectAll() if the mouse was not moved
+//---------------------------------------------------------
+
+void ScoreView::endScoreViewDrag()
+      {
+      if (!scoreViewDragging)
+            deselectAll();
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -161,6 +161,8 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       QPointF dragOffset;
 
+      bool scoreViewDragging; // decide if dragging or clearing selection
+
       // editing mode
       QVector<QRectF> grip;         // edit "grips"
       Grip curGrip;
@@ -272,6 +274,8 @@ class ScoreView : public QWidget, public MuseScoreView {
       void startFotoDrag();
       void endFotoDrag();
       void endFotoDragEdit();
+      void startScoreViewDrag();
+      void endScoreViewDrag();
 
       void posChanged(POS pos, unsigned tick);
       void loopToggled(bool);


### PR DESCRIPTION
This feature was discussed in https://musescore.org/en/node/102796

I used a QElapsedTimer to not call deselectAll() if the mouse button has been hold down for more than 450ms or the mouse has been moved (in the latter case, the timer is invalidated).

This could of course be reduced to only use a boolean variable to only react on mouse movement. But the current behaviour looks nice to me.

This PR currently only affects the behaviour in non-playing mode. In playing mode it still deselects all when the mouse is clicked.

Looking forward to hearing comments, even if it should be decided, we don't want this feature.