### PR TITLE
fix #181671 restrict all Text drag to Page Boundaries

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -337,7 +337,7 @@ QRectF Element::drag(EditData* data)
       setUserOff(QPointF(x, y));
       setGenerated(false);
 
-      if (type() == ElementType::TEXT) {         // TODO: check for other types
+      if (isText()) {         // TODO: check for other types
             //
             // restrict move to page boundaries
             //


### PR DESCRIPTION
Previously only restriced drag to elements of class Text, but not their derived classes such as Staff Text, Chord Text, System Text, etc.