### PR TITLE
Allow three thumbnails horizontally in Start Center again

### DIFF
--- a/mscore/startcenter.ui
+++ b/mscore/startcenter.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>670</width>
+    <width>700</width>
     <height>520</height>
    </rect>
   </property>


### PR DESCRIPTION
Re-solve the same problem as f121ff0cf2, for 2.1 after d1b4dd43.