### PR TITLE
suppress fallthrough warnings with newer compilers

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -377,6 +377,7 @@ void BarLine::draw(QPainter* painter) const
             case BarLineType::DOTTED:
                   pen.setStyle(Qt::DotLine);
                   painter->setPen(pen);
+                  // fall through
 
             case BarLineType::NORMAL:
                   painter->drawLine(QLineF(lw * .5, y1, lw * .5, y2));

--- a/libmscore/durationtype.cpp
+++ b/libmscore/durationtype.cpp
@@ -141,6 +141,7 @@ QString TDuration::name() const
             case DurationType::V_LONG:      return "long";
             default:
 qDebug("TDuration::name(): invalid duration type %d", int(_val));
+                  // fall through
             case DurationType::V_ZERO:
             case DurationType::V_INVALID:   return "";
             }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1938,6 +1938,7 @@ void Score::deleteItem(Element* el)
                   // else fall through
                   el = chord;
                   }
+                  // fall through
 
             case Element::Type::CHORD:
                   {
@@ -1993,6 +1994,7 @@ void Score::deleteItem(Element* el)
                   Segment* segment = rm->segment();
                   undoAddCR(rest, segment->measure(), segment->tick());
                   }
+                  // fall through
 
             case Element::Type::REST:
                   //

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -199,19 +199,31 @@ void KeySig::layout()
 
       switch(t1) {
             case 7:  addLayout(SymId::accidentalSharp, xo + 6.0 * sspread, lines[6]);
+                  // fall through
             case 6:  addLayout(SymId::accidentalSharp, xo + 5.0 * sspread, lines[5]);
+                  // fall through
             case 5:  addLayout(SymId::accidentalSharp, xo + 4.0 * sspread, lines[4]);
+                  // fall through
             case 4:  addLayout(SymId::accidentalSharp, xo + 3.0 * sspread, lines[3]);
+                  // fall through
             case 3:  addLayout(SymId::accidentalSharp, xo + 2.0 * sspread, lines[2]);
+                  // fall through
             case 2:  addLayout(SymId::accidentalSharp, xo + 1.0 * sspread, lines[1]);
+                  // fall through
             case 1:  addLayout(SymId::accidentalSharp, xo,                 lines[0]);
                      break;
             case -7: addLayout(SymId::accidentalFlat, xo + 6.0 * fspread, lines[13]);
+                  // fall through
             case -6: addLayout(SymId::accidentalFlat, xo + 5.0 * fspread, lines[12]);
+                  // fall through
             case -5: addLayout(SymId::accidentalFlat, xo + 4.0 * fspread, lines[11]);
+                  // fall through
             case -4: addLayout(SymId::accidentalFlat, xo + 3.0 * fspread, lines[10]);
+                  // fall through
             case -3: addLayout(SymId::accidentalFlat, xo + 2.0 * fspread, lines[9]);
+                  // fall through
             case -2: addLayout(SymId::accidentalFlat, xo + 1.0 * fspread, lines[8]);
+                  // fall through
             case -1: addLayout(SymId::accidentalFlat, xo,                 lines[7]);
             case 0:
                   break;

--- a/libmscore/pitchspelling.cpp
+++ b/libmscore/pitchspelling.cpp
@@ -725,9 +725,11 @@ void spell(QList<Event>& notes, int key)
                         case 3:
                               k = end - start - 3;
                               notes[end-3].setTpc(tab[(notes[end-3].dataA() % 12) * 2 + ((opt & (1<<k)) >> k)]);
+                              // fall through
                         case 2:
                               k = end - start - 2;
                               notes[end-2].setTpc(tab[(notes[end-2].dataA() % 12) * 2 + ((opt & (1<<k)) >> k)]);
+                              // fall through
                         case 1:
                               k = end - start - 1;
                               notes[end-1].setTpc(tab[(notes[end-1].dataA() % 12) * 2 + ((opt & (1<<k)) >> k)]);
@@ -797,9 +799,11 @@ void Score::spellNotelist(QList<Note*>& notes)
                         case 3:
                               k = end - start - 3;
                               changeAllTpcs(notes[end-3], tab[(notes[end-3]->pitch() % 12) * 2 + ((opt & (1<<k)) >> k)]);
+                              // fall through
                         case 2:
                               k = end - start - 2;
                               changeAllTpcs(notes[end-2], tab[(notes[end-2]->pitch() % 12) * 2 + ((opt & (1<<k)) >> k)]);
+                              // fall through
                         case 1:
                               k = end - start - 1;
                               changeAllTpcs(notes[end-1], tab[(notes[end-1]->pitch() % 12) * 2 + ((opt & (1<<k)) >> k)]);

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -296,7 +296,7 @@ SymId Rest::getSymbol(TDuration::DurationType type, int line, int lines, int* yo
             case TDuration::DurationType::V_MEASURE:
                   if (duration() >= Fraction(2, 1))
                         return SymId::restDoubleWhole;
-                  // fall trough
+                  // fall through
             case TDuration::DurationType::V_WHOLE:
                   *yoffset = 1;
                   return (line <= -2 || line >= (lines - 1)) ? SymId::restWholeLegerLine : SymId::restWhole;

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -589,8 +589,10 @@ QString TimeSig::accessibleInfo()
       switch (timeSigType()) {
             case TimeSigType::FOUR_FOUR:
                   timeSigString = tr("Common time");
+                  break;
             case TimeSigType::ALLA_BREVE:
                   timeSigString = tr("Cut time");
+                  break;
             default:
                   timeSigString = tr("%1/%2 time").arg(QString::number(numerator())).arg(QString::number(denominator()));
             }

--- a/mstyle/frameshadow.cpp
+++ b/mstyle/frameshadow.cpp
@@ -298,7 +298,9 @@ bool FrameShadowBase::event(QEvent* e) {
 
             case QEvent::MouseButtonPress:
                   releaseMouse();
+                  // fall through
             case QEvent::MouseMove:
+                  // fall through
             case QEvent::MouseButtonRelease:
                   if ( viewport ) {
                         QMouseEvent* me = static_cast<QMouseEvent*>(e);

--- a/thirdparty/rtf2html/rtf2html.cpp
+++ b/thirdparty/rtf2html/rtf2html.cpp
@@ -420,6 +420,7 @@ QString rtf2html(const QString& iString)
                case rtf_keyword::rkw_trowd:
                   CurCellDefs=CellDefsList.insert(CellDefsList.end(),
                                                   table_cell_defs());
+                  // fall through
                case rtf_keyword::rkw_row:
                   if (!trCurRow->Cells.empty())
                   {

--- a/thirdparty/xmlstream/xmlstream.cpp
+++ b/thirdparty/xmlstream/xmlstream.cpp
@@ -2116,7 +2116,8 @@ QString XmlStreamReader::readElementText(ReadElementTextBehaviour behaviour)
                     result += readElementText(behaviour);
                     break;
                 }
-                // Fall through (for ErrorOnUnexpectedElement)
+                //(for ErrorOnUnexpectedElement)
+                // fall through
             default:
                 if (d->error || behaviour == ErrorOnUnexpectedElement) {
                     if (!d->error)

--- a/thirdparty/xmlstream/xmlstream_p.h
+++ b/thirdparty/xmlstream/xmlstream_p.h
@@ -1140,10 +1140,11 @@ bool XmlStreamReaderPrivate::parse()
             case '\n':
                 ++lineNumber;
                 lastLineStart = characterOffset + readBufferPos;
+                // fall through
 
                        // Changes for MuseScore:
-            case 0x03: // this characters are illegal in xml
-            case 0x10: // we treat them as space to allow reading of broken files
+            case 0x03: // these characters are illegal in xml
+            case 0x10: // we treat them as spaces to allow reading of broken files
             case 0x11:
             case 0x12:
             case 0x0c:


### PR DESCRIPTION
As explained in more detail [here](https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/), **gcc7** warn on fallthrough occurrences whenever it doesn't recognize them as likely intentional.
In C++11 the `-Wimplicit-fallthrough` warnings can be suppressed by marking those instances with
```
[[gnu::fallthrough]];
```