### PR TITLE
fix #180966: Show and hide fingerings in tablature staves for 3.0

### DIFF
--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -124,6 +124,8 @@ void Fingering::layout()
 
 void Fingering::draw(QPainter* painter) const
       {
+      if (staff() && staff()->isTabStaff(tick()) && !staff()->staffType(tick())->showTabFingering())
+            return;
       Text::draw(painter);
       }
 

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -590,10 +590,7 @@ Note::Note(const Note& n, bool link)
             add(new Accidental(*(n._accidental)));
 
       // types in _el: SYMBOL, IMAGE, FINGERING, TEXT, BEND
-      bool tabFingering = staff()->staffType(tick())->showTabFingering();
       for (Element* e : n._el) {
-            if (e->isFingering() && staff()->isTabStaff(tick()) && !tabFingering)    // tablature has no fingering
-                  continue;
             Element* ce = e->clone();
             add(ce);
             if (link)
@@ -1578,13 +1575,11 @@ bool Note::acceptDrop(const DropData& data) const
                   }
             return true;
             }
-      bool isTablature = staff()->isTabStaff(tick());
-      bool tabFingering = staff()->staffType(tick())->showTabFingering();
       return (type == ElementType::ARTICULATION
          || type == ElementType::CHORDLINE
          || type == ElementType::TEXT
          || type == ElementType::REHEARSAL_MARK
-         || (type == ElementType::FINGERING && (!isTablature || tabFingering))
+         || type == ElementType::FINGERING
          || type == ElementType::ACCIDENTAL
          || type == ElementType::BREATH
          || type == ElementType::ARPEGGIO
@@ -1638,8 +1633,6 @@ Element* Note::drop(const DropData& data)
       {
       Element* e = data.element;
 
-      bool isTablature = staff()->isTabStaff(tick());
-      bool tabFingering = staff()->staffType(tick())->showTabFingering();
       Chord* ch = chord();
 
       switch(e->type()) {
@@ -1653,14 +1646,9 @@ Element* Note::drop(const DropData& data)
                   return e;
 
             case ElementType::FINGERING:
-                  if (!isTablature || tabFingering) {
                         e->setParent(this);
                         score()->undoAddElement(e);
                         return e;
-                        }
-                  else
-                        delete e;
-                  return 0;
 
             case ElementType::SLUR:
                   delete e;

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1121,7 +1121,6 @@ void Score::undoAddElement(Element* element)
                   if (e == parent)
                         ne = element;
                   else {
-                        bool tabFingering = e->staff()->staffType(e->tick())->showTabFingering();
                         if (element->isGlissando()) {    // and other spanners with Anchor::NOTE
                               Note* newEnd = Spanner::endElementFromSpanner(static_cast<Glissando*>(element), e);
                               if (newEnd) {
@@ -1131,8 +1130,6 @@ void Score::undoAddElement(Element* element)
                               else              //couldn't find suitable start note
                                     continue;
                               }
-                        else if (element->isFingering() && e->staff()->isTabStaff(e->tick()) && !tabFingering)
-                              continue;
                         else
                               ne = element->linkedClone();
                         }

--- a/mscore/editstafftype.ui
+++ b/mscore/editstafftype.ui
@@ -685,7 +685,7 @@
                   <item>
                    <widget class="QCheckBox" name="showTabFingering">
                     <property name="text">
-                     <string>Show fingering in tablature</string>
+                     <string>Show fingerings</string>
                     </property>
                    </widget>
                   </item>
@@ -1425,6 +1425,7 @@
   <tabstop>linesThroughRadio</tabstop>
   <tabstop>linesBrokenRadio</tabstop>
   <tabstop>showBackTied</tabstop>
+  <tabstop>showTabFingering</tabstop>
   <tabstop>durFontName</tabstop>
   <tabstop>durFontSize</tabstop>
   <tabstop>durY</tabstop>


### PR DESCRIPTION
I have corrected my code, so that it now shows and hides fingerings. Seems to work quite fine, but I'm not sure, if I should have left one of my earlier changes in the code.
BTW - if that would be wished, it would be easy to change the place of the variable in the ui in order to also be able to hide fingerings in normal staff. 