### PR TITLE
Semi-Realtime MIDI - separation of voices [WIP]

### DIFF
--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -66,7 +66,7 @@ add_library (
       synthesizerstate.cpp mcursor.cpp groups.cpp mscoreview.cpp
       noteline.cpp spannermap.cpp
       bagpembell.cpp ambitus.cpp keylist.cpp scoreElement.cpp
-      shape.cpp systemdivider.cpp midimapping.cpp
+      shape.cpp systemdivider.cpp midimapping.cpp virtualmeasure.cpp
       )
 
 set_target_properties (

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -663,6 +663,7 @@ class Score : public QObject, public ScoreElement {
 
       void repitchNote(const Position& pos, bool replace);
       void regroupNotesAndRests(int startTick, int endTick, int track);
+      void recalculateVoices(int startTick, int endTick, int staffIdx);
       void cmdAddPitch(int pitch, bool addFlag, bool insert);
       void cmdTimeDelete();
       void timeDelete(Measure*, Segment*, const Fraction&);

--- a/libmscore/virtualmeasure.cpp
+++ b/libmscore/virtualmeasure.cpp
@@ -1,0 +1,216 @@
+//=============================================================================
+//  virtualmeasure.cpp
+//
+//  Copyright (C) 2016 Peter Jonas <shoogle@users.noreply.github.com>
+//
+//  This program is free software; you can redistribute it and/or modify it
+//  under the terms of the GNU General Public License version 2 as published
+//  by the Free Software Foundation and appearing in the file LICENCE.GPL
+//=============================================================================
+
+#include <algorithm>    // std::sort
+
+#include "virtualmeasure.h"
+#include "durationtype.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   arrange
+//    Re-arrange the passage of music in the Virtual Measure.
+//---------------------------------------------------------
+
+void VirtualMeasure::arrange()
+      {
+      // Notes were already added to lowest available voice, so the arangement is already optimum.
+      // Just need to sort the voices to ensure that voices 1 and 3 are higher than voices 2 and 4.
+      for (VirtualVoice* vv: _voices) {
+            vv->sortChordsByTick();
+            for (RawChord* rc : vv->chords()) {
+                  rc->sortNotesByPitch();
+                  }
+            }
+
+      sortVoicesByAveragePitch();
+      }
+
+//---------------------------------------------------------
+//   addTiedNotes
+//    Adds a note for each duration in the list and ties it to the others in the list.
+//---------------------------------------------------------
+
+void VirtualMeasure::addTiedNotes(int pitch, int tick, const std::vector<TDuration>& dList, Note* tiedNoteFor, Note* tiedNoteBack)
+      {
+      RawNote* prev = 0;
+      int cumulativeTick = tick;
+      for (TDuration d : dList) {
+            int ticks = d.ticks();
+            RawNote* rn = new RawNote(pitch, 0, tiedNoteBack, 0, prev);
+            RawChord* rc = new RawChord(cumulativeTick, ticks, rn);
+            addChord(rc);
+            if (prev)
+                  prev->setNext(rn); // update the previous note to point to this one
+            prev = rn;
+            tiedNoteBack = 0;
+            cumulativeTick += ticks;
+            }
+      prev->setTiedNoteFor(tiedNoteFor); // tie the final note to a note outside the VirtualMeasure
+      }
+
+//---------------------------------------------------------
+//   addChord
+//    Adds a chord to the lowest-numbered voice it can go in.
+//---------------------------------------------------------
+
+void VirtualMeasure::addChord(RawChord* chord)
+      {
+      for (VirtualVoice* v : _voices) {
+            if (v->addChord(chord))
+                  return; // chord added to existing voice
+            }
+      // couldn't add chord to existing voice so create a new one
+      VirtualVoice* vv = new VirtualVoice(chord);
+      _voices.push_back(vv);
+      }
+
+bool VirtualVoice::addChord(RawChord* chord) {
+      for (RawChord* rc : _chords) {
+            // try to combine chord with an existing chord in the voice
+            if (rc->addNotesFromChord(chord))
+                  return true; // chords coincide (same start and end tick) so were combined
+            if (rc->overlaps(chord))
+                  return false; // chords overlap so can't go in this voice
+            }
+      // Chord neither coincides nor overlaps with any chords in voice, so it cannot be combined
+      // with an exiting chord, but it can still be added to the voice as a separate chord.
+      _chords.push_back(chord);
+      return true;
+      }
+
+//---------------------------------------------------------
+//   addNotesFromChord
+//---------------------------------------------------------
+
+bool RawChord::addNotesFromChord(RawChord* chord)
+      {
+      if (!coincides(chord))
+            return false;
+      for (RawNote* rn : chord->notes())
+            _notes.push_back(rn);
+      return true;
+      }
+
+//---------------------------------------------------------
+//   sortVoicesByAveragePitch
+//---------------------------------------------------------
+
+void VirtualMeasure::sortVoicesByAveragePitch()
+      {
+      qDebug("Sort Voices");
+      int n = numVoices();
+      if (n < 2)
+            return;
+
+      // sort voices by average pitch, highest first
+      std::sort(_voices.begin(), _voices.end(),
+            [] (VirtualVoice* v1, VirtualVoice* v2) { return v1->averagePitch() > v2->averagePitch(); });
+
+      // In MuseScore odd voices are higher than even voices (Voice 1 > Voice 3 > Voice 4 > Voice 2) so now
+      // sort into order: highest, lowest, 2nd highest, 2nd lowest, etc (can have more than 4 virtual voices).
+      for (int i = 1; i < n; i += 2) {
+            // move the final element (the lowest pitch
+            // note not yet moved) up to the i-th place
+            VirtualVoice* v = _voices[n-1];
+            _voices.pop_back();
+            _voices.insert(_voices.begin()+i, v);
+            }
+      }
+
+//---------------------------------------------------------
+//   sortChordsByTick
+//---------------------------------------------------------
+
+void VirtualVoice::sortChordsByTick()
+      {
+      // sort chords by tick, lowest first
+      std::sort(_chords.begin(), _chords.end(),
+            [] (RawChord* rc1, RawChord* rc2) { return rc1->tick() < rc2->tick(); });
+      }
+
+//---------------------------------------------------------
+//   sortNotesByPitch
+//---------------------------------------------------------
+
+void RawChord::sortNotesByPitch()
+      {
+      // sort notes by pitch, highest first
+      std::sort(_notes.begin(), _notes.end(),
+            [] (RawNote* rn1, RawNote* rn2) { return rn1->pitch() > rn2->pitch(); });
+      }
+
+//---------------------------------------------------------
+//   numNotes
+//---------------------------------------------------------
+
+int VirtualVoice::numNotes() const
+      {
+      int sum = 0;
+      for (RawChord* rc : _chords)
+            sum += rc->numNotes();
+      return sum;
+      }
+
+//---------------------------------------------------------
+//   sumPitches
+//---------------------------------------------------------
+
+int VirtualVoice::sumPitches() const
+      {
+      int sum = 0;
+      for (RawChord* rc : _chords)
+            sum += rc->sumPitches();
+      return sum;
+      }
+
+int RawChord::sumPitches() const
+      {
+      int sum = 0;
+      for (RawNote* rn : _notes)
+            sum += rn->pitch();
+      return sum;
+      }
+
+#if 0
+//---------------------------------------------------------
+//   print
+//---------------------------------------------------------
+
+void VirtualMeasure::print()
+      {
+      int i = 0;
+      for (VirtualVoice* v : _voices) {
+            qDebug("~VirtualVoice %i", i);
+            v->print();
+            i++;
+            }
+      }
+
+void VirtualVoice::print()
+      {
+      int i = 0;
+      for (RawChord* rc : _chords) {
+            qDebug("~~VirtualVoiceChord %i", i);
+            rc->print();
+            i++;
+            }
+      }
+
+void RawChord::print()
+      {
+      qDebug("~~~RawChord: tick = %i, ticks = %i (endTick = %i)", tick(), ticks(), endTick());
+      for (RawNote* rn : _notes)
+            rn->print();
+      }
+#endif
+
+} // namespace Ms

--- a/libmscore/virtualmeasure.h
+++ b/libmscore/virtualmeasure.h
@@ -1,0 +1,156 @@
+//=============================================================================
+//  virtualmeasure.h
+//
+//  Copyright (C) 2016 Peter Jonas <shoogle@users.noreply.github.com>
+//
+//  This program is free software; you can redistribute it and/or modify it
+//  under the terms of the GNU General Public License version 2 as published
+//  by the Free Software Foundation and appearing in the file LICENCE.GPL
+//=============================================================================
+
+#ifndef VIRTUALMEASURE_H
+#define VIRTUALMEASURE_H
+
+#include <vector>
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   VirtualMeasure
+//   ==============
+//    The VirtualMeasure provides an abstraction layer for re-arranging a section
+//   of music. It provides a place to store and operate on musical notes as simple
+//   data structures without the restrictions that normally apply. For example, the
+//   number of voices in the virtual measure is unlimited. This is helpful if you
+//   want to move notes between voices without overwriting notes already in other
+//   voice, since any overlapping notes can just be sent to a new voice. It is
+//   especially helpful when you do not know what the final arrangement is going to
+//   look like in advance. Once the re-arrangement is complete the RawNotes can be
+//   read from the VirtualMeasure and converted to "real" Notes in a real Score.
+//
+//   Usage:
+//    1) Create a VirtualMeasure object and fill it with notes from a section of a
+//      real score. (The section doesn't have to be equal to a Measure, but a
+//      Measure is a sensible choice because notes cannot cross a Measure boundary).
+//    2) Call the VirtualMeasure's "arrange()" method to optimise the voicing.
+//    3) Read the new arrangement from the VirtualMeasure and add notes to the real score.
+//
+//    The default algorithm simply optimises the voices such that everything gets
+//    put in the lowest-numbered voice possible. New voices are only added when
+//    necessary due to overlapping notes. If you want to do something more fancy then
+//    override the "arrange()" method. Some examples of things you could do:
+//
+//      * Use different voices for notes that are separated by large pitch intervals.
+//      * Reduce the number of voices required by splitting some notes into tied notes.
+//---------------------------------------------------------
+
+class Note;
+class TDuration;
+
+//---------------------------------------------------------
+//   RawNote
+//---------------------------------------------------------
+
+class RawNote {
+      int _pitch;
+
+      Note* _tiedNoteFor;     // "real" Note outside the VirtualMeasure that this
+      Note* _tiedNoteBack;    // RawNote should be tied to when it is made real.
+
+      RawNote* _next;         // Another RawNote within the VirtualMeasure to which
+      RawNote* _prev;         // this one should be tied when they are made real.
+
+   public:
+      RawNote(int pitch, Note* tiedNoteFor, Note* tiedNoteBack, RawNote* next, RawNote* prev) :
+                  _pitch(pitch), _tiedNoteFor(tiedNoteFor), _tiedNoteBack(tiedNoteBack), _next(next), _prev(prev) {}
+
+      int pitch() const             { return _pitch;   }
+      Note* tiedNoteFor()           { return _tiedNoteFor;  }
+      Note* tiedNoteBack()          { return _tiedNoteBack; }
+      RawNote* next()               { return _next; }
+      RawNote* prev()               { return _prev; }
+
+      void setNext(RawNote* rn)     { _next = rn; }
+      void setPrev(RawNote* rn)     { _prev = rn; }
+      void setTiedNoteFor(Note* n)  { _tiedNoteFor = n; }
+      void setTiedNoteBack(Note* n) { _tiedNoteBack = n; }
+      };
+
+//---------------------------------------------------------
+//   RawChord
+//---------------------------------------------------------
+
+class RawChord {
+      int _tick;
+      int _ticks;
+      std::vector<RawNote*> _notes;
+
+   public:
+      RawChord(int tick, int ticks, RawNote* note) : _tick(tick), _ticks(ticks) { _notes.push_back(note); }
+      ~RawChord()                               { for (RawNote* rn : _notes ) delete rn; }
+
+      std::vector<RawNote*>& notes()            { return _notes; }
+
+      void addNote(RawNote* note)               { _notes.push_back(note); }
+      bool addNotesFromChord(RawChord* chord);
+      bool overlaps(RawChord* c)                { return !(c->tick() >= endTick() || c->endTick() < tick()); }
+      bool coincides(RawChord* c)               { return c->tick() == tick() && c->ticks() == ticks(); }
+
+      int tick() const                          { return _tick; }
+      int ticks() const                         { return _ticks; }
+      int endTick() const                       { return tick() + ticks(); }
+      int numNotes() const                      { return _notes.size(); }
+      int sumPitches() const;
+      float averagePitch() const                { return sumPitches() * 1.0 / numNotes(); }
+
+      void sortNotesByPitch();
+      };
+
+//---------------------------------------------------------
+//   VirtualVoice
+//---------------------------------------------------------
+
+class VirtualVoice {
+      std::vector<RawChord*> _chords;
+
+   public:
+      VirtualVoice(RawChord* c)           { addChord(c); }
+      ~VirtualVoice()                     { for (RawChord* rc : _chords) delete rc; }
+
+      std::vector<RawChord*>& chords()    { return _chords; }
+
+      bool addChord(RawChord* chord);
+
+      int numChords() const               { return _chords.size(); }
+      int numNotes() const;
+      int sumPitches() const;
+      float averagePitch() const          { return sumPitches() * 1.0 / numNotes(); }
+
+      void sortChordsByTick();
+      };
+
+//---------------------------------------------------------
+//   VirtualMeasure
+//    Provides useful abstractions for manipulating voices.
+//---------------------------------------------------------
+
+class VirtualMeasure {
+      std::vector<VirtualVoice*> _voices; // Note: not limited to 4 voices
+
+   public:
+      ~VirtualMeasure()                         { for (VirtualVoice* vv : _voices) delete vv; }
+      std::vector<VirtualVoice*>& voices()      { return _voices; }
+
+      void addTiedNotes(int pitch, int tick, const std::vector<TDuration>& dList, Note* tiedNoteFor = 0, Note* tiedNoteBack = 0);
+
+      int numVoices() const   { return _voices.size(); }
+      virtual void arrange();
+
+   private:
+      void addChord(RawChord* chord);
+      void sortVoicesByAveragePitch();
+      };
+
+} // namespace Ms
+
+#endif // VIRTUALMEASURE_H

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -83,6 +83,7 @@ void Preferences::init()
       iconWidth          = 28;
 
       enableMidiInput    = true;
