### PR TITLE
43681 InputMethod position when editing Chinese/Jap text

### DIFF
--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -224,7 +224,6 @@ class Text : public Element {
 
       TextCursor* _cursor           { 0     };       // used during editing
 
-      QRectF cursorRect() const;
       const TextBlock& curLine() const;
       TextBlock& curLine();
       void drawSelection(QPainter*, const QRectF&) const;
@@ -323,6 +322,7 @@ class Text : public Element {
       virtual void paste();
 
       QRectF pageRectangle() const;
+      QRectF cursorRect() const;
 
       TextCursor* cursor() { return _cursor; }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3817,8 +3817,33 @@ bool ScoreView::fotoMode() const
 
 void ScoreView::editInputTransition(QInputMethodEvent* ie)
       {
-      if (editObject->isText())
+      if (editObject->isText()) {
             static_cast<Text*>(editObject)->inputTransition(ie);
+            QGuiApplication::inputMethod()->update(Qt::ImCursorRectangle);
+            }
+      }
+
+//---------------------------------------------------------
+//   inputMethodQuery
+//---------------------------------------------------------
+
+QVariant ScoreView::inputMethodQuery(Qt::InputMethodQuery query) const
+      {
+      // if editing a text object, place the InputMethod popup window just below the text
+      if ((query & Qt::ImCursorRectangle) && editObject && editObject->isText()) {
+            Text* text = static_cast<Text*>(editObject);
+            if (text->cursor()) {
+                  QRectF cursorRect = toPhysical(text->cursorRect().translated(text->canvasPos()));
+                  cursorRect.setWidth(1.0); // InputMethod doesn't display properly if width left at 0
+                  cursorRect.setHeight(cursorRect.height() + 5.0); // add a little margin under the cursor
+                  qDebug("cursorRect: [%3f,%3f,%3f,%3f]", cursorRect.x(), cursorRect.y(), cursorRect.width(), cursorRect.height());
+                  return QVariant(cursorRect);
+                  }
+            else
+                  return QVariant(toPhysical(text->canvasBoundingRect()));
+            }
+
+      return QWidget::inputMethodQuery(query); // fall back to QWidget's version as default
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -273,6 +273,8 @@ class ScoreView : public QWidget, public MuseScoreView {
       void cmdGotoElement(Element*);
       bool checkCopyOrCut();
 
+      QVariant inputMethodQuery(Qt::InputMethodQuery query) const;
+
    private slots:
       void enterState();
       void exitState();


### PR DESCRIPTION
If editing Chinese or Japanese text, musescore previously did not tell the operating system where to position its InputMethod popup window, and would default in middle of the bottom edge of the scoreview (as is apparently the default for a QWidget).

This code implements inputMethodQuery, which is inheirited from QWidget, and returns a QRectF when receiving an ImCursorRectangle query if the scoreview is currently editing a text object.  Will position the InputMethod just below the cursor, if it exists, or if not just below the text object's bounding rect.