### PR TITLE
fix #107891: Selection lost on enharmonic change with accidentals

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1374,7 +1374,6 @@ void Score::upDown(bool up, UpDownMode mode)
       _selection.clear();
       for (Note* note : el)
             _selection.add(note);
-      _selection.updateState();     // accidentals may have changed
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4765,6 +4765,10 @@ void ScoreView::cmdChangeEnharmonic(bool up)
                         }
                   }
             }
+
+      selection.clear();
+      for (Note* n : notes)
+            selection.add(n);
       _score->endCmd();
       }
 


### PR DESCRIPTION
In cmd.cpp, _selection.updateState() is already called when calling _selection.add(note), so no need to call again.

