### PR TITLE
fix guitar pro tests

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -470,7 +470,7 @@ void Channel::write(Xml& xml, Part* part) const
             xml.tag("mute", mute);
       if (solo)
             xml.tag("solo", solo);
-      if (part && part->masterScore()->exportMidiMapping()) {
+      if (part && part->masterScore()->exportMidiMapping() && part->score() == part->masterScore()) {
             xml.tag("midiPort",    part->masterScore()->midiMapping(channel)->port);
             xml.tag("midiChannel", part->masterScore()->midiMapping(channel)->channel);
             }

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -224,7 +224,7 @@ void Score::write(Xml& xml, bool selectionOnly)
                   xml.curTick  = measureStart->tick();
                   xml.tickDiff = xml.curTick;
                   xml.curTrack = staffIdx * VOICES;
-                  bool writeSystemElements = staffIdx == staffStart;
+                  bool writeSystemElements = (staffIdx == staffStart);
                   for (MeasureBase* m = measureStart; m != measureEnd; m = m->next())
                         writeMeasure(xml, m, staffIdx, writeSystemElements);
                   xml.etag();

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -759,7 +759,8 @@ void GuitarPro::createMeasures()
                         }
                   }
             readVolta(&bars[i].volta, m);
-//TODO-WS            m->setRepeatFlags(bars[i].repeatFlags);
+            m->setRepeatEnd(bars[i].repeatFlags & Repeat::END);
+            m->setRepeatStart(bars[i].repeatFlags & Repeat::START);
             m->setRepeatCount(bars[i].repeats);       // supported in gp5
 
             // reset the volta sequence if we have an opening repeat
@@ -1877,7 +1878,8 @@ void GuitarPro3::read(QFile* fp)
                   }
 
             readVolta(&bars[i].volta, m);
-//TODO-WS            m->setRepeatFlags(bars[i].repeatFlags);
+            m->setRepeatEnd(bars[i].repeatFlags & Repeat::END);
+            m->setRepeatStart(bars[i].repeatFlags & Repeat::START);
             m->setRepeatCount(bars[i].repeats);
 
             // reset the volta sequence if we have an opening repeat
@@ -2363,12 +2365,10 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
       int idx = 0;
 
       for (Measure* m = score->firstMeasure(); m; m = m->nextMeasure(), ++idx) {
-            //const GpBar& bar = gp->bars[idx];
-//TODO            if (bar.barLine != BarLineType::NORMAL)
-//                  m->setEndBarLineType(bar.barLine, false);
+            const GpBar& bar = gp->bars[idx];
+            if (bar.barLine != BarLineType::NORMAL && bar.barLine != BarLineType::END_REPEAT && bar.barLine != BarLineType::START_REPEAT && bar.barLine != BarLineType::END_START_REPEAT)
+                  m->setEndBarLineType(bar.barLine, 0);
             }
-//TODO      if (score->lastMeasure())
-//            score->lastMeasure()->setEndBarLineType(BarLineType::END, false);
 
       //
       // create parts (excerpts)

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -196,8 +196,8 @@ subdirs (
         importmidi
         capella
         biab
-        musicxml                      # FAIL
-#        guitarpro
+        musicxml
+        guitarpro
 #        scripting
 #        testoves                      # FAIL
         )

--- a/mtest/guitarpro/directions.gpx-ref.mscx
+++ b/mtest/guitarpro/directions.gpx-ref.mscx
@@ -881,10 +881,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>19200</tick>
         <Measure number="11">
@@ -911,10 +907,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>23040</tick>
         <Measure number="13">
@@ -941,10 +933,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>26880</tick>
         <Measure number="15">
@@ -971,10 +959,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>30720</tick>
         <Measure number="17">
@@ -1008,10 +992,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>36480</tick>
         <Measure number="20">
@@ -1045,10 +1025,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>42240</tick>
         <Measure number="23">
@@ -1082,10 +1058,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>48000</tick>
         <Measure number="26">
@@ -1112,10 +1084,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>51840</tick>
         <Measure number="28">
@@ -1142,10 +1110,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>55680</tick>
         <Measure number="30">
@@ -1221,10 +1185,6 @@
             <durationType>measure</durationType>
             <duration z="4" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>end</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         </Staff>
       <Staff id="2">
@@ -1366,10 +1326,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>15360</tick>
         <Measure number="9">
@@ -1392,10 +1348,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>19200</tick>
         <Measure number="11">
@@ -1418,10 +1370,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>23040</tick>
         <Measure number="13">
@@ -1444,10 +1392,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>26880</tick>
         <Measure number="15">
@@ -1470,10 +1414,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>30720</tick>
         <Measure number="17">
@@ -1503,10 +1443,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>36480</tick>
         <Measure number="20">
@@ -1536,10 +1472,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>42240</tick>
         <Measure number="23">
@@ -1569,10 +1501,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>48000</tick>
         <Measure number="26">
@@ -1595,10 +1523,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>51840</tick>
         <Measure number="28">
@@ -1621,10 +1545,6 @@
             <durationType>measure</durationType>
             <duration z="8" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>55680</tick>
         <Measure number="30">

--- a/mtest/guitarpro/double-bar.gpx-ref.mscx
+++ b/mtest/guitarpro/double-bar.gpx-ref.mscx
@@ -171,14 +171,15 @@
         <BarLine>
           <subtype>double</subtype>
           <span>1</span>
+          <lid>12</lid>
           </BarLine>
         </Measure>
       <Measure number="2">
         <Chord>
