### PR TITLE
fix #151521: restore selection for all linked scores on undo/redo

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -99,7 +99,8 @@ void Score::startCmd()
             return;
             }
       undo()->beginMacro();
-      undo(new SaveState(this));
+      for (Score* s : scoreList())
+            undo(new SaveState(s));
       }
 
 //---------------------------------------------------------
@@ -140,7 +141,8 @@ void Score::endCmd(bool rollback)
 
       if (MScore::debugMode)
             qDebug("===endCmd() %d", undo()->current()->childCount());
-      bool noUndo = (undo()->current()->childCount() <= 1);       // nothing to undo?
+      // nothing to undo if current undo macro has only the SaveState commands for each score
+      bool noUndo = (undo()->current()->childCount() <= scoreList().size());
       undo()->endMacro(noUndo);
       end();      // DEBUG
 


### PR DESCRIPTION
Currently, we begin each undoable command with a "SaveState" - basically remembering the input state and selection, so we can restore it on undo.  Howeve,r we only do this for the score actually being edited, not for any linked scores.  As a result, if you perform an operation while viewing the score but undo while viewing a part (or vice versa), strange things can happen.  In particular, if you had anything selected when you pressed Ctrl+Z, that may or may not still be a valid selection when the operation completes, and we have no way of detecting problems here.  As result, you can get a crash if you try doing an operation on the selection after an undo of an operation originally performed in another linked score.

I see two basic ways of dealing with this.  One is to do the same thing we do on every regular command: clear the selection in all linked scores (except the one we are actually editing).  However, due to the way things are structured, this wasn't actually as simple as it seemed it would be at first.  It turned out to be easier to do what I considered the better solution: saving/restoring state for *all* linked scores on every command.

Seems to work just fine; I haven't been able to break it.  Since it affects pretty much all commands on scores with linked parts, though, it really should get more testing.