### PR TITLE
Fix #153891: Make electric basses transposing instruments with regular bass clef

### DIFF
--- a/mtest/importmidi/instrument_clef.mscx
+++ b/mtest/importmidi/instrument_clef.mscx
@@ -44,7 +44,8 @@
       <Staff id="1">
         <StaffType group="pitched">
           </StaffType>
-        <defaultClef>F8vb</defaultClef>
+        <defaultConcertClef>F8vb</defaultConcertClef>
+        <defaultTransposingClef>F</defaultTransposingClef>
         </Staff>
       <trackName>Electric Bass</trackName>
       <Instrument>
@@ -55,8 +56,11 @@
         <maxPitchP>65</maxPitchP>
         <minPitchA>28</minPitchA>
         <maxPitchA>65</maxPitchA>
+        <transposeDiatonic>-7</transposeDiatonic>
+        <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.bass.electric</instrumentId>
-        <clef>F8vb</clef>
+        <concertClef>F8vb</concertClef>
+        <transposingClef>F</transposingClef>
         <StringData>
           <frets>24</frets>
           <string>28</string>

--- a/mtest/importmidi/meter_15-8.mscx
+++ b/mtest/importmidi/meter_15-8.mscx
@@ -44,7 +44,8 @@
       <Staff id="1">
         <StaffType group="pitched">
           </StaffType>
-        <defaultClef>F8vb</defaultClef>
+        <defaultConcertClef>F8vb</defaultConcertClef>
+        <defaultTransposingClef>F</defaultTransposingClef>
         </Staff>
       <trackName>Electric Bass</trackName>
       <Instrument>
@@ -55,8 +56,11 @@
         <maxPitchP>65</maxPitchP>
         <minPitchA>28</minPitchA>
         <maxPitchA>65</maxPitchA>
+        <transposeDiatonic>-7</transposeDiatonic>
+        <transposeChromatic>-12</transposeChromatic>
         <instrumentId>pluck.bass.electric</instrumentId>
-        <clef>F8vb</clef>
+        <concertClef>F8vb</concertClef>
+        <transposingClef>F</transposingClef>
         <StringData>
           <frets>24</frets>
           <string>28</string>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -9465,10 +9465,13 @@
                         <string>38</string>
                         <string>43</string>
                   </StringData>
-                  <clef>F8vb</clef>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>28-65</aPitchRange>
                   <pPitchRange>28-65</pPitchRange>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
                   <Channel>
                         <program value="34"/>
                   </Channel>
@@ -9535,10 +9538,13 @@
                         <string>38</string>
                         <string>43</string>
                   </StringData>
-                  <clef>F8vb</clef>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>28-65</aPitchRange>
                   <pPitchRange>28-65</pPitchRange>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
                   <Channel>
                         <program value="33"/>
                   </Channel>
@@ -9572,10 +9578,13 @@
                         <string>38</string>
                         <string>43</string>
                   </StringData>
-                  <clef>F8vb</clef>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>28-65</aPitchRange>
                   <pPitchRange>28-65</pPitchRange>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
                   <Channel>
                         <program value="35"/>
                   </Channel>
@@ -9599,10 +9608,13 @@
                         <string>38</string>
                         <string>43</string>
                   </StringData>
-                  <clef>F8vb</clef>
+                  <transposingClef>F</transposingClef>
+                  <concertClef>F8vb</concertClef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>23-65</aPitchRange>
                   <pPitchRange>23-65</pPitchRange>
+                  <transposeDiatonic>-7</transposeDiatonic>
+                  <transposeChromatic>-12</transposeChromatic>
                   <Channel>
                         <program value="33"/>
                   </Channel>


### PR DESCRIPTION
Will also update templates in https://github.com/musescore/MuseScore/pull/2926.