-          <lid>13</lid>
+          <lid>14</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>14</lid>
+            <lid>15</lid>
             <pitch>65</pitch>
             <tpc>13</tpc>
             <fret>6</fret>
@@ -186,10 +187,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>15</lid>
+          <lid>16</lid>
           <durationType>half</durationType>
           <Note>
-            <lid>16</lid>
+            <lid>17</lid>
             <pitch>52</pitch>
             <tpc>18</tpc>
             <fret>2</fret>
@@ -197,10 +198,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>17</lid>
+          <lid>18</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>18</lid>
+            <lid>19</lid>
             <pitch>60</pitch>
             <tpc>14</tpc>
             <fret>15</fret>
@@ -401,14 +402,15 @@
           <BarLine>
             <subtype>double</subtype>
             <span>1</span>
+            <lid>12</lid>
             </BarLine>
           </Measure>
         <Measure number="2">
           <Chord>
-            <lid>13</lid>
+            <lid>14</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>14</lid>
+              <lid>15</lid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <fret>6</fret>
@@ -416,10 +418,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>15</lid>
+            <lid>16</lid>
             <durationType>half</durationType>
             <Note>
-              <lid>16</lid>
+              <lid>17</lid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <fret>2</fret>
@@ -427,10 +429,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>17</lid>
+            <lid>18</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>18</lid>
+              <lid>19</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>
@@ -481,14 +483,15 @@
           <BarLine>
             <subtype>double</subtype>
             <span>1</span>
+            <lid>12</lid>
             </BarLine>
           </Measure>
         <Measure number="2">
           <Chord>
-            <lid>13</lid>
+            <lid>14</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>14</lid>
+              <lid>15</lid>
               <pitch>65</pitch>
               <tpc>13</tpc>
               <fret>6</fret>
@@ -496,10 +499,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>15</lid>
+            <lid>16</lid>
             <durationType>half</durationType>
             <Note>
-              <lid>16</lid>
+              <lid>17</lid>
               <pitch>52</pitch>
               <tpc>18</tpc>
               <fret>2</fret>
@@ -507,10 +510,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>17</lid>
+            <lid>18</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>18</lid>
+              <lid>19</lid>
               <pitch>60</pitch>
               <tpc>14</tpc>
               <fret>15</fret>

--- a/mtest/guitarpro/free-time.gpx-ref.mscx
+++ b/mtest/guitarpro/free-time.gpx-ref.mscx
@@ -177,20 +177,21 @@
         <BarLine>
           <subtype>double</subtype>
           <span>1</span>
+          <lid>15</lid>
           </BarLine>
         </Measure>
       <Measure number="2">
         <TimeSig>
-          <lid>16</lid>
+          <lid>17</lid>
           <sigN>4</sigN>
           <sigD>4</sigD>
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <Chord>
-          <lid>17</lid>
+          <lid>18</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>18</lid>
+            <lid>19</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>12</fret>
@@ -198,10 +199,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>19</lid>
+          <lid>20</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>20</lid>
+            <lid>21</lid>
             <Accidental>
               <subtype>flat</subtype>
               </Accidental>
@@ -212,10 +213,10 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>21</lid>
+          <lid>22</lid>
           <durationType>quarter</durationType>
           <Note>
-            <lid>22</lid>
+            <lid>23</lid>
             <pitch>55</pitch>
             <tpc>15</tpc>
             <fret>5</fret>
@@ -223,7 +224,7 @@
             </Note>
           </Chord>
         <Rest>
-          <lid>23</lid>
+          <lid>24</lid>
           <durationType>quarter</durationType>
           </Rest>
         </Measure>
@@ -426,20 +427,21 @@
           <BarLine>
             <subtype>double</subtype>
             <span>1</span>
+            <lid>15</lid>
             </BarLine>
           </Measure>
         <Measure number="2">
           <TimeSig>
-            <lid>16</lid>
+            <lid>17</lid>
             <sigN>4</sigN>
             <sigD>4</sigD>
             <showCourtesySig>1</showCourtesySig>
             </TimeSig>
           <Chord>
-            <lid>17</lid>
+            <lid>18</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>18</lid>
+              <lid>19</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>12</fret>
@@ -447,10 +449,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>19</lid>
+            <lid>20</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>20</lid>
+              <lid>21</lid>
               <Accidental>
                 <subtype>flat</subtype>
                 </Accidental>
@@ -461,10 +463,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>21</lid>
+            <lid>22</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>22</lid>
+              <lid>23</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -472,7 +474,7 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>23</lid>
+            <lid>24</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>
@@ -509,14 +511,15 @@
           <BarLine>
             <subtype>double</subtype>
             <span>1</span>
+            <lid>15</lid>
             </BarLine>
           </Measure>
         <Measure number="2">
           <Chord>
-            <lid>17</lid>
+            <lid>18</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>18</lid>
+              <lid>19</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>12</fret>
@@ -524,10 +527,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>19</lid>
+            <lid>20</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>20</lid>
+              <lid>21</lid>
               <pitch>63</pitch>
               <tpc>11</tpc>
               <fret>8</fret>
@@ -535,10 +538,10 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>21</lid>
+            <lid>22</lid>
             <durationType>quarter</durationType>
             <Note>
-              <lid>22</lid>
+              <lid>23</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
@@ -546,7 +549,7 @@
               </Note>
             </Chord>
           <Rest>
-            <lid>23</lid>
+            <lid>24</lid>
             <durationType>quarter</durationType>
             </Rest>
           </Measure>

