### PR TITLE
stack ledgerline below stem, not just below note

### DIFF
--- a/libmscore/ledgerline.cpp
+++ b/libmscore/ledgerline.cpp
@@ -26,7 +26,7 @@ namespace Ms {
 LedgerLine::LedgerLine(Score* s)
    : Line(s, false)
       {
-      setZ(int(Element::Type::NOTE) * 100 - 50);
+      setZ(int(Element::Type::STEM) * 100 - 50);
       setSelectable(false);
       _next = 0;
       }


### PR DESCRIPTION
see https://musescore.org/en/node/120466. 8fc970b did this (and more) for the master branch, this PR is for the 2.0.4 branch

