### PR TITLE
Added missing namespace and includes

### DIFF
--- a/all.h
+++ b/all.h
@@ -27,6 +27,8 @@
 #define ABORTN(a)
 #endif
 
+#if defined __cplusplus
+
 #include <stdio.h>
 #include <limits.h>
 #include <map>
@@ -186,6 +188,8 @@
 #undef Q_ASSERT
 #define Q_ASSERT(a)
 #endif
+
+#endif  // __cplusplus
 
 #endif
 

--- a/libmscore/cursor.cpp
+++ b/libmscore/cursor.cpp
@@ -30,6 +30,16 @@ namespace Ms {
 //   ElementW
 //---------------------------------------------------------
 
+QString ElementW::type() const
+      {
+      return QString(e->name());
+      }
+
+QVariant ElementW::tick() const
+      {
+      return QVariant(((Element*)e)->tick());
+      }
+
 QVariant ElementW::get(const QString& s) const
       {
       QVariant val;

--- a/libmscore/cursor.h
+++ b/libmscore/cursor.h
@@ -16,6 +16,7 @@
 namespace Ms {
 
 class Element;
+class ScoreElement;
 class Score;
 class Chord;
 class Rest;
@@ -25,6 +26,8 @@ class RepeatSegment;
 class ChordRest;
 class StaffText;
 class Measure;
+
+enum class SegmentType;
 
 //---------------------------------------------------------
 //   ElementW
@@ -42,8 +45,8 @@ class ElementW : public QObject {
    public:
       ElementW(ScoreElement* _e) : QObject() { e = _e; }
       ElementW() {}
-      QString type() const { return QString(e->name()); }
-      Q_INVOKABLE QVariant tick() const { return QVariant(((Element*)e)->tick()); }
+      QString type() const;
+      Q_INVOKABLE QVariant tick() const;
       Q_INVOKABLE QVariant get(const QString& s) const;
       };
 

--- a/libmscore/icon.h
+++ b/libmscore/icon.h
@@ -14,6 +14,7 @@
 #define __ICON_H__
 
 #include "element.h"
+#include "mscore.h"
 
 namespace Ms {
 

--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -23,6 +23,7 @@
 
 #include "ui_editstyle.h"
 #include "globals.h"
+#include "libmscore/mscore.h"
 #include "libmscore/style.h"
 
 namespace Ms {

--- a/mscore/inspector/inspectorBarline.h
+++ b/mscore/inspector/inspectorBarline.h
@@ -15,7 +15,9 @@
 #define __INSPECTOR_BARLINE_H__
 
 #include "inspectorBase.h"
+#include "inspectorElementBase.h"
 #include "ui_inspector_barline.h"
+#include "ui_inspector_segment.h"
 
 namespace Ms {
 

--- a/mscore/selectnotedialog.h
+++ b/mscore/selectnotedialog.h
@@ -26,6 +26,7 @@
 namespace Ms {
 
 struct NotePattern;
+class Note;
 
 //---------------------------------------------------------
 //   SelectNoteDialog


### PR DESCRIPTION
Hi, its me again!
When using my custom build files based on qmake (helpful for android my android port) some includes and a namespace are missing. Oddly enough, that the build works with cmake.
Unfortunately, there are also some missing includes in thirdparty libs.