### PR TITLE
New syntax for travis notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,18 +112,18 @@ matrix:
       script:
         - "./build/travis/job_macos/script.sh"
 
-
 notifications:
-  recipients:
-    - $NOTIFICATION_EMAIL
   email:
+    recipients:
+      - "build@musescore.org"
     on_success: change
     on_failure: always
   irc:
     channels:
-      - $NOTIFICATION_IRC
+      - "chat.freenode.net#musescore"
     on_success: change
     on_failure: change
+    skip_join: true # reduces spam. Channel must not have mode +n set.
   webhooks:
     # trigger Buildtime Trend Service to parse Travis CI log
     - https://buildtimetrend.herokuapp.com/travis


### PR DESCRIPTION
The notification syntax appears to have changed slightly since before, but that wasn't the only problem. The notification section is a custom Travis command. It doesn't run in a bash shell so the environment variables are not set. If you want to obscure the email address and IRC channel then you need to use an [encrypted string](https://docs.travis-ci.com/user/encryption-keys/#Notifications-Example) instead.