### PR TITLE
fix #185136: Show tuplet numbers in lute TAB

### DIFF
--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -108,10 +108,11 @@ void Tuplet::layout()
             qDebug("Tuplet::layout(): tuplet is empty");
             return;
             }
-      // is in a TAB without stems, skip any format: tuplets are not shown
-      if (staff() && staff()->isTabStaff() && staff()->staffType()->slashStyle())
-            return;
-
+      // in a lute TAB without stems, only numbers will be shown
+      if (staff() && staff()->isTabStaff() && staff()->staffType()->slashStyle()) {
+            _direction = MScore::Direction::UP;
+            _bracketType = BracketType::SHOW_NO_BRACKET;
+            }
       qreal _spatium = spatium();
       if (_numberType != NumberType::NO_TEXT) {
             if (_number == 0) {
@@ -502,6 +503,11 @@ void Tuplet::layout()
                   }
 
             qreal y3 = p1.y() + (p2.y() - p1.y()) * .5 - l1 * (_isUp ? 1.0 : -1.0);
+            // numbers should in tablature be shown on the same level as the flags
+            // actually the current behaviour doesn't show them on the same height, should be changed ...
+//            if (staff() && staff()->isTabStaff() && staff()->staffType()->slashStyle()) {
+//                  y3 =  (p1.y() <= p2.y()) ? p1.y() : p2.y() - l1 * (_isUp ? 1.0 : -1.0);
+//                  }
             _number->setPos(QPointF(x3, y3) - ipos());
             }
 
@@ -575,8 +581,8 @@ void Tuplet::layout()
 void Tuplet::draw(QPainter* painter) const
       {
       // if in a TAB without stems, tuplets are not shown
-      if (staff() && staff()->isTabStaff() && staff()->staffType()->slashStyle())
-            return;
+//      if (staff() && staff()->isTabStaff() && staff()->staffType()->slashStyle())
+//            return;
 
       QColor color(curColor());
       if (_number) {


### PR DESCRIPTION
This easy fix will show in lute tablature the triplet numbers above the score beside the time value flags by using the normal tuplet numbers. If accepted it would also be possible to delete the out-commented lines.