### PR TITLE
Style improvements and changed palette order

### DIFF
--- a/libmscore/bend.cpp
+++ b/libmscore/bend.cpp
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2010-2011 Werner Schweer
+//  Copyright (C) 2010-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2
@@ -73,7 +73,7 @@ void Bend::layout()
             }
       QRectF bb;
 
-      const TextStyle* st = &score()->textStyle(TextStyleType::BENCH);
+      const TextStyle* st = &score()->textStyle(TextStyleType::BEND);
       QFontMetricsF fm(st->fontMetrics(_spatium));
 
       int n   = _points.size();
@@ -165,7 +165,7 @@ void Bend::draw(QPainter* painter) const
       painter->setBrush(QBrush(curColor()));
 
       qreal _spatium = spatium();
-      const TextStyle* st = &score()->textStyle(TextStyleType::BENCH);
+      const TextStyle* st = &score()->textStyle(TextStyleType::BEND);
       QFont f = st->font(_spatium * MScore::pixelRatio);
       painter->setFont(f);
 

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2011-2013 Werner Schweer and others
+//  Copyright (C) 2011-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2
@@ -348,7 +348,7 @@ const int STAFF_GROUP_MAX = int(StaffGroup::TAB) + 1;      // out of enum to avo
 //---------------------------------------------------------
 //   Text Style Type
 //    Enumerate the list of build in text styles.
-//    Must be in sync with list in setDefaultStyle().
+//    Must be in sync with list in setDefaultStyle() in style.cpp.
 //---------------------------------------------------------
 
 MS_QML_ENUM(TextStyleType, signed char,\
@@ -357,44 +357,46 @@ MS_QML_ENUM(TextStyleType, signed char,\
       SUBTITLE,\
       COMPOSER,\
       POET,\
+      INSTRUMENT_EXCERPT,\
+      \
+      SYSTEM,\
+      STAFF,\
+      EXPRESSION,\
+      DYNAMICS,\
+      TEMPO,\
+      INSTRUMENT_CHANGE,\
+      REHEARSAL_MARK,\
+      MEASURE_NUMBER,\
+      \
       LYRIC1,\
       LYRIC2,\
+      HARMONY,\
       FINGERING,\
       LH_GUITAR_FINGERING,\
       RH_GUITAR_FINGERING,\
-      \
+      BEND,\
       STRING_NUMBER,\
       INSTRUMENT_LONG,\
       INSTRUMENT_SHORT,\
-      INSTRUMENT_EXCERPT,\
-      DYNAMICS,\
-      TECHNIQUE,\
-      TEMPO,\
-      METRONOME,\
-      MEASURE_NUMBER,\
-      TRANSLATOR,\
       \
+      REPEAT_LEFT,      /* align to start of measure */\
+      REPEAT_RIGHT,     /* align to end of measure */\
       TUPLET,\
-      SYSTEM,\
-      STAFF,\
-      HARMONY,\
-      REHEARSAL_MARK,\
-      REPEAT_LEFT,       /* align to start of measure */\
-      REPEAT_RIGHT,      /* align to end of measure */\
-      REPEAT,            /* obsolete */\
-      VOLTA,\
-      FRAME,\
-      \
-      TEXTLINE,\
       GLISSANDO,\
+      VOLTA,\
       OTTAVA,\
       PEDAL,\
       HAIRPIN,\
-      BENCH,\
+      TEXTLINE,\
+      \
       HEADER,\
       FOOTER,\
-      INSTRUMENT_CHANGE,\
+      FRAME,\
       FIGURED_BASS,\
+      TRANSLATOR,       /* obsolete */\
+      METRONOME,        /* obsolete */\
+      REPEAT,           /* obsolete */\
+      TECHNIQUE,        /* obsolete */\
       \
       TEXT_STYLES\
       )

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -495,6 +495,8 @@ void Page::doRebuildBspTree()
 //    $P          - page number, on all pages
 //    $N          - page number, if there is more than one
 //    $n          - number of pages
+//    $i          - part name, except on first page
+//    $I          - part name, on all pages
 //    $f          - file name
 //    $F          - file path+name
 //    $d          - current date
@@ -504,7 +506,7 @@ void Page::doRebuildBspTree()
 //    $C          - copyright, on first page only
 //    $c          - copyright, on all pages
 //    $$          - the $ sign itself
-//    $:tag:      - meta data tag
+//    $:tag:      - any metadata tag
 //
 //       tags already defined:
 //       (see Score::init()))
@@ -539,6 +541,11 @@ QString Page::replaceTextMacros(const QString& s) const
                               break;
                         case 'n':
                               d += QString("%1").arg(score()->npages() + score()->pageNumberOffset());
+                              break;
+                        case 'i': // not on first page
+                              if (_no) // FALLTHROUGH
+                        case 'I':
+                              d += score()->metaTag("partName").toHtmlEscaped();
                               break;
                         case 'f':
                               d += masterScore()->fileInfo()->completeBaseName().toHtmlEscaped();

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -281,6 +281,8 @@ Score::Score(MasterScore* parent)
             _style.set(StyleIdx::createMultiMeasureRests, true);
             _style.set(StyleIdx::dividerLeft, false);
             _style.set(StyleIdx::dividerRight, false);
+            _style.set(StyleIdx::evenHeaderC, "$i");
+            _style.set(StyleIdx::oddHeaderC, "$i");
             }
       _synthesizerState = parent->_synthesizerState;
       }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2002-2012 Werner Schweer
+//  Copyright (C) 2002-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2002-2011 Werner Schweer
+//  Copyright (C) 2002-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2
@@ -52,7 +52,6 @@ static const StyleType styleTypes[] {
       { StyleIdx::lyricsAlignVerseNumber,  "lyricsAlignVerseNumber",  true },
 
       { StyleIdx::figuredBassFontFamily,   "figuredBassFontFamily",   QString("MScoreBC") },
-
       { StyleIdx::figuredBassFontSize,     "figuredBassFontSize",     QVariant(8.0) },
       { StyleIdx::figuredBassYOffset,      "figuredBassYOffset",      QVariant(6.0) },
       { StyleIdx::figuredBassLineHeight,   "figuredBassLineHeight",   QVariant(1.0) },
@@ -60,21 +59,21 @@ static const StyleType styleTypes[] {
       { StyleIdx::figuredBassStyle,        "figuredBassStyle" ,       QVariant(0) },
       { StyleIdx::systemFrameDistance,     "systemFrameDistance",     Spatium(7.0) },
       { StyleIdx::frameSystemDistance,     "frameSystemDistance",     Spatium(7.0) },
+
       { StyleIdx::minMeasureWidth,         "minMeasureWidth",         Spatium(5.0) },
       { StyleIdx::barWidth,                "barWidth",                Spatium(0.16) },      // 0.1875
       { StyleIdx::doubleBarWidth,          "doubleBarWidth",          Spatium(0.16) },
-
       { StyleIdx::endBarWidth,             "endBarWidth",             Spatium(0.5) },       // 0.5
       { StyleIdx::doubleBarDistance,       "doubleBarDistance",       Spatium(0.30) },
       { StyleIdx::endBarDistance,          "endBarDistance",          Spatium(0.40) },     // 0.3
       { StyleIdx::repeatBarTips,           "repeatBarTips",           QVariant(false) },
       { StyleIdx::startBarlineSingle,      "startBarlineSingle",      QVariant(false) },
       { StyleIdx::startBarlineMultiple,    "startBarlineMultiple",    QVariant(true) },
+
       { StyleIdx::bracketWidth,            "bracketWidth",            Spatium(0.45) },
       { StyleIdx::bracketDistance,         "bracketDistance",         Spatium(0.1) },
       { StyleIdx::akkoladeWidth,           "akkoladeWidth",           Spatium(1.6) },
       { StyleIdx::akkoladeBarDistance,     "akkoladeBarDistance",     Spatium(.4) },
-
       { StyleIdx::dividerLeft,             "dividerLeft",             QVariant(false) },
       { StyleIdx::dividerLeftSym,          "dividerLeftSym",          QVariant(QString("systemDivider")) },
       { StyleIdx::dividerLeftX,            "dividerLeftX",            QVariant(0.0) },
@@ -87,7 +86,6 @@ static const StyleType styleTypes[] {
       { StyleIdx::clefLeftMargin,          "clefLeftMargin",          Spatium(0.8) },     // 0.64 (gould: <= 1)
       { StyleIdx::keysigLeftMargin,        "keysigLeftMargin",        Spatium(0.5) },
       { StyleIdx::ambitusMargin,           "ambitusMargin",           Spatium(0.5) },
-
       { StyleIdx::timesigLeftMargin,       "timesigLeftMargin",       Spatium(0.5) },
       { StyleIdx::clefKeyRightMargin,      "clefKeyRightMargin",      Spatium(0.8) },
       { StyleIdx::clefKeyDistance,         "clefKeyDistance",         Spatium(1.0) },   // gould: 1 - 1.25
@@ -96,9 +94,9 @@ static const StyleType styleTypes[] {
       { StyleIdx::keyBarlineDistance,      "keyTimesigDistance",      Spatium(1.0) },
       { StyleIdx::systemHeaderDistance,    "systemHeaderDistance",    Spatium(2.5) },     // gould: 2.5
       { StyleIdx::systemHeaderTimeSigDistance, "systemHeaderTimeSigDistance", Spatium(2.0) },  // gould: 2.0
-
       { StyleIdx::clefBarlineDistance,     "clefBarlineDistance",     Spatium(0.18) },      // was 0.5
       { StyleIdx::timesigBarlineDistance,  "timesigBarlineDistance",  Spatium(0.5) },
+
       { StyleIdx::stemWidth,               "stemWidth",               Spatium(0.13) },      // 0.09375
       { StyleIdx::shortenStem,             "shortenStem",             QVariant(true) },
       { StyleIdx::shortStemProgression,    "shortStemProgression",    Spatium(0.25) },
@@ -106,10 +104,10 @@ static const StyleType styleTypes[] {
       { StyleIdx::beginRepeatLeftMargin,   "beginRepeatLeftMargin",   Spatium(1.0) },
       { StyleIdx::minNoteDistance,         "minNoteDistance",         Spatium(0.25) },      // 0.4
       { StyleIdx::barNoteDistance,         "barNoteDistance",         Spatium(1.2) },
-
       { StyleIdx::barAccidentalDistance,   "barAccidentalDistance",   Spatium(.3) },
       { StyleIdx::multiMeasureRestMargin,  "multiMeasureRestMargin",  Spatium(1.2) },
       { StyleIdx::noteBarDistance,         "noteBarDistance",         Spatium(1.0) },
+
       { StyleIdx::measureSpacing,          "measureSpacing",          QVariant(1.2) },
       { StyleIdx::staffLineWidth,          "staffLineWidth",          Spatium(0.08) },      // 0.09375
       { StyleIdx::ledgerLineWidth,         "ledgerLineWidth",         Spatium(0.16) },     // 0.1875
@@ -117,10 +115,10 @@ static const StyleType styleTypes[] {
       { StyleIdx::accidentalDistance,      "accidentalDistance",      Spatium(0.22) },
       { StyleIdx::accidentalNoteDistance,  "accidentalNoteDistance",  Spatium(0.22) },
       { StyleIdx::beamWidth,               "beamWidth",               Spatium(0.5) },           // was 0.48
-
       { StyleIdx::beamDistance,            "beamDistance",            QVariant(0.5) },          // 0.25sp units
       { StyleIdx::beamMinLen,              "beamMinLen",              Spatium(1.32) },      // 1.316178 exactly notehead widthen beams
       { StyleIdx::beamNoSlope,             "beamNoSlope",             QVariant(false) },
+
       { StyleIdx::dotMag,                  "dotMag",                  QVariant(1.0) },
       { StyleIdx::dotNoteDistance,         "dotNoteDistance",         Spatium(0.35) },
       { StyleIdx::dotRestDistance,         "dotRestDistance",         Spatium(0.25) },
@@ -128,9 +126,9 @@ static const StyleType styleTypes[] {
       { StyleIdx::propertyDistanceHead,    "propertyDistanceHead",    Spatium(1.0) },
       { StyleIdx::propertyDistanceStem,    "propertyDistanceStem",    Spatium(1.8) },
       { StyleIdx::propertyDistance,        "propertyDistance",        Spatium(1.0) },
-
       { StyleIdx::articulationMag,         "articulationMag",         QVariant(1.0) },
       { StyleIdx::lastSystemFillLimit,     "lastSystemFillLimit",     QVariant(0.3) },
+
       { StyleIdx::hairpinY,                "hairpinY",                Spatium(7.5) },
       { StyleIdx::hairpinHeight,           "hairpinHeight",           Spatium(1.2) },
       { StyleIdx::hairpinContHeight,       "hairpinContHeight",       Spatium(0.5) },
@@ -148,20 +146,20 @@ static const StyleType styleTypes[] {
       { StyleIdx::fretNumMag,              "fretNumMag",              QVariant(2.0) },
       { StyleIdx::fretNumPos,              "fretNumPos",              QVariant(0) },
       { StyleIdx::fretY,                   "fretY",                   Spatium(2.0) },
+
       { StyleIdx::showPageNumber,          "showPageNumber",          QVariant(true) },
       { StyleIdx::showPageNumberOne,       "showPageNumberOne",       QVariant(false) },
-
       { StyleIdx::pageNumberOddEven,       "pageNumberOddEven",       QVariant(true) },
       { StyleIdx::showMeasureNumber,       "showMeasureNumber",       QVariant(true) },
       { StyleIdx::showMeasureNumberOne,    "showMeasureNumberOne",    QVariant(false) },
       { StyleIdx::measureNumberInterval,   "measureNumberInterval",   QVariant(5) },
       { StyleIdx::measureNumberSystem,     "measureNumberSystem",     QVariant(true) },
       { StyleIdx::measureNumberAllStaffs,  "measureNumberAllStaffs",  QVariant(false) },
+
       { StyleIdx::smallNoteMag,            "smallNoteMag",            QVariant(.7) },
       { StyleIdx::graceNoteMag,            "graceNoteMag",            QVariant(0.7) },
       { StyleIdx::smallStaffMag,           "smallStaffMag",           QVariant(0.7) },
       { StyleIdx::smallClefMag,            "smallClefMag",            QVariant(0.8) },
-
       { StyleIdx::genClef,                 "genClef",                 QVariant(true) },
       { StyleIdx::genKeysig,               "genKeysig",               QVariant(true) },
       { StyleIdx::genCourtesyTimesig,      "genCourtesyTimesig",      QVariant(true) },
@@ -169,10 +167,10 @@ static const StyleType styleTypes[] {
       { StyleIdx::genCourtesyClef,         "genCourtesyClef",         QVariant(true) },
       { StyleIdx::swingRatio,              "swingRatio",              QVariant(60)   },
       { StyleIdx::swingUnit,               "swingUnit",               QVariant(QString("")) },
+
       { StyleIdx::useStandardNoteNames,    "useStandardNoteNames",    QVariant(true) },
       { StyleIdx::useGermanNoteNames,      "useGermanNoteNames",      QVariant(false) },
       { StyleIdx::useFullGermanNoteNames,  "useFullGermanNoteNames",  QVariant(false) },
-
       { StyleIdx::useSolfeggioNoteNames,   "useSolfeggioNoteNames",   QVariant(false) },
       { StyleIdx::useFrenchNoteNames,      "useFrenchNoteNames",      QVariant(false) },
       { StyleIdx::automaticCapitalization, "automaticCapitalization", QVariant(true) },
@@ -182,8 +180,8 @@ static const StyleType styleTypes[] {
       { StyleIdx::chordStyle,              "chordStyle",              QVariant(QString("std")) },
       { StyleIdx::chordsXmlFile,           "chordsXmlFile",           QVariant(false) },
       { StyleIdx::chordDescriptionFile,    "chordDescriptionFile",    QVariant(QString("chords_std.xml")) },
-      { StyleIdx::concertPitch,            "concertPitch",            QVariant(false) },
 
+      { StyleIdx::concertPitch,            "concertPitch",            QVariant(false) },
       { StyleIdx::createMultiMeasureRests, "createMultiMeasureRests", QVariant(false) },
       { StyleIdx::minEmptyMeasures,        "minEmptyMeasures",        QVariant(2) },
       { StyleIdx::minMMRestWidth,          "minMMRestWidth",          Spatium(4) },
@@ -208,28 +206,28 @@ static const StyleType styleTypes[] {
       { StyleIdx::MusicalSymbolFont,       "musicalSymbolFont",       QVariant(QString("Emmentaler")) },
       { StyleIdx::MusicalTextFont,         "musicalTextFont",         QVariant(QString("MScore Text")) },
 
-      { StyleIdx::showHeader,              "showHeader",              QVariant(false) },
+      { StyleIdx::showHeader,              "showHeader",              QVariant(true) },
       { StyleIdx::headerFirstPage,         "headerFirstPage",         QVariant(false) },
       { StyleIdx::headerOddEven,           "headerOddEven",           QVariant(true) },
-      { StyleIdx::evenHeaderL,             "evenHeaderL",             QVariant(QString()) },
-      { StyleIdx::evenHeaderC,             "evenHeaderC",             QVariant(QString()) },
-      { StyleIdx::evenHeaderR,             "evenHeaderR",             QVariant(QString()) },
       { StyleIdx::oddHeaderL,              "oddHeaderL",              QVariant(QString()) },
       { StyleIdx::oddHeaderC,              "oddHeaderC",              QVariant(QString()) },
-      { StyleIdx::oddHeaderR,              "oddHeaderR",              QVariant(QString()) },
-      { StyleIdx::showFooter,              "showFooter",              QVariant(true) },
+      { StyleIdx::oddHeaderR,              "oddHeaderR",              QVariant(QString("$p")) },
+      { StyleIdx::evenHeaderL,             "evenHeaderL",             QVariant(QString("$p")) },
+      { StyleIdx::evenHeaderC,             "evenHeaderC",             QVariant(QString()) },
+      { StyleIdx::evenHeaderR,             "evenHeaderR",             QVariant(QString()) },
 
+      { StyleIdx::showFooter,              "showFooter",              QVariant(true) },
       { StyleIdx::footerFirstPage,         "footerFirstPage",         QVariant(true) },
       { StyleIdx::footerOddEven,           "footerOddEven",           QVariant(true) },
-      { StyleIdx::evenFooterL,             "evenFooterL",             QVariant(QString("$p")) },
-      { StyleIdx::evenFooterC,             "evenFooterC",             QVariant(QString("$:copyright:")) },
-      { StyleIdx::evenFooterR,             "evenFooterR",             QVariant(QString()) },
       { StyleIdx::oddFooterL,              "oddFooterL",              QVariant(QString()) },
-      { StyleIdx::oddFooterC,              "oddFooterC",              QVariant(QString("$:copyright:")) },
-      { StyleIdx::oddFooterR,              "oddFooterR",              QVariant(QString("$p")) },
+      { StyleIdx::oddFooterC,              "oddFooterC",              QVariant(QString("$C")) },
+      { StyleIdx::oddFooterR,              "oddFooterR",              QVariant(QString()) },
+      { StyleIdx::evenFooterL,             "evenFooterL",             QVariant(QString()) },
+      { StyleIdx::evenFooterC,             "evenFooterC",             QVariant(QString("$C")) },
+      { StyleIdx::evenFooterR,             "evenFooterR",             QVariant(QString()) },
+
       { StyleIdx::voltaY,                  "voltaY",                  Spatium(-3.0) },
       { StyleIdx::voltaHook,               "voltaHook",               Spatium(1.9) },
-
       { StyleIdx::voltaLineWidth,          "voltaLineWidth",          Spatium(.1) },
       { StyleIdx::voltaLineStyle,          "voltaLineStyle",          QVariant(int(Qt::SolidLine)) },
       { StyleIdx::ottavaY,                 "ottavaY",                 Spatium(-3.0) },
@@ -238,9 +236,9 @@ static const StyleType styleTypes[] {
       { StyleIdx::ottavaLineStyle,         "ottavaLineStyle",         QVariant(int(Qt::DashLine)) },
       { StyleIdx::ottavaNumbersOnly,       "ottavaNumbersOnly",       true },
       { StyleIdx::tabClef,                 "tabClef",                 QVariant(int(ClefType::TAB)) },
+
       { StyleIdx::tremoloWidth,            "tremoloWidth",            Spatium(1.2) },  // tremolo stroke width: notehead width
       { StyleIdx::tremoloBoxHeight,        "tremoloBoxHeight",        Spatium(0.65) },
-
       { StyleIdx::tremoloStrokeWidth,      "tremoloLineWidth",        Spatium(0.5) },  // was 0.35
       { StyleIdx::tremoloDistance,         "tremoloDistance",         Spatium(0.8) },
       { StyleIdx::linearStretch,           "linearStretch",           QVariant(qreal(1.5)) },
@@ -310,10 +308,10 @@ static const StyleType styleTypes[] {
       { StyleIdx::lutefingering1stAnchor,          "lutefingering1stAnchor",          int(ArticulationAnchor::BOTTOM_CHORD) },
       { StyleIdx::lutefingering2ndAnchor,          "lutefingering2ndAnchor",          int(ArticulationAnchor::BOTTOM_CHORD) },
       { StyleIdx::lutefingering3rdAnchor,          "lutefingering3rdAnchor",          int(ArticulationAnchor::BOTTOM_CHORD) },
+
       { StyleIdx::autoplaceHairpinDynamicsDistance, "autoplaceHairpinDynamicsDistance", Spatium(0.5) },
       { StyleIdx::dynamicsMinDistance,             "dynamicsMinDistance",               Spatium(0.5) },
       { StyleIdx::autoplaceVerticalAlignRange,     "autoplaceVerticalAlignRange",     int(VerticalAlignRange::SYSTEM) },
-
       { StyleIdx::textLinePlacement,         "textLinePlacement",         int(Element::Placement::ABOVE)  },
       { StyleIdx::textLinePosAbove,          "textLinePosAbove",          Spatium(-3.5) },
       { StyleIdx::textLinePosBelow,          "textLinePosBelow",          Spatium(3.5) },
@@ -356,7 +354,7 @@ static const QString ff("FreeSerif");
 
 //---------------------------------------------------------
 //   setDefaultStyle
-//    synchronize with TextStyleType
+//    synchronize with TextStyleType in mscore.h
 //---------------------------------------------------------
 
 void initStyle(MStyle* s)
@@ -367,123 +365,128 @@ void initStyle(MStyle* s)
       // never show this style
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", ""), ff, 10, false, false, false,
          AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(), OffsetType::SPATIUM, false, false,
-         false, Spatium(.2), Spatium(.5), 25, QColor(Qt::black), false, false, QColor(Qt::black),
+         false, Spatium(.2), Spatium(.5), 0, QColor(Qt::black), false, false, QColor(Qt::black),
          QColor(255, 255, 255, 0), TextStyleHidden::ALWAYS));
 
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Title"),    ff, 24, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Title"),     ff, 24, false, false, false,
          AlignmentFlags::HCENTER | AlignmentFlags::TOP,    QPointF(), OffsetType::ABS));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Subtitle"), ff, 14, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Subtitle"),  ff, 14, false, false, false,
          AlignmentFlags::HCENTER | AlignmentFlags::TOP,    QPointF(0, MM(10)), OffsetType::ABS));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Composer"), ff, 12, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Composer"),  ff, 12, false, false, false,
          AlignmentFlags::RIGHT   | AlignmentFlags::BOTTOM, QPointF(), OffsetType::ABS));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Lyricist"), ff, 12, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Lyricist"),  ff, 12, false, false, false,
          AlignmentFlags::LEFT    | AlignmentFlags::BOTTOM, QPointF(), OffsetType::ABS));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Part Name"), ff, 14, false, false, false,
