### PR TITLE
Fix #232931 follow-up: change behavior of adding breaks from palette

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -527,7 +527,6 @@ class Score : public QObject, ScoreElement {
       void cmdToggleHideEmpty();
       void cmdSetVisible();
       void cmdUnsetVisible();
-      void cmdToggleLayoutBreak(LayoutBreak::Type);
       inline virtual Movements* movements();
       inline virtual const Movements* movements() const;
 
@@ -574,6 +573,7 @@ class Score : public QObject, ScoreElement {
       void cmdHalfDuration()        { cmdIncDecDuration( 1, 0); }
       void cmdIncDurationDotted()   { cmdIncDecDuration(-1, 1); }
       void cmdDecDurationDotted()   { cmdIncDecDuration( 1, 1); }
+      void cmdToggleLayoutBreak(LayoutBreak::Type);
 
       void addRemoveBreaks(int interval, bool lock);
 

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -481,7 +481,6 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
                 || element->type() == ElementType::MARKER
                 || element->type() == ElementType::JUMP
                 || element->type() == ElementType::SPACER
-                || element->type() == ElementType::LAYOUT_BREAK
                 || element->type() == ElementType::VBOX
                 || element->type() == ElementType::HBOX
                 || element->type() == ElementType::TBOX
@@ -502,6 +501,10 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
                         if (m == last)
                               break;
                         }
+                  }
+            else if (element->type() == ElementType::LAYOUT_BREAK) {
+                  LayoutBreak* breakElement = static_cast<LayoutBreak*>(element);
+                  score->cmdToggleLayoutBreak(breakElement->layoutBreakType());
                   }
             else if (element->isClef() || element->isKeySig() || element->isTimeSig()) {
                   Measure* m1 = sel.startSegment()->measure();


### PR DESCRIPTION
I think this does no harm; I initially thought it was buggy, but it turned out to be a pre-existing Heisenbug.