### PR TITLE
First attempt to not allow gaps any more

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1807,7 +1807,7 @@ Element* Score::move(const QString& cmd)
             // also use it if we are moving to next chord
             // to catch up with the cursor and not move the selection by 2 positions
             cr = selection().cr();
-            if (cr && (cr->isGrace() || cmd == "next-chord"))
+            if (cr && (cr->isGrace() || cmd == "next-chord" || cmd == "prev-chord"))
                   ;
             else
                   cr = inputState().cr();
@@ -1836,17 +1836,17 @@ Element* Score::move(const QString& cmd)
             switch (el->type()) {
                   case Element::Type::NOTE:           // a note is a valid target
                         trg = el;
-                        cr  = static_cast<Note*>(el)->chord();
+                        cr  = toNote(el)->chord();
                         break;
                   case Element::Type::CHORD:          // a chord or a rest are valid targets
                   case Element::Type::REST:
                         trg = el;
-                        cr  = static_cast<ChordRest*>(trg);
+                        cr  = toChordRest(trg);
                         break;
                   case Element::Type::SEGMENT: {      // from segment go to top chordrest in segment
-                        Segment* seg  = static_cast<Segment*>(el);
+                        Segment* seg  = toSegment(el);
                         // if segment is not chord/rest or grace, move to next chord/rest or grace segment
-                        if (!seg->isChordRest()) {
+                        if (!seg->isChordRest1()) {
                               seg = seg->next1(Segment::Type::ChordRest);
                               if (seg == 0)     // if none found, return failure
                                     return 0;
@@ -1856,14 +1856,14 @@ Element* Score::move(const QString& cmd)
                         // if segment has a chord/rest in original element track, use it
                         if (track > -1 && track < size && seg->element(track)) {
                               trg  = seg->element(track);
-                              cr = static_cast<ChordRest*>(trg);
+                              cr = toChordRest(trg);
                               break;
                               }
                         // if not, get topmost chord/rest
                         for (int i = 0; i < size; i++)
                               if (seg->element(i)) {
                                     trg  = seg->element(i);
-                                    cr = static_cast<ChordRest*>(trg);
+                                    cr = toChordRest(trg);
                                     break;
                                     }
                         break;
@@ -1876,7 +1876,7 @@ Element* Score::move(const QString& cmd)
             if (trg && cmd == "next-chord") {
                   // if chord, go to topmost note
                   if (trg->type() == Element::Type::CHORD)
-                        trg = static_cast<Chord*>(trg)->upNote();
+                        trg = toChord(trg)->upNote();
                   setPlayNote(true);
                   select(trg, SelectType::SINGLE, 0);
                   return trg;
@@ -1900,9 +1900,11 @@ Element* Score::move(const QString& cmd)
             // find next chordrest, which might be a grace note
             // this may override note input cursor
             el = nextChordRest(cr);
+            while (el && el->isRest() && toRest(el)->isGap())
+                  el = nextChordRest(toChordRest(el));
             if (el && noteEntryMode()) {
                   // do not use if not in original or new measure (don't skip measures)
-                  Measure* m = static_cast<ChordRest*>(el)->measure();
+                  Measure* m = toChordRest(el)->measure();
                   Segment* nis = _is.segment();
                   Measure* nim = nis ? nis->measure() : nullptr;
                   if (m != oim && m != nim)
@@ -1916,36 +1918,20 @@ Element* Score::move(const QString& cmd)
                   el = cr;
             }
       else if (cmd == "prev-chord") {
-
             // note input cursor
             if (noteEntryMode() && _is.segment()) {
-
-                  // back up until we find a ChordRest segment
-                  Segment* s = _is.segment()->prev1();
-                  while (s && s->segmentType() != Segment::Type::ChordRest)
-                        s = s->prev1();
-                  if (s == 0)
-                        return 0;
-
-                  // this is the right measure
-                  Measure* m = s->measure();
-
-                  // keep backing up until we find a chordrest in right track
-                  // or until we leave the right measure
+                  Measure* m = _is.segment()->measure();
+                  Segment* s = _is.segment()->prev1(Segment::Type::ChordRest);
                   int track = _is.track();
-                  for ( ; s; s = s->prev1()) {
-                        if (s->segmentType() != Segment::Type::ChordRest)
-                              continue;
-                        if (s->element(track) || s->measure() != m)
+                  for (; s; s = s->prev1(Segment::Type::ChordRest)) {
+                        if (s->element(track) || s->measure() != m) {
+                              if (s->element(track)) {
+                                    if (s->element(track)->isRest() && toRest(s->element(track))->isGap())
+                                          continue;
+                                    }
                               break;
+                              }
                         }
-
-                  // if we did not find a chordrest in right track in right measure
-                  // then use first chordrest segment of right measure
-                  if (!s || s->measure() != m)
-                        s = m->first(Segment::Type::ChordRest);
-
-                  // move input cursor
                   _is.moveInputPos(s);
                   }
 
@@ -1953,9 +1939,11 @@ Element* Score::move(const QString& cmd)
             // find previous chordrest, which might be a grace note
             // this may override note input cursor
             el = prevChordRest(cr);
+            while (el && el->isRest() && toRest(el)->isGap())
+                  el = prevChordRest(toChordRest(el));
             if (el && noteEntryMode()) {
                   // do not use if not in original or new measure (don't skip measures)
-                  Measure* m = static_cast<ChordRest*>(el)->measure();
+                  Measure* m = toChordRest(el)->measure();
                   Segment* nis = _is.segment();
                   Measure* nim = nis ? nis->measure() : nullptr;
                   if (m != oim && m != nim)
@@ -1992,7 +1980,7 @@ Element* Score::move(const QString& cmd)
 
       if (el) {
             if (el->type() == Element::Type::CHORD)
-                  el = static_cast<Chord*>(el)->upNote();       // originally downNote
+                  el = toChord(el)->upNote();       // originally downNote
             setPlayNote(true);
             if (noteEntryMode()) {
                   // if cursor moved into a gap, selection cannot follow

--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -154,8 +154,13 @@ Segment* InputState::nextInputPos() const
       Measure* m = _segment->measure();
       Segment* s = _segment->next1(Segment::Type::ChordRest);
       for (; s; s = s->next1(Segment::Type::ChordRest)) {
-            if (s->element(_track) || s->measure() != m)
+            if (s->element(_track) || s->measure() != m) {
+                  if (s->element(_track)) {
+                        if (s->element(_track)->isRest() && toRest(s->element(_track))->isGap())
+                              continue;
+                        }
                   return s;
+                  }
             }
       return 0;
       }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2147,6 +2147,77 @@ void Measure::read(XmlReader& e, int staffIdx)
       }
 
 //---------------------------------------------------------
+//   checkMeasure
+//    after opening / paste and every read operation
+//    this method checks for gaps and fills them
+//    with invisible rests
+//---------------------------------------------------------
+
+void Measure::checkMeasue(int staffIdx)
+      {
+      for (int track = staffIdx * VOICES + 1; track % VOICES && hasVoice(track); track++) {
+            Segment* seg = first();
+            if (!seg->element(track))
+                  seg = seg->nextCR(track, false);
+            if (!seg->element(track))
+                  continue;
+
+            Segment* pseg = 0;
+            int stick = tick();
+            int ticks = seg->tick() - stick;
+
+            while (seg) {
+                  if (ticks) {
+                        Fraction f = Fraction::fromTicks(ticks);
+
+                        Rest* rest = new Rest(score());
+                        rest->setDuration(f);
+                        rest->setTrack(track);
+                        Segment* segment = getSegment(rest, stick);
+                        segment->add(rest);
+                        rest->setGap(true);
+                        seg = segment;
+                        }
+
+                  pseg = seg;
+                  stick = seg->tick() + toChordRest(seg->element(track))->actualTicks();
+                  for (Segment* s = seg->nextCR(track, true); s; s = s->nextCR(track, true)) {
+                        if (!s->element(track))
+                              continue;
+                        if (s->parent() != this) {
+                              stick = -1;
+                              break;
+                              }
+
+                        seg = s;
+                        if (seg->tick() == stick) {
+                              pseg = seg;
+                              stick = seg->tick() + toChordRest(seg->element(track))->actualTicks();
+                              continue;
+                              }
+                        else {
+                              ticks = seg->tick() - stick;
+                              break;
+                              }
+                        }
+
+                  if (stick == -1) {
+                        break;
+                        }
+                  //reached last segment in measure
+                  if (pseg == seg || stick == tick() + _len.ticks()) {
+                        if (stick + ticks < tick() + _len.ticks()) {
+                              ticks = tick() + _len.ticks() - stick;
+                              if (ticks > 0)
+                                    continue;
+                              }
+                        break;
+                        }
+                  }
+            }
+      }
+
+//---------------------------------------------------------
 //   visible
 //---------------------------------------------------------
 
@@ -2773,7 +2844,7 @@ bool Measure::empty() const
             return false;
       int n = 0;
       int tracks = _mstaves.size() * VOICES;
-      static const Segment::Type st { Segment::Type::ChordRest };
+      static const Segment::Type st = Segment::Type::ChordRest ;
       for (const Segment* s = first(st); s; s = s->next(st)) {
             bool restFound = false;
             for (int track = 0; track < tracks; ++track) {
@@ -2802,11 +2873,27 @@ bool Measure::empty() const
 
 bool Measure::isOnlyRests(int track) const
       {
-      static const Segment::Type st { Segment::Type::ChordRest };
+      static const Segment::Type st = Segment::Type::ChordRest;
       for (const Segment* s = first(st); s; s = s->next(st)) {
-            if (s->segmentType() != Segment::Type::ChordRest || !s->element(track))
+            if (s->segmentType() != st || !s->element(track))
                   continue;
             if (s->element(track)->type() != Element::Type::REST)
+                  return false;
+            }
+      return true;
+      }
+
+//---------------------------------------------------------
+//   isOnlyDeletedRests
+//---------------------------------------------------------
+
+bool Measure::isOnlyDeletedRests(int track) const
+      {
+      static const Segment::Type st { Segment::Type::ChordRest };
+      for (const Segment* s = first(st); s; s = s->next(st)) {
+            if (s->segmentType() != st || !s->element(track))
+                  continue;
+            if (s->element(track)->isRest() ? !toRest(s->element(track))->isGap() : !s->element(track)->isRest())
                   return false;
             }
       return true;

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -138,6 +138,7 @@ class Measure : public MeasureBase {
       void writeBox(Xml&) const;
       void readBox(XmlReader&);
       virtual bool isEditable() const override { return false; }
+      void checkMeasue(int idx);
 
       virtual void add(Element*) override;
       virtual void remove(Element*) override;
@@ -237,7 +238,7 @@ class Measure : public MeasureBase {
 
       bool empty() const;
       bool isOnlyRests(int track) const;
-
+      bool isOnlyDeletedRests(int track) const;
 
       int playbackCount() const      { return _playbackCount; }
       void setPlaybackCount(int val) { _playbackCount = val; }

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -421,6 +421,14 @@ PasteState Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
             int endStaff = dstStaff + staves;
             if (endStaff > nstaves())
                   endStaff = nstaves();
+            //check and add truly invisible rests insted of gaps
+            //TODO: look if this could be done different
+            Measure* dstM = tick2measureMM(dstTick);
+            Measure* endM = tick2measureMM(dstTick + tickLen);
+            for (int i = dstStaff; i < endStaff; i++) {
+                  for (Measure* m = dstM; m && m != endM->nextMeasureMM(); m = m->nextMeasureMM())
+                        m->checkMeasue(i);
+                  }
             _selection.setRange(s1, s2, dstStaff, endStaff);
             _selection.updateSelectedElements();
 

--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -43,6 +43,7 @@ class Rest : public ChordRest {
 
    protected:
       ElementList _el;              ///< symbols or images
+      bool _gap;         ///< invisible and not selectable for user
 
    public:
       Rest(Score* s = 0);
@@ -63,6 +64,10 @@ class Rest : public ChordRest {
       virtual bool acceptDrop(const DropData&) const override;
       virtual Element* drop(const DropData&) override;
       virtual void layout() override;
+
+      bool isGap() const               { return _gap;     }
+      virtual void setGap(bool f);
+      void undoChangeGap(bool v);
 
       virtual void reset() override;
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3317,9 +3317,15 @@ ChordRest* Score::findCR(int tick, int track) const
       for (Segment* ns = s; ; ns = ns->next(Segment::Type::ChordRest)) {
             if (ns == 0 || ns->tick() > tick)
                   break;
-            if (ns->element(track))
+            Element* el = ns->element(track);
+            if (el && el->isRest() && toRest(el)->isGap())
+                  continue;
+            else if (el)
                   s = ns;
             }
+      Element* el = s->element(track);
+      if (el && el->isRest() && toRest(el)->isGap())
+            s = 0;
       if (s)
             return static_cast<ChordRest*>(s->element(track));
       return nullptr;

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -283,6 +283,7 @@ void Score::readStaff(XmlReader& e)
                               measure->setTimesig(f);
                               }
                         measure->read(e, staff);
+                        measure->checkMeasue(staff);
                         if (!measure->isMMRest()) {
                               measures()->add(measure);
                               e.setLastMeasure(measure);
@@ -325,6 +326,7 @@ void Score::readStaff(XmlReader& e)
                               }
                         e.initTick(measure->tick());
                         measure->read(e, staff);
+                        measure->checkMeasue(staff);
                         if (measure->isMMRest())
                               measure = e.lastMeasure()->nextMeasure();
                         else {

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1404,8 +1404,22 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
                   w += score()->styleP(StyleIdx::noteBarDistance);
             else if (nst == Segment::Type::Clef)
                   w = qMax(w, score()->styleP(StyleIdx::clefLeftMargin));
-            else
+            else {
+                  bool isGap = false;
+                  for (int i = 0; i < score()->nstaves() * VOICES; i++) {
+                        Element* el = element(i);
+                        if (el && el->isRest() && toRest(el)->isGap())
+                              isGap = true;
+                        else if (el) {
+                              isGap = false;
+                              break;
+                              }
+                        }
+                  if (isGap)
+                        return 0.0;
+
                   w = qMax(w, score()->noteHeadWidth()) + score()->styleP(StyleIdx::minNoteDistance);
+                  }
             }
       else if (st != Segment::Type::ChordRest && nst == Segment::Type::ChordRest) {
             qreal d;

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -175,7 +175,7 @@ Segment* Selection::firstChordRestSegment() const
       if (!isRange()) return 0;
 
       for (Segment* s = _startSegment; s && (s != _endSegment); s = s->next1MM()) {
-            if (s->segmentType() == Segment::Type::ChordRest)
+            if (s->isChordRestType())
                   return s;
             }
       return 0;
@@ -189,25 +189,25 @@ ChordRest* Selection::firstChordRest(int track) const
       {
       if (_el.size() == 1) {
             Element* el = _el[0];
-            if (el->type() == Element::Type::NOTE)
-                  return static_cast<ChordRest*>(el->parent());
-            else if (el->type() == Element::Type::REST)
-                  return static_cast<ChordRest*>(el);
+            if (el->isNote())
+                  return toChordRest(el->parent());
+            else if (el->isRest())
+                  return toChordRest(el);
             return 0;
             }
       ChordRest* cr = 0;
       foreach (Element* el, _el) {
-            if (el->type() == Element::Type::NOTE)
+            if (el->isNote())
                   el = el->parent();
             if (el->isChordRest()) {
                   if (track != -1 && el->track() != track)
                         continue;
                   if (cr) {
-                        if (static_cast<ChordRest*>(el)->tick() < cr->tick())
-                              cr = static_cast<ChordRest*>(el);
+                        if (toChordRest(el)->tick() < cr->tick())
+                              cr = toChordRest(el);
                         }
                   else
-                        cr = static_cast<ChordRest*>(el);
+                        cr = toChordRest(el);
                   }
             }
       return cr;
@@ -221,25 +221,25 @@ ChordRest* Selection::lastChordRest(int track) const
       {
       if (_el.size() == 1) {
             Element* el = _el[0];
-            if (el && el->type() == Element::Type::NOTE)
-                  return static_cast<ChordRest*>(el->parent());
-            else if (el->type() == Element::Type::CHORD || el->type() == Element::Type::REST || el->type() == Element::Type::REPEAT_MEASURE)
-                  return static_cast<ChordRest*>(el);
+            if (el && el->isNote())
+                  return toChordRest(el->parent());
+            else if (el->isChord() || el->isRest() || el->type() == Element::Type::REPEAT_MEASURE)
+                  return toChordRest(el);
             return 0;
             }
       ChordRest* cr = 0;
       for (auto el : _el) {
-            if (el->type() == Element::Type::NOTE)
-                  el = ((Note*)el)->chord();
-            if (el->isChordRest() && static_cast<ChordRest*>(el)->segment()->segmentType() == Segment::Type::ChordRest) {
+            if (el->isNote())
+                  el = toNote(el)->chord();
+            if (el->isChordRest() && toChordRest(el)->segment()->isChordRestType()) {
                   if (track != -1 && el->track() != track)
                         continue;
                   if (cr) {
-                        if (((ChordRest*)el)->tick() >= cr->tick())
-                              cr = (ChordRest*)el;
+                        if (toChordRest(el)->tick() >= cr->tick())
+                              cr = toChordRest(el);
                         }
                   else
-                        cr = (ChordRest*)el;
+                        cr = toChordRest(el);
                   }
             }
       return cr;

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -3487,4 +3487,14 @@ void Score::undoChangeBarLine(Measure* measure, BarLineType barType)
             }
       }
 
+//---------------------------------------------------------
+//   undoChangeGap
+//---------------------------------------------------------
+
+void ChangeGap::flip()
+      {
+      rest->setGap(v);
+      v = !v;
+      }
+
 }

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -39,6 +39,7 @@
 #include "cleflist.h"
 #include "note.h"
 #include "drumset.h"
+#include "rest.h"
 
 Q_DECLARE_LOGGING_CATEGORY(undoRedo)
 
@@ -1305,6 +1306,20 @@ class ChangeDrumset : public UndoCommand {
       UNDO_NAME("ChangeDrumset")
       };
 
+//---------------------------------------------------------
+//   ChangeGap
+//---------------------------------------------------------
+
+class ChangeGap : public UndoCommand {
+      Rest* rest;
+      bool v;
+
+      void flip();
+
+   public:
+      ChangeGap(Rest* r, bool v) : rest(r), v(v) {}
+      UNDO_NAME("ChangeGap")
+      };
+
 }     // namespace Ms
 #endif
-

--- a/mscore/continuouspanel.cpp
+++ b/mscore/continuouspanel.cpp
@@ -22,6 +22,7 @@
 #include "libmscore/timesig.h"
 #include "libmscore/keysig.h"
 #include "libmscore/barline.h"
+#include "libmscore/rest.h"
 
 #include "preferences.h"
 #include "scoreview.h"
@@ -140,6 +141,9 @@ void ContinuousPanel::paint(const QRect&, QPainter& painter)
       for (const Element* e : el) {
             e->itemDiscovered = 0;
             if (!e->visible() && !_score->showInvisible())
+                  continue;
+
+            if (e->isRest() && toRest(e)->isGap())
                   continue;
 
             if (e->isStaffLines()) {
@@ -308,7 +312,10 @@ void ContinuousPanel::paint(const QRect&, QPainter& painter)
             if (!e->visible() && !_score->showInvisible())
                   continue;
 
-           if (e->isStaffLines()) {
+            if (e->isRest() && toRest(e)->isGap())
+                  continue;
+
+            if (e->isStaffLines()) {
                   painter.save();
                   Staff* currentStaff = _score->staff(e->staffIdx());
                   Segment* parent = _score->tick2segmentMM(tick);

--- a/mscore/debugger/debugger.cpp
+++ b/mscore/debugger/debugger.cpp
@@ -1774,7 +1774,7 @@ void ShowElementBase::setElement(Element* e)
       eb.selectable->setChecked(e->selectable());
       eb.droptarget->setChecked(e->dropTarget());
       eb.generated->setChecked(e->generated());
-      eb.visible->setChecked(e->visible());
+      eb.visible->setChecked(e->visible() && el->isRest() && !toRest(el)->isGap());
       eb.track->setValue(e->track());
       eb.z->setValue(e->z());
       eb.posx->setValue(e->ipos().x());

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2382,6 +2382,8 @@ void ScoreView::drawElements(QPainter& painter, const QList<Element*>& el)
             e->itemDiscovered = 0;
             if (!e->visible() && (score()->printing() || !score()->showInvisible()))
                   continue;
+            if (e->isRest() && toRest(e)->isGap())
+                  continue;
             QPointF pos(e->pagePos());
             painter.translate(pos);
             e->draw(&painter);
@@ -2929,13 +2931,28 @@ void ScoreView::cmd(const QAction* a)
             }
       else if (cmd == "up-chord") {
             Element* el = score()->selection().element();
-            if (el && (el->type() == Element::Type::NOTE || el->type() == Element::Type::REST))
+            if (el && (el->isNote() || el->isRest()))
                   cmdGotoElement(score()->upAlt(el));
+            el = score()->selection().element();
+            while (el->isRest() && toRest(el)->isGap() && el->voice() != 0) {
+                  el = score()->upAlt(el);
+                  cmdGotoElement(el);
+                  }
             }
       else if (cmd == "down-chord") {
             Element* el = score()->selection().element();
-            if (el && (el->type() == Element::Type::NOTE || el->type() == Element::Type::REST))
+            Element* oel = el;
+            if (el && (el->isNote() || el->isRest()))
                   cmdGotoElement(score()->downAlt(el));
+            el = score()->selection().element();
+            while (el->isRest() && toRest(el)->isGap() && el->voice() != 3) {
+                  if (score()->downAlt(el) == el) {
+                        cmdGotoElement(oel);
+                        break;
+                        }
+                  el = score()->downAlt(el);
+                  cmdGotoElement(el);
+                  }
             }
       else if (cmd == "top-chord" ) {
             Element* el = score()->selection().element();
@@ -2952,7 +2969,6 @@ void ScoreView::cmd(const QAction* a)
             if (!el && !score()->selection().elements().isEmpty() )
                 el = score()->selection().elements().first();
 
-            //cmdGotoElement(score()->nextElement(el));
             if (el)
                   cmdGotoElement(el->nextElement());
             else
@@ -5083,7 +5099,7 @@ void ScoreView::harmonyTicksTab(int ticks)
             }
 
       // look for a segment at this tick; if none, create one
-      while(segment && segment->tick() < newTick)
+      while (segment && segment->tick() < newTick)
             segment = segment->next1(Segment::Type::ChordRest);
       if (!segment || segment->tick() > newTick) {      // no ChordRest segment at this tick
             segment = new Segment(measure, Segment::Type::ChordRest, newTick);

--- a/mtest/libmscore/copypaste/copypaste14-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste14-ref.mscx
@@ -197,6 +197,7 @@
           <subtype>normal</subtype>
           <span>1</span>
           </BarLine>
+        <tick>1920</tick>
         <tick>2400</tick>
         <Chord>
           <track>1</track>

--- a/mtest/libmscore/tools/undoChangeVoice01-ref.mscx
+++ b/mtest/libmscore/tools/undoChangeVoice01-ref.mscx
@@ -243,17 +243,13 @@
             <tpc>15</tpc>
             </Note>
           </Chord>
-        <Rest>
-          <lid>97</lid>
-          <track>1</track>
-          <durationType>quarter</durationType>
-          </Rest>
+        <tick>6720</tick>
         <Chord>
-          <lid>99</lid>
+          <lid>98</lid>
           <track>1</track>
           <durationType>half</durationType>
           <Note>
-            <lid>100</lid>
+            <lid>99</lid>
             <track>1</track>
             <pitch>72</pitch>
             <tpc>14</tpc>
@@ -328,27 +324,27 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>107</lid>
+          <lid>106</lid>
           <durationType>quarter</durationType>
           </Rest>
         <tick>9600</tick>
         <Chord>
-          <lid>102</lid>
+          <lid>101</lid>
           <track>1</track>
           <durationType>quarter</durationType>
           <Note>
-            <lid>103</lid>
+            <lid>102</lid>
             <track>1</track>
             <pitch>72</pitch>
             <tpc>14</tpc>
             </Note>
           </Chord>
         <Chord>
-          <lid>104</lid>
+          <lid>103</lid>
           <track>1</track>
           <durationType>half</durationType>
           <Note>
-            <lid>105</lid>
+            <lid>104</lid>
             <track>1</track>
             <pitch>72</pitch>
             <tpc>14</tpc>
@@ -365,7 +361,7 @@
             <tpc>15</tpc>
             </Note>
           <Note>
-            <lid>106</lid>
+            <lid>105</lid>
             <track>1</track>
             <pitch>72</pitch>
             <tpc>14</tpc>
@@ -394,7 +390,7 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>110</lid>
+          <lid>109</lid>
           <Tuplet>1</Tuplet>
           <durationType>quarter</durationType>
           </Rest>
@@ -516,7 +512,7 @@
             <tpc>15</tpc>
             </Note>
           <Note>
-            <lid>108</lid>
+            <lid>107</lid>
             <track>1</track>
             <pitch>72</pitch>
             <tpc>14</tpc>
@@ -534,19 +530,19 @@
             <tpc>15</tpc>
             </Note>
           <Note>
-            <lid>109</lid>
+            <lid>108</lid>
             <track>1</track>
             <pitch>72</pitch>
             <tpc>14</tpc>
             </Note>
           </Chord>
         <Chord>
-          <lid>111</lid>
+          <lid>110</lid>
           <track>1</track>
           <Tuplet>3</Tuplet>
           <durationType>quarter</durationType>
           <Note>
-            <lid>112</lid>
+            <lid>111</lid>
             <track>1</track>
             <pitch>72</pitch>
             <tpc>14</tpc>
@@ -576,7 +572,7 @@
             <tpc>15</tpc>
             </Note>
           <Note>
-            <lid>113</lid>
+            <lid>112</lid>
             <track>1</track>
             <pitch>72</pitch>
             <tpc>14</tpc>
@@ -594,13 +590,13 @@
           <l2>24</l2>
           </Beam>
         <Chord>
-          <lid>114</lid>
+          <lid>113</lid>
           <track>1</track>
           <Tuplet>4</Tuplet>
           <durationType>eighth</durationType>
           <Beam>2</Beam>
           <Note>
-            <lid>115</lid>
+            <lid>114</lid>
             <track>1</track>
             <pitch>72</pitch>
             <tpc>14</tpc>
@@ -619,7 +615,7 @@
             <tpc>15</tpc>
             </Note>
           <Note>
-            <lid>116</lid>
+            <lid>115</lid>
             <track>1</track>
             <pitch>72</pitch>
             <tpc>14</tpc>
@@ -866,17 +862,13 @@
               <tpc>15</tpc>
               </Note>
             </Chord>
-          <Rest>
-            <lid>97</lid>
-            <track>1</track>
-            <durationType>quarter</durationType>
-            </Rest>
+          <tick>6720</tick>
           <Chord>
-            <lid>99</lid>
+            <lid>98</lid>
             <track>1</track>
             <durationType>half</durationType>
             <Note>
-              <lid>100</lid>
+              <lid>99</lid>
               <track>1</track>
               <pitch>72</pitch>
               <tpc>14</tpc>
@@ -951,27 +943,27 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>107</lid>
+            <lid>106</lid>
             <durationType>quarter</durationType>
             </Rest>
           <tick>9600</tick>
           <Chord>
-            <lid>102</lid>
+            <lid>101</lid>
             <track>1</track>
             <durationType>quarter</durationType>
             <Note>
-              <lid>103</lid>
+              <lid>102</lid>
               <track>1</track>
               <pitch>72</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <lid>104</lid>
+            <lid>103</lid>
             <track>1</track>
             <durationType>half</durationType>
             <Note>
-              <lid>105</lid>
+              <lid>104</lid>
               <track>1</track>
               <pitch>72</pitch>
               <tpc>14</tpc>
@@ -988,7 +980,7 @@
               <tpc>15</tpc>
               </Note>
             <Note>
-              <lid>106</lid>
+              <lid>105</lid>
               <track>1</track>
               <pitch>72</pitch>
               <tpc>14</tpc>
@@ -1017,7 +1009,7 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>110</lid>
+            <lid>109</lid>
             <Tuplet>5</Tuplet>
             <durationType>quarter</durationType>
             </Rest>
@@ -1139,7 +1131,7 @@
               <tpc>15</tpc>
               </Note>
             <Note>
-              <lid>108</lid>
+              <lid>107</lid>
               <track>1</track>
               <pitch>72</pitch>
               <tpc>14</tpc>
@@ -1157,19 +1149,19 @@
               <tpc>15</tpc>
               </Note>
             <Note>
-              <lid>109</lid>
+              <lid>108</lid>
               <track>1</track>
               <pitch>72</pitch>
               <tpc>14</tpc>
               </Note>
             </Chord>
           <Chord>
-            <lid>111</lid>
+            <lid>110</lid>
             <track>1</track>
             <Tuplet>7</Tuplet>
             <durationType>quarter</durationType>
             <Note>
-              <lid>112</lid>
+              <lid>111</lid>
               <track>1</track>
               <pitch>72</pitch>
               <tpc>14</tpc>
@@ -1199,7 +1191,7 @@
               <tpc>15</tpc>
               </Note>
             <Note>
-              <lid>113</lid>
+              <lid>112</lid>
               <track>1</track>
               <pitch>72</pitch>
               <tpc>14</tpc>
@@ -1217,13 +1209,13 @@
             <l2>24</l2>
             </Beam>
           <Chord>
-            <lid>114</lid>
+            <lid>113</lid>
             <track>1</track>
             <Tuplet>8</Tuplet>
             <durationType>eighth</durationType>
             <Beam>4</Beam>
             <Note>
-              <lid>115</lid>
+              <lid>114</lid>
               <track>1</track>
               <pitch>72</pitch>
               <tpc>14</tpc>
@@ -1242,7 +1234,7 @@
               <tpc>15</tpc>
               </Note>
             <Note>
-              <lid>116</lid>
+              <lid>115</lid>
               <track>1</track>
               <pitch>72</pitch>
               <tpc>14</tpc>


### PR DESCRIPTION
This PR is a first step to a MuseScore without gaps.
It implements a new attribute for rests called 'trulyInvisible' (if there is a better name for this tell me!).
By deleting a rest, it isn't really deleted, it just gets the attribute trulyInvisible, so the rest will remain in the internal timeline, but the user can't see or interact with it.

While implementing this I look at the following:
- not visible
- not selectable
- import
- copy/paste

This PR will fail on Travis, because the test tst_tools is created with the assumption of gaps, but they should already be filled with rests when importing, so this fails. Why there is a different tick in the copy/paste test I don't know yet, but I think it is also because previously there has been a gap.

The only thing which is different to the behavior of 2.0.3 is the layout. Actually the trulyInvisible rests are included in the layout, so the spaces between two notes with deleted rests between them differ. 
I pushed an example to my Dropbox: https://www.dropbox.com/sh/vem4hlvn21v8gvw/AACUF6dCSYS-nHimCL0svIeqa?dl=0

Any ideas, criticism are desirable!