### PR TITLE
Build and run fixes

### DIFF
--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -252,7 +252,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QAction* aboutAction;
       QAction* aboutQtAction;
       QAction* aboutMusicXMLAction;
-      QAction* checkForUpdateAction;
+      QAction* checkForUpdateAction        { 0 };
       QAction* askForHelpAction;
       QAction* reportBugAction;
       QAction* revertToFactoryAction;
@@ -283,7 +283,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QMenu* menuEditMeasure;
       QMenu* menuView;
       QMenu* menuWorkspaces;
-      
+
       QMenu* menuAdd;
       QMenu* menuAddMeasures;
       QMenu* menuAddFrames;
@@ -292,11 +292,11 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QMenu* menuAddPitch;
       QMenu* menuAddInterval;
       QMenu* menuTuplet;
-      
+
       QMenu* menuFormat;
       QMenu* menuTools;
       QMenu* menuVoices;
-      
+
       QMenu* menuPlugins;
       QMenu* menuHelp;
       AlbumManager* albumManager           { 0 };
@@ -327,7 +327,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       PaletteBox* paletteBox         { 0 };
       Inspector* _inspector          { 0 };
       OmrPanel* omrPanel             { 0 };
-      
+
       QPushButton* showMidiImportButton {0};
 
       bool _midiinEnabled            { true };

--- a/thirdparty/poppler/CMakeLists.txt
+++ b/thirdparty/poppler/CMakeLists.txt
@@ -134,12 +134,12 @@ add_library(poppler STATIC
    )
 
 if (APPLE)
-   set ( POPPLER_COMPILE_FLAGS "-O2 -Wno-unknown-warning-option -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-private-field -Wno-return-stack-address -Wno-shift-negative-value")
+   set ( POPPLER_COMPILE_FLAGS "-O2 -Wno-unknown-warning-option -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-private-field -Wno-return-stack-address -Wno-shift-negative-value -std=c++11")
 else (APPLE)
    if (MINGW)
-      set (POPPLER_COMPILE_FLAGS "-O2 -Wall -Wextra -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-but-set-variable -Wno-format")
+      set (POPPLER_COMPILE_FLAGS "-O2 -Wall -Wextra -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-but-set-variable -Wno-format -std=c++11")
    else (MINGW)
-      set (POPPLER_COMPILE_FLAGS "-O2 -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-but-set-variable")
+      set (POPPLER_COMPILE_FLAGS "-O2 -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-but-set-variable -std=c++11")
    endif(MINGW)
 endif(APPLE)
 


### PR DESCRIPTION
1. Fixed poppler compilation with Qt 5.7 (added C++11), based on this patch:
https://patchwork.openembedded.org/patch/121701/
The error message came from qbasicatomic.h: #  error "Qt requires C++11 support"

2. Fixed MuseScore crash on startup (not initialized pointer).

There is still a crash on exit (Ubuntu 14.04, Qt 5.7):
http://wstaw.org/m/2016/07/03/plasma-desktopOp2395.png
something happens on QObject::disconnect, but the reason is unclear.