### PR TITLE
Slur shape for anticolision

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -592,6 +592,21 @@ void Slur::computeBezier(SlurSegment* ss, QPointF p6o)
       if (ss->system() && ss->track() >= 0)
             staffOffset = QPointF(0.0, -ss->system()->staff(ss->staffIdx())->y());
 
+      QPainterPath p;
+      p.moveTo(QPointF());
+      p.cubicTo(p3 + p3o - th, p4 + p4o - th, p2);
+      ss->_shape.clear();
+      QPointF start;
+      start = t.map(start);
+      int nbShapes = 10;
+      for (int i = 1; i <= nbShapes; i++) {
+            QPointF point = t.map(p.pointAtPercent(i/float(nbShapes)));
+            QRectF re(start, point);
+            re.translate(staffOffset);
+            ss->_shape.add(re);
+            start = point;
+            }
+
       ss->path.translate(staffOffset);
       ss->shapePath.translate(staffOffset);
       }

--- a/libmscore/slur.h
+++ b/libmscore/slur.h
@@ -70,6 +70,7 @@ class SlurSegment : public SpannerSegment {
 
       QPainterPath path;
       QPainterPath shapePath;
+      Shape _shape;
       QPointF autoAdjustOffset;
 
       void computeBezier();
@@ -116,6 +117,7 @@ class SlurSegment : public SpannerSegment {
       void setSlurOffset(Grip i, const QPointF& val) { _ups[int(i)].off = val;  }
       const struct UP& ups(Grip i) const             { return _ups[int(i)]; }
       struct UP& ups(Grip i)                         { return _ups[int(i)]; }
+      virtual Shape shape() const override           { return _shape; }
 
       friend class Tie;
       friend class Slur;


### PR DESCRIPTION
Just a trial for discussion. No complex math, just using available Qt functions to get X=10 points on one of the side of the slur and making rectangles out of it.

* It seems computationally ok. I don't see any variation on tst_benchmark (which is weird to me)
* The code is simple enough
* Just adding this make slurs/staff anticolision work
* It doesn't help for notehead/articulation + slur anticollision for notes in the middle of the slur for the moment. 