### PR TITLE
partial fix #121706: custom dashed options not working

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -492,13 +492,13 @@ void Hairpin::setHairpinType(Type val)
                   setBeginText("cresc.");
                   setContinueText("(cresc.)");
                   setLineStyle(Qt::CustomDashLine);
-                  setDashGapLen(20.0);
+                  setDashGapLen(Spatium(4.0));
                   break;
             case Type::DECRESC_LINE:
                   setBeginText("dim.");
                   setContinueText("(dim.)");
                   setLineStyle(Qt::CustomDashLine);
-                  setDashGapLen(20.0);
+                  setDashGapLen(Spatium(4.0));
                   break;
             };
       }
@@ -702,7 +702,7 @@ QVariant Hairpin::propertyDefault(P_ID id) const
                   return int(Qt::CustomDashLine);
             case P_ID::DASH_GAP_LEN:
                   if (lineStyle() == Qt::CustomDashLine)
-                        return 20.0;
+                        return Spatium(4.0);
                   // fall thru
             default:
                   return TextLineBase::propertyDefault(id);

--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -492,11 +492,13 @@ void Hairpin::setHairpinType(Type val)
                   setBeginText("cresc.");
                   setContinueText("(cresc.)");
                   setLineStyle(Qt::CustomDashLine);
+                  setDashGapLen(20.0);
                   break;
             case Type::DECRESC_LINE:
                   setBeginText("dim.");
                   setContinueText("(dim.)");
                   setLineStyle(Qt::CustomDashLine);
+                  setDashGapLen(20.0);
                   break;
             };
       }
@@ -698,7 +700,10 @@ QVariant Hairpin::propertyDefault(P_ID id) const
                   if (_hairpinType == Type::CRESC_HAIRPIN || _hairpinType == Type::DECRESC_HAIRPIN)
                         return int(Qt::SolidLine);
                   return int(Qt::CustomDashLine);
-
+            case P_ID::DASH_GAP_LEN:
+                  if (lineStyle() == Qt::CustomDashLine)
+                        return 20.0;
+                  // fall thru
             default:
                   return TextLineBase::propertyDefault(id);
             }

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -1139,9 +1139,9 @@ bool SLine::readProperties(XmlReader& e)
       else if (tag == "lineStyle")
             _lineStyle = Qt::PenStyle(e.readInt());
       else if (tag == "dashLineLength")
-            _dashLineLen = e.readDouble();
+            _dashLineLen = Spatium(e.readDouble());
       else if (tag == "dashGapLength")
-            _dashGapLen = e.readDouble();
+            _dashGapLen = Spatium(e.readDouble());
       else if (tag == "lineColor")
             _lineColor = e.readColor();
       else if (Element::readProperties(e))
@@ -1224,9 +1224,9 @@ QVariant SLine::getProperty(P_ID id) const
             case P_ID::LINE_STYLE:
                   return QVariant(int(_lineStyle));
             case P_ID::DASH_LINE_LEN:
-                  return dashLineLen();
+                  return _dashLineLen;
             case P_ID::DASH_GAP_LEN:
-                  return dashGapLen();
+                  return _dashGapLen;
             default:
                   return Spanner::getProperty(id);
             }
@@ -1252,10 +1252,10 @@ bool SLine::setProperty(P_ID id, const QVariant& v)
                   _lineStyle = Qt::PenStyle(v.toInt());
                   break;
             case P_ID::DASH_LINE_LEN:
-                  setDashLineLen(v.toDouble());
+                  _dashLineLen = v.value<Spatium>();
                   break;
             case P_ID::DASH_GAP_LEN:
-                  setDashGapLen(v.toDouble());
+                  _dashGapLen = v.value<Spatium>();
                   break;
             default:
                   return Spanner::setProperty(id, v);
@@ -1280,7 +1280,7 @@ QVariant SLine::propertyDefault(P_ID id) const
                   return int(Qt::SolidLine);
             case P_ID::DASH_LINE_LEN:
             case P_ID::DASH_GAP_LEN:
