### PR TITLE
fix #22622: Partial fix, export barlines subtypes

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -4839,6 +4839,62 @@ void ExportMusicXml::writeElement(Element* el, const Measure* m, int sstaff, boo
                   // TODO: print barline only if middle
                   // if (el->subtype() != BarLineType::START_REPEAT)
                   //       bar((BarLine*) el);
+
+                  if(el->parent()==m->last()){
+                      const Measure* mmR1 = m->mmRest1(); // the multi measure rest this measure is covered by
+                      const Measure* mmRLst = mmR1->isMMRest() ? mmR1->mmRestLast() : 0; // last measure of replaced sequence of empty measures
+                      // note: use barlinetype as found in multi measure rest for last measure of replaced sequence
+                      BarLineType bst = m == mmRLst ? mmR1->endBarLineType() : m->endBarLineType();
+                      BarLine* bl =  static_cast<BarLine*>(el);
+                      if(bl->customSubtype())
+                          bst= bl->barLineType();
+                      bool visible = m->endBarLineVisible();
+                      bool needBarStyle = (bst != BarLineType::NORMAL && bst != BarLineType::START_REPEAT) || !visible;
+                      Measure* temp= const_cast<Measure*>(m);
+                      Volta* volta = findVolta(temp, false);
+
+                      if (!needBarStyle && !volta)
+                            break;
+                      xml.stag(QString("barline location=\"right\""));
+                      if (needBarStyle) {
+                            if (!visible) {
+                                  xml.tag("bar-style", QString("none"));
+                                  } else {
+                                  switch (bst) {
+                                        case BarLineType::DOUBLE:
+                                              xml.tag("bar-style", QString("light-light"));
+                                              break;
+                                        case BarLineType::END_REPEAT:
+                                              xml.tag("bar-style", QString("light-heavy"));
+                                              break;
+                                        case BarLineType::BROKEN:
+                                              xml.tag("bar-style", QString("dashed"));
+                                              break;
+                                        case BarLineType::DOTTED:
+                                              xml.tag("bar-style", QString("dotted"));
+                                              break;
+                                        case BarLineType::END:
+                                        case BarLineType::END_START_REPEAT:
+                                              xml.tag("bar-style", QString("light-heavy"));
+                                              break;
+                                        default:
+                                              qDebug("ExportMusicXml::bar(): bar subtype %d not supported", int(bst));
+                                              break;
+                                        }
+                                  }
+                            }
+                      if (volta)
+                            ending(xml, volta, false);
+                      if (bst == BarLineType::END_REPEAT || bst == BarLineType::END_START_REPEAT)
+                            {
+                            if (m->repeatCount() > 2) {
+                                  xml.tagE(QString("repeat direction=\"backward\" times=\"%1\"").arg(m->repeatCount()));
+                                  } else {
+                                  xml.tagE("repeat direction=\"backward\"");
+                                  }
+                            }
+                      xml.etag();
+                  }
                   break;
             case Element::Type::BREATH:
                   // ignore, already exported as note articulation
@@ -5102,6 +5158,7 @@ void ExportMusicXml::write(QIODevice* dev)
                                     spannerStart(this, strack, etrack, st, sstaff, seg);
                                     }
 
+
                               // write element el if necessary
                               writeElement(el, m, sstaff, part->instrument()->useDrumset());
 
@@ -5123,7 +5180,8 @@ void ExportMusicXml::write(QIODevice* dev)
                         repeatAtMeasureStop(xml, m, strack, etrack, strack);
                   // note: don't use "m->repeatFlags() & Repeat::END" here, because more
                   // barline types need to be handled besides repeat end ("light-heavy")
-                  barlineRight(m);
+                  //barlineRight(m);
+
                   xml.etag();
                   }
             staffCount += staves;
@@ -5391,4 +5449,5 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
       }
 
 }
+
 


### PR DESCRIPTION
This fixes it partially. It exports the barline styles correclty- i.e, double, dotted, dashed etc but doesn't handle staffs spanned. 