### PR TITLE
fix #197101: ctrl+home should reposition canvas

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2837,7 +2837,21 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack)
             m = static_cast<const Segment*>(el->parent()->parent())->measure();
       else if (el->type() == ElementType::MEASURE || el->type() == ElementType::VBOX)
             m = static_cast<const MeasureBase*>(el);
-      else
+      else if (el->isSpannerSegment())
+            m = static_cast<const SpannerSegment*>(el)->spanner()->startMeasure();
+      else if (el->isSpanner())
+            m = static_cast<const Spanner*>(el)->startMeasure();
+      else {
+            // attempt to find measure
+            Element* e = el->parent();
+            while (e && e->type() != ElementType::MEASURE)
+                  e = e->parent();
+            if (e)
+                  m = static_cast<Measure*>(e);
+            else
+                  return;
+            }
+      if (!m)
             return;
 
       int staffIdx = el->staffIdx();


### PR DESCRIPTION
We were giving up on adjustCanvasPosition for element types other than a small few, when in Page view.  I've added code to allow it to work for spanners as well as any elements that have Measure in their parentage, which should allow Ctrl+Home and Ctrl+end to work in just about all cases.  It also will allow the new "next-element" command (being developed by @divya-urs for GSoC) to correctly position the score as it traverses articulations, dynamics, spanners, and other elements.

It is possible there would be some negative side effect to this - some place where we rely on the fact that calling adjustCanvasPosition() is a no-op for some element types.  But I don't actually see any such cases.  And in any case, if we run into them later, better to address this at the point of call - that is, don't call adjustCanvasPosition in cases where we don't want it to do anything.

This code should be good for 2.x as well as master.