--- a/mtest/guitarpro/fret-diagram.gp4-ref.mscx
+++ b/mtest/guitarpro/fret-diagram.gp4-ref.mscx
@@ -79,7 +79,7 @@
         </VBox>
       <Measure number="1">
         <StaffText>
-          <lid>10</lid>
+          <lid>11</lid>
           <text>Capo. fret 6</text>
           </StaffText>
         <Clef>
@@ -123,11 +123,12 @@
         <BarLine>
           <subtype>double</subtype>
           <span>1</span>
+          <lid>9</lid>
           </BarLine>
         </Measure>
       <Measure number="2">
         <RehearsalMark>
-          <lid>11</lid>
+          <lid>12</lid>
           <text>Intro</text>
           </RehearsalMark>
         <Beam id="1">
@@ -135,39 +136,39 @@
           <l2>-8</l2>
           </Beam>
         <Chord>
-          <lid>12</lid>
+          <lid>13</lid>
           <durationType>eighth</durationType>
           <Beam>1</Beam>
           <Note>
-            <lid>13</lid>
+            <lid>14</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>14</lid>
+            <lid>15</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>15</lid>
+            <lid>16</lid>
             <pitch>55</pitch>
             <tpc>15</tpc>
             <fret>5</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>16</lid>
+            <lid>17</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>17</lid>
+            <lid>18</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -177,28 +178,28 @@
         <Dynamic>
           <subtype>mf</subtype>
           <velocity>80</velocity>
-          <lid>18</lid>
+          <lid>19</lid>
           </Dynamic>
         <Chord>
-          <lid>19</lid>
+          <lid>20</lid>
           <durationType>16th</durationType>
           <Beam>1</Beam>
           <Note>
-            <lid>20</lid>
+            <lid>21</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>21</lid>
+            <lid>22</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>22</lid>
+            <lid>23</lid>
             <Accidental>
               <subtype>sharp</subtype>
               </Accidental>
@@ -208,21 +209,21 @@
             <string>4</string>
             </Note>
           <Note>
-            <lid>23</lid>
+            <lid>24</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>7</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>24</lid>
+            <lid>25</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>25</lid>
+            <lid>26</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -230,46 +231,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>26</lid>
+          <lid>27</lid>
           <durationType>16th</durationType>
           <Beam>1</Beam>
           <Note>
-            <lid>27</lid>
+            <lid>28</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>28</lid>
+            <lid>29</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>29</lid>
+            <lid>30</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
-            </Note>
-          <Note>
-            <lid>30</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
             </Note>
           <Note>
             <lid>31</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
+            </Note>
+          <Note>
+            <lid>32</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>32</lid>
+            <lid>33</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -277,46 +278,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>33</lid>
+          <lid>34</lid>
           <durationType>eighth</durationType>
           <Beam>1</Beam>
           <Note>
-            <lid>34</lid>
+            <lid>35</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>35</lid>
+            <lid>36</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>36</lid>
+            <lid>37</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>37</lid>
+            <lid>38</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>7</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>38</lid>
+            <lid>39</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>39</lid>
+            <lid>40</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -328,46 +329,46 @@
           <l2>-8</l2>
           </Beam>
         <Chord>
-          <lid>40</lid>
+          <lid>41</lid>
           <durationType>eighth</durationType>
           <Beam>2</Beam>
           <Note>
-            <lid>41</lid>
+            <lid>42</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>42</lid>
+            <lid>43</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>43</lid>
+            <lid>44</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
-            </Note>
-          <Note>
-            <lid>44</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
             </Note>
           <Note>
             <lid>45</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
+            </Note>
+          <Note>
+            <lid>46</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>46</lid>
+            <lid>47</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -375,46 +376,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>47</lid>
+          <lid>48</lid>
           <durationType>16th</durationType>
           <Beam>2</Beam>
           <Note>
-            <lid>48</lid>
+            <lid>49</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>49</lid>
+            <lid>50</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>50</lid>
+            <lid>51</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
-            </Note>
-          <Note>
-            <lid>51</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
             </Note>
           <Note>
             <lid>52</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
+            </Note>
+          <Note>
+            <lid>53</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>53</lid>
+            <lid>54</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -422,46 +423,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>54</lid>
+          <lid>55</lid>
           <durationType>16th</durationType>
           <Beam>2</Beam>
           <Note>
-            <lid>55</lid>
+            <lid>56</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>56</lid>
+            <lid>57</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>57</lid>
+            <lid>58</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
-            </Note>
-          <Note>
-            <lid>58</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
             </Note>
           <Note>
             <lid>59</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
+            </Note>
+          <Note>
+            <lid>60</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>60</lid>
+            <lid>61</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -469,46 +470,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>61</lid>
+          <lid>62</lid>
           <durationType>eighth</durationType>
           <Beam>2</Beam>
           <Note>
-            <lid>62</lid>
+            <lid>63</lid>
             <pitch>38</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>63</lid>
+            <lid>64</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>64</lid>
+            <lid>65</lid>
             <pitch>54</pitch>
             <tpc>20</tpc>
             <fret>9</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>65</lid>
+            <lid>66</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>7</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>66</lid>
+            <lid>67</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>67</lid>
+            <lid>68</lid>
             <pitch>62</pitch>
             <tpc>16</tpc>
             <fret>3</fret>
@@ -516,7 +517,7 @@
             </Note>
           </Chord>
         <FretDiagram>
-          <lid>68</lid>
+          <lid>69</lid>
           <strings>7</strings>
           <string no="0">
             <marker>88</marker>
