### PR TITLE
fix #72896: solved the blank name issue within Save as option in Imag…

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -427,6 +427,7 @@ class Score : public QObject, ScoreElement {
       bool _printing              { false };      ///< True if we are drawing to a printer
       bool _playlistDirty         { true  };
       bool _autosaveDirty         { true  };
+      bool _savedCapture          { false };      ///< True if we saved an image capture
       bool _saved                 { false };    ///< True if project was already saved; only on first
                                                 ///< save a backup file will be created, subsequent
                                                 ///< saves will not overwrite the backup file.
@@ -780,8 +781,10 @@ class Score : public QObject, ScoreElement {
       bool dirty() const;
       void setCreated(bool val)      { _created = val;        }
       bool created() const           { return _created;       }
+      bool savedCapture() const      { return _savedCapture;  }
       bool saved() const             { return _saved;         }
       void setSaved(bool v)          { _saved = v;            }
+      void setSavedCapture(bool v)   { _savedCapture = v;     }
       bool printing() const          { return _printing;      }
       void setPrinting(bool val)     { _printing = val;      }
       void setAutosaveDirty(bool v)  { _autosaveDirty = v;    }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1174,18 +1174,39 @@ QString MuseScore::getFotoFilename(QString& filter, QString* selectedFilter)
             myImages.setFile(QDir::home(), preferences.myImagesPath);
       QString defaultPath = myImages.absoluteFilePath();
 
+      // compute the image capture path
+      QString myCapturePath;
+      // if no saves were made for current score, then use the score's name as default
+      if (!cs->masterScore()->savedCapture()) {
+            // set the current score's name as the default name for saved captures
+            QString scoreName = cs->masterScore()->fileInfo()->completeBaseName();
+            QString name = createDefaultFileName(scoreName);
+            QString fname = QString("%1/%2").arg(defaultPath).arg(name);
+            QFileInfo myCapture(fname);
+            if (myCapture.isRelative())
+                myCapture.setFile(QDir::home(), fname);
+            myCapturePath = myCapture.absoluteFilePath();
+            }
+      else
+            myCapturePath = lastSaveCaptureName;
+
       if (preferences.nativeDialogs) {
             QString fn;
             fn = QFileDialog::getSaveFileName(
                this,
                title,
-               defaultPath,
+               myCapturePath,
                filter,
                selectedFilter
                );
+            // if a save was made for this current score
+            if (!fn.isEmpty()) {
+                cs->masterScore()->setSavedCapture(true);
+                // store the last name used for saving an image capture
+                lastSaveCaptureName = fn;
+                }
             return fn;
             }
-
 
       QList<QUrl> urls;
       urls.append(QUrl::fromLocalFile(QDir::homePath()));
@@ -1209,9 +1230,16 @@ QString MuseScore::getFotoFilename(QString& filter, QString* selectedFilter)
       // setup side bar urls
       saveImageDialog->setSidebarUrls(urls);
 
+      // set file's name using the computed path
+      saveImageDialog->selectFile(myCapturePath);
+
       if (saveImageDialog->exec()) {
             QStringList result = saveImageDialog->selectedFiles();
             *selectedFilter = saveImageDialog->selectedNameFilter();
+            // a save was made for this current score
+            cs->masterScore()->setSavedCapture(true);
+            // store the last name used for saving an image capture
+            lastSaveCaptureName = result.front();
             return result.front();
             }
       return QString();

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -564,6 +564,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QString lastSaveCopyDirectory;
       QString lastSaveCopyFormat;
       QString lastSaveDirectory;
+      QString lastSaveCaptureName;
       SynthControl* getSynthControl() const       { return synthControl; }
       void editInPianoroll(Staff* staff);
       void editInDrumroll(Staff* staff);


### PR DESCRIPTION
…e capture feature by setting a default name consisting of current score name; every score will use this default name for its first save