### PR TITLE
2.1 fix to prevent Q or Shift+Q from resulting in 256th rests

### DIFF
--- a/libmscore/durationtype.cpp
+++ b/libmscore/durationtype.cpp
@@ -304,7 +304,10 @@ void TDuration::shiftType(int nSteps, bool stepDotted)
                   newValue = int(_val) + nSteps;
                   }
 
-            if ((newValue < int(DurationType::V_LONG)) || (newValue > int(DurationType::V_128TH)))
+            if ((newValue < int(DurationType::V_LONG)) || (newValue > int(DurationType::V_128TH)) ||
+                ((newValue >= int(DurationType::V_128TH)) && (newDots >= 1)) ||
+                ((newValue >= int(DurationType::V_64TH))  && (newDots >= 2)) ||
+                ((newValue >= int(DurationType::V_32ND))  && (newDots >= 3)))
                   setType(DurationType::V_INVALID);
             else {
                   setType(DurationType(newValue));


### PR DESCRIPTION
Prevents problem described from comments 40-44 in https://musescore.org/en/node/175461#comment-682261, whereby pressing Q or Shift+Q might produce a dotted or double-dotted note duration that would have resulted in the subsequent creation of a 256th rest (which 2.1 code does not support, and which thus created other problems).