### PR TITLE
update CentOS recipe to use CMAKE 3.5 and Qt5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
       services:
         - docker
       script:
-        - "[[ $APPIMAGE_BUILD_ARCHS == *x86_64* ]] && ./build/travis/job2_AppImage/build.sh --x86_64 --upload-branches $APPIMAGE_UPLOAD_BRANCHES || true"
+        - "if [[ $APPIMAGE_BUILD_ARCHS == *x86_64* ]]; then ./build/travis/job2_AppImage/build.sh --x86_64 --upload-branches $APPIMAGE_UPLOAD_BRANCHES; fi"
 
     # 3rd parallel build job - portable Linux AppImage 32-bit x86 build on CentOS
     - env: "JOB=AppImage_i686"
@@ -79,7 +79,7 @@ matrix:
       services:
         - docker
       script:
-        - "[[ $APPIMAGE_BUILD_ARCHS == *i686* ]] && ./build/travis/job2_AppImage/build.sh --i686 --upload-branches $APPIMAGE_UPLOAD_BRANCHES || true"
+        - "if [[ $APPIMAGE_BUILD_ARCHS == *i686* ]]; then ./build/travis/job2_AppImage/build.sh --i686 --upload-branches $APPIMAGE_UPLOAD_BRANCHES; fi"
 
     # 4th parallel build job - portable Linux AppImage armhf build on Debian crosscompiler
     - env: "JOB=AppImage_armhf"
@@ -94,7 +94,7 @@ matrix:
       before_script:
         - "sudo ./build/travis/job2_AppImage/set-binfmt-misc.sh"
       script:
-        - "[[ $APPIMAGE_BUILD_ARCHS == *armhf* ]] && ./build/travis/job2_AppImage/build.sh --armhf --upload-branches $APPIMAGE_UPLOAD_BRANCHES || true"
+        - "if [[ $APPIMAGE_BUILD_ARCHS == *armhf* ]]; then ./build/travis/job2_AppImage/build.sh --armhf --upload-branches $APPIMAGE_UPLOAD_BRANCHES; fi"
 
 notifications:
   recipients:

--- a/build/Linux+BSD/portable/Recipe
+++ b/build/Linux+BSD/portable/Recipe
@@ -55,7 +55,7 @@ cd "$(dirname "$(readlink -f "${0}")")/../../../.."
 yum -y install epel-release
 
 # basic dependencies (needed by Docker image)
-yum -y install git wget which automake
+yum -y install git wget which automake unzip
 
 if [ "${OS}" == "CentOS 6" ]; then
   # Get newer compiler than available by default
@@ -74,9 +74,23 @@ cd AppImageKit
 cd ..
 
 # MuseScore's dependencies:
+
+# get CMAKE 3.5 (Centos 6 only has CMAKE 2.8.12.2)
+CMAKE_URL="http://www.cmake.org/files/v3.5/cmake-3.5.1-Linux-x86_64.tar.gz"
+mkdir cmake && wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
+export PATH=${PWD}/cmake/bin:${PATH}
+
+# get Qt5.6 (Centos 6 doesn't have QtWebEngine)
+mkdir qt5 && wget -q -O qt5.zip http://utils.musescore.org.s3.amazonaws.com/qt560.zip
+unzip -qq qt5.zip -d qt5
+export PATH="${PWD}/qt5/bin:$PATH"
+export QT_PLUGIN_PATH="${PWD}/qt5/plugins"
+export QML2_IMPORT_PATH="${PWD}/qt5/qml"
+export LD_LIBRARY_PATH="/qt5/lib:${LD_LIBRARY_PATH}"
+
 #yum -y install epel-release
 #wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