+         AlignmentFlags::LEFT | AlignmentFlags::TOP, QPointF(0, MM(2)), OffsetType::ABS));
 
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Lyrics Odd Lines"),          ff, 11, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "System Text"),           ff, 10, false, false, false,
+         AlignmentFlags::LEFT, QPointF(0, -4.0), OffsetType::SPATIUM, true, false,
+         false, Spatium(.2), Spatium(.5), 0, Qt::black, false, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Staff Technique Text"),  ff, 10, false, false, false,
+         AlignmentFlags::LEFT, QPointF(0, -3.0), OffsetType::SPATIUM, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Staff Expression Text"), ff, 11, false, true, false,
+         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0, 8.0), OffsetType::SPATIUM, true));
+
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Dynamics"),              ff, 12, false, true, false,
+         AlignmentFlags::HCENTER | AlignmentFlags::BASELINE, QPointF(0.0, 8.0), OffsetType::SPATIUM, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Tempo"),                 ff, 12, true, false, false,
+         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0, -4.0), OffsetType::SPATIUM, true, false,
+         false, Spatium(.2), Spatium(.5), 0, Qt::black, false, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Instrument Change"),     ff, 10, true, false, false,
+         AlignmentFlags::LEFT | AlignmentFlags::TOP, QPointF(0, -3.0), OffsetType::SPATIUM, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Rehearsal Mark"),        ff, 14, true, false, false,
+         AlignmentFlags::HCENTER | AlignmentFlags::BASELINE, QPointF(0, -3.0), OffsetType::SPATIUM, true, true,
+         true, Spatium(.2), Spatium(.5), 0, Qt::black, false, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Measure Number"),        ff, 8, false, false, false,
+         AlignmentFlags::HCENTER | AlignmentFlags::BOTTOM, QPointF(.0, -2.0), OffsetType::SPATIUM, true));
+
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Lyrics Odd Lines"),      ff, 11, false, false, false,
          AlignmentFlags::HCENTER | AlignmentFlags::BASELINE, QPointF(0, 6), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Lyrics Even Lines"),         ff, 11, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Lyrics Even Lines"),     ff, 11, false, false, false,
          AlignmentFlags::HCENTER | AlignmentFlags::BASELINE, QPointF(0, 6), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Fingering"),                 ff,  8, false, false, false,
+
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Chord Symbol"),          ff, 12, false, false, false,
+         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(), OffsetType::SPATIUM, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Fingering"),             ff, 8, false, false, false,
          AlignmentFlags::CENTER, QPointF(), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "LH Guitar Fingering"),       ff,  8, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "LH Guitar Fingering"),   ff, 8, false, false, false,
          AlignmentFlags::RIGHT | AlignmentFlags::VCENTER, QPointF(-0.5, 0), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "RH Guitar Fingering"),       ff,  8, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "RH Guitar Fingering"),   ff, 8, false, false, false,
          AlignmentFlags::CENTER, QPointF(), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "String Number"),             ff,  8, false, false, false,
+
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Bend"),                  ff, 8, false, false, false,
+         AlignmentFlags::CENTER | AlignmentFlags::BOTTOM, QPointF(), OffsetType::SPATIUM, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "String Number"),         ff, 8, false, false, false,
          AlignmentFlags::CENTER, QPointF(0, -2.0), OffsetType::SPATIUM, true, false,
          true, Spatium(.1), Spatium(.2), 0, Qt::black, true, false));
 
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Instrument Name (Long)"),    ff, 12, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Long Instrument Name"),  ff, 12, false, false, false,
          AlignmentFlags::RIGHT | AlignmentFlags::VCENTER, QPointF(), OffsetType::ABS, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Instrument Name (Short)"),   ff, 12, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Short Instrument Name"), ff, 12, false, false, false,
          AlignmentFlags::RIGHT | AlignmentFlags::VCENTER, QPointF(), OffsetType::ABS, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Instrument Name (Part)"),    ff, 18, false, false, false,
-         AlignmentFlags::LEFT | AlignmentFlags::TOP, QPointF(), OffsetType::ABS));
 
-      // dynamics size is 12pt for bravura-text
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Dynamics"),  ff, 12, false, false,false,
-         AlignmentFlags::HCENTER | AlignmentFlags::BASELINE, QPointF(0.0, 8.0), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Technique"), ff, 12, false, true, false,
-         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0.0, -2.0), OffsetType::SPATIUM, true));
-
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Tempo"), ff, 12, true, false, false,
-         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0, -4.0), OffsetType::SPATIUM,
-         true, false, false, Spatium(.2), Spatium(.5), 0, Qt::black, false, true));
-
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Metronome"),      ff, 12, true, false, false,
-         AlignmentFlags::LEFT));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Measure Number"), ff, 8, false, false, false,
-         AlignmentFlags::HCENTER | AlignmentFlags::BOTTOM, QPointF(.0, -2.0), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Translator"),     ff, 11, false, false, false,
-         AlignmentFlags::HCENTER | AlignmentFlags::TOP, QPointF(0, 6)));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Tuplet"),         ff, 10, false, true, false,
-         AlignmentFlags::CENTER, QPointF(), OffsetType::ABS, true));
-
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "System"), ff,  10, false, false, false,
-         AlignmentFlags::LEFT, QPointF(0, -4.0), OffsetType::SPATIUM, true, false,
-         false, Spatium(.2), Spatium(.5), 25, Qt::black, false, true));
-
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Staff"),        ff,  10, false, false, false,
-         AlignmentFlags::LEFT, QPointF(0, -4.0), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Chord Symbol"), ff,  12, false, false, false,
-         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(), OffsetType::SPATIUM, true));
-
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Rehearsal Mark"), ff,  14,
-         true,
-         false,
-         false,
-         AlignmentFlags::HCENTER | AlignmentFlags::BASELINE,
-         QPointF(0, -3.0), OffsetType::SPATIUM,
-         true,    // hasFrame
-         true,    // square
-         true, Spatium(.2), Spatium(.5), 20, Qt::black, false, true));
-
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Repeat Text Left"), ff,  20, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Repeat Text Left"),      ff, 20, false, false, false,
          AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0, -2.0), OffsetType::SPATIUM, true, false,
-         false, Spatium(.2), Spatium(.5), 25, Qt::black, false, true));
-
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Repeat Text Right"), ff,  12, false, false, false,
+         false, Spatium(.2), Spatium(.5), 0, Qt::black, false, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Repeat Text Right"),     ff, 12, false, false, false,
          AlignmentFlags::RIGHT | AlignmentFlags::BASELINE, QPointF(0, -2.0), OffsetType::SPATIUM, true, false,
-         false, Spatium(0.2), Spatium(0.5), 25, Qt::black, false, true));
+         false, Spatium(0.2), Spatium(0.5), 0, Qt::black, false, true));
 
