### PR TITLE
fix #187556: Allow wider dashed slurs/ties

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -52,6 +52,13 @@ void SlurSegment::draw(QPainter* painter) const
                   pen.setWidthF(score()->styleP(StyleIdx::SlurDottedWidth));
                   pen.setStyle(Qt::DashLine);
                   break;
+            case 3:
+                  painter->setBrush(Qt::NoBrush);
+                  pen.setWidthF(score()->styleP(StyleIdx::SlurDottedWidth));
+                  pen.setStyle(Qt::CustomDashLine);
+                  QVector<qreal> dashes { 5.0, 5.0 };
+                  pen.setDashPattern(dashes);
+                  break;
             }
       painter->setPen(pen);
       painter->drawPath(path);

--- a/libmscore/slurtie.h
+++ b/libmscore/slurtie.h
@@ -85,7 +85,7 @@ class SlurTieSegment : public SpannerSegment {
 
 //-------------------------------------------------------------------
 //   @@ SlurTie
-//   @P lineType       int    (0 - solid, 1 - dotted, 2 - dashed)
+//   @P lineType       int  (0 - solid, 1 - dotted, 2 - dashed, 3 - wide dashed)
 //   @P slurDirection  enum (Direction.AUTO, Direction.DOWN, Direction.UP)
 //-------------------------------------------------------------------
 
@@ -93,7 +93,7 @@ class SlurTie : public Spanner {
       Q_GADGET
       Q_PROPERTY(int lineType                         READ lineType       WRITE undoSetLineType)
 
-      int _lineType;    // 0 = solid, 1 = dotted, 2 = dashed
+      int _lineType;    // 0 = solid, 1 = dotted, 2 = dashed, 3 = wide dashed
 
       static Element* editStartElement;
       static Element* editEndElement;

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -73,6 +73,13 @@ void TieSegment::draw(QPainter* painter) const
                   pen.setWidthF(score()->styleP(StyleIdx::SlurDottedWidth));
                   pen.setStyle(Qt::DashLine);
                   break;
+            case 3:
+                  painter->setBrush(Qt::NoBrush);
+                  pen.setWidthF(score()->styleP(StyleIdx::SlurDottedWidth));
+                  pen.setStyle(Qt::CustomDashLine);
+                  QVector<qreal> dashes { 5.0, 5.0 };
+                  pen.setDashPattern(dashes);
+                  break;
             }
       painter->setPen(pen);
       painter->drawPath(path);

--- a/mscore/inspector/inspector_slur.ui
+++ b/mscore/inspector/inspector_slur.ui
@@ -123,6 +123,11 @@
           <string>Dashed</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>Wide Dashed</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item row="2" column="2">


### PR DESCRIPTION
This could even make it into 2.1. All (previous) 2.x version would show the slurs/ties as solid (and a blank field for type in Inspector), but saving again (not altering those slurs/ties) would leave them unaltered, and show as wide dashed in versions that do support it