### PR TITLE
Added keyboard shortcut and menu action for fingering elements

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1319,6 +1319,7 @@ QMenu* MuseScore::genCreateMenu(QWidget* parent)
       text->addAction(getAction("chord-text"));
       text->addAction(getAction("rehearsalmark-text"));
       text->addAction(getAction("instrument-change-text"));
+      text->addAction(getAction("fingering-text"));
       text->addSeparator();
       text->addAction(getAction("lyrics"));
       text->addAction(getAction("figured-bass"));

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -83,6 +83,7 @@
 #include "libmscore/excerpt.h"
 #include "libmscore/stafftype.h"
 #include "libmscore/repeatlist.h"
+#include "libmscore/fingering.h"
 
 #include "inspector/inspector.h"
 
@@ -2790,6 +2791,8 @@ void ScoreView::cmd(const QAction* a)
             cmdAddText(TEXT::REHEARSAL_MARK);
       else if (cmd == "instrument-change-text")
             cmdAddText(TEXT::INSTRUMENT_CHANGE);
+      else if (cmd == "fingering-text")
+            cmdAddText(TEXT::FINGERING);
 
       else if (cmd == "edit-element") {
             Element* e = _score->selection().element();
@@ -5409,6 +5412,17 @@ void ScoreView::cmdAddText(TEXT type)
                   s->setTrack(cr->track());
                   s->setTextStyleType(TextStyleType::INSTRUMENT_CHANGE);
                   s->setParent(cr->segment());
+                  }
+                  break;
+            case TEXT::FINGERING:
+                  {
+                  Element* e = _score->getSelectedElement();
+                  if (!e || e->type() != Element::Type::NOTE
+                     || !e->staff()->isPitchedStaff())
+                        break;
+                  s = new Fingering(_score);
+                  s->setTextStyleType(TextStyleType::FINGERING);
+                  s->setParent(e);
                   }
                   break;
             }

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -67,7 +67,8 @@ enum class TEXT : char {
       SYSTEM,
       STAFF,
       REHEARSAL_MARK,
-      INSTRUMENT_CHANGE
+      INSTRUMENT_CHANGE,
+      FINGERING
       };
 
 //---------------------------------------------------------

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1868,6 +1868,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "fingering-text",
+         QT_TRANSLATE_NOOP("action","Fingering"),
+         QT_TRANSLATE_NOOP("action","Add fingering")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "picture",
          QT_TRANSLATE_NOOP("action","Picture"),
          QT_TRANSLATE_NOOP("action","Add picture")


### PR DESCRIPTION
Currently, fingering is added with drag & drop. Annotating a score with fingering (a common use-case for piano students or teachers) is cumbersome because the mouse must move back and forth from the palette to the notes. This PR would allow fingering to be entered with a user-definable keyboard shortcut, allowing the mouse to stay in place while the other hand enters the numbers.