### PR TITLE
fix #110711: color piano keys when MIDI keys are pressed

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2170,6 +2170,13 @@ void MuseScore::midiNoteReceived(int channel, int pitch, int velo)
                   --active;
             cv->midiNoteReceived(pitch, false, velo);
             }
+
+      if (_pianoTools && _pianoTools->isVisible()) {
+            if (velo)
+                  _pianoTools->pressPitch(pitch);
+            else
+                  _pianoTools->releasePitch(pitch);
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -50,7 +50,6 @@ HPiano::HPiano(QWidget* parent)
 
       _firstKey   = 21;
       _lastKey    = 108;   // 88 key piano
-      _currentKey = -1;
       qreal x = 0.0;
       for (int i = _firstKey; i <= _lastKey; ++i) {
             PianoKeyItem* k = new PianoKeyItem(this, i);
@@ -133,13 +132,40 @@ QSize HPiano::sizeHint() const
 //   pressKeys
 //---------------------------------------------------------
 
-void HPiano::pressKeys(QSet<int> pitches)
+void HPiano::setPressedPitches(QSet<int> pitches)
       {
-	for (PianoKeyItem* key : keys) {
-            if (pitches.contains(key->pitch()))
-                  key->setPressed(true);
-            else
-                  key->setPressed(false);
+      _pressedPitches = pitches;
+      updateAllKeys();
+      }
+
+//---------------------------------------------------------
+//   pressPitch
+//---------------------------------------------------------
+
+void HPiano::pressPitch(int pitch)
+      {
+      _pressedPitches.insert(pitch);
+      updateAllKeys();
+      }
+
+//---------------------------------------------------------
+//   releasePitch
+//---------------------------------------------------------
+
+void HPiano::releasePitch(int pitch)
+      {
+      _pressedPitches.remove(pitch);
+      updateAllKeys();
+      }
+
+//---------------------------------------------------------
+//   updateAllKeys
+//---------------------------------------------------------
+
+void HPiano::updateAllKeys()
+      {
+      for (PianoKeyItem* key : keys) {
+            key->setPressed(_pressedPitches.contains(key->pitch()));
             key->update();
             }
       }
@@ -342,7 +368,7 @@ void PianoTools::heartBeat(QList<const Ms::Note *> notes)
       for (const Note* note : notes) {
           pitches.insert(note->ppitch());
           }
-      _piano->pressKeys(pitches);
+      _piano->setPressedPitches(pitches);
       }
 
 //---------------------------------------------------------

--- a/mscore/pianotools.h
+++ b/mscore/pianotools.h
@@ -56,7 +56,7 @@ class HPiano : public QGraphicsView {
       Q_OBJECT
       int _firstKey;
       int _lastKey;
-      int _currentKey;
+      QSet<int> _pressedPitches;
       QList<PianoKeyItem*> keys;
       qreal scaleVal;
       virtual void wheelEvent(QWheelEvent*);
@@ -69,7 +69,10 @@ class HPiano : public QGraphicsView {
    public:
       HPiano(QWidget* parent = 0);
       friend class PianoKeyItem;
-      void pressKeys(QSet<int> pitches);
+      void setPressedPitches(QSet<int> pitches);
+      void pressPitch(int pitch);
+      void releasePitch(int pitch);
+      void updateAllKeys();
       virtual QSize sizeHint() const;
       };
 
@@ -92,6 +95,8 @@ class PianoTools : public QDockWidget {
 
    public:
       PianoTools(QWidget* parent = 0);
+      void pressPitch(int pitch)    { _piano->pressPitch(pitch);   }
+      void releasePitch(int pitch)  { _piano->releasePitch(pitch); }
       void heartBeat(QList<const Note*> notes);
       };
 


### PR DESCRIPTION
Works fine, except only the last key pressed is coloured when the user enters a chord in StepTime mode with the "play chords" option enabled. If "play chords" is enabled then `Seq::seek()` and eventually `Seq::unmarkNotes()` get called when the user enters a chord, which release all keys on the virtual keyboard. Modifying this behaviour is probably beyond the scope of this PR.

Personally I would like to disable the usual addNote sound effects during note entry with a MIDI keyboard and just trigger `Seq::startNote()` from within `MuseScore::midiNoteReceived()` (or perhaps in `ScoreView::midiNoteReceived()`). This way notes would last for as long as they keys are held (which is what you would expect) instead of the current fixed length. I haven't done so in this PR though.