### PR TITLE
fix #141426 restored the 2.0.3 New Score Wizard default size

### DIFF
--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -440,7 +440,7 @@ NewWizard::NewWizard(QWidget* parent)
       setPage(Page::Keysig,      p5);
       setPage(Page::Timesig,     p3);
 
-
+      resize(QSize(840, 560)); //ensure default size if no geometry in settings
       MuseScore::restoreGeometry(this);
       connect(this, SIGNAL(currentIdChanged(int)), SLOT(idChanged(int)));
       }


### PR DESCRIPTION
Showing 5 scores next to each other again by default.

For master and 2.1