### PR TITLE
fix #4954 Change staff instrument changes default clef

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2508,11 +2508,11 @@ void ChangePageFormat::flip()
 //   ChangeStaff
 //---------------------------------------------------------
 
-ChangeStaff::ChangeStaff(Staff* _staff,  bool _invisible,
-   qreal _userDist, bool _neverHide, bool _showIfEmpty, bool hide)
+ChangeStaff::ChangeStaff(Staff* _staff,  bool _invisible, ClefTypeList _clefType, qreal _userDist, bool _neverHide, bool _showIfEmpty, bool hide)
       {
       staff       = _staff;
       invisible   = _invisible;
+      clefType    = _clefType;
       userDist    = _userDist;
       neverHide   = _neverHide;
       showIfEmpty = _showIfEmpty;
@@ -2536,21 +2536,23 @@ static void notifyTimeSigs(void*, Element* e)
 
 void ChangeStaff::flip()
       {
-      bool invisibleChanged = staff->invisible() != invisible;
-
-      bool oldInvisible   = staff->invisible();
-      qreal oldUserDist   = staff->userDist();
-      bool oldNeverHide   = staff->neverHide();
-      bool oldShowIfEmpty = staff->showIfEmpty();
-      bool hide           = staff->hideSystemBarLine();
+      bool invisibleChanged    = staff->invisible() != invisible;
+      ClefTypeList oldClefType = staff->defaultClefType();
+      bool oldInvisible        = staff->invisible();
+      qreal oldUserDist        = staff->userDist();
+      bool oldNeverHide        = staff->neverHide();
+      bool oldShowIfEmpty      = staff->showIfEmpty();
+      bool hide                = staff->hideSystemBarLine();
 
       staff->setInvisible(invisible);
+      staff->setDefaultClefType(clefType);
       staff->setUserDist(userDist);
       staff->setNeverHide(neverHide);
       staff->setShowIfEmpty(showIfEmpty);
       staff->setHideSystemBarLine(hideSystemBarLine);
 
       invisible   = oldInvisible;
+      clefType    = oldClefType;
       userDist    = oldUserDist;
       neverHide   = oldNeverHide;
       showIfEmpty = oldShowIfEmpty;

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -671,6 +671,7 @@ class ChangePageFormat : public UndoCommand {
 class ChangeStaff : public UndoCommand {
       Staff* staff;
       bool   invisible;
+      ClefTypeList clefType;
       qreal  userDist;
       bool   neverHide;
       bool   showIfEmpty;
@@ -679,8 +680,7 @@ class ChangeStaff : public UndoCommand {
       void flip();
 
    public:
-      ChangeStaff(Staff*, bool invisible, qreal userDist, bool _neverHide,
-         bool _showIfEmpty, bool hide);
+      ChangeStaff(Staff*, bool _invisible, ClefTypeList _clefType, qreal _userDist, bool _neverHide, bool _showIfEmpty, bool hide);
       UNDO_NAME("ChangeStaff")
       };
 

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -339,6 +339,7 @@ void EditStaff::apply()
       instrument.setLongName(ln);
 
       bool inv       = invisible->isChecked();
+      ClefTypeList clefType = instrument.clefType(orgStaff->rstaff());
       qreal userDist = spinExtraDistance->value();
       bool nhide     = neverHide->isChecked();
       bool ifEmpty   = showIfEmpty->isChecked();
@@ -361,12 +362,13 @@ void EditStaff::apply()
       orgStaff->undoChangeProperty(P_ID::SMALL, small->isChecked());
 
       if (inv != orgStaff->invisible()
+         || clefType != orgStaff->defaultClefType()
          || userDist != orgStaff->userDist()
          || nhide != orgStaff->neverHide()
          || ifEmpty != orgStaff->showIfEmpty()
          || hideSystemBL != orgStaff->hideSystemBarLine()
          ) {
-            score->undo(new ChangeStaff(orgStaff, inv, userDist * score->spatium(), nhide, ifEmpty, hideSystemBL));
+            score->undo(new ChangeStaff(orgStaff, inv, clefType, userDist * score->spatium(), nhide, ifEmpty, hideSystemBL));
             }
 
       if ( !(*orgStaff->staffType() == *staff->staffType()) ) {


### PR DESCRIPTION
Right-clicking a staff and changing the instrument in editstaff.ui will now also change the default clef for that staff based upon instrument.clefType(orgStaff->rstaff()) such that any generated clefs (including the staff's initial clef if user did not manually drop another initial clef) will obey the new instrument's default clef for that staff.