### PR TITLE
fix #109021: wandering lines due to bad barline widths on load

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2269,7 +2269,7 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
                                     nt = BarLineType::START_REPEAT;
                               }
                         if (ot != nt) {
-                              qreal mag = bl->magS();
+                              qreal mag = bl->mag();
                               ww += BarLine::layoutWidth(this, nt, mag)
                                     - BarLine::layoutWidth(this, ot, mag);
                               }
@@ -2289,11 +2289,13 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
                   if (ww < minMeasureWidth)
                         ww = minMeasureWidth;
                   isFirstMeasure = false;
+                  //qDebug("measure %d: ww %f + minWidth %f = %f", m->no(), ww, minWidth, ww + minWidth);
                   }
 
             // collect at least one measure
             bool empty = system->measures().isEmpty();
             if (!empty && (minWidth + ww > systemWidth)) {
+                  //qDebug("=== does not fit: systemWidth = %f", systemWidth);
                   curMeasure->setSystem(oldSystem);
                   continueFlag = false;
                   break;

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3234,7 +3234,7 @@ void Measure::layoutX(qreal stretch)
 
       if (system() && system()->firstMeasure() == this && system()->barLine()) {
             BarLine* bl = system()->barLine();
-            x += BarLine::layoutWidth(score(), bl->barLineType(), bl->magS());
+            x += BarLine::layoutWidth(score(), bl->barLineType(), bl->mag());
             }
 
       qreal minNoteDistance = score()->styleS(StyleIdx::minNoteDistance).val() * _spatium;


### PR DESCRIPTION
This might not fix all the cases of so-called "wandering hairpins" that people have encountered, but it fixes the couple I have been able to reproduce.  Namely, the one in https://musescore.org/en/node/109021 and the one in https://musescore.org/en/node/180601#comment-672671.  Both were due to a discrepancy in the widths of a few measures resulting from a miscalculation of the widths of repeat barlines.  I tracked it down to a simple root cause: a "double" scaling down the barline width in cases where the score spatium is less than the nominal 1.764mm.  The same miscalculation happened with system barlines, so I applied the same simple fix there.

As I sad, I do not claim this will fix *all* cases of wandering hairpins et al.  So I left in place a couple of commented-out qDebug statements that were key in helping me track down this particular problem.  They just print the minimum widths of each measure as calculated during system layout, so we can compare the result on initial load versus after first relayout.  Any discrepancy that leads to a measure jumping from one page to another will also result in wandering hairpins, so it just becomes a matter of figuring out where the discrepancy comes from.  Chances are problems may still lurk in the the handling of other generated elements (headers, courtesy elements, etc).  But again, the cases I can reproduce actually work out perfectly for all measures (width on load same as after first relayout) except those with repeat barlines, and this PR fixes that so these also work out perfectly.
