### PR TITLE
fix #163691: crash on undo with links to self

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -3705,8 +3705,10 @@ void Unlink::undo()
       {
       if (MScore::debugMode)
             qDebug("LinkUnlink: link %p (e) to %p (le)", e, le);
-      Q_ASSERT(le != nullptr);
-      e->linkTo(le);
+      // see https://musescore.org/en/node/163691
+      // Q_ASSERT(le != nullptr);
+      if (le)
+            e->linkTo(le);
       }
 
 void LinkStaff::redo()   { s1->linkTo(s2); } // s1 is added


### PR DESCRIPTION
When we remove a linked staff, the elements on the remaining staff still contain links to the corresponding elements on the removed staff.  This is something that has bothered me for some time, and I'm pretty sure it leads to other problems as well.  So ultimately, I still think we should address this.

However, that would undoubtedly have major ramifications, so I am not going there right now.  The issue at hand - https://musescore.org/en/node/163691 - is triggered by the specific case of an element linked to itself that *results* from removal of a linked staff followed by save/reload.  If you then remove the remaining staff and undo, you get an assertion failure.  I elected to go with a "100% safe" solution.  I simply removed the assert statement that led to the crash, and just return without doing anything in that case.  No crash, and it has the added benefit of fixing the link to self thus hopefully reducing the likelihood of further problems.

Worst case, some series of steps that formerly crashed right away due the assertion failure will now crash *later*.