### PR TITLE
Fix #184381: Unnecessary "MuseScore: " prepended to most window titles and wrong title of Split Staff dialog for 2.1

### DIFF
--- a/awl/colorlabel.cpp
+++ b/awl/colorlabel.cpp
@@ -95,7 +95,7 @@ void ColorLabel::mousePressEvent(QMouseEvent*)
       if (_pixmap)
             return;
       QColor c = QColorDialog::getColor(_color, this,
-         tr("MuseScore: Select Color"),
+         tr("Select Color"),
          QColorDialog::ShowAlphaChannel
          );
       if (c.isValid()) {

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -384,7 +384,7 @@ bool Score::saveFile()
             }
 
       if (temp.error() != QFile::NoError) {
-            MScore::lastError = tr("MuseScore: Save File failed: %1").arg(temp.errorString());
+            MScore::lastError = tr("Save File failed: %1").arg(temp.errorString());
             return false;
             }
       temp.close();
@@ -403,7 +403,7 @@ bool Score::saveFile()
             if (dir.exists(backupName)) {
                   if (!dir.remove(backupName)) {
 //                      if (!MScore::noGui)
-//                            QMessageBox::critical(0, tr("MuseScore: Save File"),
+//                            QMessageBox::critical(0, tr("Save File"),
 //                               tr("Removing old backup file ") + backupName + tr(" failed"));
                         }
                   }
