### PR TITLE
fix #180286: bad layout on undo with hbox

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2496,6 +2496,7 @@ bool Score::layoutSystem1(qreal& minWidth, bool isFirstSystem, bool longName)
                               case LayoutMode::PAGE:
                               case LayoutMode::SYSTEM:
                                     continueFlag = !(curMeasure->lineBreak()
+                                                    || curMeasure->breakHint()
                                                     || curMeasure->sectionBreak()
                                                     || curMeasure->pageBreak());
                                     break;


### PR DESCRIPTION
Issue report https://musescore.org/en/node/180286 has good steps to reproduce problem in simple example, courtesy of cadiz1.

My change in https://github.com/musescore/MuseScore/pull/2068/files had an unintended side effect.  Previously we never tried to break a line after an hbox without an explicit line break - we always took another measure onto the line whether it fit or not.  Now that we are sometimes electing to break right after the hbox, we need to make make sure we honor that breakHint during undo.  We had been ignoring breakHint when set on a hbox as opposed to a measure.  That was OK before because we were basically never breaking after an hbox without an explicit line break, so this problem was never exposed.  And the symptoms are pretty hard to miss!

As far as I can tell, this change fixes the problem and should be safe.  Worst case is something *else* goes wrong with layout during the undo, but just as with the bug I am actually fixing it, it's just a temporary glitch anyhow.  That is, it corrects itself on the next "real" layout operation (not the special form used during undo).  But I think this fix is good.

This doesn't apply to master because the whole structure of system layout is changed.  It's entirely possible this problem - or a related one - still exists in some form, but I couldn't reproduce it using the original steps.