### PR TITLE
fix #174836 Tighten Beam Properties in note_groups.ui

### DIFF
--- a/mscore/note_groups.ui
+++ b/mscore/note_groups.ui
@@ -121,22 +121,6 @@
     </layout>
    </item>
    <item>
-    <widget class="Ms::Palette" name="iconPalette" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>40</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="resetGroups">
@@ -155,11 +139,58 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
-         <height>20</height>
+         <width>0</width>
+         <height>0</height>
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>134</width>
+         <height>80</height>
+        </size>
+       </property>
+       <property name="baseSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="title">
+        <string>Beam Properties</string>
+       </property>
+       <widget class="Ms::Palette" name="iconPalette" native="true">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>30</y>
+          <width>114</width>
+          <height>40</height>
+         </rect>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
1. The beam properties palette is no longer ever-expanding horizontally, but rather fixed at minimum required pixels (114) in order to display only the 4 beam property cells.  This prevents a noticeable artifact when resizing, and also makes the ui cleaner.
2. The Beam Properties palette in a QGroupBox named as such, that way it is clear what those 4 cells are.
3. The Reset button and the Beam Properties now share the same horizontal layout space.