### PR TITLE
Inspector fixes

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -940,26 +940,15 @@ InspectorSlur::InspectorSlur(QWidget* parent)
 
       Element* e = inspector->element();
       bool sameType = true;
-      Element::Type subtype = Element::Type::INVALID;
 
-      if (e->type() == Element::Type::SLUR_SEGMENT)
-            subtype = toSlurSegment(e)->spanner()->type();
       for (const auto& ee : inspector->el()) {
-            if (ee->type() != Element::Type::SLUR_SEGMENT) {
-                  sameType = false;
-                  break;
-                  }
-            if (toSlurSegment(ee)->spanner()->type() != subtype) {
+            if (ee->accessibleInfo() != e->accessibleInfo()) {
                   sameType = false;
                   break;
                   }
             }
-      if (!sameType)
-            s.elementName->setText("Slur/Tie");
-      else if (subtype == Element::Type::SLUR)
-            s.elementName->setText(tr("Slur"));
-      else if (subtype == Element::Type::TIE)
-            s.elementName->setText(tr("Tie"));
+      if (sameType)
+            s.elementName->setText(e->accessibleInfo());
 
       const std::vector<InspectorItem> iiList = {
             { P_ID::LINE_TYPE,       0, 0, s.lineType,      s.resetLineType      },

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -55,6 +55,7 @@
 #include "libmscore/bend.h"
 #include "libmscore/tremolobar.h"
 #include "libmscore/slur.h"
+#include "libmscore/breath.h"
 
 namespace Ms {
 
@@ -1206,13 +1207,24 @@ void InspectorBarLine::blockSpanDataSignals(bool val)
       }
 
 //---------------------------------------------------------
-//   InspectorRest
+//   InspectorCaesura
 //---------------------------------------------------------
 
 InspectorCaesura::InspectorCaesura(QWidget* parent) : InspectorBase(parent)
       {
       e.setupUi(addWidget());
       c.setupUi(addWidget());
+
+      Breath* b = toBreath(inspector->element());
+      bool sameType = true;
+      for (const auto& ee : inspector->el()) {
+            if (ee->accessibleInfo() != b->accessibleInfo()) {
+                  sameType = false;
+                  break;
+                  }
+            }
+      if (sameType)
+            c.elementName->setText(b->accessibleInfo());
 
       iList = {
             { P_ID::COLOR,          0, 0, e.color,         e.resetColor         },

--- a/mscore/inspector/inspector_caesura.ui
+++ b/mscore/inspector/inspector_caesura.ui
@@ -41,7 +41,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Caesura</string>
+      <string>Breath/Caesura</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -87,7 +87,7 @@
         <string>Leading space</string>
        </property>
        <property name="suffix">
-        <string extracomment="spatium unit">sec</string>
+        <string extracomment="seconds">sec</string>
        </property>
        <property name="minimum">
         <double>0.000000000000000</double>

--- a/mscore/inspector/inspector_slur.ui
+++ b/mscore/inspector/inspector_slur.ui
@@ -41,7 +41,7 @@
       </font>
      </property>
      <property name="text">
-      <string notr="true" extracomment="gets replaced programatically">Slur/Tie</string>
+      <string>Slur/Tie</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>


### PR DESCRIPTION
* in inspector differentiate breath and caesura and fix copy/paste typos in the code, reuse the already translated strings rather than introducing new (and duplicate) ones.
* fix translation of "Slur/Tie" (broke in 5ad23b98) and simply differentiation between them, reusing the already translated strings, removing duplicate ones.