### PR TITLE
Issues with tuplet settings

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -65,9 +65,9 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
 
       styleWidgets = {
       //   idx --- showPercent --- widget --- resetButton
-      { StyleIdx::voltaLineStyle,         false, voltaLineStyle,           resetVoltaLineStyle },
-      { StyleIdx::ottavaLineStyle,        false, ottavaLineStyle,          resetOttavaLineStyle },
-      { StyleIdx::pedalLineStyle,         false, pedalLineStyle,           resetPedalLineStyle },
+      { StyleIdx::voltaLineStyle,          false, voltaLineStyle,          resetVoltaLineStyle },
+      { StyleIdx::ottavaLineStyle,         false, ottavaLineStyle,         resetOttavaLineStyle },
+      { StyleIdx::pedalLineStyle,          false, pedalLineStyle,          resetPedalLineStyle },
 
       { StyleIdx::staffUpperBorder,        false, staffUpperBorder,        0 },
       { StyleIdx::staffLowerBorder,        false, staffLowerBorder,        0 },
@@ -185,6 +185,8 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { StyleIdx::tupletDirection,         false, tupletDirection,         resetTupletDirection          },
       { StyleIdx::tupletNumberType,        false, tupletNumberType,        resetTupletNumberType         },
       { StyleIdx::tupletBracketType,       false, tupletBracketType,       resetTupletBracketType        },
+      { StyleIdx::tupletMaxSlope,          false, tupletMaxSlope,          resetTupletMaxSlope           },
+      { StyleIdx::tupletOufOfStaff,        false, tupletOutOfStaff,        0 },
 
       { StyleIdx::lyricsLineHeight,        true,  lyricsLineHeight,             0 },
       { StyleIdx::repeatBarTips,           false, showRepeatBarTips,            0 },
@@ -240,8 +242,6 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { StyleIdx::capoPosition,            false, capoPosition,                 0 },
       { StyleIdx::fretNumMag,              true,  fretNumMag,                   0 },
       { StyleIdx::fretY,                   false, fretY,                        0 },
-      { StyleIdx::tupletMaxSlope,          false, tupletMaxSlope,               0 },
-      { StyleIdx::tupletOufOfStaff,        false, tupletOutOfStaff,             0 },
       { StyleIdx::barreLineWidth,          false, barreLineWidth,               0 },
       { StyleIdx::fretMag,                 false, fretMag,                      0 },
       { StyleIdx::scaleBarlines,           false, scaleBarlines,                0 },

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -17,7 +17,7 @@
    <item row="0" column="1">
     <widget class="QStackedWidget" name="pageStack">
      <property name="currentIndex">
-      <number>12</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="Page1">
       <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -6061,9 +6061,6 @@
               <widget class="QDoubleSpinBox" name="tupletMaxSlope">
                <property name="suffix">
                 <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="minimum">
-                <double>0.100000000000000</double>
                </property>
                <property name="maximum">
                 <double>1.000000000000000</double>


### PR DESCRIPTION
Separate commits to allow cherry picking into 2.0.4

* fix #120041: allow 0sp max. slope for tuplet bracket, should go into master and 2.0.4
* fix #120036: Tuplet bracket max. slope 'reset to default' doesn't work, only needed in master