### PR TITLE
fix typo in gp6 import

### DIFF
--- a/mscore/importgtp-gp6.cpp
+++ b/mscore/importgtp-gp6.cpp
@@ -549,9 +549,9 @@ int GuitarPro6::findNumMeasures(GPPartInfo* partInfo)
                   break;
             masterBar = masterBar.nextSibling();
             }
-      QString bars = masterBar.lastChildElement("Bars").toElement().text();
+      QString finalBars = masterBar.lastChildElement("Bars").toElement().text();
       //work out the number of measures (add 1 as couning from 0, and divide by number of parts)
-      int numMeasures = (bars.split(" ").last().toInt() + 1) / score->parts().length();
+      int numMeasures = (finalBars.split(" ").last().toInt() + 1) / score->parts().length();
 
       if (numMeasures > bars.size()) {
             qDebug("GuitarPro6:findNumMeasures: bars %d < numMeasures %d\n", bars.size(), numMeasures);


### PR DESCRIPTION
The variable "bars" was overwritten, but this apparently was not giving serious problems.