### PR TITLE
more system/staff text fixes

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -162,6 +162,10 @@ void Inspector::setElements(const QList<Element*>& l)
             bool sameTypes = true;
             for (Element* ee : _el) {
                   if (((_element->type() != ee->type()) && // different and
+                      (!_element->isSystemText()     || !ee->isStaffText())  && // neither system text nor
+                      (!_element->isStaffText()      || !ee->isSystemText()) && // staff text either side and
+                      (!_element->isPedalSegment()   || !ee->isTextLineSegment()) && // neither pedal nor
+                      (!_element->isTextLineSegment()|| !ee->isPedalSegment())    && // text line either side and
                       (!_element->isSlurTieSegment() || !ee->isSlurTieSegment())) || // neither Slur nor Tie either side, or
                       (ee->isNote() && toNote(ee)->chord()->isGrace() != toNote(_element)->chord()->isGrace())) // HACK
                         sameTypes = false;
@@ -1014,9 +1018,16 @@ InspectorStaffText::InspectorStaffText(QWidget* parent)
       s.setupUi(addWidget());
 
       Element* e = inspector->element();
-      Text* te   = static_cast<Text*>(e);
+      bool sameTypes = true;
 
-      s.title->setText(te->isSystemText() ? tr("System Text") : tr("Staff Text"));
+      for (const auto& ee : inspector->el()) {
+            if (e->isSystemText() != ee->isSystemText()) {
+                  sameTypes = false;
+                  break;
+                  }
+            }
+      if (sameTypes)
+            s.title->setText(e->isSystemText() ? tr("System Text") : tr("Staff Text"));
 
       const std::vector<InspectorItem> il = {
             { P_ID::FONT_FACE,        0, 0, t.fontFace,     t.resetFontFace     },

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -77,6 +77,7 @@
 #include "libmscore/stringdata.h"
 #include "libmscore/sym.h"
 #include "libmscore/system.h"
+#include "libmscore/systemtext.h"
 #include "libmscore/textframe.h"
 #include "libmscore/text.h"
 #include "libmscore/timesig.h"
@@ -5433,20 +5434,25 @@ void ScoreView::cmdAddText(TEXT type)
                   }
                   break;
             case TEXT::STAFF:
-            case TEXT::SYSTEM:
                   {
                   ChordRest* cr = _score->getSelectedChordRest();
                   if (!cr)
                         break;
                   s = new StaffText(_score);
-                  if (type == TEXT::SYSTEM) {
-                        s->setTrack(0);
-                        s->initSubStyle(SubStyle::SYSTEM);
-                        }
-                  else {
-                        s->setTrack(cr->track());
-                        s->initSubStyle(SubStyle::STAFF);
-                        }
+                  s->setTrack(cr->track());
+                  s->initSubStyle(SubStyle::STAFF);
+
+                  s->setParent(cr->segment());
+                  }
+                  break;
+            case TEXT::SYSTEM:
+                  {
+                  ChordRest* cr = _score->getSelectedChordRest();
+                  if (!cr)
+                        break;
+                  s = new SystemText(_score);
+                  s->setTrack(0);
+                  s->initSubStyle(SubStyle::SYSTEM);
                   s->setParent(cr->segment());
                   }
                   break;


### PR DESCRIPTION
* Ctrl-Shift+T enters system text and not staff text with system text style
* multi select a mix of system- and staff texts gets detected and opens the staff text inspector
* multi select a mix of pedal- and text lines gets detected and opens the the text line inspector