### PR TITLE
fix #97106: crash on undo after save with courtesy keysig

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -449,10 +449,15 @@ bool Score::saveFile()
       QFile::setPermissions(name, QFile::ReadOwner | QFile::WriteOwner | QFile::ReadUser
          | QFile::ReadGroup | QFile::ReadOther);
 
+      startCmd();
+      info.refresh();         // update file info
+      setLayoutAll(true);
+      endCmd();               // force relayout
+      undo()->undo();         // don't leave anything on undo stack
+      endUndoRedo();
+
       undo()->setClean();
       setSaved(true);
-      info.refresh();
-      update();
       return true;
       }
 


### PR DESCRIPTION
The crash is actually an assertion failure, removing a keysig from a segment that doesn't contain one.  The cause seems to be the layout that is forced at the end of the save (to update $m macro in header/footer), because it happens while not in undo mode.  Generated elements get added and removed during layout, and doing this while not in undo mode confuses the undo stack a bit.  I can't say I understand *exactly* what goes wrong in this case, but I am pretty confident this is the problem.

Assuming we want to keep the layout operation at the end of the save, the solution seems to be to do so in the context of startCmd()/endCmd().  This puts an extra macro on the stack, so I remove it afterwards.  Because endCmd() does an update() anyhow, I removed that, but I call setLayoutAll() first to make sure all linked scores get updated.  Finally, I moved this bit of code to before the undo()->setClean() just to be sure we are in a clean state after the save.

This fixes the crash and doesn't introduce any null undo steps or other artifacts that I can see.  It also fixes another small bug in the original code, where $m macros in headers/footers would only get updated on save if the score has parts.  That's because there was no setLayoutAll() call before the update(), and unless there were parts, _updateAll would generally not be set at that point.