### PR TITLE
Fix #113811: Dynamics are positioned differently depending on stem direction, and horizontal offset is added on copy and paste

### DIFF
--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -175,10 +175,7 @@ void Dynamic::layout()
                   if (e && e->isChord()) {
                         Chord* c = toChord(e);
                         qreal noteHeadWidth = score()->noteHeadWidth() * c->mag();
-                        if (c->stem() && !c->up())  // stem down
-                              rxpos() += noteHeadWidth * .25;  // center on stem + optical correction
-                        else
-                              rxpos() += noteHeadWidth * .5;   // center on notehead
+                        rxpos() += noteHeadWidth * .5;   // center on notehead
                         }
                   else
                         rxpos() += e->width() * .5;


### PR DESCRIPTION
Notwithstanding the autoplace feature enabled earlier today, this is still a necessary improvement. This replaces PR https://github.com/musescore/MuseScore/pull/2659.
