### PR TITLE
fix #176151 MultiByte char TextBlock::remove()

### DIFF
--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -568,15 +568,16 @@ void TextBlock::remove(int column)
             int rcol = 0;
             for (const QChar& c : i->text) {
                   if (col == column) {
-                        if (c.isSurrogate())
-                              i->text.remove(rcol, 2);
                         if (i->format.type() == CharFormatType::SYMBOL) {
                               i->ids.removeAt(idx);
                               if (i->ids.empty())
                                     _text.erase(i);
                               }
-                        else {
-                              i->text.remove(rcol, 1);
+                        else {                              
+                              if (c.isSurrogate())
+                                    i->text.remove(idx, 2);
+                              else
+                                    i->text.remove(idx, 1);
                               if (i->text.isEmpty())
                                     _text.erase(i);
                               }

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -112,7 +112,7 @@ class TextFragment {
 
    public:
       mutable CharFormat format;
-      QPointF pos;                  // y is relativ to TextBlock->y()
+      QPointF pos;                  // y is relative to TextBlock->y()
 
       mutable QString text;
       QList<SymId> ids;


### PR DESCRIPTION
Previously TextBlock::remove() did not delete Supplementary Multilingual Plane Unicode chars correctly.

Added tests using deletePreviousChar() for SMP Unicode as well as regular BMP Unicode as well as for text that has mixed BMP, SMP, and SMUFL symbols.