### PR TITLE
2.1-only fix for #43681: Do not rely on QInputMethod::locale() for CJK test

### DIFF
--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -213,10 +213,10 @@ void ScoreView::editKey(QKeyEvent* ev)
             }
 
 
-#ifdef Q_OS_WIN // Japenese IME on Windows needs to know when Contrl/Alt/Shift/CapsLock is pressed while in predit
+#ifdef Q_OS_WIN // ignore Contrl/Alt/Shift/CapsLock while in predit
       if (editObject->isText()) {
             Text* text = static_cast<Text*>(editObject);
-            if (text->cursor()->format()->preedit() && QGuiApplication::inputMethod()->locale().script() == QLocale::JapaneseScript &&
+            if (text->cursor()->format()->preedit() &&
                 ((key == Qt::Key_Control || (modifiers & Qt::ControlModifier)) ||
                  (key == Qt::Key_Alt || (modifiers & Qt::AltModifier)) ||
                  (key == Qt::Key_Shift || (modifiers & Qt::ShiftModifier)) ||


### PR DESCRIPTION
Previous fix for #43681 relied on QInputMethod::locale() to return the current script that the InputMethod is set to, and that worked fine for 3.0, but not 2.1.

According to debugger in 2.1, Qt was not properly updating the locale when change languages, since is always returning 0 (AnyScript).  Without an easy way to determine if Japanese is being used, the simplest solution is to have MuseScore simply ignore all Control/Alt/Shift/CapsLock while a pre-edit string exists.

This also somehow indirectly fixes the string kill glitch that was present in 2.1 when pressing these modifiers for all languages with pre-edit strings.  But I'm not entirely sure why that bug existed in the first place in 2.1, but my best guess is that Qt fixed something between 5.4 and 5.6 related to this.