### PR TITLE
Fix #109066 : Tempo Slider and Volume slider Left Double click wrong default values

### DIFF
--- a/awl/volslider.cpp
+++ b/awl/volslider.cpp
@@ -36,7 +36,7 @@ VolSlider::VolSlider(QWidget* parent)
       setScaleWidth(7);
       setLineStep(.8f);
       setPageStep(3.0f);
-      setDclickValue1(_minValue);
+      setDclickValue1(-20.5);
       setDclickValue2(0.0);
       }
 

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -58,7 +58,7 @@ PlayPanel::PlayPanel(QWidget* parent)
       enablePlay = new EnablePlayForWidget(this);
 
       tempoSlider->setDclickValue1(100.0);
-      tempoSlider->setDclickValue2(100.0);
+      tempoSlider->setDclickValue2(200.0);
       tempoSlider->setUseActualValue(true);
 
       connect(volumeSlider, SIGNAL(valueChanged(double,int)), SLOT(volumeChanged(double,int)));


### PR DESCRIPTION
Fix to Double-click sliders in play panel or synthesizer sets them to zero