-                  return 5.0;
+                  return Spatium(1.0);
             default:
                   return Spanner::propertyDefault(id);
             }

--- a/libmscore/line.h
+++ b/libmscore/line.h
@@ -75,8 +75,8 @@ class SLine : public Spanner {
       Spatium _lineWidth      { 0.15 };
       QColor _lineColor       { MScore::defaultColor };
       Qt::PenStyle _lineStyle { Qt::SolidLine };
-      qreal _dashLineLen      { 5.0   };
-      qreal _dashGapLen       { 5.0   };
+      Spatium _dashLineLen    { 1.0   };
+      Spatium _dashGapLen     { 1.0   };
       bool _diagonal          { false };
 
    protected:
@@ -109,10 +109,10 @@ class SLine : public Spanner {
       void setLineColor(const QColor& v)  { _lineColor = v;               }
       void setLineStyle(Qt::PenStyle v)   { _lineStyle = v;               }
 
-      qreal dashLineLen() const           { return _dashLineLen; }
-      void setDashLineLen(qreal val)      { _dashLineLen = val; }
-      qreal dashGapLen() const            { return _dashGapLen; }
-      void setDashGapLen(qreal val)       { _dashGapLen = val; }
+      Spatium dashLineLen() const           { return _dashLineLen; }
+      void setDashLineLen(const Spatium& v) { _dashLineLen = v; }
+      Spatium dashGapLen() const            { return _dashGapLen; }
+      void setDashGapLen(const Spatium& v)  { _dashGapLen = v; }
 
       LineSegment* frontSegment() const   { return (LineSegment*)spannerSegments().front(); }
       LineSegment* backSegment() const    { return (LineSegment*)spannerSegments().back();  }

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -242,8 +242,8 @@ static const PropertyData propertyList[] = {
       { P_ID::SYSTEM_BRACKET,      false, "type",                  P_TYPE::INT   },
       { P_ID::GAP,                 false, 0,                       P_TYPE::BOOL  },
       { P_ID::AUTOPLACE,           false, 0,                       P_TYPE::BOOL  },
-      { P_ID::DASH_LINE_LEN,       false, "dashLineLength",        P_TYPE::REAL  },
-      { P_ID::DASH_GAP_LEN,        false, "dashGapLength",         P_TYPE::REAL  },
+      { P_ID::DASH_LINE_LEN,       false, "dashLineLength",        P_TYPE::SPATIUM  },
+      { P_ID::DASH_GAP_LEN,        false, "dashGapLength",         P_TYPE::SPATIUM  },
       { P_ID::TICK,                false, 0,                       P_TYPE::INT  },
 
       { P_ID::END,                 false, "",                      P_TYPE::INT   }

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -98,7 +98,7 @@ void TextLineBaseSegment::draw(QPainter* painter) const
       qreal textlineLineWidth    = tl->lineWidth().val() * _spatium;
       QPen pen(color, textlineLineWidth, tl->lineStyle());
       if (tl->lineStyle() == Qt::CustomDashLine) {
-            QVector<qreal> dashes { tl->dashLineLen(), tl->dashGapLen() };
+            QVector<qreal> dashes { tl->dashLineLen().val() * _spatium, tl->dashGapLen().val() * _spatium };
             pen.setDashPattern(dashes);
             }
       painter->setPen(pen);

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -501,7 +501,7 @@ void InspectorBase::mapSignals(const std::vector<InspectorItem>& il)
                         QMenu* menu = new QMenu(this);
                         resetButton->setMenu(menu);
                         resetButton->setPopupMode(QToolButton::MenuButtonPopup);
-                        QAction* a = menu->addAction(tr("set style"));
+                        QAction* a = menu->addAction(tr("Set style"));
                         styleMapper->setMapping(a, i);
                         connect(a, SIGNAL(triggered()), styleMapper, SLOT(map()));
                         }

--- a/mscore/inspector/inspectorHairpin.cpp
+++ b/mscore/inspector/inspectorHairpin.cpp
@@ -41,6 +41,8 @@ InspectorHairpin::InspectorHairpin(QWidget* parent)
             { P_ID::LINE_COLOR,          0, 0, l.lineColor,         l.resetLineColor         },
             { P_ID::LINE_WIDTH,          0, 0, l.lineWidth,         l.resetLineWidth         },
             { P_ID::LINE_STYLE,          0, 0, l.lineStyle,         l.resetLineStyle         },
+            { P_ID::DASH_LINE_LEN,       0, 0, l.dashLineLength,    l.resetDashLineLength    },
+            { P_ID::DASH_GAP_LEN,        0, 0, l.dashGapLength,     l.resetDashGapLength     },
             { P_ID::HAIRPIN_CIRCLEDTIP,  0, 0, h.hairpinCircledTip, h.resetHairpinCircledTip },
             { P_ID::HAIRPIN_TYPE,        0, 0, h.hairpinType,       0                        },
             { P_ID::DYNAMIC_RANGE,       0, 0, h.dynRange,          h.resetDynRange          },

--- a/mscore/inspector/inspector_line.ui
+++ b/mscore/inspector/inspector_line.ui
@@ -303,8 +303,11 @@
        <property name="accessibleName">
         <string>Dash line length</string>
        </property>
-       <property name="maximum">
-        <double>20.000000000000000</double>
+       <property name="suffix">
+        <string extracomment="Staff space unit">sp</string>
+       </property>
+       <property name="singleStep">
+        <double>0.250000000000000</double>
        </property>
       </widget>
      </item>
@@ -313,8 +316,11 @@
        <property name="accessibleName">
         <string>Dash gap width</string>
        </property>
-       <property name="maximum">
-        <double>20.000000000000000</double>
+       <property name="suffix">
+        <string extracomment="Staff space unit">sp</string>
+       </property>
+       <property name="singleStep">
+        <double>0.250000000000000</double>
        </property>
       </widget>
      </item>

--- a/mscore/inspector/inspector_line.ui
+++ b/mscore/inspector/inspector_line.ui
@@ -97,12 +97,18 @@
        <property name="text">
         <string>Line thickness</string>
        </property>
+       <property name="buddy">
+        <cstring>lineWidth</cstring>
+       </property>
       </widget>
      </item>
      <item row="5" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Line style</string>
+       </property>
+       <property name="buddy">
+        <cstring>lineStyle</cstring>
        </property>
       </widget>
      </item>
@@ -251,6 +257,9 @@
        <property name="focusPolicy">
         <enum>Qt::TabFocus</enum>
        </property>
+       <property name="accessibleName">
+        <string>Line visible</string>
+       </property>
        <property name="text">
         <string>Line visible</string>
        </property>
@@ -261,12 +270,18 @@
        <property name="text">
         <string>Dash gap width</string>
        </property>
+       <property name="buddy">
+        <cstring>dashGapLength</cstring>
+       </property>
       </widget>
      </item>
      <item row="6" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Dash line length</string>
+       </property>
+       <property name="buddy">
+        <cstring>dashLineLength</cstring>
        </property>
       </widget>
      </item>
@@ -286,32 +301,20 @@
      <item row="6" column="1">
       <widget class="QDoubleSpinBox" name="dashLineLength">
        <property name="accessibleName">
-        <string>Line thickness</string>
-       </property>
-       <property name="minimum">
-        <double>1.000000000000000</double>
+        <string>Dash line length</string>
        </property>
        <property name="maximum">
         <double>20.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>1.000000000000000</double>
        </property>
       </widget>
      </item>
      <item row="7" column="1">
       <widget class="QDoubleSpinBox" name="dashGapLength">
        <property name="accessibleName">
-        <string>Line thickness</string>
-       </property>
-       <property name="minimum">
-        <double>1.000000000000000</double>
+        <string>Dash gap width</string>
        </property>
        <property name="maximum">
         <double>20.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>1.000000000000000</double>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
and having bad defaults and backward compatibility issues,
esp. for dim./cresc. lines.
Also fix capitalisation of  "Set style" button and
accessibility info and buddies for inspector_line.ui