### PR TITLE
fix #81711: bad path on restore session

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3676,8 +3676,11 @@ bool MuseScore::restoreSession(bool always)
                                     else if (tag == "path") {
                                           Score* score = readScore(e.readElementText());
                                           if (score) {
-                                                if (!name.isEmpty())
-                                                      score->setName(name);
+                                                if (!name.isEmpty()) {
+                                                      QFileInfo* fi = score->fileInfo();
+                                                      fi->setFile(name);
+                                                      // TODO: what if that path is no longer valid?
+                                                      }
                                                 if (cleanExit) {
                                                       // override if last session did a clean exit
                                                       created = false;


### PR DESCRIPTION
The reason the file is saved off in la-la land is that we are setting the filename to a bogus "sanitized" value.  It's a good thing to do elsewhere but not here.

Similar PR for master forthcoming.

The TODO comment is about a corner case we might want to consider - what if the original path is no longer valid (missing drive, etc)?  When we try to write to it, we could again end up in the Windows virtual store, or have other strange errors.  Better probably to set "created" to true if the path isn't writable.  But fi->isWritable() seems to return true inappropriately on Windows in cases I tried.  Not sure why, and since this is likely to be system-dependent anyhow, I'll let someone else worry about it.