### PR TITLE
Clean up lute instruments in instruments.xml

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -8963,10 +8963,14 @@
             <Instrument id="lute">
                   <longName>Lute</longName>
                   <shortName>Lt.</shortName>
-                  <description>Lute</description>
+                  <description>Rennaissance Lute in G, up to 11 courses</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
-                        <frets>13</frets>
+                        <string open="1">35</string>
+                        <string open="1">36</string>
+                        <string open="1">38</string>
+                        <string>40</string>
+                        <string>41</string>
                         <string>43</string>
                         <string>48</string>
                         <string>53</string>
@@ -8974,7 +8978,7 @@
                         <string>62</string>
                         <string>67</string>
                   </StringData>
-                  <clef>G</clef>
+                  <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>33-79</aPitchRange>
                   <pPitchRange>33-79</pPitchRange>
@@ -8983,12 +8987,21 @@
                   </Channel>
                   <genre>earlymusic</genre>
             </Instrument>
-            <Instrument id="lute-tablature">
-                  <trackName>Lute [Tablature]</trackName>
+            <Instrument id="lute-frenchtab">
+                  <trackName>Rennaissance Lute [French Tab]</trackName>
                   <init>lute</init>
-                  <description>Lute (Tablature)</description>
+                  <description>Rennaissance Lute in G (French Tablature)</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <stafftype staffTypePreset="tab6StrFrench">tablature</stafftype>
+<!--                  <clef>TAB</clef> -->
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="lute-italiantab">
+                  <trackName>Rennaissance Lute [Italian Tab]</trackName>
+                  <init>lute</init>
+                  <description>Rennaissance Lute in G (French Tablature)</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <stafftype staffTypePreset="tab6StrItalian">tablature</stafftype>
 <!--                  <clef>TAB</clef> -->
                   <genre>earlymusic</genre>
             </Instrument>
@@ -9006,7 +9019,7 @@
                         <string>62</string>
                         <string>67</string>
                   </StringData>
-                  <clef>G</clef>
+                  <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>48-79</aPitchRange>
                   <pPitchRange>48-79</pPitchRange>
@@ -9015,144 +9028,15 @@
                   </Channel>
                   <genre>earlymusic</genre>
             </Instrument>
-            <Instrument id="ren.-tenor-lute-6-course">
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <trackName>Lute 6-course</trackName>
-                  <description>Ren. Tenor Lute (6-course)</description>
+           <Instrument id="baroque-lute">
+                  <longName>Baroque Lute</longName>
+                  <shortName>Bar-Lt.</shortName>
+                  <trackName>Baroque Lute</trackName>
+                  <description>Baroque Lute (up to 14 courses)</description>
                   <musicXMLid>pluck.lute</musicXMLid>
                   <StringData>
                         <frets>13</frets>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>43-79</aPitchRange>
