### PR TITLE
fix #183816: full measure rest displaced after timesig change with invisible staves

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3779,6 +3779,8 @@ void Measure::layoutX(qreal stretch)
                               if (ps) {
                                     ss = ps;
                                     for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
+                                          if (!visible(staffIdx))
+                                                continue;
                                           int track = staffIdx * VOICES;
                                           Element* e = ss->element(track);
                                           if (e)


### PR DESCRIPTION
As per issue report, rest was being displaced due to a bad centering calculation.  We're trying to center between the time signature and the end barline, but with an invisible staff, the time signature may not have been laid out, so we get incorrect information about its position.  This PR simply skips invisible staves, which fixes the problem.  Hopefully doesn't introduce others.

Might in the future make sense to look at laying out the time signature even though the staff is invisible.