### PR TITLE
fix #182336: Color Picker window gets larger every time it's used

### DIFF
--- a/awl/colorlabel.cpp
+++ b/awl/colorlabel.cpp
@@ -94,7 +94,7 @@ void ColorLabel::mousePressEvent(QMouseEvent*)
       {
       if (_pixmap)
             return;
-      QColor c = QColorDialog::getColor(_color, this,
+      QColor c = QColorDialog::getColor(_color, NULL,
          tr("Select Color"),
          QColorDialog::ShowAlphaChannel
          );


### PR DESCRIPTION
Please let me know if it is convenient for you.