### PR TITLE
fix #102716: text isn't correctly updated when loading style

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1467,7 +1467,7 @@ void Harmony::localSpatiumChanged(qreal oldValue, qreal newValue)
 
 void Harmony::textStyleChanged()
       {
-      Text::textStyleChanged();
+      Text::styleChanged();
       render();
       }
 

--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -175,7 +175,7 @@ class Harmony : public Text {
       const ChordDescription* fromXml(const QString& s);
       virtual void spatiumChanged(qreal oldValue, qreal newValue) override;
       virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
-      virtual void textStyleChanged() override;
+      virtual void textStyleChanged();
       void setHarmony(const QString& s);
       virtual QPainterPath shape() const override;
       void calculateBoundingRect();

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2329,10 +2329,10 @@ bool Text::readProperties(XmlReader& e)
       }
 
 //---------------------------------------------------------
-//   textStyleChanged
+//   styleChanged
 //---------------------------------------------------------
 
-void Text::textStyleChanged()
+void Text::styleChanged()
       {
       setTextStyle(score()->textStyle(_styleIndex));
       score()->setLayoutAll(true);

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -304,7 +304,7 @@ class Text : public Element {
       bool readProperties(XmlReader&);
 
       void spellCheckUnderline(bool) {}
-      virtual void textStyleChanged();
+      virtual void styleChanged() override;
 
       virtual void paste();
 

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2634,7 +2634,7 @@ static void updateTextStyle(void* a, Element* e)
             Text* text = static_cast<Text*>(e);
             if (text->textStyle().name() == s) {
                   text->setTextStyle(text->score()->textStyle(s));
-                  text->textStyleChanged();
+                  text->styleChanged();
                   }
             }
       }


### PR DESCRIPTION
This solved the issue for me. Apparently, the problem was that ChangeStyle::flip() called elements' styleChanged method (more specifically in this function: https://github.com/musescore/MuseScore/blob/master/libmscore/undo.cpp#L2693), but there was no such override for text elements. Please let me know if there is anything wrong. 