### PR TITLE
fix #116556: Crash by opening the Instruments dialog box after parts …

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -254,7 +254,7 @@ void deleteExcerpt(Excerpt* excerpt)
             Staff* staff = nullptr;
             // find staff in the main score
             for (Staff* s2 : s->linkedStaves()->staves()) {
-                  if (s2->primaryStaff()) {
+                  if ((s2->score() == oscore) && s2->primaryStaff()) {
                         staff = s2;
                         break;
                         }


### PR DESCRIPTION
…deletion and undo

Ms::deleteExcerpt() did not make sure it really uses a staff of the master score to unlink staves of the excerpt. The loop using calls to Staff::primaryStaff() depends on the order of elements in _linkedStaves, since Staff::primaryStaff() will always return true if only two staves of two different scores are in the list.

With the given order of steps in <a href="https://musescore.org/en/node/116556">#116556</a> this could cause the final call to
<pre><code>oscore->undo(new UnlinkStaff(staff, s));</code></pre>
having (staff == s) both pointing to the same staff in the excerpt. The pointer to _linkedStaves in the master score was therefore never set to 0, while the LinkedStaves object itself was deleted.

Opening the Instruments Dialog window made use of this invalid _linkedStaves pointer and crashed.