### PR TITLE
Fix #114931 follow up New Score Wizard text tweaks

### DIFF
--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -159,8 +159,8 @@ TitleWizard::TitleWizard(QWidget* parent)
 NewWizardPage1::NewWizardPage1(QWidget* parent)
    : QWizardPage(parent)
       {
-      setTitle(tr("Create New Score..."));
-      setSubTitle(tr("This wizard creates a new score.\nEnter score information:"));
+      setTitle(tr("Create New Score"));
+      setSubTitle(tr("Enter score information:"));
       setAccessibleName(QWizardPage::title());
       setAccessibleDescription(QWizardPage::subTitle());
 
@@ -189,8 +189,8 @@ NewWizardPage2::NewWizardPage2(QWidget* parent)
    : QWizardPage(parent)
       {
       setFinalPage(true);
-      setTitle(tr("Create New Score..."));
-      setSubTitle(tr("Select instruments:"));
+      setTitle(tr("Create New Score"));
+      setSubTitle(tr("Choose instruments on the left to add to instrument list on the right:"));
       setAccessibleName(title());
       setAccessibleDescription(subTitle());
       w        = new InstrumentsWidget;
@@ -248,8 +248,8 @@ NewWizardPage3::NewWizardPage3(QWidget* parent)
    : QWizardPage(parent)
       {
       setFinalPage(true);
-      setTitle(tr("Create New Score..."));
-      setSubTitle(tr("Select time signature:"));
+      setTitle(tr("Create New Score"));
+      setSubTitle(tr("Choose time signature:"));
       setAccessibleName(title());
       setAccessibleDescription(subTitle());
 
@@ -267,8 +267,8 @@ NewWizardPage4::NewWizardPage4(QWidget* parent)
    : QWizardPage(parent)
       {
       setFinalPage(true);
-      setTitle(tr("Create New Score..."));
-      setSubTitle(tr("Select template file:"));
+      setTitle(tr("Create New Score"));
+      setSubTitle(tr("Choose template file:"));
       setAccessibleName(title());
       setAccessibleDescription(subTitle());
 
@@ -353,8 +353,8 @@ NewWizardPage5::NewWizardPage5(QWidget* parent)
    : QWizardPage(parent)
       {
       setFinalPage(true);
-      setTitle(tr("Create New Score..."));
-      setSubTitle(tr("Select key signature and tempo:"));
+      setTitle(tr("Create New Score"));
+      setSubTitle(tr("Choose key signature and tempo:"));
       setAccessibleName(title());
       setAccessibleDescription(subTitle());
 
@@ -419,7 +419,7 @@ NewWizard::NewWizard(QWidget* parent)
       setWizardStyle(QWizard::ClassicStyle);
       setPixmap(QWizard::LogoPixmap, QPixmap(":/data/mscore.png"));
       setPixmap(QWizard::WatermarkPixmap, QPixmap());
-      setWindowTitle(tr("MuseScore: Create New Score"));
+      setWindowTitle(tr("MuseScore: New Score Wizard"));
 
       setOption(QWizard::NoCancelButton, false);
       setOption(QWizard::CancelButtonOnLeft, true);


### PR DESCRIPTION
For master & 2.1. “Choose” preferred over “Select” to match “Choose instruments” option among templates.