### PR TITLE
Stop converting lyrics to SMuFL encodings

### DIFF
--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -681,7 +681,7 @@ static QString decodeEntities( const QString& src )
  Read the next part of a MusicXML formatted string and convert to MuseScore internal encoding.
  */
 
-static QString nextPartOfFormattedString(QXmlStreamReader& e)
+static QString nextPartOfFormattedString(QXmlStreamReader& e, bool convert2Syms = true)
       {
       //QString lang       = e.attribute(QString("xml:lang"), "it");
       QString fontWeight = e.attributes().value("font-weight").toString();
@@ -694,7 +694,11 @@ static QString nextPartOfFormattedString(QXmlStreamReader& e)
       QString txt        = e.readElementText();
       // replace HTML entities
       txt = decodeEntities(txt);
-      QString syms       = text2syms(txt);
+      QString syms;
+      if (convert2Syms)
+        syms             = text2syms(txt);
+      else
+        syms             = txt;
 
       QString importedtext;
 
@@ -5230,7 +5234,8 @@ void MusicXMLParserPass2::lyric(QMap<int, Lyrics*>& numbrdLyrics,
                    formattedText += " ";
                    else
                    */
-                  formattedText += nextPartOfFormattedString(_e);
+                  // Don't convert text to musical symbols
+                  formattedText += nextPartOfFormattedString(_e, false);
                   }
             else if (_e.name() == "extend") {
                   hasExtend = true;
@@ -5251,7 +5256,8 @@ void MusicXMLParserPass2::lyric(QMap<int, Lyrics*>& numbrdLyrics,
                         qDebug("unknown syllabic %s", qPrintable(syll));  // TODO
                   }
             else if (_e.name() == "text")
-                  formattedText += nextPartOfFormattedString(_e);
+                  // Don't convert text to musical symbols
+                  formattedText += nextPartOfFormattedString(_e, false);
             else
                   skipLogCurrElem();
             }


### PR DESCRIPTION
When trying to import a musicxml file : https://www.dropbox.com/s/s4eb57e8ds7vjil/Test.xml?dl=0
that uses a font with symbols declared in the 0xE000 - 0xF000 range : https://www.dropbox.com/s/1xmfem9rpt7fbr4/TestSerif.ttf?dl=0 the import will not work properly because MuseScore will try to convert these to SMuFL symbols, ignoring the actual font of the lyric.
I'm changing the logic so that we'll stop doing this for lyrics and leave it the same for other types of text.
This fixes issue : https://musescore.org/en/node/103221