### PR TITLE
fix #186876: notes for bass guitars show in wrong octave in tablature

### DIFF
--- a/mtest/importmidi/instrument_clef.mscx
+++ b/mtest/importmidi/instrument_clef.mscx
@@ -45,10 +45,10 @@
         <transposingClef>F</transposingClef>
         <StringData>
           <frets>24</frets>
-          <string>28</string>
-          <string>33</string>
-          <string>38</string>
-          <string>43</string>
+          <string>40</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
           </StringData>
         <Articulation>
           <velocity>100</velocity>

--- a/mtest/importmidi/meter_15-8.mscx
+++ b/mtest/importmidi/meter_15-8.mscx
@@ -45,10 +45,10 @@
         <transposingClef>F</transposingClef>
         <StringData>
           <frets>24</frets>
-          <string>28</string>
-          <string>33</string>
-          <string>38</string>
-          <string>43</string>
+          <string>40</string>
+          <string>45</string>
+          <string>50</string>
+          <string>55</string>
           </StringData>
         <Articulation>
           <velocity>100</velocity>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -9490,10 +9490,10 @@
                   <musicXMLid>pluck.bass</musicXMLid>
                   <StringData>
                         <frets>24</frets>
-                        <string>28</string>
-                        <string>33</string>
-                        <string>38</string>
-                        <string>43</string>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
                   </StringData>
                   <transposingClef>F</transposingClef>
                   <concertClef>F8vb</concertClef>
@@ -9526,10 +9526,10 @@
                   <musicXMLid>pluck.bass.acoustic</musicXMLid>
                   <StringData>
                         <frets>24</frets>
-                        <string>28</string>
-                        <string>33</string>
-                        <string>38</string>
-                        <string>43</string>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
                   </StringData>
                   <transposingClef>F</transposingClef>
                   <concertClef>F8vb</concertClef>
@@ -9563,10 +9563,10 @@
                   <musicXMLid>pluck.bass.electric</musicXMLid>
                   <StringData>
                         <frets>24</frets>
-                        <string>28</string>
-                        <string>33</string>
-                        <string>38</string>
-                        <string>43</string>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
                   </StringData>
                   <transposingClef>F</transposingClef>
                   <concertClef>F8vb</concertClef>
@@ -9632,11 +9632,11 @@
                   <musicXMLid>pluck.bass.electric</musicXMLid>
                   <StringData>
                         <frets>24</frets>
-                        <string>23</string>
-                        <string>28</string>
-                        <string>33</string>
-                        <string>38</string>
-                        <string>43</string>
+                        <string>35</string>
+                        <string>40</string>
+                        <string>45</string>
+                        <string>50</string>
+                        <string>55</string>
                   </StringData>
                   <transposingClef>F</transposingClef>
                   <concertClef>F8vb</concertClef>


### PR DESCRIPTION
should go to master and 2.1 (and I hope it applies cleanly to that, actually I'm pretty confident that it does)