### PR TITLE
Build with ninja instead of make [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
             - libsndfile1
             - wget
             - make
+            - ninja-build
             - ant
             - curl
             - libasound2-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,12 +530,12 @@ subdirs(
       )
 #      thirdparty/xmlstream
 
-#if (APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
-# With xcode, we need to have all the targets in the same project
+if (CMAKE_BUILD_TYPE MATCHES "DEBUG")
+# With ninja-build, we need to have all the targets in the same project
 add_subdirectory(mtest)
-#else(APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
-#add_subdirectory(mtest EXCLUDE_FROM_ALL)
-#endif(APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
+else(CMAKE_BUILD_TYPE MATCHES "DEBUG")
+add_subdirectory(mtest EXCLUDE_FROM_ALL)
+endif(CMAKE_BUILD_TYPE MATCHES "DEBUG")
 
 add_subdirectory(rdoc EXCLUDE_FROM_ALL)
 add_subdirectory(miditools EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,12 +530,12 @@ subdirs(
       )
 #      thirdparty/xmlstream
 
-if (APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
+#if (APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
 # With xcode, we need to have all the targets in the same project
 add_subdirectory(mtest)
-else(APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
-add_subdirectory(mtest EXCLUDE_FROM_ALL)
-endif(APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
+#else(APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
+#add_subdirectory(mtest EXCLUDE_FROM_ALL)
+#endif(APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
 
 add_subdirectory(rdoc EXCLUDE_FROM_ALL)
 add_subdirectory(miditools EXCLUDE_FROM_ALL)

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,13 @@ BUILD_SYSTEM:="ninja"# Optionally override with "make" to use it instead. (Ninja
 
 ifeq ($(BUILD_SYSTEM), "ninja")
   CMAKE_GENERATOR:=Ninja
-  BUILD_FLAGS:=-l $(shell echo $$((${CPUS}*2)))
+#  BUILD_FLAGS:=-l $(shell echo $$((${CPUS}*2)))
 else
   CMAKE_GENERATOR:=Unix Makefiles
-  BUILD_FLAGS:=-j ${CPUS}
+#  BUILD_FLAGS:=-j ${CPUS}
 endif
+
+BUILD_FLAGS:=-j $(shell echo $$(((${CPUS}*3+1)/2)))
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,10 @@ BUILD_SYSTEM:="ninja"# Optionally override with "make" to use it instead. (Ninja
 
 ifeq ($(BUILD_SYSTEM), "ninja")
   CMAKE_GENERATOR:=Ninja
+  BUILD_FLAGS:=-l $(shell echo $$((${CPUS}*2)))
 else
   CMAKE_GENERATOR:=Unix Makefiles
+  BUILD_FLAGS:=-j ${CPUS}
 endif
 
 
@@ -60,7 +62,7 @@ release:
   	  -DBUILD_LAME="${BUILD_LAME}"             \
   	  -DCMAKE_SKIP_RPATH="${NO_RPATH}"     ..; \
       ${BUILD_SYSTEM} lrelease;                             \
-      ${BUILD_SYSTEM} -l ${CPUS};                           \
+      ${BUILD_SYSTEM} ${BUILD_FLAGS};                           \
 
 
 #freetype:
@@ -82,7 +84,7 @@ debug:
   	  -DBUILD_LAME="${BUILD_LAME}"                        \
   	  -DCMAKE_SKIP_RPATH="${NO_RPATH}"     ..;            \
       ${BUILD_SYSTEM} lrelease;                           \
-      ${BUILD_SYSTEM} -l ${CPUS};                         \
+      ${BUILD_SYSTEM} ${BUILD_FLAGS};                         \
 
 #
 #  win32

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ release:
   	  -DBUILD_LAME="${BUILD_LAME}"             \
   	  -DCMAKE_SKIP_RPATH="${NO_RPATH}"     ..; \
       ${BUILD_SYSTEM} lrelease;                             \
-      ${BUILD_SYSTEM} -j ${CPUS};                           \
+      ${BUILD_SYSTEM} -l ${CPUS};                           \
 
 
 #freetype:
@@ -82,7 +82,7 @@ debug:
   	  -DBUILD_LAME="${BUILD_LAME}"                        \
   	  -DCMAKE_SKIP_RPATH="${NO_RPATH}"     ..;            \
       ${BUILD_SYSTEM} lrelease;                           \
-      ${BUILD_SYSTEM} -j ${CPUS};                         \
+      ${BUILD_SYSTEM} -l ${CPUS};                         \
 
 #
 #  win32

--- a/Makefile
+++ b/Makefile
@@ -21,22 +21,22 @@
 REVISION  := `cat mscore/revision.h`
 CPUS      := $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 1)
 
-PREFIX    = "/usr/local"
-VERSION   = "3.0b-${REVISION}"
-#VERSION = 3.0.0
+PREFIX    := "/usr/local"
+VERSION   := "3.0b-${REVISION}"
+#VERSION := 3.0.0
 
 # Override SUFFIX and LABEL when multiple versions are installed to avoid conflicts.
-SUFFIX=""# E.g.: SUFFIX="dev" --> "mscore" becomes "mscoredev"
-LABEL=""# E.g.: LABEL="Development Build" --> "MuseScore 2" becomes "MuseScore 2 Development Build"
+SUFFIX:=""# E.g.: SUFFIX="dev" --> "mscore" becomes "mscoredev"
+LABEL:=""# E.g.: LABEL="Development Build" --> "MuseScore 2" becomes "MuseScore 2 Development Build"
 
-BUILD_LAME="ON"# Non-free, required for MP3 support. Override with "OFF" to disable.
-UPDATE_CACHE="TRUE"# Override if building a DEB or RPM, or when installing to a non-standard location.
-NO_RPATH="FALSE"# Package maintainers may want to override this (e.g. Debian)
+BUILD_LAME:="ON"# Non-free, required for MP3 support. Override with "OFF" to disable.
+UPDATE_CACHE:="TRUE"# Override if building a DEB or RPM, or when installing to a non-standard location.
+NO_RPATH:="FALSE"# Package maintainers may want to override this (e.g. Debian)
 
 #
 # change path to include your Qt5 installation
 #
-BINPATH      = ${PATH}
+BINPATH := ${PATH}
 
 release:
 	if test ! -d build.release; then mkdir build.release; fi; \
@@ -129,11 +129,11 @@ install: release
 #   $  make portable
 # PREFIX sets install location *and* the name of the resulting AppDir.
 # Version is appended to PREFIX in CMakeLists.txt if MSCORE_UNSTABLE=FALSE.
-portable: PREFIX=MuseScore
-portable: SUFFIX=-portable
-portable: LABEL=Portable AppImage
-portable: NO_RPATH=TRUE
-portable: UPDATE_CACHE=FALSE
+portable: PREFIX:=MuseScore
+portable: SUFFIX:=-portable
+portable: LABEL:=Portable AppImage
+portable: NO_RPATH:=TRUE
+portable: UPDATE_CACHE:=FALSE
 portable: install
 	build_dir="$$(pwd)/build.release" && cd "$$(cat $${build_dir}/PREFIX.txt)" \
 	&& [ -L usr ] || ln -s . usr && mscore="mscore${SUFFIX}" \

--- a/build/Linux+BSD/portable/Recipe
+++ b/build/Linux+BSD/portable/Recipe
@@ -55,7 +55,7 @@ cd "$(dirname "$(readlink -f "${0}")")/../../../.."
 yum -y install epel-release
 
 # basic dependencies (needed by Docker image)
-yum -y install git wget which automake unzip
+yum -y install git wget which automake unzip ninja-build
 
 if [ "${OS}" == "CentOS 6" ]; then
   # Get newer compiler than available by default

--- a/build/Linux+BSD/portable/Recipe
+++ b/build/Linux+BSD/portable/Recipe
@@ -55,7 +55,7 @@ cd "$(dirname "$(readlink -f "${0}")")/../../../.."
 yum -y install epel-release
 
 # basic dependencies (needed by Docker image)
-yum -y install git wget which automake unzip ninja-build
+yum -y install git wget which automake unzip
 
 if [ "${OS}" == "CentOS 6" ]; then
   # Get newer compiler than available by default
@@ -111,6 +111,11 @@ fi
 
 mkdir cmake && wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
 export PATH=${PWD}/cmake/bin:${PATH}
+
+#install ninja (64-bit only)
+NINJA_URL=https://github.com/ninja-build/ninja/releases/download/v1.7.1/ninja-linux.zip
+mkdir ninja && wget  --no-check-certificate --quiet -P ninja ${NINJA_URL} && unzip ninja/*.zip -d ninja
+export PATH=${PWD}/ninja:${PATH}
 
 ##########################################################################
 # BUILD MUSESCORE

--- a/build/Linux+BSD/portable/RecipeDebian
+++ b/build/Linux+BSD/portable/RecipeDebian
@@ -71,6 +71,7 @@ fetch-build-dependencies() {
     crossbuild-essential-armhf \
     qemu-user-static \
     cmake \
+    ninja-build \
     git
 
   # forcibly install because will break aptitude dependency rules 

--- a/build/travis/job1_Tests/before_script.sh
+++ b/build/travis/job1_Tests/before_script.sh
@@ -4,4 +4,4 @@ set -e # exit on error
 set -x # echo commands
 
 cd build.debug/mtest
-make -j2
+ninja

--- a/build/travis/job1_Tests/before_script.sh
+++ b/build/travis/job1_Tests/before_script.sh
@@ -4,4 +4,4 @@ set -e # exit on error
 set -x # echo commands
 
 cd build.debug/mtest
-ninja
+#ninja # ninja is always from build directory (i.e. build.debug), never from a subdirectory

--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -77,5 +77,5 @@ set_target_properties (
 
 xcode_pch(libmscore all)
 
-ADD_DEPENDENCIES(libmscore mops1)
-ADD_DEPENDENCIES(libmscore mops2)
+#ADD_DEPENDENCIES(libmscore mops1)
+#ADD_DEPENDENCIES(libmscore mops2)


### PR DESCRIPTION
 [Ninja](https://github.com/ninja-build/ninja) is faster than make and is [officially supported by CMake](https://cmake.org/cmake/help/v3.6/generator/Ninja.html) using the `-GNinja` option to generate build.ninja files instead of a Makefile.
