### PR TITLE
fix #180171: use Shift to create chord with on-screen piano keyboard

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1914,10 +1914,13 @@ bool Score::processMidiInput()
                         startCmd();
                         cmdActive = true;
                         }
-                  if (activeMidiPitches()->empty())
-                        ev.chord = false;
-                  else
-                        ev.chord = true;
+                  if (usingNoteEntryMethod(NoteEntryMethod::REALTIME_AUTO) || usingNoteEntryMethod(NoteEntryMethod::REALTIME_MANUAL)) {
+                        // It's only a chord if multiple notes are held. (i.e. ignore shift key)
+                        if (activeMidiPitches()->empty())
+                              ev.chord = false;
+                        else
+                              ev.chord = true;
+                        }
                   // TODO: add shadow note instead of real note in realtime modes
                   // (note becomes real when realtime-advance triggered).
                   addMidiPitch(ev.pitch, ev.chord);

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -291,8 +291,8 @@ void PianoKeyItem::mousePressEvent(QGraphicsSceneMouseEvent*)
       {
       _pressed = true;
       update();
-      bool ctrl = qApp->keyboardModifiers() & Qt::ControlModifier;
-      emit piano->keyPressed(_pitch, ctrl, 80);
+      bool chord = qApp->keyboardModifiers() & Qt::ShiftModifier;
+      emit piano->keyPressed(_pitch, chord, 80);
       }
 
 //---------------------------------------------------------

--- a/mscore/pianotools.h
+++ b/mscore/pianotools.h
@@ -86,8 +86,8 @@ class PianoTools : public QDockWidget {
       HPiano* _piano;
 
    signals:
-      void keyPressed(int pitch, bool ctrl, int vel);
-      void keyReleased(int pitch, bool ctrl, int vel);
+      void keyPressed(int pitch, bool chord, int vel);
+      void keyReleased(int pitch, bool chord, int vel);
 
    protected:
       virtual void changeEvent(QEvent *event);


### PR DESCRIPTION
Issue: https://musescore.org/en/node/180171
- Fix issue with being unable to create chords using on-screen piano keyboard.
- Changed shortcut from Ctrl to Shift to match normal note entry.

Should be safe to cherry-pick into 2.1