### PR TITLE
fix #182546 #182176 Move Metronome to PlayPanel

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2051,6 +2051,7 @@ void MuseScore::showPlayPanel(bool visible)
                   return;
             playPanel = new PlayPanel(this);
             connect(playPanel, SIGNAL(gainChange(float)),     synti, SLOT(setGain(float)));
+            connect(playPanel, SIGNAL(metronomeGainChanged(float)), seq, SLOT(setMetronomeGain(float)));
             connect(playPanel, SIGNAL(relTempoChanged(double)),seq, SLOT(setRelTempo(double)));
             connect(playPanel, SIGNAL(posChange(int)),         seq, SLOT(seek(int)));
             connect(playPanel, SIGNAL(closed(bool)),          playId,   SLOT(setChecked(bool)));

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -61,7 +61,10 @@ PlayPanel::PlayPanel(QWidget* parent)
       tempoSlider->setDclickValue2(100.0);
       tempoSlider->setUseActualValue(true);
 
+      mgainSlider->setValue(seq->metronomeGain());
+
       connect(volumeSlider, SIGNAL(valueChanged(double,int)), SLOT(volumeChanged(double,int)));
+      connect(mgainSlider,  SIGNAL(valueChanged(double,int)), SLOT(metronomeGainChanged(double,int)));
       connect(posSlider,    SIGNAL(sliderMoved(int)),         SLOT(setPos(int)));
       connect(tempoSlider,  SIGNAL(valueChanged(double,int)), SLOT(relTempoChanged(double,int)));
       connect(tempoSlider,  SIGNAL(sliderPressed(int)),       SLOT(tempoSliderPressed(int)));
@@ -242,6 +245,15 @@ void PlayPanel::setGain(float val)
 void PlayPanel::volumeChanged(double val, int)
       {
       emit gainChange(val);
+      }
+
+//---------------------------------------------------------
+//   metronomeGainChanged
+//---------------------------------------------------------
+
+void PlayPanel::metronomeGainChanged(double val, int)
+      {
+      emit metronomeGainChanged(val);
       }
 
 //---------------------------------------------------------

