### PR TITLE
fix #176601 unicode insert Upper & Lower Surrogates simultaneously

### DIFF
--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -125,6 +125,7 @@ TextFragment::TextFragment(TextCursor* cursor, SymId id)
 TextFragment::TextFragment(TextCursor* cursor, const QString& s)
       {
       format = *cursor->format();
+      format.setType(CharFormatType::TEXT);
       text = s;
       }
 
@@ -455,8 +456,8 @@ int TextBlock::column(qreal x, Text* t) const
 
 void TextBlock::insert(TextCursor* cursor, const QString& s)
       {
-      int rcol;
-      auto i = fragment(cursor->column(), &rcol);
+      int rcol, ridx;
+      auto i = fragment(cursor->column(), &rcol, &ridx);
       if (i != _text.end()) {
             if (i->format.type() == CharFormatType::TEXT) {
                   if (!(i->format == *cursor->format())) {
@@ -469,7 +470,7 @@ void TextBlock::insert(TextCursor* cursor, const QString& s)
                               }
                         }
                   else
-                        i->text.insert(rcol, s);
+                        i->text.insert(ridx, s);
                   }
             else {
                   if (rcol == 0) {
@@ -488,7 +489,7 @@ void TextBlock::insert(TextCursor* cursor, const QString& s)
                   }
             }
       else {
-            if (!_text.empty() && _text.back().format == *cursor->format())
+            if (!_text.empty() && _text.back().format.type() == CharFormatType::TEXT)
                   _text.back().text.append(s);
             else
                   _text.append(TextFragment(cursor, s));
@@ -497,8 +498,8 @@ void TextBlock::insert(TextCursor* cursor, const QString& s)
 
 void TextBlock::insert(TextCursor* cursor, SymId id)
       {
-      int rcol;
-      auto i = fragment(cursor->column(), &rcol);
+      int rcol, ridx;
+      auto i = fragment(cursor->column(), &rcol, &ridx);
       if (i != _text.end()) {
             if (i->format.type() == CharFormatType::SYMBOL) {
                   if (!(i->format == *cursor->format())) {
@@ -537,16 +538,24 @@ void TextBlock::insert(TextCursor* cursor, SymId id)
 
 //---------------------------------------------------------
 //   fragment
+//    inputs:
+//      column is the column relative to the start of the TextBlock.
+//    outputs:
+//      rcol will be the column relative to the start of the TextFragment that the input column is in.
+//      ridx will be the QChar index into TextFragment's text QString relative to the start of that TextFragment.
+//
 //---------------------------------------------------------
 
-QList<TextFragment>::iterator TextBlock::fragment(int column, int* rcol)
+QList<TextFragment>::iterator TextBlock::fragment(int column, int* rcol, int* ridx)
       {
       int col = 0;
       for (auto i = _text.begin(); i != _text.end(); ++i) {
             *rcol = 0;
+            *ridx = 0;
             for (const QChar& c : i->text) {
                   if (col == column)
                         return i;
+                  ++*ridx;
                   if (c.isHighSurrogate())
                         continue;
                   ++col;
@@ -630,17 +639,18 @@ QString TextBlock::remove(int start, int n)
       int col = 0;
       QString s;
       for (auto i = _text.begin(); i != _text.end();) {
-            int idx  = 0;
             int rcol = 0;
             bool inc = true;
-            foreach (const QChar& c, i->text) {       // iterate on copy of i->text
+            for( int idx = 0; idx < i->text.length(); ) {
+                  QChar c = i->text[idx];
                   if (col == start) {
-                        if (c.isSurrogate()) {
+                        if (c.isHighSurrogate()) {
                               s += c;
-                              i->text.remove(rcol, 1);
+                              i->text.remove(idx, 1);
+                              c = i->text[idx];
                               }
                         s += c;
-                        i->text.remove(rcol, 1);
+                        i->text.remove(idx, 1);
                         if (i->format.type() == CharFormatType::SYMBOL)
                               i->ids.removeAt(idx);
                         if (i->text.isEmpty() && (_text.size() > 1)) {
@@ -811,11 +821,10 @@ QString TextBlock::text(int col1, int len) const
                   continue;
             if (f.format.type() == CharFormatType::TEXT) {
                   for (const QChar& c : f.text) {
-                        if (c.isHighSurrogate())
-                              continue;
                         if (col >= col1 && (len < 0 || ((col-col1) < len)))
                               s += XmlWriter::xmlString(c.unicode());
-                        ++col;
+                        if (!c.isHighSurrogate())
+                              ++col;
                         }
                   }
             else {
@@ -1084,6 +1093,24 @@ QColor Text::frameColor() const
 
 //---------------------------------------------------------
 //   insert
+//     version for Supplementary Unicode, which must be inputted together as a pair
+//---------------------------------------------------------
+
+void Text::insert(TextCursor* cursor, QChar highSurrogate, QChar lowSurrogate)
+      {
+      if (cursor->hasSelection())
+            deleteSelectedText();
+      if (cursor->line() >= _layout.size())
+            _layout.append(TextBlock());
+      QString surrogatePair = QString(highSurrogate).append(lowSurrogate);
+      _layout[cursor->line()].insert(cursor, surrogatePair);
+      cursor->setColumn(cursor->column() + 1);
+      cursor->clearSelection();
+      }
+
+//---------------------------------------------------------
+//   insert
+//     version for Basic Unicode
 //---------------------------------------------------------
 
 void Text::insert(TextCursor* cursor, QChar c)
@@ -1107,6 +1134,11 @@ void Text::insert(TextCursor* cursor, QChar c)
             }
       cursor->clearSelection();
       }
+
+//---------------------------------------------------------
+//   insert
+//     version for SMUFL symbols
+//---------------------------------------------------------
 
 void Text::insert(TextCursor* cursor, SymId id)
       {
@@ -1158,7 +1190,8 @@ void Text::createLayout()
       QString token;
       QString sym;
       bool symState = false;
-      for (const QChar& c : _text) {
+      for (int i = 0; i < _text.length(); i++) {
+            const QChar& c = _text[i];
             if (state == 0) {
                   if (c == '<') {
                         state = 1;
@@ -1171,8 +1204,17 @@ void Text::createLayout()
                   else {
                         if (symState)
                               sym += c;
-                        else
-                              insert(&cursor, c);
+                        else {
+                              if (c.isHighSurrogate()) {
+                                    const QChar& highSurrogate = c;
+                                    i++;
+                                    Q_ASSERT(i < _text.length());
+                                    const QChar& lowSurrogate = _text[i];
+                                    insert(&cursor, highSurrogate, lowSurrogate);
+                                    }
+                              else
+                                    insert(&cursor, c);
+                              }
                         }
                   }
             else if (state == 1) {
@@ -2458,7 +2500,8 @@ void Text::paste()
       QString sym;
       bool symState = false;
 
-      for (const QChar& c : txt) {
+      for (int i = 0; i < txt.length(); i++ ) {
+            QChar c = txt[i];
             if (state == 0) {
                   if (c == '<') {
                         state = 1;
@@ -2471,8 +2514,18 @@ void Text::paste()
                   else {
                         if (symState)
                               sym += c;
-                        else
-                              insert(_cursor, c);
+                        else {
+                              if (c.isHighSurrogate()) {
+                                    QChar highSurrogate = c;
+                                    Q_ASSERT(i + 1 < txt.length());
+                                    i++;
+                                    QChar lowSurrogate = txt[i];
+                                    insert(_cursor, highSurrogate, lowSurrogate);
+                                    }
+                              else {
+                                    insert(_cursor, c);
+                                    }
+                              }
                         }
                   }
             else if (state == 1) {
@@ -2605,12 +2658,8 @@ Element* Text::drop(const DropData& data)
                   delete e;
 
                   if (_editMode) {
-                        if (code & 0xffff0000) {
-                              insert(_cursor, QChar::highSurrogate(code));
-                              insert(_cursor, QChar::lowSurrogate(code));
-                              _cursor->setColumn(_cursor->column() - 1);
-                              _cursor->setSelectColumn(_cursor->column());
-                              }
+                        if (code & 0xffff0000)
+                              insert(_cursor, QChar::highSurrogate(code),  QChar::lowSurrogate(code));
                         else
                               insert(_cursor, QChar(code));
                         layout1();

--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -164,7 +164,7 @@ class TextBlock {
       qreal xpos(int col, const Text*) const;
       const CharFormat* formatAt(int) const;
       const TextFragment* fragment(int col) const;
-      QList<TextFragment>::iterator fragment(int col, int* rcol);
+      QList<TextFragment>::iterator fragment(int column, int* rcol, int* ridx);
       qreal y() const      { return _y; }
       void setY(qreal val) { _y = val; }
       qreal lineSpacing() const { return _lineSpacing; }
@@ -229,6 +229,7 @@ class Text : public Element {
       TextBlock& curLine();
       void drawSelection(QPainter*, const QRectF&) const;
 
+      void insert(TextCursor*, QChar, QChar);
       void insert(TextCursor*, QChar);
       void insert(TextCursor*, SymId);
       void updateCursorFormat(TextCursor*);

--- a/mtest/libmscore/text/tst_text.cpp
+++ b/mtest/libmscore/text/tst_text.cpp
@@ -38,9 +38,16 @@ class TestText : public QObject, public MTest
       void testCompatibility();
       void testDelete();
       void testReadWrite();
-      void testBMPDeletePreviousChar();
-      void testSMPDeletePreviousChar();
+      void testBasicUnicodeDeletePreviousChar();
+      void testSupplementaryUnicodeDeletePreviousChar();
       void testMixedTypesDeletePreviousChar();
+      void testSupplementaryUnicodeInsert1();
+      void testSupplementaryUnicodeInsert2();
+      void testSupplementaryUnicodePaste();
+      void testRightToLeftWithSupplementaryUnicode();
+      void testPasteSymbolAndSupplemental();
+      void testMixedSelectionDelete();
+      void testChineseBasicSupplemental();
       };
 
 //---------------------------------------------------------
@@ -432,11 +439,11 @@ void TestText::testReadWrite() {
 }
 
 //---------------------------------------------------------
-///   testBMPDeletePreviousChar
-///    text contains Basic Multilingual Plane unicode symobls
+///   testBasicUnicodeDeletePreviousChar
+///    text contains Basic Unicode symobls
 //---------------------------------------------------------
 
-void TestText::testBMPDeletePreviousChar()
+void TestText::testBasicUnicodeDeletePreviousChar()
       {
       Text* text = new Text(score);
       text->initSubStyle(SubStyle::DYNAMICS);
@@ -453,11 +460,11 @@ void TestText::testBMPDeletePreviousChar()
       }
 
 //---------------------------------------------------------
-///   testSMPDeletePreviousChar
-///    text contains Supplementary Multilingual Plane unicode symbols (https://en.wikipedia.org/wiki/Plane_(Unicode)#Supplementary_Multilingual_Plane) which store chars in pairs
+///   testSupplementaryUnicodeDeletePreviousChar
+///    text contains Supplementary Unicode symbols which store chars in pairs
 //---------------------------------------------------------
 
-void TestText::testSMPDeletePreviousChar()
+void TestText::testSupplementaryUnicodeDeletePreviousChar()
       {
       Text* text = new Text(score);
       text->initSubStyle(SubStyle::DYNAMICS);
@@ -497,8 +504,243 @@ void TestText::testMixedTypesDeletePreviousChar()
       QCOMPARE(text->xmlText(), QString("<sym>cClefSquare</sym>𝄆<sym>repeatLeft</sym><sym>textBlackNoteLongStem</sym><sym>textBlackNoteLongStem</sym>"));
       }
 
+//---------------------------------------------------------
+///   testSupplementaryUnicodeInsert1
+///    Insert a Supplementary Multilingual Plane unicode symbol behind another one.
+//---------------------------------------------------------
+
+void TestText::testSupplementaryUnicodeInsert1()
+      {
+      Text* text = new Text(score);
+      text->initSubStyle(SubStyle::DYNAMICS);
+      text->setPlainText(QString("𝄏"));
+      text->layout();
+      text->startEdit(0, QPoint());
+      text->moveCursorToStart();
+      text->insertText(QString("𝄆"));
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("𝄆𝄏"));
+      }
+
+//---------------------------------------------------------
+///   testSupplementaryUnicodeInsert2
+///    Insert a Supplementary Multilingual Plane unicode symbol behind another one.
+//---------------------------------------------------------
+
+void TestText::testSupplementaryUnicodeInsert2()
+      {
+      Text* text = new Text(score);
+      text->initSubStyle(SubStyle::DYNAMICS);
+      text->layout();
+      text->startEdit(0, QPoint());
+      text->moveCursorToStart();
+      text->insertText(QString("𝄏"));
+      text->moveCursorToStart();
+      text->insertText(QString("𝄆"));
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("𝄆𝄏"));
+      }
+
+//---------------------------------------------------------
+///   testSupplementaryUnicodePaste
+///    Paste a Supplementary Plane unicode symbols.
+//---------------------------------------------------------
+
+void TestText::testSupplementaryUnicodePaste()
+      {
+      Text* text = new Text(score);
+      text->initSubStyle(SubStyle::DYNAMICS);
+      text->setPlainText(QString(""));
+      text->layout();
+
+      QApplication::clipboard()->setText(QString("𝄏"));
+
+      text->startEdit(0, QPoint());
+      text->moveCursorToStart();
+      text->paste();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("𝄏"));
+
+      text->startEdit(0, QPoint());
+      text->moveCursorToStart();
+      text->paste();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("𝄏𝄏"));
+
+      text->startEdit(0, QPoint());
+      text->moveCursorToEnd();
+      text->paste();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("𝄏𝄏𝄏"));
+      }
+
+//---------------------------------------------------------
+///   testRightToLeftWithSupplementaryUnicode
+//---------------------------------------------------------
+
+void TestText::testRightToLeftWithSupplementaryUnicode()
+      {
+      Text* text = new Text(score);
+      text->initSubStyle(SubStyle::DYNAMICS);
+      text->setPlainText(QString(""));
+      text->layout();
+
+      text->startEdit(0, QPoint());
+      text->moveCursorToStart();
+      text->insertText(QString("𝄆"));
+      text->insertText(QString("م"));
+      text->insertText(QString("و"));
+      text->insertText(QString("س"));
+      text->insertText(QString("ي"));
+      text->insertText(QString("ق"));
+      text->insertText(QString("ى"));
+      text->insertText(QString("𝄇"));
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("𝄆موسيقى𝄇"));
+
+      text->startEdit(0, QPoint());
+      text->cursor()->setColumn(1);
+      text->deletePreviousChar();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("موسيقى𝄇"));
+
+      text->startEdit(0, QPoint());
+      text->cursor()->setColumn(5);
+      text->deleteChar();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("موسيق𝄇"));
+      }
+
+//---------------------------------------------------------
+///   testPasteSymbolAndSupplemental
+//---------------------------------------------------------
+
+void TestText::testPasteSymbolAndSupplemental()
+      {
+      Text* text = new Text(score);
+      text->initSubStyle(SubStyle::DYNAMICS);
+      text->setPlainText(QString(""));
+      text->layout();
+
+      QApplication::clipboard()->setText(QString("<sym>gClef</sym>𝄎"));
+
+      text->startEdit(0, QPoint());
+      text->moveCursorToStart();
+      text->paste();
+      text->endEdit();
+      QVERIFY(text->fragmentList()[0].format.type() == CharFormatType::SYMBOL);
+      QVERIFY(text->fragmentList()[1].format.type() == CharFormatType::TEXT);
+      QCOMPARE(text->xmlText(), QString("<sym>gClef</sym>𝄎"));
+
+      text->startEdit(0, QPoint());
+      text->moveCursorToStart();
+      text->insertText(QString("𝄎"));
+      text->endEdit();
+      QVERIFY(text->fragmentList()[0].format.type() == CharFormatType::TEXT);
+      QVERIFY(text->fragmentList()[1].format.type() == CharFormatType::SYMBOL);
+      QVERIFY(text->fragmentList()[2].format.type() == CharFormatType::TEXT);
+      QCOMPARE(text->xmlText(), QString("𝄎<sym>gClef</sym>𝄎"));
+      }
+
+//---------------------------------------------------------
+///   testMixedSelectionDelete
+//---------------------------------------------------------
+
+void TestText::testMixedSelectionDelete()
+      {
+      Text* text = new Text(score);
+      text->initSubStyle(SubStyle::DYNAMICS);
+      text->layout();
+      QApplication::clipboard()->setText(QString("[A]𝄎<sym>gClef</sym> 𝄎𝄇"));
+
+      text->startEdit(0, QPoint());
+      text->moveCursorToStart();
+      text->paste();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("[A]𝄎<sym>gClef</sym> 𝄎𝄇"));
+
+      text->startEdit(0, QPoint());
+      text->moveCursorToStart();
+      text->cursor()->setSelectColumn(4);
+      text->cursor()->setColumn(7);
+      text->deleteSelectedText();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("[A]𝄎𝄇"));
+
+      text->startEdit(0, QPoint());
+      text->cursor()->setColumn(4);
+      text->deletePreviousChar();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("[A]𝄇"));
+
+      text->startEdit(0, QPoint());
+      text->moveCursorToEnd();
+      text->insertSym(SymId::segno);
+      text->endEdit();
+      text->insertText(QString("e"));
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("[A]𝄇<sym>segno</sym>e"));
+      }
+
+//---------------------------------------------------------
+///   testChineseBasicSupplemental
+//---------------------------------------------------------
+
+void TestText::testChineseBasicSupplemental()
+      {
+      Text* text = new Text(score);
+      text->initSubStyle(SubStyle::DYNAMICS);
+      text->setPlainText(QString(""));
+      text->layout();
+
+      text->startEdit(0, QPoint());
+      text->moveCursorToStart();
+      text->insertText(QString("你"));  // this is supplemental unicode
+      text->insertText(QString("好"));  // this is basic unicode
+      text->insertText(QString("。"));
+      QApplication::clipboard()->setText(QString("我爱Musescore"));
+      text->paste();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("你好。我爱Musescore"));
+
+      text->startEdit(0, QPoint());
+      QApplication::clipboard()->setText(QString("你屠槪真軔")); // some random supplemental unicode
+      text->moveCursorToStart();
+      text->paste();
+      text->moveCursorToEnd();
+      text->paste();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("你屠槪真軔你好。我爱Musescore你屠槪真軔"));
+
+      text->startEdit(0, QPoint());
+      text->cursor()->setSelectColumn(4);
+      text->cursor()->setColumn(20);
+      text->deleteSelectedText();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("你屠槪真屠槪真軔")); // this is only supplemental
+
+      text->startEdit(0, QPoint());
+      text->cursor()->setColumn(4);
+      text->deleteChar();
+      text->deletePreviousChar();
+      text->endEdit();
+      QCOMPARE(text->xmlText(), QString("你屠槪槪真軔")); // deleted the two chars in the middle
+      }
+
+/*   text->startEdit(0, QPoint());
+   text->moveCursorToEnd();
+   text->insertSym(SymId::segno);
+   text->endEdit();
+   QCOMPARE(text->xmlText(), QString("0123abcde<sym>segno</sym>")); */
+
+//  text->cursor()->setColumn(1); // makes sure recognizes that pasted text was a single symbol occupying only one column
 
 
+/*
+      void setLine(int val)         { _line = val; }
+      void setColumn(int val)       { _column = val; }
+      void setSelectLine(int val)   { _selectLine = val; }
+      void setSelectColumn(int val) { _selectColumn = val; }*/
 
 QTEST_MAIN(TestText)
 


### PR DESCRIPTION
added new version of Text::insert which takes two chars as input, and inserts them together before incrementing the cursor, to prevent bug.