### PR TITLE
More drift

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1893,11 +1893,9 @@ void Chord::layoutPitched()
                               // (eg, a note on right side of an up stem chord)
                               // then we can count the overlap to the left towards the minimum
 
-                              // TODO: see https://musescore.org/en/node/188461
-                              if (note->ipos().x() != 0.0)                    // use x() rather than ipos().x()?
-                                    overlap += qAbs(note->ipos().x());        // remove qAbs()?
-                              else
-                                    overlap -= note->headWidth() * 0.12;      // do this regardless of x()?
+                              overlap -= note->headWidth() * 0.12;
+                              if (note->x() != 0.0)
+                                    overlap += note->x();
                               }
                         else {
                               if (shortStart)

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -432,7 +432,7 @@ void LineSegment::editDrag(const EditData& ed)
 
 void LineSegment::spatiumChanged(qreal ov, qreal nv)
       {
-      Element::spatiumChanged(ov, nv);
+      SpannerSegment::spatiumChanged(ov, nv);
       _userOff2 *= nv / ov;
       }
 
@@ -442,7 +442,7 @@ void LineSegment::spatiumChanged(qreal ov, qreal nv)
 
 void LineSegment::localSpatiumChanged(qreal ov, qreal nv)
       {
-      Element::localSpatiumChanged(ov, nv);
+      SpannerSegment::localSpatiumChanged(ov, nv);
       _userOff2 *= nv / ov;
       }
 

--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -128,6 +128,7 @@ void Stem::spatiumChanged(qreal oldValue, qreal newValue)
       {
       _userLen = (_userLen / oldValue) * newValue;
       layout();
+      Element::spatiumChanged(oldValue, newValue);
       }
 
 //---------------------------------------------------------

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -640,6 +640,7 @@ void TextLineSegment::spatiumChanged(qreal ov, qreal nv)
       textLine()->spatiumChanged(ov, nv);
       if (_text)
             _text->spatiumChanged(ov, nv);
+      LineSegment::spatiumChanged(ov, nv);
       }
 
 //---------------------------------------------------------

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -540,9 +540,10 @@ QVariant TimeSig::propertyDefault(P_ID id) const
 //   spatiumChanged
 //---------------------------------------------------------
 
-void TimeSig::spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/)
+void TimeSig::spatiumChanged(qreal oldValue, qreal newValue)
       {
       _needLayout = true;
+      Element::spatiumChanged(oldValue, newValue);
       }
 
 void TimeSig::localSpatiumChanged(qreal /*oldValue*/, qreal /*newValue*/)


### PR DESCRIPTION
Two problems fixed in this PR, in separate commits in case we want to use one but not the other, or need to revert one but not the other.

The more important fix, I think, is for https://musescore.org/en/node/187151. This is a drifting hairpin due to a bad tie calculation. In trying to enforce a minimum tie length in some cases, the calculation is badly affected by floating point roundoff, causing results to be unpredictable, leading to a hairpin shift on each save / reload. It's a small shift, but it is cumulative, so over the course of time hairpins can drift a long ways. The fix here should be good - it removes the dependency on the floating point comparison, and improves the calculation as well.

The other fix is for https://musescore.org/en/node/188061. Hairpins as well as a few other elements drift on spatium change (not on save/reload). This is simple - we are overriding spatiumChanged() for a few element types but not calling their spatiumChanged() for their parent type, meaning we don't do the userOff correction.

I found one other issue in this code (see https://musescore.org/en/node/188461), but this affects tie length only in a couple of relatively obscure corner cases - no hairpin drift. And while I think i see what needs to be done, I don't understand it fully, so I would rather deal with that separately.