+      enableRealtimeVoices = true;
       realtimeDelay      = 750; // ms
       playNotes          = true;
       playChordOnAddNote = true;
@@ -230,6 +231,7 @@ void Preferences::write()
       s.setValue("defaultColor",       MScore::defaultColor);
       s.setValue("pianoHlColor",       pianoHlColor);
       s.setValue("enableMidiInput",    enableMidiInput);
+      s.setValue("enableRealtimeVoices", enableRealtimeVoices);
       s.setValue("realtimeDelay",      realtimeDelay);
       s.setValue("playNotes",          playNotes);
       s.setValue("playChordOnAddNote", playChordOnAddNote);
@@ -382,6 +384,7 @@ void Preferences::read()
       pianoHlColor            = s.value("pianoHlColor", pianoHlColor).value<QColor>();
 
       enableMidiInput         = s.value("enableMidiInput", enableMidiInput).toBool();
+      enableRealtimeVoices    = s.value("enableRealtimeVoices", enableRealtimeVoices).toBool();
       realtimeDelay           = s.value("realtimeDelay", realtimeDelay).toInt();
       playNotes               = s.value("playNotes", playNotes).toBool();
       playChordOnAddNote      = s.value("playChordOnAddNote", playChordOnAddNote).toBool();
@@ -777,6 +780,7 @@ void PreferenceDialog::updateValues()
       iconHeight->setValue(prefs.iconHeight);
 
       enableMidiInput->setChecked(prefs.enableMidiInput);
