### PR TITLE
fix #181701 TextTools spinbox minimum set to 1.

### DIFF
--- a/libmscore/text.h
+++ b/libmscore/text.h
@@ -59,7 +59,7 @@ class CharFormat {
       void setUnderline(bool val)            { _underline   = val;  }
       void setPreedit(bool val)              { _preedit     = val;  }
       void setValign(VerticalAlignment val)  { _valign      = val;  }
-      void setFontSize(qreal val)            { _fontSize    = val;  }
+      void setFontSize(qreal val)            { Q_ASSERT(val > 0.0); _fontSize = val; }
       void setFontFamily(const QString& val) { _fontFamily  = val;  }
 
       void setFormat(FormatId, QVariant);

--- a/mscore/texttools.cpp
+++ b/mscore/texttools.cpp
@@ -93,6 +93,7 @@ TextTools::TextTools(QWidget* parent)
 
       typefaceSize = new QDoubleSpinBox(this);
       typefaceSize->setFocusPolicy(Qt::ClickFocus);
+      typefaceSize->setMinimum(1);
       tb->addWidget(typefaceSize);
 
       setWidget(tb);


### PR DESCRIPTION
This prevents a bug in 3.0 whereby musescore would be killed if set text size to 0.

I also put in a Q_ASSERT into CharFormat::setFontSize() to ensure FontSize is positive real.