### PR TITLE
Fix regression where there are multiple tied notes with the same accidental

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1798,8 +1798,8 @@ void Note::updateAccidental(AccidentalState* as)
             if ((accVal != relLineAccVal) || hidden() || as->tieContext(relLine)) {
                   as->setAccidentalVal(relLine, accVal, _tieBack != 0);
                   acci = Accidental::value2subtype(accVal);
-                  // if previous tied note has same accidental, don't show this one's
-                  if (_tieBack && _tieBack->startNote()->accidentalType() == acci)
+                  // if previous tied note has same tpc, don't show accidental
+                  if (_tieBack && _tieBack->startNote()->tpc1() == tpc1())
                         acci = AccidentalType::NONE;
                   else if (acci == AccidentalType::NONE)
                         acci = AccidentalType::NATURAL;


### PR DESCRIPTION
Follow up of: #2553 
Fixes a regression introduced then. (This should go to 2.0.4 and master.)
Before: ![before](https://cloud.githubusercontent.com/assets/17802258/15271947/94229c4e-1a2f-11e6-87b0-fa255f207abf.png)
After: ![after](https://cloud.githubusercontent.com/assets/17802258/15271948/9bc74a4e-1a2f-11e6-9456-9584b5faa97a.png)