### PR TITLE
remove intToDirection converter for QVariant

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1637,7 +1637,7 @@ void Score::cmdFlip()
                               continue;
                   else {
                         Direction dir = chord->up() ? Direction::DOWN : Direction::UP;
-                        undoChangeProperty(chord, P_ID::STEM_DIRECTION, int(dir));
+                        undoChangeProperty(chord, P_ID::STEM_DIRECTION, dir);
                         }
                   }
 
@@ -1680,13 +1680,13 @@ void Score::cmdFlip()
                         }
                   else {
                         Direction d = a->up() ? Direction::DOWN : Direction::UP;
-                        undoChangeProperty(a, P_ID::DIRECTION, int(d));
+                        undoChangeProperty(a, P_ID::DIRECTION, d);
                         }
                   }
             else if (e->isTuplet()) {
                   Tuplet* tuplet = toTuplet(e);
                   Direction d = tuplet->isUp() ? Direction::DOWN : Direction::UP;
-                  undoChangeProperty(tuplet, P_ID::DIRECTION, int(d));
+                  undoChangeProperty(tuplet, P_ID::DIRECTION, d);
                   }
             else if (e->isNoteDot()) {
                   Note* note = toNote(e->parent());

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -164,7 +164,6 @@ void Direction::fillComboBox(QComboBox* cb)
       }
 
 static Spatium doubleToSpatium(double d)       { return Spatium(d); }
-static Direction intToDirection(int i)         { return Direction(i); }
 static TextStyleType intToTextStyleType(int i) { return TextStyleType(i); }
 
 //---------------------------------------------------------
@@ -177,8 +176,6 @@ void MScore::init()
             qFatal("registerConverter Spatium::toDouble failed");
       if (!QMetaType::registerConverter<double, Spatium>(&doubleToSpatium))
             qFatal("registerConverter douobleToSpatium failed");
-      if (!QMetaType::registerConverter<int, Direction>(&intToDirection))
-            qFatal("registerConverter intToDirection failed");
       if (!QMetaType::registerConverter<int, TextStyleType>(&intToTextStyleType))
             qFatal("registerConverter intToTextStyleType failed");
 

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -1176,7 +1176,7 @@ void SlurTie::undoSetLineType(int t)
 
 void SlurTie::undoSetSlurDirection(Direction d)
       {
-      undoChangeProperty(P_ID::SLUR_DIRECTION, int(d));
+      undoChangeProperty(P_ID::SLUR_DIRECTION, d);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Since @wschweer did not like the converter from int to Direction, I removed it and corrected the explicit conversion from Direction to int in the calls to undoChangeProperty(). I tested the flip commands on notes, beams, tuplets and articulation. All seems to work fine. I also had a local test branch with added canConvert<Direction> calls, that all passed.