### PR TITLE
fix #175886: allow fretboards to be added to chord symbols

### DIFF
--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -550,7 +550,7 @@ Element* FretDiagram::drop(EditData& data)
       if (e->type() == ElementType::HARMONY) {
             Harmony* h = static_cast<Harmony*>(e);
             h->setParent(parent());
-            h->setTrack((track() / VOICES) * VOICES);
+            h->setTrack(track());
             score()->undoAddElement(h);
             }
       else {

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1616,6 +1616,36 @@ QString Harmony::screenReaderInfo() const
       }
 
 //---------------------------------------------------------
+//   acceptDrop
+//---------------------------------------------------------
+
+bool Harmony::acceptDrop(EditData& data) const
+      {
+      return data.element->type() == ElementType::FRET_DIAGRAM;
+      }
+
+//---------------------------------------------------------
+//   drop
+//---------------------------------------------------------
+
+Element* Harmony::drop(EditData& data)
+      {
+      Element* e = data.element;
+      if (e->type() == ElementType::FRET_DIAGRAM) {
+            FretDiagram* fd = toFretDiagram(e);
+            fd->setParent(parent());
+            fd->setTrack(track());
+            score()->undoAddElement(fd);
+            }
+      else {
+            qWarning("Harmony: cannot drop <%s>\n", e->name());
+            delete e;
+            e = 0;
+            }
+      return e;
+      }
+
+//---------------------------------------------------------
 //   propertyDefault
 //---------------------------------------------------------
 

--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -181,9 +181,11 @@ class Harmony : public Text {
       virtual QString accessibleInfo() const override;
       virtual QString screenReaderInfo() const override;
 
+      virtual bool acceptDrop(EditData&) const override;
+      virtual Element* drop(EditData&) override;
+
       virtual QVariant propertyDefault(P_ID id) const override;
       };
-
 
 }     // namespace Ms
 #endif

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -24,6 +24,7 @@
 #include "figuredbass.h"
 #include "glissando.h"
 #include "harmony.h"
+#include "fret.h"
 #include "hook.h"
 #include "input.h"
 #include "limits.h"
@@ -789,7 +790,6 @@ Enabling copying of more element types requires enabling pasting in Score::paste
                   case ElementType::SYSTEM_TEXT:
                   case ElementType::REHEARSAL_MARK:
                   case ElementType::INSTRUMENT_CHANGE:
-                  case ElementType::FRET_DIAGRAM:
                   case ElementType::BEND:
                   case ElementType::TREMOLOBAR:
                   case ElementType::VOLTA:
@@ -856,7 +856,8 @@ Enabling copying of more element types requires enabling pasting in Score::paste
                         seg = toFiguredBass(e)->segment();
                         break;
                   case ElementType::HARMONY:
-                        // ignore chord sybols not attached to segment
+                  case ElementType::FRET_DIAGRAM:
+                        // ignore chord symbols or fret diagrams not attached to segment
                         if (e->parent()->isSegment()) {
                               seg = toSegment(e->parent());
                               break;

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -324,7 +324,6 @@ void ScoreView::dragMoveEvent(QDragMoveEvent* event)
                   case ElementType::TRILL:
                   case ElementType::HAIRPIN:
                   case ElementType::TEXTLINE:
-                  case ElementType::FRET_DIAGRAM:
                         if (dragTimeAnchorElement(pos))
                               event->accept();
                         else
@@ -366,6 +365,7 @@ void ScoreView::dragMoveEvent(QDragMoveEvent* event)
                   case ElementType::TREMOLOBAR:
                   case ElementType::FIGURED_BASS:
                   case ElementType::LYRICS:
+                  case ElementType::FRET_DIAGRAM:
                   case ElementType::STAFFTYPE_CHANGE: {
                         QList<Element*> el = elementsAt(pos);
                         bool found = false;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -44,6 +44,7 @@
 #include "libmscore/fingering.h"
 #include "libmscore/hairpin.h"
 #include "libmscore/harmony.h"
+#include "libmscore/fret.h"
 #include "libmscore/icon.h"
 #include "libmscore/image.h"
 #include "libmscore/instrchange.h"
@@ -3934,13 +3935,31 @@ void ScoreView::cmdAddChordName()
       if (!_score->checkHasMeasures())
             return;
 
-      ChordRest* cr = _score->getSelectedChordRest();
-      if (!cr)
+      int track = -1;
+      Segment* segment = nullptr;
+      Element* el = _score->selection().element();
+      if (el && el->type() == ElementType::FRET_DIAGRAM) {
+            FretDiagram* fd = toFretDiagram(el);
+            track = fd->track();
+            while (el && !el->isSegment())
+                  el = el->parent();
+            if (el)
+                  segment = toSegment(el);
+            }
+      else {
+            ChordRest* cr = _score->getSelectedChordRest();
+            if (cr) {
+                  track = cr->track();
+                  segment = cr->segment();
+                  }
+            }
+      if (track == -1 || !segment)
             return;
+
       _score->startCmd();
       Harmony* harmony = new Harmony(_score);
-      harmony->setTrack(cr->track());
-      harmony->setParent(cr->segment());
+      harmony->setTrack(track);
+      harmony->setParent(segment);
       _score->undoAddElement(harmony);
 
       _score->select(harmony, SelectType::SINGLE, 0);


### PR DESCRIPTION
Right now we can easily attach chord symbols to any beat whether there is a note there or not (space bar while entering chord symbols to advanced beat by beat).  But there is no equivalent simple way to add fretboard diagrams.  Eventually we could consider some sort of fretboard entry mdoe with similar shortcuts to advance by beat, but that's a lot of work.  For now, an extremely simple solution seems to be to let the user drop fretboard diagrams on chord symbols.  

We should also allow adding chord symbols to fretboard diagrams (select a diagram, Ctrl+K).  This works on master but not in 2.1.  Should be simple to add this as well, but I'll need to make a 2.x-specific PR for that I guess.  Note the current PR is tested on master and works as far as chord symbols work on master at all, which is pretty sketchy.  So I should probably do a separate 2.x version of this PR anyhow.