### PR TITLE
fix #186706: export 7sus chord to MusicXML fails reimport

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -5539,7 +5539,7 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
                   QStringList l = h->xmlDegrees();
                   if (!l.isEmpty()) {
                         for (QString tag : l) {
-                              QString degreeText;
+                              bool emptyDegreeText;
                               if (h->xmlKind().startsWith("suspended")
                                   && tag.startsWith("add") && tag[3].isDigit()
                                   && !kindText.isEmpty() && kindText[0].isDigit()) {
@@ -5550,13 +5550,10 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
                                     for (int i = 0; i < kindText.length() && kindText[i].isDigit(); ++i)
                                           kindTextExtension[i] = kindText[i];
                                     int kindExtension = kindTextExtension.toInt();
-                                    if (tagDegree <= kindExtension && (tagDegree & 1) && (kindExtension & 1))
-                                          degreeText = "\"\"";
+                                    emptyDegreeText = tagDegree <= kindExtension && (tagDegree & 1) && (kindExtension & 1);
                                     }
-                              if (degreeText.isEmpty())
-                                    xml.stag("degree");
-                              else
-                                    xml.stag("degree text=" + degreeText);
+
+                              xml.stag("degree");
                               int alter = 0;
                               int idx = 3;
                               if (tag[idx] == '#') {
@@ -5567,10 +5564,16 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
                                     alter = -1;
                                     ++idx;
                                     }
-                              xml.tag("degree-value", tag.mid(idx));
+                              if (emptyDegreeText)
+                                    xml.tag("degree-value text=\"\"", tag.mid(idx));
+                              else
+                                    xml.tag("degree-value", tag.mid(idx));
                               xml.tag("degree-alter", alter);     // finale insists on this even if 0
                               if (tag.startsWith("add"))
-                                    xml.tag("degree-type", "add");
+                                    if (emptyDegreeText)
+                                          xml.tag("degree-type text=\"\"", "add");
+                                    else
+                                          xml.tag("degree-type", "add");
                               else if (tag.startsWith("sub"))
                                     xml.tag("degree-type", "subtract");
                               else if (tag.startsWith("alt"))


### PR DESCRIPTION
Not fully tested, as I made this PR against master (even though it should go into 2.1 too) and there chord symbols don't seem to work at all currently? At least they dont display there, but loading the sample MSCZ from the issue, expoting as XML and then importing that into 2.0.3 or 2.1-RC seems to work fine. These do import the chord as G7sus4 though rather than as G7sus, but that is the same thing after all.
But seee also #3124 