### PR TITLE
fix #227826: can't use Del key in text edit mode

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3089,8 +3089,6 @@ void MuseScore::changeState(ScoreState val)
                   a->setEnabled(cs && cs->selection().state() != SelState::NONE);
             else if (enable && (s->key() == "copy"))
                   a->setEnabled(cs && (cs->selection().state() != SelState::NONE || val == STATE_FOTO));
-            else if (enable && (s->key() == "delete"))
-                  a->setEnabled(cs && cs->selection().state() != SelState::NONE);
             else if (enable && (s->key() == "select-similar-range"))
                   a->setEnabled(cs && cs->selection().state() == SelState::RANGE);
             else if (enable && (s->key() == "synth-control")) {
@@ -3100,7 +3098,7 @@ void MuseScore::changeState(ScoreState val)
                         qDebug("disable synth control");
                   a->setEnabled(driver);
                   }
-            else if (s->key() == "pad-dot" || s->key() == "pad-dot-dot")
+            else if (s->key() == "pad-dot" || s->key() == "pad-dot-dot" || s->key() == "delete")
                         a->setEnabled(!(val & (STATE_ALLTEXTUAL_EDIT | STATE_EDIT)));
             else {
                   a->setEnabled(s->state() & val);


### PR DESCRIPTION
For master and 2.2, it broke with #3188, e24545a / 97178e0 in master, 13da822 in 2.2