### PR TITLE
fix #187386: Save Online shows 'upload audio' when updating score, regardless of default synthesitzer settings

### DIFF
--- a/libmscore/synthesizerstate.cpp
+++ b/libmscore/synthesizerstate.cpp
@@ -78,14 +78,13 @@ SynthesizerGroup SynthesizerState::group(const QString& name) const
 
 bool SynthesizerState::isDefaultSynthSoundfont()
       {
-      bool result = false;
       SynthesizerGroup fluid = group("Fluid");
       SynthesizerGroup zerberus = group("Zerberus");
       if (zerberus.size() == 0 && fluid.size() == 1) {
             if (fluid.front().data == "FluidR3Mono_GM.sf3")
                   return true;
             }
-      return result;
+      return false;
       }
 
 }

--- a/mscore/uploadscoredialog.cpp
+++ b/mscore/uploadscoredialog.cpp
@@ -187,6 +187,18 @@ void UploadScoreDialog::uploadError(const QString& error)
       }
 
 //---------------------------------------------------------
+//   showOrHideUploadAudio
+//---------------------------------------------------------
+
+void UploadScoreDialog::showOrHideUploadAudio()
+      {
+      uploadAudio->setEnabled(mscore->canSaveMp3());
+      bool v = !mscore->synthesizerState().isDefaultSynthSoundfont();
+      uploadAudio->setVisible(v);
+      uploadAudioHelp->setVisible(v);
+      }
+
+//---------------------------------------------------------
 //   display
 //---------------------------------------------------------
 
@@ -207,10 +219,7 @@ void UploadScoreDialog::display()
                          }
                   }
             }
-      uploadAudio->setEnabled(mscore->canSaveMp3());
-      bool v = !mscore->synthesizerState().isDefaultSynthSoundfont();
-      uploadAudio->setVisible(v);
-      uploadAudioHelp->setVisible(v);
+      showOrHideUploadAudio();
       clear();
       setVisible(true);
       }
@@ -239,6 +248,7 @@ void UploadScoreDialog::onGetScoreSuccess(const QString &t, const QString &desc,
       linkToScore->setText(tr("[%1Link%2]")
                            .arg("<a href=\"" + url + "\">")
                            .arg("</a>"));
+      showOrHideUploadAudio();
       setVisible(true);
       }
 

--- a/mscore/uploadscoredialog.h
+++ b/mscore/uploadscoredialog.h
@@ -44,6 +44,7 @@ class UploadScoreDialog : public QDialog, public Ui::UploadScoreDialog
    private:
       void upload(int nid);
       void clear();
+      void showOrHideUploadAudio();
 
    public:
       UploadScoreDialog(LoginManager*);


### PR DESCRIPTION
should go to master and 2.1