### PR TITLE
fix #85631: Range select -> Notes button in Inspector includes grace...

### DIFF
--- a/mscore/inspector/inspectorGroupElement.cpp
+++ b/mscore/inspector/inspectorGroupElement.cpp
@@ -13,6 +13,7 @@
 
 #include "libmscore/score.h"
 #include "libmscore/element.h"
+#include "libmscore/chord.h"
 #include "inspector.h"
 #include "inspectorGroupElement.h"
 
@@ -54,6 +55,11 @@ InspectorGroupElement::InspectorGroupElement(QWidget* parent)
       notes->setEnabled(true);
       hbox->addWidget(notes);
 
+      graceNotes = new QToolButton(this);
+      graceNotes->setText(tr("Grace Notes"));
+      graceNotes->setEnabled(true);
+      hbox->addWidget(graceNotes);
+
       rests = new QToolButton(this);
       rests->setText(tr("Rests"));
       rests->setEnabled(true);
@@ -61,6 +67,7 @@ InspectorGroupElement::InspectorGroupElement(QWidget* parent)
 
       _layout->addLayout(hbox);
       connect(notes, SIGNAL(clicked()), SLOT(notesClicked()));
+      connect(graceNotes, SIGNAL(clicked()), SLOT(graceNotesClicked()));
       connect(rests, SIGNAL(clicked()), SLOT(restsClicked()));
       }
 
@@ -127,8 +134,36 @@ void InspectorGroupElement::notesClicked()
       score->deselectAll();
       for (Element* e : el) {
             if (e->type() == Element::Type::NOTE) {
-                  nel.append(e);
-                  score->selection().add(e);
+                  Note* note = static_cast<Note*>(e);
+                  //if note is not grace note, then add to selection
+                  if (!note->chord()->isGrace()) {
+                        nel.append(note);
+                        score->selection().add(note);
+                        }
+                  }
+            }
+      inspector->setElements(nel);
+      score->update();
+      }
+
+//---------------------------------------------------------
+//   graceNotesClicked
+//---------------------------------------------------------
+
+void InspectorGroupElement::graceNotesClicked()
+      {
+      Score* score = inspector->el().front()->score();
+      QList<Element*> el = score->selection().elements();
+      QList<Element*> nel;
+      score->deselectAll();
+      for (Element* e : el) {
+            if (e->type() == Element::Type::NOTE) {
+                  Note* note = static_cast<Note*>(e);
+                  //if note is grace note, then add to selection
+                  if (note->chord()->isGrace()) {
+                        nel.append(note);
+                        score->selection().add(note);
+                        }
                   }
             }
       inspector->setElements(nel);

--- a/mscore/inspector/inspectorGroupElement.h
+++ b/mscore/inspector/inspectorGroupElement.h
@@ -28,6 +28,7 @@ class InspectorGroupElement : public InspectorBase {
 
       Ui::InspectorGroupElement ge;
       QToolButton* notes;
+      QToolButton* graceNotes;
       QToolButton* rests;
 
    private slots:
@@ -35,6 +36,7 @@ class InspectorGroupElement : public InspectorBase {
       void setVisible();
       void setInvisible();
       void notesClicked();
+      void graceNotesClicked();
       void restsClicked();
 
    public:


### PR DESCRIPTION
...notes in list selection, disabling Inspector

Backport of 3b3d74b, PR #2672, to the 2.1 branch