### PR TITLE
add vertical spacers and modify tooltip for key/time sig .ui (minor edit)

### DIFF
--- a/mscore/keyedit.ui
+++ b/mscore/keyedit.ui
@@ -122,7 +122,7 @@
          <item>
           <widget class="QPushButton" name="addButton">
            <property name="toolTip">
-            <string>Add time signature to palette</string>
+            <string>Add time signature to master palette</string>
            </property>
            <property name="text">
             <string>Add</string>

--- a/mscore/note_groups.ui
+++ b/mscore/note_groups.ui
@@ -140,6 +140,9 @@
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="resetGroups">
+       <property name="toolTip">
+        <string>Reset note grouping</string>
+       </property>
        <property name="text">
         <string>Reset</string>
        </property>

--- a/mscore/timedialog.ui
+++ b/mscore/timedialog.ui
@@ -234,6 +234,19 @@
         </widget>
        </item>
        <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <spacer name="horizontalSpacer_2">
@@ -257,7 +270,7 @@
             </sizepolicy>
            </property>
            <property name="toolTip">
-            <string>Add time signature to palette</string>
+            <string>Add time signature to master palette</string>
            </property>
            <property name="text">
             <string>Add</string>

--- a/mscore/timesigproperties.ui
+++ b/mscore/timesigproperties.ui
@@ -384,6 +384,19 @@
           </layout>
          </widget>
         </item>
+        <item row="2" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
       </widget>
      </item>


### PR DESCRIPTION
Add vertical spacers to key sig dialog.
Add tooltip for note grouping's "Reset" button.
Modified tooltip for key/sig master palette "Add" button to include the word "master".