### PR TITLE
fix #50926: add setting and option for MP3 bitrate

### DIFF
--- a/mscore/exportmp3.cpp
+++ b/mscore/exportmp3.cpp
@@ -655,6 +655,7 @@ bool MuseScore::saveMp3(Score* score, const QString& name)
 
       int oldSampleRate = MScore::sampleRate;
       int sampleRate = preferences.exportAudioSampleRate;
+      exporter.setBitrate(preferences.exportMp3BitRate);
 
       int inSamples = exporter.initializeStream(channels, sampleRate);
       if (inSamples < 0) {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5393,6 +5393,7 @@ int main(int argc, char* av[])
       parser.addOption(QCommandLineOption({"P", "export-score-parts"}, "Used with -o <file>.pdf, export score + parts"));
       parser.addOption(QCommandLineOption(      "no-fallback-font", "will not use Bravura as fallback musical font"));
       parser.addOption(QCommandLineOption({"f", "force"}, "Used with -o, ignore warnings reg. score being corrupted or from wrong version"));
+      parser.addOption(QCommandLineOption({"b", "bitrate"}, "Used with -o <file>.mp3, sets bitrate", "bitrate"));
 
       parser.addPositionalArgument("scorefiles", "The files to open", "[scorefile...]");
 
@@ -5504,6 +5505,15 @@ int main(int argc, char* av[])
       if (exportScoreParts && !converterMode)
             parser.showHelp(EXIT_FAILURE);
       ignoreWarnings = parser.isSet("f");
+      if (parser.isSet("b")) {
+            QString temp = parser.value("b");
+            if (temp.isEmpty())
+                   parser.showHelp(EXIT_FAILURE);
+            bool ok = false;
+            preferences.exportMp3BitRate = temp.toInt(&ok);
+            if (!ok)
+                  preferences.exportMp3BitRate = 128;
+           }
 
       QStringList argv = parser.positionalArguments();
 

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -53,8 +53,6 @@ bool useALSA = false, useJACK = false, usePortaudio = false, usePulseAudio = fal
 
 extern bool externalStyle;
 
-static int exportAudioSampleRates[2] = { 44100, 48000 };
-
 //---------------------------------------------------------
 //   Preferences
 //---------------------------------------------------------
@@ -201,7 +199,8 @@ void Preferences::init()
 #else
       nativeDialogs           = false;    // don't use system native file dialogs
 #endif
-      exportAudioSampleRate   = exportAudioSampleRates[0];
+      exportAudioSampleRate   = 44100;
+      exportMp3BitRate        = 128;
 
       workspace               = "Basic";
       exportPdfDpi            = 300;
@@ -337,6 +336,7 @@ void Preferences::write()
       s.setValue("vraster", MScore::vRaster());
       s.setValue("nativeDialogs", nativeDialogs);
       s.setValue("exportAudioSampleRate", exportAudioSampleRate);
+      s.setValue("exportMp3BitRate", exportMp3BitRate);
 
       s.setValue("workspace", workspace);
       s.setValue("exportPdfDpi", exportPdfDpi);
@@ -509,6 +509,7 @@ void Preferences::read()
 
       nativeDialogs    = s.value("nativeDialogs", nativeDialogs).toBool();
       exportAudioSampleRate = s.value("exportAudioSampleRate", exportAudioSampleRate).toInt();
+      exportMp3BitRate   = s.value("exportMp3Bitrate", exportMp3BitRate).toInt();
 
       workspace          = s.value("workspace", workspace).toString();
       exportPdfDpi       = s.value("exportPdfDpi", exportPdfDpi).toInt();
@@ -589,7 +590,54 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
 #endif
 #ifndef USE_ALSA
       alsaDriver->setVisible(false);
+#else
+      exportAudioSampleRate->clear();
+      alsaSampleRate->addItem(tr("192000"), 192000);
+      alsaSampleRate->addItem( tr("96000"),  96000);
+      alsaSampleRate->addItem( tr("88200"),  88200);
+      alsaSampleRate->addItem( tr("48000"),  48000); // default
+      alsaSampleRate->addItem( tr("44100"),  44100);
+      alsaSampleRate->addItem( tr("32000"),  32000);
+      alsaSampleRate->addItem( tr("22050"),  22050);
+
+      alsaPeriodSize->clear();
+      alsaPeriodSize->addItem(tr("4096"), 4096);
+      alsaPeriodSize->addItem(tr("2048"), 2048);
+      alsaPeriodSize->addItem(tr("1024"), 1024); // default
+      alsaPeriodSize->addItem( tr("512"),  512);
+      alsaPeriodSize->addItem( tr("256"),  256);
+      alsaPeriodSize->addItem( tr("128"),  128);
+      alsaPeriodSize->addItem(  tr("64"),   64);
 #endif
+
+      exportAudioSampleRate->clear();
+      exportAudioSampleRate->addItem(tr("44100"), 44100); // default
+      exportAudioSampleRate->addItem(tr("48000"), 48000);
+
+#ifndef USE_LAME
+      exportMp3BitRateLabel->setVisible(false);
+      exportMp3BitRate->setVisible(false);
+      exporMp3BitRateUnit->setVisible(false)
+#else
+      exportMp3BitRate->clear();
+      exportMp3BitRate->addItem(  tr("8"),   8);
+      exportMp3BitRate->addItem( tr("16"),  16);
+      exportMp3BitRate->addItem( tr("32"),  32);
+      exportMp3BitRate->addItem( tr("40"),  40);
+      exportMp3BitRate->addItem( tr("48"),  48);
+      //exportMp3BitRate->addItem( tr("56"),  56);
+      exportMp3BitRate->addItem( tr("64"),  64);
+      exportMp3BitRate->addItem( tr("80"),  80);
+      exportMp3BitRate->addItem( tr("96"),  96);
+      exportMp3BitRate->addItem(tr("112"), 112);
+      exportMp3BitRate->addItem(tr("128"), 128); // default
+      exportMp3BitRate->addItem(tr("160"), 160);
+      exportMp3BitRate->addItem(tr("192"), 192);
+      exportMp3BitRate->addItem(tr("224"), 224);
+      exportMp3BitRate->addItem(tr("256"), 256);
+      exportMp3BitRate->addItem(tr("320"), 320);
+#endif
+
 #ifndef USE_PORTAUDIO
       portaudioDriver->setVisible(false);
 #endif
@@ -663,11 +711,6 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       recordButtons->addButton(recordUndo,   RMIDI_UNDO);
       recordButtons->addButton(recordEditMode, RMIDI_NOTE_EDIT_MODE);
       recordButtons->addButton(recordRealtimeAdvance, RMIDI_REALTIME_ADVANCE);
-
-      int n = sizeof(exportAudioSampleRates)/sizeof(*exportAudioSampleRates);
-      exportAudioSampleRate->clear();
-      for (int idx = 0; idx < n; ++idx)
-            exportAudioSampleRate->addItem(QString("%1").arg(exportAudioSampleRates[idx]));
 
       connect(recordButtons,          SIGNAL(buttonClicked(int)), SLOT(recordButtonClicked(int)));
       connect(midiRemoteControlClear, SIGNAL(clicked()), SLOT(midiRemoteControlClearClicked()));
@@ -832,9 +875,10 @@ void PreferenceDialog::updateValues()
 
       alsaDevice->setText(prefs.alsaDevice);
 
-      int index = alsaSampleRate->findText(QString("%1").arg(prefs.alsaSampleRate));
+      int index = alsaSampleRate->findData(prefs.alsaSampleRate);
       alsaSampleRate->setCurrentIndex(index);
-      index = alsaPeriodSize->findText(QString("%1").arg(prefs.alsaPeriodSize));
+
+      index = alsaPeriodSize->findData(prefs.alsaPeriodSize);
       alsaPeriodSize->setCurrentIndex(index);
 
       alsaFragments->setValue(prefs.alsaFragments);
@@ -995,15 +1039,12 @@ void PreferenceDialog::updateValues()
       myPlugins->setText(prefs.myPluginsPath);
       mySoundfonts->setText(prefs.mySoundfontsPath);
 
-      idx = 0;
-      int n = sizeof(exportAudioSampleRates)/sizeof(*exportAudioSampleRates);
-      for (;idx < n; ++idx) {
-            if (exportAudioSampleRates[idx] == prefs.exportAudioSampleRate)
-                  break;
-            }
-      if (idx == n)     // if not found in table
-            idx = 0;
-      exportAudioSampleRate->setCurrentIndex(idx);
+      index = exportAudioSampleRate->findData(prefs.exportAudioSampleRate);
+      exportAudioSampleRate->setCurrentIndex(index);
+
+      index = exportMp3BitRate->findData(prefs.exportMp3BitRate);
+      exportMp3BitRate->setCurrentIndex(index);
+
       exportPdfDpi->setValue(prefs.exportPdfDpi);
       pageVertical->setChecked(MScore::verticalOrientation());
       }