@@ -415,7 +415,7 @@ bool Score::saveFile()
             if (dir.exists(name)) {
                   if (!dir.rename(name, backupName)) {
 //                      if (!MScore::noGui)
-//                            QMessageBox::critical(0, tr("MuseScore: Save File"),
+//                            QMessageBox::critical(0, tr("Save File"),
 //                               tr("Renaming old file <")
 //                               + name + tr("> to backup <") + backupName + tr("> failed"));
                         }
@@ -431,7 +431,7 @@ bool Score::saveFile()
             if (dir.exists(name)) {
                   if (!dir.remove(name)) {
 //                      if (!MScore::noGui)
-//                            QMessageBox::critical(0, tr("MuseScore: Save File"),
+//                            QMessageBox::critical(0, tr("Save File"),
 //                               tr("Removing old file") + name + tr(" failed"));
                         }
                   }

--- a/mscore/album.cpp
+++ b/mscore/album.cpp
@@ -240,7 +240,7 @@ bool Album::read(const QString& p)
       QFile f(_path);
       if (!f.open(QIODevice::ReadOnly)) {
             QMessageBox::warning(0,
-               QWidget::tr("MuseScore: Open Album failed"),
+               QWidget::tr("Open Album failed"),
                QString(strerror(errno)),
                QString::null, QWidget::tr("Quit"), QString::null, 0, 1);
             return false;

--- a/mscore/albummanager.cpp
+++ b/mscore/albummanager.cpp
@@ -73,7 +73,7 @@ void AlbumManager::addClicked()
       {
       QStringList files = mscore->getOpenScoreNames(
          tr("MuseScore Files") + " (*.mscz *.mscx)",
-         tr("MuseScore: Add Score")
+         tr("Add Score")
          );
       if (files.isEmpty())
             return;
@@ -99,7 +99,7 @@ void AlbumManager::loadClicked()
       {
       QStringList files = mscore->getOpenScoreNames(
          tr("MuseScore Album Files") + " (*.album)",
-         tr("MuseScore: Load Album")
+         tr("Load Album")
          );
       if (files.isEmpty())
             return;
@@ -139,14 +139,14 @@ void AlbumManager::createScoreClicked()
                   saveDirectory = preferences.myScoresPath;
             QString fname   = QString("%1/%2.mscz").arg(saveDirectory).arg(album->name());
             QString fn     = mscore->getSaveScoreName(
-            QWidget::tr("MuseScore: Save Album into Score"),
+            QWidget::tr("Save Album into Score"),
                   fname,
                   filter
             );
             if (fn.isEmpty())
                   return;
             if (!album->createScore(fn, checkBoxAddPageBreak->isChecked(), checkBoxAddSectionBreak->isChecked()))
-                  QMessageBox::critical(mscore, QWidget::tr("MuseScore: Save File"), tr("Error while creating score from album."));
+                  QMessageBox::critical(mscore, QWidget::tr("Save File"), tr("Error while creating score from album."));
             }
       }
 
@@ -304,7 +304,7 @@ void AlbumManager::writeAlbum()
             QString home = preferences.myScoresPath;
             QString albumName = album->name();
             QString fn = mscore->getSaveScoreName(
-               QWidget::tr("MuseScore: Save Album"),
+               QWidget::tr("Save Album"),
                albumName,
                QWidget::tr("MuseScore Files") + " (*.album)"
                );
@@ -320,14 +320,14 @@ void AlbumManager::writeAlbum()
       if (!f.open(QIODevice::WriteOnly)) {
             QString s = QWidget::tr("Open Album File\n%1\nfailed: ")
                + QString(strerror(errno));
-            QMessageBox::critical(mscore, QWidget::tr("MuseScore: Open Album File"), s.arg(album->path()));
+            QMessageBox::critical(mscore, QWidget::tr("Open Album File"), s.arg(album->path()));
             return;
             }
       Xml xml(&f);
       album->write(xml);
       if (f.error() != QFile::NoError) {
             QString s = QWidget::tr("Write Album failed: ") + f.errorString();
-            QMessageBox::critical(0, QWidget::tr("MuseScore: Write Album"), s);
+            QMessageBox::critical(0, QWidget::tr("Write Album"), s);
             }
       }
 

--- a/mscore/albummanager.ui
+++ b/mscore/albummanager.ui
@@ -14,7 +14,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Album Manager</string>
+   <string>Album Manager</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/mscore/alsa.cpp
+++ b/mscore/alsa.cpp
@@ -667,7 +667,7 @@ void AlsaAudio::alsaLoop()
       rt_param.sched_priority = 50;
       int rv = pthread_setschedparam(pthread_self(), SCHED_FIFO, &rt_param);
       if (rv == -1)
-            perror("MuseScore: set realtime scheduler failed");
+            perror("Set realtime scheduler failed");
 
       if (!alsa->pcmStart()) {
             alsa->pcmStop();

--- a/mscore/articulation.ui
+++ b/mscore/articulation.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Articulation Properties</string>
+   <string>Articulation Properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>

--- a/mscore/bend.ui
+++ b/mscore/bend.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Bend Properties</string>
+   <string>Bend Properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="verticalSpacing">

--- a/mscore/breaksdialog.ui
+++ b/mscore/breaksdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Add/Remove Line Breaks</string>
+   <string>Add/Remove Line Breaks</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/mscore/capella.cpp
+++ b/mscore/capella.cpp
@@ -2673,7 +2673,7 @@ Score::FileError importCapella(Score* score, const QString& name)
       catch (Capella::Error errNo) {
             if (!MScore::noGui) {
                   QMessageBox::warning(0,
-                     QWidget::tr("MuseScore: Import Capella"),
+                     QWidget::tr("Import Capella"),
                      QWidget::tr("Load failed: ") + cf.error(errNo),
                      QString::null, QWidget::tr("Quit"), QString::null, 0, 1);
                   }

--- a/mscore/debugger/debugger.cpp
+++ b/mscore/debugger/debugger.cpp
@@ -598,7 +598,7 @@ void Debugger::updateElement(Element* el)
       if (!found)
             qDebug("Debugger: element not found %s\n", el->name());
 
-      setWindowTitle(QString("MuseScore: Debugger: ") + el->name());
+      setWindowTitle(QString("Debugger: ") + el->name());
 
       ShowElementBase* ew = elementViews[int(el->type())];
       if (ew == 0) {

--- a/mscore/drumroll.cpp
+++ b/mscore/drumroll.cpp
@@ -194,7 +194,7 @@ void DrumrollEditor::setStaff(Staff* st)
       {
       staff = st;
       _score = staff->score();
-      setWindowTitle(tr("MuseScore: <%1> Staff: %2").arg(_score->name()).arg(st->idx()));
+      setWindowTitle(tr("<%1> Staff: %2").arg(_score->name()).arg(st->idx()));
       TempoMap* tl = _score->tempomap();
       TimeSigMap*  sl = _score->sigmap();
       for (int i = 0; i < 3; ++i)

--- a/mscore/editdrumset.cpp
+++ b/mscore/editdrumset.cpp
@@ -370,7 +370,7 @@ void EditDrumset::save()
       if (!f.open(QIODevice::WriteOnly)) {
             QString s = tr("Open File\n%1\nfailed: ")
                + QString(strerror(errno));
-            QMessageBox::critical(mscore, tr("MuseScore: Open File"), s.arg(f.fileName()));
+            QMessageBox::critical(mscore, tr("Open File"), s.arg(f.fileName()));
             return;
             }
       valueChanged();  //save last changes in name
@@ -381,7 +381,7 @@ void EditDrumset::save()
       xml.etag();
       if (f.error() != QFile::NoError) {
             QString s = tr("Write File failed: ") + f.errorString();
-            QMessageBox::critical(this, tr("MuseScore: Write Drumset"), s);
+            QMessageBox::critical(this, tr("Write Drumset"), s);
             }
       }
 

--- a/mscore/editdrumset.ui
+++ b/mscore/editdrumset.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Edit Drumset</string>
+   <string>Edit Drumset</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/mscore/editinstrument.ui
+++ b/mscore/editinstrument.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Edit Instrument Properties</string>
+   <string>Edit Instrument Properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">

--- a/mscore/editraster.ui
+++ b/mscore/editraster.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Edit Grid</string>
+   <string>Edit Grid</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Edit Staff/Part Properties</string>
+   <string>Edit Staff/Part Properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="1" column="0" colspan="2">

--- a/mscore/editstafftype.ui
+++ b/mscore/editstafftype.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Edit Staff Type</string>
+   <string>Edit Staff Type</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Edit Style</string>
+   <string>Edit Style</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_11">
    <item row="0" column="1">

--- a/mscore/excerptsdialog.ui
+++ b/mscore/excerptsdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Parts</string>
+   <string>Parts</string>
   </property>
   <layout class="QGridLayout">
    <item row="0" column="0">

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -217,7 +217,7 @@ static bool readScoreError(const QString& name, Score::FileError error, bool ask
             return false;
             }
       QMessageBox msgBox;
-      msgBox.setWindowTitle(QObject::tr("MuseScore: Load Error"));
+      msgBox.setWindowTitle(QObject::tr("Load Error"));
       msgBox.setText(msg.replace("\n", "<br/>"));
       msgBox.setDetailedText(detailedMsg);
       msgBox.setTextFormat(Qt::RichText);
@@ -299,7 +299,7 @@ void MuseScore::loadFiles()
          tr("Overture / Score Writer Files <experimental>") + " (*.ove *.scw);;" +
          tr("Bagpipe Music Writer Files <experimental>") + " (*.bww);;" +
          tr("Guitar Pro") + " (*.GTP *.GP3 *.GP4 *.GP5 *.GPX)",
-         tr("MuseScore: Load Score")
+         tr("Load Score")
          );
       for (const QString& s : files)
             openScore(s);
@@ -413,7 +413,7 @@ bool MuseScore::saveFile(Score* score)
             if (QFileInfo(fname).suffix().isEmpty())
                   fname += ".mscz";
 
-            fn = mscore->getSaveScoreName(tr("MuseScore: Save Score"), fname, filter);
+            fn = mscore->getSaveScoreName(tr("Save Score"), fname, filter);
             if (fn.isEmpty())
                   return false;
             score->fileInfo()->setFile(fn);
@@ -421,14 +421,14 @@ bool MuseScore::saveFile(Score* score)
             mscore->lastSaveDirectory = score->fileInfo()->absolutePath();
 
             if (!score->saveFile()) {
-                  QMessageBox::critical(mscore, tr("MuseScore: Save File"), MScore::lastError);
+                  QMessageBox::critical(mscore, tr("Save File"), MScore::lastError);
                   return false;
                   }
             addRecentScore(score);
             writeSessionFile(false);
             }
       else if (!score->saveFile()) {
-            QMessageBox::critical(mscore, tr("MuseScore: Save File"), MScore::lastError);
+            QMessageBox::critical(mscore, tr("Save File"), MScore::lastError);
             return false;
             }
       score->setCreated(false);
@@ -934,14 +934,14 @@ QString MuseScore::getStyleFilename(bool open, const QString& title)
             QString fn;
             if (open) {
                   fn = QFileDialog::getOpenFileName(
-                     this, tr("MuseScore: Load Style"),
+                     this, tr("Load Style"),
                      defaultPath,
                      tr("MuseScore Styles") + " (*.mss)"
                      );
                   }
             else {
                   fn = QFileDialog::getSaveFileName(
-                     this, tr("MuseScore: Save Style"),
+                     this, tr("Save Style"),
                      defaultPath,
                      tr("MuseScore Style File") + " (*.mss)"
                      );
@@ -961,7 +961,7 @@ QString MuseScore::getStyleFilename(bool open, const QString& title)
                   loadStyleDialog = new QFileDialog(this);
                   loadStyleDialog->setFileMode(QFileDialog::ExistingFile);
                   loadStyleDialog->setOption(QFileDialog::DontUseNativeDialog, true);
-                  loadStyleDialog->setWindowTitle(title.isEmpty() ? tr("MuseScore: Load Style") : title);
+                  loadStyleDialog->setWindowTitle(title.isEmpty() ? tr("Load Style") : title);
                   loadStyleDialog->setNameFilter(tr("MuseScore Style File") + " (*.mss)");
                   loadStyleDialog->setDirectory(defaultPath);
 
@@ -978,7 +978,7 @@ QString MuseScore::getStyleFilename(bool open, const QString& title)
                   saveStyleDialog->setFileMode(QFileDialog::AnyFile);
                   saveStyleDialog->setOption(QFileDialog::DontConfirmOverwrite, false);
                   saveStyleDialog->setOption(QFileDialog::DontUseNativeDialog, true);
-                  saveStyleDialog->setWindowTitle(title.isEmpty() ? tr("MuseScore: Save Style") : title);
+                  saveStyleDialog->setWindowTitle(title.isEmpty() ? tr("Save Style") : title);
                   saveStyleDialog->setNameFilter(tr("MuseScore Style File") + " (*.mss)");
                   saveStyleDialog->setDirectory(defaultPath);
 
@@ -1014,14 +1014,14 @@ QString MuseScore::getChordStyleFilename(bool open)
             QString fn;
             if (open) {
                   fn = QFileDialog::getOpenFileName(
-                     this, tr("MuseScore: Load Chord Symbols Style"),
+                     this, tr("Load Chord Symbols Style"),
                      defaultPath,
                      filter
                      );
                   }
             else {
                   fn = QFileDialog::getSaveFileName(
-                     this, tr("MuseScore: Save Chord Symbols Style"),
+                     this, tr("Save Chord Symbols Style"),
                      defaultPath,
                      filter
                      );
@@ -1042,7 +1042,7 @@ QString MuseScore::getChordStyleFilename(bool open)
                   loadChordStyleDialog = new QFileDialog(this);
                   loadChordStyleDialog->setFileMode(QFileDialog::ExistingFile);
                   loadChordStyleDialog->setOption(QFileDialog::DontUseNativeDialog, true);
-                  loadChordStyleDialog->setWindowTitle(tr("MuseScore: Load Chord Symbols Style"));
+                  loadChordStyleDialog->setWindowTitle(tr("Load Chord Symbols Style"));
                   loadChordStyleDialog->setNameFilter(filter);
                   loadChordStyleDialog->setDirectory(defaultPath);
 
@@ -1061,7 +1061,7 @@ QString MuseScore::getChordStyleFilename(bool open)
                   saveChordStyleDialog->setFileMode(QFileDialog::AnyFile);
                   saveChordStyleDialog->setOption(QFileDialog::DontConfirmOverwrite, false);
                   saveChordStyleDialog->setOption(QFileDialog::DontUseNativeDialog, true);
-                  saveChordStyleDialog->setWindowTitle(tr("MuseScore: Save Style"));
+                  saveChordStyleDialog->setWindowTitle(tr("Save Style"));
                   saveChordStyleDialog->setNameFilter(filter);
                   saveChordStyleDialog->setDirectory(defaultPath);
 
@@ -1101,7 +1101,7 @@ QString MuseScore::getScanFile(const QString& d)
             loadScanDialog = new QFileDialog(this);
             loadScanDialog->setFileMode(QFileDialog::ExistingFile);
             loadScanDialog->setOption(QFileDialog::DontUseNativeDialog, true);
-            loadScanDialog->setWindowTitle(tr("MuseScore: Choose PDF Scan"));
+            loadScanDialog->setWindowTitle(tr("Choose PDF Scan"));
             loadScanDialog->setNameFilter(filter);
             loadScanDialog->setDirectory(defaultPath);
 
@@ -1147,7 +1147,7 @@ QString MuseScore::getAudioFile(const QString& d)
             loadAudioDialog = new QFileDialog(this);
             loadAudioDialog->setFileMode(QFileDialog::ExistingFile);
             loadAudioDialog->setOption(QFileDialog::DontUseNativeDialog, true);
-            loadAudioDialog->setWindowTitle(tr("MuseScore: Choose Ogg Audio File"));
+            loadAudioDialog->setWindowTitle(tr("Choose Ogg Audio File"));
             loadAudioDialog->setNameFilter(filter);
             loadAudioDialog->setDirectory(defaultPath);
 
@@ -1177,7 +1177,7 @@ QString MuseScore::getAudioFile(const QString& d)
 
 QString MuseScore::getFotoFilename(QString& filter, QString* selectedFilter)
       {
-      QString title = tr("MuseScore: Save Image");
+      QString title = tr("Save Image");
 
       QFileInfo myImages(preferences.myImagesPath);
       if (myImages.isRelative())
@@ -1265,11 +1265,11 @@ QString MuseScore::getPaletteFilename(bool open, const QString& name)
       QString filter;
       QString wd      = QString("%1/%2").arg(QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation)).arg(QCoreApplication::applicationName());
       if (open) {
-            title  = tr("MuseScore: Load Palette");
+            title  = tr("Load Palette");
             filter = tr("MuseScore Palette") + " (*.mpal)";
             }
       else {
-            title  = tr("MuseScore: Save Palette");
+            title  = tr("Save Palette");
             filter = tr("MuseScore Palette") + " (*.mpal)";
             }
 
@@ -1347,11 +1347,11 @@ QString MuseScore::getPluginFilename(bool open)
       QString title;
       QString filter;
       if (open) {
-            title  = tr("MuseScore: Load Plugin");
+            title  = tr("Load Plugin");
             filter = tr("MuseScore Plugin") + " (*.qml)";
             }
       else {
-            title  = tr("MuseScore: Save Plugin");
+            title  = tr("Save Plugin");
             filter = tr("MuseScore Plugin File") + " (*.qml)";
             }
 
@@ -1401,7 +1401,7 @@ QString MuseScore::getPluginFilename(bool open)
                   savePluginDialog->setFileMode(QFileDialog::AnyFile);
                   savePluginDialog->setOption(QFileDialog::DontConfirmOverwrite, false);
                   savePluginDialog->setOption(QFileDialog::DontUseNativeDialog, true);
-                  savePluginDialog->setWindowTitle(tr("MuseScore: Save Plugin"));
+                  savePluginDialog->setWindowTitle(tr("Save Plugin"));
                   savePluginDialog->setNameFilter(filter);
                   savePluginDialog->setDirectory(defaultPath);
                   savePluginDialog->selectFile(fname);
@@ -1430,11 +1430,11 @@ QString MuseScore::getDrumsetFilename(bool open)
       QString title;
       QString filter;
       if (open) {
-            title  = tr("MuseScore: Load Drumset");
+            title  = tr("Load Drumset");
             filter = tr("MuseScore Drumset") + " (*.drm)";
             }
       else {
-            title  = tr("MuseScore: Save Drumset");
+            title  = tr("Save Drumset");
             filter = tr("MuseScore Drumset File") + " (*.drm)";
             }
 
@@ -1595,7 +1595,7 @@ void MuseScore::exportFile()
       fl.append(tr("Compressed MusicXML File") + " (*.mxl)");
       fl.append(tr("Uncompressed MuseScore File") + " (*.mscx)");
 
-      QString saveDialogTitle = tr("MuseScore: Export");
+      QString saveDialogTitle = tr("Export");
 
       QSettings settings;
       if (lastSaveCopyDirectory.isEmpty())
@@ -1642,7 +1642,7 @@ void MuseScore::exportFile()
       lastSaveCopyFormat = fi.suffix();
 
       if (fi.suffix().isEmpty())
-            QMessageBox::critical(this, tr("MuseScore: Export"), tr("Cannot determine file type"));
+            QMessageBox::critical(this, tr("Export"), tr("Cannot determine file type"));
       else
             saveAs(cs, true, fn, fi.suffix());
       }
@@ -1672,7 +1672,7 @@ bool MuseScore::exportParts()
       fl.append(tr("MuseScore File") + " (*.mscz)");
       fl.append(tr("Uncompressed MuseScore File") + " (*.mscx)");
 
-      QString saveDialogTitle = tr("MuseScore: Export Parts");
+      QString saveDialogTitle = tr("Export Parts");
 
       QSettings settings;
       if (lastSaveCopyDirectory.isEmpty())
@@ -1718,7 +1718,7 @@ bool MuseScore::exportParts()
 
       QString ext = fi.suffix();
       if (ext.isEmpty()) {
-            QMessageBox::critical(this, tr("MuseScore: Export Parts"), tr("Cannot determine file type"));
+            QMessageBox::critical(this, tr("Export Parts"), tr("Cannot determine file type"));
             return false;
             }
 
@@ -1785,7 +1785,7 @@ bool MuseScore::exportParts()
                   return false;
       }
       if(!noToAll)
-            QMessageBox::information(this, tr("MuseScore: Export Parts"), tr("Parts were successfully exported"));
+            QMessageBox::information(this, tr("Export Parts"), tr("Parts were successfully exported"));
       return true;
       }
 
@@ -1818,7 +1818,7 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy, const QString& path, const QStr
                   }
             catch (QString s) {
                   rv = false;
-                  QMessageBox::critical(this, tr("MuseScore: Save As"), s);
+                  QMessageBox::critical(this, tr("Save As"), s);
                   }
             cs->fileInfo()->setFile(originalScoreFName);          // restore original file name
 
