### PR TITLE
fix #104006: Make 'Instrument Change' available from ADD/Text main menu

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1301,6 +1301,7 @@ QMenu* MuseScore::genCreateMenu(QWidget* parent)
       text->addAction(getAction("staff-text"));
       text->addAction(getAction("chord-text"));
       text->addAction(getAction("rehearsalmark-text"));
+      text->addAction(getAction("instrument-change-text"));
       text->addSeparator();
       text->addAction(getAction("lyrics"));
       text->addAction(getAction("figured-bass"));

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -49,6 +49,7 @@
 #include "libmscore/harmony.h"
 #include "libmscore/icon.h"
 #include "libmscore/image.h"
+#include "libmscore/instrchange.h"
 #include "libmscore/keysig.h"
 #include "libmscore/lasso.h"
 #include "libmscore/lyrics.h"
@@ -2704,6 +2705,8 @@ void ScoreView::cmd(const QAction* a)
             cmdAddText(TEXT::STAFF);
       else if (cmd == "rehearsalmark-text")
             cmdAddText(TEXT::REHEARSAL_MARK);
+      else if (cmd == "instrument-change-text")
+            cmdAddText(TEXT::INSTRUMENT_CHANGE);
 
       else if (cmd == "edit-element") {
             Element* e = _score->selection().element();
@@ -5318,6 +5321,17 @@ void ScoreView::cmdAddText(TEXT type)
                         s->setTrack(cr->track());
                         s->setTextStyleType(TextStyleType::STAFF);
                         }
+                  s->setParent(cr->segment());
+                  }
+                  break;
+            case TEXT::INSTRUMENT_CHANGE:
+                  {
+                  ChordRest* cr = _score->getSelectedChordRest();
+                  if (!cr)
+                        break;
+                  s = new InstrumentChange(_score);
+                  s->setTrack(cr->track());
+                  s->setTextStyleType(TextStyleType::INSTRUMENT_CHANGE);
                   s->setParent(cr->segment());
                   }
                   break;

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -66,7 +66,8 @@ enum class TEXT : char {
       PART,
       SYSTEM,
       STAFF,
-      REHEARSAL_MARK
+      REHEARSAL_MARK,
+      INSTRUMENT_CHANGE
       };
 
 //---------------------------------------------------------

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1829,6 +1829,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "instrument-change-text",
+         QT_TRANSLATE_NOOP("action","Instrument Change"),
+         QT_TRANSLATE_NOOP("action","Add instrument change")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "picture",
          QT_TRANSLATE_NOOP("action","Picture"),
          QT_TRANSLATE_NOOP("action","Add picture")


### PR DESCRIPTION
I guess this isn't for 2.0.3, as it adds strings to the translations