--- a/mscore/playpanel.h
+++ b/mscore/playpanel.h
@@ -49,6 +49,7 @@ class PlayPanel : public QWidget, private Ui::PlayPanelBase {
 
    private slots:
       void volumeChanged(double,int);
+      void metronomeGainChanged(double val, int);
       void relTempoChanged(double,int);
       void relTempoChanged();
       void tempoSliderReleased(int);
@@ -60,6 +61,7 @@ class PlayPanel : public QWidget, private Ui::PlayPanelBase {
 
    signals:
       void relTempoChanged(double);
+      void metronomeGainChanged(float);
       void posChange(int);
       void gainChange(float);
       void closed(bool);

--- a/mscore/playpanel.ui
+++ b/mscore/playpanel.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>380</width>
+    <width>389</width>
     <height>293</height>
    </rect>
   </property>
@@ -153,7 +153,7 @@
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" stretch="0,0,0,0,0">
+      <layout class="QHBoxLayout" stretch="0,0,0,0">
        <property name="spacing">
         <number>1</number>
        </property>
@@ -218,32 +218,6 @@
           <bool>true</bool>
          </property>
         </widget>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QToolButton" name="countInButton">
-           <property name="text">
-            <string notr="true"/>
-           </property>
-           <property name="icon">
-            <iconset resource="musescore.qrc">
-             <normaloff>:/data/icons/media-playback-countin.svg</normaloff>:/data/icons/media-playback-countin.svg</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="metronomeButton">
-           <property name="text">
-            <string notr="true"/>
-           </property>
-           <property name="icon">
-            <iconset resource="musescore.qrc">
-             <normaloff>:/data/icons/media-playback-metronome.svg</normaloff>:/data/icons/media-playback-metronome.svg</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <spacer>
@@ -351,7 +325,41 @@
      <property name="spacing">
       <number>6</number>
      </property>
-     <item row="2" column="0">
+     <item row="0" column="1">
+      <widget class="QLabel" name="tempoLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font/>
+       </property>
+       <property name="toolTip">
+        <string>Actual tempo in quarter notes per minute</string>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="lineWidth">
+        <number>2</number>
+       </property>
+       <property name="midLineWidth">
+        <number>2</number>
+       </property>
+       <property name="text">
+        <string notr="true">120 BPM</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::NoTextInteraction</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
       <widget class="Awl::Slider" name="tempoSlider" native="true">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -391,29 +399,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="Awl::VolSlider" name="volumeSlider" native="true">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="focusPolicy">
-        <enum>Qt::TabFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>Master volume</string>
-       </property>
-       <property name="accessibleName">
-        <string>Master Volume</string>
-       </property>
-       <property name="accessibleDescription">
-        <string>Use up and down arrows to change value</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
+     <item row="3" column="2">
       <widget class="QLabel" name="label">
        <property name="text">
         <string extracomment="short text for volume slider">Volume</string>
@@ -423,51 +409,59 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="tempoLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font/>
-       </property>
-       <property name="toolTip">
-        <string>Actual tempo in quarter notes per minute</string>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="lineWidth">
-        <number>2</number>
-       </property>
-       <property name="midLineWidth">
-        <number>2</number>
-       </property>
-       <property name="text">
-        <string notr="true">120 BPM</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::NoTextInteraction</set>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string extracomment="short text for tempo slider">Tempo</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_10">
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QToolButton" name="metronomeButton">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="icon">
+          <iconset resource="musescore.qrc">
+           <normaloff>:/data/icons/media-playback-metronome.svg</normaloff>:/data/icons/media-playback-metronome.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="countInButton">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="icon">
+          <iconset resource="musescore.qrc">
+           <normaloff>:/data/icons/media-playback-countin.svg</normaloff>:/data/icons/media-playback-countin.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
-     <item row="1" column="0">
+     <item row="1" column="1">
       <widget class="QDoubleSpinBox" name="relTempoBox">
        <property name="accessibleName">
         <string>Relative tempo to 120 beats per minute</string>
@@ -501,6 +495,60 @@
        </property>
       </widget>
      </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string extracomment="short text for tempo slider">Tempo</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="Awl::VolSlider" name="mgainSlider" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Metronome volume</string>
+       </property>
+       <property name="accessibleName">
+        <string>Metronome Volume</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>Use up and down arrows to change value</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="Awl::VolSlider" name="volumeSlider" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Master volume</string>
+       </property>
+       <property name="accessibleName">
+        <string>Master Volume</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>Use up and down arrows to change value</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
@@ -521,8 +569,6 @@
   <tabstop>posSlider</tabstop>
   <tabstop>rewindButton</tabstop>
   <tabstop>playButton</tabstop>
-  <tabstop>countInButton</tabstop>
-  <tabstop>metronomeButton</tabstop>
   <tabstop>loopInButton</tabstop>
   <tabstop>loopButton</tabstop>
   <tabstop>loopOutButton</tabstop>

--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -76,8 +76,6 @@ SynthControl::SynthControl(QWidget* parent)
                   }
             }
       readSettings();
-      metronome->setDefaultAction(getAction("metronome"));
-      mgain->setValue(seq->metronomeGain());
 
       updateGui();
 
@@ -89,7 +87,6 @@ SynthControl::SynthControl(QWidget* parent)
       connect(effectA,      SIGNAL(currentIndexChanged(int)), SLOT(effectAChanged(int)));
       connect(effectB,      SIGNAL(currentIndexChanged(int)), SLOT(effectBChanged(int)));
       connect(gain,         SIGNAL(valueChanged(double,int)), SLOT(gainChanged(double,int)));
-      connect(mgain,        SIGNAL(valueChanged(double,int)), SLOT(metronomeGainChanged(double,int)));
       connect(masterTuning, SIGNAL(valueChanged(double)),     SLOT(masterTuningChanged(double)));
       connect(changeTuningButton, SIGNAL(clicked()),          SLOT(changeMasterTuning()));
       connect(loadButton,   SIGNAL(clicked()),                SLOT(loadButtonClicked()));
