### PR TITLE
fix #57586: Strange behaviour when moving slur anchors after slur cre…

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -218,6 +218,7 @@ void SlurSegment::changeAnchor(MuseScoreView* viewer, Grip curGrip, Element* ele
                         }
                   case Spanner::Anchor::CHORD:
                         spanner()->setTick(static_cast<Chord*>(element)->tick());
+                        spanner()->setTick2(spanner()->endElement()->tick());
                         spanner()->setTrack(element->track());
                         break;
                   case Spanner::Anchor::SEGMENT:


### PR DESCRIPTION
…ation

When _tick changes, so should _ticks. Maybe this signifies a larger problem?