### PR TITLE
fix #164391: don't mark score dirty on Save Online when only updating it

### DIFF
--- a/mscore/uploadscoredialog.cpp
+++ b/mscore/uploadscoredialog.cpp
@@ -131,10 +131,12 @@ void UploadScoreDialog::uploadSuccess(const QString& url)
       setVisible(false);
       Score* score = mscore->currentScore()->masterScore();
       QMap<QString, QString>  metatags = score->metaTags();
-      metatags.insert("source", url);
-      score->startCmd();
-      score->undo(new ChangeMetaTags(score, metatags));
-      score->endCmd();
+      if (metatags.value("source") != url) {
+            metatags.insert("source", url);
+            score->startCmd();
+            score->undo(new ChangeMetaTags(score, metatags));
+            score->endCmd();
+      }
       QMessageBox::information(this,
                tr("Success"),
                tr("Finished! %1Go to my score%2.")


### PR DESCRIPTION
as opposed to a first time upload.

Should go into master and 2.1.