### PR TITLE
fix #181616 disable change anchor for Instrument Change text

### DIFF
--- a/libmscore/instrchange.cpp
+++ b/libmscore/instrchange.cpp
@@ -136,35 +136,5 @@ bool InstrumentChange::setProperty(P_ID propertyId, const QVariant& v)
       return true;
       }
 
-//---------------------------------------------------------
-//   drag
-//---------------------------------------------------------
-
-QRectF InstrumentChange::drag(EditData* ed)
-      {
-      QRectF f = Element::drag(ed);
-
-      //
-      // move anchor
-      //
-      Qt::KeyboardModifiers km = qApp->keyboardModifiers();
-      if (km != (Qt::ShiftModifier | Qt::ControlModifier)) {
-            int si;
-            Segment* seg = 0;
-            if (score()->pos2measure(ed->pos, &si, 0, &seg, 0) == nullptr)
-                  return f;
-            if (seg && (seg != segment() || staffIdx() != si)) {
-                  QPointF pos1(canvasPos());
-                  score()->undo(new ChangeParent(this, seg, si));
-                  setUserOff(QPointF());
-                  layout();
-                  QPointF pos2(canvasPos());
-                  setUserOff(pos1 - pos2);
-                  ed->startMove = pos2;
-                  }
-            }
-      return f;
-      }
-
 }
 

--- a/libmscore/instrchange.h
+++ b/libmscore/instrchange.h
@@ -45,8 +45,6 @@ class InstrumentChange : public Text  {
 
       Segment* segment() const              { return toSegment(parent()); }
 
-      virtual QRectF drag(EditData*) override;
-
       virtual QVariant getProperty(P_ID propertyId) const override;
       virtual bool setProperty(P_ID propertyId, const QVariant&) override;
       virtual QVariant propertyDefault(P_ID) const override;


### PR DESCRIPTION
Removes the overridden method InstrumentChange::drag().  So now just uses Element::drag(), which won't change the anchor.