### PR TITLE
Fixes for infos shown in Score Properties

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2390,6 +2390,8 @@ Score::FileError MasterScore::read114(XmlReader& e)
       // treat reading a 1.14 file as import
       // on save warn if old file will be overwritten
       setCreated(true);
+      // don't autosave (as long as there's no change to the score)
+      setAutosaveDirty(false);
 
       return FileError::FILE_NO_ERROR;
       }

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2071,7 +2071,7 @@ void PageFormat::read(XmlReader& e)
 
 //---------------------------------------------------------
 //   read206
-//    import old version > 1.3  and < 2.x files
+//    import old version > 1.3  and < 3.x files
 //---------------------------------------------------------
 
 Score::FileError MasterScore::read206(XmlReader& e)
@@ -2092,7 +2092,7 @@ Score::FileError MasterScore::read206(XmlReader& e)
                   parseVersion(mscoreVersion());
                   }
             else if (tag == "programRevision")
-                  setMscoreRevision(e.readInt());
+                  setMscoreRevision(e.readIntHex());
             else if (tag == "Score") {
                   if (!readScore(this, e))
                         return FileError::FILE_BAD_FORMAT;

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2113,6 +2113,8 @@ Score::FileError MasterScore::read206(XmlReader& e)
       // treat reading a 2.06 file as import
       // on save warn if old file will be overwritten
       setCreated(true);
+      // don't autosave (as long as there's no change to the score)
+      setAutosaveDirty(false);
 
       return FileError::FILE_NO_ERROR;
       }

--- a/libmscore/read300.cpp
+++ b/libmscore/read300.cpp
@@ -311,7 +311,7 @@ Score::FileError MasterScore::read300(XmlReader& e)
                   parseVersion(mscoreVersion());
                   }
             else if (tag == "programRevision")
-                  setMscoreRevision(e.readInt());
+                  setMscoreRevision(e.readIntHex());
             else if (tag == "Score") {
 printf("===read score -- top %d\n", top);
                   MasterScore* score;

--- a/libmscore/xml.h
+++ b/libmscore/xml.h
@@ -84,9 +84,10 @@ class XmlReader : public QXmlStreamReader {
       bool hasAttribute(const char* s) const;
 
       // helper routines based on readElementText():
-      int readInt()         { return readElementText().toInt();    }
-      int readInt(bool* ok) { return readElementText().toInt(ok);  }
-      double readDouble()   { return readElementText().toDouble(); }
+      int readInt()         { return readElementText().toInt();      }
+      int readInt(bool* ok) { return readElementText().toInt(ok);    }
+      int readIntHex()      { return readElementText().toInt(0, 16); }
+      double readDouble()   { return readElementText().toDouble();   }
       double readDouble(double min, double max);
       bool readBool();
       QPointF readPoint();

--- a/mscore/metaedit.cpp
+++ b/mscore/metaedit.cpp
@@ -40,7 +40,12 @@ MetaEditDialog::MetaEditDialog(Score* s, QWidget* parent)
 
       level->setValue(score->mscVersion());
       version->setText(score->mscoreVersion());
-      revision->setValue(score->mscoreRevision());
+      int rev = score->mscoreRevision();
+      if (rev > 99999) { // MuseScore 1.3 is 5702, 2.0 uses a 7-digit hex SHA
+            revision->setDisplayIntegerBase(16);
+            revision->setMaximum(0xfffffff);
+            }
+      revision->setValue(rev);
       filePath->setText(score->importedFilePath());
 
       int idx = 0;


### PR DESCRIPTION
for scores from 2.0 or later, actually for scores created after the move from sourceforge to GitHub

A very similar fix should go to the 2.1 branch. This one here won't apply cleanly there though, so I made #2936