### PR TITLE
fix #117301 PulseAudio QGroupBox min height

### DIFF
--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2445,6 +2445,12 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>30</height>
+          </size>
+         </property>
          <property name="title">
           <string>PulseAudio</string>
          </property>


### PR DESCRIPTION
Make sure that the PulseAudio QGroupBox covers at least the bottom edge of the PulseAudio checkbox with consistent margin.  Purely cosmetic fix, so doesn't look unprofessional.