### PR TITLE
fix error message when writing instruments.xml fails

### DIFF
--- a/mscore/exportmp3.cpp
+++ b/mscore/exportmp3.cpp
@@ -78,7 +78,10 @@ bool MP3Exporter::findLibrary()
       QString libPath = QFileDialog::getOpenFileName(
            0, qApp->translate("MP3Exporter", "Where is %1 ?").arg(getLibraryName()),
            path,
-           getLibraryTypeString());
+           getLibraryTypeString(),
+           0,
+           preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog
+           );
 
       if (libPath.isEmpty())
             return false;

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2321,7 +2321,9 @@ void MuseScore::addImage(Score* score, Element* e)
          tr("All Supported Files") + " (*.svg *.jpg *.jpeg *.png);;" +
          tr("Scalable Vector Graphics") + " (*.svg);;" +
          tr("JPEG") + " (*.jpg *.jpeg);;" +
-         tr("PNG") + " (*.png)"
+         tr("PNG") + " (*.png)",
+         0,
+         preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog
          );
       if (fn.isEmpty())
             return;

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -102,8 +102,8 @@ void InstrumentsDialog::on_saveButton_clicked()
             }
       xml.etag();
       if (f.error() != QFile::NoError) {
-            QString s = tr("Write Style failed: ") + f.errorString();
-            QMessageBox::critical(this, tr("Write Style"), s);
+            QString s = tr("Write Instruments File failed: ") + f.errorString();
+            QMessageBox::critical(this, tr("Write Instruments File"), s);
             }
       }
 

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -20,6 +20,7 @@
 
 #include "instrdialog.h"
 #include "musescore.h"
+#include "preferences.h"
 #include "scoreview.h"
 #include "seq.h"
 #include "libmscore/barline.h"
@@ -74,7 +75,9 @@ void InstrumentsDialog::on_saveButton_clicked()
          this,
          tr("Save Instrument List"),
          ".",
-         tr("MuseScore Instruments") + " (*.xml)"
+         tr("MuseScore Instruments") + " (*.xml)",
+         0,
+         preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog
          );
       if (name.isEmpty())
             return;
@@ -116,7 +119,9 @@ void InstrumentsDialog::on_loadButton_clicked()
       QString fn = QFileDialog::getOpenFileName(
          this, tr("Load Instrument List"),
           mscoreGlobalShare + "/templates",
-         tr("MuseScore Instruments") + " (*.xml)"
+         tr("MuseScore Instruments") + " (*.xml)",
+         0,
+         preferences.nativeDialogs ? QFileDialog::Options() : QFileDialog::DontUseNativeDialog
          );
       if (fn.isEmpty())
             return;


### PR DESCRIPTION
even if this seems to be dead code right now, and make save/open instrument.xml and open image and lame_enc.dll work in non-native mode too.
May go to 2.2 too, at least it won't harm.