@@ -2177,8 +2177,8 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy)
       QStringList fl;
       fl.append(tr("MuseScore File") + " (*.mscz)");
       fl.append(tr("Uncompressed MuseScore File") + " (*.mscx)");     // for debugging purposes
-      QString saveDialogTitle = saveCopy ? tr("MuseScore: Save a Copy") :
-                                           tr("MuseScore: Save As");
+      QString saveDialogTitle = saveCopy ? tr("Save a Copy") :
+                                           tr("Save As");
 
       QSettings settings;
       if (mscore->lastSaveCopyDirectory.isEmpty())
@@ -2218,7 +2218,7 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy)
 
       if (fi.suffix().isEmpty()) {
             if (!MScore::noGui)
-                  QMessageBox::critical(mscore, tr("MuseScore: Save As"), tr("Cannot determine file type"));
+                  QMessageBox::critical(mscore, tr("Save As"), tr("Cannot determine file type"));
             return false;
             }
       return saveAs(cs, saveCopy, fn, fi.suffix());
@@ -2232,12 +2232,12 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy)
 bool MuseScore::saveSelection(Score* cs)
       {
       if (!cs->selection().isRange()) {
-            if(!MScore::noGui) QMessageBox::warning(mscore, tr("MuseScore: Save Selection"), tr("Please select one or more measures"));
+            if(!MScore::noGui) QMessageBox::warning(mscore, tr("Save Selection"), tr("Please select one or more measures"));
             return false;
             }
       QStringList fl;
       fl.append(tr("MuseScore File") + " (*.mscz)");
-      QString saveDialogTitle = tr("MuseScore: Save Selection");
+      QString saveDialogTitle = tr("Save Selection");
 
       QSettings settings;
       if (mscore->lastSaveDirectory.isEmpty())
@@ -2258,7 +2258,7 @@ bool MuseScore::saveSelection(Score* cs)
 
       QString ext = fi.suffix();
       if (ext.isEmpty()) {
-            QMessageBox::critical(mscore, tr("MuseScore: Save Selection"), tr("Cannot determine file type"));
+            QMessageBox::critical(mscore, tr("Save Selection"), tr("Cannot determine file type"));
             return false;
             }
       bool rv = true;
@@ -2267,7 +2267,7 @@ bool MuseScore::saveSelection(Score* cs)
             }
       catch (QString s) {
             rv = false;
-            QMessageBox::critical(this, tr("MuseScore: Save Selected"), s);
+            QMessageBox::critical(this, tr("Save Selected"), s);
             }
       return rv;
       }
