### PR TITLE
Fix #185116: Changes to tablature flag automatism regarding tuplets and graces

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2284,12 +2284,11 @@ void Chord::layoutTablature()
                         }
                   }
             }
-      if (!tab->genDurations()            // if tab is not set for duration symbols
-            || track2voice(track())       // or not in first voice
-            || isGrace()) {               // or chord is a grace (no dur. symbols for graces
-            //                            // wich are not used in hist. tabs anyway)
-            // no tab duration symbols
-            //
+      if (!tab->genDurations()                         // if tab is not set for duration symbols
+            || track2voice(track())                    // or not in first voice
+            || (isGrace()                              // no tab duration symbols if grace notes
+                && beamMode() == Beam::Mode::AUTO)) {  // and beammode == AUTO
+                                                       //
             delete _tabDur;   // delete an existing duration symbol
             _tabDur = 0;
             }
@@ -2316,6 +2315,7 @@ void Chord::layoutTablature()
                   || beamMode() != Beam::Mode::AUTO
                   || prevCR->durationType().type() != durationType().type()
                   || prevCR->dots() != dots()
+                  || prevCR->tuplet() != tuplet()
                   || prevCR->type() == Element::Type::REST)
                         && !noStem() ) {
                   // symbol needed; if not exist, create; if exists, update duration


### PR DESCRIPTION
As I remarked in issue #185116, there should automatically shown note duration flags for lute tablature, if there is a tuplet after notes of the same length. 
Regarding grace notes: They had been used in late baroque lute music quite often, with or without flags. Therefore it is necessary that flags are added automatically. If not needed, it is possible to hide them without problems (stemless).
