### PR TITLE
[backport to 2.1 branch] fix #84421 note_groups.ui 'Also change shorter notes' checkbox

### DIFF
--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -323,6 +323,7 @@ void ExampleView::dropEvent(QDropEvent* event)
             if (e->type() == Element::Type::NOTE) {
                   Icon* icon = static_cast<Icon*>(dragElement);
                   Chord* chord = static_cast<Note*>(e)->chord();
+                  emit beamPropertyDropped(chord, icon);
                   switch (icon->iconType()) {
                         case IconType::SBEAM:
                               chord->setBeamMode(Beam::Mode::BEGIN);

--- a/mscore/exampleview.h
+++ b/mscore/exampleview.h
@@ -20,6 +20,8 @@ namespace Ms {
 class Element;
 class Score;
 class Note;
+class Chord;
+class Icon;
 enum class Grip : signed char;
 
 //---------------------------------------------------------
@@ -55,6 +57,7 @@ class ExampleView : public QFrame, public MuseScoreView {
 
    signals:
       void noteClicked(Note*);
+      void beamPropertyDropped(Chord*, Icon*);
 
    public:
       ExampleView(QWidget* parent = 0);

--- a/mscore/noteGroups.cpp
+++ b/mscore/noteGroups.cpp
@@ -17,6 +17,7 @@
 #include "libmscore/score.h"
 #include "libmscore/part.h"
 #include "libmscore/key.h"
+#include "libmscore/icon.h"
 #include "musescore.h"
 
 namespace Ms {
@@ -82,6 +83,9 @@ NoteGroups::NoteGroups(QWidget* parent)
       connect(view8,  SIGNAL(noteClicked(Note*)), SLOT(noteClicked(Note*)));
       connect(view16, SIGNAL(noteClicked(Note*)), SLOT(noteClicked(Note*)));
       connect(view32, SIGNAL(noteClicked(Note*)), SLOT(noteClicked(Note*)));
+      connect(view8,  SIGNAL(beamPropertyDropped(Chord*,Icon*)), SLOT(beamPropertyDropped(Chord*,Icon*)));
+      connect(view16, SIGNAL(beamPropertyDropped(Chord*,Icon*)), SLOT(beamPropertyDropped(Chord*,Icon*)));
+      connect(view32, SIGNAL(beamPropertyDropped(Chord*,Icon*)), SLOT(beamPropertyDropped(Chord*,Icon*)));
       }
 
 //---------------------------------------------------------
@@ -133,20 +137,89 @@ void NoteGroups::resetClicked()
       }
 
 //---------------------------------------------------------
-//   note8Clicked
+//   noteClicked
 //---------------------------------------------------------
 
 void NoteGroups::noteClicked(Note* note)
       {
       Chord* chord = note->chord();
       if (chord->beamMode() == Beam::Mode::AUTO)
-            chord->setBeamMode(Beam::Mode::BEGIN);
+            updateBeams(chord, Beam::Mode::BEGIN);
       else if (chord->beamMode() == Beam::Mode::BEGIN)
-            chord->setBeamMode(Beam::Mode::AUTO);
+            updateBeams(chord, Beam::Mode::AUTO);
+      }
+
+//---------------------------------------------------------
+//   beamPropertyDropped
+//---------------------------------------------------------
+
+void NoteGroups::beamPropertyDropped(Chord* chord, Icon* icon)
+      {
+      switch (icon->iconType()) {
+            case IconType::SBEAM:
+                  updateBeams(chord, Beam::Mode::BEGIN);
+                  break;
+            case IconType::MBEAM:
+                  updateBeams(chord, Beam::Mode::AUTO);
+                  break;
+            case IconType::BEAM32:
+                  updateBeams(chord, Beam::Mode::BEGIN32);
+                  break;
+            case IconType::BEAM64:
+                  updateBeams(chord, Beam::Mode::BEGIN64);
+                  break;
+            default:
+                  break;
+            }
+      }
+
+//---------------------------------------------------------
+//   updateBeams
+//     takes into account current state of changeShorterCheckBox to update smaller valued notes as well
+//---------------------------------------------------------
+
+void NoteGroups::updateBeams(Chord* chord, Beam::Mode m)
+      {
+      chord->setBeamMode(m);
       chord->score()->doLayout();
+
+      if (changeShorterCheckBox->checkState() == Qt::Checked) {
+            int tick = chord->tick();
+            bool foundChord = false;
+            for (Chord* c : chords8) {
+                  if (c == chord) {
+                        foundChord = true;
+                        break;
+                        }
+                  }
+            for (Chord* c : chords16) {
+                  if (foundChord) {
+                        if (c->tick() == tick) {
+                              c->setBeamMode(m);
+                              c->score()->doLayout();
+                              break;
+                              }
+                        }
+                  else if (c == chord) {
+                        foundChord = true;
+                        break;
+                        }
+                  }
+            for (Chord* c : chords32) {
+                  if (foundChord) {
+                        if (c->tick() == tick) {
+                              c->setBeamMode(m);
+                              c->score()->doLayout();
+                              break;
+                              }
+                        }
+                  }
+            }
+
       view8->update();
       view16->update();
       view32->update();
       }
+
 }
 

--- a/mscore/noteGroups.h
+++ b/mscore/noteGroups.h
@@ -36,10 +36,12 @@ class NoteGroups : public QGroupBox, Ui::NoteGroups {
       Fraction _sig;
 
       Score* createScore(int n, TDuration::DurationType t, std::vector<Chord*>* chords);
+      void updateBeams(Chord*, Beam::Mode);
 
    private slots:
       void resetClicked();
       void noteClicked(Note*);
+      void beamPropertyDropped(Chord*, Icon*);
 
    public:
       NoteGroups(QWidget* parent);

--- a/mscore/note_groups.ui
+++ b/mscore/note_groups.ui
@@ -18,6 +18,16 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QCheckBox" name="changeShorterCheckBox">
+     <property name="text">
+      <string>Also change shorter notes</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout">
      <property name="verticalSpacing">
       <number>6</number>


### PR DESCRIPTION
If enabled, then also update the beam properties for shorter duration notes at the same tick when dropping a beam property from palette or when clicking on a note.