@@ -544,53 +545,53 @@
           <root>17</root>
           <name>sus4</name>
           <base>18</base>
-          <lid>69</lid>
+          <lid>70</lid>
           </Harmony>
         <Beam id="3">
           <l1>-11</l1>
           <l2>-11</l2>
           </Beam>
         <Chord>
-          <lid>70</lid>
+          <lid>71</lid>
           <durationType>eighth</durationType>
           <Beam>3</Beam>
           <Note>
-            <lid>71</lid>
+            <lid>72</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>72</lid>
+            <lid>73</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>73</lid>
+            <lid>74</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
-            </Note>
-          <Note>
-            <lid>74</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
             </Note>
           <Note>
             <lid>75</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
+            </Note>
+          <Note>
+            <lid>76</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>76</lid>
+            <lid>77</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -598,46 +599,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>77</lid>
+          <lid>78</lid>
           <durationType>16th</durationType>
           <Beam>3</Beam>
           <Note>
-            <lid>78</lid>
+            <lid>79</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>79</lid>
+            <lid>80</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>80</lid>
+            <lid>81</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
-            </Note>
-          <Note>
-            <lid>81</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
             </Note>
           <Note>
             <lid>82</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
+            </Note>
+          <Note>
+            <lid>83</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>83</lid>
+            <lid>84</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -645,46 +646,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>84</lid>
+          <lid>85</lid>
           <durationType>16th</durationType>
           <Beam>3</Beam>
           <Note>
-            <lid>85</lid>
+            <lid>86</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>86</lid>
+            <lid>87</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>87</lid>
+            <lid>88</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
-            </Note>
-          <Note>
-            <lid>88</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
             </Note>
           <Note>
             <lid>89</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
+            </Note>
+          <Note>
+            <lid>90</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>90</lid>
+            <lid>91</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -692,46 +693,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>91</lid>
+          <lid>92</lid>
           <durationType>eighth</durationType>
           <Beam>3</Beam>
           <Note>
-            <lid>92</lid>
+            <lid>93</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>93</lid>
+            <lid>94</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>94</lid>
+            <lid>95</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>95</lid>
+            <lid>96</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>7</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>96</lid>
+            <lid>97</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>97</lid>
+            <lid>98</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -743,46 +744,46 @@
           <l2>-11</l2>
           </Beam>
         <Chord>
-          <lid>98</lid>
+          <lid>99</lid>
           <durationType>eighth</durationType>
           <Beam>4</Beam>
           <Note>
-            <lid>99</lid>
+            <lid>100</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>100</lid>
+            <lid>101</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>101</lid>
+            <lid>102</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
-            </Note>
-          <Note>
-            <lid>102</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
             </Note>
           <Note>
             <lid>103</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
+            </Note>
+          <Note>
+            <lid>104</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>104</lid>
+            <lid>105</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -790,46 +791,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>105</lid>
+          <lid>106</lid>
           <durationType>16th</durationType>
           <Beam>4</Beam>
           <Note>
-            <lid>106</lid>
+            <lid>107</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>107</lid>
+            <lid>108</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>108</lid>
+            <lid>109</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
-            </Note>
-          <Note>
-            <lid>109</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
             </Note>
           <Note>
             <lid>110</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
+            </Note>
+          <Note>
+            <lid>111</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>111</lid>
+            <lid>112</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -837,46 +838,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>112</lid>
+          <lid>113</lid>
           <durationType>16th</durationType>
           <Beam>4</Beam>
           <Note>
-            <lid>113</lid>
+            <lid>114</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>114</lid>
+            <lid>115</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>115</lid>
+            <lid>116</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
-            </Note>
-          <Note>
-            <lid>116</lid>
-            <pitch>57</pitch>
-            <tpc>17</tpc>
-            <fret>7</fret>
-            <string>3</string>
             </Note>
           <Note>
             <lid>117</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
+            <fret>7</fret>
+            <string>3</string>
+            </Note>
+          <Note>
+            <lid>118</lid>
+            <pitch>57</pitch>
+            <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>118</lid>
+            <lid>119</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -884,46 +885,46 @@
             </Note>
           </Chord>
         <Chord>
-          <lid>119</lid>
+          <lid>120</lid>
           <durationType>eighth</durationType>
           <Beam>4</Beam>
           <Note>
-            <lid>120</lid>
+            <lid>121</lid>
             <pitch>40</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
             <string>6</string>
             </Note>
           <Note>
-            <lid>121</lid>
+            <lid>122</lid>
             <pitch>45</pitch>
             <tpc>17</tpc>
             <fret>5</fret>
             <string>5</string>
             </Note>
           <Note>
-            <lid>122</lid>
+            <lid>123</lid>
             <pitch>50</pitch>
             <tpc>16</tpc>
             <fret>5</fret>
             <string>4</string>
             </Note>
           <Note>
-            <lid>123</lid>
+            <lid>124</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>7</fret>
             <string>3</string>
             </Note>
           <Note>
-            <lid>124</lid>
+            <lid>125</lid>
             <pitch>57</pitch>
             <tpc>17</tpc>
             <fret>2</fret>
             <string>2</string>
             </Note>
           <Note>
-            <lid>125</lid>
+            <lid>126</lid>
             <pitch>64</pitch>
             <tpc>18</tpc>
             <fret>5</fret>
@@ -1033,7 +1034,7 @@
           </VBox>
         <Measure number="1">
           <StaffText>
-            <lid>10</lid>
+            <lid>11</lid>
             <text>Capo. fret 6</text>
             </StaffText>
           <Clef>
