### PR TITLE
Makefile: Use POSIX way of finding CPU count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #=============================================================================
 
 REVISION  = `cat mscore/revision.h`
-CPUS      = $(shell grep -c processor /proc/cpuinfo)
+CPUS      = $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 1)
 # Avoid build errors when processor=0 (as in m68k)
 ifeq ($(CPUS), 0)
   CPUS=1


### PR DESCRIPTION
This should work on most Unices, and even on Haiku.

Linux uses _NPROCESSORS_ONLN but some others use NPROCESSORS_ONLN,
so we fallback.

(the check for CPUS = 0 can probably be dropped but I don't have an m68k machine running GNU/Linux around to test 😏)