### PR TITLE
fix #15121: Ledger lines don't appear for notes beyond staff in drum …

### DIFF
--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -105,7 +105,7 @@ class Chord : public ChordRest {
       virtual qreal downPos() const;
       virtual qreal centerX() const;
       void createLedgerLines(int track, std::vector<LedgerLineData> &vecLines, bool visible);
-      void addLedgerLines(int move);
+      void addLedgerLines();
       void processSiblings(std::function<void(Element*)> func) const;
 
       void layoutPitched();

--- a/libmscore/ledgerline.cpp
+++ b/libmscore/ledgerline.cpp
@@ -61,7 +61,8 @@ qreal LedgerLine::measureXPos() const
 void LedgerLine::layout()
       {
       setLineWidth(score()->styleS(StyleIdx::ledgerLineWidth) * chord()->mag());
-      setColor(staff()->color());
+      if (staff())
+            setColor(staff()->color());
       Line::layout();
       }
 


### PR DESCRIPTION
…palette

I edited `Chord::addLedgerLines` to work with palettes and called it in `Chord::layoutPitched` for the palette part of the function. `Chord::scanElements` was edited so that the palette ledger lines could be painted. `LedgerLine::layout` was edited so that the staff color would be used only if the staff existed.

Should track be initialized to 0 in `addLedgerLines`?