### PR TITLE
Palette: Single click to insert support

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -295,6 +295,10 @@ Element* Palette::element(int idx)
 
 void Palette::mousePressEvent(QMouseEvent* ev)
       {
+      if (!_disableSingleClick) {
+          handleMouseClickInsert(ev);
+          }
+
       dragStartPosition = ev->pos();
       dragIdx           = idx(dragStartPosition);
 
@@ -318,8 +322,8 @@ void Palette::mousePressEvent(QMouseEvent* ev)
 
 void Palette::mouseMoveEvent(QMouseEvent* ev)
       {
-      if ((currentIdx != -1) && (dragIdx == currentIdx) && (ev->buttons() & Qt::LeftButton)
-         && (ev->pos() - dragStartPosition).manhattanLength() > QApplication::startDragDistance())
+      if (!_disableDragAndDrop && ((currentIdx != -1) && (dragIdx == currentIdx) && (ev->buttons() & Qt::LeftButton)
+         && (ev->pos() - dragStartPosition).manhattanLength() > QApplication::startDragDistance()))
             {
             PaletteCell* cell = cellAt(currentIdx);
             if (cell && cell->element) {
@@ -358,6 +362,18 @@ void Palette::mouseMoveEvent(QMouseEvent* ev)
       }
 
 //---------------------------------------------------------
+//   mouseDoubleClickEvent
+//---------------------------------------------------------
+
+void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
+      {
+      if (_disableDoubleClick)
+            return;
+
+      handleMouseClickInsert(ev);
+      }
+
+//---------------------------------------------------------
 //   applyDrop
 //---------------------------------------------------------
 
@@ -392,13 +408,11 @@ printf("<<<%s>>>\n", a.data());
       }
 
 //---------------------------------------------------------
-//   mouseDoubleClickEvent
+//   handleMouseClickInsert
 //---------------------------------------------------------
 
-void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
+void Palette::handleMouseClickInsert(QMouseEvent* ev)
       {
-      if (_disableDoubleClick)
-            return;
       int i = idx(ev->pos());
       if (i == -1)
             return;

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -104,6 +104,7 @@ class PaletteScrollArea : public QScrollArea {
 class Palette : public QWidget {
       Q_OBJECT
 
+
       QString _name;
       QList<PaletteCell*> cells;
       QList<PaletteCell*> dragCells;  // used for filter & backup
@@ -118,6 +119,8 @@ class Palette : public QWidget {
       qreal extraMag;
       bool _drawGrid;
       bool _selectable;
+      bool _disableDragAndDrop { false };
+      bool _disableSingleClick { true };
       bool _disableDoubleClick { false };
       bool _readOnly;
       bool _systemPalette;
@@ -130,6 +133,7 @@ class Palette : public QWidget {
       virtual void paintEvent(QPaintEvent*) override;
       virtual void mousePressEvent(QMouseEvent*) override;
       virtual void mouseDoubleClickEvent(QMouseEvent*) override;
+      void handleMouseClickInsert(QMouseEvent*);
       virtual void mouseMoveEvent(QMouseEvent*) override;
       virtual void leaveEvent(QEvent*) override;
       virtual bool event(QEvent*) override;
@@ -182,6 +186,8 @@ class Palette : public QWidget {
       void setSelected(int idx)      { selectedIdx = idx;  }
       bool readOnly() const          { return _readOnly;   }
       void setReadOnly(bool val);
+      void setDisableDragAndDrop(bool val) { _disableDragAndDrop = val; }
+      void setDisableSingleClick(bool val) { _disableSingleClick = val; }
       void setDisableDoubleClick(bool val) { _disableDoubleClick = val; }
 
       bool systemPalette() const     { return _systemPalette; }


### PR DESCRIPTION
This PR is somewhat optional:
Drag & drop of palette elements (articulations) is a bit nasty on touch devices. I think it is easier to select (a note) first and add the desired element (e. g. staccato) by a single touch on the palette element (instead of a 'double click').

Therefor I added a 'single click' option to the palette. I use this for my android build.