### PR TITLE
fix #109941: playback in excerpt plays full score

### DIFF
--- a/mscore/jackaudio.cpp
+++ b/mscore/jackaudio.cpp
@@ -536,8 +536,8 @@ void JackAudio::putEvent(const NPlayEvent& e, unsigned framePos)
       if (!preferences.useJackMidi)
             return;
 
-      int portIdx = seq->score()->midiPort(e.channel());
-      int chan    = seq->score()->midiChannel(e.channel());
+      int portIdx = seq->score()->masterScore()->midiPort(e.channel());
+      int chan    = seq->score()->masterScore()->midiChannel(e.channel());
 
 // qDebug("JackAudio::putEvent %d:%d  pos %d(%d)", portIdx, chan, framePos, _segmentSize);
 

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -206,7 +206,7 @@ void Seq::setScoreView(ScoreView* v)
       cv = v;
       if (cs)
             disconnect(cs, SIGNAL(playlistChanged()), this, SLOT(setPlaylistChanged()));
-      cs = cv ? cv->score()->masterScore() : 0;
+      cs = cv ? cv->score() : 0;
 
       if (!heartBeatTimer->isActive())
             heartBeatTimer->start(20);    // msec
@@ -911,7 +911,7 @@ void Seq::initInstruments(bool realTime)
                   _driver->updateOutPortCount(maxMidiOutPort + 1);
             }
 
-      foreach(const MidiMapping& mm, *cs->midiMapping()) {
+      foreach(const MidiMapping& mm, *cs->masterScore()->midiMapping()) {
             Channel* channel = mm.articulation;
             foreach(const MidiCoreEvent& e, channel->init) {
                   if (e.type() == ME_INVALID)
@@ -1136,17 +1136,17 @@ void Seq::stopNotes(int channel, bool realTime)
       };
       // Stop notes in all channels
       if (channel == -1) {
-            for(int ch = 0; ch < cs->midiMapping()->size(); ch++) {
+            for(int ch = 0; ch < cs->masterScore()->midiMapping()->size(); ch++) {
                   send(NPlayEvent(ME_CONTROLLER, ch, CTRL_SUSTAIN, 0));
                   send(NPlayEvent(ME_CONTROLLER, ch, CTRL_ALL_NOTES_OFF, 0));
-                  if (cs->midiChannel(ch) != 9)
+                  if (cs->masterScore()->midiChannel(ch) != 9)
                         send(NPlayEvent(ME_PITCHBEND,  ch, 0, 64));
                   }
             }
       else {
             send(NPlayEvent(ME_CONTROLLER, channel, CTRL_SUSTAIN, 0));
             send(NPlayEvent(ME_CONTROLLER, channel, CTRL_ALL_NOTES_OFF, 0));
-            if (cs->midiChannel(channel) != 9)
+            if (cs->masterScore()->midiChannel(channel) != 9)
                   send(NPlayEvent(ME_PITCHBEND,  channel, 0, 64));
             }
       if (preferences.useAlsaAudio || preferences.useJackAudio || preferences.usePulseAudio || preferences.usePortaudioAudio)
@@ -1355,11 +1355,11 @@ void Seq::putEvent(const NPlayEvent& event, unsigned framePos)
       if (!cs)
             return;
       int channel = event.channel();
-      if (channel >= cs->midiMapping()->size()) {
-            qDebug("bad channel value %d >= %d", channel, cs->midiMapping()->size());
+      if (channel >= cs->masterScore()->midiMapping()->size()) {
+            qDebug("bad channel value %d >= %d", channel, cs->masterScore()->midiMapping()->size());
             return;
             }
-      int syntiIdx= _synti->index(cs->midiMapping(channel)->articulation->synti);
+      int syntiIdx= _synti->index(cs->masterScore()->midiMapping(channel)->articulation->synti);
       _synti->play(event, syntiIdx);
       if (_driver != 0 && (preferences.useJackMidi || preferences.useAlsaAudio))
             _driver->putEvent(event, framePos);

--- a/mscore/seq.h
+++ b/mscore/seq.h
@@ -106,7 +106,7 @@ class Seq : public QObject, public Sequencer {
 
       mutable QMutex mutex;
 
-      MasterScore* cs;
+      Score* cs;
       ScoreView* cv;
       bool running;                       // true if sequencer is available
       Transport state;                    // STOP, PLAY, STARTING=3
@@ -222,7 +222,7 @@ class Seq : public QObject, public Sequencer {
       void setController(int, int, int);
       virtual void sendEvent(const NPlayEvent&);
       void setScoreView(ScoreView*);
-      MasterScore* score() const   { return cs; }
+      Score* score() const   { return cs; }
       ScoreView* viewer() const { return cv; }
       void initInstruments(bool realTime = false);
 


### PR DESCRIPTION
Fix <a href="https://musescore.org/en/node/109941">#109941</a>
I changed back Seq::cs from type MasterScore* to Score*.

However, for the playback to work, the instrument's channels of the excerpt score need to be set.
Version 2.0.x uses a separate midimapper for each score. This PR keeps the unique midimapper in MasterScore and just copies the channels to the instruments in the excerpt. This is done in MasterScore::reorderMidiMapping().
As a consequence the mixer settings are shared for the master score and all excerpts. The mixer window will however still show the settings for all instruments in the master score and not only those also present in the part.
Exporting parts to midi will also use the same midi channels for the instruments in the full score and the parts.

Should I try to update this PR to limit the mixer window to the instruments present in the part?
What do you think about this approach anyway?