### PR TITLE
fix #173366: corruption on paste

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -421,6 +421,12 @@ PasteStatus Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
             //if (s2 == s2->measure()->first()) {
             //      s2 = s2->measure()->prevMeasureMM()->last();
             //      }
+            // sanity check on selection
+            if (s1 && s2 && s1->tick() >= s2->tick()) {
+                  // just select the start measure
+                  s1 = s1->measure()->first();
+                  s2 = s1->measure()->last();
+                  }
             int endStaff = dstStaff + staves;
             if (endStaff > nstaves())
                   endStaff = nstaves();


### PR DESCRIPTION
The corruption (could crash on other systems I guess) is due to a bad selection after the first paste - the end segment is actually before the firt.  That's because tick2segmentMM is forcing the tick to the start of the measure for some reason probably useful in other situations).

While I'm sure someone could find a real fix, this is a quick fix that just does a sanity check after the paste, selecting the start measure if end segment isn't after start segment.