### PR TITLE
Export all excerpts as png images

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2230,9 +2230,9 @@ static bool processNonGui()
                         }
                   else {
                         if (cs->excerpts().size() == 0) {
-                              QList<Excerpt*> exceprts = Excerpt::createAllExcerpt(cs->masterScore());
+                              auto exceprts = Excerpt::createAllExcerpt(cs->masterScore());
                       
-                              foreach(Excerpt* e, exceprts) {
+                              for(Excerpt* e: exceprts) {
                                     Score* nscore = new Score(e->oscore());
                                     e->setPartScore(nscore);
                                     nscore->setName(e->title()); // needed before AddExcerpt
@@ -2247,7 +2247,7 @@ static bool processNonGui()
                               return false;
                         int idx = 0;
                         int padding = QString("%1").arg(cs->excerpts().size()).size();
-                        foreach(Excerpt* e, cs->excerpts()) {
+                        for(Excerpt* e: cs->excerpts()) {
                               QString suffix = QString("__excerpt__%1.png").arg(idx, padding, 10, QLatin1Char('0'));
                               QString excerptFn = fn.left(fn.size() - 4) + suffix;
                               if (!mscore->savePng(e->partScore(), excerptFn))

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2223,7 +2223,7 @@ static bool processNonGui()
                         return mscore->savePdf(scores, fn);
                         }
                   }
-            if (fn.endsWith(".png")) {
+            else if (fn.endsWith(".png")) {
                   if (!exportScoreParts)
                         return mscore->savePng(cs, fn);
                   else {
@@ -2246,20 +2246,15 @@ static bool processNonGui()
                         int idx = 0;
                         int padding = QString("%1").arg(cs->excerpts().size()).size();
                         foreach(Excerpt* e, cs->excerpts()) {
-                              QString excerptName = fn.left(fn.size() - 4) + QString("__exc__%1.png").arg(idx, padding, 10, QLatin1Char('0'));
-                              if (!mscore->savePng(e->partScore(), excerptName))
+                              QString suffix = QString("__exc__%1.png").arg(idx, padding, 10, QLatin1Char('0'));
+                              QString excerptFn = fn.left(fn.size() - 4) + suffix;
+                              if (!mscore->savePng(e->partScore(), excerptFn))
                                     return false;
                               idx++;
-                        }
+                              }
                         return true;
                         }
-            }
-/*	
-            else if (fn.endsWith(".png")) {
-                  cs->switchToPageMode();
-                  rv = mscore->savePng(cs, fn);
                   }
-*/
             else if (fn.endsWith(".svg")) {
                   cs->switchToPageMode();
                   rv = mscore->saveSvg(cs, fn);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2224,11 +2224,13 @@ static bool processNonGui()
                         }
                   }
             else if (fn.endsWith(".png")) {
-                  if (!exportScoreParts)
+                  if (!exportScoreParts) {
+                        cs->switchToPageMode();
                         return mscore->savePng(cs, fn);
+                        }
                   else {
                         if (cs->excerpts().size() == 0) {
-                              QList<Excerpt*> exceprts = Excerpt::createAllExcerpt(cs);
+                              QList<Excerpt*> exceprts = Excerpt::createAllExcerpt(cs->masterScore());
                       
                               foreach(Excerpt* e, exceprts) {
                                     Score* nscore = new Score(e->oscore());
@@ -2246,7 +2248,7 @@ static bool processNonGui()
                         int idx = 0;
                         int padding = QString("%1").arg(cs->excerpts().size()).size();
                         foreach(Excerpt* e, cs->excerpts()) {
-                              QString suffix = QString("__exc__%1.png").arg(idx, padding, 10, QLatin1Char('0'));
+                              QString suffix = QString("__excerpt__%1.png").arg(idx, padding, 10, QLatin1Char('0'));
                               QString excerptFn = fn.left(fn.size() - 4) + suffix;
                               if (!mscore->savePng(e->partScore(), excerptFn))
                                     return false;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2223,10 +2223,43 @@ static bool processNonGui()
                         return mscore->savePdf(scores, fn);
                         }
                   }
+            if (fn.endsWith(".png")) {
+                  if (!exportScoreParts)
+                        return mscore->savePng(cs, fn);
+                  else {
+                        if (cs->excerpts().size() == 0) {
+                              QList<Excerpt*> exceprts = Excerpt::createAllExcerpt(cs);
+                      
+                              foreach(Excerpt* e, exceprts) {
+                                    Score* nscore = new Score(e->oscore());
+                                    e->setPartScore(nscore);
+                                    nscore->setName(e->title()); // needed before AddExcerpt
+                                    nscore->style()->set(StyleIdx::createMultiMeasureRests, true);
+                                    cs->startCmd();
+                                    cs->undo(new AddExcerpt(nscore));
+                                    createExcerpt(e);
+                                    cs->endCmd();
+                                    }
+                              }
+                        if (!mscore->savePng(cs, fn))
+                              return false;
+                        int idx = 0;
+                        int padding = QString("%1").arg(cs->excerpts().size()).size();
+                        foreach(Excerpt* e, cs->excerpts()) {
+                              QString excerptName = fn.left(fn.size() - 4) + QString("__exc__%1.png").arg(idx, padding, 10, QLatin1Char('0'));
+                              if (!mscore->savePng(e->partScore(), excerptName))
+                                    return false;
+                              idx++;
+                        }
+                        return true;
+                        }
+            }
+/*	
             else if (fn.endsWith(".png")) {
                   cs->switchToPageMode();
                   rv = mscore->savePng(cs, fn);
                   }
+*/
             else if (fn.endsWith(".svg")) {
                   cs->switchToPageMode();
                   rv = mscore->saveSvg(cs, fn);


### PR DESCRIPTION
Adding support for `-P` command-line argument to export all excerpts as PNG images, like exporting a PDF document.
A suffix of  `'__excerpt__%1'`, where the variable is the index number for the excerpt, is appended to the file name.