### PR TITLE
fix #100101: pre-populate Album Manager with default "Untitled"

### DIFF
--- a/mscore/albummanager.cpp
+++ b/mscore/albummanager.cpp
@@ -60,6 +60,7 @@ AlbumManager::AlbumManager(QWidget* parent)
       createScore->setEnabled(false);
 
       MuseScore::restoreGeometry(this);
+      createNewClicked();
       }
 
 //---------------------------------------------------------
@@ -337,6 +338,9 @@ void MuseScore::showAlbumManager()
       if (albumManager == 0)
             albumManager = new AlbumManager(this);
       albumManager->show();
+      
+      // focus on album name on opening the Album Manager
+      albumManager->albumName->setFocus();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
- Create an empty album with name as "Untitled" when Album Manager window opens up.
- On reopening album manager focus on album name textbox