### PR TITLE
Fix debug build for XCode with CMake>=3.5.0.

### DIFF
--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -130,19 +130,19 @@ endif(APPLE)
 
 string(REPLACE ";" ";-I" INC "${QT_INCLUDES}")
 
-if (APPLE)
+if (APPLE AND (CMAKE_VERSION VERSION_LESS "3.5.0"))
 set_target_properties (
       testutils
       PROPERTIES
       COMPILE_FLAGS "-include all.h -D TESTROOT=\\\\\"${PROJECT_SOURCE_DIR}\\\\\" -g -Wall -Wextra"
       )
-else (APPLE)
+else (APPLE AND (CMAKE_VERSION VERSION_LESS "3.5.0"))
 set_target_properties (
       testutils
       PROPERTIES
       COMPILE_FLAGS "-include all.h -D TESTROOT=\\\"${PROJECT_SOURCE_DIR}\\\" -g -Wall -Wextra"
       )
-endif(APPLE)
+endif (APPLE AND (CMAKE_VERSION VERSION_LESS "3.5.0"))
 
 #      COMPILE_FLAGS "-include all.h -I ${INC} -D TESTROOT=\\\"${PROJECT_SOURCE_DIR}\\\" -g -Wall -Wextra"
 

--- a/mtest/cmake.inc
+++ b/mtest/cmake.inc
@@ -56,7 +56,7 @@ set_target_properties (
       ${TARGET}
       PROPERTIES
       AUTOMOC true
-      COMPILE_FLAGS "-include all.h -D QT_GUI_LIB -D TESTROOT=\\\\\"${PROJECT_SOURCE_DIR}\\\\\" -g -Wall -Wextra"
+      COMPILE_FLAGS "-include all.h -D QT_GUI_LIB -D TESTROOT=\\\"${PROJECT_SOURCE_DIR}\\\" -g -Wall -Wextra"
       LINK_FLAGS    "-g -stdlib=libc++"
       )
 else(APPLE)
@@ -68,5 +68,13 @@ set_target_properties (
       LINK_FLAGS    "-g"
       )
 endif(APPLE)
+
+if (APPLE AND (CMAKE_VERSION VERSION_LESS "3.5.0"))
+set_target_properties (
+      ${TARGET}
+      PROPERTIES
+      COMPILE_FLAGS "-include all.h -D QT_GUI_LIB -D TESTROOT=\\\\\"${PROJECT_SOURCE_DIR}\\\\\" -g -Wall -Wextra"
+      )
+endif (APPLE AND (CMAKE_VERSION VERSION_LESS "3.5.0"))
 
 add_test(${TARGET} ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}  -xunitxml -o result.xml)


### PR DESCRIPTION
The XCode generator was fixed in CMake 3.5.0, so the escaping hacks are not necessary (and do not work).