-yum -y install cmake mesa-libGL-devel pulseaudio-libs-devel alsa-lib-devel jack-audio-connection-kit-devel portaudio-devel libsndfile-devel libvorbis-devel qt5-qtbase-devel qt5-qttools-libs-designercomponents qt5-qttools-devel qt5-qtdeclarative-devel qt5-qtscript-devel qt5-qtwebkit-devel qt5-qtxmlpatterns-devel qt5-qtquick1-devel qt5-qtsvg-devel qt5-qttools-devel qt5-qttools-static qt5-qtmultimedia-devel qt5-qtwebchannel-devel qt5-qtimageformats qt5-qtquickcontrols
+yum -y install mesa-libGL-devel pulseaudio-libs-devel alsa-lib-devel jack-audio-connection-kit-devel portaudio-devel libsndfile-devel libvorbis-devel fontconfig libxslt libXcomposite libXcursor libXrender zlib-devel cups-libs mesa-libEGL
 
 # Install LAME (get this dependency last because rpmforge and epel-release conflict)
 wget http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el6.rf.$(arch).rpm

--- a/build/Linux+BSD/portable/copy-libs
+++ b/build/Linux+BSD/portable/copy-libs
@@ -79,8 +79,9 @@ getCrossPlatformDependencies() {
   copyLib libQt5Sql.so.5
   copyLib libQt5Svg.so.5
   #copyLib libQt5WebChannel.so.5  # Not present on Debian, and apparently not needed
-  copyLib libQt5WebKit.so.5
-  copyLib libQt5WebKitWidgets.so.5
+  copyLib libQt5WebEngine.so.5
+  copyLib libQt5WebEngineCore.so.5
+  copyLib libQt5WebEngineWidgets.so.5
   copyLib libQt5Widgets.so.5
   copyLib libQt5XmlPatterns.so.5
   copyLib libQt5Xml.so.5
@@ -103,7 +104,7 @@ getCrossPlatformDependencies() {
   # except some as listed in "mscore/CMakeLists.txt".
   export -f copy copyQt # make functions available to xargs
   find "$qt_prefix/qml" \! -type d \
-    | grep -vE "QtGraphicalEffects|QtMultimedia|QtSensors|QtTest|QtWebKit" \
+    | grep -vE "QtGraphicalEffects|QtMultimedia|QtSensors|QtTest|QtWebEngine" \
     | sed "s|$qt_prefix/||" | xargs -n1 -I '%%%' \
         bash -c "qt_prefix='$qt_prefix' qt_dest='$qt_dest' copyQt %%%"
 }
@@ -259,9 +260,9 @@ building_on_CentOS_6() {
   copyLib libjpeg.so.62
   copyLib libssl.so.10
   copyLib libtiff.so.3
-  copyLib libicudata.so.42 # moved from cross-platform
-  copyLib libicui18n.so.42 # moved from cross-platform
-  copyLib libicuuc.so.42 # moved from cross-platform
+  copyLib libicudata.so.56 # moved from cross-platform
+  copyLib libicui18n.so.56 # moved from cross-platform
+  copyLib libicuuc.so.56 # moved from cross-platform
 
   # Needed by Fedora 22:
   copyLib libmng.so.1
@@ -274,6 +275,11 @@ building_on_CentOS_6() {
   #copyLib libpulse.so.0
   #copyLib libpulsecommon-8.0.so
   #copyLib libasound_module_pcm_pulse.so  # found in /usr/lib64/alsa-lib/
+
+  # after upgrade to Qt 5.6, check-depends in CentOS 6 said following were provided by neither
+  copyLib libEGL.so.1
+  copyLib libcups.so.2
+  
 }
 
 locateLib() {


### PR DESCRIPTION
@shoogle, I think we need to update the CentOS AppImage Recipe to use CMAKE 3.5 and Qt 5.6 (need to use QWebEngine instead of QWebKit).  I got CMAKE working here by using the same binaries that are used in test job.  But then I found that QWebEngine is not available in the CentOS 6 repos (and even in https://dl.fedoraproject.org/pub/epel/6/x86_64/repoview/letter_q.group.html I don't see any QWebEngine, just QWebKit).  So I tried just copying the same binaries for qt5.6 that are used in the test job, and pointed LD_LIBRARY_PATH there.  I don't know if that is appropriate.  But that just gives me a bunch of errors about not being able to find qt components (https://travis-ci.org/ericfont/MuseScore/jobs/123194377#L2534-L2641).  So I'm not sure what needs to be done now to get qt5.6 w/ QWebEngine working with the AppImage build.