### PR TITLE
fix #116586: load sfz in background

### DIFF
--- a/zerberus/CMakeLists.txt
+++ b/zerberus/CMakeLists.txt
@@ -14,8 +14,23 @@ include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
 
 QT5_WRAP_UI (zerberusUi zerberus_gui.ui)
 
+include_directories(
+      ${PROJECT_SOURCE_DIR}/thirdparty
+      ${QTSINGLEAPPLICATION_INCLUDE_DIRS}
+      )
+
+QT5_WRAP_UI (ui_headers
+      ../mscore/insertmeasuresdialog.ui
+      ../mscore/measuresdialog.ui
+      ../mscore/aboutbox.ui
+      ../mscore/aboutmusicxmlbox.ui
+      ../mscore/startdialog.ui
+      ../mscore/uploadscoredialog.ui
+      )
+
 add_library (zerberus STATIC
       ${zerberusUi}
+      ${ui_headers}
       channel.cpp
       instrument.cpp
       sfz.cpp

--- a/zerberus/zerberusgui.cpp
+++ b/zerberus/zerberusgui.cpp
@@ -13,6 +13,7 @@
 #include "zerberusgui.h"
 
 #include "mscore/preferences.h"
+#include "mscore/musescore.h"
 
 //---------------------------------------------------------
 //   SfzListDialog
@@ -173,7 +174,9 @@ void ZerberusGui::loadSfz() {
             QFuture<bool> future = QtConcurrent::run(zerberus(), &Zerberus::addSoundFont, sfName);
             _futureWatcher.setFuture(future);
             _progressTimer->start(1000);
-            _progressDialog->exec();
+            _progressDialog->open();
+            _progressBar = Ms::mscore->showProgressBar();
+            _progressBar->setFormat(tr("Loading sfz %p\%"));
             }
       }
 
@@ -215,6 +218,7 @@ void ZerberusGui::cancelLoadClicked()
 void ZerberusGui::updateProgress()
       {
       _progressDialog->setValue(zerberus()->loadProgress());
+      _progressBar->setValue(zerberus()->loadProgress());
       }
 
 //---------------------------------------------------------
@@ -237,6 +241,8 @@ void ZerberusGui::onSoundFontLoaded()
       bool wasNotCanceled = !_progressDialog->wasCanceled();
       _progressTimer->stop();
       _progressDialog->reset();
+      Ms::mscore->hideProgressBar();
+      _progressBar = 0;
       if (loaded) {
             QListWidgetItem* item = new QListWidgetItem;
             item->setText(_loadedSfName);

--- a/zerberus/zerberusgui.h
+++ b/zerberus/zerberusgui.h
@@ -17,6 +17,7 @@
 #include "ui_zerberus_gui.h"
 #include "zerberus.h"
 #include <QDialogButtonBox>
+#include <QProgressBar>
 
 class QProgressDialog;
 
@@ -59,6 +60,7 @@ class ZerberusGui : public Ms::SynthesizerGui, Ui::ZerberusGui {
       QString _loadedSfPath;
       QString _loadedSfName;
       QProgressDialog* _progressDialog;
+      QProgressBar* _progressBar;
       QTimer * _progressTimer;
       std::vector<struct SfzNamePath> _sfzToLoad;
       void loadSfz();


### PR DESCRIPTION
load sfz files in background and display a progress bar in the status bar