### PR TITLE
follow up to ad860c0 (PR #2673)

### DIFF
--- a/fluid/fluid_gui.ui
+++ b/fluid/fluid_gui.ui
@@ -50,7 +50,11 @@
         <string/>
        </property>
        <property name="text">
-        <string notr="true" extracomment="gets replaced with arrowUp icon">↑</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../mscore/musescore.qrc">
+         <normaloff>:/data/icons/arrow_up.svg</normaloff>:/data/icons/arrow_up.svg</iconset>
        </property>
       </widget>
      </item>
@@ -69,7 +73,11 @@
         <string>Move Soundfont down</string>
        </property>
        <property name="text">
-        <string notr="true" extracomment="gets replaced with arrowDown icon">↓</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../mscore/musescore.qrc">
+         <normaloff>:/data/icons/arrow_down.svg</normaloff>:/data/icons/arrow_down.svg</iconset>
        </property>
       </widget>
      </item>
@@ -116,6 +124,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../mscore/musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/fluid/fluidgui.cpp
+++ b/fluid/fluidgui.cpp
@@ -85,8 +85,6 @@ FluidGui::FluidGui(Synthesizer* s)
       connect(soundFontDelete, SIGNAL(clicked()), SLOT(soundFontDeleteClicked()));
       connect(soundFonts,      SIGNAL(itemSelectionChanged ()),  SLOT(updateUpDownButtons()));
       updateUpDownButtons();
-      soundFontUp->setIcon(*icons[int(Icons::arrowUp_ICON)]);
-      soundFontDown->setIcon(*icons[int(Icons::arrowDown_ICON)]);
       }
 
 //---------------------------------------------------------

--- a/mscore/aboutbox.ui
+++ b/mscore/aboutbox.ui
@@ -132,6 +132,10 @@
              <property name="text">
               <string notr="true"/>
              </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-copy.svg</normaloff>:/data/icons/edit-copy.svg</iconset>
+             </property>
             </widget>
            </item>
            <item>

--- a/mscore/albummanager.cpp
+++ b/mscore/albummanager.cpp
@@ -38,8 +38,6 @@ AlbumManager::AlbumManager(QWidget* parent)
       {
       setupUi(this);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
-      up->setIcon(*icons[int(Icons::arrowUp_ICON)]);
-      down->setIcon(*icons[int(Icons::arrowDown_ICON)]);
 
       album = 0;
       connect(add,         SIGNAL(clicked()), SLOT(addClicked()));

--- a/mscore/albummanager.ui
+++ b/mscore/albummanager.ui
@@ -85,7 +85,11 @@
         <string>Move current score up in list</string>
        </property>
        <property name="text">
-        <string notr="true" extracomment="gets replaced with arrowUp Icon">↑</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="musescore.qrc">
+         <normaloff>:/data/icons/arrow_up.svg</normaloff>:/data/icons/arrow_up.svg</iconset>
        </property>
       </widget>
      </item>
@@ -114,7 +118,11 @@
         <string>Move current score down in list</string>
        </property>
        <property name="text">
-        <string notr="true" extracomment="gets replaced with arrowDown Icon">↓</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="musescore.qrc">
+         <normaloff>:/data/icons/arrow_down.svg</normaloff>:/data/icons/arrow_down.svg</iconset>
        </property>
       </widget>
      </item>
@@ -248,7 +256,9 @@
   <tabstop>checkBoxAddPageBreak</tabstop>
   <tabstop>createScore</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="musescore.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/mscore/debugger/measure.ui
+++ b/mscore/debugger/measure.ui
@@ -31,14 +31,22 @@
            <string notr="true"/>
           </property>
           <property name="text">
-           <string notr="true">previous</string>
+           <string notr="true"/>
+          </property>
+          <property name="icon">
+           <iconset resource="../musescore.qrc">
+            <normaloff>:/data/icons/go-previous.svg</normaloff>:/data/icons/go-previous.svg</iconset>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QPushButton" name="nextButton">
           <property name="text">
-           <string notr="true">next</string>
+           <string notr="true"/>
+          </property>
+          <property name="icon">
+           <iconset resource="../musescore.qrc">
+            <normaloff>:/data/icons/go-next.svg</normaloff>:/data/icons/go-next.svg</iconset>
           </property>
          </widget>
         </item>
@@ -510,6 +518,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -55,12 +55,6 @@ EditStaff::EditStaff(Staff* s, int /*tick*/, QWidget* parent)
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       setModal(true);
 
-      const QIcon &editIcon = *icons[int(Icons::edit_ICON)];
-      minPitchASelect->setIcon(editIcon);
-      maxPitchASelect->setIcon(editIcon);
-      minPitchPSelect->setIcon(editIcon);
-      maxPitchPSelect->setIcon(editIcon);
-
       Part* part        = orgStaff->part();
       instrument        = *part->instrument(/*tick*/);
       Score* score      = part->score();

--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -188,7 +188,11 @@
         <item>
          <widget class="QToolButton" name="minPitchASelect">
           <property name="text">
-           <string notr="true">...</string>
+           <string notr="true"/>
+          </property>
+          <property name="icon">
+           <iconset resource="musescore.qrc">
+            <normaloff>:/data/icons/edit.svg</normaloff>:/data/icons/edit.svg</iconset>
           </property>
          </widget>
         </item>
@@ -209,7 +213,11 @@
         <item>
          <widget class="QToolButton" name="maxPitchASelect">
           <property name="text">
-           <string notr="true">...</string>
+           <string notr="true"/>
+          </property>
+          <property name="icon">
+           <iconset resource="musescore.qrc">
+            <normaloff>:/data/icons/edit.svg</normaloff>:/data/icons/edit.svg</iconset>
           </property>
          </widget>
         </item>
@@ -249,7 +257,11 @@
         <item>
          <widget class="QToolButton" name="minPitchPSelect">
           <property name="text">
-           <string notr="true">...</string>
+           <string notr="true"/>
+          </property>
+          <property name="icon">
+           <iconset resource="musescore.qrc">
+            <normaloff>:/data/icons/edit.svg</normaloff>:/data/icons/edit.svg</iconset>
           </property>
          </widget>
         </item>
@@ -270,7 +282,11 @@
         <item>
          <widget class="QToolButton" name="maxPitchPSelect">
           <property name="text">
-           <string notr="true">...</string>
+           <string notr="true"/>
+          </property>
+          <property name="icon">
+           <iconset resource="musescore.qrc">
+            <normaloff>:/data/icons/edit.svg</normaloff>:/data/icons/edit.svg</iconset>
           </property>
          </widget>
         </item>
@@ -920,7 +936,9 @@
   <tabstop>numOfStrings</tabstop>
   <tabstop>editStringData</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="musescore.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -245,9 +245,6 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       };
 
 
-      const QIcon &editIcon = *icons[int(Icons::edit_ICON)];
-      chordDescriptionFileButton->setIcon(editIcon);
-
       pageList->setCurrentRow(0);
 
       articulationTable->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -389,8 +386,6 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
                   Direction::fillComboBox(cb);
                   }
             if (sw.reset) {
-                  sw.reset->setIcon(*icons[int(Icons::reset_ICON)]);
-                  sw.reset->setToolTip(tr("reset to default"));
                   connect(sw.reset, SIGNAL(clicked()), mapper, SLOT(map()));
                   mapper->setMapping(sw.reset, int(sw.idx));
                   }

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -2348,8 +2348,11 @@
             </item>
             <item row="0" column="2">
              <widget class="QToolButton" name="resetMinMeasureWidth">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2359,8 +2362,11 @@
             </item>
             <item row="8" column="2">
              <widget class="QToolButton" name="resetKeysigLeftMargin">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2370,8 +2376,11 @@
             </item>
             <item row="11" column="2">
              <widget class="QToolButton" name="resetClefBarlineDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2381,8 +2390,11 @@
             </item>
             <item row="2" column="2">
              <widget class="QToolButton" name="resetBarNoteDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2392,8 +2404,11 @@
             </item>
             <item row="3" column="2">
              <widget class="QToolButton" name="resetBarGraceDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2403,8 +2418,11 @@
             </item>
             <item row="4" column="2">
              <widget class="QToolButton" name="resetBarAccidentalDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2414,8 +2432,11 @@
             </item>
             <item row="5" column="2">
              <widget class="QToolButton" name="resetNoteBarDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2425,8 +2446,11 @@
             </item>
             <item row="6" column="2">
              <widget class="QToolButton" name="resetMinNoteDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2436,8 +2460,11 @@
             </item>
             <item row="7" column="2">
              <widget class="QToolButton" name="resetClefLeftMargin">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2447,8 +2474,11 @@
             </item>
             <item row="9" column="2">
              <widget class="QToolButton" name="resetTimesigLeftMargin">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2458,8 +2488,11 @@
             </item>
             <item row="10" column="2">
              <widget class="QToolButton" name="resetClefKeyRightMargin">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2469,8 +2502,11 @@
             </item>
             <item row="18" column="2">
              <widget class="QToolButton" name="resetMultiMeasureRestMargin">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2480,8 +2516,11 @@
             </item>
             <item row="19" column="2">
              <widget class="QToolButton" name="resetStaffLineWidth">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2541,8 +2580,11 @@
             </item>
             <item row="12" column="2">
              <widget class="QToolButton" name="resetClefKeyDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2552,8 +2594,11 @@
             </item>
             <item row="13" column="2">
              <widget class="QToolButton" name="resetClefTimesigDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2563,8 +2608,11 @@
             </item>
             <item row="14" column="2">
              <widget class="QToolButton" name="resetKeyTimesigDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2584,8 +2632,11 @@
             </item>
             <item row="15" column="2">
              <widget class="QToolButton" name="resetKeyBarlineDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2625,8 +2676,11 @@
             </item>
             <item row="16" column="2">
              <widget class="QToolButton" name="resetSystemHeaderDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2655,8 +2709,11 @@
             </item>
             <item row="0" column="6">
              <widget class="QToolButton" name="resetMeasureSpacing">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2727,8 +2784,11 @@
             </item>
             <item row="16" column="6">
              <widget class="QToolButton" name="resetSystemHeaderTimeSigDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -2779,8 +2839,11 @@
             </item>
             <item row="9" column="6">
              <widget class="QToolButton" name="resetTimesigBarlineDistance">
