### PR TITLE
add libporttime.so to copyLibs for AppImage

### DIFF
--- a/build/Linux+BSD/portable/copy-libs
+++ b/build/Linux+BSD/portable/copy-libs
@@ -51,6 +51,7 @@ getCrossPlatformDependencies() {
   #copyLib libvorbisfile.so # Assume provided by system
   copyLib libportaudio.so.2
   copyLib libportmidi.so
+  copyLib libporttime.so
   #copyLib libeay32.so # Assume provided by system
   #copyLib ssleay32.so # Assume provided by system
 


### PR DESCRIPTION
Running AppImage on linux complained about not having "libporttime.so.0"...I forgot to add it to the copyLibs which is needed since I've added PortMidi output.