### PR TITLE
add libporttime.so.0 to copyLibs for AppImage

### DIFF
--- a/build/Linux+BSD/portable/copy-libs
+++ b/build/Linux+BSD/portable/copy-libs
@@ -50,7 +50,8 @@ getCrossPlatformDependencies() {
   #copyLib libvorbis.so # Assume provided by system
   #copyLib libvorbisfile.so # Assume provided by system
   copyLib libportaudio.so.2
-  copyLib libportmidi.so
+  copyLib libportmidi.so.0
+  copyLib libporttime.so.0
   #copyLib libeay32.so # Assume provided by system
   #copyLib ssleay32.so # Assume provided by system
 


### PR DESCRIPTION
Running AppImage on linux complained about not having libporttime.so.0, since I forgot to add it to the copyLibs.  I'm also appending .0 to the libportmidi.so just to be more precise (according to https://packages.ubuntu.com/trusty/amd64/libportmidi0/filelist that is the extension).