### PR TITLE
fix #51741: no beam for stemless slash notation

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2979,8 +2979,10 @@ void Chord::setSlash(bool flag, bool stemless)
       undoChangeProperty(P_ID::STEM_DIRECTION, static_cast<int>(MScore::Direction::AUTO));
 
       // make stemless if asked
-      if (stemless)
+      if (stemless) {
             undoChangeProperty(P_ID::NO_STEM, true);
+            undoChangeProperty(P_ID::BEAM_MODE, int(Beam::Mode::NONE));
+            }
 
       // voice-dependent attributes - line, size, offset, head
       if (track() % VOICES < 2) {

--- a/mtest/libmscore/tools/undoSlashFill01-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashFill01-ref.mscx
@@ -340,6 +340,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -352,6 +353,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -385,6 +387,7 @@
         <tick>1920</tick>
         <Chord>
           <track>1</track>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -399,6 +402,7 @@
           </Chord>
         <Chord>
           <track>1</track>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -413,6 +417,7 @@
           </Chord>
         <Chord>
           <track>1</track>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -427,6 +432,7 @@
           </Chord>
         <Chord>
           <track>1</track>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -472,6 +478,7 @@
         <Chord>
           <offset x="0" y="-0.5"/>
           <track>2</track>
+          <BeamMode>no</BeamMode>
           <small>1</small>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
@@ -488,6 +495,7 @@
         <Chord>
           <offset x="0" y="-0.5"/>
           <track>2</track>
+          <BeamMode>no</BeamMode>
           <small>1</small>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
@@ -504,6 +512,7 @@
         <Chord>
           <offset x="0" y="-0.5"/>
           <track>2</track>
+          <BeamMode>no</BeamMode>
           <small>1</small>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
@@ -520,6 +529,7 @@
         <Chord>
           <offset x="0" y="-0.5"/>
           <track>2</track>
+          <BeamMode>no</BeamMode>
           <small>1</small>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
@@ -539,6 +549,7 @@
           <subtype>line</subtype>
           </LayoutBreak>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -551,6 +562,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -563,6 +575,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -575,6 +588,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -603,6 +617,7 @@
           <durationType>half</durationType>
           </Rest>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -615,6 +630,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -629,6 +645,7 @@
         </Measure>
       <Measure number="2">
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -641,6 +658,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -653,6 +671,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -665,6 +684,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -679,6 +699,7 @@
         </Measure>
       <Measure number="3">
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -691,6 +712,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -703,6 +725,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -715,6 +738,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -729,6 +753,7 @@
         </Measure>
       <Measure number="4">
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -741,6 +766,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -753,6 +779,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>
@@ -765,6 +792,7 @@
             </Note>
           </Chord>
         <Chord>
+          <BeamMode>no</BeamMode>
           <durationType>quarter</durationType>
           <noStem>1</noStem>
           <Note>


### PR DESCRIPTION
As discussed in issue report, time signatures where slash notation results in eighth notes or shorter should not use beams in "fill with slashes".  I thought about only setting the "no beam" property according to duration, but actually, it's good to always set it, so no beam occurs if you use "fill with slashes" on 6/8 (yielding two dotted quarter slashes) and then change the durations.

BTW, this should also be merged for master, but since my current build system is based on 2.1, it's easier to submit that way.