### PR TITLE
fix #224136: crash on click of note with palette filtered

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -283,7 +283,7 @@ void Palette::setGrid(int hh, int vv)
 
 Element* Palette::element(int idx)
       {
-      if (idx < size() &&  cellAt(idx))
+      if (idx < size() && cellAt(idx))
             return cellAt(idx)->element;
       else
             return 0;
@@ -1426,7 +1426,7 @@ QSize Palette::sizeHint() const
 void Palette::actionToggled(bool /*val*/)
       {
       selectedIdx = -1;
-      int nn = size();
+      int nn = ccp()->size();
       for (int n = 0; n < nn; ++n) {
             Element* e = cellAt(n)->element;
             if (e && e->type() == ElementType::ICON) {

--- a/mscore/palettebox.cpp
+++ b/mscore/palettebox.cpp
@@ -102,7 +102,7 @@ void PaletteBox::retranslate()
       }
 
 //---------------------------------------------------------
-//   retransfilterPaletteslate
+//   filterPalettes
 //---------------------------------------------------------
 
 void PaletteBox::filterPalettes(const QString& text)


### PR DESCRIPTION
Simple fix for this.  Probably similar fixes needed elsewhere.  See also https://musescore.org/en/node/224121, for example.  not immeidaltely obvious what fix is for that one though.