### PR TITLE
Fix Dizi channel.

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -255,10 +255,10 @@
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>69-100</aPitchRange>
+                  <aPitchRange>69-95</aPitchRange>
                   <pPitchRange>69-100</pPitchRange>
                   <Channel>
-                        <program value="67"/>
+                        <program value="72"/>
                   </Channel>
                   <genre>ethnic</genre>
             </Instrument>
@@ -269,10 +269,10 @@
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>67-98</aPitchRange>
+                  <aPitchRange>67-93</aPitchRange>
                   <pPitchRange>67-98</pPitchRange>
                   <Channel>
-                        <program value="67"/>
+                        <program value="72"/>
                   </Channel>
                   <genre>ethnic</genre>
             </Instrument>
@@ -283,10 +283,10 @@
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>76-107</aPitchRange>
+                  <aPitchRange>76-102</aPitchRange>
                   <pPitchRange>76-107</pPitchRange>
                   <Channel>
-                        <program value="67"/>
+                        <program value="72"/>
                   </Channel>
                   <genre>ethnic</genre>
             </Instrument>
@@ -297,10 +297,10 @@
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>74-105</aPitchRange>
+                  <aPitchRange>74-100</aPitchRange>
                   <pPitchRange>74-105</pPitchRange>
                   <Channel>
-                        <program value="67"/>
+                        <program value="72"/>
                   </Channel>
                   <genre>ethnic</genre>
             </Instrument>
@@ -311,10 +311,10 @@
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>72-103</aPitchRange>
+                  <aPitchRange>72-98</aPitchRange>
                   <pPitchRange>72-103</pPitchRange>
                   <Channel>
-                        <program value="67"/>
+                        <program value="72"/>
                   </Channel>
                   <genre>ethnic</genre>
             </Instrument>
@@ -325,10 +325,10 @@
                   <musicXMLid>wind.flutes.di-zi</musicXMLid>
                   <clef>G</clef>
                   <barlineSpan>1</barlineSpan>
-                  <aPitchRange>71-102</aPitchRange>
+                  <aPitchRange>71-97</aPitchRange>
                   <pPitchRange>71-102</pPitchRange>
                   <Channel>
-                        <program value="67"/>
+                        <program value="72"/>
                   </Channel>
                   <genre>ethnic</genre>
             </Instrument>


### PR DESCRIPTION
According to the Roland GS and Yamaha XG, the Dizi (笛子, also known as Di (笛) or Bang Di (梆笛)) belongs to channel 73 (1-128) or 72 (0-127).

Yamaha XG specifications v2.00:
http://www.jososoft.dk/yamaha/pdf/XGspec2-00e.pdf

Roland GS:
http://www.voidaudio.net/gsinstrument.html

![qq20160913-0](https://cloud.githubusercontent.com/assets/2240638/18461331/20868dfa-79ab-11e6-942e-e307ef8e54ed.png)

And according to the recommended key ranges of Piccolo and Flute in GM2 v1.2a, the E Dizi, F Dizi, G Dizi, and A Dizi are similar to Piccolo, the C Dizi is similar to Flute, and the D Dizi is between Piccolo and Flute.