### PR TITLE
Fix #176671: Slash notehead position needs adjusting

### DIFF
--- a/fonts/bravura/metadata.json
+++ b/fonts/bravura/metadata.json
@@ -35051,11 +35051,11 @@
         "noteheadSlashHorizontalEnds": {
             "stemDownNW": [
                 0.0, 
-                -1.0
+                -1.25
             ], 
             "stemUpSE": [
                 2.12, 
-                1.0
+                1.25
             ]
         }, 
         "noteheadSlashHorizontalEndsMuted": {
@@ -35101,11 +35101,11 @@
         "noteheadSlashWhiteHalf": {
             "stemDownNW": [
                 0.0, 
-                -1.0
+                -1.25
             ], 
             "stemUpSE": [
                 3.12, 
-                1.0
+                1.25
             ]
         }, 
         "noteheadSlashWhiteMuted": {

--- a/fonts/mscore/metadata.json
+++ b/fonts/mscore/metadata.json
@@ -1483,11 +1483,11 @@
         "noteheadSlashHorizontalEnds": {
             "stemDownNW": [
                 0.0,
-                -1.0
+                -1.25
             ],
             "stemUpSE": [
                 2.12,
-                1.0
+                1.25
             ]
         },
         "noteheadSlashHorizontalEndsMuted": {
@@ -1533,11 +1533,11 @@
         "noteheadSlashWhiteHalf": {
             "stemDownNW": [
                 0.0,
-                -1.0
+                -1.25
             ],
             "stemUpSE": [
                 3.12,
-                1.0
+                1.25
             ]
         },
         "noteheadSlashWhiteMuted": {

--- a/fonts/musejazz/metadata.json
+++ b/fonts/musejazz/metadata.json
@@ -5231,21 +5231,21 @@
         "noteheadSlashHorizontalEnds": {
             "stemDownNW": [
                 0.0,
-                -0.8
+                -1.0
             ],
             "stemUpSE": [
                 2.152,
-                0.788
+                1.0
             ]
         },
         "noteheadSlashWhiteHalf": {
             "stemDownNW": [
                 0.0,
-                -1.024
+                -1.3
             ],
             "stemUpSE": [
                 3.356,
-                0.932
+                1.2
             ]
         },
         "noteheadTriangleDownBlack": {


### PR DESCRIPTION
3 commits for easy cherry-picking the 1st (for Emmentaler) into 2.2, the 2nd (for Musejazz) into master and possibly ignoring the 3rd (for Bravura, could go into 2.2 and master), 