### PR TITLE
fix #25271: Part export automatic numeration of same instruments

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -1137,7 +1137,7 @@ QList<Excerpt*> Excerpt::createAllExcerpt(MasterScore *score)
       QList<Excerpt*> all;
       for (Part* part : score->parts()) {
             if (part->show()) {
-                  Excerpt* e   = new Excerpt(score);
+                  Excerpt* e = new Excerpt(score);
                   e->parts().append(part);
                   for (int i = part->startTrack(), j = 0; i < part->endTrack(); i++, j++) {
                         e->tracks().insert(i, j);
@@ -1154,22 +1154,27 @@ QList<Excerpt*> Excerpt::createAllExcerpt(MasterScore *score)
 //   createName
 //---------------------------------------------------------
 
-QString Excerpt::createName(const QString& partName, QList<Excerpt*> excerptList)
+QString Excerpt::createName(const QString& partName, QList<Excerpt*>& excerptList)
       {
-      QString n = partName.simplified();
-      QString name;
-      int count = excerptList.count();
-      for (int i = 0;; ++i) {
-            name = i ? QString("%1-%2").arg(n).arg(i) : QString("%1").arg(n);
-            Excerpt* ee = 0;
-            for (int k = 0; k < count; ++k) {
-                  ee = excerptList[k];
-                  if (ee->title() == name)
-                        break;
-                  }
-            if ((ee == 0) || (ee->title() != name))
+      QString name = partName.simplified();
+      int count = 0;    // no of occurences of partName
+      
+      for (Excerpt* e : excerptList) {
+            // if <partName> already exists, change <partName> to <partName 1>
+            if (e->title().compare(name) == 0) {
+                  e->setTitle(e->title() + " 1");
+                  count = 1;
                   break;
+                  }
+          
+            QRegExp rx("^(.+)\\s\\d+$");
+            if (rx.indexIn(e->title()) > -1 && rx.cap(1) == name)
+                  count++;
             }
+      
+      if (count > 0)
+            name += QString(" %1").arg(count + 1);
+      
       return name;
       }
 

--- a/libmscore/excerpt.h
+++ b/libmscore/excerpt.h
@@ -66,7 +66,7 @@ class Excerpt : public QObject {
       void setTitle(const QString& s) { _title = s;    }
 
       static QList<Excerpt*> createAllExcerpt(MasterScore* score);
-      static QString createName(const QString& partName, QList<Excerpt*>);
+      static QString createName(const QString& partName, QList<Excerpt*>&);
       static void createExcerpt(Excerpt*);
       static void cloneStaves(Score* oscore, Score* score, const QList<int>& map, QMultiMap<int, int>& allTracks);
       static void cloneStaff(Staff* ostaff, Staff* nstaff);


### PR DESCRIPTION
Implemented a function _**renameWithNumbers**_ which takes in a ExcerptList and renames properly.
<img width="825" alt="part-export" src="https://cloud.githubusercontent.com/assets/14026308/21656356/cb15120a-d2e3-11e6-89be-42957e4805ae.png">