### PR TITLE
fix #102716: update text on load style

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2701,9 +2701,17 @@ static void updateTimeSigs(void*, Element* e)
             }
       }
 
-static void updateTextStyle2(void*, Element* e)
+static void updateTextStyle2(void* data, Element* e)
       {
       e->styleChanged();
+      if (e->isText()) {
+            Text* t = static_cast<Text*>(e);
+            TextStyleType tst = t->textStyleType();
+            MStyle* oldStyle = static_cast<MStyle*>(data);
+            TextStyle ots = oldStyle->textStyle(tst);
+            TextStyle nts = t->score()->textStyle(tst);
+            t->textStyle().restyle(ots, nts);
+            }
       }
 
 //---------------------------------------------------------
@@ -2724,7 +2732,7 @@ void ChangeStyle::flip()
             score->spatiumChanged(score->style()->spatium(), style.spatium());
 
       score->setStyle(style);
-      score->scanElements(0, updateTextStyle2);
+      score->scanElements(&tmp, updateTextStyle2);
       score->setLayoutAll(true);
 
       style = tmp;


### PR DESCRIPTION
I think this is the right fix, but definitely let's test.

The idea is - when updating text elements to reflect a change in style, use TextStyle::restyle() to update only those properties that had not already been customized.  In order to do this, all I needed to do was pass a pointer to the original score style in to updateTextStyle2() and then pass the text style from that and the corresponding text style from the new score style in to TextStyle::restyle.

It seems to work exactly as I expect.  text elements that had not been customized at all are fully updated to the new style, text elements that had been customized keep their customizations but have their uncustomized properties updated.