### PR TITLE
Selection of overlapping elements

### DIFF
--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -113,7 +113,7 @@ void ExampleView::startEdit(Element*, Grip /*startGrip*/)
       {
       }
 
-Element* ExampleView::elementNear(QPointF)
+Element* ExampleView::elementNear(QPointF, bool)
       {
       return 0;
       }

--- a/mscore/exampleview.h
+++ b/mscore/exampleview.h
@@ -72,7 +72,7 @@ class ExampleView : public QFrame, public MuseScoreView {
       virtual void cmdAddHairpin(bool) {}
       virtual void startEdit();
       virtual void startEdit(Element*, Grip);
-      virtual Element* elementNear(QPointF);
+      virtual Element* elementNear(QPointF, bool);
       virtual void drawBackground(QPainter*, const QRectF&) const;
       };
 

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -633,7 +633,7 @@ void PianorollEditor::startEdit(Element*, Grip)
 //   elementNear
 //---------------------------------------------------------
 
-Element* PianorollEditor::elementNear(QPointF)
+Element* PianorollEditor::elementNear(QPointF, bool)
       {
       return 0;
       }

--- a/mscore/pianoroll.h
+++ b/mscore/pianoroll.h
@@ -101,7 +101,7 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       virtual void cmdAddHairpin(bool) {}
       virtual void startEdit();
       virtual void startEdit(Element*, Grip);
-      virtual Element* elementNear(QPointF);
+      virtual Element* elementNear(QPointF, bool);
       virtual void drawBackground(QPainter* /*p*/, const QRectF& /*r*/) const {}
 
       void setLocator(POS pos, int tick) { locator[int(pos)].setTick(tick); }

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -448,7 +448,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       Lasso* fotoLasso() const    { return _foto;    }
       Element* getEditObject()    { return editObject; }
       void setEditObject(Element* e) { editObject = e; }
-      virtual Element* elementNear(QPointF);
+      virtual Element* elementNear(QPointF, bool first = true);
       void editFretDiagram(FretDiagram*);
       void editBendProperties(Bend*);
       void editTremoloBarProperties(TremoloBar*);


### PR DESCRIPTION
Seeking feedback - does the following make sense, how does it feel in practice?

This PR implements two related tweaks to how clicking works with respect to selection of overlapping elements:

1) For elements that overlap, Ctrl+click will now cycle through all overlapping elements.  So if one element in a stack is selected, Ctrl+click will deselect it (as it currently does) but also select the next deeper element in in the stack.

2) For purpose of selection, stems are considered to be deeper in the stack than notes (although I left the _actual_ z-order alone, because it seems important for layout in tab staves).  Thus, clicking the overlap area between the notehead and stem will select the note rather than the stem.  This makes it much easier to select a note at small magnifications.

Apparently Inkscape uses "Alt" instead of "Ctrl" to do the cycle thing.  In principle I assume we could do this as well, but my system seems unable to captrue Alt+click - I guess the OS (Ubuntu running in a chroot under Chrome OS) traps it.  It doesn't work for me in Inkspace, and I can't get it to work in MuseScore either.  Which in itself makes me prefer Ctrl, but if Alt+click really is a standard for this sort of operation and if it works on "most" systems, we could certainly use that instead.

I should note there appear to be issues with Ctr+click in the current master - if an object is already selected and you Ctrl+click to deselect it, the visual feedback doesn't seem to update properly.  It _is_ deselected (as a subsequent oepration like Delete demonstrates), but the display is not updated.  I guess that's related to the new incremental layout code.  My code does the deslection a bit differently, but seems to have the same issue in the end.
