### PR TITLE
Fix #177216: Changed other dynamic to export text instead of dynTypeName

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -3581,7 +3581,10 @@ void ExportMusicXml::dynamic(Dynamic const* const dyn, int staff)
             xml.tagE(dynTypeName);
             }
       else if (dynTypeName != "") {
-            xml.tag("other-dynamics", dynTypeName);
+            QString dynText = dynTypeName;
+            if (dyn->dynamicType() == Dynamic::Type::OTHER)
+                dynText = dyn->plainText();
+            xml.tag("other-dynamics", dynText);
             }
       xml.etag();
 


### PR DESCRIPTION
Pretty much what the title says, all I did was add a check for if the dynamic is of type "OTHER" and if so, use the text element's text instead of the dynamic type.