### PR TITLE
expose class BarLine with property barLineType to QML

### DIFF
--- a/libmscore/barline.h
+++ b/libmscore/barline.h
@@ -57,10 +57,15 @@ struct BarLineTableItem {
 
 //---------------------------------------------------------
 //   @@ BarLine
+//
+//   @P barLineType  enum  (BarLineType.NORMAL, .DOUBLE, .START_REPEAT, .END_REPEAT, .BROKEN, .END, .END_START_REPEAT, .DOTTED)
 //---------------------------------------------------------
 
 class BarLine : public Element {
       Q_OBJECT
+
+      Q_PROPERTY(Ms::MSQE_BarLineType::E barLineType READ qmlBarLineType)
+      Q_ENUMS(Ms::MSQE_BarLineType::E)
 
       BarLineType _barLineType { BarLineType::NORMAL };
       int _span                { 1 };           // number of staves spanned by the barline
@@ -80,7 +85,7 @@ class BarLine : public Element {
       void drawDots(QPainter* painter, qreal x) const;
 
    public:
-      BarLine(Score*);
+      BarLine(Score* s = 0);
       BarLine &operator=(const BarLine&) = delete;
 
       virtual BarLine* clone() const override     { return new BarLine(*this); }
@@ -129,6 +134,8 @@ class BarLine : public Element {
       BarLineType barLineType() const    { return _barLineType;  }
       static BarLineType barLineType(const QString&);
 
+      Ms::MSQE_BarLineType::E qmlBarLineType() const { return static_cast<Ms::MSQE_BarLineType::E>(_barLineType); }
+
       virtual int subtype() const override         { return int(_barLineType); }
       virtual QString subtypeName() const override { return qApp->translate("barline", barLineTypeName().toUtf8()); }
 
@@ -150,5 +157,8 @@ class BarLine : public Element {
       virtual QString accessibleExtraInfo() const override;
       };
 }     // namespace Ms
+
+Q_DECLARE_METATYPE(Ms::MSQE_BarLineType::E);
+
 #endif
 

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -56,6 +56,7 @@
 #include "fraction.h"
 #include "excerpt.h"
 #include "spatium.h"
+#include "barline.h"
 
 namespace Ms {
 
@@ -205,6 +206,7 @@ void MScore::init()
 
       //classed enumerations
       qRegisterMetaType<MSQE_TextStyleType::E>("TextStyleType");
+      qRegisterMetaType<MSQE_BarLineType::E>("BarLineType");
 #endif
 
 //      DPMM = DPI / INCH;       // dots/mm
@@ -415,6 +417,7 @@ QQmlEngine* MScore::qml()
             qmlRegisterType<StemSlash>  ("MuseScore", 1, 0, "StemSlash");
             qmlRegisterType<Beam>       ("MuseScore", 1, 0, "Beam");
             qmlRegisterType<Excerpt>    ("MuseScore", 1, 0, "Excerpt");
+            qmlRegisterType<BarLine>    ("MuseScore", 1, 0, "BarLine");
             qmlRegisterType<FractionWrapper>   ("MuseScore", 1, 1, "Fraction");
             qRegisterMetaType<FractionWrapper*>("FractionWrapper*");
 
@@ -423,6 +426,7 @@ QQmlEngine* MScore::qml()
 
             //classed enumerations
             qmlRegisterUncreatableType<MSQE_TextStyleType>("MuseScore", 1, 0, "TextStyleType", tr("You can't create an enum"));
+            qmlRegisterUncreatableType<MSQE_BarLineType>("MuseScore", 1, 0, "BarLineType", tr("You can't create an enum"));
 
             //-----------virtual classes
             qmlRegisterType<ChordRest>();

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -393,16 +393,16 @@ MS_QML_ENUM(TextStyleType, signed char,\
 //   BarLineType
 //---------------------------------------------------------
 
-enum class BarLineType : int {
-      NORMAL           = 1,
-      DOUBLE           = 2,
-      START_REPEAT     = 4,
-      END_REPEAT       = 8,
-      BROKEN           = 0x10,
-      END              = 0x20,
-      END_START_REPEAT = 0x40,
-      DOTTED           = 0x80
-      };
+MS_QML_ENUM(BarLineType, int,\
+      NORMAL           = 1,\
+      DOUBLE           = 2,\
+      START_REPEAT     = 4,\
+      END_REPEAT       = 8,\
+      BROKEN           = 0x10,\
+      END              = 0x20,\
+      END_START_REPEAT = 0x40,\
+      DOTTED           = 0x80\
+      )
 
 constexpr BarLineType operator| (BarLineType t1, BarLineType t2) {
       return static_cast<BarLineType>(static_cast<int>(t1) | static_cast<int>(t2));


### PR DESCRIPTION
Using the Enumeration exposal technique discussed in https://musescore.org/en/node/99576 following <a href="https://github.com/musescore/MuseScore/pull/2408">jeetee's PR#2408</a> this is to replace my <a href="https://github.com/musescore/MuseScore/pull/1931">PR#1931</a>.