### PR TITLE
fix #174831 simplify note group UI's mini score

### DIFF
--- a/mscore/noteGroups.cpp
+++ b/mscore/noteGroups.cpp
@@ -31,20 +31,19 @@ Score* NoteGroups::createScore(int n, TDuration::DurationType t, std::vector<Cho
       {
       MCursor c;
       c.setTimeSig(_sig);
-      c.createScore("score8");
+      c.createScore("");
       c.addPart("voice");
       c.move(0, 0);
       c.addKeySig(Key::C);
-      TimeSig* nts = c.addTimeSig(_sig);
       GroupNode node {0, 0};
       Groups ng;
       ng.push_back(node);
-      nts->setGroups(ng);
 
       for (int i = 0; i < n; ++i) {
-            Chord* chord = c.addChord(67, t);
+            Chord* chord = c.addChord(77, t);
             int tick = chord->rtick();
             chord->setBeamMode(_groups.beamMode(tick, t));
+            chord->setStemDirection(Direction::UP);
             chords->push_back(chord);
             }
       c.score()->style().set(StyleIdx::pageEvenLeftMargin, 0.0);
@@ -54,6 +53,11 @@ Score* NoteGroups::createScore(int n, TDuration::DurationType t, std::vector<Cho
       c.score()->style().set(StyleIdx::linearStretch, 1.3);
       c.score()->style().set(StyleIdx::MusicalSymbolFont, QString("Bravura"));
       c.score()->style().set(StyleIdx::MusicalTextFont, QString("Bravura Text"));
+      c.score()->style().set(StyleIdx::startBarlineSingle, true);
+
+      c.score()->staff(0)->setLines(0, 1); // single line only
+      c.score()->staff(0)->staffType(0)->setGenClef(false); // no clef
+
       return c.score();
       }
 

--- a/mscore/timedialog.h
+++ b/mscore/timedialog.h
@@ -34,7 +34,6 @@ class TimeDialog : public QWidget, Ui::TimeDialogBase {
       PaletteScrollArea* _timePalette;
       Palette* sp;
       bool _dirty;
-      TimeSig* timesig;
 
       int denominator() const;
       int denominator2Idx(int) const;


### PR DESCRIPTION
Previously included a clef, even though clef is irrelevant for this UI, and would not reflect the clef of the time sig's staff anyway, so I've removed.

Previously included an explicit time signature, but that time sig never reflected the designated symbol or custom text for num/denom, so I've removed that time sig for simplity from this UI.

Previously had 5-staff line, but since only dealing with beam properties, pitches are irrelevant, so 1-staff is sufficient.