### PR TITLE
fix #120156: Infinite loop with an XML

### DIFF
--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -5587,7 +5587,6 @@ void MusicXMLParserPass2::notations(Note* note, ChordRest* cr, const int tick,
                         else if (_e.name() == "tremolo") {
                               tremoloType = _e.attributes().value("type").toString();
                               tremolo = _e.readElementText().toInt();
-                              _e.readNext();
                               }
                         else if (_e.name() == "accidental-mark")
                               skipLogCurrElem();


### PR DESCRIPTION
Considered adding a test case, but decided against it, as the issue was a local bug in the tremolo parsing code (readElementText() must not be followed by readNext()) and affects nothing else. A test case would only verify I do not make the same mistake again.