### PR TITLE
fix #113201: tremolo bar appears above wrong staff

### DIFF
--- a/libmscore/tremolobar.cpp
+++ b/libmscore/tremolobar.cpp
@@ -27,7 +27,7 @@ namespace Ms {
 TremoloBar::TremoloBar(Score* s)
    : Element(s)
       {
-      setFlags(ElementFlag::MOVABLE | ElementFlag::SELECTABLE);
+      setFlags(ElementFlag::MOVABLE | ElementFlag::SELECTABLE | ElementFlag::ON_STAFF);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Reinstates earlier fix as noted in issue report.