### PR TITLE
fix #185876: mavigator affects all open scores

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1550,8 +1550,8 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
       setPos(cs->inputPos());
       //showMessage(cs->filePath(), 2000);
       if (_navigator && _navigator->widget()) {
-            navigator()->setScore(cs);
             navigator()->setScoreView(view);
+            navigator()->setScore(cs);
             }
       ScoreAccessibility::instance()->updateAccessibilityInfo();
       }

--- a/mscore/navigator.cpp
+++ b/mscore/navigator.cpp
@@ -171,7 +171,8 @@ void Navigator::setScoreView(ScoreView* v)
 
 void Navigator::setScore(Score* v)
       {
-      _cv    = 0;
+      // see https://musescore.org/en/node/185876
+      //_cv    = 0;
       _score = v;
       rescale();
       updateViewRect();


### PR DESCRIPTION
As per analysis in issue report, the problem is a bad interaction between Navigator::setScoreView() and Navigator::setScore().  Specifically, the fact that Navigator::setScore() clears _cv prevents Navigator::setScoreView() from disconnecting the signals for the previous score upon switching to a new one.  When the call to setScore(0 was first added, it broke the blue rectangle for the navigator.  But this turns out to be for the same reason.  So I put the order of calls back the way it was (makes more sense, and it is how it done elsewhere), but removed the clearing of _cv.

BTW, I am not actually to reproduce the problem that caused the setScore() call to be added in the first place, but I will trust that it was necessary in some cases.  I guess probably it was the update() call within setScore() that was the key, because everything else setScore() does is reproduced in setScoreView().  I suspect we could also fix the current bug by removing the call to setScore() from MuseScore::setCurrentScoreView() and instead adding an update() call to the end of Navigator::setScoreView().  But since I cannot reproduce the problem that calling setScore() was intended to fix, I would rather not assume that this would be sufficient.