-      // for backward compatibility
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Repeat Text"), ff,  12, false, false, false,
-         AlignmentFlags::RIGHT | AlignmentFlags::BASELINE, QPointF(0, -2.0), OffsetType::SPATIUM, true, false,
-         false, Spatium(0.2), Spatium(0.5), 25, Qt::black, false, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Tuplet"),    ff, 10, false, true, false,
+         AlignmentFlags::CENTER, QPointF(), OffsetType::ABS, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Glissando"), ff, 8, false, true, false,
+         AlignmentFlags::HCENTER | AlignmentFlags::BASELINE, QPointF(), OffsetType::SPATIUM, true));
 
       // y offset may depend on voltaHook style element
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Volta"),     ff, 11, true, false, false,
          AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0.5, 1.9), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Frame"),     ff, 12, false, false, false,
-         AlignmentFlags::LEFT | AlignmentFlags::TOP));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Ottava"),    ff, 12, false, true, false,
+         AlignmentFlags::LEFT | AlignmentFlags::VCENTER, QPointF(), OffsetType::SPATIUM, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Pedal"),     ff, 12, false, false, false,
+         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0.0, 0.15), OffsetType::SPATIUM, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Hairpin"),   ff, 11, false, true, false,
+         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(), OffsetType::SPATIUM, true));
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Text Line"), ff, 12, false, false, false,
          AlignmentFlags::LEFT | AlignmentFlags::VCENTER, QPointF(), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Glissando"), ff, 8, false, true, false,
-         AlignmentFlags::HCENTER | AlignmentFlags::BASELINE, QPointF(), OffsetType::SPATIUM, true));
 
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Ottava"),            ff, 12, false, true, false,
-         AlignmentFlags::LEFT | AlignmentFlags::VCENTER, QPointF(), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Pedal"),             ff, 12, false, false, false,
-         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0.0, 0.15), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Hairpin"),           ff, 12, false, true, false,
-         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Bend"),              ff, 8, false, false, false,
-         AlignmentFlags::CENTER | AlignmentFlags::BOTTOM, QPointF(), OffsetType::SPATIUM, true));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Header"),            ff, 8, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Header"),    ff, 10, false, false, false,
          AlignmentFlags::HCENTER | AlignmentFlags::TOP));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Footer"),            ff, 8, false, false, false,
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Footer"),    ff, 8, false, false, false,
          AlignmentFlags::HCENTER | AlignmentFlags::BOTTOM, QPointF(0.0, MM(5)), OffsetType::ABS));
-      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Instrument Change"), ff,  12, true, false, false,
-         AlignmentFlags::LEFT | AlignmentFlags::BOTTOM, QPointF(0, -3.0), OffsetType::SPATIUM, true));
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Frame"),     ff, 12, false, false, false,
+         AlignmentFlags::LEFT | AlignmentFlags::TOP));
 
 /*      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Lyrics Verse Number"),ff, 11, false, false, false,
          AlignmentFlags::RIGHT | AlignmentFlags::BASELINE, QPointF(), OffsetType::SPATIUM, true));
 */
+
       s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Figured Bass"), "MScoreBC", 8, false, false, false,
          AlignmentFlags::LEFT | AlignmentFlags::TOP, QPointF(0, 6), OffsetType::SPATIUM, true, false,