@@ -1077,11 +1078,12 @@
           <BarLine>
             <subtype>double</subtype>
             <span>1</span>
+            <lid>9</lid>
             </BarLine>
           </Measure>
         <Measure number="2">
           <RehearsalMark>
-            <lid>11</lid>
+            <lid>12</lid>
             <text>Intro</text>
             </RehearsalMark>
           <Beam id="5">
@@ -1089,39 +1091,39 @@
             <l2>-8</l2>
             </Beam>
           <Chord>
-            <lid>12</lid>
+            <lid>13</lid>
             <durationType>eighth</durationType>
             <Beam>5</Beam>
             <Note>
-              <lid>13</lid>
+              <lid>14</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>14</lid>
+              <lid>15</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>16</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>16</lid>
+              <lid>17</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>17</lid>
+              <lid>18</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1131,28 +1133,28 @@
           <Dynamic>
             <subtype>mf</subtype>
             <velocity>80</velocity>
-            <lid>18</lid>
+            <lid>19</lid>
             </Dynamic>
           <Chord>
-            <lid>19</lid>
+            <lid>20</lid>
             <durationType>16th</durationType>
             <Beam>5</Beam>
             <Note>
-              <lid>20</lid>
+              <lid>21</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>21</lid>
+              <lid>22</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>22</lid>
+              <lid>23</lid>
               <Accidental>
                 <subtype>sharp</subtype>
                 </Accidental>
@@ -1162,21 +1164,21 @@
               <string>4</string>
               </Note>
             <Note>
-              <lid>24</lid>
+              <lid>25</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>23</lid>
+              <lid>24</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>25</lid>
+              <lid>26</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1184,46 +1186,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>26</lid>
+            <lid>27</lid>
             <durationType>16th</durationType>
             <Beam>5</Beam>
             <Note>
-              <lid>27</lid>
+              <lid>28</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>28</lid>
+              <lid>29</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>29</lid>
+              <lid>30</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>32</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
               </Note>
             <Note>
               <lid>31</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <lid>30</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>32</lid>
+              <lid>33</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1231,46 +1233,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>33</lid>
+            <lid>34</lid>
             <durationType>eighth</durationType>
             <Beam>5</Beam>
             <Note>
-              <lid>34</lid>
+              <lid>35</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>35</lid>
+              <lid>36</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>36</lid>
+              <lid>37</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>38</lid>
+              <lid>39</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>37</lid>
+              <lid>38</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>39</lid>
+              <lid>40</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1282,46 +1284,46 @@
             <l2>-8</l2>
             </Beam>
           <Chord>
-            <lid>40</lid>
+            <lid>41</lid>
             <durationType>eighth</durationType>
             <Beam>6</Beam>
             <Note>
-              <lid>41</lid>
+              <lid>42</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>42</lid>
+              <lid>43</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>43</lid>
+              <lid>44</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>46</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
               </Note>
             <Note>
               <lid>45</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <lid>44</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>46</lid>
+              <lid>47</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1329,46 +1331,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>47</lid>
+            <lid>48</lid>
             <durationType>16th</durationType>
             <Beam>6</Beam>
             <Note>
-              <lid>48</lid>
+              <lid>49</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>49</lid>
+              <lid>50</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>50</lid>
+              <lid>51</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>53</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
               </Note>
             <Note>
               <lid>52</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <lid>51</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>53</lid>
+              <lid>54</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1376,46 +1378,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>54</lid>
+            <lid>55</lid>
             <durationType>16th</durationType>
             <Beam>6</Beam>
             <Note>
-              <lid>55</lid>
+              <lid>56</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>56</lid>
+              <lid>57</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>57</lid>
+              <lid>58</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>60</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
               </Note>
             <Note>
               <lid>59</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <lid>58</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>60</lid>
+              <lid>61</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1423,46 +1425,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>61</lid>
+            <lid>62</lid>
             <durationType>eighth</durationType>
             <Beam>6</Beam>
             <Note>
-              <lid>62</lid>
+              <lid>63</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>63</lid>
+              <lid>64</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>64</lid>
+              <lid>65</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>66</lid>
+              <lid>67</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>65</lid>
+              <lid>66</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>67</lid>
+              <lid>68</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1470,7 +1472,7 @@
               </Note>
             </Chord>
           <FretDiagram>
-            <lid>68</lid>
+            <lid>69</lid>
             <strings>7</strings>
             <string no="0">
               <marker>88</marker>
@@ -1498,53 +1500,53 @@
             <root>17</root>
             <name>sus4</name>
             <base>18</base>
-            <lid>69</lid>
+            <lid>70</lid>
             </Harmony>
           <Beam id="7">
             <l1>-11</l1>
             <l2>-11</l2>
             </Beam>
           <Chord>
-            <lid>70</lid>
+            <lid>71</lid>
             <durationType>eighth</durationType>
             <Beam>7</Beam>
             <Note>
-              <lid>71</lid>
+              <lid>72</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>72</lid>
+              <lid>73</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>73</lid>
+              <lid>74</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>76</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
               </Note>
             <Note>
               <lid>75</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <lid>74</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>76</lid>
+              <lid>77</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1552,46 +1554,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>77</lid>
+            <lid>78</lid>
             <durationType>16th</durationType>
             <Beam>7</Beam>
             <Note>
-              <lid>78</lid>
+              <lid>79</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>79</lid>
+              <lid>80</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>80</lid>
+              <lid>81</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>83</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
               </Note>
             <Note>
               <lid>82</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <lid>81</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>83</lid>
