### PR TITLE
Set object name for timeline

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -74,6 +74,7 @@ TDockWidget::TDockWidget(QWidget* w)
       setMinimumHeight(50);
 
       setWindowTitle(tr("Timeline"));
+      setObjectName("Timeline");
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Removes extra output complaining about lack of object name