### PR TITLE
fix some warning/error messages from lupdate

### DIFF
--- a/libmscore/durationtype.h
+++ b/libmscore/durationtype.h
@@ -88,7 +88,7 @@ void populateRhythmicList(std::vector<TDuration>* dList, const Fraction& l, bool
 void splitCompoundBeatsForList(std::vector<TDuration>* dList, const Fraction& l, bool isRest, int rtickStart, const TimeSigFrac& nominal, int maxDots);
 }     // namespace Ms
 
-Q_DECLARE_METATYPE(Ms::TDuration)
+Q_DECLARE_METATYPE(Ms::TDuration);
 
 #endif
 

--- a/mscore/webpage.h
+++ b/mscore/webpage.h
@@ -80,7 +80,7 @@ class MyWebPage: public QWebPage
 
 class MyWebView: public QWebView
       {
-      //Q_OBJECT
+      Q_OBJECT
 
       MyWebPage m_page;
       QProgressBar* progressBar;

--- a/omr/pattern.cpp
+++ b/omr/pattern.cpp
@@ -135,10 +135,7 @@ double Pattern::match(const QImage* img, int col, int row, double bg_parm) const
       uchar b  = (b1 >> shift) | (b2 << (7 - shift));
       uchar v = a ^ b;
       k += Omr::bitsSetTable[v];
-      }
 #endif
-
-      
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
`lupdate` issues several warning/error messages:

1. `...libmscore/durationtype.cpp:759: Qualifying with unknown namespace/class ::TDuration`
2. `...libmscore/read206.cpp:1196: Cannot invoke tr() like this`
3. `...libmscore/read206.cpp:1196: Class 'Ms' lacks Q_OBJECT macro`
4. `...mscore/editdrumset.cpp:72: Class 'Ms' lacks Q_OBJECT macro`
5. `...mscore/webpage.cpp:173: Class 'Ms::MyWebView' lacks Q_OBJECT macro`
6. `...omr/pattern.cpp:259: Excess closing brace in C++ code (or abuse of the C++ preprocessor)`

2nd and 3rd got fixed by #2848, this PR fixes 5th and 6th. I still fail to understand 1st and 4th, also I don't get why `lupdate` takes 5 1/2 hours in QtCreator on Windows, while it only takes 2 minutes for @lasconic (on Mac or Linux?)

The added semicolon in durationtype.h is largely unrelated, it just appeases the syntax highlighting in QtCreator and is a NOP otherwise