### PR TITLE
Fix #237396 incorrect handling of indexOf failure in Shortcut::getMen…

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3771,6 +3771,8 @@ QString Shortcut::keysToString() const
 QString Shortcut::getMenuShortcutString(const QMenu *menu)
       {
       int shortcutKeyPosition = menu->title().indexOf('&') + 1;
+      if (shortcutKeyPosition == 0)
+          return QString("");
       return QString("Alt+") + menu->title().at(shortcutKeyPosition);
       }
 


### PR DESCRIPTION
…uShortcutString

The failure case of indexOf in Shortcut::getMenuShortcutstring is not
correctly handled, causing an application crash when running a debug
build with assertions enabled --> QString.at asserts that the index is
smaller than the string size. If the menu has no title (e.g. a
separator) then it will try to assert that 0 < 0 and fail.

Signed-off-by: Frank Vanbever <frank.vanbever@gmail.com>