+              <property name="toolTip">
+               <string>Reset to default</string>
+              </property>
               <property name="text">
-               <string>...</string>
+               <string notr="true"/>
               </property>
               <property name="icon">
                <iconset resource="musescore.qrc">
@@ -4177,13 +4240,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Default vertical position' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4196,13 +4263,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Line thickness' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4215,13 +4286,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Height' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4234,13 +4309,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Continue height' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4390,13 +4469,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Default vertical position' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4409,13 +4492,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Hook height' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4428,13 +4515,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Line thickness' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4447,13 +4538,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Line style' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4484,13 +4579,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Default vertical position' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4612,13 +4711,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Hook height' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4631,13 +4734,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Line thickness' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4650,13 +4757,17 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="accessibleName">
              <string>Reset 'Line style' value</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4689,10 +4800,14 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>Reset value</string>
+             <string>Reset to default</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4819,8 +4934,15 @@
           </item>
           <item row="3" column="3">
            <widget class="QToolButton" name="resetPedalLineStyle">
+            <property name="toolTip">
+             <string>Reset to default</string>
+            </property>
             <property name="text">
-             <string>...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
             </property>
            </widget>
           </item>
@@ -4977,7 +5099,11 @@
              <item row="0" column="2">
               <widget class="QToolButton" name="chordDescriptionFileButton">
                <property name="text">
-                <string notr="true">...</string>
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
                </property>
               </widget>
              </item>
@@ -5021,7 +5147,7 @@
                <item>
                 <widget class="QRadioButton" name="useStandardNoteNames">
                  <property name="toolTip">
-                  <string>A, B♭, B, C, C♯, ...</string>
+                  <string notr="true">A, B♭, B, C, C♯, ...</string>
                  </property>
                  <property name="text">
                   <string>Standard</string>
@@ -5031,7 +5157,7 @@
                <item>
                 <widget class="QRadioButton" name="useGermanNoteNames">
                  <property name="toolTip">
-                  <string>A, B♭, H, C, C♯, ...</string>
+                  <string notr="true">A, B♭, H, C, C♯, ...</string>
                  </property>
                  <property name="text">
                   <string>German</string>
@@ -5041,7 +5167,7 @@
                <item>
                 <widget class="QRadioButton" name="useFullGermanNoteNames">
                  <property name="toolTip">
