### PR TITLE
fix #5163 Add PortAudio Midi Output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
             - curl
             - libasound2-dev
             - portaudio19-dev
+            - libportmidi-dev
             - libsndfile1-dev
             - zlib1g-dev
             - libfreetype6-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ endif (APPLE)
 # Disable components not supported on Linux/BSD
 if (NOT APPLE AND NOT MINGW)
       set(NIX_NOT_AVAIL "Not available on Linux/BSD")
-      option(BUILD_PORTMIDI "PortMidi disabled on Linux. (It uses ALSA but it's better to use ALSA directly)" OFF)
+      #option(BUILD_PORTMIDI "PortMidi disabled on Linux. (It uses ALSA but it's better to use ALSA directly)" OFF)
 endif (NOT APPLE AND NOT MINGW)
 
 option(AEOLUS        "Enable pipe organ synthesizer"      OFF)

--- a/build/Linux+BSD/portable/RecipeDebian
+++ b/build/Linux+BSD/portable/RecipeDebian
@@ -52,6 +52,7 @@ fetch-build-dependencies() {
     libsndfile1-dev:$ARCH \
     libasound2-dev:$ARCH \
     portaudio19-dev:$ARCH \
+    libportmidi-dev:$ARCH \
     zlib1g-dev:$ARCH \
     libfreetype6-dev:$ARCH \
     libmp3lame-dev:$ARCH \

--- a/build/Linux+BSD/portable/copy-libs
+++ b/build/Linux+BSD/portable/copy-libs
@@ -50,6 +50,7 @@ getCrossPlatformDependencies() {
   #copyLib libvorbis.so # Assume provided by system
   #copyLib libvorbisfile.so # Assume provided by system
   copyLib libportaudio.so.2
+  copyLib libportmidi.so
   #copyLib libeay32.so # Assume provided by system
   #copyLib ssleay32.so # Assume provided by system
 

--- a/build/Linux+BSD/portable/x86_32/Recipe
+++ b/build/Linux+BSD/portable/x86_32/Recipe
@@ -48,6 +48,7 @@ yum -y install \
   libxslt-devel \
   mesa-libGL-devel \
   portaudio-devel \
+  portmidi-devel \
   pulseaudio-libs-devel
 
 # get Qt

--- a/build/Linux+BSD/portable/x86_64/Recipe
+++ b/build/Linux+BSD/portable/x86_64/Recipe
@@ -42,6 +42,7 @@ apt-get -y install \
   alsa \
   libasound2-dev \
   portaudio19-dev \
+  libportmidi-dev \
   libsndfile1-dev \
   zlib1g-dev \
   libfreetype6-dev \

--- a/fluid/fluid.cpp
+++ b/fluid/fluid.cpp
@@ -191,9 +191,11 @@ void Fluid::play(const PlayEvent& event)
             int midiPitch = event.dataB() * 128 + event.dataA();  // msb * 128 + lsb
             cp->pitchBend(midiPitch);
             }
-      if (err)
-            qWarning("FluidSynth error: event 0x%2x channel %d: %s",
-               type, ch, qPrintable(error()));
+      if (err) {
+            // TODO: distinguish between types of error code.
+            // Lack of a soundfont should not produce qDebug messages, because user could deliberately be using MIDI out only.
+            //qWarning("FluidSynth error: event 0x%2x channel %d: %s", type, ch, qPrintable(error()));
+            }
       }
 
 //---------------------------------------------------------
@@ -335,7 +337,8 @@ void Fluid::program_change(int chan, int prognum)
 
       Preset* preset = find_preset(banknum, prognum);
       if (!preset) {
-            qDebug("Fluid::program_change: preset %d %d not found", banknum, prognum);
+            //Suppressing qDebug because might not have soundfont if using MIDI out only.
+            //qDebug("Fluid::program_change: preset %d %d not found", banknum, prognum);
             preset = find_preset(0, 0);
             }
 

--- a/mscore/mididriver.h
+++ b/mscore/mididriver.h
@@ -59,6 +59,7 @@ class Port {
       bool operator<(const Port& p) const;
       friend class MidiDriver;
       friend class AlsaMidiDriver;
+      friend class PortMidiDriver;
       };
 
 //---------------------------------------------------------

