### PR TITLE
Build x86 AppImages on Ubuntu 12.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
       services:
         - docker
       script:
-        - "[[ $APPIMAGE_BUILD_ARCHS == *x86_64* ]] && ./build/travis/job2_AppImage/build.sh --x86_64 --upload-branches $APPIMAGE_UPLOAD_BRANCHES || true"
+        - "if [[ $APPIMAGE_BUILD_ARCHS == *x86_64* ]]; then ./build/travis/job2_AppImage/build.sh --x86_64 --upload-branches $APPIMAGE_UPLOAD_BRANCHES; fi"
 
     # 3rd parallel build job - portable Linux AppImage 32-bit x86 build on CentOS
     - env: "JOB=AppImage_i686"
@@ -81,7 +81,7 @@ matrix:
       services:
         - docker
       script:
-        - "[[ $APPIMAGE_BUILD_ARCHS == *i686* ]] && ./build/travis/job2_AppImage/build.sh --i686 --upload-branches $APPIMAGE_UPLOAD_BRANCHES || true"
+        - "if [[ $APPIMAGE_BUILD_ARCHS == *i686* ]]; then ./build/travis/job2_AppImage/build.sh --i686 --upload-branches $APPIMAGE_UPLOAD_BRANCHES; fi"
 
     # 4th parallel build job - portable Linux AppImage armhf build on Debian crosscompiler
     - env: "JOB=AppImage_armhf"
@@ -96,7 +96,8 @@ matrix:
       before_script:
         - "sudo ./build/travis/job2_AppImage/set-binfmt-misc.sh"
       script:
-        - "[[ $APPIMAGE_BUILD_ARCHS == *armhf* ]] && ./build/travis/job2_AppImage/build.sh --armhf --upload-branches $APPIMAGE_UPLOAD_BRANCHES || true"
+        - "if [[ $APPIMAGE_BUILD_ARCHS == *armhf* ]]; then ./build/travis/job2_AppImage/build.sh --armhf --upload-branches $APPIMAGE_UPLOAD_BRANCHES; fi"
+
     # 5th parallel build job - mac osx build
     - env: "JOB=MacOSX"
       os: osx

