### PR TITLE
Fixes for platforms (android) without Printer or Webengine support

### DIFF
--- a/all.h
+++ b/all.h
@@ -44,7 +44,7 @@
 #include <QLoggingCategory>
 #include <QModelIndex>
 
-#ifndef Q_OS_WIN
+#ifdef QT_WEBENGINE_LIB
 // no precompiled QtWebEngine in Qt 5.6 windows gcc
 #include <QWebEngineView>
 #endif
@@ -96,14 +96,16 @@
 #include <QToolBar>
 #include <QTreeWidget>
 #include <QFileDialog>
+#ifdef QT_PRINTSUPPORT_LIB
 #include <QPrintDialog>
+#include <QPrinter>
+#endif
 #include <QColorDialog>
 #include <QDockWidget>
 #include <QStackedWidget>
 #include <QStackedLayout>
 #include <QListWidget>
 #include <QMessageBox>
-#include <QPrinter>
 #include <QComboBox>
 #include <QMainWindow>
 #include <QMenu>

--- a/build/FindQt5.cmake
+++ b/build/FindQt5.cmake
@@ -30,6 +30,7 @@ foreach(_component ${_components})
   find_package(Qt5${_component})
   list(APPEND QT_LIBRARIES ${Qt5${_component}_LIBRARIES})
   list(APPEND QT_INCLUDES ${Qt5${_component}_INCLUDE_DIRS})
+  add_definitions(${Qt5${_component}_DEFINITIONS})
 endforeach()
 
 include_directories(${QT_INCLUDES})

--- a/mscore/exportaudio.cpp
+++ b/mscore/exportaudio.cpp
@@ -19,7 +19,9 @@
 //=============================================================================
 
 #include "config.h"
+#ifdef HAS_AUDIOFILE
 #include <sndfile.h>
+#endif
 #include "libmscore/score.h"
 #include "libmscore/note.h"
 #include "libmscore/part.h"

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1508,6 +1508,7 @@ QString MuseScore::getDrumsetFilename(bool open)
 
 void MuseScore::printFile()
       {
+#ifndef QT_NO_PRINTER
       LayoutMode layoutMode = cs->layoutMode();
       if (layoutMode != LayoutMode::PAGE) {
             cs->setLayoutMode(LayoutMode::PAGE);
@@ -1583,6 +1584,7 @@ void MuseScore::printFile()
             cs->setLayoutMode(layoutMode);
             cs->doLayout();
             }
+#endif
       }
 
 //---------------------------------------------------------
@@ -1985,6 +1987,7 @@ bool MuseScore::savePdf(Score* cs, const QString& saveName)
 
 bool MuseScore::savePdf(QList<Score*> cs, const QString& saveName)
       {
+#ifndef QT_NO_PRINTER
       if (cs.empty())
             return false;
       Score* firstScore = cs[0];
@@ -2061,6 +2064,7 @@ bool MuseScore::savePdf(QList<Score*> cs, const QString& saveName)
       p.end();
       MScore::pdfPrinting = false;
       MScore::pixelRatio = pr;
+#endif
       return true;
       }
 

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -754,7 +754,11 @@ bool ScoreView::saveFotoAs(bool printMode, const QRectF& r)
             int idx = fl.indexOf(selectedFilter);
             if (idx != -1) {
                   static const char* extensions[] = {
-                        "png", "pdf", "svg"
+                        "png",
+#ifndef QT_NO_PRINTER
+                        "pdf",
+#endif
+                        "svg"
                         };
                   ext = extensions[idx];
                   }
@@ -781,6 +785,7 @@ bool ScoreView::saveFotoAs(bool printMode, const QRectF& r)
 
       double pr = MScore::pixelRatio;
       if (ext == "pdf") {
+#ifndef QT_NO_PRINTER
             QPrinter printer(QPrinter::HighResolution);
             mag = printer.logicalDpiX() / DPI;
             printer.setPaperSize(QSizeF(r.width() * mag, r.height() * mag) , QPrinter::DevicePixel);
@@ -794,6 +799,7 @@ bool ScoreView::saveFotoAs(bool printMode, const QRectF& r)
             MScore::pixelRatio = DPI / printer.logicalDpiX();
             QPainter p(&printer);
             paintRect(printMode, p, r, mag);
+#endif
             }
       else if (ext == "svg") {
             // note that clipping is not implemented

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5614,6 +5614,7 @@ int main(int argc, char* av[])
 
       // initialize current page size from default printer
       if (!MScore::testMode) {
+#ifndef QT_NO_PRINTER
             QPrinter p;
             if (p.isValid()) {
                   QRectF psf = p.paperRect(QPrinter::Inch);
@@ -5621,6 +5622,7 @@ int main(int argc, char* av[])
                   MScore::defaultStyle().set(StyleIdx::pageHeight, psf.height());
                   MScore::defaultStyle().set(StyleIdx::pagePrintableWidth, psf.width()-20.0/INCH);
                   }
+#endif
             }
 
 #ifdef SCRIPT_INTERFACE

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -1952,6 +1952,7 @@ void Preferences::updatePluginList()
 
 void PreferenceDialog::printShortcutsClicked()
       {
+#ifndef QT_NO_PRINTER
       QPrinter printer(QPrinter::HighResolution);
       const MStyle& s = MScore::defaultStyle();
       qreal pageW = s.value(StyleIdx::pageWidth).toReal();
@@ -2014,5 +2015,6 @@ void PreferenceDialog::printShortcutsClicked()
             item = shortcutList->itemBelow(item);
             }
       p.end();
+#endif
       }
 }


### PR DESCRIPTION
Using `QT_WEBENGINE_LIB` define to include `QWebEngineView` if available.

Using `QT_NO_PRINTER` to exclude code that requires `QPrinter`. On android QPrinter is not available.

With this commit MuseScore can be compiled and launched on android.

Required to add QT definitions to `FindQt5.cmake` so that defines are set during the build of PCH.