### PR TITLE
Partial Fix #214986 - Break multimeasure rests for breath marks

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1913,6 +1913,9 @@ static bool validMMRestMeasure(Measure* m)
 
       int n = 0;
       for (Segment* s = m->first(); s; s = s->next()) {
+            if (s->isBreathType())
+                  return false;
+
             for (Element* e : s->annotations()) {
                   if (!(e->isRehearsalMark() || e->isTempoText() || e->isHarmony() || e->isStaffText()))
                         return false;


### PR DESCRIPTION
This is a very simple pull request: breath segments cause a multi measure rest to be broken.

This is important because caesuras, which are represented as a breath type, are often present in every part in orchestral scores; instrumentalists need to know when these occur so they can count correctly.

Attached is a file which demonstrates this change.
[MMBreakTest.mscz.zip](https://github.com/musescore/MuseScore/files/1012942/MMBreakTest.mscz.zip)

There are some potential improvements to this functionality; for example, including the measure with the breath mark in the multi measure rest, not deleting the breath mark (so that it appears) but still breaking afterward.

UPDATED from https://github.com/musescore/MuseScore/pull/3176 to be based on master