### PR TITLE
fix #166231: Ambitus gets reported an octave to high

### DIFF
--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -744,10 +744,10 @@ Element* Ambitus::prevElement()
 
 QString Ambitus::accessibleInfo() const
       {
-      return tr("%1; Top pitch: %2%3; Bottom pitch: %4%5").arg(Element::accessibleInfo())\
-                                                          .arg(tpc2name(topTpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false))\
-                                                          .arg(QString::number(topOctave()))\
-                                                          .arg(tpc2name(bottomTpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false))\
+      return tr("%1; Top pitch: %2%3; Bottom pitch: %4%5").arg(Element::accessibleInfo())
+                                                          .arg(tpc2name(topTpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false))
+                                                          .arg(QString::number(topOctave()))
+                                                          .arg(tpc2name(bottomTpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false))
                                                           .arg(QString::number(bottomOctave()));
       }
 
@@ -757,11 +757,7 @@ QString Ambitus::accessibleInfo() const
 
 QString Ambitus::screenReaderInfo() const
       {
-      return tr("%1; Top pitch: %2%3; Bottom pitch: %4%5").arg(Element::screenReaderInfo())\
-                                                          .arg(tpc2name(topTpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, true))\
-                                                          .arg(QString::number(topOctave()))\
-                                                          .arg(tpc2name(bottomTpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, true))\
-                                                          .arg(QString::number(bottomOctave()));
+      return accessibleInfo();
       }
 }
 

--- a/libmscore/ambitus.h
+++ b/libmscore/ambitus.h
@@ -50,14 +50,14 @@ class Ambitus : public Element {
       void initFrom(Ambitus* a);
 
       // getters and setters
-      virtual ElementType type() const override     { return ElementType::AMBITUS;    }
+      virtual ElementType type() const override       { return ElementType::AMBITUS; }
       NoteHead::Group noteHeadGroup() const           { return _noteHeadGroup;}
       NoteHead::Type noteHeadType() const             { return _noteHeadType; }
       MScore::DirectionH direction() const            { return _dir;          }
       bool hasLine() const                            { return _hasLine;      }
       Spatium lineWidth() const                       { return _lineWidth;    }
-      int topOctave() const                           { return _topPitch / 12;}
-      int bottomOctave() const                        { return _bottomPitch / 12;}
+      int topOctave() const                           { return (_topPitch / 12) - 1; }
+      int bottomOctave() const                        { return (_bottomPitch / 12) - 1; }
       int topPitch() const                            { return _topPitch;     }
       int bottomPitch() const                         { return _bottomPitch;  }
       int topTpc() const                              { return _topTpc;       }


### PR DESCRIPTION
in Inspector, status bar and screen reader.
Also getting rid of superfluos backslashes and an unneeded code duplication