### PR TITLE
fix #105666: add support for Croatian instruments (Tambura)

### DIFF
--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -294,8 +294,8 @@ void GuitarPro::initGuitarProDrumset()
       gpDrumset->drum(70) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Maracas"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
       gpDrumset->drum(71) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Short Whistle"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
       gpDrumset->drum(72) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Long Whistle"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
-      gpDrumset->drum(73) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Short Guiro"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
-      gpDrumset->drum(74) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Long Guiro"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
+      gpDrumset->drum(73) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", u8"Short Güiro"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
+      gpDrumset->drum(74) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", u8"Long Güiro"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
       gpDrumset->drum(75) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Claves"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
       gpDrumset->drum(76) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Hi Wood Block"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);
       gpDrumset->drum(77) = DrumInstrument(QT_TRANSLATE_NOOP("drumset", "Low Wood Block"), NoteHead::Group::HEAD_NORMAL, 3, Direction::UP);

--- a/mscore/webpage.h
+++ b/mscore/webpage.h
@@ -80,7 +80,7 @@ class MyWebPage: public QWebPage
 
 class MyWebView: public QWebView
       {
-      //Q_OBJECT
+      Q_OBJECT
 
       MyWebPage m_page;
       QProgressBar* progressBar;

--- a/mtest/guitarpro/all-percussion.gp5-ref.mscx
+++ b/mtest/guitarpro/all-percussion.gp5-ref.mscx
@@ -388,14 +388,14 @@
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Short Guiro</name>
+          <name>Short Güiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="74">
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Long Guiro</name>
+          <name>Long Güiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="75">
@@ -1674,14 +1674,14 @@
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Short Guiro</name>
+            <name>Short Güiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="74">
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Long Guiro</name>
+            <name>Long Güiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="75">

--- a/mtest/libmscore/midimapping/test14-ref.mscx
+++ b/mtest/libmscore/midimapping/test14-ref.mscx
@@ -500,14 +500,14 @@
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Short Guiro</name>
+          <name>Short Güiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="74">
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Long Guiro</name>
+          <name>Long Güiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="75">
@@ -1705,14 +1705,14 @@
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Short Guiro</name>
+            <name>Short Güiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="74">
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Long Guiro</name>
+            <name>Long Güiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="75">

--- a/mtest/libmscore/midimapping/test15-ref.mscx
+++ b/mtest/libmscore/midimapping/test15-ref.mscx
@@ -492,14 +492,14 @@
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Short Guiro</name>
+          <name>Short Güiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="74">
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Long Guiro</name>
+          <name>Long Güiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="75">
@@ -1864,14 +1864,14 @@
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Short Guiro</name>
+            <name>Short Güiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="74">
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Long Guiro</name>
+            <name>Long Güiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="75">

--- a/mtest/libmscore/midimapping/test16-ref.mscx
+++ b/mtest/libmscore/midimapping/test16-ref.mscx
@@ -492,14 +492,14 @@
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Short Guiro</name>
+          <name>Short Güiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="74">
           <head>0</head>
           <line>3</line>
           <voice>0</voice>
-          <name>Long Guiro</name>
+          <name>Long Güiro</name>
           <stem>1</stem>
           </Drum>
         <Drum pitch="75">
@@ -1739,14 +1739,14 @@
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Short Guiro</name>
+            <name>Short Güiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="74">
             <head>0</head>
             <line>3</line>
             <voice>0</voice>
-            <name>Long Guiro</name>
+            <name>Long Güiro</name>
             <stem>1</stem>
             </Drum>
           <Drum pitch="75">

--- a/share/instruments/generateTs.py
+++ b/share/instruments/generateTs.py
@@ -5,8 +5,9 @@ import xml.etree.ElementTree as ET
 
 def addMessage(f, text, comment=''):
     if (comment):
-        f.write("//: " + comment.encode('utf8') + "\n")
-    f.write('QT_TRANSLATE_NOOP("InstrumentsXML", "' + text.encode('utf8') + '"),\n')
+        f.write('QT_TRANSLATE_NOOP3("InstrumentsXML", u8"' + text.encode('utf8') + '", u8"' + comment.encode('utf8') + '"),\n')
+    else:
+        f.write('QT_TRANSLATE_NOOP("InstrumentsXML", u8"' + text.encode('utf8') + '"),\n')
     
 
 

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -9318,6 +9318,119 @@
 <!--                  <clef>TAB</clef> -->
                   <genre>common</genre>
             </Instrument>
+            <Instrument id="prima">
+                  <longName>Prima</longName>
+                  <shortName>Pr.</shortName>
+                  <description>Prima</description>
+                  <musicXMLid>pluck.tambura.prima</musicXMLid>
+                  <StringData>
+                        <frets>15</frets>
+                        <string>52</string>
+                        <string>57</string>
+                        <string>62</string>
+                        <string>67</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>64-91</aPitchRange>
+                  <pPitchRange>64-91</pPitchRange>
+                  <transposeDiatonic>7</transposeDiatonic>
+                  <transposeChromatic>12</transposeChromatic>
+                  <Channel>
+                        <program value="24"/>
+                  </Channel>
+                  <genre>ethnic</genre>
+            </Instrument>
+            <Instrument id="brac">
+                  <longName>Brač</longName>
+                  <shortName>Br.</shortName>
+                  <description>Brač</description>
+                  <musicXMLid>pluck.tambura.brac</musicXMLid>
+                  <StringData>
+                        <frets>15</frets>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>52-79</aPitchRange>
+                  <pPitchRange>52-79</pPitchRange>
+                  <Channel>
+                        <program value="24"/>
+                  </Channel>
+                  <genre>ethnic</genre>
+            </Instrument>
+            <Instrument id="celo">
+                  <longName>Čelo</longName>
+                  <shortName>Č.</shortName>
+                  <description>Čelo</description>
+                  <musicXMLid>pluck.tambura.celo</musicXMLid>
+                  <StringData>
+                        <frets>15</frets>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>3-60</aPitchRange>
+                  <pPitchRange>3-60</pPitchRange>
+                  <transposeDiatonic>-14</transposeDiatonic>
+                  <transposeChromatic>-24</transposeChromatic>
+                  <Channel>
+                        <program value="24"/>
+                  </Channel>
+                  <genre>ethnic</genre>
+            </Instrument>
+            <Instrument id="bugarija">
+                  <longName>Bugarija</longName>
+                  <shortName>Bu.</shortName>
+                  <description>Bugarija</description>
+                  <musicXMLid>pluck.tambura.bugarija</musicXMLid>
+                  <StringData>
+                        <frets>15</frets>
+                        <string>38</string>
+                        <string>42</string>
+                        <string>45</string>
+                        <string>50</string>
+                  </StringData>
+                  <clef>G</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>43-66</aPitchRange>
+                  <pPitchRange>43-66</pPitchRange>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  <Channel>
+                        <program value="24"/>
+                  </Channel>
+                  <genre>ethnic</genre>
+            </Instrument>
+            <Instrument id="berda">
+                  <longName>Berda</longName>
+                  <shortName>Be.</shortName>
+                  <description>Berda</description>
+                  <musicXMLid>pluck.tambura.berda</musicXMLid>
+                  <StringData>
+                        <frets>15</frets>
+                        <string>28</string>
+                        <string>33</string>
+                        <string>38</string>
+                        <string>43</string>
+                  </StringData>
+                  <clef>F</clef>
+                  <barlineSpan>1</barlineSpan>
+                  <aPitchRange>28-66</aPitchRange>
+                  <pPitchRange>28-66</pPitchRange>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
+                  <Channel>
+                        <program value="32"/>
+                  </Channel>
+                  <genre>ethnic</genre>
+            </Instrument>
       </InstrumentGroup>
       <InstrumentGroup id="strings">
             <name>Strings</name>

--- a/share/instruments/instrumentsxml.h
+++ b/share/instruments/instrumentsxml.h
@@ -548,7 +548,7 @@ QT_TRANSLATE_NOOP("InstrumentsXML", "B She."),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Brass"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Brass"),
 //: Brass
