### PR TITLE
fix #109626: add option to force loading score in converter mode

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -141,6 +141,7 @@ static QString createDefaultFileName(QString fn)
 //   readScoreError
 //    if "ask" is true, ask to ignore; returns true if
 //    ignore is pressed by user
+//    returns true if -f is used in converter mode
 //---------------------------------------------------------
 
 static bool readScoreError(const QString& name, Score::FileError error, bool ask)
@@ -187,10 +188,13 @@ static bool readScoreError(const QString& name, Score::FileError error, bool ask
                   msg += MScore::lastError;
                   break;
             }
-      int rv = false;
-      if (converterMode || pluginMode) {
+      if (converterMode && canIgnore && ignoreWarnings) {
+            fprintf(stderr, "%s\n\nWarning ignored, forcing score to load\n", qPrintable(msg));
+            return true;
+            }
+       if (converterMode || pluginMode) {
             fprintf(stderr, "%s\n", qPrintable(msg));
-            return rv;
+            return false;
             }
       QMessageBox msgBox;
       msgBox.setWindowTitle(QObject::tr("MuseScore: Load Error"));
@@ -211,7 +215,7 @@ static bool readScoreError(const QString& name, Score::FileError error, bool ask
                );
             msgBox.exec();
             }
-      return rv;
+      return false;
       }
 
 //---------------------------------------------------------

--- a/mscore/globals.h
+++ b/mscore/globals.h
@@ -35,6 +35,7 @@ extern double converterDpi;
 extern double guiScaling;
 extern int trimMargin;
 extern bool noWebView;
+extern bool ignoreWarnings;
 
 //---------------------------------------------------------
 // MsWidget

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -142,6 +142,7 @@ double guiScaling = 0.0;
 int trimMargin = -1;
 bool noWebView = false;
 bool exportScoreParts = false;
+bool ignoreWarnings = false;
 
 QString mscoreGlobalShare;
 
@@ -4799,7 +4800,8 @@ int main(int argc, char* av[])
       parser.addOption(QCommandLineOption({"t", "test-mode"}, "Set testMode flag for all files"));
       parser.addOption(QCommandLineOption({"M", "midi-operations"}, "Specify MIDI import operations file", "file"));
       parser.addOption(QCommandLineOption({"w", "no-webview"}, "No web view in start center"));
-      parser.addOption(QCommandLineOption({"P", "export-score-parts"}, "used with -o <file>.pdf, export score + parts"));
+      parser.addOption(QCommandLineOption({"P", "export-score-parts"}, "Used with -o <file>.pdf, export score + parts"));
+      parser.addOption(QCommandLineOption({"f", "force"}, "Used with -o, ignore warnings reg. score being corrupted or from wrong version"));
 
       parser.addPositionalArgument("scorefiles", "The files to open", "[scorefile...]");
 
@@ -4884,6 +4886,7 @@ int main(int argc, char* av[])
       exportScoreParts = parser.isSet("export-score-parts");
       if (exportScoreParts && !converterMode)
             parser.showHelp(EXIT_FAILURE);
+      ignoreWarnings = parser.isSet("f");
 
       QStringList argv = parser.positionalArguments();
 


### PR DESCRIPTION
to allow overriding the warnings reg. a score being corrupted, too old or too new, the same way the dialog in interactive mode allows overiding the warning.

Might be helpful esp. in connection with PR #2581