### PR TITLE
fix #110376 fix #110371: Problems with New All and Delete in Excerptsdialog

### DIFF
--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -379,17 +379,13 @@ void ExcerptsDialog::accept()
       qDebug() << "\nFirst pass : delete unwanted parts";
 
       int pos = 0;
-      for (Excerpt* e : score->excerpts()) {
+      for (int i = score->excerpts().size() -1; i >= 0; i--) {
+            Excerpt* e = score->excerpts().at(i);
             if (!isInPartsList(e)) {
                   // Delete it because not in the list anymore
                   if (e->partScore()) {
                         Score* partScore = e->partScore();
                         qDebug() << " - Deleting parts : " << ExcerptItem(e).excerpt()->title();
-
-                        // Swap Excerpts to the end before deleting, so if undoing, the part will be reordered
-                        int lastPos = score->excerpts().size()-1;
-                        if ((lastPos > 0) && (pos != lastPos))
-                              score->undo(new SwapExcerpt(score, pos, lastPos));
 
                         deleteExcerpt(e);
                         // remove the excerpt


### PR DESCRIPTION
The problem was the swap of the voices in order to restore the order of the Excerpts by an undo command. It caused a SEGFAULT, because the excerpts were swapped and then deleted, so you aren't able to refer on the excerpts you want to delete and haven't yet anymore.