### PR TITLE
Fix #209331: Updated Descriptions of Enharmonic shortcuts to reflect current implementation

### DIFF
--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -687,11 +687,11 @@
     <seq>R</seq>
     </SC>
   <SC>
-    <key>enh-up</key>
+    <key>enh-both</key>
     <seq>J</seq>
     </SC>
   <SC>
-    <key>enh-down</key>
+    <key>enh-current</key>
     <seq>Ctrl+J</seq>
     </SC>
   <SC>

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2009,9 +2009,9 @@ void ScoreView::cmd(const QAction* a)
             changeVoice(2);
       else if (cmd == "voice-4")
             changeVoice(3);
-      else if (cmd == "enh-up")
+      else if (cmd == "enh-both")
             cmdChangeEnharmonic(true);
-      else if (cmd == "enh-down")
+      else if (cmd == "enh-current")
             cmdChangeEnharmonic(false);
       else if (cmd == "revision") {
             Score* s = _score->masterScore();
@@ -3271,7 +3271,7 @@ void ScoreView::cmdAddHairpin(HairpinType type)
 //   cmdChangeEnharmonic
 //---------------------------------------------------------
 
-void ScoreView::cmdChangeEnharmonic(bool up)
+void ScoreView::cmdChangeEnharmonic(bool both)
       {
       _score->startCmd();
       Selection selection = _score->selection();
@@ -3281,7 +3281,7 @@ void ScoreView::cmdChangeEnharmonic(bool up)
             if (staff->part()->instrument()->useDrumset())
                   continue;
             if (staff->isTabStaff(n->tick())) {
-                  int string = n->line() + (up ? 1 : -1);
+                  int string = n->line() + (both ? 1 : -1);
                   int fret   = staff->part()->instrument()->stringData()->fret(n->pitch(), string, staff, n->chord()->tick());
                   if (fret != -1) {
                         score()->undoChangeProperty(n, P_ID::FRET, fret);
@@ -3324,7 +3324,7 @@ void ScoreView::cmdChangeEnharmonic(bool up)
                         }
                   else {
                         n->undoSetTpc(tpc);
-                        if (up || staff->part()->instrument(n->chord()->tick())->transpose().isZero()) {
+                        if (both || staff->part()->instrument(n->chord()->tick())->transpose().isZero()) {
                               // change both spellings
                               int t = n->transposeTpc(tpc);
                               if (n->concertPitch())

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2549,15 +2549,17 @@ Shortcut Shortcut::_sc[] = {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY_STAFF_PITCHED | STATE_NOTE_ENTRY_STAFF_DRUM,
          "enh-up",
-         QT_TRANSLATE_NOOP("action","Enharmonic Up"),
-         QT_TRANSLATE_NOOP("action","Enharmonic up")
+         QT_TRANSLATE_NOOP("action","Change Enharmonic Spelling (Both Modes)"),
+         QT_TRANSLATE_NOOP("action","Change enharmonic spelling (both modes)"),
+         QT_TRANSLATE_NOOP("action","Change enharmonic note (alters the spelling in concert pitch and transposed mode)")
          },
       {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY_STAFF_PITCHED | STATE_NOTE_ENTRY_STAFF_DRUM,
          "enh-down",
-         QT_TRANSLATE_NOOP("action","Enharmonic Down"),
-         QT_TRANSLATE_NOOP("action","Enharmonic down")
+         QT_TRANSLATE_NOOP("action","Change Enharmonic Spelling (Current Mode)"),
+         QT_TRANSLATE_NOOP("action","Change enharmonic spelling (current mode)"),
+         QT_TRANSLATE_NOOP("action","Change enharmonic note (alters the spelling in the current mode only)")
          },
       {
          MsWidget::MAIN_WINDOW,

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2548,7 +2548,7 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY_STAFF_PITCHED | STATE_NOTE_ENTRY_STAFF_DRUM,
-         "enh-up",
+         "enh-both",
          QT_TRANSLATE_NOOP("action","Change Enharmonic Spelling (Both Modes)"),
          QT_TRANSLATE_NOOP("action","Change enharmonic spelling (both modes)"),
          QT_TRANSLATE_NOOP("action","Change enharmonic note (alters the spelling in concert pitch and transposed mode)")
@@ -2556,7 +2556,7 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY_STAFF_PITCHED | STATE_NOTE_ENTRY_STAFF_DRUM,
-         "enh-down",
+         "enh-current",
          QT_TRANSLATE_NOOP("action","Change Enharmonic Spelling (Current Mode)"),
          QT_TRANSLATE_NOOP("action","Change enharmonic spelling (current mode)"),
          QT_TRANSLATE_NOOP("action","Change enharmonic note (alters the spelling in the current mode only)")


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/10680296/26587955/8715d6ce-4571-11e7-9eeb-8e8ad986be2a.png)
