### PR TITLE
fix #232111 ensure Timeline instrument names scroll

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -214,6 +214,7 @@ void TRowLabels::updateLabels(std::vector<QString> labels, int height)
       meta_labels.push_back(li_p);
 
       setMaximumWidth(max_width);
+      setSceneRect(0, 0, max_width, parent->getHeight());
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Without this line, the timeline instrument names wouldn't scroll on linux machine when scrolling timeline up/down.