### PR TITLE
fix #175031: selectable palette in Note Group UI.

### DIFF
--- a/libmscore/mscoreview.cpp
+++ b/libmscore/mscoreview.cpp
@@ -13,6 +13,7 @@
 #include "mscoreview.h"
 #include "score.h"
 #include "page.h"
+#include "measure.h"
 
 namespace Ms {
 
@@ -77,6 +78,41 @@ const QList<Element*> MuseScoreView::elementsAt(const QPointF& p)
       return el;
       }
 
+//---------------------------------------------------------
+//   horizontallyNearestChordRestSegment
+//    p is in canvas coordinates
+//---------------------------------------------------------
+
+Segment* MuseScoreView::horizontallyNearestChordRestSegment(const QPointF& p)
+      {
+      Segment* chordRest = 0;
+      Page* page = point2page(p);
+      if (page) {
+            qreal pointHoizontalPosRelativeToPage = p.x() - page->pos().x();
+
+            Measure* m = page->searchMeasure(p);
+            if (m) {
+                  chordRest = m->segments().firstCRSegment();
+                  if (chordRest) {
+                        qreal chordRestDX = pointHoizontalPosRelativeToPage - (chordRest->x() + chordRest->bbox().center().x());
+                        Segment *nextChordRest = chordRest->nextCR();
+                        while (nextChordRest) {
+                              qreal nextChordRestDX = pointHoizontalPosRelativeToPage - (nextChordRest->x() + nextChordRest->bbox().center().x());
+                              if (nextChordRestDX < 0) {
+                                    // now need to compare distance to the chordrest on the left vs to the chordrest on the right
+                                    if (-nextChordRestDX < chordRestDX)
+                                          chordRest = nextChordRest;
+                                    break;
+                                    }
+                              chordRestDX = nextChordRestDX;
+                              chordRest = nextChordRest;
+                              nextChordRest = chordRest->nextCR();
+                              }
+                        }
+                  }
+            }
+      return chordRest;
+      }
 
 }
 

--- a/libmscore/mscoreview.h
+++ b/libmscore/mscoreview.h
@@ -18,6 +18,7 @@ namespace Ms {
 class Element;
 class Score;
 class Note;
+class Segment;
 class Page;
 enum class Grip : int;
 enum class HairpinType : char;
@@ -36,6 +37,7 @@ class MuseScoreView {
       Page* point2page(const QPointF&);
       Element* elementAt(const QPointF& p);
       const QList<Element*> elementsAt(const QPointF&);
+      Segment* horizontallyNearestChordRestSegment(const QPointF&);
       virtual Element* elementNear(QPointF) { return 0; }
 
       virtual void layoutChanged() {}

--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -392,6 +392,20 @@ void ExampleView::mousePressEvent(QMouseEvent* event)
                   break;
                   }
             }
+
+      Segment* s = horizontallyNearestChordRestSegment(pos);
+      if (s)
+            emit horizontallyNearestChordRestSegmentClicked(s);
+      }
+
+//---------------------------------------------------------
+//   mouseMoveEvent
+//---------------------------------------------------------
+
+void ExampleView::mouseMoveEvent(QMouseEvent* event)
+      {
+      QPointF pos(imatrix.map(QPointF(event->pos())));
+      emit horizontallyNearestChordRestSegmentMouseOver(horizontallyNearestChordRestSegment(pos));
       }
 
 //---------------------------------------------------------

--- a/mscore/exampleview.h
+++ b/mscore/exampleview.h
@@ -51,10 +51,13 @@ class ExampleView : public QFrame, public MuseScoreView {
       virtual void dragMoveEvent(QDragMoveEvent*);
       virtual void dropEvent(QDropEvent*);
       virtual void mousePressEvent(QMouseEvent*);
+      virtual void mouseMoveEvent(QMouseEvent*);
       virtual QSize sizeHint() const;
 
    signals:
       void noteClicked(Note*);
+      void horizontallyNearestChordRestSegmentClicked(Segment*);
+      void horizontallyNearestChordRestSegmentMouseOver(Segment*);
       void beamPropertyDropped(Chord*, Icon*);
 
    public:

--- a/mscore/noteGroups.h
+++ b/mscore/noteGroups.h
@@ -40,7 +40,7 @@ class NoteGroups : public QGroupBox, Ui::NoteGroups {
 
    private slots:
       void resetClicked();
-      void noteClicked(Note*);
+      void horizontallyNearestChordRestSegmentClicked(Segment*);
       void beamPropertyDropped(Chord*, Icon*);
 
    public:

--- a/mscore/note_groups.ui
+++ b/mscore/note_groups.ui
@@ -32,71 +32,7 @@
      <property name="verticalSpacing">
       <number>6</number>
      </property>
-     <item row="1" column="0" colspan="2">
-      <widget class="QLabel" name="label_10">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>1/16</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="Ms::ExampleView" name="view16">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
-       </property>
-       <property name="lineWidth">
-        <number>2</number>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0" colspan="2">
-      <widget class="QLabel" name="label_11">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>1/32</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="Ms::ExampleView" name="view32">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
-       </property>
-       <property name="lineWidth">
-        <number>2</number>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
+     <item row="0" column="0">
       <widget class="Ms::ExampleView" name="view8">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
@@ -115,16 +51,41 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0" colspan="2">
-      <widget class="QLabel" name="label_9">
+     <item row="1" column="0">
+      <widget class="Ms::ExampleView" name="view16">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="text">
-        <string>1/8</string>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <property name="lineWidth">
+        <number>2</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="Ms::ExampleView" name="view32">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <property name="lineWidth">
+        <number>2</number>
        </property>
       </widget>
      </item>
@@ -141,19 +102,6 @@
         <string>Reset</string>
        </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
      </item>
      <item>
       <widget class="QGroupBox" name="groupBox">
@@ -176,7 +124,7 @@
         </size>
        </property>
        <property name="title">
-        <string>Beam Properties</string>
+        <string>Beam Property Selector</string>
        </property>
        <widget class="Ms::Palette" name="iconPalette" native="true">
         <property name="geometry">
@@ -201,6 +149,19 @@
         </property>
        </widget>
       </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
Clicking notes toggles between palette's currently selected beam mode and auto.
Initial default selected beam mode is BEGIN, which will keep default behavior similar behavior prior to this commit.