### PR TITLE
fix/avoid compiler warnings

### DIFF
--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -511,7 +511,7 @@ void PianorollEditor::moveLocator(int i, const Pos& pos)
 //   cmd
 //---------------------------------------------------------
 
-void PianorollEditor::cmd(QAction* a)
+void PianorollEditor::cmd(QAction* /*a*/)
       {
       //score()->startCmd();
       gv->setStaff(staff, locator);

--- a/thirdparty/poppler/CMakeLists.txt
+++ b/thirdparty/poppler/CMakeLists.txt
@@ -121,8 +121,18 @@ add_library(poppler STATIC
 
 set_target_properties(poppler
       PROPERTIES
-      COMPILE_FLAGS
-            "-O2 -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-private-field"
+      if (APPLE)
+         COMPILE_FLAGS
+            "-O2 -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-private-field -Wno-return-stack-address -Wno-shift-negative-value"
+      else (APPLE)
+         if (MINGW)
+            COMPILE_FLAGS
+               "-O2 -Wall -Wextra -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-but-set-variable -Wno-format"
+         else (MINGW)
+             COMPILE_FLAGS
+                "-O2 -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-but-set-variable"
+         endif(MINGW)
+      endif(APPLE)
       )
 
 include_directories(


### PR DESCRIPTION
* fix a compiler warning reg. unused parameter introduced by d16c5ed, this one could and probably should go to the 2.0.4 branch too
* avoid compiler warnings in poppler code, introduced with #2594, some only showing on Linux (and as such on Travis), others only showning on Mac/Travis (latest XCode?), some more on Windows, but only if warnings for that code gets enabled, only needed/usable in master branch so far