### PR TITLE
fix #106916: Lyrics don't have underscores or hyphens

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3460,15 +3460,13 @@ bool Score::collectPage(LayoutContext& lc)
                         }
                   sp->layout();
                   }
-            }
 
-#if 0
-      for (Spanner* sp : _unmanagedSpanner) {
-            //if (sp->tick() >= etick || sp->tick2() < stick)
-            //     continue;
-            sp->layout();
+            for (Spanner* sp : _unmanagedSpanner) {
+                  if (sp->tick() >= etick || sp->tick2() < stick)
+                        continue;
+                  sp->layout();
+                  }
             }
-#endif
 
       page->rebuildBspTree();
       lc.pageChanged = lc.systemChanged || (lc.pageOldSystem != (page->systems().empty() ? 0 : page->systems().back()));


### PR DESCRIPTION
Add LyricsLine to the spanner list instead to the unmanaged spanner list in Lyrics::layout1().

The section that calls layout() for spanners in the unmanaged spanner list in Score::collectPage() (file layout.cpp:3465) has been commented out, so unmanaged spanners don't show:
<pre>
#if 0
      for (Spanner* sp : _unmanagedSpanner) {
            //if (sp->tick() >= etick || sp->tick2() < stick)
            //     continue;
            sp->layout();
            }
#endif
</pre>

Lyrics::layout1() was the only place where Score::addUnmanagedSpanner() was used.
So I assume, Werner wants to get rid of unmanaged spanners completely.