### PR TITLE
Fix #118556: Crash when appending measure (CTRL-B) in part

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3012,7 +3012,7 @@ MeasureBase* Score::insertMeasure(Element::Type type, MeasureBase* measure, bool
                         Fraction timeStretch(_root->staff(staffIdx)->timeStretch(tick));
                         rest->setDuration(toMeasure(omb)->len() * timeStretch);
                         rest->setTrack(track);
-                        undoAddCR(rest, toMeasure(rootMeasure), tick);
+                        _root->undoAddCR(rest, toMeasure(rootMeasure), tick);
                         }
                   }
             }


### PR DESCRIPTION
Fix <a href="https://musescore.org/en/node/118556">#118556</a>
MeasureBase* Score::insertMeasure() used the wrong score in its call to undoAddCR() when it was not called from the root score.