### PR TITLE
fix #10728:Add ability to rename part title

### DIFF
--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -257,7 +257,7 @@ void ExcerptsDialog::excerptChanged(QListWidgetItem* cur, QListWidgetItem*)
             b = false;
             }
       partList->setEnabled(b);
-      title->setEnabled(b);
+      title->setEnabled(true);
 
       bool flag = excerptList->currentItem() != 0;
       int n = excerptList->count();


### PR DESCRIPTION
The part title is no longer grayed out and we are able to rename it .