-         false, Spatium(0.0), Spatium(0.0), 25, QColor(Qt::black), false,      // default params
-         false, QColor(Qt::black), QColor(255, 255, 255, 0),                   // default params
-         TextStyleHidden::IN_EDITOR));                                         // don't show in Style Editor
+         false, Spatium(0.0), Spatium(0.0), 0, QColor(Qt::black), false, // default params
+         false, QColor(Qt::black), QColor(255, 255, 255, 0),             // default params
+         TextStyleHidden::IN_EDITOR));                                   // show in Inspector, hide in Edit Text Styles
+
+      // following 3 styles unused, temporarily kept for backward compatibility
+      // not visible in UI, but rescues text properties from MuseScore 2
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Translator"),      ff, 11, false, false, false,
+         AlignmentFlags::HCENTER | AlignmentFlags::TOP, QPointF(0, MM(10)), OffsetType::ABS, true, false,
+         false, Spatium(.2), Spatium(.5), 0, QColor(Qt::black), false, false, QColor(Qt::black),
+         QColor(255, 255, 255, 0), TextStyleHidden::ALWAYS));           // make style not accessible in UI
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Metronome"),       ff, 12, true, false, false,
+         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0, 0), OffsetType::SPATIUM, true, false,
+         false, Spatium(.2), Spatium(.5), 0, QColor(Qt::black), false, false, QColor(Qt::black),
+         QColor(255, 255, 255, 0), TextStyleHidden::ALWAYS));           // make style not accessible in UI
+            // TODO: compatibility layer to switch text to Tempo style on import
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Repeat Text"),     ff, 12, false, false, false,
+         AlignmentFlags::RIGHT | AlignmentFlags::BASELINE, QPointF(0, -2.0), OffsetType::SPATIUM, true, false,
+         false, Spatium(.2), Spatium(.5), 0, QColor(Qt::black), false, false, QColor(Qt::black),
+         QColor(255, 255, 255, 0), TextStyleHidden::ALWAYS));           // make style not accessible in UI
+            // TODO: compatibility layer to switch text to Repeat Text Right style on import
+      s->addTextStyle(TextStyle(QT_TRANSLATE_NOOP ("TextStyle", "Technique"),       ff, 12, false, true, false,
+         AlignmentFlags::LEFT | AlignmentFlags::BASELINE, QPointF(0.0, -2.0), OffsetType::SPATIUM, true, false,
+         false, Spatium(.2), Spatium(.5), 0, QColor(Qt::black), false, false, QColor(Qt::black),
+         QColor(255, 255, 255, 0), TextStyleHidden::ALWAYS));           // make style not accessible in UI
+            // TODO: compatibility layer to switch text to Expression style while assigning these properties
 
 #undef MM
 

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2002-2011 Werner Schweer
+//  Copyright (C) 2002-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2
@@ -39,7 +39,6 @@ enum class StyleIdx : int {
       staffLowerBorder,
       staffDistance,
       akkoladeDistance,
-
       minSystemDistance,
       maxSystemDistance,
 
@@ -63,8 +62,8 @@ enum class StyleIdx : int {
       figuredBassStyle,
       systemFrameDistance,
       frameSystemDistance,
-      minMeasureWidth,
 
+      minMeasureWidth,
       barWidth,
       doubleBarWidth,
       endBarWidth,
@@ -91,7 +90,6 @@ enum class StyleIdx : int {
       keysigLeftMargin,
       ambitusMargin,
       timesigLeftMargin,
-
       clefKeyRightMargin,
 /**/      clefKeyDistance,
 /**/      clefTimesigDistance,
@@ -99,7 +97,6 @@ enum class StyleIdx : int {
       keyBarlineDistance,
       systemHeaderDistance,
       systemHeaderTimeSigDistance,
-
       clefBarlineDistance,
       timesigBarlineDistance,
 
@@ -139,12 +136,11 @@ enum class StyleIdx : int {
       hairpinHeight,
       hairpinContHeight,
       hairpinLineWidth,
-
       pedalY,
       pedalLineWidth,
       pedalLineStyle,
-
       trillY,
+
       harmonyY,
       harmonyFretDist,
       minHarmonyDistance,
@@ -161,8 +157,8 @@ enum class StyleIdx : int {
       showMeasureNumberOne,
       measureNumberInterval,
       measureNumberSystem,
-
       measureNumberAllStaffs,
+
       smallNoteMag,
       graceNoteMag,
       smallStaffMag,
@@ -173,7 +169,6 @@ enum class StyleIdx : int {
       genCourtesyTimesig,
       genCourtesyKeysig,
       genCourtesyClef,
-
       swingRatio,
       swingUnit,
 
@@ -189,6 +184,7 @@ enum class StyleIdx : int {
       chordStyle,
       chordsXmlFile,
       chordDescriptionFile,
+
       concertPitch,
       createMultiMeasureRests,
       minEmptyMeasures,
@@ -204,12 +200,10 @@ enum class StyleIdx : int {
       ArpeggioNoteDistance,
       ArpeggioLineWidth,
       ArpeggioHookLen,
-
       SlurEndWidth,
       SlurMidWidth,
       SlurDottedWidth,
       MinTieLength,
-
       SectionPause,
       MusicalSymbolFont,
       MusicalTextFont,
@@ -217,34 +211,32 @@ enum class StyleIdx : int {
       showHeader,
       headerFirstPage,
       headerOddEven,
-      evenHeaderL,
-      evenHeaderC,
-      evenHeaderR,
       oddHeaderL,
       oddHeaderC,
       oddHeaderR,
+      evenHeaderL,
+      evenHeaderC,
+      evenHeaderR,
 
       showFooter,
       footerFirstPage,
       footerOddEven,
-      evenFooterL,
-      evenFooterC,
-      evenFooterR,
       oddFooterL,
       oddFooterC,
       oddFooterR,
+      evenFooterL,
+      evenFooterC,
+      evenFooterR,
 
       voltaY,
       voltaHook,
       voltaLineWidth,
       voltaLineStyle,
-
       ottavaY,
       ottavaHook,
       ottavaLineWidth,
       ottavaLineStyle,
       ottavaNumbersOnly,
-
       tabClef,
 
       tremoloWidth,
@@ -275,7 +267,6 @@ enum class StyleIdx : int {
       fretMag,
       scaleBarlines,
       barGraceDistance,
-
       minVerticalDistance,
       ornamentStyle,
       spatium,
@@ -326,7 +317,6 @@ enum class StyleIdx : int {
       autoplaceHairpinDynamicsDistance,
       dynamicsMinDistance,
       autoplaceVerticalAlignRange,
-
       textLinePlacement,
       textLinePosAbove,
       textLinePosBelow,

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2011-2014 Werner Schweer
+//  Copyright (C) 2011-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2
@@ -2268,13 +2268,13 @@ bool Text::readProperties(XmlReader& e)
                         case 11: st = TextStyleType::INSTRUMENT_EXCERPT; break;
 
                         case 12: st = TextStyleType::DYNAMICS;  break;
-                        case 13: st = TextStyleType::TECHNIQUE;   break;
+                        case 13: st = TextStyleType::EXPRESSION;     break;
                         case 14: st = TextStyleType::TEMPO;     break;
-                        case 15: st = TextStyleType::METRONOME; break;
+                        case 15: st = TextStyleType::TEMPO;     break;
                         case 16: st = TextStyleType::FOOTER;    break;  // TextStyleType::COPYRIGHT
                         case 17: st = TextStyleType::MEASURE_NUMBER; break;
-                        case 18: st = TextStyleType::FOOTER; break;    // TextStyleType::PAGE_NUMBER_ODD
-                        case 19: st = TextStyleType::FOOTER; break;    // TextStyleType::PAGE_NUMBER_EVEN
+                        case 18: st = TextStyleType::HEADER; break;    // TextStyleType::PAGE_NUMBER_ODD
+                        case 19: st = TextStyleType::HEADER; break;    // TextStyleType::PAGE_NUMBER_EVEN
                         case 20: st = TextStyleType::TRANSLATOR; break;
                         case 21: st = TextStyleType::TUPLET;     break;
 
@@ -2282,7 +2282,7 @@ bool Text::readProperties(XmlReader& e)
                         case 23: st = TextStyleType::STAFF;          break;
                         case 24: st = TextStyleType::HARMONY;        break;
                         case 25: st = TextStyleType::REHEARSAL_MARK; break;
-                        case 26: st = TextStyleType::REPEAT;         break;
+                        case 26: st = TextStyleType::REPEAT_RIGHT;   break;
                         case 27: st = TextStyleType::VOLTA;          break;
                         case 28: st = TextStyleType::FRAME;          break;
                         case 29: st = TextStyleType::TEXTLINE;       break;
@@ -2290,7 +2290,7 @@ bool Text::readProperties(XmlReader& e)
                         case 31: st = TextStyleType::STRING_NUMBER;  break;
 
                         case 32: st = TextStyleType::OTTAVA;  break;
-                        case 33: st = TextStyleType::BENCH;   break;
+                        case 33: st = TextStyleType::BEND;    break;
                         case 34: st = TextStyleType::HEADER;  break;
                         case 35: st = TextStyleType::FOOTER;  break;
                         case 0:

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2014 Werner Schweer
+//  Copyright (C) 2014-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2
@@ -179,7 +179,7 @@ class TextBlock {
 ///    Graphic representation of a text.
 //
 //   @P text           string  the raw text
-//   @P textStyleType  enum   (TextStyleType.DEFAULT, .TITLE, .SUBTITLE, .COMPOSER, .POET, .LYRIC1, .LYRIC2, .FINGERING, .LH_GUITAR_FINGERING, .RH_GUITAR_FINGERING, .STRING_NUMBER, .INSTRUMENT_LONG, .INSTRUMENT_SHORT, .INSTRUMENT_EXCERPT, .DYNAMICS, .TECHNIQUE, .TEMPO, .METRONOME, .MEASURE_NUMBER, .TRANSLATOR, .TUPLET, .SYSTEM, .STAFF, .HARMONY, .REHEARSAL_MARK, .REPEAT_LEFT, .REPEAT_RIGHT, .REPEAT, .VOLTA, .FRAME, .TEXTLINE, .GLISSANDO, .OTTAVA, .PEDAL, .HAIRPIN, .BENCH, .HEADER, .FOOTER, .INSTRUMENT_CHANGE, .FIGURED_BASS)
+//   @P textStyleType  enum   (TextStyleType.DEFAULT, .TITLE, .SUBTITLE, .COMPOSER, .POET, .LYRIC1, .LYRIC2, .FINGERING, .LH_GUITAR_FINGERING, .RH_GUITAR_FINGERING, .STRING_NUMBER, .INSTRUMENT_LONG, .INSTRUMENT_SHORT, .INSTRUMENT_EXCERPT, .DYNAMICS, .TECHNIQUE, .TEMPO, .METRONOME, .MEASURE_NUMBER, .TRANSLATOR, .TUPLET, .EXPRESSION, .SYSTEM, .STAFF, .HARMONY, .REHEARSAL_MARK, .REPEAT_LEFT, .REPEAT_RIGHT, .REPEAT, .VOLTA, .FRAME, .TEXTLINE, .GLISSANDO, .OTTAVA, .PEDAL, .HAIRPIN, .BEND, .HEADER, .FOOTER, .INSTRUMENT_CHANGE, .FIGURED_BASS)
 //---------------------------------------------------------
 
 class Text : public Element {

--- a/libmscore/tremolobar.cpp
+++ b/libmscore/tremolobar.cpp
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2010-2011 Werner Schweer
+//  Copyright (C) 2010-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -555,6 +555,10 @@
     <seq>Ctrl+T</seq>
     </SC>
   <SC>
+    <key>expression-text</key>
+    <seq>Ctrl+E</seq>
+    </SC>
+  <SC>
     <key>chord-text</key>
     <seq>Ctrl+K</seq>
     </SC>
@@ -612,7 +616,7 @@
     </SC>
   <SC>
     <key>edit-element</key>
-    <seq>Ctrl+E</seq>
+    <seq>Alt+Shift+E</seq>
     </SC>
   <SC>
     <key>reset</key>

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2002-2016 Werner Schweer
+//  Copyright (C) 2002-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2
@@ -367,6 +367,10 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
             + tr("file name")
             + QString("</i></td></tr><tr><td>$F</td><td>-</td><td><i>")
             + tr("file path+name")
+            + QString("</i></td></tr><tr><td>$i</td><td>-</td><td><i>")
+            + tr("part name, except on first page")
+            + QString("</i></td></tr><tr><td>$I</td><td>-</td><td><i>")
+            + tr("part name, on all pages")
             + QString("</i></td></tr><tr><td>$d</td><td>-</td><td><i>")
             + tr("current date")
             + QString("</i></td></tr><tr><td>$D</td><td>-</td><td><i>")
@@ -382,9 +386,11 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
             + QString("</i></td></tr><tr><td>$$</td><td>-</td><td><i>")
             + tr("the $ sign itself")
             + QString("</i></td></tr><tr><td>$:tag:</td><td>-</td><td><i>")
-            + tr("meta data tag, see below")
+            + tr("metadata tag, see below")
             + QString("</i></td></tr></table><p>")
-            + tr("Available meta data tags and their current values:")
+            + tr("Available metadata tags and their current values")
+            + QString("<br />")
+            + tr("(in File > Score Properties...):")
             + QString("</p><table>");
       // show all tags for current score/part, see also Score::init()
       if (!cs->isMaster()) {

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -5760,7 +5760,7 @@
            <item row="1" column="0">
             <widget class="QLabel" name="label_601">
              <property name="text">
-              <string>Fret offset number font size:</string>
+              <string>Fret number font size:</string>
              </property>
              <property name="buddy">
               <cstring>fretNumMag</cstring>

--- a/mscore/importove.cpp
+++ b/mscore/importove.cpp
@@ -2288,7 +2288,7 @@ void OveToMScore::convertExpressions(Measure* measure, int part, int staff, int 
             int absTick = mtt_->getTick(measure->no(), expressionPtr->getTick());
             Text* t = new Text(score_);
 
-            t->setTextStyleType(TextStyleType::TECHNIQUE);
+            t->setTextStyleType(TextStyleType::EXPRESSION);
             t->setPlainText(expressionPtr->getText());
             t->setTrack(track);
 

--- a/mscore/masterpalette.cpp
+++ b/mscore/masterpalette.cpp
@@ -3,7 +3,7 @@
 //  Music Composition & Notation
 //  $Id: masterpalette.cpp
 //
-//  Copyright (C) 2002-2016 Werner Schweer
+//  Copyright (C) 2002-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2
@@ -145,7 +145,6 @@ MasterPalette::MasterPalette(QWidget* parent)
 
       treeWidget->clear();
 
-      addPalette(MuseScore::newGraceNotePalette(false));
       addPalette(MuseScore::newClefsPalette(false));
       keyEditor = new KeyEditor;
 
@@ -160,26 +159,26 @@ MasterPalette::MasterPalette(QWidget* parent)
       stack->addWidget(timeDialog);
       treeWidget->addTopLevelItem(timeItem);
 
-      addPalette(MuseScore::newBarLinePalette(false));
-      addPalette(MuseScore::newLinesPalette(false));
-      addPalette(MuseScore::newArpeggioPalette());
-      addPalette(MuseScore::newBreathPalette());
       addPalette(MuseScore::newBracketsPalette());
-      addPalette(MuseScore::newArticulationsPalette(false));
-
       addPalette(MuseScore::newAccidentalsPalette(false));
-
+      addPalette(MuseScore::newArticulationsPalette(false));
+      addPalette(MuseScore::newBreathPalette());
+      addPalette(MuseScore::newGraceNotePalette(false));
+      addPalette(MuseScore::newNoteHeadsPalette());
+      addPalette(MuseScore::newLinesPalette(false));
+      addPalette(MuseScore::newBarLinePalette(false));
+      addPalette(MuseScore::newArpeggioPalette());
+      addPalette(MuseScore::newTremoloPalette());
+      addPalette(MuseScore::newTextPalette());
+      addPalette(MuseScore::newTempoPalette(false, true));
       addPalette(MuseScore::newDynamicsPalette(false, true));
       addPalette(MuseScore::newFingeringPalette());
-      addPalette(MuseScore::newNoteHeadsPalette());
-      addPalette(MuseScore::newTremoloPalette());
       addPalette(MuseScore::newRepeatsPalette());
-      addPalette(MuseScore::newTempoPalette(false, true));
-      addPalette(MuseScore::newTextPalette());
-      addPalette(MuseScore::newBreaksPalette());
+      addPalette(MuseScore::newFretboardDiagramPalette());
       addPalette(MuseScore::newBagpipeEmbellishmentPalette());
-      addPalette(MuseScore::newBeamPalette(false));
+      addPalette(MuseScore::newBreaksPalette());
       addPalette(MuseScore::newFramePalette());
+      addPalette(MuseScore::newBeamPalette(false));
 
       symbolItem = new QTreeWidgetItem();
       symbolItem->setData(0, Qt::UserRole, -1);

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -236,7 +236,7 @@ Palette* MuseScore::newKeySigPalette(bool basic)
       sp->setName(QT_TRANSLATE_NOOP("Palette", "Key Signatures"));
       sp->setMag(1.0);
       sp->setGrid(56, 64);
-      sp->setYOffset(0.0);
+      sp->setYOffset(0.5);
 
       for (int i = 0; i < 7; ++i) {
             KeySig* k = new KeySig(gscore);
@@ -602,7 +602,7 @@ Palette* MuseScore::newBracketsPalette()
       Palette* sp = new Palette;
       sp->setName(QT_TRANSLATE_NOOP("Palette", "Brackets"));
       sp->setMag(0.7);
-      sp->setGrid(42, 60);
+      sp->setGrid(40, 60);
       sp->setDrawGrid(true);
 
       Bracket* b1 = new Bracket(gscore);
@@ -651,7 +651,7 @@ Palette* MuseScore::newArpeggioPalette()
       {
       Palette* sp = new Palette();
       sp->setName(QT_TRANSLATE_NOOP("Palette", "Arpeggios && Glissandos"));
-      sp->setGrid(27, 60);
+      sp->setGrid(27, 50);
       sp->setDrawGrid(true);
 
       for (int i = 0; i < 6; ++i) {
@@ -716,7 +716,7 @@ Palette* MuseScore::newClefsPalette(bool basic)
       sp->setName(QT_TRANSLATE_NOOP("Palette", "Clefs"));
       sp->setMag(0.8);
       sp->setGrid(33, 60);
-      sp->setYOffset(1.0);
+      sp->setYOffset(0.5);
       static std::vector<ClefType> clefs1  {
             ClefType::G,   ClefType::F, ClefType::C3, ClefType::C4
             };
@@ -776,8 +776,8 @@ Palette* MuseScore::newBagpipeEmbellishmentPalette()
       Palette* sp = new Palette;
       sp->setName(QT_TRANSLATE_NOOP("Palette", "Bagpipe Embellishments"));
       sp->setMag(0.8);
-      sp->setGrid(60, 80);
-
+      sp->setYOffset(2.0);
+      sp->setGrid(55, 55);
       for (int i = 0; i < BagpipeEmbellishment::nEmbellishments(); ++i) {
             BagpipeEmbellishment* b  = new BagpipeEmbellishment(gscore);
             b->setEmbelType(i);
@@ -796,7 +796,7 @@ Palette* MuseScore::newLinesPalette(bool basic)
       Palette* sp = new Palette;
       sp->setName(QT_TRANSLATE_NOOP("Palette", "Lines"));
       sp->setMag(.8);
-      sp->setGrid(82, 35);
+      sp->setGrid(75, 28);
       sp->setDrawGrid(true);
 
       qreal w = gscore->spatium() * 8;
@@ -993,11 +993,12 @@ struct TempoPattern {
       QString pattern;
       double f;
       bool relative;
+      bool italian;
       bool followText;
       bool basic;
       bool masterOnly;
 
-      TempoPattern(const QString& s, double v, bool r, bool f, bool b, bool m) : pattern(s), f(v), relative(r), followText(f), basic(b), masterOnly(m) {}
+      TempoPattern(const QString& s, double v, bool r, bool i, bool f, bool b, bool m) : pattern(s), f(v), relative(r), italian(i), followText(f), basic(b), masterOnly(m) {}
       };
 
 //---------------------------------------------------------
@@ -1016,34 +1017,34 @@ Palette* MuseScore::newTempoPalette(bool basic, bool master)
       sp->setDrawGrid(true);
 
       static const TempoPattern tps[] = {
-            TempoPattern("<sym>metNoteHalfUp</sym> = 80",    80.0/ 30.0, false, true, true, false),                // 1/2
-            TempoPattern("<sym>metNoteQuarterUp</sym> = 80", 80.0/ 60.0, false, true, true, false),                // 1/4
-            TempoPattern("<sym>metNote8thUp</sym> = 80",     80.0/120.0, false, true, true, false),                // 1/8
-            TempoPattern("<sym>metNoteHalfUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80",    120/ 30.0, false, true, false, false),   // dotted 1/2
-            TempoPattern("<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80", 120/ 60.0, false, true, true, false),   // dotted 1/4
-            TempoPattern("<sym>metNote8thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80",     120/120.0, false, true, false, false),   // dotted 1/8
+            TempoPattern("<sym>metNoteHalfUp</sym> = 80",    80.0/ 30.0, false, false, true, true, false),                // 1/2
+            TempoPattern("<sym>metNoteQuarterUp</sym> = 80", 80.0/ 60.0, false, false, true, true, false),                // 1/4
+            TempoPattern("<sym>metNote8thUp</sym> = 80",     80.0/120.0, false, false, true, true, false),                // 1/8
+            TempoPattern("<sym>metNoteHalfUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80",    120/ 30.0, false, false, true, false, false),   // dotted 1/2
+            TempoPattern("<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80", 120/ 60.0, false, false, true, true, false),   // dotted 1/4
+            TempoPattern("<sym>metNote8thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = 80",     120/120.0, false, false, true, false, false),   // dotted 1/8
 
-            TempoPattern("Grave",             35.0/60.0, false, false, false, false),
-            TempoPattern("Largo",             50.0/60.0, false, false, false, false),
-            TempoPattern("Lento",             52.5/60.0, false, false, false, false),
-            TempoPattern("Larghetto",         63.0/60.0, false, false, false, true),
-            TempoPattern("Adagio",            71.0/60.0, false, false, false, false),
-            TempoPattern("Andante",           92.0/60.0, false, false, false, false),
-            TempoPattern("Andantino",         94.0/60.0, false, false, false, true),
-            TempoPattern("Moderato",         114.0/60.0, false, false, false, false),
-            TempoPattern("Allegretto",       116.0/60.0, false, false, false, false),
-            TempoPattern("Allegro moderato", 118.0/60.0, false, false, false, true),
-            TempoPattern("Allegro",          144.0/60.0, false, false, false, false),
-            TempoPattern("Vivace",           172.0/60.0, false, false, false, false),
-            TempoPattern("Presto",           187.0/60.0, false, false, false, false),
-            TempoPattern("Prestissimo",      200.0/60.0, false, false, false, true),
+            TempoPattern("Grave",             35.0/60.0, false, true, false, false, false),
+            TempoPattern("Largo",             50.0/60.0, false, true, false, false, false),
+            TempoPattern("Lento",             52.5/60.0, false, true, false, false, false),
+            TempoPattern("Larghetto",         63.0/60.0, false, true, false, false, true),
+            TempoPattern("Adagio",            71.0/60.0, false, true, false, false, false),
+            TempoPattern("Andante",           92.0/60.0, false, true, false, false, false),
+            TempoPattern("Andantino",         94.0/60.0, false, true, false, false, true),
+            TempoPattern("Moderato",         114.0/60.0, false, true, false, false, false),
+            TempoPattern("Allegretto",       116.0/60.0, false, true, false, false, false),
+            TempoPattern("Allegro moderato", 118.0/60.0, false, true, false, false, true),
+            TempoPattern("Allegro",          144.0/60.0, false, true, false, false, false),
+            TempoPattern("Vivace",           172.0/60.0, false, true, false, false, false),
+            TempoPattern("Presto",           187.0/60.0, false, true, false, false, false),
+            TempoPattern("Prestissimo",      200.0/60.0, false, true, false, false, true),
 
-            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym>", 3.0/2.0, true, true, false, false),
-            TempoPattern("<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = <sym>metNoteQuarterUp</sym>", 2.0/3.0, true, true, false, false),
-            TempoPattern("<sym>metNoteHalfUp</sym> = <sym>metNoteQuarterUp</sym>",    1.0/2.0, true, true, false, false),
-            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteHalfUp</sym>",    2.0/1.0, true, true, false, false),
-            TempoPattern("<sym>metNote8thUp</sym> = <sym>metNote8thUp</sym>",         1.0/1.0, true, true, false, false),
-            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteQuarterUp</sym>", 1.0/1.0, true, true, false, false),
+            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym>", 3.0/2.0, true, false, true, false, false),
+            TempoPattern("<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = <sym>metNoteQuarterUp</sym>", 2.0/3.0, true, false, true, false, false),
+            TempoPattern("<sym>metNoteHalfUp</sym> = <sym>metNoteQuarterUp</sym>",    1.0/2.0, true, false, true, false, false),
+            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteHalfUp</sym>",    2.0/1.0, true, false, true, false, false),
+            TempoPattern("<sym>metNote8thUp</sym> = <sym>metNote8thUp</sym>",         1.0/1.0, true, false, true, false, false),
+            TempoPattern("<sym>metNoteQuarterUp</sym> = <sym>metNoteQuarterUp</sym>", 1.0/1.0, true, false, true, false, false),
             };
       for (TempoPattern tp : tps) {
             if (!tp.basic && basic)
@@ -1057,11 +1058,29 @@ Palette* MuseScore::newTempoPalette(bool basic, bool master)
                   tt->setRelative(tp.f);
                   sp->append(tt, tr("Metric modulation"), QString(), 1.5);
                   }
+            else if (tp.italian) {
+                  tt->setTempo(tp.f);
+                  sp->append(tt, tr("Tempo text"), QString(), 1.3);
+            }
             else {
                   tt->setTempo(tp.f);
                   sp->append(tt, tr("Tempo text"), QString(), 1.5);
                   }
-            }
+            };
+
+//      (swing text and tempo text don't currently overlap properties)
+//      StaffText* st = new StaffText(gscore);
+//      st->setTextStyleType(TextStyleType::TEMPO);
+//      st->setXmlText(tr("Swing"));
+//      st->setSwing(true);
+//      sp->append(st, tr("Swing"), QString(), 1.3);
+//      
+//      st = new StaffText(gscore);
+//      st->setTextStyleType(TextStyleType::TEMPO);
+//      st->setXmlText(tr("Straight"));
+//      st->setSwing(false);
+//      sp->append(st, tr("Straight"), QString(), 1.3);
+
       return sp;
       }
 
@@ -1073,19 +1092,27 @@ Palette* MuseScore::newTextPalette()
       {
       Palette* sp = new Palette;
       sp->setName(QT_TRANSLATE_NOOP("Palette", "Text"));
-      sp->setMag(0.65);
+      sp->setMag(0.85);
       sp->setGrid(84, 28);
       sp->setDrawGrid(true);
 
       StaffText* st = new StaffText(gscore);
       st->setTextStyleType(TextStyleType::STAFF);
-      st->setXmlText(tr("Staff Text"));
-      sp->append(st, tr("Staff text"));
+      st->setXmlText(tr("Technique"));
+      sp->append(st, tr("Staff technique text"));
 
       st = new StaffText(gscore);
-      st->setTextStyleType(TextStyleType::SYSTEM);
-      st->setXmlText(tr("System Text"));
-      sp->append(st, tr("System text"));
+      st->setTextStyleType(TextStyleType::EXPRESSION);
+      st->setXmlText(tr("Expression"));
+      sp->append(st, tr("Staff expression text"));
+
+      InstrumentChange* is = new InstrumentChange(gscore);
+      is->setXmlText(tr("Change Instr."));
+      sp->append(is, tr("Instrument change"));
+            
+      RehearsalMark* rhm = new RehearsalMark(gscore);
+      rhm->setXmlText("B1");
+      sp->append(rhm, tr("Rehearsal mark"));
 
       st = new StaffText(gscore);
       st->setTextStyleType(TextStyleType::TEMPO);
@@ -1093,13 +1120,10 @@ Palette* MuseScore::newTextPalette()
       st->setSwing(true);
       sp->append(st, tr("Swing"));
 
-      RehearsalMark* rhm = new RehearsalMark(gscore);
-      rhm->setXmlText("B1");
-      sp->append(rhm, tr("Rehearsal mark"));
-
-      InstrumentChange* is = new InstrumentChange(gscore);
-      is->setXmlText(tr("Instrument"));
-      sp->append(is, tr("Instrument change"));
+      st = new StaffText(gscore);
+      st->setTextStyleType(TextStyleType::SYSTEM);
+      st->setXmlText(tr("System Text"));
+      sp->append(st, tr("System text"));
 
       return sp;
       }
@@ -1146,72 +1170,12 @@ Palette* MuseScore::newTimePalette()
       return sp;
       }
 
-//---------------------------------------------------------
-//   setAdvancedPalette
-//---------------------------------------------------------
+//-----------------------------------
+//    newFretboardDiagramPalette
+//-----------------------------------
 
-void MuseScore::setAdvancedPalette()
+Palette* MuseScore::newFretboardDiagramPalette()
       {
-      mscore->getPaletteBox();
-      paletteBox->clear();
-      paletteBox->addPalette(newGraceNotePalette(false));
-      paletteBox->addPalette(newClefsPalette(false));
-      paletteBox->addPalette(newKeySigPalette());
-      paletteBox->addPalette(newTimePalette());
-      paletteBox->addPalette(newBarLinePalette(false));
-      paletteBox->addPalette(newLinesPalette(false));
-      paletteBox->addPalette(newArpeggioPalette());
-      paletteBox->addPalette(newBreathPalette());
-      paletteBox->addPalette(newBracketsPalette());
-      paletteBox->addPalette(newArticulationsPalette(false));
-      paletteBox->addPalette(newAccidentalsPalette());
-      paletteBox->addPalette(newDynamicsPalette(false));
-      paletteBox->addPalette(newFingeringPalette());
-      paletteBox->addPalette(newNoteHeadsPalette());
-      paletteBox->addPalette(newTremoloPalette());
-      paletteBox->addPalette(newRepeatsPalette());
-      paletteBox->addPalette(newTempoPalette(false));
-      paletteBox->addPalette(newTextPalette());
-      paletteBox->addPalette(newBreaksPalette());
-      paletteBox->addPalette(newBagpipeEmbellishmentPalette());
-
-#if 0
-      //-----------------------------------
-      //    staff state changes
-      //-----------------------------------
-
-      sp = new Palette;
-      sp->setName(QT_TRANSLATE_NOOP("Palette", "Staff Changes"));
-      sp->setMag(.7);
-      sp->setGrid(42, 36);
-      sp->setDrawGrid(true);
-
-      StaffState* st = new StaffState(gscore);
-      st->setSubtype(StaffStateType::VISIBLE);
-      sp->append(st, tr("Set visible"));
-
-      st = new StaffState(gscore);
-      st->setSubtype(StaffStateType::INVISIBLE);
-      sp->append(st, tr("Set invisible"));
-
-      st = new StaffState(gscore);
-      st->setSubtype(StaffStateType::TYPE);
-      sp->append(st, tr("Change staff type"));
-
-      st = new StaffState(gscore);
-      st->setSubtype(StaffStateType::INSTRUMENT);
-      sp->append(st, tr("Change instrument"));
-
-      paletteBox->addPalette(sp);
-#endif
-
-      paletteBox->addPalette(newBeamPalette(false));
-      paletteBox->addPalette(newFramePalette());
-
-      //-----------------------------------
-      //    Symbols
-      //-----------------------------------
-
       Palette* sp = new Palette;
       sp->setName(QT_TRANSLATE_NOOP("Palette", "Fretboard Diagrams"));
       sp->setGrid(42, 45);
@@ -1266,7 +1230,71 @@ void MuseScore::setAdvancedPalette()
       fret = FretDiagram::fromString(gscore, "X212O2");
       sp->append(fret, "B7");
 
+      return sp;
+      }
+
+//---------------------------------------------------------
+//   setAdvancedPalette
+//---------------------------------------------------------
+
+void MuseScore::setAdvancedPalette()
+      {
+      mscore->getPaletteBox();
+      paletteBox->clear();
+      paletteBox->addPalette(newClefsPalette(false));
+      paletteBox->addPalette(newKeySigPalette());
+      paletteBox->addPalette(newTimePalette());
+      paletteBox->addPalette(newBracketsPalette());
+      paletteBox->addPalette(newAccidentalsPalette());
+      paletteBox->addPalette(newArticulationsPalette(false));
+      paletteBox->addPalette(newBreathPalette());
+      paletteBox->addPalette(newGraceNotePalette(false));
+      paletteBox->addPalette(newNoteHeadsPalette());
+      paletteBox->addPalette(newLinesPalette(false));
+      paletteBox->addPalette(newBarLinePalette(false));
+      paletteBox->addPalette(newArpeggioPalette());
+      paletteBox->addPalette(newTremoloPalette());
+      paletteBox->addPalette(newTextPalette());
+      paletteBox->addPalette(newTempoPalette(false));
+      paletteBox->addPalette(newDynamicsPalette(false));
+      paletteBox->addPalette(newFingeringPalette());
+      paletteBox->addPalette(newRepeatsPalette());
+      paletteBox->addPalette(newFretboardDiagramPalette());
+      paletteBox->addPalette(newBagpipeEmbellishmentPalette());
+      paletteBox->addPalette(newBreaksPalette());
+      paletteBox->addPalette(newFramePalette());
+      paletteBox->addPalette(newBeamPalette(false));
+
+#if 0
+      //-----------------------------------
+      //    staff state changes
+      //-----------------------------------
+
+      sp = new Palette;
+      sp->setName(QT_TRANSLATE_NOOP("Palette", "Staff Changes"));
+      sp->setMag(.7);
+      sp->setGrid(42, 36);
+      sp->setDrawGrid(true);
+
+      StaffState* st = new StaffState(gscore);
+      st->setSubtype(StaffStateType::VISIBLE);
+      sp->append(st, tr("Set visible"));
+
+      st = new StaffState(gscore);
+      st->setSubtype(StaffStateType::INVISIBLE);
+      sp->append(st, tr("Set invisible"));
+
+      st = new StaffState(gscore);
+      st->setSubtype(StaffStateType::TYPE);
+      sp->append(st, tr("Change staff type"));
+
+      st = new StaffState(gscore);
+      st->setSubtype(StaffStateType::INSTRUMENT);
+      sp->append(st, tr("Change instrument"));
+
       paletteBox->addPalette(sp);
+#endif
+
       }
 
 //---------------------------------------------------------
@@ -1277,27 +1305,29 @@ void MuseScore::setBasicPalette()
       {
       mscore->getPaletteBox();
       paletteBox->clear();
-      paletteBox->addPalette(newGraceNotePalette(true));
       paletteBox->addPalette(newClefsPalette(true));
       paletteBox->addPalette(newKeySigPalette(true));
       paletteBox->addPalette(newTimePalette());
-      paletteBox->addPalette(newBarLinePalette(true));
-      paletteBox->addPalette(newLinesPalette(true));
-//      paletteBox->addPalette(newArpeggioPalette());
-//      paletteBox->addPalette(newBreathPalette());
 //      paletteBox->addPalette(newBracketsPalette());
-      paletteBox->addPalette(newArticulationsPalette(true));
       paletteBox->addPalette(newAccidentalsPalette(true));
+      paletteBox->addPalette(newArticulationsPalette(true));
+//      paletteBox->addPalette(newBreathPalette());
+      paletteBox->addPalette(newGraceNotePalette(true));
+//      paletteBox->addPalette(newNoteHeadsPalette());
+      paletteBox->addPalette(newLinesPalette(true));
+      paletteBox->addPalette(newBarLinePalette(true));
+//      paletteBox->addPalette(newArpeggioPalette());
+//      paletteBox->addPalette(newTremoloPalette());
+      paletteBox->addPalette(newTextPalette());
+      paletteBox->addPalette(newTempoPalette(true));
       paletteBox->addPalette(newDynamicsPalette(true));
 //      paletteBox->addPalette(newFingeringPalette());
-//      paletteBox->addPalette(newNoteHeadsPalette());
-//      paletteBox->addPalette(newTremoloPalette());
       paletteBox->addPalette(newRepeatsPalette());
-      paletteBox->addPalette(newTempoPalette(true));
-      paletteBox->addPalette(newTextPalette());
+//      paletteBox->addPalette(newFretboardDiagramPalette());
+//      paletteBox->addPalette(newBagpipeEmbellishmentPalette());
       paletteBox->addPalette(newBreaksPalette());
-      paletteBox->addPalette(newBeamPalette(true));
 //      paletteBox->addPalette(newFramePalette());
+      paletteBox->addPalette(newBeamPalette(true));
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Music Composition & Notation
 //
-//  Copyright (C) 2002-2016 Werner Schweer
+//  Copyright (C) 2002-2016 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2
@@ -1047,6 +1047,7 @@ MuseScore::MuseScore()
       menuAddText->addSeparator();
       menuAddText->addAction(getAction("system-text"));
       menuAddText->addAction(getAction("staff-text"));
+      menuAddText->addAction(getAction("expression-text"));
       menuAddText->addAction(getAction("chord-text"));
       menuAddText->addAction(getAction("rehearsalmark-text"));
       menuAddText->addAction(getAction("instrument-change-text"));

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -708,6 +708,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       static Palette* newAccidentalsPalette(bool basic = false);
       static Palette* newBarLinePalette(bool basic);
       static Palette* newLinesPalette(bool basic);
+      static Palette* newFretboardDiagramPalette();
 
       Inspector* inspector()           { return _inspector; }
       PluginCreator* pluginCreator()   { return _pluginCreator; }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2880,6 +2880,8 @@ void ScoreView::cmd(const QAction* a)
             cmdAddText(TEXT::SYSTEM);
       else if (cmd == "staff-text")
             cmdAddText(TEXT::STAFF);
+      else if (cmd == "expression-text")
+            cmdAddText(TEXT::EXPRESSION);
       else if (cmd == "rehearsalmark-text")
             cmdAddText(TEXT::REHEARSAL_MARK);
       else if (cmd == "instrument-change-text")
@@ -5616,6 +5618,17 @@ void ScoreView::cmdAddText(TEXT type)
                   s->setParent(cr->segment());
                   }
                   break;
+            case TEXT::EXPRESSION:
+                  {
+                  ChordRest* cr = _score->getSelectedChordRest();
+                  if (!cr)
+                        break;
+                  s = new StaffText(_score);  
+                  s->setTrack(cr->track());
+                  s->setTextStyleType(TextStyleType::EXPRESSION);
+                  s->setParent(cr->segment());
+                  }
+                  break;    
             case TEXT::INSTRUMENT_CHANGE:
                   {
                   ChordRest* cr = _score->getSelectedChordRest();

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -66,6 +66,7 @@ enum class TEXT : char {
       PART,
       SYSTEM,
       STAFF,
+      EXPRESSION,
       REHEARSAL_MARK,
       INSTRUMENT_CHANGE
       };

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1863,8 +1863,15 @@ Shortcut Shortcut::_sc[] = {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "staff-text",
-         QT_TRANSLATE_NOOP("action","Staff Text"),
-         QT_TRANSLATE_NOOP("action","Add staff text")
+         QT_TRANSLATE_NOOP("action","Staff Technique Text"),
+         QT_TRANSLATE_NOOP("action","Add technique staff text")
+         },
+       {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "expression-text",
+         QT_TRANSLATE_NOOP("action","Staff Expression Text"),
+         QT_TRANSLATE_NOOP("action","Add expression staff text")
          },
       {
          MsWidget::SCORE_TAB,

--- a/mtest/guitarpro/accent.gpx-ref.mscx
+++ b/mtest/guitarpro/accent.gpx-ref.mscx
@@ -191,6 +191,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -311,7 +313,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/all-percussion.gp5-ref.mscx
+++ b/mtest/guitarpro/all-percussion.gp5-ref.mscx
@@ -1301,6 +1301,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1797,7 +1799,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Percussions</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/arpeggio.gpx-ref.mscx
+++ b/mtest/guitarpro/arpeggio.gpx-ref.mscx
@@ -203,6 +203,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -323,7 +325,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
+++ b/mtest/guitarpro/artificial-harmonic.gpx-ref.mscx
@@ -372,6 +372,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -492,7 +494,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/barre.gpx-ref.mscx
+++ b/mtest/guitarpro/barre.gpx-ref.mscx
@@ -198,6 +198,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -318,7 +320,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/basic-bend.gp5-ref.mscx
+++ b/mtest/guitarpro/basic-bend.gp5-ref.mscx
@@ -137,6 +137,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -224,7 +226,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/beams-stems-ledger-lines.gp5-ref.mscx
+++ b/mtest/guitarpro/beams-stems-ledger-lines.gp5-ref.mscx
@@ -937,6 +937,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1024,7 +1026,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic (DADGAD)</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/bend.gp3-ref.mscx
+++ b/mtest/guitarpro/bend.gp3-ref.mscx
@@ -245,6 +245,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -334,7 +336,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Guitar I</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/bend.gp4-ref.mscx
+++ b/mtest/guitarpro/bend.gp4-ref.mscx
@@ -267,6 +267,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -354,7 +356,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Guitar I</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/bend.gp5-ref.mscx
+++ b/mtest/guitarpro/bend.gp5-ref.mscx
@@ -246,7 +246,9 @@
       <currentLayer>0</currentLayer>
       <Division>480</Division>
       <Style>
-        <createMultiMeasureRests>1</createMultiMeasureRests>
+      	<createMultiMeasureRests>1</createMultiMeasureRests>
+      	<oddHeaderC>$i</oddHeaderC>
+      	<evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -334,7 +336,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Guitar I</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/brush.gp4-ref.mscx
+++ b/mtest/guitarpro/brush.gp4-ref.mscx
@@ -175,6 +175,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -262,7 +264,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/brush.gp5-ref.mscx
+++ b/mtest/guitarpro/brush.gp5-ref.mscx
@@ -165,6 +165,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -252,7 +254,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/brush.gpx-ref.mscx
+++ b/mtest/guitarpro/brush.gpx-ref.mscx
@@ -203,6 +203,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -323,7 +325,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/copyright.gp3-ref.mscx
+++ b/mtest/guitarpro/copyright.gp3-ref.mscx
@@ -123,6 +123,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -212,7 +214,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/copyright.gp4-ref.mscx
+++ b/mtest/guitarpro/copyright.gp4-ref.mscx
@@ -135,6 +135,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -222,7 +224,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/copyright.gp5-ref.mscx
+++ b/mtest/guitarpro/copyright.gp5-ref.mscx
@@ -125,6 +125,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -212,7 +214,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/copyright.gpx-ref.mscx
+++ b/mtest/guitarpro/copyright.gpx-ref.mscx
@@ -187,6 +187,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -307,7 +309,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/crescendo-diminuendo.gpx-ref.mscx
+++ b/mtest/guitarpro/crescendo-diminuendo.gpx-ref.mscx
@@ -221,6 +221,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -341,7 +343,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/dead-note.gpx-ref.mscx
+++ b/mtest/guitarpro/dead-note.gpx-ref.mscx
@@ -189,6 +189,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -309,7 +311,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/directions.gpx-ref.mscx
+++ b/mtest/guitarpro/directions.gpx-ref.mscx
@@ -542,6 +542,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -664,7 +666,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/dotted-gliss.gp3-ref.mscx
+++ b/mtest/guitarpro/dotted-gliss.gp3-ref.mscx
@@ -178,6 +178,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -277,7 +279,7 @@
             <text>Queen</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Guitar 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/dotted-tuplets.gp5-ref.mscx
+++ b/mtest/guitarpro/dotted-tuplets.gp5-ref.mscx
@@ -187,6 +187,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -274,7 +276,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Bells</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/double-bar.gpx-ref.mscx
+++ b/mtest/guitarpro/double-bar.gpx-ref.mscx
@@ -216,6 +216,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -336,7 +338,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/dynamic.gp5-ref.mscx
+++ b/mtest/guitarpro/dynamic.gp5-ref.mscx
@@ -235,6 +235,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -322,7 +324,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/fade-in.gp4-ref.mscx
+++ b/mtest/guitarpro/fade-in.gp4-ref.mscx
@@ -152,6 +152,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -239,7 +241,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/fade-in.gp5-ref.mscx
+++ b/mtest/guitarpro/fade-in.gp5-ref.mscx
@@ -153,6 +153,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -240,7 +242,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/fermata.gpx-ref.mscx
+++ b/mtest/guitarpro/fermata.gpx-ref.mscx
@@ -288,6 +288,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -408,7 +410,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/fingering.gp4-ref.mscx
+++ b/mtest/guitarpro/fingering.gp4-ref.mscx
@@ -314,6 +314,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -401,7 +403,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/fingering.gp5-ref.mscx
+++ b/mtest/guitarpro/fingering.gp5-ref.mscx
@@ -294,6 +294,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -381,7 +383,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/fingering.gpx-ref.mscx
+++ b/mtest/guitarpro/fingering.gpx-ref.mscx
@@ -339,6 +339,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -459,7 +461,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/free-time.gpx-ref.mscx
+++ b/mtest/guitarpro/free-time.gpx-ref.mscx
@@ -235,6 +235,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -355,7 +357,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/fret-diagram.gp4-ref.mscx
+++ b/mtest/guitarpro/fret-diagram.gp4-ref.mscx
@@ -939,6 +939,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1028,7 +1030,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/fret-diagram.gp5-ref.mscx
+++ b/mtest/guitarpro/fret-diagram.gp5-ref.mscx
@@ -924,6 +924,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1013,7 +1015,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/fret-diagram.gpx-ref.mscx
+++ b/mtest/guitarpro/fret-diagram.gpx-ref.mscx
@@ -907,6 +907,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -993,7 +995,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic (DADGAD, capo 6)</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/ghost-note.gpx-ref.mscx
+++ b/mtest/guitarpro/ghost-note.gpx-ref.mscx
@@ -174,6 +174,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -294,7 +296,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/ghost_note.gp3-ref.mscx
+++ b/mtest/guitarpro/ghost_note.gp3-ref.mscx
@@ -226,6 +226,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -313,7 +315,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/grace-before-beat.gpx-ref.mscx
+++ b/mtest/guitarpro/grace-before-beat.gpx-ref.mscx
@@ -211,6 +211,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -331,7 +333,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/grace-on-beat.gpx-ref.mscx
+++ b/mtest/guitarpro/grace-on-beat.gpx-ref.mscx
@@ -202,6 +202,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -322,7 +324,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/grace.gp5-ref.mscx
+++ b/mtest/guitarpro/grace.gp5-ref.mscx
@@ -340,6 +340,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -429,7 +431,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>E. Guitar 2</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/heavy-accent.gp5-ref.mscx
+++ b/mtest/guitarpro/heavy-accent.gp5-ref.mscx
@@ -132,6 +132,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -219,7 +221,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/high-pitch.gp3-ref.mscx
+++ b/mtest/guitarpro/high-pitch.gp3-ref.mscx
@@ -279,6 +279,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -377,7 +379,7 @@
             <text>Boria</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 3</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/keysig.gp4-ref.mscx
+++ b/mtest/guitarpro/keysig.gp4-ref.mscx
@@ -1918,6 +1918,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -2019,7 +2021,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/keysig.gp5-ref.mscx
+++ b/mtest/guitarpro/keysig.gp5-ref.mscx
@@ -1898,6 +1898,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1999,7 +2001,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/legato-slide.gp4-ref.mscx
+++ b/mtest/guitarpro/legato-slide.gp4-ref.mscx
@@ -174,6 +174,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -261,7 +263,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/legato-slide.gp5-ref.mscx
+++ b/mtest/guitarpro/legato-slide.gp5-ref.mscx
@@ -175,6 +175,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -262,7 +264,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/legato-slide.gpx-ref.mscx
+++ b/mtest/guitarpro/legato-slide.gpx-ref.mscx
@@ -213,6 +213,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -333,7 +335,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/let-ring.gp4-ref.mscx
+++ b/mtest/guitarpro/let-ring.gp4-ref.mscx
@@ -179,6 +179,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -266,7 +268,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/let-ring.gp5-ref.mscx
+++ b/mtest/guitarpro/let-ring.gp5-ref.mscx
@@ -159,6 +159,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -246,7 +248,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/let-ring.gpx-ref.mscx
+++ b/mtest/guitarpro/let-ring.gpx-ref.mscx
@@ -197,6 +197,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -317,7 +319,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/mordents.gpx-ref.mscx
+++ b/mtest/guitarpro/mordents.gpx-ref.mscx
@@ -195,6 +195,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -315,7 +317,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/multivoices.gpx-ref.mscx
+++ b/mtest/guitarpro/multivoices.gpx-ref.mscx
@@ -395,6 +395,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -515,7 +517,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Classical Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/palm-mute.gp4-ref.mscx
+++ b/mtest/guitarpro/palm-mute.gp4-ref.mscx
@@ -178,6 +178,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -265,7 +267,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/palm-mute.gp5-ref.mscx
+++ b/mtest/guitarpro/palm-mute.gp5-ref.mscx
@@ -158,6 +158,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -245,7 +247,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/palm-mute.gpx-ref.mscx
+++ b/mtest/guitarpro/palm-mute.gpx-ref.mscx
@@ -196,6 +196,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -316,7 +318,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/pick-up-down.gp4-ref.mscx
+++ b/mtest/guitarpro/pick-up-down.gp4-ref.mscx
@@ -177,6 +177,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -264,7 +266,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/pick-up-down.gp5-ref.mscx
+++ b/mtest/guitarpro/pick-up-down.gp5-ref.mscx
@@ -157,6 +157,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -244,7 +246,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/pick-up-down.gpx-ref.mscx
+++ b/mtest/guitarpro/pick-up-down.gpx-ref.mscx
@@ -195,6 +195,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -315,7 +317,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/rasg.gpx-ref.mscx
+++ b/mtest/guitarpro/rasg.gpx-ref.mscx
@@ -170,6 +170,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -290,7 +292,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/repeated-bars.gpx-ref.mscx
+++ b/mtest/guitarpro/repeated-bars.gpx-ref.mscx
@@ -194,6 +194,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -314,7 +316,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/repeats.gpx-ref.mscx
+++ b/mtest/guitarpro/repeats.gpx-ref.mscx
@@ -211,6 +211,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -331,7 +333,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/rest-centered.gp4-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gp4-ref.mscx
@@ -140,6 +140,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -227,7 +229,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/rest-centered.gp5-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gp5-ref.mscx
@@ -135,6 +135,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -222,7 +224,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/rest-centered.gpx-ref.mscx
+++ b/mtest/guitarpro/rest-centered.gpx-ref.mscx
@@ -168,6 +168,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -288,7 +290,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/sforzato.gp4-ref.mscx
+++ b/mtest/guitarpro/sforzato.gp4-ref.mscx
@@ -164,6 +164,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -251,7 +253,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/shift-slide.gp4-ref.mscx
+++ b/mtest/guitarpro/shift-slide.gp4-ref.mscx
@@ -168,6 +168,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -255,7 +257,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/shift-slide.gp5-ref.mscx
+++ b/mtest/guitarpro/shift-slide.gp5-ref.mscx
@@ -169,6 +169,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -256,7 +258,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/shift-slide.gpx-ref.mscx
+++ b/mtest/guitarpro/shift-slide.gpx-ref.mscx
@@ -207,6 +207,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -327,7 +329,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-in-above.gp4-ref.mscx
+++ b/mtest/guitarpro/slide-in-above.gp4-ref.mscx
@@ -189,6 +189,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -276,7 +278,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-in-above.gp5-ref.mscx
+++ b/mtest/guitarpro/slide-in-above.gp5-ref.mscx
@@ -190,6 +190,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -277,7 +279,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-in-above.gpx-ref.mscx
+++ b/mtest/guitarpro/slide-in-above.gpx-ref.mscx
@@ -228,6 +228,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -348,7 +350,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-in-below.gp4-ref.mscx
+++ b/mtest/guitarpro/slide-in-below.gp4-ref.mscx
@@ -189,6 +189,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -276,7 +278,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-in-below.gp5-ref.mscx
+++ b/mtest/guitarpro/slide-in-below.gp5-ref.mscx
@@ -190,6 +190,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -277,7 +279,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-in-below.gpx-ref.mscx
+++ b/mtest/guitarpro/slide-in-below.gpx-ref.mscx
@@ -228,6 +228,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -348,7 +350,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-out-down.gp4-ref.mscx
+++ b/mtest/guitarpro/slide-out-down.gp4-ref.mscx
@@ -189,6 +189,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -276,7 +278,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-out-down.gp5-ref.mscx
+++ b/mtest/guitarpro/slide-out-down.gp5-ref.mscx
@@ -190,6 +190,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -277,7 +279,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-out-down.gpx-ref.mscx
+++ b/mtest/guitarpro/slide-out-down.gpx-ref.mscx
@@ -228,6 +228,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -348,7 +350,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-out-up.gp4-ref.mscx
+++ b/mtest/guitarpro/slide-out-up.gp4-ref.mscx
@@ -201,6 +201,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -288,7 +290,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-out-up.gp5-ref.mscx
+++ b/mtest/guitarpro/slide-out-up.gp5-ref.mscx
@@ -202,6 +202,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -289,7 +291,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slide-out-up.gpx-ref.mscx
+++ b/mtest/guitarpro/slide-out-up.gpx-ref.mscx
@@ -235,6 +235,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -355,7 +357,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slur-notes-effect-mask.gp5-ref.mscx
+++ b/mtest/guitarpro/slur-notes-effect-mask.gp5-ref.mscx
@@ -341,6 +341,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -426,7 +428,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Bass</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slur.gp4-ref.mscx
+++ b/mtest/guitarpro/slur.gp4-ref.mscx
@@ -161,6 +161,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -248,7 +250,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/slur.gpx-ref.mscx
+++ b/mtest/guitarpro/slur.gpx-ref.mscx
@@ -198,6 +198,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -318,7 +320,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/tap-slap-pop.gp5-ref.mscx
+++ b/mtest/guitarpro/tap-slap-pop.gp5-ref.mscx
@@ -169,6 +169,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -256,7 +258,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Steel Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/tap-slap-pop.gpx-ref.mscx
+++ b/mtest/guitarpro/tap-slap-pop.gpx-ref.mscx
@@ -207,6 +207,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -327,7 +329,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/tempo.gp3-ref.mscx
+++ b/mtest/guitarpro/tempo.gp3-ref.mscx
@@ -253,6 +253,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -342,7 +344,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/tempo.gp4-ref.mscx
+++ b/mtest/guitarpro/tempo.gp4-ref.mscx
@@ -275,6 +275,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -362,7 +364,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/tempo.gp5-ref.mscx
+++ b/mtest/guitarpro/tempo.gp5-ref.mscx
@@ -255,6 +255,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -342,7 +344,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/testIrrTuplet.gp4-ref.mscx
+++ b/mtest/guitarpro/testIrrTuplet.gp4-ref.mscx
@@ -210,6 +210,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -297,7 +299,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Gtr 2</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/text.gpx-ref.mscx
+++ b/mtest/guitarpro/text.gpx-ref.mscx
@@ -196,6 +196,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -316,7 +318,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/timer.gpx-ref.mscx
+++ b/mtest/guitarpro/timer.gpx-ref.mscx
@@ -1269,6 +1269,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1395,7 +1397,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/tremolo-bar.gpx-ref.mscx
+++ b/mtest/guitarpro/tremolo-bar.gpx-ref.mscx
@@ -284,6 +284,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -404,7 +406,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/tremolos.gp5-ref.mscx
+++ b/mtest/guitarpro/tremolos.gp5-ref.mscx
@@ -143,6 +143,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -230,7 +232,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/tremolos.gpx-ref.mscx
+++ b/mtest/guitarpro/tremolos.gpx-ref.mscx
@@ -199,6 +199,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -319,7 +321,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/trill.gp4-ref.mscx
+++ b/mtest/guitarpro/trill.gp4-ref.mscx
@@ -152,6 +152,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -239,7 +241,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/trill.gpx-ref.mscx
+++ b/mtest/guitarpro/trill.gpx-ref.mscx
@@ -197,6 +197,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -317,7 +319,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/tuplet-with-slur.gp4-ref.mscx
+++ b/mtest/guitarpro/tuplet-with-slur.gp4-ref.mscx
@@ -210,6 +210,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -297,7 +299,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Gtr 2</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/turn.gpx-ref.mscx
+++ b/mtest/guitarpro/turn.gpx-ref.mscx
@@ -195,6 +195,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -315,7 +317,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/vibrato.gpx-ref.mscx
+++ b/mtest/guitarpro/vibrato.gpx-ref.mscx
@@ -257,6 +257,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -377,7 +379,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Electric Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/volta.gp3-ref.mscx
+++ b/mtest/guitarpro/volta.gp3-ref.mscx
@@ -800,6 +800,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -896,7 +898,7 @@
             <text>Test</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/volta.gp4-ref.mscx
+++ b/mtest/guitarpro/volta.gp4-ref.mscx
@@ -663,6 +663,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -752,7 +754,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/volta.gp5-ref.mscx
+++ b/mtest/guitarpro/volta.gp5-ref.mscx
@@ -1306,6 +1306,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1405,7 +1407,7 @@
             <text>F. Tarrega</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/volta.gpx-ref.mscx
+++ b/mtest/guitarpro/volta.gpx-ref.mscx
@@ -252,6 +252,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -372,7 +374,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/volume-swell.gpx-ref.mscx
+++ b/mtest/guitarpro/volume-swell.gpx-ref.mscx
@@ -191,6 +191,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -311,7 +313,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/guitarpro/wah.gpx-ref.mscx
+++ b/mtest/guitarpro/wah.gpx-ref.mscx
@@ -195,6 +195,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -315,7 +317,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/chordsymbol/add-part-ref.mscx
+++ b/mtest/libmscore/chordsymbol/add-part-ref.mscx
@@ -131,6 +131,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>

--- a/mtest/libmscore/chordsymbol/add-part.mscx
+++ b/mtest/libmscore/chordsymbol/add-part.mscx
@@ -123,6 +123,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -202,7 +204,7 @@
         <VBox>
           <height>10</height>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text></text>
             </Text>
           </VBox>

--- a/mtest/libmscore/chordsymbol/no-system-ref.mscx
+++ b/mtest/libmscore/chordsymbol/no-system-ref.mscx
@@ -250,6 +250,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <TextStyle>
           <halign>left</halign>
           <valign>baseline</valign>
@@ -333,7 +335,7 @@
         <VBox>
           <height>10</height>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>
@@ -393,6 +395,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <TextStyle>
           <halign>left</halign>
           <valign>baseline</valign>
@@ -479,7 +483,7 @@
           <height>10</height>
           <lid>11</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto Saxophone</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/chordsymbol/transpose-part-ref.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-part-ref.mscx
@@ -152,6 +152,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1584</page-height>
           <page-width>1224</page-width>
@@ -237,7 +239,7 @@
           <height>10</height>
           <lid>9</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/chordsymbol/transpose-part.mscx
+++ b/mtest/libmscore/chordsymbol/transpose-part.mscx
@@ -153,6 +153,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1584</page-height>
           <page-width>1224</page-width>
@@ -238,7 +240,7 @@
           <height>10</height>
           <lid>11</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/clef_courtesy/clef_courtesy01-ref.mscx
+++ b/mtest/libmscore/clef_courtesy/clef_courtesy01-ref.mscx
@@ -14,11 +14,8 @@
       <staffLineWidth>0.15</staffLineWidth>
       <genCourtesyTimesig>0</genCourtesyTimesig>
       <sectionPause>2</sectionPause>
-      <showHeader>1</showHeader>
-      <evenHeaderL>$p</evenHeaderL>
-      <evenHeaderR>$:workTitle:</evenHeaderR>
       <oddHeaderL>$:workTitle:</oddHeaderL>
-      <oddHeaderR>$p</oddHeaderR>
+      <evenHeaderR>$:workTitle:</evenHeaderR>
       <footerOddEven>0</footerOddEven>
       <evenFooterL>$:copyright:</evenFooterL>
       <evenFooterC>$:plate:</evenFooterC>

--- a/mtest/libmscore/clef_courtesy/clef_courtesy02-ref.mscx
+++ b/mtest/libmscore/clef_courtesy/clef_courtesy02-ref.mscx
@@ -15,11 +15,8 @@
       <genCourtesyTimesig>0</genCourtesyTimesig>
       <genCourtesyClef>0</genCourtesyClef>
       <sectionPause>2</sectionPause>
-      <showHeader>1</showHeader>
-      <evenHeaderL>$p</evenHeaderL>
-      <evenHeaderR>$:workTitle:</evenHeaderR>
       <oddHeaderL>$:workTitle:</oddHeaderL>
-      <oddHeaderR>$p</oddHeaderR>
+      <evenHeaderR>$:workTitle:</evenHeaderR>
       <footerOddEven>0</footerOddEven>
       <evenFooterL>$:copyright:</evenFooterL>
       <evenFooterC>$:plate:</evenFooterC>

--- a/mtest/libmscore/clef_courtesy/clef_courtesy03-ref.mscx
+++ b/mtest/libmscore/clef_courtesy/clef_courtesy03-ref.mscx
@@ -14,11 +14,8 @@
       <staffLineWidth>0.15</staffLineWidth>
       <genCourtesyTimesig>0</genCourtesyTimesig>
       <sectionPause>2</sectionPause>
-      <showHeader>1</showHeader>
-      <evenHeaderL>$p</evenHeaderL>
-      <evenHeaderR>$:workTitle:</evenHeaderR>
       <oddHeaderL>$:workTitle:</oddHeaderL>
-      <oddHeaderR>$p</oddHeaderR>
+      <evenHeaderR>$:workTitle:</evenHeaderR>
       <footerOddEven>0</footerOddEven>
       <evenFooterL>$:copyright:</evenFooterL>
       <evenFooterC>$:plate:</evenFooterC>

--- a/mtest/libmscore/compat114/style-ref.mscx
+++ b/mtest/libmscore/compat114/style-ref.mscx
@@ -80,8 +80,8 @@
       <ArpeggioNoteDistance>0.7</ArpeggioNoteDistance>
       <ArpeggioLineWidth>0.19</ArpeggioLineWidth>
       <ArpeggioHookLen>0.9</ArpeggioHookLen>
-      <evenFooterL>$P</evenFooterL>
       <oddFooterR>$P</oddFooterR>
+      <evenFooterL>$P</evenFooterL>
       <voltaY>0</voltaY>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>

--- a/mtest/libmscore/compat114/textstyles-ref.mscx
+++ b/mtest/libmscore/compat114/textstyles-ref.mscx
@@ -139,7 +139,7 @@
         <halign>left</halign>
         <valign>bottom</valign>
         <offsetType>absolute</offsetType>
-        <name>Instrument Name (Part)</name>
+        <name>Part Name</name>
         <family>MuseJazz</family>
         <size>18</size>
         </TextStyle>

--- a/mtest/libmscore/measure/gaps.mscx
+++ b/mtest/libmscore/measure/gaps.mscx
@@ -313,6 +313,8 @@
       <Style>
         <lastSystemFillLimit>0</lastSystemFillLimit>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.36</page-height>
           <page-width>1190.88</page-width>
@@ -405,7 +407,7 @@
             <text>gaps</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Piano</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/measure/measure-1-ref.mscx
+++ b/mtest/libmscore/measure/measure-1-ref.mscx
@@ -327,6 +327,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -421,7 +423,7 @@
             <text>measure</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Piano</text>
             </Text>
           </VBox>
@@ -570,6 +572,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -655,7 +659,7 @@
             <text>measure</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/measure/measure-1.mscx
+++ b/mtest/libmscore/measure/measure-1.mscx
@@ -292,6 +292,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -378,7 +380,7 @@
             <text>measure</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Piano</text>
             </Text>
           </VBox>
@@ -514,6 +516,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -593,7 +597,7 @@
             <text>measure</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/measure/measure-2-ref.mscx
+++ b/mtest/libmscore/measure/measure-2-ref.mscx
@@ -324,6 +324,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -418,7 +420,7 @@
             <text>measure</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Piano</text>
             </Text>
           </VBox>
@@ -565,6 +567,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -650,7 +654,7 @@
             <text>measure</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/measure/measure-3-ref.mscx
+++ b/mtest/libmscore/measure/measure-3-ref.mscx
@@ -327,6 +327,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -421,7 +423,7 @@
             <text>measure</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Piano</text>
             </Text>
           </VBox>
@@ -570,6 +572,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -655,7 +659,7 @@
             <text>measure</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/midimapping/test14-ref.mscx
+++ b/mtest/libmscore/midimapping/test14-ref.mscx
@@ -767,6 +767,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -856,7 +858,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>
@@ -913,6 +915,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1002,7 +1006,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 2</text>
             </Text>
           </VBox>
@@ -1054,6 +1058,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1143,7 +1149,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 3</text>
             </Text>
           </VBox>
@@ -1195,6 +1201,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1284,7 +1292,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 4</text>
             </Text>
           </VBox>
@@ -1336,6 +1344,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1830,7 +1840,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 5</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/midimapping/test15-ref.mscx
+++ b/mtest/libmscore/midimapping/test15-ref.mscx
@@ -802,6 +802,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -889,7 +891,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>
@@ -979,6 +981,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1066,7 +1070,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 2</text>
             </Text>
           </VBox>
@@ -1151,6 +1155,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1238,7 +1244,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 3</text>
             </Text>
           </VBox>
@@ -1323,6 +1329,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1410,7 +1418,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 4</text>
             </Text>
           </VBox>
@@ -1495,6 +1503,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1987,7 +1997,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 5</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/midimapping/test16-ref.mscx
+++ b/mtest/libmscore/midimapping/test16-ref.mscx
@@ -777,6 +777,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -864,7 +866,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 1</text>
             </Text>
           </VBox>
@@ -929,6 +931,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1016,7 +1020,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 2</text>
             </Text>
           </VBox>
@@ -1076,6 +1080,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1163,7 +1169,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 3</text>
             </Text>
           </VBox>
@@ -1223,6 +1229,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1310,7 +1318,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 4</text>
             </Text>
           </VBox>
@@ -1370,6 +1378,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1862,7 +1872,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Track 5</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/midimapping/test17-ref.mscx
+++ b/mtest/libmscore/midimapping/test17-ref.mscx
@@ -810,6 +810,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -930,7 +932,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>
@@ -1042,6 +1044,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1162,7 +1166,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>
@@ -1274,6 +1278,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1394,7 +1400,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>
@@ -1506,6 +1512,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1626,7 +1634,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Acoustic Guitar</text>
             </Text>
           </VBox>
@@ -1738,6 +1746,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -2003,7 +2013,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Drumset</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/midimapping/test3withMapping.mscx
+++ b/mtest/libmscore/midimapping/test3withMapping.mscx
@@ -43,6 +43,8 @@
       <Page>
         <System>
           </System>
+        <System>
+          </System>
         </Page>
       </PageList>
     <Part>

--- a/mtest/libmscore/midimapping/test7-ref.mscx
+++ b/mtest/libmscore/midimapping/test7-ref.mscx
@@ -43,6 +43,8 @@
       <Page>
         <System>
           </System>
+        <System>
+          </System>
         </Page>
       </PageList>
     <Part>

--- a/mtest/libmscore/parts/part-54346-parts.mscx
+++ b/mtest/libmscore/parts/part-54346-parts.mscx
@@ -305,6 +305,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -402,7 +404,7 @@
             <text>Test</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>B♭ Trumpet</text>
             </Text>
           </VBox>
@@ -494,6 +496,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -589,7 +593,7 @@
             <text>Test</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>C Trumpet</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-all-appendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-appendmeasures.mscx
@@ -272,7 +272,7 @@
           </Chord>
         <StaffText>
           <lid>30</lid>
-          <style>System</style>
+          <style>System Text</style>
           <text>system-text</text>
           </StaffText>
         <Chord>
@@ -949,6 +949,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1027,7 +1029,7 @@
             <text>testpart2</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1170,7 +1172,7 @@
             </Chord>
           <StaffText>
             <lid>30</lid>
-            <style>System</style>
+            <style>System Text</style>
             <text>system-text</text>
             </StaffText>
           <Chord>
@@ -1516,6 +1518,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1594,7 +1598,7 @@
             <text>testpart2</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>
@@ -1680,7 +1684,7 @@
             </Chord>
           <StaffText>
             <lid>30</lid>
-            <style>System</style>
+            <style>System Text</style>
             <text>system-text</text>
             </StaffText>
           <Chord>

--- a/mtest/libmscore/parts/part-all-insertmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-insertmeasures.mscx
@@ -940,6 +940,8 @@ p, li { white-space: pre-wrap; }
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1019,7 +1021,7 @@ p, li { white-space: pre-wrap; }
             <text>testpart2</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1482,6 +1484,8 @@ p, li { white-space: pre-wrap; }
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1561,7 +1565,7 @@ p, li { white-space: pre-wrap; }
             <text>testpart2</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-all-parts.mscx
+++ b/mtest/libmscore/parts/part-all-parts.mscx
@@ -272,7 +272,7 @@
           </Chord>
         <StaffText>
           <lid>30</lid>
-          <style>System</style>
+          <style>System Text</style>
           <text>system-text</text>
           </StaffText>
         <Chord>
@@ -935,6 +935,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1013,7 +1015,7 @@
             <text>testpart2</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1156,7 +1158,7 @@
             </Chord>
           <StaffText>
             <lid>30</lid>
-            <style>System</style>
+            <style>System Text</style>
             <text>system-text</text>
             </StaffText>
           <Chord>
@@ -1495,6 +1497,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1573,7 +1577,7 @@
             <text>testpart2</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>
@@ -1659,7 +1663,7 @@
             </Chord>
           <StaffText>
             <lid>30</lid>
-            <style>System</style>
+            <style>System Text</style>
             <text>system-text</text>
             </StaffText>
           <Chord>

--- a/mtest/libmscore/parts/part-all-uappendmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uappendmeasures.mscx
@@ -272,7 +272,7 @@
           </Chord>
         <StaffText>
           <lid>30</lid>
-          <style>System</style>
+          <style>System Text</style>
           <text>system-text</text>
           </StaffText>
         <Chord>
@@ -935,6 +935,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1013,7 +1015,7 @@
             <text>testpart2</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1156,7 +1158,7 @@
             </Chord>
           <StaffText>
             <lid>30</lid>
-            <style>System</style>
+            <style>System Text</style>
             <text>system-text</text>
             </StaffText>
           <Chord>
@@ -1495,6 +1497,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1573,7 +1577,7 @@
             <text>testpart2</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>
@@ -1659,7 +1663,7 @@
             </Chord>
           <StaffText>
             <lid>30</lid>
-            <style>System</style>
+            <style>System Text</style>
             <text>system-text</text>
             </StaffText>
           <Chord>

--- a/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
+++ b/mtest/libmscore/parts/part-all-uinsertmeasures.mscx
@@ -272,7 +272,7 @@
           </Chord>
         <StaffText>
           <lid>30</lid>
-          <style>System</style>
+          <style>System Text</style>
           <text>system-text</text>
           </StaffText>
         <Chord>
@@ -935,6 +935,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1013,7 +1015,7 @@
             <text>testpart2</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1156,7 +1158,7 @@
             </Chord>
           <StaffText>
             <lid>30</lid>
-            <style>System</style>
+            <style>System Text</style>
             <text>system-text</text>
             </StaffText>
           <Chord>
@@ -1495,6 +1497,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1573,7 +1577,7 @@
             <text>testpart2</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>
@@ -1659,7 +1663,7 @@
             </Chord>
           <StaffText>
             <lid>30</lid>
-            <style>System</style>
+            <style>System Text</style>
             <text>system-text</text>
             </StaffText>
           <Chord>

--- a/mtest/libmscore/parts/part-all.mscx
+++ b/mtest/libmscore/parts/part-all.mscx
@@ -242,7 +242,7 @@
             </Note>
           </Chord>
         <StaffText>
-          <style>System</style>
+          <style>System Text</style>
           <text>system-text</text>
           </StaffText>
         <Chord>

--- a/mtest/libmscore/parts/part-breath-add.mscx
+++ b/mtest/libmscore/parts/part-breath-add.mscx
@@ -685,6 +685,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -763,7 +765,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1062,6 +1064,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1140,7 +1144,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-breath-del.mscx
+++ b/mtest/libmscore/parts/part-breath-del.mscx
@@ -681,6 +681,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -759,7 +761,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1054,6 +1056,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1132,7 +1136,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-breath-parts.mscx
+++ b/mtest/libmscore/parts/part-breath-parts.mscx
@@ -694,6 +694,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -777,7 +779,7 @@
             <text>breath</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1076,6 +1078,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1159,7 +1163,7 @@
             <text>breath</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-breath-uadd.mscx
+++ b/mtest/libmscore/parts/part-breath-uadd.mscx
@@ -681,6 +681,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -759,7 +761,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1054,6 +1056,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1132,7 +1136,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-breath-udel.mscx
+++ b/mtest/libmscore/parts/part-breath-udel.mscx
@@ -685,6 +685,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -763,7 +765,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1062,6 +1064,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1140,7 +1144,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-breath-uradd.mscx
+++ b/mtest/libmscore/parts/part-breath-uradd.mscx
@@ -685,6 +685,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -763,7 +765,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1062,6 +1064,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1140,7 +1144,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-breath-urdel.mscx
+++ b/mtest/libmscore/parts/part-breath-urdel.mscx
@@ -681,6 +681,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -759,7 +761,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1054,6 +1056,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1132,7 +1136,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-chordline-add.mscx
+++ b/mtest/libmscore/parts/part-chordline-add.mscx
@@ -685,6 +685,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -763,7 +765,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1062,6 +1064,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1140,7 +1144,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-chordline-del.mscx
+++ b/mtest/libmscore/parts/part-chordline-del.mscx
@@ -676,6 +676,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -754,7 +756,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1044,6 +1046,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1122,7 +1126,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-chordline-parts.mscx
+++ b/mtest/libmscore/parts/part-chordline-parts.mscx
@@ -680,6 +680,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -758,7 +760,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1052,6 +1054,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1130,7 +1134,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-chordline-uadd.mscx
+++ b/mtest/libmscore/parts/part-chordline-uadd.mscx
@@ -681,6 +681,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -759,7 +761,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1054,6 +1056,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1132,7 +1136,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-chordline-udel.mscx
+++ b/mtest/libmscore/parts/part-chordline-udel.mscx
@@ -680,6 +680,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -758,7 +760,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1052,6 +1054,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1130,7 +1134,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-chordline-uradd.mscx
+++ b/mtest/libmscore/parts/part-chordline-uradd.mscx
@@ -685,6 +685,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -763,7 +765,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1062,6 +1064,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1140,7 +1144,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-chordline-urdel.mscx
+++ b/mtest/libmscore/parts/part-chordline-urdel.mscx
@@ -676,6 +676,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -754,7 +756,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1044,6 +1046,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1122,7 +1126,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-empty-parts.mscx
+++ b/mtest/libmscore/parts/part-empty-parts.mscx
@@ -681,6 +681,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -759,7 +761,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1054,6 +1056,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1132,7 +1136,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-fingering-add.mscx
+++ b/mtest/libmscore/parts/part-fingering-add.mscx
@@ -686,6 +686,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -764,7 +766,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1064,6 +1066,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1142,7 +1146,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-fingering-del.mscx
+++ b/mtest/libmscore/parts/part-fingering-del.mscx
@@ -686,6 +686,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -769,7 +771,7 @@
             <text>fingering</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1064,6 +1066,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1147,7 +1151,7 @@
             <text>fingering</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-fingering-parts.mscx
+++ b/mtest/libmscore/parts/part-fingering-parts.mscx
@@ -691,6 +691,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -774,7 +776,7 @@
             <text>fingering</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1074,6 +1076,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1157,7 +1161,7 @@
             <text>fingering</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-fingering-uadd.mscx
+++ b/mtest/libmscore/parts/part-fingering-uadd.mscx
@@ -681,6 +681,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -759,7 +761,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1054,6 +1056,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1132,7 +1136,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-fingering-udel.mscx
+++ b/mtest/libmscore/parts/part-fingering-udel.mscx
@@ -691,6 +691,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -774,7 +776,7 @@
             <text>fingering</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1074,6 +1076,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1157,7 +1161,7 @@
             <text>fingering</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-fingering-uradd.mscx
+++ b/mtest/libmscore/parts/part-fingering-uradd.mscx
@@ -686,6 +686,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -764,7 +766,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1064,6 +1066,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1142,7 +1146,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-fingering-urdel.mscx
+++ b/mtest/libmscore/parts/part-fingering-urdel.mscx
@@ -686,6 +686,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -769,7 +771,7 @@
             <text>fingering</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1064,6 +1066,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1147,7 +1151,7 @@
             <text>fingering</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-image-parts.mscx
+++ b/mtest/libmscore/parts/part-image-parts.mscx
@@ -689,6 +689,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -772,7 +774,7 @@
             <size w="38.52" h="38.64"/>
             </Image>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1072,6 +1074,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1155,7 +1159,7 @@
             <size w="38.52" h="38.64"/>
             </Image>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-symbol-add.mscx
+++ b/mtest/libmscore/parts/part-symbol-add.mscx
@@ -685,6 +685,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -763,7 +765,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1062,6 +1064,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1140,7 +1144,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-symbol-del.mscx
+++ b/mtest/libmscore/parts/part-symbol-del.mscx
@@ -681,6 +681,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -759,7 +761,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1054,6 +1056,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1132,7 +1136,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-symbol-parts.mscx
+++ b/mtest/libmscore/parts/part-symbol-parts.mscx
@@ -685,6 +685,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -763,7 +765,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1062,6 +1064,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1140,7 +1144,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-symbol-uadd.mscx
+++ b/mtest/libmscore/parts/part-symbol-uadd.mscx
@@ -681,6 +681,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -759,7 +761,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1054,6 +1056,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1132,7 +1136,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-symbol-udel.mscx
+++ b/mtest/libmscore/parts/part-symbol-udel.mscx
@@ -685,6 +685,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -763,7 +765,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1062,6 +1064,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1140,7 +1144,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-symbol-uradd.mscx
+++ b/mtest/libmscore/parts/part-symbol-uradd.mscx
@@ -685,6 +685,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -763,7 +765,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1062,6 +1064,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1140,7 +1144,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/part-symbol-urdel.mscx
+++ b/mtest/libmscore/parts/part-symbol-urdel.mscx
@@ -681,6 +681,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -759,7 +761,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Alto</text>
             </Text>
           </VBox>
@@ -1054,6 +1056,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1132,7 +1136,7 @@
             <text>testpart1</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Tenor</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/partStyle-score-ref.mscx
+++ b/mtest/libmscore/parts/partStyle-score-ref.mscx
@@ -393,6 +393,8 @@
       <Style>
         <frameSystemDistance>21</frameSystemDistance>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <TextStyle>
           <halign>center</halign>
           <valign>top</valign>
@@ -626,6 +628,8 @@
       <Style>
         <frameSystemDistance>21</frameSystemDistance>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <TextStyle>
           <halign>center</halign>
           <valign>top</valign>

--- a/mtest/libmscore/parts/partStyle-score-reload.mscx
+++ b/mtest/libmscore/parts/partStyle-score-reload.mscx
@@ -475,7 +475,7 @@
             <text>Style Score</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text></text>
             </Text>
           </VBox>
@@ -713,7 +713,7 @@
             <text>Style Score</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text></text>
             </Text>
           </VBox>

--- a/mtest/libmscore/parts/style_test.mss
+++ b/mtest/libmscore/parts/style_test.mss
@@ -267,7 +267,7 @@
       <halign>left</halign>
       <valign>top</valign>
       <offsetType>absolute</offsetType>
-      <name>Instrument Name (Part)</name>
+      <name>Part Name</name>
       <family>FreeSerif</family>
       <size>18</size>
       </TextStyle>

--- a/mtest/libmscore/parts/voices-ref.mscx
+++ b/mtest/libmscore/parts/voices-ref.mscx
@@ -934,6 +934,8 @@
       <Style>
         <lastSystemFillLimit>0</lastSystemFillLimit>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1037,7 +1039,7 @@
             <text>voices</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Piano</text>
             </Text>
           </VBox>
@@ -1453,6 +1455,8 @@
       <Style>
         <lastSystemFillLimit>0</lastSystemFillLimit>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1683.78</page-height>
           <page-width>1190.55</page-width>
@@ -1547,7 +1551,7 @@
             <text>voices</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Trombone</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/spanners/glissando-cloning02-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning02-ref.mscx
@@ -166,6 +166,8 @@
       <Division>480</Division>
       <Style>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <TextStyle>
           <halign>left</halign>
           <valign>top</valign>
@@ -264,7 +266,7 @@
           <height>10</height>
           <lid>0</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/spanners/glissando-cloning04-ref.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning04-ref.mscx
@@ -263,7 +263,7 @@
           <height>10</height>
           <lid>1</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/spanners/glissando-cloning04.mscx
+++ b/mtest/libmscore/spanners/glissando-cloning04.mscx
@@ -254,7 +254,7 @@
           <height>10</height>
           <lid>1</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/timesig/timesig-03-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-03-ref.mscx
@@ -186,6 +186,7 @@
             </Note>
           </Chord>
         <StaffText>
+          <style>Staff Technique Text</style>
           <text>simile</text>
           </StaffText>
         <HairPin id="2">

--- a/mtest/libmscore/timesig/timesig-03.mscx
+++ b/mtest/libmscore/timesig/timesig-03.mscx
@@ -181,7 +181,7 @@
         </Measure>
       <Measure number="3">
         <StaffText>
-          <style>Staff</style>
+          <style>Staff Technique Text</style>
           <text>simile</text>
           </StaffText>
         <HairPin id="2">

--- a/mtest/libmscore/tools/undoChangeVoice.mscx
+++ b/mtest/libmscore/tools/undoChangeVoice.mscx
@@ -591,6 +591,8 @@
       <Style>
         <lastSystemFillLimit>0</lastSystemFillLimit>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1584</page-height>
           <page-width>1224</page-width>
@@ -687,7 +689,7 @@
             <text>Composer</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Piano</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/tools/undoChangeVoice01-ref.mscx
+++ b/mtest/libmscore/tools/undoChangeVoice01-ref.mscx
@@ -630,6 +630,8 @@
       <Style>
         <lastSystemFillLimit>0</lastSystemFillLimit>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1584</page-height>
           <page-width>1224</page-width>
@@ -726,7 +728,7 @@
             <text>Composer</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Piano</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/tools/undoChangeVoice02-ref.mscx
+++ b/mtest/libmscore/tools/undoChangeVoice02-ref.mscx
@@ -597,6 +597,8 @@
       <Style>
         <lastSystemFillLimit>0</lastSystemFillLimit>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1584</page-height>
           <page-width>1224</page-width>
@@ -693,7 +695,7 @@
             <text>Composer</text>
             </Text>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Piano</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/tools/undoResequencePart.mscx
+++ b/mtest/libmscore/tools/undoResequencePart.mscx
@@ -312,6 +312,8 @@
         <lastSystemFillLimit>0.03</lastSystemFillLimit>
         <showMeasureNumber>0</showMeasureNumber>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1584</page-height>
           <page-width>1224</page-width>
@@ -397,7 +399,7 @@
           <height>10</height>
           <lid>49</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/tools/undoResequencePart01-ref.mscx
+++ b/mtest/libmscore/tools/undoResequencePart01-ref.mscx
@@ -309,6 +309,8 @@
         <lastSystemFillLimit>0.03</lastSystemFillLimit>
         <showMeasureNumber>0</showMeasureNumber>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1584</page-height>
           <page-width>1224</page-width>
@@ -394,7 +396,7 @@
           <height>10</height>
           <lid>34</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/libmscore/tools/undoResequencePart02-ref.mscx
+++ b/mtest/libmscore/tools/undoResequencePart02-ref.mscx
@@ -309,6 +309,8 @@
         <lastSystemFillLimit>0.03</lastSystemFillLimit>
         <showMeasureNumber>0</showMeasureNumber>
         <createMultiMeasureRests>1</createMultiMeasureRests>
+        <oddHeaderC>$i</oddHeaderC>
+        <evenHeaderC>$i</evenHeaderC>
         <page-layout>
           <page-height>1584</page-height>
           <page-width>1224</page-width>
@@ -394,7 +396,7 @@
           <height>10</height>
           <lid>34</lid>
           <Text>
-            <style>Instrument Name (Part)</style>
+            <style>Part Name</style>
             <text>Flute</text>
             </Text>
           </VBox>

--- a/mtest/musicxml/io/testInstrumentChangeMIDIportExport_ref.xml
+++ b/mtest/musicxml/io/testInstrumentChangeMIDIportExport_ref.xml
@@ -1062,7 +1062,7 @@
     <measure number="2">
       <direction placement="above">
         <direction-type>
-          <words font-weight="bold" font-size="12">Voice</words>
+          <words font-weight="bold">Voice</words>
           </direction-type>
         <staff>1</staff>
         </direction>

--- a/mtest/scripting/testTextStyle-ref.mscx
+++ b/mtest/scripting/testTextStyle-ref.mscx
@@ -115,7 +115,7 @@
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <StaffText>
-          <style>Figured Bass</style>
+          <style>System Text</style>
           <text>System Text</text>
           </StaffText>
         <Rest>
@@ -125,7 +125,7 @@
         </Measure>
       <Measure number="2">
         <StaffText>
-          <text>Staff Text</text>
+          <text>Staff Technique Text</text>
           </StaffText>
         <Rest>
           <durationType>measure</durationType>
@@ -134,8 +134,8 @@
         </Measure>
       <Measure number="3">
         <StaffText>
-          <style>String Number</style>
-          <text>Styled Technique Text</text>
+          <style>Staff Expression Text</style>
+          <text>Expression Text</text>
           </StaffText>
         <Rest>
           <durationType>measure</durationType>

--- a/mtest/scripting/testTextStyle.mscx
+++ b/mtest/scripting/testTextStyle.mscx
@@ -115,7 +115,7 @@
           <showCourtesySig>1</showCourtesySig>
           </TimeSig>
         <StaffText>
-          <style>System</style>
+          <style>System Text</style>
           <text>System Text</text>
           </StaffText>
         <Rest>
@@ -125,7 +125,7 @@
         </Measure>
       <Measure number="2">
         <StaffText>
-          <text>Staff Text</text>
+          <text>Staff Technique Text</text>
           </StaffText>
         <Rest>
           <durationType>measure</durationType>
@@ -134,8 +134,8 @@
         </Measure>
       <Measure number="3">
         <StaffText>
-          <style>Technique</style>
-          <text>Styled Technique Text</text>
+          <style>Staff Expression Text</style>
+          <text>Expression Text</text>
           </StaffText>
         <Rest>
           <durationType>measure</durationType>

--- a/mtest/scripting/testTextStyle.qml
+++ b/mtest/scripting/testTextStyle.qml
@@ -10,7 +10,7 @@ MuseScore {
                               if (seg.annotations[i].textStyleType === TextStyleType.SYSTEM) {
                                     seg.annotations[i].textStyleType = TextStyleType.FIGURED_BASS;
                               }
-                              else if (seg.annotations[i].textStyleType === TextStyleType.TECHNIQUE) {
+                              else if (seg.annotations[i].textStyleType === TextStyleType.EXPRESSION) {
                                     seg.annotations[i].textStyleType = TextStyleType.STRING_NUMBER;
                               }
                         }


### PR DESCRIPTION
* Italic 12-pt “Technique” and roman 10-pt “Staff” styles replaced with italic 11-pt “Expression” and roman 10-pt “Staff Technique Text” styles
* Rehearsal marks default with right-angle corners
* Some legacy text styles hidden
* Text styles list reordered
* Shortcut Ctrl+E for Expression text, default shortcut for “Edit element” changed to Alt+Shift+E
* Text palette contents changed accordingly
* Default page numbers in header instead of footer
* Part name in header of linked parts
* Palettes reordered to group related categories (e.g., kinds of text), and tweaked display properties of some

See https://musescore.org/en/node/113381.