### PR TITLE
fix #188091: landscape forces A4

### DIFF
--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -65,8 +65,8 @@ const PaperSize paperSizes[] = {
       PaperSize("Comm10E",   MM(105),  MM(241)),
       PaperSize("DLE",       MM(110),  MM(220)),
       PaperSize("Folio",     MM(210),  MM(330)),
-      PaperSize("Ledger",    MM(432),  MM(279)),
-      PaperSize("Tabloid",   MM(279),  MM(432)),
+      PaperSize("Ledger",    17,       11),
+      PaperSize("Tabloid",   11,       17),
       PaperSize(0,           MM(1),    MM(1))   // mark end of list
       };
 

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -62,8 +62,8 @@ PageSettings::PageSettings(QWidget* parent)
       connect(buttonApply,          SIGNAL(clicked()),            SLOT(apply()));
       connect(buttonApplyToAllParts,SIGNAL(clicked()),            SLOT(applyToAllParts()));
       connect(buttonOk,             SIGNAL(clicked()),            SLOT(ok()));
-      connect(portraitButton,       SIGNAL(clicked()),            SLOT(portraitClicked()));
-      connect(landscapeButton,      SIGNAL(clicked()),            SLOT(landscapeClicked()));
+      connect(portraitButton,       SIGNAL(clicked()),            SLOT(orientationToggled()));
+      connect(landscapeButton,      SIGNAL(clicked()),            SLOT(orientationToggled()));
       connect(twosided,             SIGNAL(toggled(bool)),        SLOT(twosidedToggled(bool)));
       connect(pageHeight,           SIGNAL(valueChanged(double)), SLOT(pageHeightChanged(double)));
       connect(pageWidth,            SIGNAL(valueChanged(double)), SLOT(pageWidthChanged(double)));
@@ -286,27 +286,10 @@ void PageSettings::mmClicked()
       updateValues();
       }
 
-//---------------------------------------------------------
-//   portraitClicked
-//---------------------------------------------------------
-
-void PageSettings::portraitClicked()
+void PageSettings::orientationToggled()
       {
       PageFormat pf;
-      double f  = mmUnit ? 1.0/INCH : 1.0;
-      pf.setPrintableWidth(pf.width() - (oddPageLeftMargin->value() + oddPageRightMargin->value())  * f);
-      preview->score()->setPageFormat(pf);
-      updateValues();
-      updatePreview(0);
-      }
-
-//---------------------------------------------------------
-//   landscapeClicked
-//---------------------------------------------------------
-
-void PageSettings::landscapeClicked()
-      {
-      PageFormat pf;
+      pf.copy(*preview->score()->pageFormat());
       pf.setSize(QSizeF(pf.height(), pf.width()));
       double f  = mmUnit ? 1.0/INCH : 1.0;
       pf.setPrintableWidth(pf.width() - (oddPageLeftMargin->value() + oddPageRightMargin->value())  * f);

--- a/mscore/pagesettings.h
+++ b/mscore/pagesettings.h
@@ -68,8 +68,7 @@ class PageSettings : public QDialog, private Ui::PageSettingsBase {
       void pageHeightChanged(double);
       void pageWidthChanged(double);
       void pageOffsetChanged(int val);
-      void portraitClicked();
-      void landscapeClicked();
+      void orientationToggled();
 
    public:
       PageSettings(QWidget* parent = 0);


### PR DESCRIPTION
Regarding the landscape button, the problem was just a missing "pf.copy(*preview->score()->pageFormat());" that was left out during the conversion from the checkbox to the radio button.  But really, there was no need to have two separate functions here, so I recombined them for simplicity.

The Tabloid issue is interesting.  I didn't realize this, but Tabloid and Ledger are the same paper size.  Ledger is just what it is sometimes called when used in landscape orientation.  So, setting to Tabloid *is* the same as setting to Ledger, and that why the UI gets confused about it.  Not sure there is anything to do about that the way we implement this, so I mostly left that alone.  Except, since these sizes are supposed to be in inches, I just changed the initialization.  The old values were in mm and resulted in the dimensions being slightly off.