### PR TITLE
fix #211461: show text of other dynamics in status line

### DIFF
--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -373,7 +373,19 @@ QVariant Dynamic::propertyDefault(P_ID id) const
 
 QString Dynamic::accessibleInfo() const
       {
-      return QString("%1: %2").arg(Element::accessibleInfo()).arg(this->dynamicTypeName());
+      QString s;
+
+      if (dynamicType() == Dynamic::Type::OTHER) {
+            s = plainText().simplified();
+            if (s.length() > 20) {
+                  s.truncate(20);
+                  s += "...";
+                  }
+            }
+      else {
+            s = dynamicTypeName();
+            }
+      return QString("%1: %2").arg(Element::accessibleInfo()).arg(s);
       }
 
 }


### PR DESCRIPTION
Recently we changed the behavior of other dynamics (aside from the standard ones) to export their text to MusicXML.  This PR makes the status line & screenreader do the same.

Note the issue references originally was about a request for a change in playback semantics upon editing the dynamic text.  But 1) the main requested change was apparently already made for 2.1 (not clearing the velocity setting on edit), and 2) the further request to possible *update* the velocity according to the modified text does not actually make sense to me.