### PR TITLE
fix #120061: fix clicking sound in playback due to filter init

### DIFF
--- a/fluid/voice.cpp
+++ b/fluid/voice.cpp
@@ -300,6 +300,12 @@ void Voice::write(unsigned n, float* out, float* reverb, float* chorus)
 
       /******************* mod env **********************/
 
+      // if we wouldn't calculate sample accurate volume
+      // we wouldn't advance beyond FLUID_VOICE_ENVDELAY in the first call of voice::write
+      // and effectively always skip the first buffer rendering thus adding n to modenv_count
+      if (ticks == 0 && volenv_section > FLUID_VOICE_ENVDELAY)
+            modenv_count += n;
+
       env_data = &modenv_data[modenv_section];
 
       /* skip to the next section of the envelope if necessary */


### PR DESCRIPTION
probably this https://github.com/musescore/MuseScore/blob/master/fluid/voice.cpp#L513
is happening and is normally not audible due to the fact that it is happening during the attack phase. Because of sample accurate volume - modenv and volenv got "out of sync" and the filter change happens while the sound isn't at the very beginning of the attack phase. This should fix this and recreates fluidsynth's "normal" behaviour.