### PR TITLE
(work in progress) fix #174831 supplemental: set expanding & remove Spacer

### DIFF
--- a/mscore/note_groups.ui
+++ b/mscore/note_groups.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>680</width>
+    <width>704</width>
     <height>255</height>
    </rect>
   </property>
@@ -124,6 +124,12 @@
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="resetGroups">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="toolTip">
         <string>Reset note grouping</string>
        </property>
@@ -133,22 +139,9 @@
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox">
+      <widget class="QGroupBox" name="beamPropertiesGroupBox">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -173,20 +166,20 @@
          <rect>
           <x>10</x>
           <y>30</y>
-          <width>114</width>
+          <width>571</width>
           <height>40</height>
          </rect>
         </property>
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
         <property name="minimumSize">
          <size>
-          <width>0</width>
-          <height>0</height>
+          <width>114</width>
+          <height>40</height>
          </size>
         </property>
        </widget>


### PR DESCRIPTION
For the Note Group UI, I've:
1. removed the spacer and set the Reset button width to fixed, so now the Beam Properties QGroupBox will take up all the horizontal space.
2. set the horizontal size for the Palette to be much larger than necessary to prevent glitches like lasconic experienced in his mac running 2.1dev.

When Time Signature Properties is opened, now looks like:

![screenshot 149](https://cloud.githubusercontent.com/assets/6502474/23103286/ff1d1fc2-f686-11e6-8021-9ab09ba7d0e6.png)

At minimum width looks like (unfortunately have the empty palette cells cutoff in middle):

![screenshot 150](https://cloud.githubusercontent.com/assets/6502474/23103303/40388438-f687-11e6-989f-78d0c2eb1d80.png)

At very large width unfortunately can see empty space the to right of the palette.  (I couldn't figure out how to get that palette to be expanding horizontally inside that QGroupBox, event though they are both set to expanding horizontally):

![screenshot 151](https://cloud.githubusercontent.com/assets/6502474/23103307/5bbcdf38-f687-11e6-93c0-f6033e9f3936.png)

and the UI when inside Master Palette editor with minimum width:

![screenshot 153](https://cloud.githubusercontent.com/assets/6502474/23103325/b8c0472e-f687-11e6-82c7-1b5ad3361d3b.png)

This is the best I can do at the moment.  I was trying to figure out a way for the palette to give a proper width hint and then not draw the extra cells, but I couldn't get that to work.  So this is a fallback I'm submitting now before I got to sleep.  I still want to rather figure out a good way for the palette to know to resize to minimum width, but I think I'm going to have to study the qt documentation for that.