### PR TITLE
follow up for fix #69751

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1122,6 +1122,9 @@ QString ChordRest::durationUserName() const
             case 3:
                   dotString += tr("Triple dotted %1").arg(durationType().durationTypeUserName()).trimmed();
                   break;
+            case 4:
+                  dotString += tr("Quadruple dotted %1").arg(durationType().durationTypeUserName()).trimmed();
+                  break;
             default:
                   dotString += durationType().durationTypeUserName();
             }

--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -343,6 +343,8 @@ QString TempoText::duration2userName(const TDuration t)
                   break;
             case 3: dots = tr("Triple dotted %1").arg(t.durationTypeUserName());
                   break;
+            case 4: dots = tr("Quadruple dotted %1").arg(t.durationTypeUserName());
+                  break;
             default:
                   dots = t.durationTypeUserName();
                   break;

--- a/mscore/inspector/inspectorNote.cpp
+++ b/mscore/inspector/inspectorNote.cpp
@@ -110,17 +110,21 @@ InspectorNote::InspectorNote(QWidget* parent)
 
       QHBoxLayout* hbox = new QHBoxLayout;
       dot1 = new QToolButton(this);
-      dot1->setText(tr("Dot1"));
+      dot1->setText(tr("Dot 1"));
       dot1->setEnabled(false);
       hbox->addWidget(dot1);
       dot2 = new QToolButton(this);
-      dot2->setText(tr("Dot2"));
+      dot2->setText(tr("Dot 2"));
       dot2->setEnabled(false);
       hbox->addWidget(dot2);
       dot3 = new QToolButton(this);
-      dot3->setText(tr("Dot3"));
+      dot3->setText(tr("Dot 3"));
       dot3->setEnabled(false);
       hbox->addWidget(dot3);
+      dot4 = new QToolButton(this);
+      dot4->setText(tr("Dot 4"));
+      dot4->setEnabled(false);
+      hbox->addWidget(dot4);
       _layout->addLayout(hbox);
 
       hbox = new QHBoxLayout;
@@ -148,6 +152,7 @@ InspectorNote::InspectorNote(QWidget* parent)
       connect(dot1,     SIGNAL(clicked()),     SLOT(dot1Clicked()));
       connect(dot2,     SIGNAL(clicked()),     SLOT(dot2Clicked()));
       connect(dot3,     SIGNAL(clicked()),     SLOT(dot3Clicked()));
+      connect(dot4,     SIGNAL(clicked()),     SLOT(dot4Clicked()));
       connect(hook,     SIGNAL(clicked()),     SLOT(hookClicked()));
       connect(stem,     SIGNAL(clicked()),     SLOT(stemClicked()));
       connect(beam,     SIGNAL(clicked()),     SLOT(beamClicked()));
@@ -160,12 +165,13 @@ InspectorNote::InspectorNote(QWidget* parent)
 
 void InspectorNote::setElement()
       {
-      Note* note = static_cast<Note*>(inspector->element());
+      Note* note = toNote(inspector->element());
 
       int n = note->dots().size();
       dot1->setEnabled(n > 0);
       dot2->setEnabled(n > 1);
       dot3->setEnabled(n > 2);
+      dot4->setEnabled(n > 3);
       stem->setEnabled(note->chord()->stem());
       hook->setEnabled(note->chord()->hook());
       beam->setEnabled(note->chord()->beam());
@@ -221,6 +227,23 @@ void InspectorNote::dot3Clicked()
             return;
       if (note->dots().size() > 2) {
             NoteDot* dot = note->dot(2);
+            dot->score()->select(dot);
+            inspector->setElement(dot);
+            dot->score()->update();
+            }
+      }
+
+//---------------------------------------------------------
+//   dot4Clicked
+//---------------------------------------------------------
+
+void InspectorNote::dot4Clicked()
+      {
+      Note* note = toNote(inspector->element());
+      if (note == 0)
+            return;
+      if (note->dots().size() > 3) {
+            NoteDot* dot = note->dot(3);
             dot->score()->select(dot);
             inspector->setElement(dot);
             dot->score()->update();

--- a/mscore/inspector/inspectorNote.h
+++ b/mscore/inspector/inspectorNote.h
@@ -36,6 +36,7 @@ class InspectorNote : public InspectorBase {
       QToolButton* dot1;
       QToolButton* dot2;
       QToolButton* dot3;
+      QToolButton* dot4;
       QToolButton* hook;
       QToolButton* stem;
       QToolButton* beam;
@@ -47,6 +48,7 @@ class InspectorNote : public InspectorBase {
       void dot1Clicked();
       void dot2Clicked();
       void dot3Clicked();
+      void dot4Clicked();
       void hookClicked();
       void stemClicked();
       void beamClicked();

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -325,6 +325,7 @@ void MuseScore::updateInputState(Score* score)
             getAction("pad-dot")->setEnabled(true);
             getAction("pad-dotdot")->setEnabled(true);
             getAction("pad-dot3")->setEnabled(true);
+            getAction("pad-dot4")->setEnabled(true);
             }
       switch (is.duration().type()) {
             case TDuration::DurationType::V_128TH:

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1365,9 +1365,9 @@ Shortcut Shortcut::_sc[] = {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "pad-dot4",
-         QT_TRANSLATE_NOOP("action","Quadrupel Augmentation Dot"),
-         QT_TRANSLATE_NOOP("action","Note duration: Quadrupel augmentation dot"),
-         QT_TRANSLATE_NOOP("action","Quadrupel augmentation dot"),
+         QT_TRANSLATE_NOOP("action","Quadruple Augmentation Dot"),
+         QT_TRANSLATE_NOOP("action","Note duration: Quadruple augmentation dot"),
+         QT_TRANSLATE_NOOP("action","Quadruple augmentation dot"),
          Icons::dot4_ICON,
          Qt::WindowShortcut,
          ShortcutFlags::A_CMD | ShortcutFlags::A_CHECKABLE


### PR DESCRIPTION
Extend InspectorNote (to have buttons for all 4 dots), ChordRest::durationUserName() and  TempoText::duration2userName() for the 4th dot, fix typo in shortcuts and fix enable toolbar icon in MuseScore::updateInputState()