### PR TITLE
fix #43681 ScoreView text edit ignore Ctrl/Shift/Alt/Caps for Win Japanese IME

### DIFF
--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -214,6 +214,20 @@ void ScoreView::editKey(QKeyEvent* ev)
                   }
             }
 
+
+#ifdef Q_OS_WIN // Japenese IME on Windows needs to know when Contrl/Alt/Shift/CapsLock is pressed while in predit
+      if (editObject->isText()) {
+            Text* text = static_cast<Text*>(editObject);
+            if (text->cursor()->format()->preedit() && QGuiApplication::inputMethod()->locale().script() == QLocale::JapaneseScript &&
+                ((key == Qt::Key_Control || (modifiers & Qt::ControlModifier)) ||
+                 (key == Qt::Key_Alt || (modifiers & Qt::AltModifier)) ||
+                 (key == Qt::Key_Shift || (modifiers & Qt::ShiftModifier)) ||
+                 (key == Qt::Key_CapsLock))) {
+                  return; // musescore will ignore this key event so that the IME can handle it
+                  }
+            }
+#endif
+
       if (!((modifiers & Qt::ShiftModifier) && (key == Qt::Key_Backtab))) {
             if (editObject->edit(this, curGrip, key, modifiers, s)) {
                   if (editObject->isText())

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1300,6 +1300,9 @@ MuseScore::MuseScore()
       initOsc();
       startAutoSave();
 
+      QInputMethod* im = QGuiApplication::inputMethod();
+      connect(im, SIGNAL(localeChanged()), SLOT(inputMethodLocaleChanged()));
+
       if (enableExperimental) {
             cornerLabel = new QLabel(this);
             cornerLabel->setScaledContents(true);
@@ -2987,6 +2990,15 @@ void MuseScore::clipboardChanged()
       bool flag = true;
       getAction("paste")->setEnabled(flag);
       getAction("swap")->setEnabled(flag);
+      }
+
+//---------------------------------------------------------
+//   inputMethodLocaleChanged
+//---------------------------------------------------------
+
+void MuseScore::inputMethodLocaleChanged()
+      {
+      qDebug("Input method QLocale::Script enum now #%d.", QGuiApplication::inputMethod()->locale().script());
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -472,6 +472,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void removeTab(int);
       void removeTab();
       void clipboardChanged();
+      void inputMethodLocaleChanged();
       void endSearch();
       void saveScoreDialogFilterSelected(const QString&);
 #ifdef OSC


### PR DESCRIPTION
MuseScore ScoreView will ignore these key events, so will propagate upwards to Windows' Input Method to handle, if typing Japanese Script.