### PR TITLE
fix #10421: hack to recover crescendo lines after save with pre 2.0.3

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -418,6 +418,13 @@ void Hairpin::read(XmlReader& e)
             if (!_continueText)
                   setContinueText(cresc ? "(cresc.)" : "(dim.)");
             }
+
+      // see issue #10412
+      if (lineStyle() == Qt::CustomDashLine) {
+            QString sv = score()->mscoreVersion();
+            if (sv == "2.0.2" || sv == "2.0.1" || sv == "2.0.0")
+                  _useTextLine = true;
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
best to be applied to 2.0.3 only, hence submitted agains that.