@@ -165,7 +162,6 @@ void MuseScore::showSynthControl(bool val)
             connect(synthControl, SIGNAL(closed(bool)), a,     SLOT(setChecked(bool)));
             if (mixer)
                   connect(synthControl, SIGNAL(soundFontChanged()), mixer, SLOT(patchListChanged()));
-            connect(synthControl, SIGNAL(metronomeGainChanged(float)), seq, SLOT(setMetronomeGain(float)));
             }
       synthControl->setVisible(val);
       }
@@ -177,15 +173,6 @@ void MuseScore::showSynthControl(bool val)
 void SynthControl::gainChanged(double val, int)
       {
       emit gainChanged(val);
-      }
-
-//---------------------------------------------------------
-//   metronomeGainChanged
-//---------------------------------------------------------
-
-void SynthControl::metronomeGainChanged(double val, int)
-      {
-      emit metronomeGainChanged(val);
       }
 
 //---------------------------------------------------------

--- a/mscore/synthcontrol.h
+++ b/mscore/synthcontrol.h
@@ -47,7 +47,6 @@ class SynthControl : public QWidget, Ui::SynthControl {
 
    private slots:
       void gainChanged(double, int);
-      void metronomeGainChanged(double val, int);
       void masterTuningChanged(double);
       void changeMasterTuning();
       void effectAChanged(int);
@@ -60,7 +59,6 @@ class SynthControl : public QWidget, Ui::SynthControl {
 
    signals:
       void gainChanged(float);
-      void metronomeGainChanged(float);
       void soundFontChanged();
       void closed(bool);
 

--- a/mscore/synthcontrol.ui
+++ b/mscore/synthcontrol.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>602</width>
-    <height>281</height>
+    <height>407</height>
    </rect>
   </property>
   <property name="focusPolicy">
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Synthesizer</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0">
+  <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
    <property name="leftMargin">
     <number>10</number>
    </property>
@@ -89,10 +89,10 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="2" rowspan="3">
+   <item row="0" column="1" rowspan="3">
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="Awl::MeterSlider" name="gain">
+      <widget class="Awl::MeterSlider" name="gain" native="true">
        <property name="focusPolicy">
         <enum>Qt::TabFocus</enum>
        </property>
@@ -105,7 +105,7 @@
        <property name="accessibleDescription">
         <string>Use up and down arrows to modify</string>
        </property>
-       <property name="channel">
+       <property name="channel" stdset="0">
         <number>2</number>
        </property>
       </widget>
@@ -127,28 +127,6 @@
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="0" column="1">
-    <widget class="Awl::VolSlider" name="mgain">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-     <property name="accessibleName">
-      <string>Metronome gain</string>
-     </property>
-     <property name="accessibleDescription">
-      <string>Use up and down arrows to modify</string>
-     </property>
-     <property name="center">
-      <bool>true</bool>
-     </property>
-    </widget>
    </item>
    <item row="0" column="0" rowspan="2">
     <widget class="QTabWidget" name="tabWidget">
@@ -324,13 +302,6 @@
      </widget>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QToolButton" name="metronome">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -356,8 +327,6 @@
   <tabstop>effectB</tabstop>
   <tabstop>masterTuning</tabstop>
   <tabstop>changeTuningButton</tabstop>
-  <tabstop>metronome</tabstop>
-  <tabstop>mgain</tabstop>
   <tabstop>gain</tabstop>
   <tabstop>saveButton</tabstop>
   <tabstop>loadButton</tabstop>


### PR DESCRIPTION
Moving the Metronome out of the Synth and into the PlayPanel fixes two problem:

182176 Synthesizer Metronome button not lined up with Metronome vol slider if adjust right edge of window.
182546 Metronome's volume and it's mute status are not saved/loaded from score or default.