### PR TITLE
fix #121746: ask for confirmation before deleting a workspace

### DIFF
--- a/mscore/palettebox.cpp
+++ b/mscore/palettebox.cpp
@@ -124,7 +124,7 @@ void PaletteBox::updateWorkspaces()
       const QList<Workspace*> pl = Workspace::workspaces();
       int idx = 0;
       int curIdx = -1;
-      foreach (Workspace* p, pl) {
+      for (Workspace* p : pl) {
             workspaceList->addItem(qApp->translate("Ms::Workspace", p->name().toUtf8()), p->path());
             if (p->name() == preferences.workspace)
                   curIdx = idx;
@@ -203,8 +203,8 @@ void PaletteBox::paletteCmd(PaletteCommand cmd, int slot)
                   {
                   QMessageBox::StandardButton reply;
                   reply = QMessageBox::question(0,
-                             QWidget::tr("Warning"),
                              QWidget::tr("Are you sure?"),
+                             QWidget::tr("Do you really want to delete the '%1' palette?").arg(palette->name()),
                              QMessageBox::Yes | QMessageBox::No,
                              QMessageBox::Yes
                              );

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -68,13 +68,13 @@ void MuseScore::showWorkspaceMenu()
             connect(workspaces, SIGNAL(triggered(QAction*)), SLOT(changeWorkspace(QAction*)));
             }
       else {
-            foreach(QAction* a, workspaces->actions())
+            for (QAction* a : workspaces->actions())
                   workspaces->removeAction(a);
             }
       menuWorkspaces->clear();
 
       const QList<Workspace*> pl = Workspace::workspaces();
-      foreach (Workspace* p, pl) {
+      for (Workspace* p : pl) {
             QAction* a = workspaces->addAction(qApp->translate("Ms::Workspace", p->name().toUtf8()));
             a->setCheckable(true);
             a->setData(p->path());
@@ -111,7 +111,7 @@ void MuseScore::createNewWorkspace()
       s = s.replace( QRegExp( "[" + QRegExp::escape( "\\/:*?\"<>|" ) + "]" ), "_" ); //FAT/NTFS special chars
       for (;;) {
             bool notFound = true;
-            foreach(Workspace* p, Workspace::workspaces()) {
+            for (Workspace* p : Workspace::workspaces()) {
                   if ((qApp->translate("Ms::Workspace", p->name().toUtf8()).toLower() == s.toLower()) ||
                      (s.toLower() == QString("basic")) || (s.toLower() == QString("advanced"))) {
                         notFound = false;
@@ -152,7 +152,7 @@ void MuseScore::deleteWorkspace()
             return;
       preferences.dirty = true;
       Workspace* workspace = 0;
-      foreach(Workspace* p, Workspace::workspaces()) {
+      for (Workspace* p : Workspace::workspaces()) {
             if (p->name() == a->text()) { // no need for qApp->translate since "Basic" and "Advanced" are not deletable
                   workspace = p;
                   break;
@@ -160,6 +160,17 @@ void MuseScore::deleteWorkspace()
             }
       if (!workspace)
             return;
+
+      QMessageBox::StandardButton reply;
+      reply = QMessageBox::question(0,
+                 QWidget::tr("Are you sure?"),
+                 QWidget::tr("Do you really want to delete the '%1' workspace?").arg(workspace->name()),
+                 QMessageBox::Yes | QMessageBox::No,
+                 QMessageBox::Yes
+                 );
+      if (reply != QMessageBox::Yes)
+            return;
+
       Workspace::workspaces().removeOne(workspace);
       QFile f(workspace->path());
       f.remove();
@@ -209,7 +220,7 @@ void MuseScore::changeWorkspace(Workspace* p)
 
 void Workspace::initWorkspace()
       {
-      foreach(Workspace* p, Workspace::workspaces()) {
+      for (Workspace* p : Workspace::workspaces()) {
             if (p->name() == preferences.workspace) {
                   currentWorkspace = p;
                   break;
@@ -274,7 +285,7 @@ void Workspace::write()
       xml.stag("rootfiles");
       xml.stag(QString("rootfile full-path=\"%1\"").arg(Xml::xmlString("workspace.xml")));
       xml.etag();
-      foreach (ImageStoreItem* ip, imageStore) {
+      for (ImageStoreItem* ip : imageStore) {
             if (!ip->isUsed(gscore))
                   continue;
             QString dstPath = QString("Pictures/") + ip->hashName();
@@ -286,7 +297,7 @@ void Workspace::write()
       f.addFile("META-INF/container.xml", cbuf.data());
 
       // save images
-      foreach(ImageStoreItem* ip, imageStore) {
+      for (ImageStoreItem* ip : imageStore) {
             if (!ip->isUsed(gscore))
                   continue;
             QString dstPath = QString("Pictures/") + ip->hashName();
@@ -358,7 +369,7 @@ void Workspace::read()
       //
       // load images
       //
-      foreach(const QString& s, images)
+      for (const QString& s : images)
             imageStore.add(s, f.fileData(s));
 
       if (rootfile.isEmpty()) {
@@ -456,7 +467,7 @@ QList<Workspace*>& Workspace::workspaces()
             QStringList nameFilters;
             nameFilters << "*.workspace";
 
-            foreach (const QString& s, path) {
+            for (const QString& s : path) {
                   QDir dir(s);
                   QStringList pl = dir.entryList(nameFilters, QDir::Files, QDir::Name);
 
@@ -464,7 +475,7 @@ QList<Workspace*>& Workspace::workspaces()
                         Workspace* p = 0;
                         QFileInfo fi(s + "/" + entry);
                         QString name(fi.completeBaseName());
-                        foreach (Workspace* w, _workspaces) {
+                        for (Workspace* w : _workspaces) {
                               if (w->name() == name) {
                                     p = w;
                                     break;
@@ -500,7 +511,7 @@ Workspace* Workspace::createNewWorkspace(const QString& name)
 
       PaletteBox* paletteBox = mscore->getPaletteBox();
       QList<Palette*> pl = paletteBox->palettes();
-      foreach (Palette* p, pl) {
+      for (Palette* p : pl) {
             p->setSystemPalette(false);
             for (int i = 0; i < p->size(); ++i)
                   p->setCellReadOnly(i, false);


### PR DESCRIPTION
and change Qt's `foreach(a, b)` to C++11's `for (a : b)`
Also improve the delete palette message
Should go to master and 2.0.4, just like PR #2525 