+              <lid>84</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1599,46 +1601,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>84</lid>
+            <lid>85</lid>
             <durationType>16th</durationType>
             <Beam>7</Beam>
             <Note>
-              <lid>85</lid>
+              <lid>86</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>86</lid>
+              <lid>87</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>87</lid>
+              <lid>88</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>90</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
               </Note>
             <Note>
               <lid>89</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <lid>88</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>90</lid>
+              <lid>91</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1646,46 +1648,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>91</lid>
+            <lid>92</lid>
             <durationType>eighth</durationType>
             <Beam>7</Beam>
             <Note>
-              <lid>92</lid>
+              <lid>93</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>93</lid>
+              <lid>94</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>94</lid>
+              <lid>95</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>96</lid>
+              <lid>97</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>95</lid>
+              <lid>96</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>97</lid>
+              <lid>98</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1697,46 +1699,46 @@
             <l2>-11</l2>
             </Beam>
           <Chord>
-            <lid>98</lid>
+            <lid>99</lid>
             <durationType>eighth</durationType>
             <Beam>8</Beam>
             <Note>
-              <lid>99</lid>
+              <lid>100</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>100</lid>
+              <lid>101</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>101</lid>
+              <lid>102</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>104</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
               </Note>
             <Note>
               <lid>103</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <lid>102</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>104</lid>
+              <lid>105</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1744,46 +1746,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>105</lid>
+            <lid>106</lid>
             <durationType>16th</durationType>
             <Beam>8</Beam>
             <Note>
-              <lid>106</lid>
+              <lid>107</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>107</lid>
+              <lid>108</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>108</lid>
+              <lid>109</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>111</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
               </Note>
             <Note>
               <lid>110</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <lid>109</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>111</lid>
+              <lid>112</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1791,46 +1793,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>112</lid>
+            <lid>113</lid>
             <durationType>16th</durationType>
             <Beam>8</Beam>
             <Note>
-              <lid>113</lid>
+              <lid>114</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>114</lid>
+              <lid>115</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>115</lid>
+              <lid>116</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
+              </Note>
+            <Note>
+              <lid>118</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
+              <fret>2</fret>
+              <string>2</string>
               </Note>
             <Note>
               <lid>117</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
-              <fret>2</fret>
-              <string>2</string>
-              </Note>
-            <Note>
-              <lid>116</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>118</lid>
+              <lid>119</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1838,46 +1840,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>119</lid>
+            <lid>120</lid>
             <durationType>eighth</durationType>
             <Beam>8</Beam>
             <Note>
-              <lid>120</lid>
+              <lid>121</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>121</lid>
+              <lid>122</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>122</lid>
+              <lid>123</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>124</lid>
+              <lid>125</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>123</lid>
+              <lid>124</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>125</lid>
+              <lid>126</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -1903,6 +1905,7 @@
           <BarLine>
             <subtype>double</subtype>
             <span>1</span>
+            <lid>9</lid>
             </BarLine>
           </Measure>
         <Measure number="2">
@@ -1911,39 +1914,39 @@
             <l2>52</l2>
             </Beam>
           <Chord>
-            <lid>12</lid>
+            <lid>13</lid>
             <durationType>eighth</durationType>
             <Beam>9</Beam>
             <Note>
-              <lid>13</lid>
+              <lid>14</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>14</lid>
+              <lid>15</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>15</lid>
+              <lid>16</lid>
               <pitch>55</pitch>
               <tpc>15</tpc>
               <fret>5</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>16</lid>
+              <lid>17</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>17</lid>
+              <lid>18</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1951,46 +1954,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>19</lid>
+            <lid>20</lid>
             <durationType>16th</durationType>
             <Beam>9</Beam>
             <Note>
-              <lid>20</lid>
+              <lid>21</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>21</lid>
+              <lid>22</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>22</lid>
+              <lid>23</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>23</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>24</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>25</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>25</lid>
+              <lid>26</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -1998,46 +2001,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>26</lid>
+            <lid>27</lid>
             <durationType>16th</durationType>
             <Beam>9</Beam>
             <Note>
-              <lid>27</lid>
+              <lid>28</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>28</lid>
+              <lid>29</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>29</lid>
+              <lid>30</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>30</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>31</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>32</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>32</lid>
+              <lid>33</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2045,46 +2048,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>33</lid>
+            <lid>34</lid>
             <durationType>eighth</durationType>
             <Beam>9</Beam>
             <Note>
-              <lid>34</lid>
+              <lid>35</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>35</lid>
+              <lid>36</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>36</lid>
+              <lid>37</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>37</lid>
+              <lid>38</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>38</lid>
+              <lid>39</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>39</lid>
+              <lid>40</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2096,46 +2099,46 @@
             <l2>52</l2>
             </Beam>
           <Chord>
-            <lid>40</lid>
+            <lid>41</lid>
             <durationType>eighth</durationType>
             <Beam>10</Beam>
             <Note>
-              <lid>41</lid>
+              <lid>42</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>42</lid>
+              <lid>43</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>43</lid>
+              <lid>44</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>44</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>45</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>46</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>46</lid>
+              <lid>47</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2143,46 +2146,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>47</lid>
+            <lid>48</lid>
             <durationType>16th</durationType>
             <Beam>10</Beam>
             <Note>
-              <lid>48</lid>
+              <lid>49</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>49</lid>
+              <lid>50</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>50</lid>
+              <lid>51</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>51</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>52</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>53</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>53</lid>
+              <lid>54</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2190,46 +2193,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>54</lid>
+            <lid>55</lid>
             <durationType>16th</durationType>
             <Beam>10</Beam>
             <Note>
