### PR TITLE
fix #109651: add hint at the download page when loading pre 0.9.6 scores

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -178,7 +178,10 @@ static bool readScoreError(const QString& name, Score::FileError error, bool ask
             case Score::FileError::FILE_TOO_OLD:
                   msg += QObject::tr("It was last saved with version 0.9.5 or older.\n"
                                      "You can convert this score by opening and then\n"
-                                     "saving with MuseScore version 1.x");
+                                     "saving with MuseScore version 1.x.\n"
+                                     "Visit the %1MuseScore download page%2 to obtain such a 1.x version.")
+                              .arg("<a href=\"http://musescore.org/download#older-versions\">")
+                              .arg("</a>");
                   canIgnore = true;
                   break;
             case Score::FileError::FILE_TOO_NEW:


### PR DESCRIPTION
This PR is specificially done for the 2.0.4 branch, a corresponding change for the master branch, AKA 3.0,  is in a different PR, #2581