-                  <string>A, B, H, C, Cis</string>
+                  <string notr="true">A, B, H, C, Cis</string>
                  </property>
                  <property name="text">
                   <string>Full German</string>
@@ -5051,7 +5177,7 @@
                <item>
                 <widget class="QRadioButton" name="useSolfeggioNoteNames">
                  <property name="toolTip">
-                  <string>Do, Do♯, Re♭, Re, ...</string>
+                  <string notr="true">Do, Do♯, Re♭, Re, ...</string>
                  </property>
                  <property name="text">
                   <string>Solfeggio</string>
@@ -5061,7 +5187,7 @@
                <item>
                 <widget class="QRadioButton" name="useFrenchNoteNames">
                  <property name="toolTip">
-                  <string>Do, Do♯, Ré♭, Ré, ...</string>
+                  <string notr="true">Do, Do♯, Ré♭, Ré, ...</string>
                  </property>
                  <property name="text">
                   <string>French</string>

--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -76,9 +76,6 @@ ExcerptsDialog::ExcerptsDialog(MasterScore* s, QWidget* parent)
             partList->addItem(item);
             }
 
-      moveUpButton->setIcon(*icons[int(Icons::arrowUp_ICON)]);
-      moveDownButton->setIcon(*icons[int(Icons::arrowDown_ICON)]);
-
       connect(newButton, SIGNAL(clicked()), SLOT(newClicked()));
       connect(newAllButton, SIGNAL(clicked()), SLOT(newAllClicked()));
       connect(deleteButton, SIGNAL(clicked()), SLOT(deleteClicked()));

--- a/mscore/excerptsdialog.ui
+++ b/mscore/excerptsdialog.ui
@@ -52,7 +52,11 @@
              <string>Move part up</string>
             </property>
             <property name="text">
-             <string notr="true" extracomment="gets replaced with arrowUp icon">↑</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/arrow_up.svg</normaloff>:/data/icons/arrow_up.svg</iconset>
             </property>
            </widget>
           </item>
@@ -71,7 +75,11 @@
              <string>Move part down</string>
             </property>
             <property name="text">
-             <string notr="true" extracomment="gets replaced with arrowDown icon">↓</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/arrow_down.svg</normaloff>:/data/icons/arrow_down.svg</iconset>
             </property>
            </widget>
           </item>
@@ -168,7 +176,9 @@
   <tabstop>newAllButton</tabstop>
   <tabstop>newButton</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="musescore.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/mscore/harmonyedit.cpp
+++ b/mscore/harmonyedit.cpp
@@ -46,7 +46,6 @@ ChordStyleEditor::ChordStyleEditor(QWidget* parent)
       setWindowTitle(tr("MuseScore: Chord Symbols Style Editor"));
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-      fileButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
       chordList = 0;
       score = 0;
 

--- a/mscore/harmonyedit.ui
+++ b/mscore/harmonyedit.ui
@@ -100,7 +100,11 @@
      <item>
       <widget class="QPushButton" name="fileButton">
        <property name="text">
-        <string>Load...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="musescore.qrc">
+         <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
        </property>
       </widget>
      </item>
@@ -136,7 +140,9 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="musescore.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/mscore/icons.h
+++ b/mscore/icons.h
@@ -53,7 +53,7 @@ enum class Icons : signed char { Invalid_ICON = -1,
       timesig_allabreve_ICON, timesig_common_ICON, timesig_prolatio01_ICON, timesig_prolatio02_ICON,
       timesig_prolatio03_ICON, timesig_prolatio04_ICON, timesig_prolatio05_ICON, timesig_prolatio07_ICON,
       timesig_prolatio08_ICON, timesig_prolatio10_ICON, timesig_prolatio11_ICON, edit_ICON, reset_ICON, close_ICON,
-      arrowUp_ICON, arrowDown_ICON,
+      //arrowUp_ICON, arrowDown_ICON,
       voice1_ICON, voice2_ICON, voice3_ICON, voice4_ICON,
       ICONS
       };

--- a/mscore/importmidi/importmidi_panel.cpp
+++ b/mscore/importmidi/importmidi_panel.cpp
@@ -121,9 +121,6 @@ bool ImportMidiPanel::isMidiFile(const QString &fileName)
 
 void ImportMidiPanel::setupUi()
       {
-      _ui->pushButtonUp->setIcon(*icons[int(Icons::arrowUp_ICON)]);
-      _ui->pushButtonDown->setIcon(*icons[int(Icons::arrowDown_ICON)]);
-
       connect(_updateUiTimer, SIGNAL(timeout()), this, SLOT(updateUi()));
       connect(_ui->pushButtonApply, SIGNAL(clicked()), SLOT(applyMidiImport()));
       connect(_ui->pushButtonCancel, SIGNAL(clicked()), SLOT(cancelChanges()));

--- a/mscore/importmidi/importmidi_panel.ui
+++ b/mscore/importmidi/importmidi_panel.ui
@@ -79,7 +79,7 @@
            <string>Close MIDI import panel</string>
           </property>
           <property name="text">
-           <string notr="true">...</string>
+           <string notr="true"/>
           </property>
           <property name="icon">
            <iconset resource="../musescore.qrc">
@@ -121,7 +121,7 @@
            <string>Move track up</string>
           </property>
           <property name="text">
-           <string/>
+           <string notr="true"/>
           </property>
           <property name="icon">
            <iconset resource="../musescore.qrc">
@@ -144,7 +144,7 @@
            <string>Move track down</string>
           </property>
           <property name="text">
-           <string/>
+           <string notr="true"/>
           </property>
           <property name="icon">
            <iconset resource="../musescore.qrc">

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -237,9 +237,6 @@ void InspectorBase::setElement()
                         val = QVariant(f.denominator());
                   }
 
-	      if (ii.r)
-		      ii.r->setIcon(*icons[int(Icons::reset_ICON)]);
-
             ii.w->blockSignals(true);
             setValue(ii, val);
             ii.w->blockSignals(false);

--- a/mscore/inspector/inspector_accidental.ui
+++ b/mscore/inspector/inspector_accidental.ui
@@ -87,7 +87,11 @@
         <string>Reset 'Small' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -135,7 +139,11 @@
         <string>Reset 'Has bracket' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -168,6 +176,8 @@
   <tabstop>hasBracket</tabstop>
   <tabstop>resetHasBracket</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_ambitus.ui
+++ b/mscore/inspector/inspector_ambitus.ui
@@ -211,7 +211,12 @@
         <string>Reset 'Line thickness' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normalon>:/data/icons/edit-reset.svg</normalon>
