### PR TITLE
fix #189741: corruption on change duration with local timesig

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1606,16 +1606,22 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
                               }
                         }
                   }
+            Fraction stretch = score()->staff(staffIdx)->timeStretch(tick());
             // if just a single rest
             if (rests == 1 && chords == 0) {
                   // if measure value didn't change, stick to whole measure rest
                   if (_timesig == nf) {
-                        rest->undoChangeProperty(P_ID::DURATION, QVariant::fromValue<Fraction>(nf));
+                        rest->undoChangeProperty(P_ID::DURATION, QVariant::fromValue<Fraction>(nf * stretch));
                         rest->undoChangeProperty(P_ID::DURATION_TYPE, QVariant::fromValue<TDuration>(TDuration::DurationType::V_MEASURE));
                         }
                   else {      // if measure value did change, represent with rests actual measure value
+#if 0
+                        // any reason not to do this instead?
+                        s->undoRemoveElement(rest);
+                        s->setRest(tick(), staffIdx * VOICES, nf * stretch, false, 0, false);
+#else
                         // convert the measure duration in a list of values (no dots for rests)
-                        QList<TDuration> durList = toDurationList(nf, false, 0);
+                        QList<TDuration> durList = toDurationList(nf * stretch, false, 0);
 
                         // set the existing rest to the first value of the duration list
                         for (ScoreElement* e : rest->linkList()) {
@@ -1624,15 +1630,16 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
                               }
 
                         // add rests for any other duration list value
-                        int tickOffset = tick() + durList[0].ticks();
+                        int tickOffset = tick() + rest->actualTicks();
                         for (int i = 1; i < durList.count(); i++) {
                               Rest* newRest = new Rest(s);
                               newRest->setDurationType(durList.at(i));
                               newRest->setDuration(durList.at(i).fraction());
                               newRest->setTrack(rest->track());
                               score()->undoAddCR(newRest, this, tickOffset);
-                              tickOffset += durList.at(i).ticks();
+                              tickOffset += newRest->actualTicks();
                               }
+#endif
                         }
                   continue;
                   }
@@ -1679,7 +1686,7 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
                         // add rest to measure
                         int rtick = tick() + nl - n;
                         int track = staffIdx * VOICES + voice;
-                        s->setRest(rtick, track, Fraction::fromTicks(n), false, 0, false);
+                        s->setRest(rtick, track, Fraction::fromTicks(n) * stretch, false, 0, false);
                         }
                   }
             }


### PR DESCRIPTION
In the issue https://musescore.org/en/node/189741, I propose disabling the change actual duration command for a measure affected by a local time signature.  But due to the way things are structured, detecting this at the right time seemed tricky, whereas actually fixing the main problem (initial state of measure not converted correctly) is pretty straightforward.  This PR suggests two ways of getting the job done.

Still, because this affects how the change actual duration command works, I don't know that it is worth merging for 2.1 right now.  Maybe better to wait until we have some more fixes for other local time signature issues and can do more rigorous testing.
