### PR TITLE
fix #9352: transpose by range (for 2.1)

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -900,7 +900,7 @@ Element* ChordRest::drop(const DropData& data)
                   {
                   // transpose
                   Harmony* harmony = static_cast<Harmony*>(e);
-                  Interval interval = staff()->part()->instrument()->transpose();
+                  Interval interval = staff()->part()->instrument(tick())->transpose();
                   if (!score()->styleB(StyleIdx::concertPitch) && !interval.isZero()) {
                         interval.flip();
                         int rootTpc = transposeTpc(harmony->rootTpc(), interval, true);

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -422,7 +422,7 @@ void Score::cmdAddInterval(int val, const QList<Note*>& nl)
                   npitch        = line2pitch(line, clef, key);
 
                   int ntpc   = pitch2tpc(npitch, key, Prefer::NEAREST);
-                  Interval v = on->part()->instrument()->transpose();
+                  Interval v = on->part()->instrument(tick)->transpose();
                   if (v.isZero())
                         ntpc1 = ntpc2 = ntpc;
                   else {
@@ -1235,8 +1235,11 @@ void Score::upDown(bool up, UpDownMode mode)
                   case StaffGroup::PERCUSSION:
                         {
                         const Drumset* ds = part->instrument()->drumset();
-                        if (ds)
+                        if (ds) {
                               newPitch = up ? ds->prevPitch(pitch) : ds->nextPitch(pitch);
+                              newTpc1 = pitch2tpc(newPitch, Key::C, Prefer::NEAREST);
+                              newTpc2 = newTpc1;
+                              }
                         }
                         break;
                   case StaffGroup::TAB:

--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -190,11 +190,15 @@ void createExcerpt(Excerpt* excerpt)
             for (Staff* staff : score->staves()) {
                   if (staff->staffType()->group() == StaffGroup::PERCUSSION)
                         continue;
+                  // if this staff has no transposition, and no instrument changes, we can skip it
                   Interval interval = staff->part()->instrument()->transpose();
-                  if (interval.isZero())
+                  if (interval.isZero() && staff->part()->instruments()->size() == 1)
                         continue;
-                  if (oscore->styleB(StyleIdx::concertPitch))
-                        interval.flip();
+                  bool flip = false;
+                  if (oscore->styleB(StyleIdx::concertPitch)) {
+                        interval.flip();  // flip the transposition for the original instrument
+                        flip = true;      // transposeKeys() will flip transposition for each instrument change
+                        }
 
                   int staffIdx   = staff->idx();
                   int startTrack = staffIdx * VOICES;
@@ -203,9 +207,15 @@ void createExcerpt(Excerpt* excerpt)
                   int endTick = 0;
                   if (score->lastSegment())
                         endTick = score->lastSegment()->tick();
-                  score->transposeKeys(staffIdx, staffIdx+1, 0, endTick, interval);
+                  score->transposeKeys(staffIdx, staffIdx+1, 0, endTick, interval, true, flip);
 
                   for (auto segment = score->firstSegment(Segment::Type::ChordRest); segment; segment = segment->next1(Segment::Type::ChordRest)) {
+                        Interval interval = staff->part()->instrument(segment->tick())->transpose();
+                        if (interval.isZero())
+                              continue;
+                        if (oscore->styleB(StyleIdx::concertPitch))
+                              interval.flip();
+
                         for (auto e : segment->annotations()) {
                               if ((e->type() != Element::Type::HARMONY) || (e->track() < startTrack) || (e->track() >= endTrack))
                                     continue;

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -199,7 +199,9 @@ void Harmony::write(Xml& xml) const
             int rRootTpc = _rootTpc;
             int rBaseTpc = _baseTpc;
             if (staff()) {
-                  const Interval& interval = part()->instrument()->transpose();
+                  Segment* segment = static_cast<Segment*>(parent());
+                  int tick = segment ? segment->tick() : -1;
+                  const Interval& interval = part()->instrument(tick)->transpose();
                   if (xml.clipboardmode && !score()->styleB(StyleIdx::concertPitch) && interval.chromatic) {
                         rRootTpc = transposeTpc(_rootTpc, interval, true);
                         rBaseTpc = transposeTpc(_baseTpc, interval, true);
@@ -743,7 +745,9 @@ void Harmony::endEdit()
                   // we may now need to change the TPC's and the text, and re-render
                   if (score()->styleB(StyleIdx::concertPitch) != h->score()->styleB(StyleIdx::concertPitch)) {
                         Part* partDest = h->part();
-                        Interval interval = partDest->instrument()->transpose();
+                        Segment* segment = static_cast<Segment*>(parent());
+                        int tick = segment ? segment->tick() : -1;
+                        Interval interval = partDest->instrument(tick)->transpose();
                         if (!interval.isZero()) {
                               if (!h->score()->styleB(StyleIdx::concertPitch))
                                     interval.flip();

--- a/libmscore/instrchange.cpp
+++ b/libmscore/instrchange.cpp
@@ -58,8 +58,9 @@ InstrumentChange::~InstrumentChange()
 
 void InstrumentChange::setInstrument(const Instrument& i)
       {
-      delete _instrument;
-      _instrument = new Instrument(i);
+      *_instrument = i;
+      //delete _instrument;
+      //_instrument = new Instrument(i);
       }
 
 //---------------------------------------------------------
@@ -86,6 +87,19 @@ void InstrumentChange::read(XmlReader& e)
                   _instrument->read(e);
             else if (!Text::readProperties(e))
                   e.unknown();
+            }
+      QString sv = score()->mscoreVersion();
+      sv.truncate(3);
+      if (sv == "2.0") {
+            // 2.0.x versions did not honor transposition of instrument change
+            // except in ways that it should not have
+            // notes entered before the instrument change was added would not be altered,
+            // so original transposition remained in effect
+            // notes added afterwards would be transposed by both intervals, resulting in tpc corruption
+            // here we set the instrument change to inherit the staff transposition to emulate previous versions
+            // in Note::read(), we attempt to fix the tpc corruption
+            Interval v = staff() ? staff()->part()->instrument()->transpose() : 0;
+            _instrument->setTranspose(v);
             }
       }
 

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -38,7 +38,7 @@ namespace Ms {
 //   transposeChord
 //---------------------------------------------------------
 
-static void transposeChord(Chord* c, Interval srcTranspose)
+static void transposeChord(Chord* c, Interval srcTranspose, int tick)
       {
       // set note track
       // check if staffMove moves a note to a
@@ -49,7 +49,7 @@ static void transposeChord(Chord* c, Interval srcTranspose)
       if (nn < 0 || nn >= c->score()->nstaves())
             c->setStaffMove(0);
       Part* part = c->part();
-      Interval dstTranspose = part->instrument()->transpose();
+      Interval dstTranspose = part->instrument(tick)->transpose();
 
       if (srcTranspose != dstTranspose) {
             if (!dstTranspose.isZero()) {
@@ -205,7 +205,7 @@ PasteStatus Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                                           for (int i = 0; i < graceNotes.size(); ++i) {
                                                 Chord* gc = graceNotes[i];
                                                 gc->setGraceIndex(i);
-                                                transposeChord(gc, e.transpose());
+                                                transposeChord(gc, e.transpose(), tick);
                                                 chord->add(gc);
                                                 }
                                           graceNotes.clear();
@@ -304,7 +304,7 @@ PasteStatus Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                               harmony->setTrack(e.track());
                               // transpose
                               Part* partDest = staff(e.track() / VOICES)->part();
-                              Interval interval = partDest->instrument()->transpose();
+                              Interval interval = partDest->instrument(e.tick())->transpose();
                               if (!styleB(StyleIdx::concertPitch) && !interval.isZero()) {
                                     interval.flip();
                                     int rootTpc = transposeTpc(harmony->rootTpc(), interval, true);
@@ -461,7 +461,7 @@ void Score::pasteChordRest(ChordRest* cr, int tick, const Interval& srcTranspose
       {
 // qDebug("pasteChordRest %s at %d, len %d/%d", cr->name(), tick, cr->duration().numerator(), cr->duration().denominator() );
       if (cr->type() == Element::Type::CHORD)
-            transposeChord(static_cast<Chord*>(cr), srcTranspose);
+            transposeChord(static_cast<Chord*>(cr), srcTranspose, tick);
 
       Measure* measure = tick2measure(tick);
       if (!measure)
@@ -657,7 +657,7 @@ void Score::pasteSymbols(XmlReader& e, ChordRest* dst)
                               el->setTrack(trackZeroVoice(destTrack));
                               // transpose
                               Part* partDest = staff(track2staff(destTrack))->part();
-                              Interval interval = partDest->instrument()->transpose();
+                              Interval interval = partDest->instrument(destTick)->transpose();
                               if (!styleB(StyleIdx::concertPitch) && !interval.isZero()) {
                                     interval.flip();
                                     int rootTpc = transposeTpc(el->rootTpc(), interval, true);

--- a/libmscore/pitchspelling.cpp
+++ b/libmscore/pitchspelling.cpp
@@ -746,8 +746,9 @@ void spell(QList<Event>& notes, int key)
 void changeAllTpcs(Note* n, int tpc1)
       {
       Interval v;
+      int tick = n && n->chord() ? n->chord()->tick() : -1;
       if (n && n->part() && n->part()->instrument()) {
-            v = n->part()->instrument()->transpose();
+            v = n->part()->instrument(tick)->transpose();
             v.flip();
             }
       int tpc2 = Ms::transposeTpc(tpc1, v, true);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -532,7 +532,7 @@ class Score : public QObject, public ScoreElement {
       void addRemoveBreaks(int interval, bool lock);
 
       bool transpose(Note* n, Interval, bool useSharpsFlats);
-      void transposeKeys(int staffStart, int staffEnd, int tickStart, int tickEnd, const Interval&);
+      void transposeKeys(int staffStart, int staffEnd, int tickStart, int tickEnd, const Interval&, bool useInstrument = false, bool flip = false);
       bool transpose(TransposeMode mode, TransposeDirection, Key transposeKey, int transposeInterval,
          bool trKeys, bool transposeChordNames, bool useDoubleSharpsFlats);
 
@@ -1071,7 +1071,7 @@ class Score : public QObject, public ScoreElement {
       void setNoteHeadWidth( qreal n) { _noteHeadWidth = n; }
 
       QList<int> uniqueStaves() const;
-      void transpositionChanged(Part*, Interval);
+      void transpositionChanged(Part*, Interval, int tickStart = 0, int tickEnd = -1);
 
       void moveUp(ChordRest*);
       void moveDown(ChordRest*);

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -460,7 +460,7 @@ void Staff::write(Xml& xml) const
 
       // for copy/paste we need to know the actual transposition
       if (xml.clipboardmode) {
-            Interval v = part()->instrument()->transpose();
+            Interval v = part()->instrument()->transpose(); // TODO: tick?
             if (v.diatonic)
                   xml.tag("transposeDiatonic", v.diatonic);
             if (v.chromatic)

--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -157,7 +157,7 @@ void StringData::fretChords(Chord * chord) const
       int   count = 0;
       // store staff pitch offset at this tick, to speed up actual note pitch calculations
       // (ottavas not implemented yet)
-      int transp = chord->staff() ? chord->part()->instrument()->transpose().chromatic : 0;
+      int transp = chord->staff() ? chord->part()->instrument()->transpose().chromatic : 0;     // TODO: tick?
       int pitchOffset = /*chord->staff()->pitchOffset(chord->segment()->tick())*/ - transp;
       // if chord parent is not a segment, the chord is special (usually a grace chord):
       // fret it by itself, ignoring the segment
@@ -257,7 +257,7 @@ void StringData::fretChords(Chord * chord) const
 
 int StringData::pitchOffsetAt(Staff* staff, int /*tick*/)
       {
-      int transp = staff ? staff->part()->instrument()->transpose().chromatic : 0;
+      int transp = staff ? staff->part()->instrument()->transpose().chromatic : 0;  // TODO: tick?
       return (/*staff->pitchOffset(tick)*/ - transp);
       }
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -568,6 +568,8 @@ void System::setInstrumentNames(bool longName)
             return;
             }
 
+      // TODO: ml is normally empty here, so we are unable to retrieve tick
+      // thus, staff name does not reflect current instrument
       int tick = ml.isEmpty() ? 0 : ml.front()->tick();
       for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
             SysStaff* staff = _staves[staffIdx];

--- a/mscore/editstaff.h
+++ b/mscore/editstaff.h
@@ -43,6 +43,7 @@ class EditStaff : public QDialog, private Ui::EditStaffBase {
       Staff*      orgStaff;
       Instrument  instrument;
       int         _minPitchA, _maxPitchA, _minPitchP, _maxPitchP;
+      int         _tickStart, _tickEnd;
 
       virtual void hideEvent(QHideEvent*);
       void apply();
@@ -76,7 +77,7 @@ class EditStaff : public QDialog, private Ui::EditStaffBase {
       void instrumentChanged();
 
    public:
-      EditStaff(Staff*, QWidget* parent = 0);
+      EditStaff(Staff*, int tick, QWidget* parent = 0);
       };
 
 

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1272,7 +1272,7 @@ static void pitch2xml(const Note* note, QString& s, int& alter, int& octave)
       {
 
       const Staff* st = note->staff();
-      const Instrument* instr = st->part()->instrument();
+      const Instrument* instr = st->part()->instrument();   // TODO: tick
       const Interval intval = instr->transpose();
 
       s      = tpc2stepName(note->tpc());

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -275,7 +275,7 @@ static void xmlSetPitch(Note* n, int step, int alter, int octave, const int octa
       //const Staff* staff = n->score()->staff(track / VOICES);
       //const Instrument* instr = staff->part()->instr();
 
-      const Interval intval = instr->transpose();
+      const Interval intval = instr->transpose();     // TODO: tick
 
       //qDebug("  staff=%p instr=%p dia=%d chro=%d",
       //       staff, instr, (int) intval.diatonic, (int) intval.chromatic);

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -459,7 +459,7 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
                                           KeySig* okeysig = new KeySig(score);
                                           okeysig->setKeySigEvent(staff->keySigEvent(tick1));
                                           if (!score->styleB(StyleIdx::concertPitch) && !okeysig->isCustom() && !okeysig->isAtonal()) {
-                                                Interval v = staff->part()->instrument()->transpose();
+                                                Interval v = staff->part()->instrument(tick1)->transpose();
                                                 if (!v.isZero()) {
                                                       Key k = okeysig->key();
                                                       okeysig->setKey(transposeKey(k, v));

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1205,7 +1205,8 @@ void ScoreView::measurePopup(const QPoint& gpos, Measure* obj)
             mscore->editInPianoroll(staff);
             }
       else if (cmd == "staff-properties") {
-            EditStaff editStaff(staff, this);
+            int tick = obj ? obj->tick() : -1;
+            EditStaff editStaff(staff, tick, this);
             connect(&editStaff, SIGNAL(instrumentChanged()), mscore, SLOT(instrumentChanged()));
             editStaff.exec();
             }
@@ -4699,7 +4700,7 @@ void ScoreView::cmdChangeEnharmonic(bool up)
                         }
                   else {
                         n->undoSetTpc(tpc);
-                        if (up || staff->part()->instrument()->transpose().isZero()) {
+                        if (up || staff->part()->instrument(n->chord()->tick())->transpose().isZero()) {
                               // change both spellings
                               int t = n->transposeTpc(tpc);
                               if (n->concertPitch())

--- a/mtest/libmscore/instrumentchange/copy-ref.mscx
+++ b/mtest/libmscore/instrumentchange/copy-ref.mscx
@@ -165,17 +165,30 @@
             <maxPitchA>80</maxPitchA>
             <transposeDiatonic>-1</transposeDiatonic>
             <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>brass.trumpet.bflat</instrumentId>
             <Articulation>
               <velocity>100</velocity>
               <gateTime>100</gateTime>
               </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
             <Articulation name="staccato">
               <velocity>100</velocity>
-              <gateTime>85</gateTime>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="tenuto">
               <velocity>100</velocity>
               <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="sforzato">
               <velocity>120</velocity>
@@ -195,6 +208,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -202,6 +216,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -211,6 +226,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -218,6 +234,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -227,6 +244,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -234,6 +252,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -243,6 +262,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -250,6 +270,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -259,6 +280,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -266,6 +288,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -275,6 +298,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -282,6 +306,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -291,6 +316,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -298,6 +324,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <BarLine>
@@ -360,17 +387,30 @@
             <maxPitchA>80</maxPitchA>
             <transposeDiatonic>-1</transposeDiatonic>
             <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>brass.trumpet.bflat</instrumentId>
             <Articulation>
               <velocity>100</velocity>
               <gateTime>100</gateTime>
               </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
             <Articulation name="staccato">
               <velocity>100</velocity>
-              <gateTime>85</gateTime>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="tenuto">
               <velocity>100</velocity>
               <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="sforzato">
               <velocity>120</velocity>
@@ -390,6 +430,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -397,6 +438,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -406,6 +448,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -413,6 +456,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -422,6 +466,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -429,6 +474,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -438,6 +484,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -445,6 +492,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -454,6 +502,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -461,6 +510,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         </Measure>
@@ -470,6 +520,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -477,6 +528,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <BarLine>

--- a/mtest/libmscore/instrumentchange/copy.mscx
+++ b/mtest/libmscore/instrumentchange/copy.mscx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<museScore version="2.00">
+<museScore version="2.06">
   <Score>
     <LayerTag id="0" tag="default"></LayerTag>
     <currentLayer>0</currentLayer>
@@ -27,10 +27,15 @@
     <showUnprintable>1</showUnprintable>
     <showFrames>1</showFrames>
     <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
     <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
     <metaTag name="movementNumber"></metaTag>
     <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
     <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
     <metaTag name="workNumber"></metaTag>
     <metaTag name="workTitle">Instrument Change</metaTag>
     <PageList>
@@ -43,13 +48,15 @@
       </PageList>
     <Part>
       <Staff id="1">
-        <type>0</type>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
         <bracket type="-1" span="0"/>
         </Staff>
       <trackName>Flute</trackName>
       <Instrument>
-        <longName pos="0">Flute</longName>
-        <shortName pos="0">Fl.</shortName>
+        <longName>Flute</longName>
+        <shortName>Fl.</shortName>
         <trackName>Flute</trackName>
         <minPitchP>59</minPitchP>
         <maxPitchP>98</maxPitchP>
@@ -78,13 +85,15 @@
       </Part>
     <Part>
       <Staff id="2">
-        <type>0</type>
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
         <bracket type="-1" span="0"/>
         </Staff>
       <trackName>Oboe</trackName>
       <Instrument>
-        <longName pos="0">Oboe</longName>
-        <shortName pos="0">Ob.</shortName>
+        <longName>Oboe</longName>
+        <shortName>Ob.</shortName>
         <trackName>Oboe</trackName>
         <minPitchP>58</minPitchP>
         <maxPitchP>93</maxPitchP>
@@ -124,9 +133,6 @@
           <concertClefType>G</concertClefType>
           <transposingClefType>G</transposingClefType>
           </Clef>
-        <KeySig>
-          <accidental>0</accidental>
-          </KeySig>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>
@@ -146,16 +152,12 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="2">
         <InstrumentChange>
           <Instrument>
-            <longName pos="0">B♭ Trumpet</longName>
-            <shortName pos="0">B♭ Tpt.</shortName>
+            <longName>B♭ Trumpet</longName>
+            <shortName>B♭ Tpt.</shortName>
             <trackName>B♭ Trumpet</trackName>
             <minPitchP>52</minPitchP>
             <maxPitchP>85</maxPitchP>
@@ -163,17 +165,30 @@
             <maxPitchA>80</maxPitchA>
             <transposeDiatonic>-1</transposeDiatonic>
             <transposeChromatic>-2</transposeChromatic>
+            <instrumentId>brass.trumpet.bflat</instrumentId>
             <Articulation>
               <velocity>100</velocity>
               <gateTime>100</gateTime>
               </Articulation>
+            <Articulation name="staccatissimo">
+              <velocity>100</velocity>
+              <gateTime>33</gateTime>
+              </Articulation>
             <Articulation name="staccato">
               <velocity>100</velocity>
-              <gateTime>85</gateTime>
+              <gateTime>50</gateTime>
+              </Articulation>
+            <Articulation name="portato">
+              <velocity>100</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="tenuto">
               <velocity>100</velocity>
               <gateTime>100</gateTime>
+              </Articulation>
+            <Articulation name="marcato">
+              <velocity>120</velocity>
+              <gateTime>67</gateTime>
               </Articulation>
             <Articulation name="sforzato">
               <velocity>120</velocity>
@@ -186,7 +201,6 @@
               <program value="59"/>
               </Channel>
             </Instrument>
-          <style>Instrument Change</style>
           <text>Trumpet</text>
           </InstrumentChange>
         <Chord>
@@ -194,6 +208,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -201,12 +216,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="3">
         <Chord>
@@ -214,6 +226,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -221,12 +234,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="4">
         <Chord>
@@ -234,6 +244,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -241,12 +252,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="5">
         <Chord>
@@ -254,6 +262,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -261,12 +270,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="6">
         <Chord>
@@ -274,6 +280,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -281,12 +288,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="7">
         <Chord>
@@ -294,6 +298,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -301,12 +306,9 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="8">
         <Chord>
@@ -314,6 +316,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <Chord>
@@ -321,6 +324,7 @@
           <Note>
             <pitch>72</pitch>
             <tpc>14</tpc>
+            <tpc2>16</tpc2>
             </Note>
           </Chord>
         <BarLine>
@@ -335,9 +339,6 @@
           <concertClefType>G</concertClefType>
           <transposingClefType>G</transposingClefType>
           </Clef>
-        <KeySig>
-          <accidental>0</accidental>
-          </KeySig>
         <TimeSig>
           <sigN>4</sigN>
           <sigD>4</sigD>
@@ -357,10 +358,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="2">
         <Chord>
@@ -377,10 +374,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="3">
         <Chord>
@@ -397,10 +390,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="4">
         <Chord>
@@ -417,10 +406,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="5">
         <Chord>
@@ -437,10 +422,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="6">
         <Chord>
@@ -457,10 +438,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="7">
         <Chord>
@@ -477,10 +454,6 @@
             <tpc>14</tpc>
             </Note>
           </Chord>
-        <BarLine>
-          <subtype>normal</subtype>
-          <span>1</span>
-          </BarLine>
         </Measure>
       <Measure number="8">
         <Chord>


### PR DESCRIPTION
This is my initial cut at incorporating my previous code from master into 2.1, to implement the ability for instrument change to affect transposition.

Right now the code works for me as well as it does on master, but there are some issues I want to investigate and hopefully see resolved.  See in particular:

https://musescore.org/en/node/78591
https://musescore.org/en/node/62416

See in particular my comment in the latter: https://musescore.org/en/node/62416#comment-664481.  Not only do staff properties changes not propagate, neither do instrument change commands.  So if you add an instrument change text to the score and then do a change instrument on it, it works in the score, and the text appears in the part, but it has no effect on playback (or transposition).  This affects 2.0.3 and probably should be filed separately, but I'm not sure yet if it's really just another symptom of the same issue or not.

Right now I am still struggling with build issues - I can build but not debug on my branch, apparently my build is not getting any debug info despite setting CMAKE_BUILD_TYPE=Debug.  So I have some work to do before I can really continue with this.  But if anyone else wants to try out this code and investigatye those issues at all, please be my guest.