### PR TITLE
Let TDuration::isValid() validate durations

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2095,7 +2095,7 @@ void Score::cmdHalfDuration()
 
       ChordRest* cr = static_cast<ChordRest*>(el);
       TDuration d = _is.duration().shift(1);
-      if (!d.isValid() || (d.type() > TDuration::DurationType::V_64TH))
+      if (!d.isValid())
             return;
       if (cr->type() == Element::Type::CHORD && (static_cast<Chord*>(cr)->noteType() != NoteType::NORMAL)) {
             //
@@ -2125,7 +2125,7 @@ void Score::cmdDoubleDuration()
 
       ChordRest* cr = static_cast<ChordRest*>(el);
       TDuration d = _is.duration().shift(-1);
-      if (!d.isValid() || (d.type() < TDuration::DurationType::V_WHOLE))
+      if (!d.isValid())
             return;
       if (cr->type() == Element::Type::CHORD && (static_cast<Chord*>(cr)->noteType() != NoteType::NORMAL)) {
             //

--- a/libmscore/durationtype.cpp
+++ b/libmscore/durationtype.cpp
@@ -291,7 +291,7 @@ TDuration TDuration::shift(int v) const
       if (_val == DurationType::V_MEASURE || _val == DurationType::V_INVALID || _val == DurationType::V_ZERO)
             return TDuration();
       int newValue = int(_val) + v;
-      if ((newValue < int(DurationType::V_LONG)) || (newValue > int(DurationType::V_256TH)))
+      if ((newValue < int(DurationType::V_LONG)) || (newValue > int(DurationType::V_128TH)))
             return TDuration();
       return TDuration(DurationType(newValue));
       }


### PR DESCRIPTION
`Score::cmdDoubleDuration()` fails to double any wider than a Whole Note. Similarly, `Score::cmdHalfDuration()` fails to shorten beyond 64ths. This seems to be the result of a redundant hard-coding of validating durations, possibly from an earlier version before such durations were supported. I suggest we let `TDuration::isValid()` handle this so that any future modifications to how durations are handled can be made without tracking down redundant validations.

One issue though is that this does expose the current lack of display support for 256ths (no flags are drawn). I thought to edit `TDuration::isValid()` to exclude 256ths, but I'm not sure if that will interfere with things other people are working on. 

PS: This is my first PR on any project, please advise me if I'm doing anything wrong! :)