### PR TITLE
fix #116276: Change enharmonic doesn't work as expected with linked s…

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4704,7 +4704,9 @@ void ScoreView::cmdAddHairpin(bool decrescendo)
 void ScoreView::cmdChangeEnharmonic(bool up)
       {
       _score->startCmd();
-      for (Note* n : _score->selection().noteList()) {
+      Selection selection = _score->selection();
+      QList<Note*> notes = selection.uniqueNotes();
+      for (Note* n : notes) {
             Staff* staff = n->staff();
             if (staff->part()->instrument()->useDrumset())
                   continue;
@@ -4731,28 +4733,18 @@ void ScoreView::cmdChangeEnharmonic(bool up)
                         24, 24, 12,  // 70  A#   A#  Bb
                         31, 19,  7,  // 71  A##  B   Cb
                         };
-                  int tpc  = n->tpc();
-                  int line = n->line();
+                  int tpc = n->tpc();
                   int i;
                   for (i = 0; i < 36; ++i) {
                         if (tab[i] == tpc) {
-                              int k = i % 3;
-                              i-= k;
-                              if ((k < 2) && tab[i] == tab[i+1])
-                                    ++k;
-                              if (k < 2) {
-                                    ++k;
-                                    tpc = tab[i + k];
-                                    ++line;
+                              if ((i % 3) < 2) {
+                                    if (tab[i] == tab[i + 1])
+                                          tpc = tab[i + 2];
+                                    else
+                                          tpc = tab[i + 1];
                                     }
                               else {
-                                    if (tab[i + 2] != tab[i + 1])
-                                          --line;
-                                    --k;
-                                    if (tab[i + 1] != tab[i])
-                                          --line;
-                                    --k;
-                                    tpc = tab[i];
+                                    tpc = tab[i - 2];
                                     }
                               break;
                               }


### PR DESCRIPTION
…taves also selected

I used selection.uniqueNotes() in replace of selection.noteList() to have only unique notes get enharmonically changed.

Also, I simplified the code for getting the new tpc (line is not used and k is unnecessary).