### PR TITLE
fix #118916 append rests at end results in two end barlines

### DIFF
--- a/mtest/libmscore/parts/part-all-appendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-appendmeasures.mscx
@@ -592,11 +592,6 @@
           <lid>112</lid>
           <durationType>quarter</durationType>
           </Rest>
-        <BarLine>
-          <subtype>end</subtype>
-          <span>1</span>
-          <lid>113</lid>
-          </BarLine>
         </Measure>
       <Measure number="33">
         <Rest>
@@ -929,11 +924,6 @@
           <lid>170</lid>
           <durationType>quarter</durationType>
           </Rest>
-        <BarLine>
-          <subtype>end</subtype>
-          <span>1</span>
-          <lid>171</lid>
-          </BarLine>
         </Measure>
       <Measure number="33">
         <Rest>
@@ -1494,11 +1484,6 @@
             <lid>112</lid>
             <durationType>quarter</durationType>
             </Rest>
-          <BarLine>
-            <subtype>end</subtype>
-            <span>1</span>
-            <lid>113</lid>
-            </BarLine>
           </Measure>
         <Measure number="33">
           <Rest>
@@ -1937,11 +1922,6 @@
             <lid>170</lid>
             <durationType>quarter</durationType>
             </Rest>
-          <BarLine>
-            <subtype>end</subtype>
-            <span>1</span>
-            <lid>171</lid>
-            </BarLine>
           </Measure>
         <Measure number="33">
           <Rest>


### PR DESCRIPTION
The problem was, that the old end barline wasn't deleted or set to normal.