### PR TITLE
Expose containers to scripting (read-only)

### DIFF
--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -71,10 +71,10 @@ class Chord : public ChordRest {
             };
 
       Q_PROPERTY(Ms::Beam* beam              READ beam)
-//      Q_PROPERTY(QQmlListProperty<Ms::Chord> graceNotes READ qmlGraceNotes)
+      Q_PROPERTY(QQmlListProperty<Ms::Chord> graceNotes READ qmlGraceNotes)
       Q_PROPERTY(Ms::Hook* hook              READ hook)
-//      Q_PROPERTY(QQmlListProperty<Ms::Lyrics> lyrics READ qmlLyrics)
-//      Q_PROPERTY(QQmlListProperty<Ms::Note> notes READ qmlNotes)
+      Q_PROPERTY(QQmlListProperty<Ms::Lyrics> lyrics READ qmlLyrics)
+      Q_PROPERTY(QQmlListProperty<Ms::Note> notes READ qmlNotes)
       Q_PROPERTY(Ms::Stem* stem              READ stem)
       Q_PROPERTY(Ms::StemSlash* stemSlash    READ stemSlash)
       Q_PROPERTY(int stemDirection    READ stemDirection)
@@ -142,9 +142,9 @@ class Chord : public ChordRest {
       void layoutStem();
       void layoutArpeggio2();
 
-//TODO      QQmlListProperty<Ms::Note> qmlNotes()       { return QQmlListProperty<Ms::Notes>(this, _notes); }
-//TODO      QQmlListProperty<Ms::Lyrics> qmlLyrics()    { return QQmlListProperty<Ms::Lyrics>(this, _lyricsList); }
-//TODO      QQmlListProperty<Ms::Chord> qmlGraceNotes() { return QQmlListProperty<Ms::Chord>(this, _graceNotes);  }
+      QQmlListProperty<Ms::Note> qmlNotes()           { return QmlListAccess<Ms::Note>(this, _notes); }
+      QQmlListProperty<Ms::Lyrics> qmlLyrics()        { return QmlListAccess<Ms::Lyrics>(this, _lyricsList); }
+      QQmlListProperty<Ms::Chord> qmlGraceNotes()     { return QmlListAccess<Ms::Chord>(this, _graceNotes); }
 
       std::vector<Note*>& notes()                 { return _notes; }
       const std::vector<Note*>& notes() const     { return _notes; }

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -544,6 +544,33 @@ inline static int limit(int val, int min, int max)
 Q_DECLARE_FLAGS(Align, AlignmentFlags);
 Q_DECLARE_OPERATORS_FOR_FLAGS(Align);
 
+//---------------------------------------------------------
+//   qml access to containers
+//
+//   QmlListAccess provides a convenience interface for
+//   QQmlListProperty providing read-only access to plugins
+//   for std::vector, QVector and QList items
+//---------------------------------------------------------
+
+template <typename T> class QmlListAccess : public QQmlListProperty<T> {
+public:
+      QmlListAccess<T>(QObject* obj, std::vector<T*>& container)
+            : QQmlListProperty<T>(obj, &container, &stdVectorCount, &stdVectorAt) {};
+
+      QmlListAccess<T>(QObject* obj, QVector<T*>& container)
+            : QQmlListProperty<T>(obj, &container, &qVectorCount, &qVectorAt) {};
+
+      QmlListAccess<T>(QObject* obj, QList<T*>& container)
+            : QQmlListProperty<T>(obj, &container, &qListCount, &qListAt) {};
+
+      static int stdVectorCount(QQmlListProperty<T>* l)     { return static_cast<std::vector<T*>*>(l->data)->size(); }
+      static T* stdVectorAt(QQmlListProperty<T>* l, int i)  { return static_cast<std::vector<T*>*>(l->data)->at(i); }
+      static int qVectorCount(QQmlListProperty<T>* l)       { return static_cast<QVector<T*>*>(l->data)->size(); }
+      static T* qVectorAt(QQmlListProperty<T>* l, int i)    { return static_cast<QVector<T*>*>(l->data)->at(i); }
+      static int qListCount(QQmlListProperty<T>* l)         { return static_cast<QList<T*>*>(l->data)->size(); }
+      static T* qListAt(QQmlListProperty<T>* l, int i)      { return static_cast<QList<T*>*>(l->data)->at(i); }
+      };
+
 }     // namespace Ms
 
 Q_DECLARE_METATYPE(Ms::Direction);

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -152,9 +152,9 @@ class Note : public Element {
       Q_OBJECT
       Q_PROPERTY(Ms::Accidental*                accidental        READ accidental)
       Q_PROPERTY(int                            accidentalType    READ qmlAccidentalType  WRITE qmlSetAccidentalType)
-//      Q_PROPERTY(QQmlListProperty<Ms::NoteDot>  dots              READ qmlDots)
+      Q_PROPERTY(QQmlListProperty<Ms::NoteDot>  dots              READ qmlDots)
       Q_PROPERTY(int                            dotsCount         READ qmlDotsCount)
-//      Q_PROPERTY(QQmlListProperty<Ms::Element>  elements          READ qmlElements)
+      Q_PROPERTY(QQmlListProperty<Ms::Element>  elements          READ qmlElements)
       Q_PROPERTY(int                            fret              READ fret               WRITE undoSetFret)
       Q_PROPERTY(bool                           ghost             READ ghost              WRITE undoSetGhost)
       Q_PROPERTY(Ms::NoteHead::Group            headGroup         READ headGroup          WRITE undoSetHeadGroup)
@@ -369,7 +369,7 @@ class Note : public Element {
 
       ElementList el()                            { return _el; }
       const ElementList el() const                { return _el; }
-//TODO      QQmlListProperty<Ms::Element> qmlElements() { return QQmlListProperty<Ms::Element>(this, _el); }
+      QQmlListProperty<Ms::Element> qmlElements() { return QmlListAccess<Ms::Element>(this, _el); }
 
       int subchannel() const                    { return _subchannel; }
       void setSubchannel(int val)               { _subchannel = val;  }
@@ -396,7 +396,7 @@ class Note : public Element {
       const QVector<NoteDot*>& dots() const       { return _dots;             }
       QVector<NoteDot*>& dots()                   { return _dots;             }
 
-//TODO      QQmlListProperty<Ms::NoteDot> qmlDots() { return QQmlListProperty<Ms::NoteDot>(this, _dots);  }
+      QQmlListProperty<Ms::NoteDot> qmlDots() { return QmlListAccess<Ms::NoteDot>(this, _dots);  }
 
       int qmlDotsCount();
       void updateAccidental(AccidentalState*);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -326,7 +326,7 @@ class Score : public QObject, public ScoreElement {
       Q_OBJECT
       Q_PROPERTY(QString                        composer          READ composer)
       Q_PROPERTY(int                            duration          READ duration)
-//TODO-ws      Q_PROPERTY(QQmlListProperty<Ms::Excerpt>  excerpts          READ qmlExcerpts)
+      Q_PROPERTY(QQmlListProperty<Ms::Excerpt>  excerpts          READ qmlExcerpts)
       Q_PROPERTY(Ms::Measure*                   firstMeasure      READ firstMeasure)
       Q_PROPERTY(Ms::Measure*                   firstMeasureMM    READ firstMeasureMM)
       Q_PROPERTY(int                            harmonyCount      READ harmonyCount)
@@ -498,7 +498,7 @@ class Score : public QObject, public ScoreElement {
       void selectAdd(Element* e);
       void selectRange(Element* e, int staffIdx);
 
-      QQmlListProperty<Ms::Part> qmlParts() { return QQmlListProperty<Ms::Part>(this, _parts); }
+      QQmlListProperty<Ms::Part> qmlParts() { return QmlListAccess<Ms::Part>(this, _parts); }
 
       void getNextMeasure(LayoutContext&);      // get next measure for layout
       bool collectPage(LayoutContext&);
@@ -528,6 +528,8 @@ class Score : public QObject, public ScoreElement {
 
       virtual inline QList<Excerpt*>& excerpts();
       virtual inline const QList<Excerpt*>& excerpts() const;
+
+      QQmlListProperty<Ms::Excerpt> qmlExcerpts() { return QmlListAccess<Ms::Excerpt>(this, excerpts()); }
 
       virtual const char* name() const override { return "Score"; }
 
@@ -1116,7 +1118,6 @@ class MasterScore : public Score {
       QSet<int> occupiedMidiChannels;     // each entry is port*16+channel, port range: 0-inf, channel: 0-15
       unsigned int searchMidiMappingFrom; // makes getting next free MIDI mapping faster
 
-      QQmlListProperty<Ms::Excerpt> qmlExcerpts() { return QQmlListProperty<Ms::Excerpt>(this, _excerpts); }
       void parseVersion(const QString&);
       void reorderMidiMapping();
       void removeDeletedMidiMapping();

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1275,18 +1275,6 @@ QString Segment::accessibleExtraInfo() const
       return rez + " " + startSpanners + " " + endSpanners;
       }
 
-//--------------------------------------------------------
-//   qmlAnnotations
-//--------------------------------------------------------
-
-QQmlListProperty<Ms::Element> Segment::qmlAnnotations()
-      {
-      QList<Element*> qmlAnnotations;
-      for (Element* e : _annotations)
-            qmlAnnotations.append(e);
-      return QQmlListProperty<Ms::Element>(this, qmlAnnotations);
-      }
-
 //---------------------------------------------------------
 //   createShapes
 //---------------------------------------------------------

--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -195,7 +195,7 @@ class Segment : public Element {
       void removeAnnotation(Element* e);
       bool findAnnotationOrElement(Element::Type type, int minTrack, int maxTrack);
 
-      QQmlListProperty<Ms::Element> qmlAnnotations();
+      QQmlListProperty<Ms::Element> qmlAnnotations()  { return QmlListAccess<Ms::Element>(this, _annotations); }
 
       qreal dotPosX(int staffIdx) const          { return _dotPosX[staffIdx];  }
       void setDotPosX(int staffIdx, qreal val)   { _dotPosX[staffIdx] = val;   }


### PR DESCRIPTION
To solve problems like <a href="https://musescore.org/en/node/115971">Regression: Qml access to annotations leads to crash</a>, I'm using the QQmlListProperty(QObject\*, void\*, CountFunction, AtFunction) constructor to access containers such as std::vector\<T\*\> and QVector\<T\*\> without building a temporary or secondary QList\<T\*\>. This provides a clean read-only access for plugins.

Qt documentation does not recommend to use QQmlListProperty(QObject\*, QList\<T\*\>\&) in production code anyway (<a href="http://doc.qt.io/qt-5/qqmllistproperty.html#QQmlListProperty">see here</a>).

This first commit exposes Chord::notes and Chord::graceNotes which allows to run the noteNames plugin, which doesn't work with the current master.

If this approach is considered good, I'll try to add the other properties (including Segment::annotations) and rename and squash commits.

One more thought: The creation of a new QQmlListProperty every time the function is called, might be a waste of memory, since Qt documentation says, that "The list property remains valid while object exists". We could therefore consider to remember the list for further calls in the same object.

Please comment.