### PR TITLE
make CMAKE_BUILD_TYPE case insensitive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,6 +555,7 @@ subdirs(
       )
 #      thirdparty/xmlstream
 
+string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
 if (APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
 # With xcode, we need to have all the targets in the same project
 add_subdirectory(mtest)

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -427,6 +427,7 @@ if (MINGW)
       ${PROJECT_BINARY_DIR}/resfile.o
       PROPERTIES generated true
       )
+   string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
    # Windows: Add -mconsole to LINK_FLAGS to get a console window for debug output
    if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
      set_target_properties( mscore


### PR DESCRIPTION
for the benefit of Qt Creator which seems to prefer Debug over DEBUG