### PR TITLE
fix #111116: Cannot add courtesy accidentals for a tied note

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1626,8 +1626,10 @@ void Chord::cmdUpdateNotes(AccidentalState* as)
 
       if (staffGroup == StaffGroup::STANDARD) {
             for (Note* note : lnotes) {
-                  if (note->tieBack()) {
-                        if (note->accidental() && note->tpc() == note->tieBack()->startNote()->tpc()) {
+                  if (note->tieBack() && note->tpc() == note->tieBack()->startNote()->tpc()) {
+                        // same pitch
+                        if (note->accidental() && note->accidental()->role() == AccidentalRole::AUTO) {
+                              // not courtesy
                               // TODO: remove accidental only if note is not
                               // on new system
                               score()->undoRemoveElement(note->accidental());

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1449,15 +1449,17 @@ static void changeAccidental2(Note* n, int pitch, int tpc)
             tpc1 = tpc2;
             tpc2 = tpc;
             }
-      score->undoChangePitch(n, pitch, tpc1, tpc2);
+
       if (!st->isTabStaff()) {
             //
             // handle ties
             //
             if (n->tieBack()) {
-                  score->undoRemoveElement(n->tieBack());
-                  if (n->tieFor())
-                        score->undoRemoveElement(n->tieFor());
+                  if (pitch != n->pitch()) {
+                        score->undoRemoveElement(n->tieBack());
+                        if (n->tieFor())
+                              score->undoRemoveElement(n->tieFor());
+                        }
                   }
             else {
                   Note* nn = n;
@@ -1467,6 +1469,7 @@ static void changeAccidental2(Note* n, int pitch, int tpc)
                         }
                   }
             }
+      score->undoChangePitch(n, pitch, tpc1, tpc2);
       }
 
 //---------------------------------------------------------
@@ -1518,7 +1521,7 @@ void Score::changeAccidental(Note* note, AccidentalType accidental)
       // precautionary or microtonal accidental
       // either way, we display it unconditionally
       // both for this note and for any linked notes
-      else if (acc == acc2 || accidental > AccidentalType::NATURAL)
+      else if (acc == acc2 || pitch == note->pitch() || accidental > AccidentalType::NATURAL)
             forceAdd = true;
 
       for (ScoreElement* se : note->linkList()) {


### PR DESCRIPTION
In chord.cpp:
* (for tied notes) remove the accidental if it is not a courtesy accidental

In cmd.cpp:
* remove the ties if the pitches are different
* also check pitches to see if the user is trying to add a courtesy