### PR TITLE
fix #75816 Implement space management for formatted text

### DIFF
--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -1522,7 +1522,7 @@ void Text::startEdit(MuseScoreView*, const QPointF& pt)
       setEditMode(true);
       if (_cursor == nullptr)
             _cursor = new TextCursor();
-            _cursor->setText(this);
+      _cursor->setText(this);
       _cursor->setLine(0);
       _cursor->setColumn(0);
       _cursor->clearSelection();

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -279,7 +279,6 @@ class Text : public Element {
       bool edit(MuseScoreView*, Grip, int key, Qt::KeyboardModifiers, const QString&);
 
       void setFormat(FormatId, QVariant);
-      QString getBaby()                      { return _text; }
       bool deletePreviousChar();
       bool deleteChar();
       void deleteSelectedText();

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -273,11 +273,13 @@ class Text : public Element {
       void setLayoutToParentWidth(bool v) { _layoutToParentWidth = v;   }
 
       void startEdit(MuseScoreView*, const QPointF&);
+      QString manageSpacing(QString t);
+
       void endEdit();
       bool edit(MuseScoreView*, Grip, int key, Qt::KeyboardModifiers, const QString&);
 
       void setFormat(FormatId, QVariant);
-
+      QString getBaby()                      { return _text; }
       bool deletePreviousChar();
       bool deleteChar();
       void deleteSelectedText();


### PR DESCRIPTION
The code added in this branch implements the handling of spaces in formatted text, and fixes the bug reported here : https://musescore.org/en/node/75816