+        </iconset>
        </property>
       </widget>
      </item>
@@ -485,7 +490,11 @@
         <string>Reset 'Has line' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -797,7 +806,11 @@
         <string>Reset 'Head group' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -829,7 +842,11 @@
         <string>Reset 'Direction' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -897,7 +914,11 @@
         <string>Reset 'Head type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -965,6 +986,8 @@
   <tabstop>bottomTpc</tabstop>
   <tabstop>bottomOctave</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_arpeggio.ui
+++ b/mscore/inspector/inspector_arpeggio.ui
@@ -103,7 +103,11 @@
         <string>Reset 'Play' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -111,6 +115,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_articulation.ui
+++ b/mscore/inspector/inspector_articulation.ui
@@ -176,7 +176,11 @@
         <string>Reset 'Direction' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -218,7 +222,11 @@
         <string>Reset 'Anchor' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -231,7 +239,11 @@
         <string>Reset 'Time stretch' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -280,7 +292,11 @@
         <string>Reset 'Ornament style' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -303,7 +319,11 @@
         <string>Reset 'Play' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -323,6 +343,8 @@
   <tabstop>playArticulation</tabstop>
   <tabstop>resetPlayArticulation</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_barline.ui
+++ b/mscore/inspector/inspector_barline.ui
@@ -110,7 +110,11 @@
         <string>Reset 'Type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -179,7 +183,11 @@
         <string>Reset 'Span' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -205,7 +213,11 @@
         <string>Reset 'Span from' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -218,7 +230,11 @@
         <string>Reset 'Span to' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -289,6 +305,8 @@
   <tabstop>spanTo</tabstop>
   <tabstop>resetSpanTo</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_beam.ui
+++ b/mscore/inspector/inspector_beam.ui
@@ -198,7 +198,11 @@
         <string>Reset 'Direction' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -264,7 +268,11 @@
         <string>Reset 'Grow right' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -283,7 +291,11 @@
         <string>Reset 'Grow left' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -321,7 +333,11 @@
         <string>Reset 'User position' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -353,7 +369,11 @@
         <string>Reset 'Local relayout' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -398,7 +418,11 @@
         <string>Reset 'Horizontal' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -422,6 +446,8 @@
   <tabstop>y1</tabstop>
   <tabstop>y2</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_bend.ui
+++ b/mscore/inspector/inspector_bend.ui
@@ -115,7 +115,11 @@
         <string>Reset 'Play' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -146,6 +150,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_caesura.ui
+++ b/mscore/inspector/inspector_caesura.ui
@@ -122,7 +122,11 @@
         <string>Reset 'Pause' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -134,6 +138,8 @@
   <tabstop>pause</tabstop>
   <tabstop>resetPause</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_chord.ui
+++ b/mscore/inspector/inspector_chord.ui
@@ -84,7 +84,11 @@
         <string>Reset 'Vertical offset' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -138,7 +142,11 @@
         <string>Reset 'Horizontal offset' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -189,7 +197,11 @@
         <string>Reset 'Stem direction' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -240,7 +252,11 @@
         <string>Reset 'Small' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -253,7 +269,11 @@
         <string>Reset 'Stemless' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -311,6 +331,8 @@
   <tabstop>stemDirection</tabstop>
   <tabstop>resetStemDirection</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_clef.ui
+++ b/mscore/inspector/inspector_clef.ui
@@ -106,7 +106,11 @@
         <string>Reset 'Show courtesy' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -114,6 +118,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_dynamic.ui
+++ b/mscore/inspector/inspector_dynamic.ui
@@ -91,7 +91,11 @@
         <string>Reset 'Velocity' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -143,7 +147,11 @@
         <string>Reset 'Dynamic range' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -156,7 +164,11 @@
         <string>Reset 'Placement' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -191,6 +203,8 @@
   <tabstop>velocity</tabstop>
   <tabstop>resetVelocity</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_element.ui
+++ b/mscore/inspector/inspector_element.ui
@@ -159,7 +159,11 @@
         <string>Reset 'Horizontal offset' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -203,7 +207,11 @@
         <string>Reset 'Vertical offset' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -241,14 +249,22 @@
         <string>Reset 'Color' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
      <item row="3" column="2">
       <widget class="QToolButton" name="hRaster">
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/raster-horizontal.svg</normaloff>:/data/icons/raster-horizontal.svg</iconset>
        </property>
        <property name="checkable">
         <bool>true</bool>
@@ -261,7 +277,11 @@
         <string/>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/raster-vertical.svg</normaloff>:/data/icons/raster-vertical.svg</iconset>
        </property>
        <property name="checkable">
         <bool>true</bool>
@@ -330,7 +350,11 @@
         <string>Reset 'Visible' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -356,7 +380,11 @@
         <string>Reset 'Automatic placement' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -383,6 +411,8 @@
   <tabstop>vRaster</tabstop>
   <tabstop>resetY</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_fret.ui
+++ b/mscore/inspector/inspector_fret.ui
@@ -103,7 +103,11 @@
         <string>Reset 'Size in staff space units' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -134,6 +138,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -107,7 +107,11 @@
         <string>Reset 'Text' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -120,7 +124,11 @@
         <string>Reset 'Type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -140,7 +148,11 @@
         <string>Reset 'Style' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -204,7 +216,11 @@
         <string>Reset 'Show text' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -240,7 +256,11 @@
         <string>Reset 'Play' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -256,6 +276,8 @@
   <tabstop>showText</tabstop>
   <tabstop>resetShowText</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_hairpin.ui
+++ b/mscore/inspector/inspector_hairpin.ui
@@ -87,7 +87,11 @@
         <string>Reset 'Type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -124,7 +128,11 @@
         <string>Reset 'Height' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -168,7 +176,11 @@
         <string>Reset 'Velocity change' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -201,7 +213,11 @@
         <string>Reset 'Continue height' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -214,7 +230,11 @@
         <string>Reset 'Dynamic range' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -247,7 +267,11 @@
         <string>Reset 'Circled tip' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -291,8 +315,15 @@
        <property name="toolTip">
         <string>Reset value</string>
        </property>
+       <property name="accessibleName">
+        <string>Reset 'Text line' vslue</string>
+       </property>
        <property name="text">