@@ -1343,8 +1384,8 @@ void PreferenceDialog::apply()
          || (prefs.usePortaudioAudio != portaudioDriver->isChecked())
          || (prefs.usePulseAudio != pulseaudioDriver->isChecked())
          || (prefs.alsaDevice != alsaDevice->text())
-         || (prefs.alsaSampleRate != alsaSampleRate->currentText().toInt())
-         || (prefs.alsaPeriodSize != alsaPeriodSize->currentText().toInt())
+         || (prefs.alsaSampleRate != alsaSampleRate->currentData().toInt())
+         || (prefs.alsaPeriodSize != alsaPeriodSize->currentData().toInt())
          || (prefs.alsaFragments != alsaFragments->value())
             ) {
             if (seq)
@@ -1353,8 +1394,8 @@ void PreferenceDialog::apply()
             prefs.usePortaudioAudio  = portaudioDriver->isChecked();
             prefs.usePulseAudio      = pulseaudioDriver->isChecked();
             prefs.alsaDevice         = alsaDevice->text();
-            prefs.alsaSampleRate     = alsaSampleRate->currentText().toInt();
-            prefs.alsaPeriodSize     = alsaPeriodSize->currentText().toInt();
+            prefs.alsaSampleRate     = alsaSampleRate->currentData().toInt();
+            prefs.alsaPeriodSize     = alsaPeriodSize->currentData().toInt();
             prefs.alsaFragments      = alsaFragments->value();
             preferences = prefs;
             if (seq) {
@@ -1400,8 +1441,8 @@ void PreferenceDialog::apply()
       prefs.myPluginsPath      = myPlugins->text();
       prefs.mySoundfontsPath = mySoundfonts->text();
 
-      int idx = exportAudioSampleRate->currentIndex();
-      prefs.exportAudioSampleRate = exportAudioSampleRates[idx];
+      prefs.exportAudioSampleRate = exportAudioSampleRate->currentData().toInt();
+      prefs.exportMp3BitRate   = exportMp3BitRate->currentData().toInt();
 
       prefs.midiExpandRepeats  = expandRepeats->isChecked();
       prefs.midiExportRPNs     = exportRPNs->isChecked();

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -177,6 +177,7 @@ struct Preferences {
       bool nativeDialogs;
 
       int exportAudioSampleRate;
+      int exportMp3BitRate;
 
       QString workspace;
       int exportPdfDpi;

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -328,18 +328,14 @@
             <property name="accessibleName">
              <string>Select delay (in minutes) between auto saves</string>
             </property>
+            <property name="suffix">
+             <string extracomment="minutes">min</string>
+            </property>
             <property name="minimum">
              <number>1</number>
             </property>
             <property name="value">
              <number>2</number>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_27">
-            <property name="text">
-             <string>minutes</string>
             </property>
            </widget>
           </item>
@@ -703,6 +699,9 @@
             <property name="accessibleName">
              <string>Icon Width</string>
             </property>
+            <property name="suffix">
+             <string extracomment="pixel">px</string>
+            </property>
             <property name="minimum">
              <number>5</number>
             </property>
@@ -729,6 +728,9 @@
            <widget class="QSpinBox" name="iconHeight">
             <property name="accessibleName">
              <string>Icon Height</string>
+            </property>
+            <property name="suffix">
+             <string extracomment="pixel">px</string>
             </property>
             <property name="minimum">
              <number>5</number>
@@ -1094,6 +1096,9 @@
             <property name="accessibleName">
              <string>Proximity for selecting elements:</string>
             </property>
+            <property name="suffix">
+             <string extracomment="pixel">px</string>
+            </property>
             <property name="minimum">
              <number>1</number>
             </property>
@@ -1187,7 +1192,7 @@
              <string>Delay between notes in automatic Real-time mode</string>
             </property>
             <property name="suffix">
-             <string>ms</string>
+             <string extracomment="milliseconds">ms</string>
             </property>
             <property name="minimum">
              <number>300</number>
@@ -1250,7 +1255,7 @@
              <string>Default duration</string>
             </property>
             <property name="suffix">
-             <string>ms</string>
+             <string extracomment="milliseconds">ms</string>
             </property>
             <property name="minimum">
              <number>20</number>
@@ -2720,17 +2725,7 @@
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_5">
-          <item row="1" column="4">
-           <widget class="QLabel" name="label_12">
-            <property name="text">
-             <string>Period Size:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
+          <item row="1" column="5">
            <widget class="QSpinBox" name="alsaFragments">
             <property name="accessibleName">
              <string>Fragments</string>
@@ -2745,7 +2740,37 @@
              <number>8</number>
             </property>
             <property name="value">
-             <number>2</number>
+             <number>3</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="alsaDevice">
+            <property name="accessibleName">
+             <string>Device</string>
+            </property>
+            <property name="text">
+             <string notr="true">default</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string>Fragments:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="6">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Period Size:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
@@ -2766,52 +2791,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="5">
-           <widget class="QComboBox" name="alsaPeriodSize">
-            <property name="accessibleName">
-             <string>Period Size</string>
-            </property>
-            <property name="accessibleDescription">
-             <string>Choose period size</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>4096</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>2048</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>1024</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>512</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>256</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>128</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>64</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item row="1" column="6">
+          <item row="1" column="8">
            <spacer name="horizontalSpacer_9">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -2824,14 +2804,52 @@
             </property>
            </spacer>
           </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="label_13">
-            <property name="text">
-             <string>Fragments:</string>
+          <item row="1" column="7">
+           <widget class="QComboBox" name="alsaPeriodSize">
+            <property name="accessibleName">
+             <string>Period Size</string>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            <property name="accessibleDescription">
+             <string>Choose period size</string>
             </property>
+            <property name="currentIndex">
+             <number>2</number>
+            </property>
+            <item>
+             <property name="text">
+              <string notr="true">4096</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">2048</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">1024</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">512</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">256</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">128</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">64</string>
+             </property>
+            </item>
            </widget>
           </item>
           <item row="1" column="1">
@@ -2842,52 +2860,65 @@
             <property name="accessibleDescription">
              <string>Choose sample rate</string>
             </property>
+            <property name="currentIndex">
+             <number>3</number>
+            </property>
             <item>
              <property name="text">
-              <string>192000</string>
+              <string notr="true">192000</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>96000</string>
+              <string notr="true">96000</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>88200</string>
+              <string notr="true">88200</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>48000</string>
+              <string notr="true">48000</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>44100</string>
+              <string notr="true">44100</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>32000</string>
+              <string notr="true">32000</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>22050</string>
+              <string notr="true">22050</string>
              </property>
             </item>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="alsaDevice">
-            <property name="accessibleName">
-             <string>Device</string>
-            </property>
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_22">
             <property name="text">
-             <string notr="true">default</string>
+             <string extracomment="Hertz">Hz</string>
             </property>
            </widget>
+          </item>
+          <item row="1" column="3">
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
@@ -3345,7 +3376,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Resolution DPI:</string>
+             <string>Resolution:</string>
             </property>
            </widget>
           </item>
@@ -3379,6 +3410,9 @@
             </property>
             <property name="accessibleDescription">
              <string>Choose resolution DPI</string>
+            </property>
+            <property name="suffix">
+             <string extracomment="dots per inch">DPI</string>
             </property>
             <property name="minimum">
              <number>32</number>
@@ -3429,60 +3463,8 @@
          </layout>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QGroupBox" name="groupBox_16">
-         <property name="accessibleName">
-          <string>Audio</string>
-         </property>
-         <property name="title">
-          <string>Audio</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_12">
-          <item>
-           <widget class="QLabel" name="label_18">
-            <property name="text">
-             <string>Sample rate:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="exportAudioSampleRate">
-            <property name="accessibleName">
-             <string>Sample rate</string>
-            </property>
-            <property name="accessibleDescription">
-             <string>Choose sample rate</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>44100</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>48000</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item row="3" column="0" colspan="2">
-        <widget class="QGroupBox" name="groupBox_22">
+        <widget class="QGroupBox" name="exportMp3VBR">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -3552,21 +3534,24 @@
          <property name="title">
           <string>PDF</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_11">
-          <item row="1" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
            <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Resolution DPI:</string>
+             <string>Resolution:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item>
            <widget class="QSpinBox" name="exportPdfDpi">
             <property name="accessibleName">
              <string>Resolution DPI</string>
             </property>
             <property name="accessibleDescription">
              <string>Choose resolution DPI</string>
+            </property>
+            <property name="suffix">
+             <string extracomment="dots per inch">DPI</string>
             </property>
             <property name="minimum">
              <number>75</number>
@@ -3579,7 +3564,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
+          <item>
            <spacer name="horizontalSpacer_3">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -3591,6 +3576,162 @@
              </size>
             </property>
            </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QGroupBox" name="groupBox_16">
+         <property name="accessibleName">
+          <string>Audio</string>
+         </property>
+         <property name="title">
+          <string>Audio</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_15">
+          <item row="1" column="2">
+           <widget class="QComboBox" name="exportMp3BitRate">
+            <property name="currentText">
+             <string>128</string>
+            </property>
+            <property name="currentIndex">
+             <number>8</number>
+            </property>
+            <item>
+             <property name="text">
+              <string notr="true">32</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">40</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">48</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">56</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">64</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">80</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">96</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">112</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">128</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">160</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">192</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">224</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">256</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">320</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Sample rate:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QComboBox" name="exportAudioSampleRate">
+            <property name="accessibleName">
+             <string>Sample rate</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Choose sample rate</string>
+            </property>
+            <property name="currentIndex">
+             <number>0</number>
+            </property>
+            <item>
+             <property name="text">
+              <string notr="true">44100</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">48000</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string extracomment="Hertz">Hz</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QLabel" name="exporMp3BitRateUnit">
+            <property name="text">
+             <string>kBit/s</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="4">
+           <spacer name="horizontalSpacer_19">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="exportMp3BitRateLabel">
+            <property name="text">
+             <string>MP3 Bitrate:</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
and some code (style) and UI cleanup

We may want this in master and 2.1. Not sure it'd apply cleanly to 2.1, but am willing to create a separate PR for that purpose if need be.
Adjusting the handbook would need to be done too, in at least 3 places (Preferences, including a new picture, File formats/MP3 Export and Command line options)