### PR TITLE
Fix #109066 : Metronome Gain and Volume slider Left Double click wrong default values

### DIFF
--- a/awl/volslider.cpp
+++ b/awl/volslider.cpp
@@ -36,7 +36,7 @@ VolSlider::VolSlider(QWidget* parent)
       setScaleWidth(7);
       setLineStep(.8f);
       setPageStep(3.0f);
-      setDclickValue1(_minValue);
+      setDclickValue1(0.0);
       setDclickValue2(0.0);
       }
 

--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -78,6 +78,8 @@ SynthControl::SynthControl(QWidget* parent)
       readSettings();
       metronome->setDefaultAction(getAction("metronome"));
       mgain->setValue(seq->metronomeGain());
+      mgain->setDclickValue1(seq->metronomeGain() - 10.75f);
+      mgain->setDclickValue2(seq->metronomeGain() - 10.75f);
 
       updateGui();
 


### PR DESCRIPTION
This does the same as #3135, but I've modified nasehim's commit to be mergable into 2.1, accounting for my #3086 change of moving metronome gain from synth ui into play panel and renaming it from mgain into mgainSlider in 3.0.