### PR TITLE
fix #103156 fix #74871: prevent the own group settings from being overwritten.

### DIFF
--- a/mscore/timedialog.cpp
+++ b/mscore/timedialog.cpp
@@ -195,11 +195,12 @@ void TimeDialog::paletteChanged(int idx)
       Groups g = e->groups();
       if (g.empty())
             g = Groups::endings(sig);
-      groups->setSig(sig, g);
+
       zNominal->setValue(sig.numerator());
       nNominal->setCurrentIndex(denominator2Idx(sig.denominator()));
       zText->setText(e->numeratorString());
       nText->setText(e->denominatorString());
+      groups->setSig(sig, g);
       }
 
 }


### PR DESCRIPTION
Quite easy to fix as I found the problem....
If you change the selected time signature, you're making also changes to the numeriator and denumeriator, so your group settings will in this case always be set to the dafault.