### PR TITLE
Fix incorrect version in Linux desktop entry file

### DIFF
--- a/build/Linux+BSD/mscore.desktop.in
+++ b/build/Linux+BSD/mscore.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.1@This_is_version_of_Desktop_Entry_Specification@@It_is_NOT_MuseScore_version@
+Version=1.0@This_is_version_of_Desktop_Entry_Specification@@It_is_NOT_MuseScore_version@
 Name=@MUSESCORE_NAME_VERSION@@Variables_substituted_by_CMAKE_on_installation@
 GenericName=Music notation
 GenericName[de]=Notensatz


### PR DESCRIPTION
The [Desktop Entry Specification 1.1](https://specifications.freedesktop.org/desktop-entry-spec/1.1/index.html) states that ["entries that confirm with this version of the specification should use `1.0`."](https://specifications.freedesktop.org/desktop-entry-spec/1.1/ar01s05.html) The use of `1.1` breaks some tools that expect the version listed to be `1.0` (such as openSUSE's update-desktop-files tool).