### PR TITLE
palette navigation

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4599,6 +4599,26 @@ void MuseScore::cmd(QAction* a)
                QString("Command %1 not valid in current state").arg(cmdn));
             return;
             }
+      if (cmdn == "palette-search") {
+            PaletteBox* pb = getPaletteBox();
+            QLineEdit* sb = pb->searchBox();
+            sb->setFocus();
+            if (pb->noSelection())
+                  pb->setKeyboardNavigation(false);
+            else
+                  pb->setKeyboardNavigation(true);
+            return;
+            }
+      if (cmdn == "apply-current-palette-element") {
+            PaletteBox* pb = getPaletteBox();
+            for (Palette* p : pb->palettes()) {
+                  if (p->getCurrentIdx() != -1) {
+                        p->applyPaletteElement();
+                        break;
+                        }
+                  }
+            return;
+            }
       if (cmdn == "repeat-cmd") {
             a  = lastCmd;
             sc = lastShortcut;

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -134,13 +134,13 @@ class Palette : public QWidget {
       virtual void leaveEvent(QEvent*) override;
       virtual bool event(QEvent*) override;
       virtual void resizeEvent(QResizeEvent*) override;
+      void applyPaletteElement(PaletteCell* cell);
 
       virtual void dragEnterEvent(QDragEnterEvent*) override;
       virtual void dragMoveEvent(QDragMoveEvent*) override;
       virtual void dropEvent(QDropEvent*) override;
       virtual void contextMenuEvent(QContextMenuEvent*) override;
 
-      int idx(const QPoint&) const;
       int idx2(const QPoint&) const;
       QRect idxRect(int) const;
 
@@ -160,6 +160,9 @@ class Palette : public QWidget {
       Palette(QWidget* parent = 0);
       virtual ~Palette();
 
+      void nextPaletteElement();
+      void prevPaletteElement();
+      void applyPaletteElement();
       PaletteCell* append(Element*, const QString& name, QString tag = QString(),
          qreal mag = 1.0);
       PaletteCell* add(int idx, Element*, const QString& name,
@@ -205,8 +208,13 @@ class Palette : public QWidget {
       bool filter(const QString& text);
       void setShowContextMenu(bool val) { _showContextMenu = val; }
 
+      int getCurrentIdx() { return currentIdx; }
+      void setCurrentIdx(int i) { currentIdx = i; }
+      bool isFilterActive() { return filterActive == true; }
+      QList<PaletteCell*> getDragCells() { return dragCells; }
       virtual int heightForWidth(int) const;
       virtual QSize sizeHint() const;
+      int idx(const QPoint&) const;
       };
 
 

--- a/mscore/palettebox.h
+++ b/mscore/palettebox.h
@@ -32,10 +32,11 @@ class PaletteBox : public QDockWidget {
       QVBoxLayout* vbox;
       Palette* newPalette(const QString& name, int slot);
       QComboBox* workspaceList;
-      QLineEdit* searchBox;
+      QLineEdit* _searchBox;
       const int paletteStretch = 1000;
       QAction* singlePaletteAction;
       QToolButton* addWorkspaceButton;
+      bool keyboardNavigation = false;
 
    private slots:
       void paletteCmd(PaletteCommand, int);
@@ -60,6 +61,13 @@ class PaletteBox : public QDockWidget {
       void clear();
       QList<Palette*> palettes() const;
       void updateWorkspaces();
+      QLineEdit* searchBox() { return _searchBox; }
+      bool noSelection();
+      void mousePressEvent(QMouseEvent* ev, Palette* p1);
+      void navigation(QKeyEvent *event);
+      bool eventFilter(QObject* obj, QEvent *event);
+      void setKeyboardNavigation(bool val) { keyboardNavigation = val; }
+      bool getKeyboardNavigation() { return keyboardNavigation; }
       };
 
 //---------------------------------------------------------

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1928,7 +1928,7 @@ void ScoreView::cmd(const char* s)
             if (el && el->type() == ElementType::NOTE)
                   cmdGotoElement(score()->downAltCtrl(static_cast<Note*>(el)));
             }
-      else if (cmd == "next-segment-element"){
+      else if (cmd == "next-segment-element") {
             Element* el = score()->selection().element();
             if (!el && !score()->selection().elements().isEmpty() )
                 el = score()->selection().elements().first();
@@ -1938,7 +1938,7 @@ void ScoreView::cmd(const char* s)
             else
                   cmdGotoElement(score()->firstElement());
             }
-      else if (cmd == "prev-segment-element"){
+      else if (cmd == "prev-segment-element") {
             Element* el = score()->selection().element();
             if (!el && !score()->selection().elements().isEmpty())
                 el = score()->selection().elements().last();
@@ -1948,7 +1948,7 @@ void ScoreView::cmd(const char* s)
             else
                   cmdGotoElement(score()->lastElement());
             }
-      else if (cmd == "next-element"){
+      else if (cmd == "next-element") {
             Element* el = score()->selection().element();
             if (!el && !score()->selection().elements().isEmpty() )
                 el = score()->selection().elements().first();
@@ -1958,7 +1958,7 @@ void ScoreView::cmd(const char* s)
             else
                   cmdGotoElement(score()->firstElement());
             }
-      else if (cmd == "prev-element"){
+      else if (cmd == "prev-element") {
             Element* el = score()->selection().element();
             if (!el && !score()->selection().elements().isEmpty())
                 el = score()->selection().elements().last();
@@ -1968,10 +1968,10 @@ void ScoreView::cmd(const char* s)
             else
                   cmdGotoElement(score()->lastElement());
             }
-      else if (cmd == "first-element"){
+      else if (cmd == "first-element") {
             cmdGotoElement(score()->firstElement());
             }
-      else if (cmd == "last-element"){
+      else if (cmd == "last-element") {
             cmdGotoElement(score()->lastElement());
             }
       else if (cmd == "rest" || cmd == "rest-TAB")

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -859,6 +859,28 @@ Shortcut Shortcut::_sc[] = {
          ShortcutFlags::A_CMD
          },
       {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "palette-search",
+         QT_TRANSLATE_NOOP("action","Palette Search"),
+         QT_TRANSLATE_NOOP("action","Palette Search"),
+         QT_TRANSLATE_NOOP("action","Palette Search"),
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CMD
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "apply-current-palette-element",
+         QT_TRANSLATE_NOOP("action","Apply Current Palette Element"),
+         QT_TRANSLATE_NOOP("action","Apply current palette element"),
+         QT_TRANSLATE_NOOP("action","Apply current palette element"),
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CMD
+         },
+      {
          MsWidget::SCORE_TAB,
          STATE_NORMAL,
          "first-element",


### PR DESCRIPTION
The palette search results can be navigated using the arrow keys, and a palette element can be applied using the Enter key. These work if the keyboard focus is on the palette search box. There is a shortcut command to apply the currently selected palette element. This does not require keyboard focus to be on the search box. There is also a shortcut command to set focus to the palette search box.  On applying a palette element, focus shifts to the score.