-              <lid>55</lid>
+              <lid>56</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>56</lid>
+              <lid>57</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>57</lid>
+              <lid>58</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>58</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>59</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>60</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>60</lid>
+              <lid>61</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2237,46 +2240,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>61</lid>
+            <lid>62</lid>
             <durationType>eighth</durationType>
             <Beam>10</Beam>
             <Note>
-              <lid>62</lid>
+              <lid>63</lid>
               <pitch>38</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>63</lid>
+              <lid>64</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>64</lid>
+              <lid>65</lid>
               <pitch>54</pitch>
               <tpc>20</tpc>
               <fret>9</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>65</lid>
+              <lid>66</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>66</lid>
+              <lid>67</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>67</lid>
+              <lid>68</lid>
               <pitch>62</pitch>
               <tpc>16</tpc>
               <fret>3</fret>
@@ -2288,46 +2291,46 @@
             <l2>52</l2>
             </Beam>
           <Chord>
-            <lid>70</lid>
+            <lid>71</lid>
             <durationType>eighth</durationType>
             <Beam>11</Beam>
             <Note>
-              <lid>71</lid>
+              <lid>72</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>72</lid>
+              <lid>73</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>73</lid>
+              <lid>74</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>74</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>75</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>76</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>76</lid>
+              <lid>77</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2335,46 +2338,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>77</lid>
+            <lid>78</lid>
             <durationType>16th</durationType>
             <Beam>11</Beam>
             <Note>
-              <lid>78</lid>
+              <lid>79</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>79</lid>
+              <lid>80</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>80</lid>
+              <lid>81</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>81</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>82</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>83</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>83</lid>
+              <lid>84</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2382,46 +2385,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>84</lid>
+            <lid>85</lid>
             <durationType>16th</durationType>
             <Beam>11</Beam>
             <Note>
-              <lid>85</lid>
+              <lid>86</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>86</lid>
+              <lid>87</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>87</lid>
+              <lid>88</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>88</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>89</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>90</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>90</lid>
+              <lid>91</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2429,46 +2432,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>91</lid>
+            <lid>92</lid>
             <durationType>eighth</durationType>
             <Beam>11</Beam>
             <Note>
-              <lid>92</lid>
+              <lid>93</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>93</lid>
+              <lid>94</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>94</lid>
+              <lid>95</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>95</lid>
+              <lid>96</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>96</lid>
+              <lid>97</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>97</lid>
+              <lid>98</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2480,46 +2483,46 @@
             <l2>52</l2>
             </Beam>
           <Chord>
-            <lid>98</lid>
+            <lid>99</lid>
             <durationType>eighth</durationType>
             <Beam>12</Beam>
             <Note>
-              <lid>99</lid>
+              <lid>100</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>100</lid>
+              <lid>101</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>101</lid>
+              <lid>102</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>102</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>103</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>104</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>104</lid>
+              <lid>105</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2527,46 +2530,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>105</lid>
+            <lid>106</lid>
             <durationType>16th</durationType>
             <Beam>12</Beam>
             <Note>
-              <lid>106</lid>
+              <lid>107</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>107</lid>
+              <lid>108</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>108</lid>
+              <lid>109</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>109</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>110</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>111</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>111</lid>
+              <lid>112</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2574,46 +2577,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>112</lid>
+            <lid>113</lid>
             <durationType>16th</durationType>
             <Beam>12</Beam>
             <Note>
-              <lid>113</lid>
+              <lid>114</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>114</lid>
+              <lid>115</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>115</lid>
+              <lid>116</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
-              </Note>
-            <Note>
-              <lid>116</lid>
-              <pitch>57</pitch>
-              <tpc>17</tpc>
-              <fret>7</fret>
-              <string>3</string>
               </Note>
             <Note>
               <lid>117</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
+              <fret>7</fret>
+              <string>3</string>
+              </Note>
+            <Note>
+              <lid>118</lid>
+              <pitch>57</pitch>
+              <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>118</lid>
+              <lid>119</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
@@ -2621,46 +2624,46 @@
               </Note>
             </Chord>
           <Chord>
-            <lid>119</lid>
+            <lid>120</lid>
             <durationType>eighth</durationType>
             <Beam>12</Beam>
             <Note>
-              <lid>120</lid>
+              <lid>121</lid>
               <pitch>40</pitch>
               <tpc>18</tpc>
               <fret>5</fret>
               <string>6</string>
               </Note>
             <Note>
-              <lid>121</lid>
+              <lid>122</lid>
               <pitch>45</pitch>
               <tpc>17</tpc>
               <fret>5</fret>
               <string>5</string>
               </Note>
             <Note>
-              <lid>122</lid>
+              <lid>123</lid>
               <pitch>50</pitch>
               <tpc>16</tpc>
               <fret>5</fret>
               <string>4</string>
               </Note>
             <Note>
-              <lid>123</lid>
+              <lid>124</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>7</fret>
               <string>3</string>
               </Note>
             <Note>
-              <lid>124</lid>
+              <lid>125</lid>
               <pitch>57</pitch>
               <tpc>17</tpc>
               <fret>2</fret>
               <string>2</string>
               </Note>
             <Note>
-              <lid>125</lid>
+              <lid>126</lid>
               <pitch>64</pitch>
               <tpc>18</tpc>
               <fret>5</fret>