-                  <pPitchRange>43-79</pPitchRange>
-                  <Channel>
-                        <program value="25"/>
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ren.-tenor-lute-7-course">
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <trackName>Lute 7-course</trackName>
-                  <description>Ren. Tenor Lute (7-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string>38</string>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>38-79</aPitchRange>
-                  <pPitchRange>38-79</pPitchRange>
-                  <Channel>
-                        <program value="25"/>
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ren.-tenor-lute-8-course">
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <trackName>Lute 8-course</trackName>
-                  <description>Ren. Tenor Lute (8-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string>38</string>
-                        <string>41</string>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>38-79</aPitchRange>
-                  <pPitchRange>38-79</pPitchRange>
-                  <Channel>
-                        <program value="25"/>
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ren.-tenor-lute-9-course">
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <trackName>Lute 9-course</trackName>
-                  <description>Ren. Tenor Lute (9-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string open="1">36</string>
-                        <string>38</string>
-                        <string>41</string>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>36-79</aPitchRange>
-                  <pPitchRange>36-79</pPitchRange>
-                  <Channel>
-                        <program value="25"/>
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="ren.-tenor-lute-10-course">
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <trackName>Lute 10-course</trackName>
-                  <description>Ren. Tenor Lute (10-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
-                        <string open="1">36</string>
-                        <string open="1">38</string>
-                        <string>40</string>
-                        <string>41</string>
-                        <string>43</string>
-                        <string>48</string>
-                        <string>53</string>
-                        <string>57</string>
-                        <string>62</string>
-                        <string>67</string>
-                  </StringData>
-                  <clef>G</clef>
-                  <barlineSpan>1</barlineSpan>
-                  <aPitchRange>36-79</aPitchRange>
-                  <pPitchRange>36-79</pPitchRange>
-                  <Channel>
-                        <program value="25"/>
-                  </Channel>
-                  <genre>earlymusic</genre>
-            </Instrument>
-            <Instrument id="baroque-lute-13-course">
-                  <longName>Lute</longName>
-                  <shortName>Lt.</shortName>
-                  <trackName>Lute 13-course</trackName>
-                  <description>Baroque Lute (13-course)</description>
-                  <musicXMLid>pluck.lute</musicXMLid>
-                  <StringData>
-                        <frets>13</frets>
+                        <string open="1">31</string>
                         <string open="1">33</string>
                         <string open="1">35</string>
                         <string open="1">36</string>
@@ -9167,13 +9051,22 @@
                         <string>62</string>
                         <string>65</string>
                   </StringData>
-                  <clef>G</clef>
+                  <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>33-77</aPitchRange>
                   <pPitchRange>33-77</pPitchRange>
                   <Channel>
                         <program value="25"/>
                   </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="baroque-lute-frenchtab">
+                  <trackName>Baroque Lute [French Tab]</trackName>
+                  <init>baroque-lute</init>
+                  <description>Baroque Lute (French Tablature)</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <stafftype staffTypePreset="tab6StrFrench">tablature</stafftype>
+<!--                  <clef>TAB</clef> -->
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="archlute-14-course">
@@ -9198,13 +9091,22 @@
                         <string>62</string>
                         <string>67</string>
                   </StringData>
-                  <clef>G</clef>
+                  <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>29-77</aPitchRange>
                   <pPitchRange>29-77</pPitchRange>
                   <Channel>
                         <program value="25"/>
                   </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="archlute-italiantab">
+                  <trackName>Archlute [Italian Tab]</trackName>
+                  <init>archlute</init>
+                  <description>Archlute (Italian Tablature)</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <stafftype staffTypePreset="tab6StrItalian">tablature</stafftype>
+<!--                  <clef>TAB</clef> -->
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="theorbo-14-course">
@@ -9229,13 +9131,31 @@
                         <string>52</string>
                         <string>57</string>
                   </StringData>
-                  <clef>G</clef>
+                  <clef>G8vb</clef>
                   <barlineSpan>1</barlineSpan>
                   <aPitchRange>31-71</aPitchRange>
                   <pPitchRange>31-71</pPitchRange>
                   <Channel>
                         <program value="25"/>
                   </Channel>
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="theorbo-italiantab">
+                  <trackName>Theorbo [Italian Tab]</trackName>
+                  <init>theorbo-14-course</init>
+                  <description>Theorbo (Italian Tablature)</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <stafftype staffTypePreset="tab6StrItalian">tablature</stafftype>
+<!--                  <clef>TAB</clef> -->
+                  <genre>earlymusic</genre>
+            </Instrument>
+            <Instrument id="theorbo-frenchtab">
+                  <trackName>Theorbo [French Tab]</trackName>
+                  <init>theorbo-14-course</init>
+                  <description>Theorbo (French Tablature)</description>
+                  <musicXMLid>pluck.lute</musicXMLid>
+                  <stafftype staffTypePreset="tab6StrFrench">tablature</stafftype>
+<!--                  <clef>TAB</clef> -->
                   <genre>earlymusic</genre>
             </Instrument>
             <Instrument id="mandolin">


### PR DESCRIPTION
For lute instruments I think it is helpful to have the possibility to choose tablature in instruments.xml directly, as normally these instruments are notated in tablature (french or italian). 
Also I think that it is not necessary to have for instruments with different course-number different instruments, as you always - or at least often - have to change the tuning of the basses. And if you don't need them, it doesn't harm imho. And it is very easy to delete not needed string in staff properties / strings.
So I have changed the lute instruments to the following:
lute (i.e. notation -> G8vb)
Rennaissance lute (French tab)
Rennaissance lute (Italian tab)
Baroque lute (i.e. notation -> G8vb, up to 14 courses!)
Baroque lute (French tab)
Archlute
Archlute (Italian tab, no french tab here!)
Theorbo
Theorbo (Italian tab)
Theorbo (French tab, used in France)

Probably for 5-course lute also tablature versions should be added, and it would be good to add mandora (late lute instrument in the 18th century, only with french tab).

If that is acceptable, I think it would be good to have that in 2.1 also, as the first question of a new user  (I did some examples in musescore 2.1) was: how can I change lute to tablature?





   