### PR TITLE
fix #117656: Appended measures in different time signature

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2910,8 +2910,11 @@ void Score::getNextMeasure(LayoutContext& lc)
       // update time signature map
       // create event if measure len and time signature are different
       // even if they are equivalent 4/4 vs 2/2
+      // also check if nominal time signature has changed
 
-      if (isMaster() && !measure->len().identical(lc.sig)) {
+      if (isMaster() && (!measure->len().identical(lc.sig)
+                        || (lc.prevMeasure && lc.prevMeasure->isMeasure()
+                            && !measure->timesig().identical(toMeasure(lc.prevMeasure)->timesig())))) {
             lc.sig = measure->len();
             sigmap()->add(lc.tick, SigEvent(lc.sig, measure->timesig(), measure->no()));
             }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -381,6 +381,7 @@ void Score::fixTicks()
             staff->clearTimeSig();
 
       Fraction sig(fm->len());
+      Fraction nomSig(fm->timesig());
 
       if (isMaster()) {
             tempomap()->clear();
@@ -469,11 +470,12 @@ void Score::fixTicks()
             // update time signature map
             // create event if measure len and time signature are different
             // even if they are equivalent 4/4 vs 2/2
+            // also check if nominal time signature has changed
 
-            if (isMaster() && ((m->len().numerator() != sig.numerator())
-               || (m->len().denominator() != sig.denominator()))) {
+            if (isMaster() && (!sig.identical(m->len()) || !nomSig.identical(m->timesig()))) {
                   sig = m->len();
-                  sigmap()->add(tick, SigEvent(sig, m->timesig(),  m->no()));
+                  nomSig = m->timesig();
+                  sigmap()->add(tick, SigEvent(sig, nomSig,  m->no()));
                   }
 
             tick += measureTicks;


### PR DESCRIPTION
Fix <a href="https://musescore.org/en/node/117656">#117656</a>:
Also add sigmap entries in Score::getNextMeasure() and Score::fixTicks() if nominal time signature has changed.