### PR TITLE
fix #116091: Regression: "Flip stem direction" command broken

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1640,7 +1640,8 @@ void Score::cmdFlip()
                         undoChangeProperty(chord, P_ID::STEM_DIRECTION, int(dir));
                         }
                   }
-            else if (e->isBeam()) {
+
+            if (e->isBeam()) {
                   Beam* beam = toBeam(e);
                   Direction dir = beam->up() ? Direction::DOWN : Direction::UP;
                   undoChangeProperty(beam, P_ID::STEM_DIRECTION, dir);

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -164,6 +164,7 @@ void Direction::fillComboBox(QComboBox* cb)
       }
 
 static Spatium doubleToSpatium(double d)       { return Spatium(d); }
+static Direction intToDirection(int i)         { return Direction(i); }
 
 //---------------------------------------------------------
 //   init
@@ -175,7 +176,8 @@ void MScore::init()
             qFatal("registerConverter Spatium::toDouble failed");
       if (!QMetaType::registerConverter<double, Spatium>(&doubleToSpatium))
             qFatal("registerConverter douobleToSpatium failed");
-
+      if (!QMetaType::registerConverter<int, Direction>(&intToDirection))
+            qFatal("registerConverter intToDirection failed");
 
 #ifdef SCRIPT_INTERFACE
       qRegisterMetaType<Element::Type>     ("ElementType");


### PR DESCRIPTION
Fix <a href="https://musescore.org/en/node/116091">#116091</a>:

<ol><li>I added a converter int->Direction for use with QVariant, because the conversion in Chord::setProperty() didn't work and always returned the default value Direction::AUTO.
<pre><code>            case P_ID::STEM_DIRECTION:
                  setStemDirection(v.value&lt;Direction>());
                  break;</code></pre>
</li>
<li>I broke the if-elseif chain in Score::cmdFlip() because the "fall through" for the beam case when there's only one beamed note selected (no range selection) didn't work.</li></ol>