### PR TITLE
fix #117766: Crash if first measure of score is part of a

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3662,6 +3662,14 @@ void Score::doLayoutRange(int stick, int etick)
       if (m->prevMeasureMM()) {
             m = m->prevMeasureMM();
             }
+
+      // if the first measure of the score is part of a multi measure rest
+      // m->system() will return a nullptr. We need to find the multi measure
+      // rest which replaces the measure range
+      if (!m->system() && m->hasMMRest())
+            m = m->mmRest();
+      Q_ASSERT(m->system());
+
       Page* p    = m->system()->page();
       System* s  = p->systems().front();
 


### PR DESCRIPTION
Fix <a href="https://musescore.org/en/node/117766">#117766</a>

If a measure is part of a multi measure rest, m->system() returns null. This is no problem if there is a previous measure, because Score::doLayoutRange() calls m->prevMeasureMM(), which will return a measure with a valid system pointer.
There's however no previous measure for the first measure of a score and m->prevMeasureMM() would not return a valid measure in this case, which lead to a null pointer crash.