@@ -2280,7 +2280,7 @@ void MuseScore::addImage(Score* score, Element* e)
       {
       QString fn = QFileDialog::getOpenFileName(
          0,
-         tr("MuseScore: Insert Image"),
+         tr("Insert Image"),
          "",            // lastOpenPath,
          tr("All Supported Files") + " (*.svg *.jpg *.jpeg *.png);;" +
          tr("Scalable Vector Graphics") + " (*.svg);;" +

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -638,7 +638,7 @@ void ScoreView::fotoContextPopup(QContextMenuEvent* ev)
       else if (cmd == "set-res") {
             bool ok;
             double resolution = QInputDialog::getDouble(this,
-               tr("MuseScore: Set Output Resolution"),
+               tr("Set Output Resolution"),
                tr("Set output resolution for PNG/SVG"),
                preferences.pngResolution,
                16.0, 2400.0, 1,
@@ -763,7 +763,7 @@ bool ScoreView::saveFotoAs(bool printMode, const QRectF& r)
             }
 
       if (ext.isEmpty()) {
-            QMessageBox::critical(mscore, tr("MuseScore: Save As"), tr("Cannot determine file type"));
+            QMessageBox::critical(mscore, tr("Save As"), tr("Cannot determine file type"));
             return false;
             }
 

--- a/mscore/fretdprops.ui
+++ b/mscore/fretdprops.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Fretboard Diagram Properties</string>
+   <string>Fretboard Diagram Properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/mscore/glissandoprop.ui
+++ b/mscore/glissandoprop.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Glissando Properties</string>
+   <string>Glissando Properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/mscore/harmonyedit.cpp
+++ b/mscore/harmonyedit.cpp
@@ -44,7 +44,7 @@ ChordStyleEditor::ChordStyleEditor(QWidget* parent)
       {
       setObjectName("ChordStyleEditor");
       setupUi(this);
-      setWindowTitle(tr("MuseScore: Chord Symbols Style Editor"));
+      setWindowTitle(tr("Chord Symbols Style Editor"));
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
       fileButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -2308,7 +2308,7 @@ Score::FileError importGTP(Score* score, const QString& name)
       catch(GuitarPro::GuitarProError errNo) {
             if (!MScore::noGui) {
                   QMessageBox::warning(0,
-                     QWidget::tr("MuseScore: Import Guitar Pro"),
+                     QWidget::tr("Import Guitar Pro"),
                      QWidget::tr("Load failed: ") + gp->error(errNo),
                      QString::null, QWidget::tr("Quit"), QString::null, 0, 1);
                   }

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -1196,7 +1196,7 @@ Score::FileError importMidi(Score *score, const QString &name)
             catch (QString errorText) {
                   if (!MScore::noGui) {
                         QMessageBox::warning(0,
-                           QWidget::tr("MuseScore: Load MIDI"),
+                           QWidget::tr("Load MIDI"),
                            QWidget::tr("Load failed: ") + errorText,
                            QString::null, QWidget::tr("Quit"), QString::null, 0, 1);
                         }

--- a/mscore/insertmeasuresdialog.ui
+++ b/mscore/insertmeasuresdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Insert Measures</string>
+   <string>Insert Measures</string>
   </property>
   <layout class="QVBoxLayout">
    <property name="margin">

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -71,7 +71,7 @@ void InstrumentsDialog::on_saveButton_clicked()
       {
       QString name = QFileDialog::getSaveFileName(
          this,
-         tr("MuseScore: Save Instrument List"),
+         tr("Save Instrument List"),
          ".",
          tr("MuseScore Instruments") + " (*.xml)"
          );
@@ -86,7 +86,7 @@ void InstrumentsDialog::on_saveButton_clicked()
       if (!f.open(QIODevice::WriteOnly)) {
             QString s = tr("Open Instruments File\n%1\nfailed: ")
                + QString(strerror(errno));
-            QMessageBox::critical(mscore, tr("MuseScore: Open Instruments File"), s.arg(f.fileName()));
+            QMessageBox::critical(mscore, tr("Open Instruments File"), s.arg(f.fileName()));
             return;
             }
 
@@ -102,7 +102,7 @@ void InstrumentsDialog::on_saveButton_clicked()
       xml.etag();
       if (f.error() != QFile::NoError) {
             QString s = tr("Write Style failed: ") + f.errorString();
-            QMessageBox::critical(this, tr("MuseScore: Write Style"), s);
+            QMessageBox::critical(this, tr("Write Style"), s);
             }
       }
 
@@ -113,7 +113,7 @@ void InstrumentsDialog::on_saveButton_clicked()
 void InstrumentsDialog::on_loadButton_clicked()
       {
       QString fn = QFileDialog::getOpenFileName(
-         this, tr("MuseScore: Load Instrument List"),
+         this, tr("Load Instrument List"),
           mscoreGlobalShare + "/templates",
          tr("MuseScore Instruments") + " (*.xml)"
          );
@@ -122,7 +122,7 @@ void InstrumentsDialog::on_loadButton_clicked()
       QFile f(fn);
       if (!loadInstrumentTemplates(fn)) {
             QMessageBox::warning(0,
-               QWidget::tr("MuseScore: Load Style Failed"),
+               QWidget::tr("Load Style Failed"),
                QString(strerror(errno)),
                QString::null, QWidget::tr("Quit"), QString::null, 0, 1);
             return;

--- a/mscore/instrdialog.ui
+++ b/mscore/instrdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Instruments</string>
+   <string>Instruments</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/mscore/instrwidget.ui
+++ b/mscore/instrwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Instruments</string>
+   <string>Instruments</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/mscore/keyedit.cpp
+++ b/mscore/keyedit.cpp
@@ -270,7 +270,7 @@ KeyEditor::KeyEditor(QWidget* parent)
    : QWidget(parent, Qt::WindowFlags(Qt::Dialog | Qt::Window))
       {
       setupUi(this);
-      setWindowTitle(tr("MuseScore: Key Signatures"));
+      setWindowTitle(tr("Key Signatures"));
 
       // create key signature palette
 

--- a/mscore/layer.cpp
+++ b/mscore/layer.cpp
@@ -132,7 +132,7 @@ void LayerManager::addTagClicked()
             return;
             }
       bool ok;
-      QString item = QInputDialog::getItem(this, tr("MuseScore: select layer tag"), tr("layer tag"),
+      QString item = QInputDialog::getItem(this, tr("Select layer tag"), tr("layer tag"),
          items, 0, false, &ok);
       if (ok && !item.isEmpty()) {
 //            uint tagBits = 0;
@@ -165,7 +165,7 @@ void LayerManager::deleteTagClicked()
       QString s = item->text();
       QStringList items = s.split(",");
       bool ok;
-      QString tag = QInputDialog::getItem(this, tr("MuseScore: select layer tag"), tr("layer tag"),
+      QString tag = QInputDialog::getItem(this, tr("Select layer tag"), tr("layer tag"),
          items, 0, false, &ok);
       if (ok && !tag.isEmpty()) {
             items.removeOne(tag);

--- a/mscore/layer.ui
+++ b/mscore/layer.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Layers</string>
+   <string>Layers</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/mscore/lineproperties.ui
+++ b/mscore/lineproperties.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Line Properties</string>
+   <string>Line Properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">

--- a/mscore/masterpalette.ui
+++ b/mscore/masterpalette.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Master Palette</string>
+   <string>Master Palette</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>

--- a/mscore/measureproperties.cpp
+++ b/mscore/measureproperties.cpp
@@ -116,7 +116,7 @@ void MeasureProperties::gotoPreviousMeasure()
 void MeasureProperties::setMeasure(Measure* _m)
       {
       m = _m;
-      setWindowTitle(tr("MuseScore: Measure Properties for Measure %1").arg(m->no()+1));
+      setWindowTitle(tr("Measure Properties for Measure %1").arg(m->no()+1));
       m->score()->deselectAll();
       m->score()->select(m, SelectType::ADD, 0);
 

--- a/mscore/measureproperties.ui
+++ b/mscore/measureproperties.ui
@@ -14,7 +14,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Measure Properties</string>
+   <string>Measure Properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>

--- a/mscore/measuresdialog.ui
+++ b/mscore/measuresdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Append Measures</string>
+   <string>Append Measures</string>
   </property>
   <layout class="QVBoxLayout">
    <property name="margin">

--- a/mscore/mediadialog.cpp
+++ b/mscore/mediadialog.cpp
@@ -39,7 +39,7 @@ MediaDialog::MediaDialog(QWidget* /*parent*/)
       setObjectName("MediaDialog");
       setupUi(this);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
-      setWindowTitle(tr("MuseScore: Additional Media"));
+      setWindowTitle(tr("Additional Media"));
       scanFileButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
       audioFileButton->setIcon(*icons[int(Icons::fileOpen_ICON)]);
 

--- a/mscore/metaedit.cpp
+++ b/mscore/metaedit.cpp
@@ -75,7 +75,7 @@ MetaEditDialog::MetaEditDialog(Score* s, QWidget* parent)
 void MetaEditDialog::newClicked()
       {
       QString s = QInputDialog::getText(this,
-         tr("MuseScore: Input Tag Name"),
+         tr("Input Tag Name"),
          tr("New tag name:")
          );
       QGridLayout* grid = static_cast<QGridLayout*>(scrollWidget->layout());

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -98,7 +98,7 @@ Mixer::Mixer(QWidget* parent)
    : QScrollArea(parent)
       {
       setObjectName("Mixer");
-      setWindowTitle(tr("MuseScore: Mixer"));
+      setWindowTitle(tr("Mixer"));
       setWidgetResizable(true);
       setWindowFlags(Qt::Tool);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2626,7 +2626,7 @@ bool MuseScore::readLanguages(const QString& path)
                 error.sprintf(qPrintable(tr("Error reading language file %s at line %d column %d: %s\n")),
                    qPrintable(qf.fileName()), line, column, qPrintable(err));
                 QMessageBox::warning(0,
-                   QWidget::tr("MuseScore: Load Languages Failed:"),
+                   QWidget::tr("Load Languages Failed:"),
                    error,
                    QString::null, QWidget::tr("Quit"), QString::null, 0, 1);
                 return false;
@@ -4260,7 +4260,7 @@ void MuseScore::cmd(QAction* a)
             }
       if (cs && (sc->state() & _sstate) == 0) {
             QMessageBox::warning(0,
-               QWidget::tr("MuseScore: Invalid Command"),
+               QWidget::tr("Invalid Command"),
                QString("Command %1 not valid in current state").arg(cmdn));
             return;
             }
@@ -4579,7 +4579,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             if (!name.isEmpty()) {
                   if (!cs->saveStyle(name)) {
                         QMessageBox::critical(this,
-                           tr("MuseScore: Save Style"), MScore::lastError);
+                           tr("Save Style"), MScore::lastError);
                         }
                   }
             }
@@ -4589,7 +4589,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   cs->startCmd();
                   if (!cs->loadStyle(name)) {
                         QMessageBox::critical(this,
-                           tr("MuseScore: Load Style"), MScore::lastError);
+                           tr("Load Style"), MScore::lastError);
                         }
                   cs->endCmd();
                   }
@@ -4771,7 +4771,7 @@ void MuseScore::closeScore(Score* score)
 
 void MuseScore::noteTooShortForTupletDialog()
       {
-      QMessageBox::warning(this, tr("MuseScore: Warning"),
+      QMessageBox::warning(this, tr("Warning"),
         tr("Cannot create tuplet: Note value is too short")
         );
       }

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -403,7 +403,7 @@ NewWizard::NewWizard(QWidget* parent)
       setWizardStyle(QWizard::ClassicStyle);
       setPixmap(QWizard::LogoPixmap, QPixmap(":/data/mscore.png"));
       setPixmap(QWizard::WatermarkPixmap, QPixmap());
-      setWindowTitle(tr("MuseScore: New Score Wizard"));
+      setWindowTitle(tr("New Score Wizard"));
 
       setOption(QWizard::NoCancelButton, false);
       setOption(QWizard::CancelButtonOnLeft, true);

--- a/mscore/pagesettings.ui
+++ b/mscore/pagesettings.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Page Settings</string>
+   <string>Page Settings</string>
   </property>
   <layout class="QGridLayout">
    <property name="leftMargin">

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -1275,7 +1275,7 @@ bool Palette::read(const QString& p)
 static void writeFailed(const QString& path)
       {
       QString s = qApp->translate("Palette", "Writing Palette File\n%1\nfailed: ");
-      QMessageBox::critical(mscore, qApp->translate("Palette", "MuseScore: Writing Palette File"), s.arg(path));
+      QMessageBox::critical(mscore, qApp->translate("Palette", "Writing Palette File"), s.arg(path));
       }
 
 //---------------------------------------------------------

--- a/mscore/palette.ui
+++ b/mscore/palette.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Palette Properties</string>
+   <string>Palette Properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -252,7 +252,7 @@ void PianorollEditor::setStaff(Staff* st)
             }
       staff = st;
       if (staff) {
-            setWindowTitle(tr("MuseScore: <%1> Staff: %2").arg(_score->name()).arg(st->idx()));
+            setWindowTitle(tr("<%1> Staff: %2").arg(_score->name()).arg(st->idx()));
             TempoMap* tl = _score->tempomap();
             TimeSigMap*  sl = _score->sigmap();
             for (int i = 0; i < 3; ++i)

--- a/mscore/playpanel.ui
+++ b/mscore/playpanel.ui
@@ -20,7 +20,7 @@
    <enum>Qt::ClickFocus</enum>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Play Panel</string>
+   <string>Play Panel</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2">
    <item>

--- a/mscore/pluginCreator.cpp
+++ b/mscore/pluginCreator.cpp
@@ -432,7 +432,7 @@ void PluginCreator::savePlugin()
       QFile f(path);
       QFileInfo fi(f);
       if(fi.suffix() != "qml" ) {
-            QMessageBox::critical(mscore, tr("MuseScore: Save Plugin"), tr("Cannot determine file type"));
+            QMessageBox::critical(mscore, tr("Save Plugin"), tr("Cannot determine file type"));
             return;
       }
 

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Preferences</string>
+   <string>MuseScore Preferences</string>
   </property>
   <property name="accessibleName">
    <string>MuseScore Preferences</string>

--- a/mscore/sectionbreak.ui
+++ b/mscore/sectionbreak.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Section Break Properties</string>
+   <string>Section Break Properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="2" column="0">

--- a/mscore/sectionbreak.ui
+++ b/mscore/sectionbreak.ui
@@ -15,36 +15,13 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="2" column="0">
-    <widget class="QCheckBox" name="_startWithLongNames">
+    <widget class="QCheckBox" name="_startWithMeasureOne">
      <property name="text">
-      <string>Start new section with long instrument names</string>
+      <string>Start new section with measure number one</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>41</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="0">
+   <item row="0" column="0">
     <layout class="QFormLayout" name="formLayout">
      <property name="fieldGrowthPolicy">
       <enum>QFormLayout::ExpandingFieldsGrow</enum>
@@ -71,7 +48,7 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="1">
+   <item row="0" column="1">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -87,28 +64,35 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="0">
-    <spacer name="verticalSpacer">
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="_startWithLongNames">
+     <property name="text">
+      <string>Start new section with long instrument names</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>30</height>
+       <height>41</height>
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="_startWithMeasureOne">
-     <property name="text">
-      <string>Start new section with measure number one</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/mscore/selectdialog.ui
+++ b/mscore/selectdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Select</string>
+   <string>Select</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>

--- a/mscore/selectinstr.ui
+++ b/mscore/selectinstr.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Select Instrument</string>
+   <string>Select Instrument</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/mscore/selectnotedialog.ui
+++ b/mscore/selectnotedialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Select Notes</string>
+   <string>Select Notes</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>

--- a/mscore/splitstaff.ui
+++ b/mscore/splitstaff.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Edit Staff/Part Properties</string>
+   <string>Edit Staff/Part Properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/mscore/stafftextproperties.cpp
+++ b/mscore/stafftextproperties.cpp
@@ -55,13 +55,13 @@ StaffTextProperties::StaffTextProperties(const StaffText* st, QWidget* parent)
       setObjectName("StaffTextProperties");
       setupUi(this);
       if (st->systemFlag()) {
-            setWindowTitle(tr("MuseScore: System Text Properties"));
+            setWindowTitle(tr("System Text Properties"));
             tabWidget->removeTab(tabWidget->indexOf(tabAeolusStops)); // Aeolus settings  for staff text only
             //if (!enableExperimental) tabWidget->removeTab(tabWidget->indexOf(tabMIDIAction));
             tabWidget->removeTab(tabWidget->indexOf(tabChangeChannel)); // Channel switching  for staff text only
             }
       else {
-            setWindowTitle(tr("MuseScore: Staff Text Properties"));
+            setWindowTitle(tr("Staff Text Properties"));
             //tabWidget->removeTab(tabWidget->indexOf(tabSwingSettings)); // Swing settings for system text only, could be disabled here, if desired
 #ifndef AEOLUS
             tabWidget->removeTab(tabWidget->indexOf(tabAeolusStops));

--- a/mscore/symboldialog.cpp
+++ b/mscore/symboldialog.cpp
@@ -84,7 +84,7 @@ SymbolDialog::SymbolDialog(QWidget* parent)
             }
       fontList->setCurrentIndex(currentIndex);
 
-      setWindowTitle(tr("MuseScore: Symbols"));
+      setWindowTitle(tr("Symbols"));
       QLayout* l = new QVBoxLayout();
       frame->setLayout(l);
       createSymbolPalette();

--- a/mscore/textpalette.ui
+++ b/mscore/textpalette.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Special Characters</string>
+   <string>Special Characters</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/mscore/textproperties.cpp
+++ b/mscore/textproperties.cpp
@@ -51,7 +51,7 @@ TextProperties::TextProperties(Text* t, QWidget* parent)
       {
       setObjectName("TextProperties");
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
-      setWindowTitle(tr("MuseScore: Text Properties"));
+      setWindowTitle(tr("Text Properties"));
       QGridLayout* layout = new QGridLayout;
 
       tp = new TextProp;

--- a/mscore/textstyle.cpp
+++ b/mscore/textstyle.cpp
@@ -198,7 +198,7 @@ void TextStyleDialog::applyToAllParts()
 
 void TextStyleDialog::newClicked()
       {
-      QString s = QInputDialog::getText(this, tr("MuseScore: Read Style Name"),
+      QString s = QInputDialog::getText(this, tr("Read Style Name"),
          tr("Text style name:"));
       if (s.isEmpty())
             return;
@@ -213,7 +213,7 @@ void TextStyleDialog::newClicked()
                   }
             if (!notFound) {
                   s = QInputDialog::getText(this,
-                     tr("MuseScore: Read Style Name"),
+                     tr("Read Style Name"),
                      tr("'%1' does already exist,\nplease choose a different name:").arg(s)
                      );
                   if (s.isEmpty())

--- a/mscore/textstyle.ui
+++ b/mscore/textstyle.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Edit Text Styles</string>
+   <string>Edit Text Styles</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">

--- a/mscore/timedialog.cpp
+++ b/mscore/timedialog.cpp
@@ -39,7 +39,7 @@ TimeDialog::TimeDialog(QWidget* parent)
    : QWidget(parent, Qt::WindowFlags(Qt::Dialog | Qt::Window))
       {
       setupUi(this);
-      setWindowTitle(tr("MuseScore: Time Signatures"));
+      setWindowTitle(tr("Time Signatures"));
 
       QLayout* l = new QVBoxLayout();
       l->setContentsMargins(0, 0, 0, 0);

--- a/mscore/transposedialog.ui
+++ b/mscore/transposedialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Transpose</string>
+   <string>Transpose</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>

--- a/mscore/tremolobar.ui
+++ b/mscore/tremolobar.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Tremolo Bar Properties</string>
+   <string>Tremolo Bar Properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="verticalSpacing">

--- a/mscore/tupletdialog.cpp
+++ b/mscore/tupletdialog.cpp
@@ -117,7 +117,7 @@ Tuplet* MuseScore::tupletDialog()
 
       if (tuplet->baseLen() == TDuration::DurationType::V_INVALID) {
             QMessageBox::warning(0,
-               tr("MuseScore: Tuplet Error"),
+               tr("Tuplet Error"),
                tr("Cannot create tuplet with ratio %1 for duration %2").arg(tuplet->ratio().print()).arg(f1.print()));
             delete tuplet;
             return 0;

--- a/mscore/tupletdialog.ui
+++ b/mscore/tupletdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MuseScore: Create Tuplet</string>
+   <string>Create Tuplet</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">

--- a/mscore/uploadscoredialog.cpp
+++ b/mscore/uploadscoredialog.cpp
@@ -27,7 +27,7 @@ void MuseScore::showUploadScoreDialog()
             return;
       if (!currentScore()->sanityCheck()) {
             QMessageBox msgBox;
-            msgBox.setWindowTitle(QObject::tr("MuseScore: Upload Error"));
+            msgBox.setWindowTitle(QObject::tr("Upload Error"));
             msgBox.setText(tr("This score cannot be saved online. Please fix the corrupted measures and try again."));
             msgBox.setDetailedText(MScore::lastError);
             msgBox.setTextFormat(Qt::RichText);

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -104,7 +104,7 @@ void MuseScore::showWorkspaceMenu()
 
 void MuseScore::createNewWorkspace()
       {
-      QString s = QInputDialog::getText(this, tr("MuseScore: Read Workspace Name"),
+      QString s = QInputDialog::getText(this, tr("Read Workspace Name"),
          tr("Workspace name:"));
       if (s.isEmpty())
             return;
@@ -120,7 +120,7 @@ void MuseScore::createNewWorkspace()
                   }
             if (!notFound) {
                   s = QInputDialog::getText(this,
-                     tr("MuseScore: Read Workspace Name"),
+                     tr("Read Workspace Name"),
                      tr("'%1' does already exist,\nplease choose a different name:").arg(s)
                      );
                   if (s.isEmpty())
@@ -237,7 +237,7 @@ void Workspace::initWorkspace()
 static void writeFailed(const QString& _path)
       {
       QString s = qApp->translate("Workspace", "Writing Workspace File\n%1\nfailed: ");
-      QMessageBox::critical(mscore, qApp->translate("Workspace", "MuseScore: Writing Workspace File"), s.arg(_path));
+      QMessageBox::critical(mscore, qApp->translate("Workspace", "Writing Workspace File"), s.arg(_path));
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See #3111.