-        <string>...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -316,6 +347,8 @@
   <tabstop>hairpinContHeight</tabstop>
   <tabstop>resetHairpinContHeight</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_hbox.ui
+++ b/mscore/inspector/inspector_hbox.ui
@@ -73,9 +73,6 @@
       <number>3</number>
      </property>
      <property name="verticalSpacing">
-      <number>0</number>
-     </property>
-     <property name="verticalSpacing">
       <number>6</number>
      </property>
      <item row="1" column="1">
@@ -180,7 +177,11 @@
         <string>Reset 'Left gap' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -193,7 +194,11 @@
         <string>Reset 'Right gap' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -208,6 +213,8 @@
   <tabstop>resetRightGap</tabstop>
   <tabstop>width</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_image.ui
+++ b/mscore/inspector/inspector_image.ui
@@ -104,7 +104,11 @@
         <string>Reset 'Scale to frame size' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -240,7 +244,11 @@
         <string>Reset 'Lock aspect ratio' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -253,7 +261,11 @@
         <string>Reset 'Size in staff space units' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -305,6 +317,8 @@
   <tabstop>sizeIsSpatium</tabstop>
   <tabstop>resetSizeIsSpatium</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_jump.ui
+++ b/mscore/inspector/inspector_jump.ui
@@ -132,7 +132,11 @@
         <string>Reset 'Jump to' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -145,7 +149,11 @@
         <string>Reset 'Play until' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -158,7 +166,11 @@
         <string>Reset 'Continue at' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -174,6 +186,8 @@
   <tabstop>continueAt</tabstop>
   <tabstop>resetContinueAt</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_keysig.ui
+++ b/mscore/inspector/inspector_keysig.ui
@@ -97,7 +97,11 @@
         <string>Reset 'Show courtesy' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -109,6 +113,8 @@
   <tabstop>showCourtesy</tabstop>
   <tabstop>resetShowCourtesy</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_line.ui
+++ b/mscore/inspector/inspector_line.ui
@@ -84,7 +84,11 @@
         <string>Reset 'Line color' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -124,7 +128,11 @@
         <string>Reset 'Allow diagonal' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -203,7 +211,11 @@
         <string>Reset 'Line thickness' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -216,7 +228,11 @@
         <string>Reset 'Line style' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -235,7 +251,11 @@
         <string>Reset 'Line visible' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -270,6 +290,8 @@
   <tabstop>lineStyle</tabstop>
   <tabstop>resetLineStyle</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_marker.ui
+++ b/mscore/inspector/inspector_marker.ui
@@ -84,7 +84,11 @@
         <string>Reset 'Marker type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -111,7 +115,11 @@
         <string>Reset 'Label' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -179,6 +187,8 @@
   <tabstop>jumpLabel</tabstop>
   <tabstop>resetJumpLabel</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_note.ui
+++ b/mscore/inspector/inspector_note.ui
@@ -93,7 +93,11 @@
         <string>Reset 'Tuning' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -138,7 +142,11 @@
         <string>Reset 'Velocity' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -401,7 +409,11 @@
         <string>Reset 'Velocity type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -436,7 +448,11 @@
         <string>Reset 'Dot position' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -462,7 +478,11 @@
         <string>Reset 'Play' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -481,7 +501,11 @@
         <string>Reset 'Small' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -545,7 +569,11 @@
         <string>Reset 'Mirror head' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -580,7 +608,11 @@
         <string>Reset 'Head group' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -599,7 +631,11 @@
         <string>Reset 'Head type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -612,7 +648,11 @@
         <string>Reset 'Fix to line' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -625,7 +665,11 @@
         <string>Reset 'Line' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -653,6 +697,8 @@
   <tabstop>velocity</tabstop>
   <tabstop>resetVelocity</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_ottava.ui
+++ b/mscore/inspector/inspector_ottava.ui
@@ -91,7 +91,11 @@
         <string>Reset 'Type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -165,7 +169,11 @@
         <string>Reset 'Placement' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -191,7 +199,11 @@
         <string>Reset 'Numbers only' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -207,6 +219,8 @@
   <tabstop>numbersOnly</tabstop>
   <tabstop>resetNumbersOnly</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_rest.ui
+++ b/mscore/inspector/inspector_rest.ui
@@ -84,7 +84,11 @@
         <string>Reset 'Small' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -109,6 +113,8 @@
   <tabstop>small</tabstop>
   <tabstop>resetSmall</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_segment.ui
+++ b/mscore/inspector/inspector_segment.ui
@@ -122,7 +122,11 @@
         <string>Reset 'Leading space' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>

--- a/mscore/inspector/inspector_slur.ui
+++ b/mscore/inspector/inspector_slur.ui
@@ -90,7 +90,11 @@
         <string>Reset 'Line type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -150,7 +154,11 @@
         <string>Reset 'Direction' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -205,6 +213,8 @@
   <tabstop>slurDirection</tabstop>
   <tabstop>resetSlurDirection</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_spacer.ui
+++ b/mscore/inspector/inspector_spacer.ui
@@ -119,7 +119,11 @@
         <string>Reset 'Height' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -127,6 +131,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_tbox.ui
+++ b/mscore/inspector/inspector_tbox.ui
@@ -104,7 +104,11 @@
         <string>Reset 'Top gap' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -117,7 +121,11 @@
         <string>Reset 'Bottom gap' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -159,7 +167,11 @@
         <string>Reset 'Right margin' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -201,7 +213,11 @@
         <string>Reset 'Bottom margin' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -243,7 +259,11 @@
         <string>Reset 'Top margin' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -256,7 +276,11 @@
         <string>Reset 'Left margin' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -367,6 +391,8 @@
   <tabstop>bottomMargin</tabstop>
   <tabstop>resetBottomMargin</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_tempotext.ui
+++ b/mscore/inspector/inspector_tempotext.ui
@@ -87,7 +87,11 @@
         <string>Reset 'Follow text' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -107,7 +111,11 @@
         <string>Reset 'Tempo' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -156,6 +164,8 @@
   <tabstop>tempo</tabstop>
   <tabstop>resetTempo</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_text.ui
+++ b/mscore/inspector/inspector_text.ui
@@ -104,7 +104,11 @@
         <string>Reset 'Style' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -119,6 +123,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_timesig.ui
+++ b/mscore/inspector/inspector_timesig.ui
@@ -63,9 +63,6 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
      <property name="leftMargin">
       <number>0</number>
      </property>