+      enableRealtimeVoices->setChecked(prefs.enableRealtimeVoices);
       realtimeDelay->setValue(prefs.realtimeDelay);
       playNotes->setChecked(prefs.playNotes);
       playChordOnAddNote->setChecked(prefs.playChordOnAddNote);
@@ -1271,6 +1275,7 @@ void PreferenceDialog::apply()
       prefs.bgUseColor     = bgColorButton->isChecked();
       prefs.fgUseColor     = fgColorButton->isChecked();
       prefs.enableMidiInput = enableMidiInput->isChecked();
+      prefs.enableRealtimeVoices = enableRealtimeVoices->isChecked();
       prefs.realtimeDelay   = realtimeDelay->value();
       prefs.playNotes      = playNotes->isChecked();
       prefs.playChordOnAddNote = playChordOnAddNote->isChecked();

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -93,6 +93,7 @@ struct Preferences {
       QColor dropColor;
       QColor pianoHlColor;
       bool enableMidiInput;
+      bool enableRealtimeVoices;
       int realtimeDelay;
       bool playNotes;         // play notes on click
       bool playChordOnAddNote;

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -1158,13 +1158,23 @@
            </widget>
           </item>
           <item row="2" column="0">
+           <widget class="QCheckBox" name="enableRealtimeVoices">
+            <property name="accessibleName">
+             <string>Enable multi-voice entry in Real-time mode</string>
+            </property>
+            <property name="text">
+             <string>Enable multi-voice entry in Real-time mode</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
            <widget class="QLabel" name="label_56">
             <property name="text">
              <string>Delay between notes in automatic Real-time mode:</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QSpinBox" name="realtimeDelay">
             <property name="accessibleName">
              <string>Delay between notes in automatic Real-time mode</string>
@@ -1186,7 +1196,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
+          <item row="3" column="2">
            <spacer name="horizontalSpacer_4">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -5369,7 +5369,10 @@ void ScoreView::cmdRealtimeAdvance()
             }
       if (prevCR->measure() != is.segment()->measure()) {
             // just advanced across barline. Now simplify tied notes.
-            score()->regroupNotesAndRests(prevCR->measure()->tick(), is.segment()->measure()->tick(), is.track());
+            if (preferences.enableRealtimeVoices)
+                  score()->recalculateVoices(prevCR->measure()->tick(), is.segment()->measure()->tick(), is.track() / VOICES);
+            else
+                  score()->regroupNotesAndRests(prevCR->measure()->tick(), is.segment()->measure()->tick(), is.track());
             }
       _score->endCmd();
       }


### PR DESCRIPTION
Definitely a work-in-progress at the moment. The voice recalculation works perfectly, but there are bugs when it comes to entering the newly calculated voice into the score. The pre-existing `setNoteRest()` function appears to have problems with higher voices. It seems like ChordRests are being created but then ignored, so when the chord looks for the next ChordRest the new ones are missed and things get corrupted.

Voice separation works some of the time, but crashes consistently with certain inputs, such as when playing short low notes at the same time as long high notes. For example, playing an E whole-note while playing C quarters causes a crash, but playing E quarters against a C whole note is fine.
