### PR TITLE
fix #187136: Shortcuts for "Increase/Decrease active duration" don't work

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3262,6 +3262,8 @@ void Score::cmd(const QAction* a)
             { "time-delete",                [this]{ cmdTimeDelete();                                            }},
             { "pitch-up-octave",            [this]{ cmdPitchUpOctave();                                         }},
             { "pitch-down-octave",          [this]{ cmdPitchDownOctave();                                       }},
+            { "pad-note-increase",          [this]{ cmdPadNoteIncreaseTAB();                                    }},
+            { "pad-note-decrease",          [this]{ cmdPadNoteDecreaseTAB();                                    }},
             { "pad-note-increase-TAB",      [this]{ cmdPadNoteIncreaseTAB();                                    }},
             { "pad-note-decrease-TAB",      [this]{ cmdPadNoteDecreaseTAB();                                    }},
             { "toggle-mmrest",              [this]{ cmdToggleMmrest();                                          }},


### PR DESCRIPTION
This PR is for master, PR for 2.1 in #3128