@@ -76,6 +73,9 @@
       <number>0</number>
      </property>
      <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <property name="spacing">
       <number>0</number>
      </property>
      <item row="0" column="2">
@@ -93,7 +93,11 @@
         <string>Reset 'Show courtesy' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -124,6 +128,8 @@
   <tabstop>showCourtesy</tabstop>
   <tabstop>resetShowCourtesy</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_tremolo.ui
+++ b/mscore/inspector/inspector_tremolo.ui
@@ -103,7 +103,11 @@
         <string>Reset 'Size in staff space units' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -134,6 +138,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_trill.ui
+++ b/mscore/inspector/inspector_trill.ui
@@ -127,7 +127,11 @@
         <string>Reset 'Type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -144,7 +148,34 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="playArticulation">
+       <property name="text">
+        <string>Play</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QToolButton" name="resetOrnamentStyle">
+       <property name="toolTip">
+        <string>Reset value</string>
+       </property>
+       <property name="accessibleName">
+        <string>Reset 'Ornament style' value</string>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1" colspan="2">
       <widget class="QComboBox" name="ornamentStyle">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -167,30 +198,7 @@
        </item>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="QToolButton" name="resetOrnamentStyle">
-       <property name="toolTip">
-        <string>Reset value</string>
-       </property>
-       <property name="accessibleName">
-        <string>Reset 'Ornament style' value</string>
-       </property>
-       <property name="text">
-        <string notr="true">...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="playArticulation">
-       <property name="text">
-        <string>Play</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
+     <item row="2" column="3">
       <widget class="QToolButton" name="resetPlayArticulation">
        <property name="toolTip">
         <string>Reset value</string>
@@ -199,7 +207,11 @@
         <string>Reset 'Play' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -207,6 +219,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_tuplet.ui
+++ b/mscore/inspector/inspector_tuplet.ui
@@ -87,7 +87,11 @@
         <string>Reset 'Number type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -100,7 +104,11 @@
         <string>Reset 'Bracket type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -200,7 +208,11 @@
         <string>Reset 'Direction' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -216,6 +228,8 @@
   <tabstop>bracketType</tabstop>
   <tabstop>resetBracketType</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_vbox.ui
+++ b/mscore/inspector/inspector_vbox.ui
@@ -63,9 +63,6 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
      <property name="leftMargin">
       <number>0</number>
      </property>
@@ -76,6 +73,9 @@
       <number>0</number>
      </property>
      <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <property name="spacing">
       <number>0</number>
      </property>
      <item row="5" column="0">
@@ -97,7 +97,11 @@
         <string>Reset 'Top gap' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -110,7 +114,11 @@
         <string>Reset 'Bottom gap' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -328,7 +336,11 @@
         <string>Reset 'Left margin' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -341,7 +353,11 @@
         <string>Reset 'Right margin' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -354,7 +370,11 @@
         <string>Reset 'Top margin' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -367,7 +387,11 @@
         <string>Reset 'Bottom margin' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -397,6 +421,8 @@
   <tabstop>bottomMargin</tabstop>
   <tabstop>resetBottomMargin</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_volta.ui
+++ b/mscore/inspector/inspector_volta.ui
@@ -63,9 +63,6 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <property name="spacing">
-      <number>0</number>
-     </property>
      <property name="leftMargin">
       <number>0</number>
      </property>
@@ -76,6 +73,9 @@
       <number>0</number>
      </property>
      <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <property name="spacing">
       <number>0</number>
      </property>
      <item row="0" column="1" colspan="2">
@@ -111,7 +111,11 @@
         <string>Reset 'Type' value</string>
        </property>
        <property name="text">
-        <string notr="true">...</string>
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
        </property>
       </widget>
      </item>
