### PR TITLE
Clearer, sentence-case label for new checkbox, and restore smaller window size

### DIFF
--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>999</width>
-    <height>865</height>
+    <width>920</width>
+    <height>640</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -155,10 +155,10 @@
              <item row="0" column="2">
               <widget class="QCheckBox" name="optimizeStyleCheckbox">
                <property name="toolTip">
-                <string>MuseScore will change style to suit the font better</string>
+                <string>MuseScore will change the style to suit the font better</string>
                </property>
                <property name="text">
-                <string> use style default settings for the font</string>
+                <string>Automatically load style settings based on font</string>
                </property>
                <property name="checked">
                 <bool>true</bool>


### PR DESCRIPTION
Unfortunately I can't test to make sure the window size works, as an XCode update has temporarily broken my build system. If this makes it too small to fit its contents, then feel free to alter appropriately. The window won't fit on small screens at present, though.