### PR TITLE
fix #187366: Save Online dialog has excess space between changelog and Save/Cancel buttons

### DIFF
--- a/mscore/uploadscoredialog.ui
+++ b/mscore/uploadscoredialog.ui
@@ -360,32 +360,6 @@ p, li { white-space: pre-wrap; }
        <item>
         <widget class="QTextEdit" name="changes"/>
        </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </item>
     </layout>


### PR DESCRIPTION
Should go to master and 2.1