### PR TITLE
Fix #188051: corruption on delete with no/modified time signature

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2474,15 +2474,12 @@ void Score::cmdDeleteSelection()
                               for (Measure* m = s1->measure(); m; m = m->nextMeasure()) {
                                     Staff* staff = Score::staff(track / VOICES);
                                     int tick = m->tick();
-                                    TimeSig* ts = staff->timeSig(tick);
-                                    if (ts) {
-                                          Fraction f = ts->sig();
-                                          Rest* r = setRest(tick, track, f, false, 0);
-                                          if (!cr)
-                                                cr = r;
-                                          if (s2 && (m == s2->measure()))
-                                                break;
-                                          }
+                                    Fraction ff = m->stretchedLen(staff);
+                                    Rest* r = setRest(tick, track, ff, false, 0);
+                                    if (!cr)
+                                          cr = r;
+                                    if (s2 && (m == s2->measure()))
+                                          break;
                                     }
                               }
                         else {


### PR DESCRIPTION
Basically, deleting (contents of) a measure corrupts it in any of the following cases:

- no time signature (eg, initial time signature deleted
- actual duration not same as nominal
- local time signature

In 2.0.3, these three cases all worked individually, all it failed in measures with both local time signature *and* actual not equal nominal.

The section of code involved has an interesting history - seems it was added to help with corruption (?), disabled when a problem was found, re-enabled to fix another problem, but other problems were introduced.  So I don't have huge confidence in what this code is doing, and maybe we should also consider disabling it again and finding another fix for https://musescore.org/en/node/167416.

*But*, if we have faith in this code in general, the code in this PR seems to fix the problems here.