### PR TITLE
Save audio to QIODevice support

### DIFF
--- a/all.h
+++ b/all.h
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <math.h>
 #include <array>
+#include <functional>
 
 #include <QtGui>
 #include <QLoggingCategory>

--- a/mscore/exportaudio.cpp
+++ b/mscore/exportaudio.cpp
@@ -30,7 +30,162 @@
 
 namespace Ms {
 
+///
+/// \brief Function to synthesize audio and output it into a generic QIODevice
+/// \param The score to output
+/// \param The output device
+/// \param An optional callback function that will be notified with the progress in range [0, 1]
+/// \return True on success, false otherwise.
+///
+/// If the callback function is non zero an returns false the export will be canceled.
+///
+bool MuseScore::saveAudio(Score* score, QIODevice *device, std::function<bool(float)> updateProgress)
+    {
+    if (!device) {
+        qDebug() << "Invalid device";
+        return false;
+    }
+
+    if (!device->open(QIODevice::WriteOnly)) {
+        qDebug() << "Could not write to device";
+        return false;
+    }
+
+    EventMap events;
+    score->renderMidi(&events);
+    if(events.size() == 0)
+          return false;
+
+    MasterSynthesizer* synti = synthesizerFactory();
+    synti->init();
+    int sampleRate = preferences.exportAudioSampleRate;
+    synti->setSampleRate(sampleRate);
+    bool r = synti->setState(score->synthesizerState());
+    if (!r)
+        synti->init();
+
+    int oldSampleRate  = MScore::sampleRate;
+    MScore::sampleRate = sampleRate;
+
+    float peak  = 0.0;
+    double gain = 1.0;
+    EventMap::const_iterator endPos = events.cend();
+    --endPos;
+    const int et = (score->utick2utime(endPos->first) + 1) * MScore::sampleRate;
+    const int maxEndTime = (score->utick2utime(endPos->first) + 3) * MScore::sampleRate;
+
+    bool cancelled = false;
+    for (int pass = 0; pass < 2; ++pass) {
+          EventMap::const_iterator playPos;
+          playPos = events.cbegin();
+          synti->allSoundsOff(-1);
+
+          //
+          // init instruments
+          //
+          foreach(Part* part, score->parts()) {
+                const InstrumentList* il = part->instruments();
+                for(auto i = il->begin(); i!= il->end(); i++) {
+                      foreach(const Channel* a, i->second->channel()) {
+                            a->updateInitList();
+                            foreach(MidiCoreEvent e, a->init) {
+                                  if (e.type() == ME_INVALID)
+                                        continue;
+                                  e.setChannel(a->channel);
+                                  int syntiIdx = synti->index(score->masterScore()->midiMapping(a->channel)->articulation->synti);
+                                  synti->play(e, syntiIdx);
+                                  }
+                            }
+                      }
+                }
+
+          static const unsigned FRAMES = 512;
+          float buffer[FRAMES * 2];
+          int playTime = 0;
+
+          for (;;) {
+                unsigned frames = FRAMES;
+                //
+                // collect events for one segment
+                //
+                float max = 0.0;
+                memset(buffer, 0, sizeof(float) * FRAMES * 2);
+                int endTime = playTime + frames;
+                float* p = buffer;
+                for (; playPos != events.cend(); ++playPos) {
+                      int f = score->utick2utime(playPos->first) * MScore::sampleRate;
+                      if (f >= endTime)
+                            break;
+                      int n = f - playTime;
+                      if (n) {
+                            synti->process(n, p);
+                            p += 2 * n;
+                            }
+
+                      playTime  += n;
+                      frames    -= n;
+                      const NPlayEvent& e = playPos->second;
+                      if (e.isChannelEvent()) {
+                            int channelIdx = e.channel();
+                            Channel* c = score->masterScore()->midiMapping(channelIdx)->articulation;
+                            if (!c->mute) {
+                                  synti->play(e, synti->index(c->synti));
+                                  }
+                            }
+                      }
+                if (frames) {
+                      synti->process(frames, p);
+                      playTime += frames;
+                      }
+                if (pass == 1) {
+                      for (unsigned i = 0; i < FRAMES * 2; ++i) {
+                            max = qMax(max, qAbs(buffer[i]));
+                            buffer[i] *= gain;
+                            }
+                      device->write(reinterpret_cast<const char*>(buffer), 2 * FRAMES * sizeof(float));
+                      }
+                else {
+                      for (unsigned i = 0; i < FRAMES * 2; ++i) {
+                            max = qMax(max, qAbs(buffer[i]));
+                            peak = qMax(peak, qAbs(buffer[i]));
+                            }
+                      }
+                playTime = endTime;
+                if (updateProgress) {
+                    // normalize to [0, 1] range
+                    if (!updateProgress((pass * et + playTime) / 2.0 / et)) {
+                        cancelled = true;
+                        break;
+                    }
+                      }
+                if (playTime >= et)
+                      synti->allNotesOff(-1);
+                // create sound until the sound decays
+                if (playTime >= et && max*peak < 0.000001)
+                      break;
+                // hard limit
+                if (playTime > maxEndTime)
+                      break;
+                }
+          if (cancelled)
+                break;
+          if (pass == 0 && peak == 0.0) {
+                qDebug("song is empty");
+                break;
+                }
+          gain = 0.99 / peak;
+          }
+
+    MScore::sampleRate = oldSampleRate;
+    delete synti;
+
+    device->close();
+
+    return !cancelled;
+}
+
 #ifdef HAS_AUDIOFILE
+
 
 //---------------------------------------------------------
 //   saveAudio
@@ -38,6 +193,58 @@ namespace Ms {
 
 bool MuseScore::saveAudio(Score* score, const QString& name)
       {
+    // QIODevice - SoundFile wrapper class
+    class SoundFileDevice : public QIODevice {
+    private:
+        SF_INFO info;
+        SNDFILE *sf = nullptr;
+        const QString filename;
+    public:
+        SoundFileDevice(int sampleRate, int format, const QString& name)
+            : filename(name) {
+            memset(&info, 0, sizeof(info));
+            info.channels   = 2;
+            info.samplerate = sampleRate;
+            info.format     = format;
+        }
+        ~SoundFileDevice() {
+            if (sf) {
+                sf_close(sf);
+                sf = nullptr;
+            }
+        }
+
+        virtual qint64 readData(char *data, qint64 maxlen) override final {
+            Q_UNUSED(data);
+            qDebug() << "Error: No write supported!";
+            return maxlen;
+        }
+
+        virtual qint64 writeData(const char *data, qint64 len) override final {
+            int trueFrames = len / sizeof(float) / 2;
+            sf_writef_float(sf, reinterpret_cast<const float*>(data), trueFrames);
+            return trueFrames * 2 * sizeof(float);
+        }
+
+        bool open(QIODevice::OpenMode mode) {
+            if ((mode & QIODevice::WriteOnly) == 0) {
+                return false;
+            }
+            sf     = sf_open(qPrintable(filename), SFM_WRITE, &info);
+            if (sf == 0) {
+                  qDebug("open soundfile failed: %s", sf_strerror(sf));
+                  return false;
+            }
+            return QIODevice::open(mode);
+        }
+        void close() {
+            if (sf && sf_close(sf)) {
+                  qDebug("close soundfile failed");
+            }
+            sf = nullptr;
+            QIODevice::close();
+        }
+    };
       int format;
       if (name.endsWith(".wav"))
             format = SF_FORMAT_WAV | SF_FORMAT_PCM_16;
@@ -66,18 +273,11 @@ bool MuseScore::saveAudio(Score* score, const QString& name)
       int oldSampleRate  = MScore::sampleRate;
       MScore::sampleRate = sampleRate;
 
-      SF_INFO info;
-      memset(&info, 0, sizeof(info));
-      info.channels   = 2;
-      info.samplerate = sampleRate;
-      info.format     = format;
-      SNDFILE* sf     = sf_open(qPrintable(name), SFM_WRITE, &info);
-      if (sf == 0) {
-            qDebug("open soundfile failed: %s", sf_strerror(sf));
-            delete synti;
-            MScore::sampleRate = oldSampleRate;
-            return false;
-            }
+
+      SoundFileDevice device(sampleRate, format, name);
+
+      // dummy callback function that will be used if there is no gui
+      std::function<bool(float)> progressCallback = [](float) {return true;};
 
       QProgressDialog progress(this);
       progress.setWindowFlags(Qt::WindowFlags(Qt::Dialog | Qt::FramelessWindowHint | Qt::WindowTitleHint));
@@ -85,131 +285,40 @@ bool MuseScore::saveAudio(Score* score, const QString& name)
       //progress.setCancelButton(0);
       progress.setCancelButtonText(tr("Cancel"));
       progress.setLabelText(tr("Exporting..."));
-      if (!MScore::noGui)
+      if (!MScore::noGui) {
+          // callback function that will update the progress bar
+          // it will return false and thus cancel the export if the user
+          // cancels the progress dialog.
+          progressCallback = [&progress](float v) -> bool {
+              if (progress.wasCanceled())
+                    return false;
+              progress.setValue(v * 1000);
+              qApp->processEvents();
+              return true;
+          };
+
             progress.show();
+      }
 
-      float peak  = 0.0;
-      double gain = 1.0;
-      EventMap::const_iterator endPos = events.cend();
-      --endPos;
-      const int et = (score->utick2utime(endPos->first) + 1) * MScore::sampleRate;
-      const int maxEndTime = (score->utick2utime(endPos->first) + 3) * MScore::sampleRate;
+      // The range is set arbitrarily to 1000 as steps.
+      // The callback will return float numbers between 0 and 1
+      // which will be scaled into integer 0 to 1000 numbers
+      // which allows a smooth transition.
+      progress.setRange(0, 1000);
 
-      progress.setRange(0, et);
-
-      for (int pass = 0; pass < 2; ++pass) {
-            EventMap::const_iterator playPos;
-            playPos = events.cbegin();
-            synti->allSoundsOff(-1);
-
-            //
-            // init instruments
-            //
-            foreach(Part* part, score->parts()) {
-                  const InstrumentList* il = part->instruments();
-                  for(auto i = il->begin(); i!= il->end(); i++) {
-                        foreach(const Channel* a, i->second->channel()) {
-                              a->updateInitList();
-                              foreach(MidiCoreEvent e, a->init) {
-                                    if (e.type() == ME_INVALID)
-                                          continue;
-                                    e.setChannel(a->channel);
-                                    int syntiIdx = synti->index(score->masterScore()->midiMapping(a->channel)->articulation->synti);
-                                    synti->play(e, syntiIdx);
-                                    }
-                              }
-                        }
-                  }
-
-            static const unsigned FRAMES = 512;
-            float buffer[FRAMES * 2];
-            int playTime = 0;
-
-            for (;;) {
-                  unsigned frames = FRAMES;
-                  //
-                  // collect events for one segment
-                  //
-                  float max = 0.0;
-                  memset(buffer, 0, sizeof(float) * FRAMES * 2);
-                  int endTime = playTime + frames;
-                  float* p = buffer;
-                  for (; playPos != events.cend(); ++playPos) {
-                        int f = score->utick2utime(playPos->first) * MScore::sampleRate;
-                        if (f >= endTime)
-                              break;
-                        int n = f - playTime;
-                        if (n) {
-                              synti->process(n, p);
-                              p += 2 * n;
-                              }
-
-                        playTime  += n;
-                        frames    -= n;
-                        const NPlayEvent& e = playPos->second;
-                        if (e.isChannelEvent()) {
-                              int channelIdx = e.channel();
-                              Channel* c = score->masterScore()->midiMapping(channelIdx)->articulation;
-                              if (!c->mute) {
-                                    synti->play(e, synti->index(c->synti));
-                                    }
-                              }
-                        }
-                  if (frames) {
-                        synti->process(frames, p);
-                        playTime += frames;
-                        }
-                  if (pass == 1) {
-                        for (unsigned i = 0; i < FRAMES * 2; ++i) {
-                              max = qMax(max, qAbs(buffer[i]));
-                              buffer[i] *= gain;
-                              }
-                        sf_writef_float(sf, buffer, FRAMES);
-                        }
-                  else {
-                        for (unsigned i = 0; i < FRAMES * 2; ++i) {
-                              max = qMax(max, qAbs(buffer[i]));
-                              peak = qMax(peak, qAbs(buffer[i]));
-                              }
-                        }
-                  playTime = endTime;
-                  if (!MScore::noGui) {
-                        if (progress.wasCanceled())
-                              break;
-                        progress.setValue((pass * et + playTime) / 2);
-                        qApp->processEvents();
-                        }
-                  if (playTime >= et)
-                        synti->allNotesOff(-1);
-                  // create sound until the sound decays
-                  if (playTime >= et && max*peak < 0.000001)
-                        break;
-                  // hard limit
-                  if (playTime > maxEndTime)
-                        break;
-                  }
-            if (progress.wasCanceled())
-                  break;
-            if (pass == 0 && peak == 0.0) {
-                  qDebug("song is empty");
-                  break;
-                  }
-            gain = 0.99 / peak;
-            }
+      // Save the audio to the SoundFile device
+      bool result = saveAudio(score, &device, progressCallback);
 
       bool wasCanceled = progress.wasCanceled();
       progress.close();
 
       MScore::sampleRate = oldSampleRate;
       delete synti;
-      if (sf_close(sf)) {
-            qDebug("close soundfile failed");
-            return false;
-            }
+
       if (wasCanceled)
             QFile::remove(name);
 
-      return true;
+      return result;
       }
 
 #endif // HAS_AUDIOFILE

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -649,6 +649,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void addImage(Score*, Element*);
 
       bool savePng(Score*, const QString& name, bool screenshot, bool transparent, double convDpi, int trimMargin, QImage::Format format);
+      bool saveAudio(Score*, QIODevice *device, std::function<bool(float)> updateProgress = nullptr);
       bool saveAudio(Score*, const QString& name);
       bool saveMp3(Score*, const QString& name);
       bool saveSvg(Score*, const QString& name);


### PR DESCRIPTION
This PR adds a function to write the synthesized audio data directly into a generic QIODevice instead of a file. The previous saveAudio makes use of this function to reduce 'copy and paste'.

The updateProgress function can be used as a callback to update the progress bar.

Background: I want to work directly with generated raw audio data which is why there is no need for an intermediate file layer. 