### PR TITLE
fix #86406 by XML escaping lyrics in MIDI import

### DIFF
--- a/mscore/importmidi/importmidi_lyrics.cpp
+++ b/mscore/importmidi/importmidi_lyrics.cpp
@@ -215,7 +215,7 @@ void addLyricsToScore(
             QString text = MidiCharset::convertToCharset(it->second);
             if (originalTime != ReducedFraction(0, 1) || !isTitlePrefix(text)) { // not title
                   score->addLyrics(quantizedTime.ticks(), staffAddTo->idx(),
-                                   removeSlashes(text));
+                                   removeSlashes(text).toHtmlEscaped());
                   }
             }
       }


### PR DESCRIPTION
Lyrics in MIDI files might contain text that is invalid when added to an XML document verbatim. This causes errors on opening a saved file containing such lyrics (see https://musescore.org/en/node/86406).

This PR escapes the lyrics when importing a MIDI file. That resolves the errors on opening. 