### PR TITLE
Fix #119976: Inter-staff spacing for lyrics with dashes and melismas

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3555,7 +3555,12 @@ System* Score::collectSystem(LayoutContext& lc)
                         Spanner* sp = ss->spanner();
                         if (sp->tick() < m->endTick() && sp->tick2() > m->tick()) {
                               // spanner shape must be translated from system coordinate space to measure coordinate space
-                              m->staffShape(sp->staffIdx()).add(ss->shape().translated(ss->pos() - m->pos()));
+                              if (ss->type() == Element::Type::LYRICSLINE_SEGMENT) {
+                                    m->staffShape(sp->staffIdx()).add(ss->shape().translated(-m->pos()));
+                                    }
+                              else {
+                                    m->staffShape(sp->staffIdx()).add(ss->shape().translated(ss->pos() - m->pos()));
+                                    }
                               }
                         }
                   }


### PR DESCRIPTION
Spanner shapes need to be corrected from system to measure space, but
not lyrics line spanners.