### PR TITLE
Fix #214996 - Display measure number range for multimeasure rests

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -518,14 +518,25 @@ void Measure::layout2()
                   if (score()->styleB(Sid::measureNumberSystem))
                         smn = system()->firstMeasure() == this;
                   else {
+                        int interval = score()->styleI(Sid::measureNumberInterval);
                         smn = (no() == 0 && score()->styleB(Sid::showMeasureNumberOne)) ||
-                              ( ((no() + 1) % score()->styleI(Sid::measureNumberInterval)) == (score()->styleB(Sid::showMeasureNumberOne) ? 1 : 0) );
+                              ((no()+1) % interval == 0 ) ||
+                              // We're in a multimeasure rest, and we want to show the range
+                              (_mmRestCount > 0 && score()->styleB(Sid::showMeasureNumberRange) &&
+                                    // And the rest encompasses a measure we would normally display a number for
+                                    // Either the rest is longer than the measureNumberInterval...
+                                    (_mmRestCount >= interval ||
+                                          // ...or one is inside it (the modulo of the final measure is less than the modulo of the current)
+                                          (no()+1) % interval > (no() + _mmRestCount) % interval));
                         }
                   }
             }
       QString s;
-      if (smn)
+      if (smn && _mmRestCount && score()->styleB(Sid::createMultiMeasureRests) && score()->styleB(Sid::showMeasureNumberRange)) {
+            s = QString("%1 - %2").arg(no() + 1).arg(no() + _mmRestCount);
+      } else if (smn) {
             s = QString("%1").arg(no() + 1);
+      }
       int nn = 1;
       bool nas = score()->styleB(Sid::measureNumberAllStaffs);
 
@@ -3956,4 +3967,3 @@ void Measure::computeMinWidth()
       }
 
 }
-

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -532,11 +532,13 @@ void Measure::layout2()
                   }
             }
       QString s;
-      if (smn && _mmRestCount && score()->styleB(Sid::createMultiMeasureRests) && score()->styleB(Sid::showMeasureNumberRange)) {
-            s = QString("%1 - %2").arg(no() + 1).arg(no() + _mmRestCount);
-      } else if (smn) {
-            s = QString("%1").arg(no() + 1);
-      }
+      if (smn) {
+            if (_mmRestCount && score()->styleB(Sid::createMultiMeasureRests) && score()->styleB(Sid::showMeasureNumberRange))
+                   s = QString("%1 - %2").arg(no() + 1).arg(no() + _mmRestCount);
+            else
+                   s = QString("%1").arg(no() + 1);
+            }
+
       int nn = 1;
       bool nas = score()->styleB(Sid::measureNumberAllStaffs);
 

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -124,6 +124,7 @@ static const StyleVal2 style114[] = {
       { Sid::showMeasureNumber,            QVariant(true) },
       { Sid::showMeasureNumberOne,         QVariant(false) },
       { Sid::measureNumberInterval,        QVariant(5) },
+      { Sid::showMeasureNumberRange,       QVariant(false) },
       { Sid::measureNumberSystem,          QVariant(true) },
       { Sid::measureNumberAllStaffs,       QVariant(false) },
       { Sid::smallNoteMag,                 QVariant(qreal(0.7)) },
@@ -3014,4 +3015,3 @@ Score::FileError MasterScore::read114(XmlReader& e)
       }
 
 }
-

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -155,6 +155,7 @@ struct StyleVal2 {
       { Sid::showMeasureNumber,           QVariant(true) },
       { Sid::showMeasureNumberOne,        QVariant(false) },
       { Sid::measureNumberInterval,       QVariant(5) },
+      { Sid::showMeasureNumberRange,      QVariant(false) },
       { Sid::measureNumberSystem,         QVariant(true) },
       { Sid::measureNumberAllStaffs,      QVariant(false) },
       { Sid::smallNoteMag,                QVariant(.7) },
@@ -2733,4 +2734,3 @@ Score::FileError MasterScore::read206(XmlReader& e)
       }
 
 }
