### PR TITLE
fix #138721: translate master palette items

### DIFF
--- a/mscore/masterpalette.cpp
+++ b/mscore/masterpalette.cpp
@@ -129,6 +129,7 @@ void MasterPalette::addPalette(Palette* sp)
       psa->setRestrictHeight(false);
       QTreeWidgetItem* item = new QTreeWidgetItem(QStringList(sp->name()));
       item->setData(0, Qt::UserRole, stack->count());
+      item->setText(0, qApp->translate("Palette", sp->name().toUtf8().data()).replace("&&","&"));
       stack->addWidget(psa);
       treeWidget->addTopLevelItem(item);
       }
@@ -183,6 +184,7 @@ MasterPalette::MasterPalette(QWidget* parent)
 
       symbolItem = new QTreeWidgetItem();
       symbolItem->setData(0, Qt::UserRole, -1);
+      symbolItem->setText(0, QT_TRANSLATE_NOOP("MasterPalette", "Symbols"));
       treeWidget->addTopLevelItem(symbolItem);
 
       for (const QString& s : smuflRanges()->keys()) {
@@ -203,9 +205,9 @@ MasterPalette::MasterPalette(QWidget* parent)
 
 void MasterPalette::retranslate(bool firstTime)
       {
-      keyItem->setText(0, tr("Key Signatures"));
-      timeItem->setText(0, tr("Time Signatures"));
-      symbolItem->setText(0, tr("Symbols"));
+      keyItem->setText(0, qApp->translate("Palette", "Key Signatures"));
+      timeItem->setText(0, qApp->translate("Palette", "Time Signatures"));
+      symbolItem->setText(0, qApp->translate("MasterPalette", "Symbols"));
       if (!firstTime)
             retranslateUi(this);
       }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4664,11 +4664,11 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
       else if (cmd == "masterpalette")
             showMasterPalette();
       else if (cmd == "key-signatures")
-            showMasterPalette(tr("Key Signatures"));
+            showMasterPalette(qApp->translate("Palette", "Key Signatures"));
       else if (cmd == "time-signatures")
-            showMasterPalette(tr("Time Signatures"));
+            showMasterPalette(qApp->translate("Palette", "Time Signatures"));
       else if (cmd == "symbols")
-            showMasterPalette(tr("Symbols"));
+            showMasterPalette(qApp->translate("MasterPalette", "Symbols"));
       else if (cmd == "toggle-statusbar") {
             preferences.showStatusBar = a->isChecked();
             _statusBar->setVisible(preferences.showStatusBar);


### PR DESCRIPTION
and reuse existing translations for "Key Signatures", "Time Signatures"
and "Symbols", not just to reuse but also to make sure they when used as
an (optional) argument to MasterPalette::showMasterPalette(). and work
properly when invoked via a shortcut.
In master palette get rid of double ampersands in palette names.
