### PR TITLE
fix #97821: PageSettings remember window resize

### DIFF
--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -30,6 +30,9 @@
 
 namespace Ms {
 
+static const int DEFAULT_POS_X  = 300;
+static const int DEFAULT_POS_Y  = 100;
+
 //---------------------------------------------------------
 //   PageSettings
 //---------------------------------------------------------
@@ -46,6 +49,10 @@ PageSettings::PageSettings(QWidget* parent)
       preview->setPreviewOnly(true);
 
       static_cast<QVBoxLayout*>(previewGroup->layout())->insertWidget(0, sa);
+
+      QSettings settings;
+      restoreGeometry(settings.value("pageSettings/geometry").toByteArray());
+      move(settings.value("pageSettings/pos", QPoint(DEFAULT_POS_X, DEFAULT_POS_Y)).toPoint());
 
       mmUnit = true;      // should be made a global configuration item
 
@@ -81,7 +88,44 @@ PageSettings::PageSettings(QWidget* parent)
 
 PageSettings::~PageSettings()
       {
+      QSettings settings;
+
+
+            settings.setValue("pageSettings/pos", pos());
+            settings.setValue("pageSettings/geometry", saveGeometry());
+
       }
+
+//---------------------------------------------------------
+//   closeEvent
+//
+//    Called when the PageSettings is closed with its own button
+//    but not when it is hidden with the main menu command
+//---------------------------------------------------------
+
+void PageSettings::closeEvent(QCloseEvent* ev)
+      {
+      emit closed(false);
+      QWidget::closeEvent(ev);
+      }
+
+//---------------------------------------------------------
+//   hideEvent
+//
+//    Called both when the PageSettings is closed with its own button and
+//    when it is hidden via the main menu command
+//
+//    Stores widget geometry and position into settings.
+//---------------------------------------------------------
+
+void PageSettings::hideEvent(QHideEvent* ev)
+      {
+      QSettings settings;
+      settings.setValue("pageSettings/pos", pos());
+      settings.setValue("pageSettings/geometry", saveGeometry());
+      QWidget::hideEvent(ev);
+      }
+
 
 //---------------------------------------------------------
 //   setScore

--- a/mscore/pagesettings.h
+++ b/mscore/pagesettings.h
@@ -38,6 +38,8 @@ class PageSettings : public QDialog, private Ui::PageSettingsBase {
       Navigator* preview;
       bool mmUnit;
       Score* cs;
+      virtual void closeEvent(QCloseEvent*);
+      virtual void hideEvent (QHideEvent* event);
       void updateValues();
       void updatePreview(int);
       void blockSignals(bool);
@@ -67,6 +69,9 @@ class PageSettings : public QDialog, private Ui::PageSettingsBase {
       void pageHeightChanged(double);
       void pageWidthChanged(double);
       void pageOffsetChanged(int val);
+
+   signals:
+      void closed(bool);
 
    public:
       PageSettings(QWidget* parent = 0);


### PR DESCRIPTION
PageSettings will remember the last user resize even after closing