### PR TITLE
fix #180991: layout jump due to courtesy keysig barline

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2152,6 +2152,8 @@ qreal Score::cautionaryWidth(Measure* m, bool& hasCourtesy)
       ns           = nm->findSegment(Segment::Type::KeySig, tick);
 
       qreal wwMax  = 0.0;
+      qreal oblMax = 0.0;
+      qreal nblMax = 0.0;
       if (showCourtesy && ns) {
             qreal leftMargin = point(styleS(StyleIdx::keysigLeftMargin));
             for (int staffIdx = 0; staffIdx < _staves.size(); ++staffIdx) {
@@ -2160,6 +2162,21 @@ qreal Score::cautionaryWidth(Measure* m, bool& hasCourtesy)
                   KeySig* nks = static_cast<KeySig*>(ns->element(track));
 
                   if (nks && nks->showCourtesy() && !nks->generated()) {
+
+                        // account for generated double barline
+                         Segment* bls = m->findSegment(Segment::Type::EndBarLine, tick);
+                         if (bls && bls->element(track)) {
+                               BarLine* bl = static_cast<BarLine*>(bls->element(track));
+                               qreal mag = bl->mag();
+                               qreal oWidth = BarLine::layoutWidth(this, bl->barLineType(), mag);
+                               oblMax = qMax(oblMax, oWidth);
+                               // double barline not generated for repeat end
+                               if (bl->generated() && !(m->repeatFlags() & Repeat::END)) {
+                                     qreal nWidth = BarLine::layoutWidth(this, BarLineType::DOUBLE, mag);
+                                     nblMax = qMax(nblMax, nWidth);
+                                     }
+                               }
+
                         Segment* s  = m->findSegment(Segment::Type::KeySigAnnounce, tick);
 
                         if (s && s->element(track)) {
@@ -2174,7 +2191,8 @@ qreal Score::cautionaryWidth(Measure* m, bool& hasCourtesy)
                         }
                   }
             }
-      w += wwMax;
+      qreal blDiff = nblMax > oblMax ? nblMax - oblMax : 0.0;
+      w += wwMax + blDiff;
 
       return w;   //* 1.5
       }


### PR DESCRIPTION
We have code in cautionaryWidth() to estimate the width of courtesy elements that do not yet exist but would need to be added if a given measure ends a system, and this solves a number of "jumping layout" problems (measures flipping from system to system on every relayout) that previously existed (eg, during 2.0 beta).  However, this code does not account for the double barline that normally gets added for courtesy key signatures.  So in the cases where this makes the difference between a measure fitting or not, we still get the jumping layout issue.  And this also potentially leads to the "wandering hairpin" issue (manually adjust spanners jumping position between save and load).

This PR fixes the estimate performed in cautionaryWidt() to account for any increase in measure width that the double barlines would cause.  It checks staff by staff to see where there would in fact be double bars needed and to account for staff scaling.  I can't guarantee the calculation always comes out exactly right, but accounting for the barlines is definitely better than not.