### PR TITLE
fix #181811 validate instrument text name after editing

### DIFF
--- a/libmscore/iname.cpp
+++ b/libmscore/iname.cpp
@@ -73,6 +73,11 @@ void InstrumentName::endEdit()
 
       QString s = plainText();
 
+      if (!validateText(s)) {
+            qWarning("Invalid instrument name: <%s>", s.toUtf8().data());
+            return;
+            }
+
       if (_instrumentNameType == InstrumentNameType::LONG)
             instrument->setLongName(s);
       else


### PR DESCRIPTION
I've tested this and verified that the validateText(s) I inserted here properly changes an '&' into an 'amp;' 