### PR TITLE
Break multimeasure rests for breath marks

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1789,6 +1789,10 @@ static bool validMMRestMeasure(Measure* m)
 #endif
 
       for (Segment* s = m->first(); s; s = s->next()) {
+	    if (s->segmentType() == Segment::Type::Breath) {
+		return false;
+		}
+
             for (Element* e : s->annotations()) {
                   if (e->type() != Element::Type::REHEARSAL_MARK &&
                       e->type() != Element::Type::TEMPO_TEXT &&


### PR DESCRIPTION
This is a very simple pull request: breath segments cause a multi measure rest to be broken.

This is important because caesuras, which are represented as a breath type, are often present in every part in orchestral scores; instrumentalists need to know when these occur so they can count correctly.

Attached is a file which demonstrates this change.
[MMBreakTest.mscz.zip](https://github.com/musescore/MuseScore/files/1012942/MMBreakTest.mscz.zip)

There are some potential improvements to this functionality; for example, including the measure with the breath mark in the multi measure rest, not deleting the breath mark (so that it appears) but still breaking afterward.