### PR TITLE
fix #182171 correct update rect to cover entire meter rect

### DIFF
--- a/awl/mslider.cpp
+++ b/awl/mslider.cpp
@@ -82,7 +82,7 @@ void MeterSlider::setMeterVal(int channel, double v, double peak)
       if (mustRedraw) {
             int kh = sliderSize().height();
             int mh = height() - kh;
-            update(20, kh / 2, _meterWidth-1, mh);
+            update(_meterLeftEdge, kh / 2, _meterWidth-1, mh);
             }
       }
 
@@ -179,7 +179,7 @@ void MeterSlider::paintEvent(QPaintEvent* ev)
       //---------------------------------------------------
 
       int mw = _meterWidth / _channel;
-      int x  = 18;
+      int x  = _meterLeftEdge;
       int y1 = kh / 2;
       int y3 = h - y1;
 
@@ -210,7 +210,7 @@ void MeterSlider::paintEvent(QPaintEvent* ev)
       x += 4;
 
       // optimize common case:
-      if (ev->rect() == QRect(20, kh/2, _meterWidth-1, mh))
+      if (ev->rect() == QRect(_meterLeftEdge, kh/2, _meterWidth-1, mh))
             return;
 
       QColor sc(isEnabled() ? _scaleColor : Qt::gray);
@@ -234,14 +234,14 @@ void MeterSlider::paintEvent(QPaintEvent* ev)
    	p.setFont(f);
       p.setPen(QPen(Qt::darkGray, 2));
    	QFontMetrics fm(f);
-      int xt = 20 - fm.width("00") - 5;
+      int xt = _meterLeftEdge - fm.width("00") - 3;
 
       QString s;
    	for (int i = 10; i < 70; i += 10) {
       	h  = y1 + lrint(i * mh / range);
          	s.setNum(i - 10);
   		p.drawText(xt,  h - 3, s);
-		p.drawLine(15, h, 20, h);
+            p.drawLine(_meterLeftEdge - 3, h, _meterLeftEdge - 1, h);
          	}
 
       //---------------------------------------------------

--- a/awl/mslider.h
+++ b/awl/mslider.h
@@ -41,6 +41,7 @@ class MeterSlider : public VolSlider
       std::vector<double> meterPeak;
       int yellowScale, redScale;
       int _meterWidth;
+      static const int _meterLeftEdge = 18;
       QPixmap onPm, offPm;  // cached pixmap values
 
       virtual void mousePressEvent(QMouseEvent*);


### PR DESCRIPTION
Also utilized private static const int to hold _meterLeftEdge for readability and so that if this number is modified, both lines of the code that are affected will still be correct.
Also shortened the notches so that their right edge is just before the left edge of the meter, so that the notches don't have to be redrawn every audio frame when the meter's rect needs to be updated.