### PR TITLE
fix #65846: Ledger lines do not change color with staff

### DIFF
--- a/libmscore/ledgerline.cpp
+++ b/libmscore/ledgerline.cpp
@@ -13,6 +13,7 @@
 #include "ledgerline.h"
 #include "chord.h"
 #include "measure.h"
+#include "staff.h"
 #include "system.h"
 #include "score.h"
 
@@ -60,6 +61,7 @@ qreal LedgerLine::measureXPos() const
 void LedgerLine::layout()
       {
       setLineWidth(score()->styleS(StyleIdx::ledgerLineWidth) * chord()->mag());
+      setColor(staff()->color());
       Line::layout();
       }
 


### PR DESCRIPTION
Now, all ledger lines of a staff have the same color as the staff's staff lines.