-QT_TRANSLATE_NOOP("InstrumentsXML", "Br."),
+QT_TRANSLATE_NOOP3("InstrumentsXML", "Br.", "Brass"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Horn in F"),
 //: Horn in F
 QT_TRANSLATE_NOOP("InstrumentsXML", "F Hn."),
@@ -717,7 +717,7 @@ QT_TRANSLATE_NOOP("InstrumentsXML", "Rag Dung"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Rg. Dng."),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Bugle"),
 //: Bugle
-QT_TRANSLATE_NOOP("InstrumentsXML", "Bu."),
+QT_TRANSLATE_NOOP3("InstrumentsXML", "Bu.", "Bugle"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Soprano Bugle"),
 //: Soprano Bugle
 QT_TRANSLATE_NOOP("InstrumentsXML", "Sop. Bu."),
@@ -1056,7 +1056,7 @@ QT_TRANSLATE_NOOP("InstrumentsXML", "Tam-tam"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Tam-tam"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Bells"),
 //: Bells
-QT_TRANSLATE_NOOP("InstrumentsXML", "Be."),
+QT_TRANSLATE_NOOP3("InstrumentsXML", "Be.", "Bells"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Sleigh Bells"),
 //: Sleigh Bells
 QT_TRANSLATE_NOOP("InstrumentsXML", "Sle. Be."),
@@ -1117,8 +1117,8 @@ QT_TRANSLATE_NOOP("InstrumentsXML", "Clv."),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Castanets"),
 //: Castanets
 QT_TRANSLATE_NOOP("InstrumentsXML", "Cst."),
-QT_TRANSLATE_NOOP("InstrumentsXML", "Guiro"),
-//: Guiro
+QT_TRANSLATE_NOOP("InstrumentsXML", "Güiro"),
+//: Güiro
 QT_TRANSLATE_NOOP("InstrumentsXML", "Gro."),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Maracas"),
 //: Maracas
@@ -1563,6 +1563,21 @@ QT_TRANSLATE_NOOP("InstrumentsXML", "5-str. Electric Bass"),
 //: 5-str. Electric Bass
 QT_TRANSLATE_NOOP("InstrumentsXML", "El. B."),
 QT_TRANSLATE_NOOP("InstrumentsXML", "5-str. Electric Bass [Tablature]"),
+QT_TRANSLATE_NOOP("InstrumentsXML", "Prima"),
+//: Prima
+QT_TRANSLATE_NOOP("InstrumentsXML", "Pr."),
+QT_TRANSLATE_NOOP("InstrumentsXML", "Brač"),
+//: Brač
+QT_TRANSLATE_NOOP3("InstrumentsXML", "Br.", "Brač"),
+QT_TRANSLATE_NOOP("InstrumentsXML", "Čelo"),
+//: Čelo
+QT_TRANSLATE_NOOP("InstrumentsXML", "Č."),
+QT_TRANSLATE_NOOP("InstrumentsXML", "Bugarija"),
+//: Bugarija
+QT_TRANSLATE_NOOP3("InstrumentsXML", "Bu.", "Bugarija"),
+QT_TRANSLATE_NOOP("InstrumentsXML", "Berda"),
+//: Berda
+QT_TRANSLATE_NOOP3("InstrumentsXML", "Be.", "Berda"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Strings"),
 QT_TRANSLATE_NOOP("InstrumentsXML", "Erhu"),
 //: Erhu


### PR DESCRIPTION
As instrumentsxml.h is never touched by a C/C++ compiler, 8-bit ASCII and UTF-8 characters should never cause any kind of comapitibilty or standards compliance problems, and actually never had so far with at
least the ♭ being used in multiple places, so we can as well have ü, č and Č there too.
So fix Güiro in other places too, in C++ code in a C++11 compatible manner.

While at it fix some duplicate short instrument names and also a fix/workaround for an lupdate diagnostic