-

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -154,7 +154,6 @@ struct StyleVal2 {
       { Sid::pageNumberOddEven,           QVariant(true) },
       { Sid::showMeasureNumber,           QVariant(true) },
       { Sid::showMeasureNumberOne,        QVariant(false) },
-      { Sid::measureNumberInterval,       QVariant(5) },
       { Sid::showMeasureNumberRange,      QVariant(false) },
       { Sid::measureNumberSystem,         QVariant(true) },
       { Sid::measureNumberAllStaffs,      QVariant(false) },

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -202,6 +202,7 @@ static const StyleType styleTypes[] {
       { Sid::vibratoPlacement,        "vibratoPlacement",        int(Placement::ABOVE)  },
       { Sid::vibratoPosAbove,         "vibratoPosAbove",         Spatium(-1) },
       { Sid::vibratoPosBelow,         "vibratoPosBelow",         Spatium(1) },
+      { Sid::showMeasureNumberRange,  "showMeasureNumberRange",  QVariant(false) },
 
       { Sid::harmonyY,                "harmonyY",                Spatium(2.5) },
       { Sid::harmonyFretDist,         "harmonyFretDist",         Spatium(0.5) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -195,6 +195,7 @@ enum class Sid {
       pageNumberOddEven,
       showMeasureNumber,
       showMeasureNumberOne,
+      showMeasureNumberRange,
       measureNumberInterval,
       measureNumberSystem,
 

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -871,7 +871,6 @@ void EditStyle::setValues()
       toggleFooterOddEven(lstyle.value(Sid::footerOddEven).toBool());
 
       showMeasureNumberRange->setChecked(lstyle.value(Sid::showMeasureNumberRange).toBool());
-
       }
 
 //---------------------------------------------------------

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -271,6 +271,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
 
       { Sid::showMeasureNumber,          false, showMeasureNumber,            0 },
       { Sid::showMeasureNumberOne,       false, showFirstMeasureNumber,       0 },
+      { Sid::showMeasureNumberRange,     false, showMeasureNumberRange,       0 },
       { Sid::measureNumberInterval,      false, intervalMeasureNumber,        0 },
       { Sid::measureNumberSystem,        false, showEverySystemMeasureNumber, 0 },
       { Sid::measureNumberAllStaffs,     false, showAllStaffsMeasureNumber,   0 },
@@ -868,6 +869,9 @@ void EditStyle::setValues()
 
       toggleHeaderOddEven(lstyle.value(Sid::headerOddEven).toBool());
       toggleFooterOddEven(lstyle.value(Sid::footerOddEven).toBool());
+
+      showMeasureNumberRange->setChecked(lstyle.value(Sid::showMeasureNumberRange).toBool());
+
       }
 
 //---------------------------------------------------------
@@ -1090,4 +1094,3 @@ void EditStyle::resetStyleValue(int i)
       }
 
 }
-

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -401,6 +401,13 @@
                   </property>
                  </widget>
                 </item>
+                <item row="2" column="0">
+                  <widget class="QCheckBox" name="showMeasureNumberRange">
+                   <property name="text">
+                    <string>Display Measure Number Range</string>
+                   </property>
+                  </widget>
+                </item>
                </layout>
               </item>
              </layout>
@@ -11521,6 +11528,7 @@
   <tabstop>multiMeasureRests</tabstop>
   <tabstop>minEmptyMeasures</tabstop>
   <tabstop>minMeasureWidth</tabstop>
+  <tabstop>showMeasureNumberRange</tabstop>
   <tabstop>hideEmptyStaves</tabstop>
   <tabstop>dontHideStavesInFirstSystem</tabstop>
   <tabstop>crossMeasureValues</tabstop>

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -404,7 +404,7 @@
                 <item row="2" column="0">
                   <widget class="QCheckBox" name="showMeasureNumberRange">
                    <property name="text">
-                    <string>Display Measure Number Range</string>
+                    <string>Display measure number range</string>
                    </property>
                   </widget>
                 </item>


### PR DESCRIPTION
This pull request is to allow users to configure the display of measure number ranges for multimeasure rests. It is meant to be fairly flexible; if the multimeasure rest doesn't encompass (start on or extend over) a measure at the desired interval, then it will not show, but otherwise it will (if the setting is enabled).

I debated where to add the setting, whether to put it with the multimeasure rest settings in Score, or with the measure number settings in Header, Footer, Numbers. I eventually put it in Score.

Note that it does NOT handle the case where the measure numbers are altered within the MMR. I suspect it would be better to break the MMR in that case and print a new measure number.

Updated from https://github.com/musescore/MuseScore/pull/3175 to be based on master and follow spacing convention