### PR TITLE
fix #97106: remove update on save

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -449,12 +449,10 @@ bool Score::saveFile()
       QFile::setPermissions(name, QFile::ReadOwner | QFile::WriteOwner | QFile::ReadUser
          | QFile::ReadGroup | QFile::ReadOther);
 
-      startCmd();
       info.refresh();         // update file info
-      setLayoutAll(true);
-      endCmd();               // force relayout
-      undo()->undo();         // don't leave anything on undo stack
-      endUndoRedo();
+      // TODO: update score
+      // calling update() has undo implications
+      // see https://musescore.org/en/node/97106
 
       undo()->setClean();
       setSaved(true);


### PR DESCRIPTION
See issue report https://musescore.org/en/node/97106.  Safer to skip the update - otherwise, redo is disabled (even if we fix the other regression my previous fix introduced).  That measn $m won't automatically update on save.  Better that than losing the ability to redo after a save, I think