### PR TITLE
fix export part of #111271

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -2440,9 +2440,14 @@ void ExportMusicXml::chord(Chord* chord, int staff, const QVector<Lyrics*>* ll, 
             xml.tag(useDrumset ? "display-octave" : "octave", octave);
             xml.etag();
 
+            // time signature stretch factor
+            const Fraction str = note->chord()->staff()->timeStretch(note->chord()->tick());
+            // chord's actual ticks corrected for stretch
+            const int strActTicks = note->chord()->actualTicks() * str.numerator() / str.denominator();
+
             // duration
             if (!grace)
-                  xml.tag("duration", note->chord()->actualTicks() / div);
+                  xml.tag("duration", strActTicks / div);
 
             if (note->tieBack())
                   xml.tagE("tie type=\"stop\"");
@@ -2478,11 +2483,10 @@ void ExportMusicXml::chord(Chord* chord, int staff, const QVector<Lyrics*>* ll, 
                   nrmTicks = determineTupletNormalTicks(chord);
                   }
 
-            QString s = tick2xml(note->chord()->actualTicks() * actNotes * tremCorr / nrmNotes, &dots);
-            if (s.isEmpty()) {
-                  qDebug("no note type found for ticks %d",
-                         note->chord()->actualTicks());
-                  }
+            QString s = tick2xml(strActTicks * actNotes * tremCorr / nrmNotes, &dots);
+            if (s.isEmpty())
+                  qDebug("no note type found for ticks %d", strActTicks);
+
             if (note->small())
                   xml.tag("type size=\"cue\"", s);
             else


### PR DESCRIPTION
Fix export part of #111271 (local time signatures) only. Import is more work, was asked to provide the export fix quickly. Regression test will be updated together with import fix.

Should also be synced to 2.0.4.

Submitter requests a Windows nightly build with this fix, which I cannot do. Alternatively I could convert his file for him.