### PR TITLE
fix #186571: update copyright in license shown by installer

### DIFF
--- a/LICENSE.GPL
+++ b/LICENSE.GPL
@@ -1,5 +1,5 @@
 MuseScore, free and open source music notation software
-Copyright (C) 2002-2015 Werner Schweer and others
+Copyright (C) 2002-2017 Werner Schweer and others
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of the GNU General Public License version 2 as published 

--- a/LICENSE.rtf
+++ b/LICENSE.rtf
@@ -1,7 +1,7 @@
 {\rtf1\ansi\ansicpg1252\deff0\nouicompat{\fonttbl{\f0\fnil\fcharset0 Courier New;}{\f1\fnil\fcharset77 Courier New;}}
 {\*\generator Riched20 6.3.9600}\viewkind4\uc1 
 \pard\sa200\sl276\slmult1\f0\fs18\lang12 MuseScore, free and open source music notation software.\par
-Copyright (C) 2002-2015 Werner Schweer and others.\par
+Copyright (C) 2002-2017 Werner Schweer and others.\par
 This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation and reproduce below with the following exception:\par
 - If you create a document which uses fonts included in MuseScore, and embed this font or unaltered portions of this font into the document, then this font does not by itself cause the resulting document to be covered by the GNU General Public License. This exception does not however invalidate any other reasons why the document might be covered by the GNU General Public License. If you modify this font, you may extend this exception to your version of the font, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.\par
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.\par


### PR DESCRIPTION
Actually for the 2.1 branch, but won't harm in the master branch