--- a/mscore/pa.cpp
+++ b/mscore/pa.cpp
@@ -47,6 +47,7 @@ static PaStream* stream;
 int paCallback(const void*, void* out, long unsigned frames,
    const PaStreamCallbackTimeInfo*, PaStreamCallbackFlags, void *)
       {
+      seq->setInitialMillisecondTimestampWithLatency();
       seq->process((unsigned)frames, (float*)out);
       return 0;
       }
@@ -96,8 +97,10 @@ bool Portaudio::init(bool)
             qDebug("using PortAudio Version: %s", Pa_GetVersionText());
 
       PaDeviceIndex idx = preferences.portaudioDevice;
-      if (idx < 0)
+      if (idx < 0) {
             idx = Pa_GetDefaultOutputDevice();
+            qDebug("No device selected.  PortAudio detected %d devices.  Will use the default device (index %d).", Pa_GetDeviceCount(), idx);
+            }
 
       const PaDeviceInfo* di = Pa_GetDeviceInfo(idx);
 
@@ -271,6 +274,83 @@ void Portaudio::midiRead()
       {
       if (midiDriver)
             midiDriver->read();
+      }
+
+//---------------------------------------------------------
+//   putEvent
+//---------------------------------------------------------
+
+// Prevent killing sequencer with wrong data
+#define less128(__less) ((__less >=0 && __less <= 127) ? __less : 0)
+
+// TODO: this was copied from Jack version...I'd like to eventually unify these two, so that they handle midi event types in the same manner
+void Portaudio::putEvent(const NPlayEvent& e, unsigned framePos)
+      {
+      PortMidiDriver* portMidiDriver = static_cast<PortMidiDriver*>(midiDriver);
+      if (!portMidiDriver || !portMidiDriver->getOutputStream() || !portMidiDriver->canOutput())
+            return;
+
+      int portIdx = seq->score()->midiPort(e.channel());
+      int chan    = seq->score()->midiChannel(e.channel());
+
+      if (portIdx < 0 ) {
+            qDebug("Portaudio::putEvent: invalid port %d", portIdx);
+            return;
+            }
+
+      if (midiOutputTrace) {
+            int a     = e.dataA();
+            int b     = e.dataB();
+            qDebug("MidiOut<%d>: Portaudio: %02x %02x %02x, chan: %i", portIdx, e.type(), a, b, chan);
+            }
+
+      switch(e.type()) {
+            case ME_NOTEON:
+            case ME_NOTEOFF:
+            case ME_POLYAFTER:
+            case ME_CONTROLLER:
+                  // Catch CTRL_PROGRAM and let other ME_CONTROLLER events to go
+                  if (e.dataA() == CTRL_PROGRAM) {
+                        // Convert CTRL_PROGRAM event to ME_PROGRAM
+                        long msg = Pm_Message(ME_PROGRAM | chan, less128(e.dataB()), 0);
+                        PmError error = Pm_WriteShort(portMidiDriver->getOutputStream(), seq->getCurrentMillisecondTimestampWithLatency(framePos), msg);
+                        if (error != pmNoError) {
+                              qDebug("Portaudio: error %d", error);
+                              return;
+                              }
+                        break;
+                        }
+                  //Fallback
+            case ME_PITCHBEND:
+                  {
+                  long msg = Pm_Message(e.type() | chan, less128(e.dataA()), less128(e.dataB()));
+                  PmError error = Pm_WriteShort(portMidiDriver->getOutputStream(), seq->getCurrentMillisecondTimestampWithLatency(framePos), msg);
+                  if (error != pmNoError) {
+                        qDebug("Portaudio: error %d", error);
+                        return;
+                        }
+                  }
+                  break;
+
+            case ME_PROGRAM:
+            case ME_AFTERTOUCH:
+                  {
+                  long msg = Pm_Message(e.type() | chan, less128(e.dataA()), 0);
+                  PmError error = Pm_WriteShort(portMidiDriver->getOutputStream(), seq->getCurrentMillisecondTimestampWithLatency(framePos), msg);
+                  if (error != pmNoError) {
+                        qDebug("Portaudio: error %d", error);
+                        return;
+                        }
+                  }
+                  break;
+            case ME_SONGPOS:
+            case ME_CLOCK:
+            case ME_START:
+            case ME_CONTINUE:
+            case ME_STOP:
+                  qDebug("Portaudio: event type %x not supported", e.type());
+                  break;
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/pa.h
+++ b/mscore/pa.h
@@ -28,6 +28,7 @@ namespace Ms {
 class Synth;
 class Seq;
 class MidiDriver;
+class NPlayEvent;
 enum class Transport : char;
 
 //---------------------------------------------------------
@@ -56,6 +57,7 @@ class Portaudio : public Driver {
       virtual Transport getState() override;
       virtual int sampleRate() const { return _sampleRate; }
       virtual void midiRead();
+      virtual void putEvent(const NPlayEvent&, unsigned framePos);
 
       int framePos() const;
       float* getLBuffer(long n);
@@ -67,7 +69,7 @@ class Portaudio : public Driver {
       int deviceIndex(int apiIdx, int apiDevIdx);
       int currentApi() const;
       int currentDevice() const;
-      MidiDriver* mididriver() {return midiDriver;}
+      MidiDriver* mididriver() { return midiDriver; }
       };
 
 

--- a/mscore/pm.h
+++ b/mscore/pm.h
@@ -41,8 +41,9 @@ class Seq;
 class PortMidiDriver : public MidiDriver {
       int inputId;
       int outputId;
-      PmStream* inputStream;
       QTimer* timer;
+      PmStream* inputStream;
+      PmStream* outputStream;
 
    public:
       PortMidiDriver(Seq*);
@@ -55,7 +56,13 @@ class PortMidiDriver : public MidiDriver {
       virtual void read();
       virtual void write(const Event&);
       QStringList deviceInList() const;
-      int getDeviceIn(const QString& name);
+      QStringList deviceOutList() const;
+      int getDeviceIn(const QString& interfaceAndName);
+      int getDeviceOut(const QString& interfaceAndName);
+      PmStream* getInputStream() { return inputStream; }
+      PmStream* getOutputStream() { return outputStream; }
+      bool canOutput() { return outputStream != 0; }
+      bool isSameCoreMidiIacBus(const QString& inInterfaceAndName, const QString& outInterfaceAndName);
       };
 
 

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -114,12 +114,16 @@ void Preferences::init()
 
       rememberLastConnections = true;
 
-      alsaDevice         = "default";
-      alsaSampleRate     = 48000;
-      alsaPeriodSize     = 1024;
-      alsaFragments      = 3;
-      portaudioDevice    = -1;
-      portMidiInput      = "";
+      alsaDevice                = "default";
+      alsaSampleRate            = 48000;
+      alsaPeriodSize            = 1024;
+      alsaFragments             = 3;
+      portaudioDevice           = -1;
+      portMidiInput             = "";
+      portMidiInputBufferCount  = 100;
+      portMidiOutput            = "";
+      portMidiOutputBufferCount = 65536;
+      portMidiOutputLatencyMilliseconds = 0;
 
       antialiasedDrawing       = true;
       sessionStart             = SessionStart::SCORE;
@@ -257,7 +261,9 @@ void Preferences::write()
       s.setValue("alsaPeriodSize",     alsaPeriodSize);
       s.setValue("alsaFragments",      alsaFragments);
       s.setValue("portaudioDevice",    portaudioDevice);
-      s.setValue("portMidiInput",   portMidiInput);
+      s.setValue("portMidiInput",      portMidiInput);
+      s.setValue("portMidiOutput",     portMidiOutput);
+      s.setValue("portMidiOutputLatencyMilliseconds", portMidiOutputLatencyMilliseconds);
 
       s.setValue("layoutBreakColor",   MScore::layoutBreakColor.name(QColor::NameFormat::HexArgb));
       s.setValue("frameMarginColor",   MScore::frameMarginColor.name(QColor::NameFormat::HexArgb));
@@ -432,6 +438,8 @@ void Preferences::read()
       alsaFragments      = s.value("alsaFragments", alsaFragments).toInt();
       portaudioDevice    = s.value("portaudioDevice", portaudioDevice).toInt();
       portMidiInput      = s.value("portMidiInput", portMidiInput).toString();
+      portMidiOutput     = s.value("portMidiOutput", portMidiOutput).toString();
+      portMidiOutputLatencyMilliseconds = s.value("portMidiOutputLatencyMilliseconds", portMidiOutputLatencyMilliseconds).toInt();
       MScore::layoutBreakColor   = readColor("layoutBreakColor", MScore::layoutBreakColor);
       MScore::frameMarginColor   = readColor("frameMarginColor", MScore::frameMarginColor);
       antialiasedDrawing      = s.value("antialiasedDrawing", antialiasedDrawing).toBool();
@@ -953,7 +961,7 @@ void PreferenceDialog::updateValues()
                   connect(portaudioApi, SIGNAL(activated(int)), SLOT(portaudioApiActivated(int)));
 #ifdef USE_PORTMIDI
                   PortMidiDriver* midiDriver = static_cast<PortMidiDriver*>(audio->mididriver());
-                  if(midiDriver){
+                  if (midiDriver) {
                         QStringList midiInputs = midiDriver->deviceInList();
                         int curMidiInIdx = 0;
                         portMidiInput->clear();
@@ -963,6 +971,19 @@ void PreferenceDialog::updateValues()
                                     curMidiInIdx = i;
                               }
                         portMidiInput->setCurrentIndex(curMidiInIdx);
+
+                        QStringList midiOutputs = midiDriver->deviceOutList();
+                        int curMidiOutIdx = -1; // do not set a midi out device if user never selected one
+                        portMidiOutput->clear();
+                        portMidiOutput->addItem("", -1);
+                        for(int i = 0; i < midiOutputs.size(); ++i) {
+                              portMidiOutput->addItem(midiOutputs.at(i), i);
+                              if (midiOutputs.at(i) == prefs.portMidiOutput)
+                                    curMidiOutIdx = i + 1;
+                              }
+                        portMidiOutput->setCurrentIndex(curMidiOutIdx);
+
+                        portMidiOutputLatencyMilliseconds->setValue(prefs.portMidiOutputLatencyMilliseconds);
                         }
 #endif
                   }
@@ -976,7 +997,7 @@ void PreferenceDialog::updateValues()
       //
       // score settings
       //
-      scale->setValue(prefs.mag*100.0);
+      scale->setValue(prefs.mag * 100.0);
       showMidiControls->setChecked(prefs.showMidiControls);
 
       defaultPlayDuration->setValue(MScore::defaultPlayDuration);
@@ -1424,6 +1445,15 @@ void PreferenceDialog::apply()
 
 #ifdef USE_PORTMIDI
       prefs.portMidiInput = portMidiInput->currentText();
+      prefs.portMidiOutput = portMidiOutput->currentText();
+      if (seq->driver() && static_cast<PortMidiDriver*>(static_cast<Portaudio*>(seq->driver())->mididriver())->isSameCoreMidiIacBus(prefs.portMidiInput, prefs.portMidiOutput)) {
+            QMessageBox msgBox;
+            msgBox.setWindowTitle(tr("Possible MIDI Loopback"));
+            msgBox.setIcon(QMessageBox::Warning);
+            msgBox.setText(tr("Warning: You used the same CoreMIDI IAC bus for input and output.  This will cause problematic loopback, whereby MuseScore's outputted MIDI messages will be sent back to MuseScore as input, causing confusion.  To avoid this problem, access Audio MIDI Setup via Spotlight to create a dedicated virtual port for MuseScore's MIDI output, restart MuseScore, return to Preferences, and select your new virtual port for MuseScore's MIDI output.  Other programs may then use that dedicated virtual port to receive MuseScore's MIDI output."));
+            msgBox.exec();
+            }
+      prefs.portMidiOutputLatencyMilliseconds = portMidiOutputLatencyMilliseconds->value();
 #endif
 
       if (lastSession->isChecked())

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -117,6 +117,10 @@ struct Preferences {
       int alsaFragments;
       int portaudioDevice;
       QString portMidiInput;
+      QString portMidiOutput;
+      int portMidiInputBufferCount;
+      int portMidiOutputBufferCount;
+      int portMidiOutputLatencyMilliseconds;
 
       bool antialiasedDrawing;
       SessionStart sessionStart;

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2699,7 +2699,7 @@
            </spacer>
           </item>
           <item row="0" column="0">
-           <widget class="QLabel" name="label_21">
+           <widget class="QLabel" name="portAudioApiLabel">
             <property name="text">
              <string>API:</string>
             </property>
@@ -2754,7 +2754,7 @@
            </widget>
           </item>
           <item row="0" column="2">
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="portAudioDeviceLabel">
             <property name="text">
              <string>Device:</string>
             </property>
@@ -2778,6 +2778,68 @@
              <string>Choose device</string>
             </property>
            </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QLabel" name="portMidiOutputLabel">
+            <property name="text">
+             <string>MIDI Output:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="4">
+           <widget class="QComboBox" name="portMidiOutput">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="accessibleName">
+             <string>MIDI Output</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Choose MIDI Output</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="6">
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="QLabel" name="portMidiOutputLatencyLabel">
+              <property name="text">
+               <string>MIDI Output Latency:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="portMidiOutputLatencyMilliseconds">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Latency&lt;/span&gt; is a delay in milliseconds applied to timestamps, to inform the driver about when the output should actually occur.&lt;/p&gt;&lt;p&gt;If &lt;span style=&quot; font-weight:600;&quot;&gt;latency&lt;/span&gt; is zero, MIDI messages are delivered as fast as possible, but may contain jitter.&lt;/p&gt;&lt;p&gt;Setting &lt;span style=&quot; font-weight:600;&quot;&gt;latency&lt;/span&gt; greater than zero may help the driver alleviate any jitter.&lt;/p&gt;&lt;p&gt;Adjusting &lt;span style=&quot; font-weight:600;&quot;&gt;latency&lt;/span&gt; can help synchronize your midi hardware with MuseScore's internal audio synthesizer, so that they both sound notes at the same time.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="accessibleName">
+               <string>MIDI Output Latency</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>Choose MIDI Output Latency</string>
+              </property>
+              <property name="suffix">
+               <string extracomment="milliseconds">ms</string>
+              </property>
+              <property name="maximum">
+               <number>999</number>
+              </property>
+              <property name="displayIntegerBase">
+               <number>10</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -2833,7 +2895,7 @@
            </widget>
           </item>
           <item row="1" column="4">
-           <widget class="QLabel" name="label_13">
+           <widget class="QLabel" name="alsaFragmentsLabel">
             <property name="text">
              <string>Fragments:</string>
             </property>
@@ -2843,7 +2905,7 @@
            </widget>
           </item>
           <item row="1" column="6">
-           <widget class="QLabel" name="label_12">
+           <widget class="QLabel" name="alsaPeriodLabel">
             <property name="text">
              <string>Period Size:</string>
             </property>
@@ -2853,14 +2915,14 @@
            </widget>
           </item>
           <item row="0" column="0">
-           <widget class="QLabel" name="label_10">
+           <widget class="QLabel" name="alsaDeviceLabel">
             <property name="text">
              <string>Device:</string>
             </property>
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_11">
+           <widget class="QLabel" name="alsaSampleRateLabel">
             <property name="text">
              <string>Sample rate:</string>
             </property>
@@ -2979,7 +3041,7 @@
            </widget>
           </item>
           <item row="1" column="2">
-           <widget class="QLabel" name="label_22">
+           <widget class="QLabel" name="alsaSampleRateHzLabel">
             <property name="text">
              <string extracomment="Hertz">Hz</string>
             </property>
@@ -3161,7 +3223,7 @@
           </palette>
          </property>
          <property name="text">
-          <string>Attention: Any changes on this page require a restart of MuseScore.</string>
+          <string>Attention: Any changes on this page require a restart of MuseScore.  Precise MIDI output timing is only possible via JACK.</string>
          </property>
         </widget>
        </item>
@@ -4164,6 +4226,8 @@
   <tabstop>portaudioApi</tabstop>
   <tabstop>portaudioDevice</tabstop>
   <tabstop>portMidiInput</tabstop>
+  <tabstop>portMidiOutput</tabstop>
+  <tabstop>portMidiOutputLatencyMilliseconds</tabstop>
   <tabstop>alsaDriver</tabstop>
   <tabstop>alsaDevice</tabstop>
   <tabstop>alsaSampleRate</tabstop>


### PR DESCRIPTION
I've tested this on my windows machine, and I'm able to play Midi from MuseScore through a USB Midi synth.  Note, I need to clean this up.  I thought I would have to do some more complicated things in order to make sure playback did not jitter (as I mentioned in https://musescore.org/en/node/21053#comment-717401), but it seems to be fine as is.  I'd rather keep this PortAudio midi out as simple & stupid and not overload the codebase with special precision timing.  If someone wants super precise timing, they can use a specialized tool for that called "Jack".  Anyway, I might experiment on a slower machine just to see if this timing matters.  Note, there is also a "latency" which can be set when calling portaudio...I might try messing with that to help avoid any possible jitter, in which case I will have to properly send the timestamp parameter when calling putEvent.  Maybe that latency can be exposed via preferences in case a particular user finds his system needs it.  Note, most of the code is simply copied and modified of previously-existing code...in particular Portaudio::putEvent() is pretty-much a duplicate of Jackaudio::putEvent().