### PR TITLE
fix #197176: palette double click ignores voice filter

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -524,7 +524,7 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
                   for (Segment* s = startSegment; s && s != endSegment; s = s->next1()) {
                         for (int track = track1; track < track2; ++track) {
                               Element* e = s->element(track);
-                              if (e == 0)
+                              if (e == 0 || !score->selectionFilter().canSelect(e) || !score->selectionFilter().canSelectVoice(track))
                                     continue;
                               if (e->type() == Element::Type::CHORD) {
                                     Chord* chord = static_cast<Chord*>(e);


### PR DESCRIPTION
Right now we ignore the filter on mouse double click.  This PR keeps the basic code we have for applying double click, but checks the filter.  I wonder, though, if instead of looping through segments and elements, we shouldn't simply loop through selection().elements() as is done in addArticulation().  That way the drop could also be applied to lines and other elements that would be missed when looping through segments.  But that represents a bigger change than what I am doing here.