### PR TITLE
Enable extern lute fonts

### DIFF
--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -193,6 +193,17 @@ void MScore::init()
       _defaultStyleForParts = 0;
       _baseStyle            = new MStyle(*_defaultStyle);
 
+      char mscoreTabPath_help[100];
+      QString wd = QString("%1/%2").arg(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)).arg(QCoreApplication::applicationName());
+      QString mscoreTabPath1 = QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("fonts_directory", "Fonts"))).absoluteFilePath() + "/mscoreTab.ttf";
+      QFileInfo check_file (mscoreTabPath1);
+      if (check_file.exists()) {
+            strcpy(mscoreTabPath_help,mscoreTabPath1.toAscii().constData());
+//            qDebug("mscore.cpp: print path: mscoreTabPath_help = <%s>", qPrintable(mscoreTabPath_help));
+            }
+      else strcpy(mscoreTabPath_help,":/fonts/mscoreTab.ttf");
+      const char * mscoreTabPath= mscoreTabPath_help;
+
       //
       //  load internal fonts
       //
@@ -208,7 +219,7 @@ void MScore::init()
             ":/fonts/FreeSerifBold.ttf",
             ":/fonts/FreeSerifItalic.ttf",
             ":/fonts/FreeSerifBoldItalic.ttf",
-            ":/fonts/mscoreTab.ttf",
+            mscoreTabPath,
             ":/fonts/mscore-BC.ttf",
             ":/fonts/bravura/BravuraText.otf",
             ":/fonts/gootville/GootvilleText.otf",

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -1337,9 +1337,14 @@ const StaffType* StaffType::getDefaultPreset(StaffGroup grp)
 
 std::vector<StaffType> StaffType::_presets;
 
+
 void StaffType::initStaffTypes()
       {
-      readConfigFile(0);          // get TAB font config, before initStaffTypes()
+      QString wd      = QString("%1/%2").arg(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)).arg(QCoreApplication::applicationName());
+      QString fileName = QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("fonts_directory", "Fonts"))).absoluteFilePath() + "/fonts_tablature.xml";
+      QFileInfo check_file (fileName);
+      fileName = check_file.exists() ? fileName : "";
+      readConfigFile(fileName);          // get TAB font config, before initStaffTypes()
 
       _presets = {
 //                       group,              xml-name,  human-readable-name,        lin dst clef  bars stmless time  key  ledger


### PR DESCRIPTION
As I'm not sure, if it still is possible to include this request into 2.1, I wanted to try it now (even this might be too late).
This little code change doesn't change anything for the normal behaviour. No user will notice anything, as the current code is default.

The change enables the possibility to have one extern lute font with different styles in a "Font"-directory in the default musescore-documents directory.
You only need two files: fonts_tablature.xml and mscoreTab.ttf (as far as it seems the otf isn't needed). This gives the possibility to change fonts without being urged to compile the program every time (that's more for people who want to change the fonts or add new styles). 
And it enables to share such fonts very easily with other peoples, as they only have to be copied in the above mentioned directory.

But the change deliberately neither includes a possibility to make this dir, nor to change the path, which is not needed, but could be added later. 

Especially for historical lute tablatures this is a good thing, as there had been many different styles for  tablature signs. So everyone could add the font, that he wants to use. And it is much easier to adjust the fonts, if you want to change some of the signs or behaviour. 
    
It is very senseful to have this possibility, as it doesn't make sense to add more intern tablature fonts to musescore - there are already 8 styles available, which seems to be much, but you have to take into account, that there had been many different lute instruments and even more font styles (much of the lute repertoire is in manuscript). 
Maurizio Gavioli proposed this to me, having already the same idea.

If it is to late to include in 2.1 (or if there are problems with the code), I would like to include it in 3.0-dev surely!