@@ -119,6 +123,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -355,8 +355,6 @@ InstrumentsWidget::InstrumentsWidget(QWidget* parent)
    : QWidget(parent)
       {
       setupUi(this);
-      upButton->setIcon(*icons[int(Icons::arrowUp_ICON)]);
-      downButton->setIcon(*icons[int(Icons::arrowDown_ICON)]);
       splitter->setStretchFactor(0, 10);
       splitter->setStretchFactor(1, 0);
       splitter->setStretchFactor(2, 15);

--- a/mscore/instrwidget.ui
+++ b/mscore/instrwidget.ui
@@ -219,7 +219,11 @@
           <string>Up</string>
          </property>
          <property name="text">
-          <string notr="true" extracomment="gets replaced with arrowUp icon">↑</string>
+          <string notr="true"/>
+         </property>
+         <property name="icon">
+          <iconset resource="musescore.qrc">
+           <normaloff>:/data/icons/arrow_up.svg</normaloff>:/data/icons/arrow_up.svg</iconset>
          </property>
         </widget>
        </item>
@@ -238,7 +242,11 @@
           <string>Down</string>
          </property>
          <property name="text">
-          <string notr="true" extracomment="gets replaced with arrowDown icon">↓</string>
+          <string notr="true"/>
+         </property>
+         <property name="icon">
+          <iconset resource="musescore.qrc">
+           <normaloff>:/data/icons/arrow_down.svg</normaloff>:/data/icons/arrow_down.svg</iconset>
          </property>
         </widget>
        </item>
@@ -370,6 +378,8 @@
   <tabstop>linkedButton</tabstop>
   <tabstop>partiturList</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/measureproperties.ui
+++ b/mscore/measureproperties.ui
@@ -457,7 +457,11 @@
             <string>Go to previous measure</string>
            </property>
            <property name="text">
-            <string notr="true" extracomment="&amp;larr;">←</string>
+            <string notr="true"/>
+           </property>
+           <property name="icon">
+            <iconset resource="musescore.qrc">
+             <normaloff>:/data/icons/go-previous.svg</normaloff>:/data/icons/go-previous.svg</iconset>
            </property>
           </widget>
          </item>
@@ -467,7 +471,11 @@
             <string>Go to next measure</string>
            </property>
            <property name="text">
-            <string notr="true" extracomment="&amp;rarr;">→</string>
+            <string notr="true"/>
+           </property>
+           <property name="icon">
+            <iconset resource="musescore.qrc">
+             <normaloff>:/data/icons/go-next.svg</normaloff>:/data/icons/go-next.svg</iconset>
            </property>
           </widget>
          </item>
@@ -502,7 +510,9 @@
   <tabstop>previousButton</tabstop>
   <tabstop>nextButton</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="musescore.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/mscore/mediadialog.cpp
+++ b/mscore/mediadialog.cpp
@@ -39,8 +39,6 @@ MediaDialog::MediaDialog(QWidget* /*parent*/)
       setupUi(this);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       setWindowTitle(tr("MuseScore: Additional Media"));
-      scanFileButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      audioFileButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
 
       connect(addScan,         SIGNAL(clicked()), SLOT(addScanPressed()));
       connect(removeScan,      SIGNAL(clicked()), SLOT(removeScanPressed()));

--- a/mscore/mediadialog.ui
+++ b/mscore/mediadialog.ui
@@ -39,7 +39,11 @@
           <item>
            <widget class="QToolButton" name="scanFileButton">
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
             </property>
            </widget>
           </item>
@@ -115,7 +119,11 @@
           <item>
            <widget class="QToolButton" name="audioFileButton">
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
             </property>
            </widget>
           </item>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3253,8 +3253,6 @@ AboutBoxDialog::AboutBoxDialog()
       revisionLabel->setText(tr("Revision: %1").arg(revision));
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-      copyRevisionButton->setIcon(*icons[int(Icons::copy_ICON)]);
-
       copyrightLabel->setText(QString("<span style=\"font-size:10pt;\">%1</span>")
                               .arg(tr(   "Visit %1www.musescore.org%2 for new versions and more information.\n"
                                          "Support MuseScore with your %3donation%4.\n\n"

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -648,7 +648,7 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       for (int idx = 0; idx < n; ++idx)
             exportAudioSampleRate->addItem(QString("%1").arg(exportAudioSampleRates[idx]));
 
-      restartWarningLanguage->setText("");
+      restartWarningLanguage->hide();
       connect(language, SIGNAL(currentIndexChanged(int)), SLOT(languageChanged(int)));
 
       connect(recordButtons,          SIGNAL(buttonClicked(int)), SLOT(recordButtonClicked(int)));
@@ -688,7 +688,7 @@ PreferenceDialog::~PreferenceDialog()
 
 void PreferenceDialog::languageChanged(int /*val*/)
       {
-      restartWarningLanguage->setText(tr("The language will be changed once you restart MuseScore."));
+      restartWarningLanguage->show();
       }
 
 //---------------------------------------------------------

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -547,21 +547,6 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       setupUi(this);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       setModal(true);
-      startWithButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      instrumentList1Button->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      instrumentList2Button->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      defaultStyleButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      partStyleButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      myScoresButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      myStylesButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      myTemplatesButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      myPluginsButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      mySoundfontsButton->setIcon(*icons[int(Icons::edit_ICON)]);
-      myImagesButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-
-      bgWallpaperSelect->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      fgWallpaperSelect->setIcon(*icons[int(Icons::fileOpen_ICON)]);
-      styleFileButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
       shortcutsChanged        = false;
 
 #ifndef USE_JACK

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -165,7 +165,11 @@
                <string>Opens a file dialog for selecting the starting score</string>
               </property>
               <property name="text">
-               <string/>
+               <string notr="true"/>
+              </property>
+              <property name="icon">
+               <iconset resource="musescore.qrc">
+                <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
               </property>
              </widget>
             </item>
@@ -534,7 +538,11 @@
              <string>Opens a folder dialog for selecting the score folder</string>
             </property>
             <property name="text">
-             <string/>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
             </property>
            </widget>
           </item>
@@ -550,7 +558,11 @@
              <string>Opens a folder dialog for selecting the style folder</string>
             </property>
             <property name="text">
-             <string/>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
             </property>
            </widget>
           </item>
@@ -609,7 +621,11 @@
              <string>Opens a folder dialog for selecting the plugin folder</string>
             </property>
             <property name="text">
-             <string/>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
             </property>
            </widget>
           </item>
@@ -648,7 +664,11 @@
              <string>Opens a folder dialog for selecting the template folder</string>
             </property>
             <property name="text">
-             <string/>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
             </property>
            </widget>
           </item>
@@ -666,6 +686,10 @@
             <property name="text">
              <string/>
             </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
+            </property>
            </widget>
           </item>
           <item row="4" column="2">
@@ -680,7 +704,11 @@
              <string>Opens a dialog for configuring the SoundFont folders</string>
             </property>
             <property name="text">
-             <string/>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/edit.svg</normaloff>:/data/icons/edit.svg</iconset>
             </property>
            </widget>
           </item>
@@ -886,7 +914,11 @@
                <string>Opens a file dialog for selecting the wallpaper file</string>
               </property>
               <property name="text">
-               <string/>
+               <string notr="true"/>
+              </property>
+              <property name="icon">
+               <iconset resource="musescore.qrc">
+                <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
               </property>
              </widget>
             </item>
@@ -1003,7 +1035,11 @@
                <string>Opens a file dialog for selecting the wallpaper file</string>
               </property>
               <property name="text">
-               <string/>
+               <string notr="true"/>
+              </property>
+              <property name="icon">
+               <iconset resource="musescore.qrc">
+                <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
               </property>
              </widget>
             </item>
@@ -1321,7 +1357,12 @@
              <string>Rewind is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1337,7 +1378,12 @@
              <string>Rewind record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1360,7 +1406,12 @@
              <string>Is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1376,7 +1427,12 @@
              <string>Toggle play record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1422,7 +1478,12 @@
              <string>Whole note is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1435,7 +1496,12 @@
              <string>Half note is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1448,7 +1514,12 @@
              <string>Whole note record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1461,7 +1532,12 @@
              <string>Half note record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1504,7 +1580,12 @@
              <string>Rest is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1517,7 +1598,12 @@
              <string>Quarter note is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1530,7 +1616,12 @@
              <string>Quarter note record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1543,7 +1634,12 @@
              <string>Eighth note is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1556,7 +1652,12 @@
              <string>Eighth note record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1596,7 +1697,12 @@
              <string>Augmentation dot is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1609,7 +1715,12 @@
              <string>Augmentation dot record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1622,7 +1733,12 @@
              <string>Double augmentation dot is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1635,7 +1751,12 @@
              <string>Double augmentation dot record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1648,7 +1769,12 @@
              <string>Tie is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1661,7 +1787,12 @@
              <string>Tie record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1674,7 +1805,12 @@
              <string>Rest record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1749,7 +1885,12 @@
              <string>Play is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1765,7 +1906,12 @@
              <string>Stop is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1781,7 +1927,12 @@
              <string>Play record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1797,7 +1948,12 @@
              <string>Stop record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1823,7 +1979,12 @@
              <string>Note input is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1839,7 +2000,12 @@
              <string>Note input record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1862,7 +2028,12 @@
              <string>16th note is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1875,7 +2046,12 @@
              <string>16th note record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1888,7 +2064,12 @@
              <string>32nd note is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1901,7 +2082,12 @@
              <string>32nd note record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1934,7 +2120,12 @@
              <string>64th note is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1947,7 +2138,12 @@
              <string>64th note record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1960,7 +2156,12 @@
              <string>Undo is active</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/darkgreendot.svg</normaloff>
+              <normalon>:/data/greendot.svg</normalon>:/data/darkgreendot.svg</iconset>
             </property>
            </widget>
           </item>
@@ -1973,7 +2174,12 @@
              <string>Undo record</string>
             </property>
             <property name="text">
-             <string notr="true">...</string>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/recordOff.svg</normaloff>
+              <normalon>:/data/recordOn.svg</normalon>:/data/recordOff.svg</iconset>
             </property>
            </widget>
           </item>
@@ -2144,6 +2350,10 @@
             <property name="text">
              <string/>
             </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
+            </property>
            </widget>
           </item>
           <item row="0" column="0">
@@ -2198,7 +2408,11 @@
              <string>Opens a file dialog for selecting a style file</string>
             </property>
             <property name="text">
-             <string/>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
             </property>
            </widget>
           </item>
@@ -2234,7 +2448,11 @@
              <string>Opens a file dialog for selecting a style file for part</string>
             </property>
             <property name="text">
-             <string/>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
             </property>
            </widget>
           </item>
@@ -2260,7 +2478,11 @@
              <string>Opens a file dialog for selecting a instrument list file</string>
             </property>
             <property name="text">
-             <string/>
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="musescore.qrc">
+              <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
             </property>
            </widget>
           </item>
@@ -2866,7 +3088,11 @@
                <string>Opens a file dialog for selecting a style file</string>
               </property>
               <property name="text">
-               <string>Browse...</string>
+               <string notr="true"/>
+              </property>
+              <property name="icon">
+               <iconset resource="musescore.qrc">
+                <normaloff>:/data/icons/document-open.svg</normaloff>:/data/icons/document-open.svg</iconset>
               </property>
              </widget>
             </item>
@@ -3728,6 +3954,8 @@
   <tabstop>drawAntialiased</tabstop>
   <tabstop>proximity</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/textprop.cpp
+++ b/mscore/textprop.cpp
@@ -33,17 +33,6 @@ TextProp::TextProp(QWidget* parent)
    : QWidget(parent)
       {
       setupUi(this);
-      //set the icon here or the style can't color them
-      alignLeft->setIcon(*icons[int(Icons::textLeft_ICON)]);
-      alignHCenter->setIcon(*icons[int(Icons::textCenter_ICON)]);
-      alignRight->setIcon(*icons[int(Icons::textRight_ICON)]);
-      alignTop->setIcon(*icons[int(Icons::textTop_ICON)]);
-      alignVCenter->setIcon(*icons[int(Icons::textVCenter_ICON)]);
-      alignBaseline->setIcon(*icons[int(Icons::textBaseline_ICON)]);
-      alignBottom->setIcon(*icons[int(Icons::textBottom_ICON)]);
-      fontBold->setIcon(*icons[int(Icons::textBold_ICON)]);
-      fontItalic->setIcon(*icons[int(Icons::textItalic_ICON)]);
-      fontUnderline->setIcon(*icons[int(Icons::textUnderline_ICON)]);
 
       QButtonGroup* g1 = new QButtonGroup(this);
       g1->addButton(alignLeft);

--- a/mscore/textproperties.ui
+++ b/mscore/textproperties.ui
@@ -582,7 +582,7 @@
             <string>Align left edge of text to reference point</string>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true"/>
            </property>
            <property name="icon">
             <iconset resource="musescore.qrc">
@@ -605,7 +605,7 @@
             <string>Center text on reference point</string>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true"/>
            </property>
            <property name="icon">
             <iconset resource="musescore.qrc">
@@ -628,7 +628,7 @@
             <string>Align top edge of text to reference point</string>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true"/>
            </property>
            <property name="icon">
             <iconset resource="musescore.qrc">
@@ -651,7 +651,7 @@
             <string>Align right edge of text to reference point</string>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true"/>
            </property>
            <property name="icon">
             <iconset resource="musescore.qrc">
@@ -684,7 +684,7 @@
             <string>Align baseline of text to reference point</string>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true"/>
            </property>
            <property name="icon">
             <iconset resource="musescore.qrc">
@@ -707,7 +707,7 @@
             <string>Center text vertical to reference point</string>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true"/>
            </property>
            <property name="icon">
             <iconset resource="musescore.qrc">
@@ -730,7 +730,7 @@
             <string>Align bottom edge of text to reference point</string>
            </property>
            <property name="text">
-            <string notr="true">...</string>
+            <string notr="true"/>
            </property>
            <property name="icon">
             <iconset resource="musescore.qrc">

--- a/mscore/uploadscoredialog.cpp
+++ b/mscore/uploadscoredialog.cpp
@@ -196,7 +196,7 @@ void UploadScoreDialog::onGetScoreSuccess(const QString &t, const QString &desc,
       tags->setText(tag);
       updateExistingCb->setChecked(true);
       updateExistingCb->setVisible(true);
-      linkToScore->setText(tr("[%1link%2]")
+      linkToScore->setText(tr("[%1Link%2]")
                            .arg("<a href=\"" + url + "\">")
                            .arg("</a>"));
       setVisible(true);

--- a/mscore/uploadscoredialog.ui
+++ b/mscore/uploadscoredialog.ui
@@ -337,7 +337,7 @@ p, li { white-space: pre-wrap; }
        <item row="0" column="1">
         <widget class="QLabel" name="linkToScore">
          <property name="text">
-          <string extracomment="Hyperlink">Link</string>
+          <string notr="true" extracomment="Hyperlink, gets set/unset programatically">Link</string>
          </property>
          <property name="openExternalLinks">
           <bool>true</bool>


### PR DESCRIPTION
and use icons from the resource in ui files rather than use setIcon(), so in QtCreator those dialogs looks more like in reality. Also reduce (useless) strings to translate.