### PR TITLE
Show Slur or Tie instead of Slur/Tie in inspector.

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -54,6 +54,7 @@
 #include "libmscore/tuplet.h"
 #include "libmscore/bend.h"
 #include "libmscore/tremolobar.h"
+#include "libmscore/slur.h"
 
 namespace Ms {
 
@@ -898,6 +899,35 @@ InspectorSlur::InspectorSlur(QWidget* parent)
       {
       e.setupUi(addWidget());
       s.setupUi(addWidget());
+
+      Inspector* inspector = static_cast<Inspector*>(parent);
+
+      if (inspector != nullptr) {
+            Element* e = inspector->element();
+            bool sameType = true;
+            int subtype = static_cast<int>(Element::Type::INVALID);
+
+            if (e->type() == Element::Type::SLUR_SEGMENT)
+                  subtype = static_cast<int>(static_cast<SlurSegment*>(e)->spanner()->type());
+
+            for (const auto& ee : inspector->el()) {
+                  if (ee->type() != Element::Type::SLUR_SEGMENT) {
+                        sameType = false;
+                        break;
+                        }
+                  if (static_cast<int>(static_cast<SlurSegment*>(ee)->spanner()->type()) != subtype) {
+                        sameType = false;
+                        break;
+                        }
+                  }
+
+            if (!sameType)
+                  s.elementName->setText("Slur/Tie");
+            else if (subtype == static_cast<int>(Element::Type::SLUR))
+                  s.elementName->setText(tr("Slur"));
+            else if (subtype == static_cast<int>(Element::Type::TIE))
+                  s.elementName->setText(tr("Tie"));
+            }
 
       iList = {
             { P_ID::COLOR,           0, 0, e.color,         e.resetColor         },

--- a/mscore/inspector/inspector_slur.ui
+++ b/mscore/inspector/inspector_slur.ui
@@ -41,7 +41,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Slur/Tie</string>
+      <string notr="true">Slur/Tie</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>


### PR DESCRIPTION
This fixes one issue from https://musescore.org/en/node/100996