--- a/mtest/guitarpro/keysig.gp4-ref.mscx
+++ b/mtest/guitarpro/keysig.gp4-ref.mscx
@@ -1960,8 +1960,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>

--- a/mtest/guitarpro/keysig.gp5-ref.mscx
+++ b/mtest/guitarpro/keysig.gp5-ref.mscx
@@ -1940,8 +1940,6 @@
             </System>
           <System>
             </System>
-          <System>
-            </System>
           </Page>
         </PageList>
       <Part>

--- a/mtest/guitarpro/repeats.gpx-ref.mscx
+++ b/mtest/guitarpro/repeats.gpx-ref.mscx
@@ -203,10 +203,6 @@
             <string>3</string>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>end-repeat</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       </Staff>
     <Score>
@@ -433,10 +429,6 @@
               <string>3</string>
               </Note>
             </Chord>
-          <BarLine>
-            <subtype>end-repeat</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         </Staff>
       <Staff id="2">
@@ -510,10 +502,6 @@
               <string>3</string>
               </Note>
             </Chord>
-          <BarLine>
-            <subtype>end-repeat</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         </Staff>
       <name>S-Gt</name>

--- a/mtest/guitarpro/timer.gpx-ref.mscx
+++ b/mtest/guitarpro/timer.gpx-ref.mscx
@@ -1485,10 +1485,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>3840</tick>
         <Measure number="3">
@@ -1612,10 +1608,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>13440</tick>
         <Measure number="8">
@@ -1730,10 +1722,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>23040</tick>
         <Measure number="13">
@@ -1848,10 +1836,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>32640</tick>
         <Measure number="18">
@@ -1966,10 +1950,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>42240</tick>
         <Measure number="23">
@@ -2084,10 +2064,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>51840</tick>
         <Measure number="28">
@@ -2202,10 +2178,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>61440</tick>
         <Measure number="33">
@@ -2355,10 +2327,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>72960</tick>
         <Measure number="39">
@@ -2473,10 +2441,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>82560</tick>
         <Measure number="44">
@@ -2591,10 +2555,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>92160</tick>
         <Measure number="49">
@@ -2733,10 +2693,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>3840</tick>
         <Measure number="3">
@@ -2860,10 +2816,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>13440</tick>
         <Measure number="8">
@@ -2978,10 +2930,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>23040</tick>
         <Measure number="13">
@@ -3096,10 +3044,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>32640</tick>
         <Measure number="18">
@@ -3214,10 +3158,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>42240</tick>
         <Measure number="23">
@@ -3332,10 +3272,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>51840</tick>
         <Measure number="28">
@@ -3450,10 +3386,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>61440</tick>
         <Measure number="33">
@@ -3603,10 +3535,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>72960</tick>
         <Measure number="39">
@@ -3721,10 +3649,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>82560</tick>
         <Measure number="44">
@@ -3839,10 +3763,6 @@
             <durationType>measure</durationType>
             <duration z="12" n="4"/>
             </Rest>
-          <BarLine>
-            <subtype>normal</subtype>
-            <span>1</span>
-            </BarLine>
           </Measure>
         <tick>92160</tick>
         <Measure number="49">

--- a/mtest/guitarpro/volta.gp3-ref.mscx
+++ b/mtest/guitarpro/volta.gp3-ref.mscx
@@ -456,10 +456,6 @@
         </Measure>
       <Measure number="7">
         <startRepeat/>
-        <BarLine>
-          <subtype>start-repeat</subtype>
-          <span>1</span>
-          </BarLine>
         <endSpanner id="5"/>
         <Volta id="6">
           <lid>117</lid>
@@ -1275,10 +1271,6 @@
           </Measure>
         <Measure number="7">
           <startRepeat/>
-          <BarLine>
-            <subtype>start-repeat</subtype>
-            <span>1</span>
-            </BarLine>
           <endSpanner id="12"/>
           <Volta id="13">
             <lid>117</lid>
@@ -1895,10 +1887,6 @@
             </Chord>
           </Measure>
         <Measure number="7">
-          <BarLine>
-            <subtype>start-repeat</subtype>
-            <span>1</span>
-            </BarLine>
           <Chord>
             <lid>59</lid>
             <durationType>quarter</durationType>

--- a/mtest/guitarpro/volta.gp4-ref.mscx
+++ b/mtest/guitarpro/volta.gp4-ref.mscx
@@ -473,10 +473,6 @@
         </Measure>
       <Measure number="7">
         <startRepeat/>
-        <BarLine>
-          <subtype>start-repeat</subtype>
-          <span>1</span>
-          </BarLine>
         <endSpanner id="5"/>
         <Volta id="6">
           <lid>94</lid>
@@ -1156,10 +1152,6 @@
           </Measure>
         <Measure number="7">
           <startRepeat/>
-          <BarLine>
-            <subtype>start-repeat</subtype>
-            <span>1</span>
-            </BarLine>
           <endSpanner id="12"/>
           <Volta id="13">
             <lid>94</lid>
@@ -1627,10 +1619,6 @@
             </Chord>
           </Measure>
         <Measure number="7">
-          <BarLine>
-            <subtype>start-repeat</subtype>
-            <span>1</span>
-            </BarLine>
           <Chord>
             <lid>63</lid>
             <durationType>quarter</durationType>


### PR DESCRIPTION
* Barline handling is different. Now MuseScore doesn't store barlines if they are normal, or if they are repeat start/end.
* A change on storing midiPort in Parts, not sure if it was on purpose or not but I reverted to the former implementation.
* Other minor changes due to the more compact layout.