### PR TITLE
fix #186386: pitches in Edit Drumset not sorted in numeric order

### DIFF
--- a/mscore/editdrumset.cpp
+++ b/mscore/editdrumset.cpp
@@ -102,7 +102,7 @@ void EditDrumset::updateList()
       pitchList->clear();
       for (int i = 0; i < 128; ++i) {
             QTreeWidgetItem* item = new QTreeWidgetItem(pitchList);
-            item->setText(Column::PITCH, QString("%1").arg(i));
+            item->setText(Column::PITCH, QString("%1").arg(i, 3)); // 3 digits, padded with space, needed to get the sorting and alignment right
             item->setText(Column::NOTE, pitch2string(i));
             if (nDrumset.shortcut(i) == 0)
                   item->setText(Column::SHORTCUT, "");


### PR DESCRIPTION
have those pitch numbers with 3 digits, padded with spaces gets the sorting right (numerically) and improves the alignment (should be right aligned, but looks more like centered, in any case better than the previous left aligned)