### PR TITLE
Fix #179551: MusicXML Not Exporting Positioning

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1622,6 +1622,16 @@ Element* Element::findMeasure()
             return 0;
       }
 
+const Element* Element::findMeasure() const
+      {
+      if (type() == Element::Type::MEASURE)
+            return this;
+      else if (_parent)
+            return _parent->findMeasure();
+      else
+            return 0;
+      }
+
 //---------------------------------------------------------
 //   undoSetColor
 //---------------------------------------------------------

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -325,6 +325,7 @@ class Element : public QObject, public ScoreElement {
       Element* parent() const                 { return _parent;     }
       void setParent(Element* e)              { _parent = e;        }
       Element* findMeasure();
+      const Element* findMeasure() const;
 
       qreal spatium() const;
 

--- a/libmscore/line.h
+++ b/libmscore/line.h
@@ -90,9 +90,6 @@ class SLine : public Spanner {
       Qt::PenStyle _lineStyle;
       bool _diagonal;
 
-   protected:
-      virtual QPointF linePos(Grip, System** system) const;
-
    public:
       SLine(Score* s);
       SLine(const SLine&);
@@ -103,6 +100,7 @@ class SLine : public Spanner {
       virtual LineSegment* createLineSegment() = 0;
       void setLen(qreal l);
       virtual const QRectF& bbox() const override;
+      virtual QPointF linePos(Grip, System** system) const;
 
       virtual void write(Xml&) const override;
       virtual void read(XmlReader&) override;

--- a/libmscore/pedal.h
+++ b/libmscore/pedal.h
@@ -53,15 +53,13 @@ class Pedal : public TextLine {
       PropertyStyle lineWidthStyle;
       PropertyStyle lineStyleStyle;
 
-   protected:
-      QPointF linePos(Grip, System**) const override;
-
    public:
       Pedal(Score* s);
       virtual Pedal* clone() const override       { return new Pedal(*this); }
       virtual Element::Type type() const override { return Element::Type::PEDAL; }
       virtual void read(XmlReader&) override;
       LineSegment* createLineSegment();
+      QPointF linePos(Grip, System**) const override;
       virtual void setYoff(qreal) override;
       virtual bool setProperty(P_ID propertyId, const QVariant& val) override;
       virtual QVariant propertyDefault(P_ID propertyId) const override;

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -336,25 +336,25 @@ public:
 //   while all other elements are relative to their position or the nearest note.
 //---------------------------------------------------------
 
-static QString addPositioningAttributes (QString &xml, Element const* const el, bool isSpanStart = true)
+static QString addPositioningAttributes(QString& xml, Element const* const el, bool isSpanStart = true)
     {
+        if (!preferences.musicxmlExportLayout)
+            return xml;
+
         const float positionElipson = 0.1f;
-        float defaultX, defaultY, relativeX, relativeY = 0;
+        float defaultX = 0, defaultY = 0, relativeX = 0, relativeY = 0;
         float spatium = el->spatium();
 
-        if (SLine const* const span = dynamic_cast<SLine const* const>(el))
-        {
+        if (SLine const* const span = dynamic_cast<SLine const* const>(el)) {
             SpannerSegment* seg;
-            if(isSpanStart)
-            {
+            if(isSpanStart) {
                 seg = span->spannerSegments().first();
                 QPointF userOff = seg->userOff();
                 QPointF p = seg->pos();
                 defaultX = userOff.x();
                 defaultY = p.y();
             }
-            else
-            {
+            else {
                 seg = span->spannerSegments().last();
                 QPointF userOff = seg->userOff(); // This is the offset accessible from the inspector
                 QPointF userOff2 = seg->userOff2(); // Offset of the actual dragged anchor, which doesn't affect the inspector offset
@@ -394,8 +394,7 @@ static QString addPositioningAttributes (QString &xml, Element const* const el, 
                 qDebug("defaultX : %f", defaultX); */
             }
         }
-        else
-        {
+        else {
             // defaultX = el->ipos().x();
             // finale doesn't play nicely with defaultX's for some reason, espeically dynamics, which causes an incorrect offset, but we can account
             // for this by using pos() instead of userOff() for relativeX
@@ -407,15 +406,14 @@ static QString addPositioningAttributes (QString &xml, Element const* const el, 
         defaultX *=  10 / spatium; defaultY *=  -10 / spatium; // convert into spatium tenths for musicxml
         relativeX *=  10 / spatium; relativeY *=  -10 / spatium;
 
-        if (preferences.musicxmlExportLayout && fabsf(defaultX) > positionElipson)
+        if (fabsf(defaultX) > positionElipson)
               xml += QString(" default-x=\"%1\"").arg(QString::number(defaultX, 'f', 2));
-        if (preferences.musicxmlExportLayout && fabsf(defaultY) > positionElipson)
+        if (fabsf(defaultY) > positionElipson)
               xml += QString(" default-y=\"%1\"").arg(QString::number(defaultY, 'f', 2));
-        if (preferences.musicxmlExportLayout && fabsf(relativeX) > positionElipson)
+        if (fabsf(relativeX) > positionElipson)
               xml += QString(" relative-x=\"%1\"").arg(QString::number(relativeX, 'f', 2));
-        if (preferences.musicxmlExportLayout && fabsf(relativeY) > positionElipson)
+        if (fabsf(relativeY) > positionElipson)
               xml += QString(" relative-y=\"%1\"").arg(QString::number(relativeY, 'f', 2));
-
 
         return xml;
     }
@@ -3831,7 +3829,7 @@ static void directionJump(Xml& xml, const Jump* const jp)
       if (sound != "") {
             xml.stag("direction placement=\"above\"");
             xml.stag("direction-type");
-            QString positioning = " ";
+            QString positioning = "";
             addPositioningAttributes(positioning, jp);
             if (type != "") xml.tagE(type + positioning);
             if (words != "") xml.tag("words" + positioning, words);
@@ -3886,7 +3884,7 @@ static void directionMarker(Xml& xml, const Marker* const m)
       if (sound != "") {
             xml.stag("direction placement=\"above\"");
             xml.stag("direction-type");
-            QString positioning = " ";
+            QString positioning = "";
             addPositioningAttributes(positioning, m);
             if (type != "") xml.tagE(type + positioning);
             if (words != "") xml.tag("words" + positioning, words);

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -348,14 +348,16 @@ static QString addPositioningAttributes (QString &xml, Element const* const el, 
                 seg = span->spannerSegments().first();
                 QPointF userOff = seg->userOff();
                 QPointF p = seg->pos();
-                defaultX = userOff.x() * 10 / spatium;
-                defaultY = p.y() * -10 / spatium;
+                defaultX = userOff.x();
+                defaultY = p.y();
             }
             else
             {
                 seg = span->spannerSegments().last();
                 QPointF userOff = seg->userOff(); // This is the offset accessible from the inspector
                 QPointF userOff2 = seg->userOff2(); // Offset of the actual dragged anchor, which doesn't affect the inspector offset
+                QPointF pos = seg->pos();
+                QPointF pos2 = seg->pos2();
 
                 Note* n = dynamic_cast<Note*>(span->endElement());
                 ChordRest* cr = n ? n->chord() : dynamic_cast<ChordRest*>(span->endElement());
@@ -372,11 +374,11 @@ static QString addPositioningAttributes (QString &xml, Element const* const el, 
                 float mX = cr ?  m->pos().x() : m->tick2pos(t); // Distance the start of the measure is from the beginning of the line
                 float crSpace = cr ? cr->x() + cr->space().rw() : 0; // this is the space between the left edge of hte note to the right edge of the note
 
-                defaultX = (m->width() - ((linePos.x() - mX - crSpace) + (userOff2.x() + userOff.x())));
+                defaultX = (((linePos.x() - mX - crSpace) + (userOff2.x() + userOff.x())) - m->width());
                 // add the position of the end anchor to the offset to get the absolute X
                 // the x's go from the right edge for some reason, so you must subtract the measure width and multiply by -10 instead of 10 to get a negative
                 // LinePos includes the measureX, so we must subtract that because defaultX is relative to the current measure
-                defaultX *=  -10 / spatium; // convert into spatium tenths for musicxml
+                defaultY = pos.y() + pos2.y();
 
              /* qDebug("CR SegPos X: %f", cr->segment()->pos().x());
                 qDebug("CR Pos X: %f", cr->pos().x());
@@ -389,6 +391,8 @@ static QString addPositioningAttributes (QString &xml, Element const* const el, 
                 qDebug("defaultX : %f", defaultX); */
             }
         }
+
+        defaultX *=  10 / spatium; defaultY *=  -10 / spatium; // convert into spatium tenths for musicxml
 
         if (preferences.musicxmlExportLayout && fabsf(defaultX) > positionElipson)
               xml += QString(" default-x=\"%1\"").arg(QString::number(defaultX, 'f', 2));

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -331,6 +331,75 @@ public:
       };
 
 //---------------------------------------------------------
+//   addPositioningAttributes
+//---------------------------------------------------------
+
+static QString addPositioningAttributes (QString &xml, Element const* const el, bool isSpanStart = true)
+    {
+        const float positionElipson = 0.1f;
+        float defaultX, defaultY;
+        float spatium = el->spatium();
+
+        if (SLine const* const span = dynamic_cast<SLine const* const>(el))
+        {
+            SpannerSegment* seg;
+            if(isSpanStart)
+            {
+                seg = span->spannerSegments().first();
+                QPointF userOff = seg->userOff();
+                QPointF p = seg->pos();
+                defaultX = userOff.x() * 10 / spatium;
+                defaultY = p.y() * -10 / spatium;
+            }
+            else
+            {
+                seg = span->spannerSegments().last();
+                QPointF userOff = seg->userOff(); // This is the offset accessible from the inspector
+                QPointF userOff2 = seg->userOff2(); // Offset of the actual dragged anchor, which doesn't affect the inspector offset
+
+                Note* n = dynamic_cast<Note*>(span->endElement());
+                ChordRest* cr = n ? n->chord() : dynamic_cast<ChordRest*>(span->endElement());
+                int t = span->tick2();
+                Measure* m = cr ? cr->measure() : span->score()->tick2measure(t);
+
+                if (!cr)
+                    qDebug("ExportMusicXml::addPositionAttribute: Expected ChordRest or Note from endElement, got %s (%p)",
+                           Element::name(span->endElement()->type()), span->endElement());
+
+                System* s;
+                QPointF linePos(span->linePos(Grip::END, &s)); // find the position of the end anchor
+
+                float mX = cr ?  m->pos().x() : m->tick2pos(t); // Distance the start of the measure is from the beginning of the line
+                float crSpace = cr ? cr->x() + cr->space().rw() : 0; // this is the space between the left edge of hte note to the right edge of the note
+
+                defaultX = (m->width() - ((linePos.x() - mX - crSpace) + (userOff2.x() + userOff.x())));
+                // add the position of the end anchor to the offset to get the absolute X
+                // the x's go from the right edge for some reason, so you must subtract the measure width and multiply by -10 instead of 10 to get a negative
+                // LinePos includes the measureX, so we must subtract that because defaultX is relative to the current measure
+                defaultX *=  -10 / spatium; // convert into spatium tenths for musicxml
+
+             /* qDebug("CR SegPos X: %f", cr->segment()->pos().x());
+                qDebug("CR Pos X: %f", cr->pos().x());
+                qDebug("CR Space: %f", cr->space().rw());
+                qDebug("measure pos X: %f", m->pos().x());
+                qDebug("measure width : %f", m->width());
+                qDebug("linePos2 x: %f", linePos.x());
+                qDebug("userOFf2 x: %f", userOff2.x());
+                qDebug("userOFf x: %f", userOff.x());
+                qDebug("defaultX : %f", defaultX); */
+            }
+        }
+
+        if (preferences.musicxmlExportLayout && fabsf(defaultX) > positionElipson)
+              xml += QString(" default-x=\"%1\"").arg(QString::number(defaultX, 'f', 2));
+        if (preferences.musicxmlExportLayout && fabsf(defaultY) > positionElipson)
+              xml += QString(" default-y=\"%1\"").arg(QString::number(defaultY, 'f', 2));
+
+
+        return xml;
+    }
+
+//---------------------------------------------------------
 //   tag
 //---------------------------------------------------------
 
@@ -670,6 +739,7 @@ static void glissando(const Glissando* gli, int number, bool start, Notations& n
             }
       tagName += QString(" number=\"%1\" type=\"%2\"").arg(number).arg(start ? "start" : "stop");
       tagName += color2xml(gli);
+      addPositioningAttributes(tagName, gli, start);
       notations.tag(xml);
       if (start && gli->showText() && gli->text() != "")
             xml.tag(tagName, gli->text());
@@ -1397,6 +1467,7 @@ static void ending(Xml& xml, Volta* v, bool left)
                   number += ", ";
             number += QString("%1").arg(i);
             }
+      QString voltaXml = "ending number=\"%1\" type=\"%2\"";
       if (left) {
             type = "start";
             }
@@ -1415,7 +1486,8 @@ static void ending(Xml& xml, Volta* v, bool left)
                         break;
                   }
             }
-      xml.tagE(QString("ending number=\"%1\" type=\"%2\"").arg(number).arg(type));
+      addPositioningAttributes(voltaXml, v, left);
+      xml.tagE(voltaXml.arg(number).arg(type));
       }
 
 //---------------------------------------------------------
@@ -1730,7 +1802,9 @@ void ExportMusicXml::wavyLineStartStop(Chord* chord, Notations& notations, Ornam
             if (n >= 0) {
                   notations.tag(xml);
                   ornaments.tag(xml);
-                  xml.tagE(QString("wavy-line type=\"stop\" number=\"%1\"").arg(n + 1));
+                  QString trillXml = QString("wavy-line type=\"stop\" number=\"%1\"").arg(n + 1);
+                  addPositioningAttributes(trillXml, tr, false);
+                  xml.tagE(trillXml);
                   }
             trillStop.remove(chord);
             }
@@ -1749,7 +1823,8 @@ void ExportMusicXml::wavyLineStartStop(Chord* chord, Notations& notations, Ornam
                         xml.tagE("trill-mark");
                         QString tagName = "wavy-line type=\"start\"";
                         tagName += QString(" number=\"%1\"").arg(n + 1);
-                        tagName += color2xml(tr);
+                        tagName += color2xml(tr);                        
+                        addPositioningAttributes(tagName, tr, true);
                         xml.tagE(tagName);
                         }
                   else
@@ -3295,27 +3370,30 @@ void ExportMusicXml::hairpin(Hairpin const* const hp, int staff, int tick)
 
       directionTag(xml, attr, hp);
       xml.stag("direction-type");
-            
+
+      QString hairpinXml;
       if (hp->tick() == tick) {
             if ( hp->hairpinType() == Hairpin::Type::CRESCENDO ) {
                   if ( hp->hairpinCircledTip() ) {
-                        xml.tagE(QString("wedge type=\"crescendo\" niente=\"yes\" number=\"%1\"").arg(n + 1));
+                        hairpinXml = QString("wedge type=\"crescendo\" niente=\"yes\" number=\"%1\"").arg(n + 1);
                         }
                   else {
-                        xml.tagE(QString("wedge type=\"crescendo\" number=\"%1\"").arg(n + 1));
+                      hairpinXml = QString("wedge type=\"crescendo\" number=\"%1\"").arg(n + 1);
                         }
                   }
             else {
-                  xml.tagE(QString("wedge type=\"diminuendo\" number=\"%1\"").arg(n + 1));
+                hairpinXml = QString("wedge type=\"diminuendo\" number=\"%1\"").arg(n + 1);
                   }
             }
       else {
             if ( hp->hairpinCircledTip() && hp->hairpinType() == Hairpin::Type::DECRESCENDO )
-                  xml.tagE(QString("wedge type=\"stop\" niente=\"yes\" number=\"%1\"").arg(n + 1));
+                  hairpinXml = QString("wedge type=\"stop\" niente=\"yes\" number=\"%1\"").arg(n + 1);
             else
-                  xml.tagE(QString("wedge type=\"stop\" number=\"%1\"").arg(n + 1));
+                  hairpinXml = QString("wedge type=\"stop\" number=\"%1\"").arg(n + 1);
 
             }
+      addPositioningAttributes(hairpinXml, hp, hp->tick() == tick);
+      xml.tagE(hairpinXml);
       xml.etag();
       directionETag(xml, staff);
       }
@@ -3356,6 +3434,7 @@ void ExportMusicXml::ottava(Ottava const* const ot, int staff, int tick)
       directionTag(xml, attr, ot);
       xml.stag("direction-type");
 
+      QString octaveShiftXml;
       Ottava::Type st = ot->ottavaType();
       if (ot->tick() == tick) {
             const char* sz = 0;
@@ -3381,16 +3460,18 @@ void ExportMusicXml::ottava(Ottava const* const ot, int staff, int tick)
                         qDebug("ottava subtype %hhd not understood", st);
                   }
             if (sz && tp)
-                  xml.tagE(QString("octave-shift type=\"%1\" size=\"%2\" number=\"%3\"").arg(tp).arg(sz).arg(n + 1));
+                  octaveShiftXml = QString("octave-shift type=\"%1\" size=\"%2\" number=\"%3\"").arg(tp).arg(sz).arg(n + 1);
             }
       else {
             if (st == Ottava::Type::OTTAVA_8VA || st == Ottava::Type::OTTAVA_8VB)
-                  xml.tagE(QString("octave-shift type=\"stop\" size=\"8\" number=\"%1\"").arg(n + 1));
+                  octaveShiftXml = QString("octave-shift type=\"stop\" size=\"8\" number=\"%1\"").arg(n + 1);
             else if (st == Ottava::Type::OTTAVA_15MA || st == Ottava::Type::OTTAVA_15MB)
-                  xml.tagE(QString("octave-shift type=\"stop\" size=\"15\" number=\"%1\"").arg(n + 1));
+                  octaveShiftXml = QString("octave-shift type=\"stop\" size=\"15\" number=\"%1\"").arg(n + 1);
             else
                   qDebug("ottava subtype %hhd not understood", st);
             }
+      addPositioningAttributes(octaveShiftXml, ot, ot->tick() == tick);
+      xml.tagE(octaveShiftXml);
       xml.etag();
       directionETag(xml, staff);
       }
@@ -3403,10 +3484,13 @@ void ExportMusicXml::pedal(Pedal const* const pd, int staff, int tick)
       {
       directionTag(xml, attr, pd);
       xml.stag("direction-type");
+      QString pedalXml;
       if (pd->tick() == tick)
-            xml.tagE("pedal type=\"start\" line=\"yes\"");
+            pedalXml = "pedal type=\"start\" line=\"yes\"";
       else
-            xml.tagE("pedal type=\"stop\" line=\"yes\"");
+            pedalXml = "pedal type=\"stop\" line=\"yes\"";
+      addPositioningAttributes(pedalXml, pd, pd->tick() == tick);
+      xml.tagE(pedalXml);
       xml.etag();
       directionETag(xml, staff);
       }


### PR DESCRIPTION
In these commits, I created a function that will add default-x, default-y, relative-x, and relative-y attributes to most elements depending on their type. I then added calls to this function for all of the exported elements that are specified in my testing document, PositioningTest.mscz, found in the issue tracker.

The behavior of the position exporter was designed around Finale, since Finale follows the MusicXML spec closer than any other notation engine. Thus, the compatibility with other notation software is not known.