--- a/build/Linux+BSD/portable/copy-libs
+++ b/build/Linux+BSD/portable/copy-libs
@@ -24,6 +24,8 @@ main() {
     building_on_Debian_Jessie # aka "Debian 8"
   elif [ "$(grep "CentOS release 6" /etc/*release*)" ]; then
     building_on_CentOS_6
+  elif [ "$(grep "Ubuntu precise (12.04.* LTS)" /etc/*release*)" ]; then
+    building_on_Ubuntu_12-04
   else
     echo "${0}: Warning: Not running on a supported build system!" >&2
     # Try to fetch all dependencies, just in case
@@ -107,6 +109,12 @@ getCrossPlatformDependencies() {
     | sed "s|$qt_prefix/||" | xargs -n1 -I '%%%' \
         bash -c "qt_prefix='$qt_prefix' qt_dest='$qt_dest' copyQt %%%"
 }
+
+##########################################################################
+# LINUX-ONLY DEPENDENCIES (no equivalents in "mscore/CMakeLists.txt")
+# These differ depending on the distribution used to build the AppImage.
+# Note: always check the oldest supported distribution first
+##########################################################################
 
 ########################################################
 # copy libs specific if building on Debian 8 "Jessie"
@@ -233,12 +241,6 @@ building_on_Debian_Jessie() {
   #copyLib libasound_module_pcm_pulse.so #can add, but if mscore run without alsa, will complain missing
 }
 
-
-##########################################################################
-# LINUX-ONLY DEPENDENCIES (no equivalents in "mscore/CMakeLists.txt")
-# These differ depending on the distribution used to build the AppImage.
-# Note: always check the oldest supported distribution first
-##########################################################################
 building_on_CentOS_6() {
   # Needed by Centos 6.7:
   dest_dir="$lib_dest"
@@ -274,6 +276,39 @@ building_on_CentOS_6() {
   #copyLib libpulse.so.0
   #copyLib libpulsecommon-8.0.so
   #copyLib libasound_module_pcm_pulse.so  # found in /usr/lib64/alsa-lib/
+}
+
+building_on_Ubuntu_12-04() {
+  # Needed by Ubuntu 12.04
+  dest_dir="$lib_dest"
+  copyLib libopenal.so.1
+
+  dest_dir="$qt_dest/lib"
+  copyLib libEnginio.so.1
+  copyLib libicui18n.so.53
+  copyLib libicuuc.so.53
+  copyLib libicudata.so.53
+  copyLib libQt5Bluetooth.so.5
+  copyLib libQt5DBus.so.5
+  copyLib libQt5Location.so.5
+  copyLib libQt5Nfc.so.5
+  copyLib libQt5QuickParticles.so.5
+  copyLib libQt5WebChannel.so.5
+  copyLib libQt5WebEngine.so.5
+  copyLib libQt5WebSockets.so.5
+  copyLib libQt5WebView.so.5
+  copyLib libQt5WebEngineCore.so.5
+
+  # Needed by CentOS 7
+  copyLib libjack.so.0
+
+  # Needed by Fedora 22
+  copyLib libgstapp-0.10.so.0
+  copyLib libgstbase-0.10.so.0
+  copyLib libgstinterfaces-0.10.so.0
+  copyLib libgstpbutils-0.10.so.0
+  copyLib libgstreamer-0.10.so.0
+  copyLib libgstvideo-0.10.so.0
 }
 
 locateLib() {

--- a/build/Linux+BSD/portable/x86_32/Dockerfile
+++ b/build/Linux+BSD/portable/x86_32/Dockerfile
@@ -1,3 +1,4 @@
-FROM toopher/centos-i386:centos6
+FROM ivochkin/ubuntu-i386:precise
 ADD Recipe /Recipe
-RUN bash -ex Recipe && yum clean all
+RUN linux32 --32bit i386 bash -ex Recipe && apt-get clean autoclean
+RUN apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/*

--- a/build/Linux+BSD/portable/x86_32/Recipe
+++ b/build/Linux+BSD/portable/x86_32/Recipe
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script should be run in a CentOS 6 Docker image
+# This script should be run in an Ubuntu 12.04 "Precise Pangolin" Docker image
 
 set -e # Halt on errors
 set -x # Be verbose
@@ -12,48 +12,56 @@ set -x # Be verbose
 # go one-up from MuseScore root dir regardless of where script was run from:
 cd "$(dirname "$(readlink -f "${0}")")/../../../../.."
 
-yum -y install epel-release
+apt-get update # no package lists in Docker image
 
-# basic dependencies (needed by Docker image)
-yum -y install git wget which automake unzip
+# basic dependencies (needed by Docker but provided on Travis)
+apt-get -y install \
+  git \
+  unzip \
+  libxslt1-dev \
+  libxrender-dev \
+  libxcomposite-dev \
+  libdrm-dev \
+  libgl1-mesa-dev \
+  libopenal1 \
+  gstreamer0.10-plugins-base \
+  python-software-properties # installs `add-apt-repository`
 
-# get newer compiler than available by default
-if [ ! -f "/etc/yum.repos.d/devtools-2.repo" ]; then
-  wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
-  yum -y install devtoolset-2-gcc devtoolset-2-gcc-c++ devtoolset-2-binutils
+# get newer compiler
+if [ ! -f /etc/apt/sources.list.d/ubuntu-toolchain-r-test-precise.list ]; then
+  add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  apt-get update
 fi
-source /opt/rh/devtoolset-2/enable # enable new compiler
 
-# build AppImageKit now to avoid conflicts with MuseScore's dependencies (LAME)
-if [ ! -d "AppImageKit" ]; then
-  git clone https://github.com/probonopd/AppImageKit.git
-  cd AppImageKit
-  git reset --hard 076a88a57d7ca1a8d77bdbf7d8e92f37eea03dab
-  rm -rf .git*
-  ./build.sh
-  cd ..
-fi
+# MuseScore dependencies (same as on Travis)
+apt-get -y install \
+  g++-4.8 \
+  wget \
+  make \
+  curl \
+  alsa \
+  libasound2-dev \
+  portaudio19-dev \
+  libsndfile1-dev \
+  zlib1g-dev \
+  libfreetype6-dev \
+  libfontconfig1-dev \
+  lame \
+  libmp3lame-dev \
+  libegl1-mesa-dev \
+  libpulse-dev
 
-# MuseScore's dependencies:
-yum -y install \
-  alsa-lib-devel \
-  fontconfig-devel \
-  freetype-devel \
-  jack-audio-connection-kit-devel \
-  libsndfile-devel \
-  libvorbis-devel \
-  libXcomposite-devel \
-  libXcursor-devel \
-  libXrender-devel \
-  libxslt-devel \
-  mesa-libGL-devel \
-  portaudio-devel \
-  pulseaudio-libs-devel
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
 
 # get Qt
 if [ ! -d "qt5" ]; then
   mkdir qt5
-  wget -q -O qt5.zip http://utils.musescore.org.s3.amazonaws.com/qt542-x86.zip
+  if [ "$(arch)" = "i686" ]; then
+    QT_URL="http://utils.musescore.org.s3.amazonaws.com/qt542-x86.zip"
+  else
+    QT_URL="http://utils.musescore.org.s3.amazonaws.com/qt542.zip"
+  fi
+  wget -q -O qt5.zip "${QT_URL}"
   unzip -qq qt5.zip -d qt5
   rm -f qt5.zip
 fi
@@ -61,15 +69,6 @@ export PATH="${PWD}/qt5/bin:$PATH"
 export QT_PLUGIN_PATH="${PWD}/qt5/plugins"
 export QML2_IMPORT_PATH="${PWD}/qt5/qml"
 export LD_LIBRARY_PATH="${PWD}/qt5/lib:$LD_LIBRARY_PATH"
-
-# install LAME (get this dependency last because rpmforge and epel-release conflict)
-if [ "$(arch)" = "i686" ]; then
-  nux_url="http://li.nux.ro/download/nux/dextop/el6/i386/nux-dextop-release-0-2.el6.nux.noarch.rpm"
-else
-  nux_url="http://li.nux.ro/download/nux/dextop/el6/$(arch)/nux-dextop-release-0-2.el6.nux.noarch.rpm"
-fi
-rpm -Uvh "${nux_url}" || true # don't fail if already installed
-yum -y install lame-devel
 
 # install cmake
 if [ ! -d cmake ]; then
@@ -82,6 +81,16 @@ if [ ! -d cmake ]; then
   wget --no-check-certificate --quiet -O - "${CMAKE_URL}" | tar --strip-components=1 -xz -C cmake
 fi
 export PATH="${PWD}/cmake/bin:${PATH}"
+
+# build AppImageKit
+if [ ! -d "AppImageKit" ]; then
+  git clone https://github.com/probonopd/AppImageKit.git
+  cd AppImageKit
+  git reset --hard 076a88a57d7ca1a8d77bdbf7d8e92f37eea03dab
+  rm -rf .git*
+  ./build.sh
+  cd ..
+fi
 
 # Build MuseScore on Travis but not on Docker Hub (reduce container size)
 [ -d "MuseScore" ] || exit 0
@@ -103,7 +112,7 @@ appimage="$(echo "$appdir" | sed 's|\.AppDir$|.AppImage|')"
 
 cd ../AppImageKit/AppImageAssistant.AppDir
 
-./package  "$appdir" "$appimage"
+./package "$appdir" "$appimage"
 
 # allow access to AppImage from outside the chroot
 chmod a+rwx "$appimage"

--- a/build/Linux+BSD/portable/x86_64/Dockerfile
+++ b/build/Linux+BSD/portable/x86_64/Dockerfile
@@ -1,3 +1,4 @@
-FROM library/centos:6
+FROM library/ubuntu:12.04
 ADD Recipe /Recipe
-RUN bash -ex Recipe && yum clean all
+RUN bash -ex Recipe && apt-get clean autoclean
+RUN apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/*

--- a/build/Linux+BSD/portable/x86_64/Recipe
+++ b/build/Linux+BSD/portable/x86_64/Recipe
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script should be run in a CentOS 6 Docker image
+# This script should be run in an Ubuntu 12.04 "Precise Pangolin" Docker image
 
 set -e # Halt on errors
 set -x # Be verbose
@@ -12,48 +12,56 @@ set -x # Be verbose
 # go one-up from MuseScore root dir regardless of where script was run from:
 cd "$(dirname "$(readlink -f "${0}")")/../../../../.."
 
-yum -y install epel-release
+apt-get update # no package lists in Docker image
 
-# basic dependencies (needed by Docker image)
-yum -y install git wget which automake unzip
+# basic dependencies (needed by Docker but provided on Travis)
+apt-get -y install \
+  git \
+  unzip \
+  libxslt1-dev \
+  libxrender-dev \
+  libxcomposite-dev \
+  libdrm-dev \
+  libgl1-mesa-dev \
+  libopenal1 \
+  gstreamer0.10-plugins-base \
+  python-software-properties # installs `add-apt-repository`
 
-# get newer compiler than available by default
-if [ ! -f "/etc/yum.repos.d/devtools-2.repo" ]; then
-  wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
-  yum -y install devtoolset-2-gcc devtoolset-2-gcc-c++ devtoolset-2-binutils
+# get newer compiler
+if [ ! -f /etc/apt/sources.list.d/ubuntu-toolchain-r-test-precise.list ]; then
+  add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  apt-get update
 fi
-source /opt/rh/devtoolset-2/enable # enable new compiler
 
-# build AppImageKit now to avoid conflicts with MuseScore's dependencies (LAME)
-if [ ! -d "AppImageKit" ]; then
-  git clone https://github.com/probonopd/AppImageKit.git
-  cd AppImageKit
-  git reset --hard 076a88a57d7ca1a8d77bdbf7d8e92f37eea03dab
-  rm -rf .git*
-  ./build.sh
-  cd ..
-fi
+# MuseScore dependencies (same as on Travis)
+apt-get -y install \
+  g++-4.8 \
+  wget \
+  make \
+  curl \
+  alsa \
+  libasound2-dev \
+  portaudio19-dev \
+  libsndfile1-dev \
+  zlib1g-dev \
+  libfreetype6-dev \
+  libfontconfig1-dev \
+  lame \
+  libmp3lame-dev \
+  libegl1-mesa-dev \
+  libpulse-dev
 
-# MuseScore's dependencies:
-yum -y install \
-  alsa-lib-devel \
-  fontconfig-devel \
-  freetype-devel \
-  jack-audio-connection-kit-devel \
-  libsndfile-devel \
-  libvorbis-devel \
-  libXcomposite-devel \
-  libXcursor-devel \
-  libXrender-devel \
-  libxslt-devel \
-  mesa-libGL-devel \
-  portaudio-devel \
-  pulseaudio-libs-devel
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
 
 # get Qt
 if [ ! -d "qt5" ]; then
   mkdir qt5
-  wget -q -O qt5.zip http://utils.musescore.org.s3.amazonaws.com/qt542.zip
+  if [ "$(arch)" = "i686" ]; then
+    QT_URL="http://utils.musescore.org.s3.amazonaws.com/qt542-x86.zip"
+  else
+    QT_URL="http://utils.musescore.org.s3.amazonaws.com/qt542.zip"
+  fi
+  wget -q -O qt5.zip "${QT_URL}"
   unzip -qq qt5.zip -d qt5
   rm -f qt5.zip
 fi
@@ -61,15 +69,6 @@ export PATH="${PWD}/qt5/bin:$PATH"
 export QT_PLUGIN_PATH="${PWD}/qt5/plugins"
 export QML2_IMPORT_PATH="${PWD}/qt5/qml"
 export LD_LIBRARY_PATH="${PWD}/qt5/lib:$LD_LIBRARY_PATH"
-
-# install LAME (get this dependency last because rpmforge and epel-release conflict)
-if [ "$(arch)" = "i686" ]; then
-  nux_url="http://li.nux.ro/download/nux/dextop/el6/i386/nux-dextop-release-0-2.el6.nux.noarch.rpm"
-else
-  nux_url="http://li.nux.ro/download/nux/dextop/el6/$(arch)/nux-dextop-release-0-2.el6.nux.noarch.rpm"
-fi
-rpm -Uvh "${nux_url}" || true # don't fail if already installed
-yum -y install lame-devel
 
 # install cmake
 if [ ! -d cmake ]; then
@@ -82,6 +81,16 @@ if [ ! -d cmake ]; then
   wget --no-check-certificate --quiet -O - "${CMAKE_URL}" | tar --strip-components=1 -xz -C cmake
 fi
 export PATH="${PWD}/cmake/bin:${PATH}"
+
+# build AppImageKit
+if [ ! -d "AppImageKit" ]; then
+  git clone https://github.com/probonopd/AppImageKit.git
+  cd AppImageKit
+  git reset --hard 076a88a57d7ca1a8d77bdbf7d8e92f37eea03dab
+  rm -rf .git*
+  ./build.sh
+  cd ..
+fi
 
 # Build MuseScore on Travis but not on Docker Hub (reduce container size)
 [ -d "MuseScore" ] || exit 0
@@ -103,7 +112,7 @@ appimage="$(echo "$appdir" | sed 's|\.AppDir$|.AppImage|')"
 
 cd ../AppImageKit/AppImageAssistant.AppDir
 
-./package  "$appdir" "$appimage"
+./package "$appdir" "$appimage"
 
 # allow access to AppImage from outside the chroot
 chmod a+rwx "$appimage"

--- a/build/travis/job2_AppImage/build.sh
+++ b/build/travis/job2_AppImage/build.sh
@@ -22,10 +22,10 @@ docker_tag="latest" # Docker terminology for master branch
 [ "$branch" == "master" ] || docker_tag="$branch" # other branches use branch name
 
 function rebuild-docker-image() { # $1 is arch (e.g. x86_64)
-  if [ $(git diff --name-only HEAD HEAD~1 | grep "^build/Linux+BSD/portable/$1") ]; then
+  if [ "$(git diff --name-only HEAD HEAD~1 | grep "^build/Linux+BSD/portable/$1")" ]; then
     # Need to update image on Docker Hub
     set +x # keep env secret
-    echo "Triggering rebuild of $DOCKER_USER/musescore-$1$docker_tag on Docker Hub."
+    echo "Triggering rebuild of $DOCKER_USER/musescore-$1:$docker_tag on Docker Hub."
     data="{\"source_type\": \"Branch\", \"source_name\": \"$branch\"}"
     url="https://registry.hub.docker.com/u/$DOCKER_USER/musescore-$1/trigger/$DOCKER_TRIGGER/"
     curl -H "Content-Type: application/json" --data "$data" -X POST "$url"
@@ -75,7 +75,7 @@ case "$1" in
     # Build MuseScore AppImage inside 32-bit x86 Docker image
     (set +x; DOCKER_TRIGGER="$DOCKER_TRIGGER_X86_32" rebuild-docker-image x86_32)
     docker run -i -v "${PWD}:/MuseScore" "$DOCKER_USER/musescore-x86_32:$docker_tag" /bin/bash -c \
-      "/MuseScore/build/Linux+BSD/portable/x86_32/Recipe $makefile_overrides"
+      "linux32 --32bit i386 /MuseScore/build/Linux+BSD/portable/x86_32/Recipe $makefile_overrides"
     ;;
 
   * )


### PR DESCRIPTION
This moves the AppImage builds from CentOS 6.7 to Ubuntu 12.04, and fixes a number of bugs in the AppImage and Docker builds. For example, the Travis AppImage build jobs will now be properly marked as "failed" if there are fatal errors.

The Ubuntu AppImages work on all of the same distros as the CentOS AppImages did, except they only work on CentOS 7 and not CentOS 6. They have been tested working on:
- Ubuntu 12.04, 16.04 and 16.10
- Debian 8
- Fedora 22
- OpenSuse 13.1