### PR TITLE
Fix #182336: Color Picker window gets larger every time it's used

### DIFF
--- a/awl/colorlabel.cpp
+++ b/awl/colorlabel.cpp
@@ -94,10 +94,6 @@ void ColorLabel::mousePressEvent(QMouseEvent*)
       {
       if (_pixmap)
             return;
-      //QColor c = QColorDialog::getColor(_color, this,
-        // tr("MuseScore: Select Color"),
-         //QColorDialog::ShowAlphaChannel
-         //);
       QColor c = QColorDialog::getColor(_color, NULL,
         tr("MuseScore: Select Color"),
             QColorDialog::ShowAlphaChannel);

--- a/awl/colorlabel.cpp
+++ b/awl/colorlabel.cpp
@@ -94,10 +94,13 @@ void ColorLabel::mousePressEvent(QMouseEvent*)
       {
       if (_pixmap)
             return;
-      QColor c = QColorDialog::getColor(_color, this,
-         tr("MuseScore: Select Color"),
-         QColorDialog::ShowAlphaChannel
-         );
+      //QColor c = QColorDialog::getColor(_color, this,
+        // tr("MuseScore: Select Color"),
+         //QColorDialog::ShowAlphaChannel
+         //);
+      QColor c = QColorDialog::getColor(_color, NULL,
+        tr("MuseScore: Select Color"),
+            QColorDialog::ShowAlphaChannel);
       if (c.isValid()) {
             if (_color != c) {
                   _color = c;


### PR DESCRIPTION
I observed that color picker does not change the height on El Capitan OS if the second parameter for QColorDialog::getColor is NULL. 