### PR TITLE
fix #152206 follow up: show correct revision in score properties after (auto-)save too

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -703,7 +703,7 @@ bool Score::saveFile(QIODevice* f, bool msczFormat, bool onlySelection)
       if (!onlySelection) {
             //update version values for i.e. plugin access
             _mscoreVersion = VERSION;
-            _mscoreRevision = revision.toInt();
+            _mscoreRevision = revision.toInt(0, 16);
             _mscVersion = MSCVERSION;
             }
       return true;


### PR DESCRIPTION
PR is for master, but should go to and apply cleanly to 2.1 too