### PR TITLE
fix #165496: Import MIDI track volume

### DIFF
--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -703,6 +703,9 @@ std::multimap<int, MTrack> createMTrackList(TimeSigMap *sigmap, const MidiFile *
                         }
                   else if (e.type() == ME_PROGRAM)
                         track.program = e.dataB();
+                  else if (e.type() == ME_CONTROLLER && e.controller() == CTRL_VOLUME) {
+                        track.volumes.insert({tick, e.value()});
+                        }
                   }
             if (hasNotes) {
                   ++trackIndex;

--- a/mscore/importmidi/importmidi_inner.cpp
+++ b/mscore/importmidi/importmidi_inner.cpp
@@ -30,6 +30,7 @@ MTrack::MTrack(const MTrack &other)
       , division(other.division)
       , isDivisionInTps(other.isDivisionInTps)
       , hadInitialNotes(other.hadInitialNotes)
+      , volumes(other.volumes)
       , chords(other.chords)
       {
       updateTupletsFromChords();
@@ -46,6 +47,7 @@ MTrack& MTrack::operator=(MTrack other)
       std::swap(division, other.division);
       std::swap(isDivisionInTps, other.isDivisionInTps);
       std::swap(hadInitialNotes, other.hadInitialNotes);
+      std::swap(volumes, other.volumes);
       std::swap(chords, other.chords);
       updateTupletsFromChords();
 

--- a/mscore/importmidi/importmidi_inner.h
+++ b/mscore/importmidi/importmidi_inner.h
@@ -83,6 +83,7 @@ class MTrack {
       bool isDivisionInTps;       // ticks per second
       bool hadInitialNotes;
 
+      std::multimap<ReducedFraction, int> volumes;
       std::multimap<ReducedFraction, MidiChord> chords;
       std::multimap<ReducedFraction, MidiTuplet::TupletData> tuplets;   // <tupletOnTime, ...>
 

--- a/mscore/importmidi/importmidi_instrument.cpp
+++ b/mscore/importmidi/importmidi_instrument.cpp
@@ -432,6 +432,16 @@ void createInstruments(Score *score, QList<MTrack> &tracks)
                   tracks[idx].staff = part->staff(i);
                   }
 
+            // only importing a single volume per track here, skip when multiple volumes
+            // are defined, or the single volume is not defined on tick 0.
+            if (track.volumes.size() == 1) {
+                  for (auto &i: track.volumes) {
+                        if (i.first == ReducedFraction(0, 1)) {
+                              part->instrument()->channel(0)->volume = i.second;
+                              }
+                        }
+                  }
+
             score->appendPart(part);
             }
       }

--- a/mtest/importmidi/instrument_channels.mscx
+++ b/mtest/importmidi/instrument_channels.mscx
@@ -67,6 +67,7 @@
           </Articulation>
         <Channel>
           <program value="48"/>
+          <controller ctrl="7" value="50"/>
           <midiPort>0</midiPort>
           <midiChannel>0</midiChannel>
           </Channel>
@@ -129,6 +130,7 @@
           </Articulation>
         <Channel>
           <program value="56"/>
+          <controller ctrl="7" value="33"/>
           <midiPort>1</midiPort>
           <midiChannel>0</midiChannel>
           </Channel>
@@ -186,6 +188,7 @@
           </Articulation>
         <Channel>
           <program value="57"/>
+          <controller ctrl="7" value="37"/>
           <midiPort>1</midiPort>
           <midiChannel>2</midiChannel>
           </Channel>

--- a/mtest/importmidi/perc_remove_ties.mscx
+++ b/mtest/importmidi/perc_remove_ties.mscx
@@ -251,6 +251,7 @@
         <Channel>
           <controller ctrl="0" value="1"/>
           <program value="0"/>
+          <controller ctrl="7" value="105"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/importmidi/perc_short_notes.mscx
+++ b/mtest/importmidi/perc_short_notes.mscx
@@ -251,6 +251,7 @@
         <Channel>
           <controller ctrl="0" value="1"/>
           <program value="0"/>
+          <controller ctrl="7" value="127"/>
           </Channel>
         </Instrument>
       </Part>

--- a/mtest/importmidi/pickup_turn_off.mscx
+++ b/mtest/importmidi/pickup_turn_off.mscx
@@ -67,6 +67,7 @@
           </Articulation>
         <Channel>
           <program value="52"/>
+          <controller ctrl="7" value="127"/>
           </Channel>
         </Instrument>
       </Part>


### PR DESCRIPTION
Import the volume of a MIDI track when that track contains a single volume control event at tick 0.

For more information, see: [#165496](https://musescore.org/en/node/165496)