### PR TITLE
Prevent Q or Shift+Q from resulting in 2048th rests 3.0-only

### DIFF
--- a/libmscore/durationtype.cpp
+++ b/libmscore/durationtype.cpp
@@ -310,7 +310,11 @@ void TDuration::shiftType(int nSteps, bool stepDotted)
                   newValue = int(_val) + nSteps;
                   }
 
-            if ((newValue < int(DurationType::V_LONG)) || (newValue > int(DurationType::V_1024TH)))
+            if ((newValue < int(DurationType::V_LONG)) || (newValue > int(DurationType::V_1024TH)) ||
+                 ((newValue >= int(DurationType::V_1024TH)) && (newDots >= 1)) ||
+                 ((newValue >= int(DurationType::V_512TH))  && (newDots >= 2)) ||
+                 ((newValue >= int(DurationType::V_256TH))  && (newDots >= 3)) ||
+                 ((newValue >= int(DurationType::V_128TH))  && (newDots >= 4)))
                   setType(DurationType::V_INVALID);
             else {
                   setType(DurationType(newValue));


### PR DESCRIPTION
Must prevent Q or Shift+Q from resulting in a note with a number of dots that would result in a 2048th rest to balance it out.  This causes problems because 2048th durations don't work on 3.0.