### PR TITLE
fix #152506: Introduce a time signature in a measure which the Actual…

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -766,7 +766,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                   fm = s ? 0 : fm->nextMeasure();
                   }
             else {
-                  if (sigmap()->timesig(seg->tick()).timesig().identical(ns)) {
+                  if (sigmap()->timesig(seg->tick()).nominal().identical(ns)) {
                         // no change to global time signature,
                         // but we need to rewrite any staves with local time signatures
                         for (int i = 0; i < nstaves(); ++i) {


### PR DESCRIPTION
… duration is exactly identical leads to corruption/crash