### PR TITLE
fix #108146: crash when entering Advanced Staff Properties dialog

### DIFF
--- a/mscore/data/tab_sample.mscx
+++ b/mscore/data/tab_sample.mscx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="1.24">
+<museScore version="2.06">
   <programVersion>2.0.0</programVersion>
-  <programRevision>7eca27a</programRevision>
+  <programRevision>6e47f74</programRevision>
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
@@ -12,15 +12,9 @@
       <staffUpperBorder>0</staffUpperBorder>
       <staffLowerBorder>0</staffLowerBorder>
       <maxSystemDistance>8.5</maxSystemDistance>
-      <figuredBassFontFamily>MScoreBC</figuredBassFontFamily>
       <bracketWidth>0.3</bracketWidth>
       <bracketDistance>0.2</bracketDistance>
-      <beamMinLen>1.32</beamMinLen>
-      <beamNoSlope>0</beamNoSlope>
       <showMeasureNumber>0</showMeasureNumber>
-      <smallNoteMag>0.7</smallNoteMag>
-      <graceNoteMag>0.7</graceNoteMag>
-      <smallStaffMag>0.7</smallStaffMag>
       <showFooter>0</showFooter>
       <evenFooterL></evenFooterL>
       <evenFooterC></evenFooterC>

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -72,8 +72,8 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
 
       // load a sample tabulature score in preview
       MasterScore* sc = new MasterScore(MScore::defaultStyle());
-      if (readScore(sc, QString(":/data/tab_sample.mscx"), false) == Score::FileError::FILE_NO_ERROR)
-            preview->setScore(sc);
+      Q_ASSERT(readScore(sc, QString(":/data/tab_sample.mscx"), false) == Score::FileError::FILE_NO_ERROR);
+      preview->setScore(sc);
 
       setValues();
 
@@ -485,12 +485,10 @@ void EditStaffType::tabStemThroughCompatibility(bool checked)
 void EditStaffType::updatePreview()
       {
       setFromDlg();
-      if (preview) {
-            preview->score()->staff(0)->setStaffType(&staffType);
-            preview->score()->doLayout();
-            preview->updateAll();
-            preview->update();
-            }
+      preview->score()->staff(0)->setStaffType(&staffType);
+      preview->score()->doLayout();
+      preview->updateAll();
+      preview->update();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
by updating the tab_sample.mscx score to report `mscVersion() == 206` (may need to get revisited later in the development process). If this still fails (or again, in some futur version), crash on the spot.
Additionaly removed the check for `preview` in`EditStaffType::updatePreview()` on @wschweers's request.