### PR TITLE
fix #232481 timeline scroll range account for scrollbar

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -216,7 +216,7 @@ void TRowLabels::updateLabels(std::vector<QString> labels, int height)
       meta_labels.push_back(li_p);
 
       setMaximumWidth(max_width);
-      setSceneRect(0, 0, max_width, parent->getHeight());
+      setSceneRect(0, 0, max_width, parent->getHeight() + parent->horizontalScrollBar()->height());
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This is supplemental fix to #3238, which I discovered wasn't quite right after closer inspection.