### PR TITLE
fix #181656: layout glitch after hbox on undo

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2362,16 +2362,6 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
             minWidth -= cautionaryW;
             }
 
-      //
-      // remember line breaks in list of measures
-      //
-      int n = system->measures().size() - 1;
-      if (n >= 0) {
-            for (int i = 0; i < n; ++i)
-                  undoChangeProperty(system->measure(i), P_ID::BREAK_HINT, false);
-            undoChangeProperty(system->measures().last(), P_ID::BREAK_HINT, true);
-            }
-
       if (firstMeasure && lastMeasure && firstMeasure != lastMeasure)
             removeGeneratedElements(firstMeasure, lastMeasure);
 
@@ -2869,6 +2859,21 @@ QList<System*> Score::layoutSystemRow(qreal rowWidth, bool isFirstSystem, bool u
                         }
                   }
             firstInRow = false;
+            }
+      //
+      // remember line breaks in list of measures
+      //
+      for (System* system : sl) {
+            int n = system->measures().size() - 1;
+            if (n >= 0) {
+                  for (int i = 0; i < n; ++i)
+                        undoChangeProperty(system->measure(i), P_ID::BREAK_HINT, false);
+                  // only set hint for last system in row
+                  if (system == sl.last())
+                        undoChangeProperty(system->measures().last(), P_ID::BREAK_HINT, true);
+                  else
+                        undoChangeProperty(system->measures().last(), P_ID::BREAK_HINT, false);
+                  }
             }
       //
       // dont stretch last system row, if accumulated minWidth is <= lastSystemFillLimit


### PR DESCRIPTION
My previous fix in #3052 had an unfortunate side effect: now that we pay attention to break hints on hboxes, we start to see that they are actually set inappropriately on "internal" hboxes.  That is, hboxes within a system row.  That's because they are seen as ending a system, and the code that sets the break hints does so system by system.  So now we are actually always breaking after hboxes while in undo state - the first layout after an undo.

This current PR moves the setting of break hints from Score::layoutSystem() to Score::layoutSystemRow(), and checks to only set the hint to true on the last measurebase of the row, not on the last measure of each system.

This fixes the current problem without compromising the fix to the previous problem.  I can't swear it doesn't have some *other* unforeseen side effect.  But all this break hint stuff only affects layout in undo state, so worst case is there is some *other* temporary glitch on undo.

It wouldn't break my heart to simply revert the fix in #3052 (thus leaving the previous bug unfixed for 2.1).  This all becomes moot for 3.0 it seems anyhow.  But I *do* think this current PR is the "right" solution, at least to the extent I understand how these break hints are designed to work.