### PR TITLE
Fix #215876: Empty volta line text is not preserved and reverts to "1."

### DIFF
--- a/libmscore/volta.cpp
+++ b/libmscore/volta.cpp
@@ -171,8 +171,6 @@ void VoltaSegment::styleChanged()
 Volta::Volta(Score* s)
    : TextLineBase(s)
       {
-      setBeginText("1.");
-
       setBeginTextPlace(PlaceText::BELOW);
       setContinueTextPlace(PlaceText::BELOW);
 


### PR DESCRIPTION
for 2.2 and master