### PR TITLE
Palette shortcut

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -29,8 +29,8 @@ include_directories(
       )
 
 if (SCRIPT_INTERFACE)
-      set (SCRIPT_FILES mscorePlugins pluginCreator.cpp qmledit.cpp pluginManager.cpp)
-      set (SCRIPT_UI   pluginCreator.ui pluginManager.ui)
+      set (SCRIPT_FILES mscorePlugins pluginCreator.cpp qmledit.cpp pluginManager.cpp paletteShortcutManager.cpp)
+      set (SCRIPT_UI   pluginCreator.ui pluginManager.ui paletteShortcutManager.ui)
 endif (SCRIPT_INTERFACE)
 
 QT5_WRAP_UI (ui_headers

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1544,7 +1544,13 @@ Palette* MuseScore::newFretboardDiagramPalette()
 
 void MuseScore::setAdvancedPalette()
       {
-      mscore->getPaletteBox();
+      bool empty = true;
+      QList<Shortcut> shortcuts;  // stores advanced workspace shortcuts
+      if (!preferences.paletteCellListAdv.isEmpty())
+            empty = false;
+      for (PaletteCellDescription d : preferences.paletteCellListAdv) {
+            shortcuts.append(d.cell->shortcut);
+            }
       paletteBox->clear();
       paletteBox->addPalette(newClefsPalette(PaletteType::ADVANCED));
       paletteBox->addPalette(newKeySigPalette(PaletteType::ADVANCED));
@@ -1571,6 +1577,31 @@ void MuseScore::setAdvancedPalette()
       paletteBox->addPalette(newBreaksPalette());
       paletteBox->addPalette(newFramePalette());
       paletteBox->addPalette(newBeamPalette(PaletteType::ADVANCED));
+      // set shortcuts in new palettes
+      QList<PaletteCell*> cells;
+      for (Palette* p : paletteBox->palettes()) {
+            for (PaletteCell* cell : p->getCells()) {
+                  cells.append(cell);
+                  }
+            }
+      preferences.paletteCellList.clear();
+      for (int i = 0; i < shortcuts.size(); i++) {
+            PaletteCell* cell = cells[i];
+            if (cell->name == "Show More") {
+                  continue;
+                  }
+            if (!empty)
+                  cell->shortcut = shortcuts[i];
+            int s = preferences.paletteCellList.size();
+            cell->id = s;
+            PaletteCellDescription pd;
+            pd.cell = cell;
+            pd.description = cell->name;
+            pd.shortcut = cell->shortcut;
+            pd.shortcut.setDescr(cell->name);
+            pd.shortcut.setState(STATE_NORMAL | STATE_NOTE_ENTRY);
+            preferences.paletteCellList.append(pd);
+            }
       }
 
 //---------------------------------------------------------
@@ -1579,7 +1610,13 @@ void MuseScore::setAdvancedPalette()
 
 void MuseScore::setBasicPalette()
       {
-      mscore->getPaletteBox();
+      bool empty = true;
+      QList<Shortcut> shortcuts;  // stores basic workspace shortcuts
+      if (!preferences.paletteCellListBasic.isEmpty())
+            empty = false;
+      for (PaletteCellDescription d : preferences.paletteCellListBasic) {
+            shortcuts.append(d.cell->shortcut);
+            }
       paletteBox->clear();
       paletteBox->addPalette(newClefsPalette(PaletteType::BASIC));
       paletteBox->addPalette(newKeySigPalette(PaletteType::BASIC));
@@ -1595,6 +1632,28 @@ void MuseScore::setBasicPalette()
       paletteBox->addPalette(newRepeatsPalette());
       paletteBox->addPalette(newBreaksPalette());
       paletteBox->addPalette(newBeamPalette(PaletteType::BASIC));
+      int i = 0;
+      preferences.paletteCellList.clear();
+      for (Palette* p : paletteBox->palettes()) {
+            for (PaletteCell* cell : p->getCells()) {
+                  if (cell->name == "Show More") {
+                        i++;
+                        continue;
+                        }
+                  if (!empty)
+                        cell->shortcut = shortcuts[i];
+                  int s = preferences.paletteCellList.size();
+                  cell->id = s;
+                  PaletteCellDescription pd;
+                  pd.cell = cell;
+                  pd.description = cell->name;
+                  pd.shortcut = cell->shortcut;
+                  pd.shortcut.setDescr(cell->name);
+                  pd.shortcut.setState(STATE_NORMAL | STATE_NOTE_ENTRY);
+                  preferences.paletteCellList.append(pd);
+                  i++;
+                  }
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -36,7 +36,6 @@
 #include "mixer.h"
 #include "selectionwindow.h"
 #include "palette.h"
-#include "palettebox.h"
 #include "libmscore/part.h"
 #include "libmscore/drumset.h"
 #include "libmscore/instrtemplate.h"
@@ -4260,6 +4259,55 @@ void MuseScore::showPluginManager()
       }
 
 //---------------------------------------------------------
+//   showPaletteShortcutManager
+//---------------------------------------------------------
+
+void MuseScore::showPaletteShortcutManager()
+      {
+#ifdef SCRIPT_INTERFACE
+      if (!paletteShortcutManager)
+            paletteShortcutManager = new PaletteShortcutManager(0);
+      paletteShortcutManager->init();
+      paletteShortcutManager->show();
+#endif
+      }
+
+//---------------------------------------------------------
+//   getPaletteShortcutManager
+//---------------------------------------------------------
+
+PaletteShortcutManager* MuseScore::getPaletteShortcutManager()
+      {
+#ifdef SCRIPT_INTERFACE
+      if (!paletteShortcutManager)
+            paletteShortcutManager = new PaletteShortcutManager(0);
+      paletteShortcutManager->init1();
+      return paletteShortcutManager;
+#endif
+      }
+
+QMenuBar* MuseScore::getMenuBar()
+      {
+      return menuBar();
+      }
+
+//---------------------------------------------------------
+//   loadPaletteShortcuts
+//---------------------------------------------------------
+
+void MuseScore::loadPaletteShortcuts()
+      {
+      if (!paletteShortcutMapper) {
+            paletteShortcutMapper = new QSignalMapper(this);
+            connect(paletteShortcutMapper, SIGNAL(mapped(int)), SLOT(paletteShortcutTriggered(int)));
+            }
+      for (int i = 0; i < preferences.paletteCellList.size(); ++i) {
+            PaletteCellDescription* d = &preferences.paletteCellList[i];
+            registerPaletteShortcut(d);
+            }
+      }
+
+//---------------------------------------------------------
 //   showMediaDialog
 //---------------------------------------------------------
 
@@ -4962,6 +5010,21 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             showPluginCreator(a);
       else if (cmd == "plugin-manager")
             showPluginManager();
+      else if (cmd == "palette-shortcut-manager")
+            showPaletteShortcutManager();
+      else if (cmd == "set-palette-shortcut") {
+            PaletteBox* pb = mscore->getPaletteBox();
+            for (Palette* p : pb->palettes()) {
+                  if (p->getCurrentIdx() != -1) {
+                        PaletteCell* c = p->getCells()[p->getCurrentIdx()];
+                        if (c == 0)
+                              return;
+                        PaletteShortcutManager* pm = getPaletteShortcutManager();
+                        pm->setShortcut(c);
+                        return;
+                        }
+                  }
+            }
       else if(cmd == "resource-manager"){
             ResourceManager r(0);
             r.exec();
@@ -5482,6 +5545,63 @@ SynthesizerState MuseScore::synthesizerState()
       {
       SynthesizerState state;
       return synti ? synti->state() : state;
+      }
+
+//---------------------------------------------------------
+//   registerPaletteShortcut
+//---------------------------------------------------------
+
+void MuseScore::registerPaletteShortcut(PaletteCellDescription* p)
+      {
+      bool alreadyPresent = false;
+      int paletteShortcutIdx = -1;
+
+      for (int i = 0; i < paletteShortcuts.size(); i++) {
+            if (paletteShortcuts[i]->id == p->cell->id) {
+                  paletteShortcutIdx = i;
+                  alreadyPresent = true;
+                  break;
+                  }
+            }
+      if (paletteShortcutIdx == -1) {
+            paletteShortcuts.append(p->cell);
+            paletteShortcutIdx = paletteShortcuts.size() - 1;
+            }
+      QAction* a = p->shortcut.action();
+      if (!alreadyPresent) {
+            paletteCellActions.append(a);
+            }
+      if (!paletteShortcutMapper) {
+            paletteShortcutMapper = new QSignalMapper(this);
+            connect(paletteShortcutMapper, SIGNAL(mapped(int)), SLOT(paletteShortcutTriggered(int)));
+            }
+      connect(a, SIGNAL(triggered()), paletteShortcutMapper, SLOT(map()));
+      paletteShortcutMapper->setMapping(a, paletteShortcutIdx);
+      }
+
+//---------------------------------------------------------
+//   unregisterPaletteShortcut
+//---------------------------------------------------------
+
+void MuseScore::unregisterPaletteShortcut(PaletteCellDescription* p)
+      {
+      paletteShortcuts.removeAll(p->cell);
+      QAction* a = p->shortcut.action();
+      paletteCellActions.removeAll(a);
+      disconnect(a, SIGNAL(triggered()), paletteShortcutMapper, SLOT(map()));
+      paletteShortcutMapper->removeMappings(a);
+      }
+
+//---------------------------------------------------------
+//   paletteShortcutTriggered
+//---------------------------------------------------------
+
+void MuseScore::paletteShortcutTriggered(int i)
+      {
+      PaletteCell* c = paletteShortcuts[i];
+      Palette* p = c->parent;
+      if (p)
+            p->applyPaletteElement(c);
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -34,6 +34,10 @@
 #include "libmscore/musescoreCore.h"
 #include "libmscore/score.h"
 #include "newwizard.h"
+#include "preferences.h"
+#include "paletteShortcutManager.h"
+#include "pluginManager.h"
+#include "pluginCreator.h"
 
 namespace Ms {
 
@@ -91,6 +95,7 @@ class Sym;
 class MasterPalette;
 class PluginCreator;
 class PluginManager;
+class PaletteShortcutManager;
 class MasterSynthesizer;
 class SynthesizerState;
 class Driver;
@@ -101,6 +106,7 @@ class HelpBrowser;
 class ToolbarEditor;
 
 struct PluginDescription;
+struct PaletteCellDescription;
 enum class SelState : char;
 enum class IconType : signed char;
 enum class MagIdx : char;
@@ -277,6 +283,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       MasterPalette* masterPalette         { 0 };
       PluginCreator* _pluginCreator        { 0 };
       PluginManager* pluginManager         { 0 };
+      PaletteShortcutManager* paletteShortcutManager { 0 };
       SelectionWindow* selectionWindow     { 0 };
 
       QMenu* menuFile;
@@ -334,6 +341,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       bool _midiinEnabled            { true };
       QList<QString> plugins;
+      QList<PaletteCell*> paletteShortcuts;
       ScriptEngine* se               { 0 };
       QString pluginPath;
 
@@ -342,7 +350,9 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       QTimer* autoSaveTimer;
       QList<QAction*> pluginActions;
+      QList<QAction*> paletteCellActions;
       QSignalMapper* pluginMapper        { 0 };
+      QSignalMapper* paletteShortcutMapper { 0 };
 
       PianorollEditor* pianorollEditor   { 0 };
       DrumrollEditor* drumrollEditor     { 0 };
@@ -518,6 +528,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void dirtyChanged(Score*);
       void setPos(int tick);
       void pluginTriggered(int);
+      void paletteShortcutTriggered(int);
       void handleMessage(const QString& message);
       void setCurrentScoreView(ScoreView*);
       void setCurrentScoreView(int);
@@ -565,6 +576,12 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void updateDrumTools(const Drumset* ds);
       void showPluginCreator(QAction*);
       void showPluginManager();
+      void showPaletteShortcutManager();
+      PaletteShortcutManager* getPaletteShortcutManager();
+      bool paletteShortcutMapperNull() { return paletteShortcutMapper == 0; }
+      void clearPaletteShortcutMapper() { paletteShortcutMapper = 0; }
+      PreferenceDialog* getPreferenceDialog() { return preferenceDialog; }
+      void clearPaletteShortcuts() { paletteShortcuts.clear(); }
 
 //      void updateTabNames();
       QProgressBar* showProgressBar();
@@ -589,6 +606,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       virtual void setCurrentView(int tabIdx, int idx);
       void loadPlugins();
       void unloadPlugins();
+      void loadPaletteShortcuts();
 
       ScoreState state() const { return _sstate; }
       void changeState(ScoreState);
@@ -735,12 +753,17 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void registerPlugin(PluginDescription*);
       void unregisterPlugin(PluginDescription*);
 
+      void registerPaletteShortcut(PaletteCellDescription*);
+      void unregisterPaletteShortcut(PaletteCellDescription*);
+
       Q_INVOKABLE void showStartcenter(bool);
       void showPlayPanel(bool);
 
       QFileInfoList recentScores() const;
       void saveDialogState(const char* name, QFileDialog* d);
       void restoreDialogState(const char* name, QFileDialog* d);
+
+      QMenuBar* getMenuBar();
 
       QPixmap extractThumbnail(const QString& name);
 

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -24,6 +24,7 @@
 #include "ui_palette.h"
 #include "ui_cellproperties.h"
 #include "libmscore/sym.h"
+#include "shortcut.h"
 
 namespace Ms {
 
@@ -39,10 +40,13 @@ class Palette;
 
 struct PaletteCell {
       ~PaletteCell();
-
+      PaletteCell(Palette* p);
       Element* element { 0 };
       QString name;           // used for tool tip
       QString tag;
+      Palette* parent;
+      Shortcut shortcut;
+      int id;
 
       bool drawStaff { false };
       double x       { 0.0   };
@@ -137,7 +141,6 @@ class Palette : public QWidget {
       virtual void leaveEvent(QEvent*) override;
       virtual bool event(QEvent*) override;
       virtual void resizeEvent(QResizeEvent*) override;
-      void applyPaletteElement(PaletteCell* cell);
 
       virtual void dragEnterEvent(QDragEnterEvent*) override;
       virtual void dragMoveEvent(QDragMoveEvent*) override;
@@ -218,6 +221,8 @@ class Palette : public QWidget {
       virtual int heightForWidth(int) const;
       virtual QSize sizeHint() const;
       int idx(const QPoint&) const;
+      QList<PaletteCell*> getCells() { return cells; }
+      void applyPaletteElement(PaletteCell* cell);
       };
 
 

--- a/mscore/paletteShortcutManager.cpp
+++ b/mscore/paletteShortcutManager.cpp
@@ -1,0 +1,330 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//  $Id: palette.cpp 5576 2012-04-24 19:15:22Z wschweer $
+//
+//  Copyright (C) 2011 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENSE.GPL
+//=============================================================================
+
+#include "paletteShortcutManager.h"
+#include "shortcutcapturedialog.h"
+#include "musescore.h"
+#include "palette.h"
+#include "palettebox.h"
+#include "libmscore/arpeggio.h"
+#include "libmscore/bagpembell.h"
+#include "libmscore/glissando.h"
+#include "libmscore/pedal.h"
+#include "libmscore/tempotext.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   PaletteShortcutManager
+//---------------------------------------------------------
+
+PaletteShortcutManager::PaletteShortcutManager(QWidget *parent) : QDialog(parent)
+      {
+      setObjectName("PaletteShortcutManager");
+      setupUi(this);
+      setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
+      connect(definePaletteShortcut, SIGNAL(clicked()), SLOT(definePaletteShortcutClicked()));
+      connect(clearPaletteShortcut, SIGNAL(clicked()), SLOT(clearPaletteShortcutClicked()));
+      readSettings();
+      }
+
+//---------------------------------------------------------
+//   setIds
+//---------------------------------------------------------
+
+void PaletteShortcutManager::setIds()
+      {
+      int i = 0;
+      for (Palette* p : mscore->getPaletteBox()->palettes()) {
+            for (PaletteCell* c : p->getCells()) {
+                  if (c->name == "Show More") {
+                        continue;
+                        }
+                  c->id = i;
+                  PaletteCellDescription pd = preferences.paletteCellList[i];
+                  preferences.paletteCellList[i].cell = c;
+                  i++;
+                  }
+            }
+      }
+
+//---------------------------------------------------------
+//   init
+//---------------------------------------------------------
+
+void PaletteShortcutManager::init()
+      {
+      localShortcuts.clear();
+      for (const Shortcut* s : Shortcut::shortcuts())
+            localShortcuts[s->key()] = new Shortcut(*s);
+      shortcutsChanged = false;
+
+      int n = preferences.paletteCellList.size();
+      paletteCellList->clear();
+      paletteCellList->setSortingEnabled(false);
+      for (int i = 0; i < n; ++i) {
+            PaletteCellDescription& d = preferences.paletteCellList[i];
+            if (d.cell->name == "Show More") {
+                  continue;
+                  }
+            Shortcut* s = &d.shortcut;
+            if (s->keys().isEmpty())
+                  localShortcuts[s->key()] = new Shortcut(*s);
+            else
+                  localShortcuts[s->key()] = s;
+
+            QString itemName = d.cell->parent->name().replace("&&", "&") + ": " + d.cell->name;
+            QListWidgetItem* item = new QListWidgetItem(itemName,  paletteCellList);
+            item->setFlags(item->flags() | Qt::ItemIsEnabled);
+            item->setData(Qt::UserRole, i);
+            }
+
+      if (n) {
+            paletteCellList->setCurrentRow(0);
+            paletteCellListItemChanged(paletteCellList->item(0), 0);
+            }
+
+      connect(paletteCellList, SIGNAL(itemChanged(QListWidgetItem*)), SLOT(paletteCellLoadToggled(QListWidgetItem*)));
+      connect(paletteCellList, SIGNAL(currentItemChanged(QListWidgetItem*, QListWidgetItem*)),
+          SLOT(paletteCellListItemChanged(QListWidgetItem*, QListWidgetItem*)));
+      }
+
+//---------------------------------------------------------
+//   init1
+//---------------------------------------------------------
+
+void PaletteShortcutManager::init1()
+      {
+      localShortcuts.clear();
+      for (const Shortcut* s : Shortcut::shortcuts())
+            localShortcuts[s->key()] = new Shortcut(*s);
+      shortcutsChanged = false;
+      }
+
+//---------------------------------------------------------
+//   apply
+//---------------------------------------------------------
+
+void PaletteShortcutManager::accept()
+      {
+      if (shortcutsChanged) {
+            shortcutsChanged = false;
+            for (const Shortcut* s : localShortcuts) {
+                  Shortcut* os = Shortcut::getShortcut(s->key());
+                  if (os) {
+                        if (!os->compareKeys(*s))
+                              os->setKeys(s->keys());
+                        }
+                  }
+            Shortcut::dirty = true;
+            }
+      preferences.write();
+      disconnect(paletteCellList, SIGNAL(itemChanged(QListWidgetItem*)));
+      disconnect(paletteCellList, SIGNAL(currentItemChanged(QListWidgetItem*, QListWidgetItem*)));
+      QDialog::accept();
+      }
+
+//---------------------------------------------------------
+//   closeEvent
+//---------------------------------------------------------
+
+void PaletteShortcutManager::closeEvent(QCloseEvent* ev)
+      {
+      emit closed(false);
+      QWidget::closeEvent(ev);
+      }
+
+//---------------------------------------------------------
+//   paletteCellListItemChanged
+//---------------------------------------------------------
+
+void PaletteShortcutManager::paletteCellListItemChanged(QListWidgetItem* item, QListWidgetItem*)
+      {
+      if (!item)
+            return;
+      int idx = item->data(Qt::UserRole).toInt();
+      const PaletteCellDescription& d = preferences.paletteCellList[idx];
+      paletteCellName->setText(d.cell->name);
+      paletteShortcut->setText(d.shortcut.keysToString());
+      paletteCellDescription->setText(d.description);
+      }
+
+//---------------------------------------------------------
+//   definePaletteShortcutClicked
+//---------------------------------------------------------
+
+void PaletteShortcutManager::definePaletteShortcutClicked()
+      {
+      QListWidgetItem* item = paletteCellList->currentItem();
+      if (!item)
+            return;
+      for (Shortcut* s : Shortcut::shortcuts()) {
+            if (s->keys().isEmpty())
+                  localShortcuts[s->key()] = new Shortcut(*s);
+            else
+                  localShortcuts[s->key()] = s;
+            }
+      int idx = item->data(Qt::UserRole).toInt();
+      PaletteCellDescription* pd = &preferences.paletteCellList[idx];
+      Shortcut* s = &pd->shortcut;
+      s->setDescr(pd->description);
+      s->setState(STATE_NORMAL | STATE_NOTE_ENTRY);
+      ShortcutCaptureDialog sc(s, localShortcuts, this);
+      int rv = sc.exec();
+      if (rv == 0)            // abort
+            return;
+      if (rv == 2)            // replace
+            s->clear();
+
+      s->addShortcut(sc.getKey());
+      pd->shortcut = *s;
+      QAction* action = s->action();
+      action->setShortcuts(s->keys());
+      mscore->addAction(action);
+      preferences.paletteCellList[idx] = *pd;
+      mscore->registerPaletteShortcut(pd);
+      bool found = false;
+      for (Palette* p : mscore->getPaletteBox()->palettes()) {
+            for (PaletteCell* c : p->getCells()) {
+                  if (c->id == pd->cell->id) {
+                        c->shortcut = pd->shortcut;
+                        found = true;
+                        break;
+                        }
+                  }
+            if (found)
+                  break;
+            }
+      paletteShortcut->setText(s->keysToString());
+      preferences.dirty = true;
+      }
+
+//---------------------------------------------------------
+//   setShortcut
+//---------------------------------------------------------
+
+void PaletteShortcutManager::setShortcut(PaletteCell* &cell)
+      {
+      if (!cell)
+             return;
+      setIds();
+      cell->shortcut.setState(STATE_NORMAL | STATE_NOTE_ENTRY);
+      ShortcutCaptureDialog sc(&cell->shortcut, localShortcuts, this);
+      int rv = sc.exec();
+      if (rv == 0)            // abort
+            return;
+      if (rv == 2)            // replace
+            cell->shortcut.clear();
+
+      cell->shortcut.addShortcut(sc.getKey());
+      QAction* action = cell->shortcut.action();
+      action->setShortcuts(cell->shortcut.keys());
+      mscore->addAction(action);
+      PaletteCellDescription d;
+      d.cell = cell;
+      d.description = cell->name;
+      d.shortcut = cell->shortcut;
+      d.shortcut.setDescr(cell->name);
+      d.shortcut.setState(STATE_NORMAL | STATE_NOTE_ENTRY);
+      mscore->registerPaletteShortcut(&d);
+
+      PaletteCellDescription* pd = 0;
+      if (cell->id != -1) {
+            pd = &preferences.paletteCellList[cell->id];
+            Q_ASSERT(pd->cell->id == cell->id);
+            }
+      if (pd) {
+            pd->shortcut = cell->shortcut;
+            pd->shortcut.setDescr(cell->name);
+            preferences.paletteCellList[cell->id] = *pd;
+            }
+      paletteShortcut->setText(cell->shortcut.keysToString());
+      preferences.dirty = true;
+      }
+
+//---------------------------------------------------------
+//   clearShortcut
+//---------------------------------------------------------
+
+void PaletteShortcutManager::clearShortcut(PaletteCell* cell)
+      {
+      PaletteCellDescription* pd = 0;
+      if (cell->id != -1) {
+            pd = &preferences.paletteCellList[cell->id];
+            Q_ASSERT(pd->cell->id == cell->id);
+            }
+      if (pd) {
+            pd->shortcut.clear();
+            mscore->unregisterPaletteShortcut(pd);
+            preferences.paletteCellList[cell->id] = *pd;
+            paletteShortcut->setText(pd->shortcut.keysToString());
+            }
+      else {
+            PaletteCellDescription d;
+            d.cell = cell;
+            d.description = cell->name;
+            d.shortcut = cell->shortcut;
+            d.shortcut.setDescr(cell->name);
+            d.shortcut.setState(STATE_NORMAL | STATE_NOTE_ENTRY);
+            mscore->unregisterPaletteShortcut(&d);
+            }
+      }
+
+//---------------------------------------------------------
+//   clearPaletteShortcutClicked
+//---------------------------------------------------------
+
+void PaletteShortcutManager::clearPaletteShortcutClicked()
+      {
+      setIds();
+      QListWidgetItem* item = paletteCellList->currentItem();
+      if (!item)
+            return;
+      int idx = item->data(Qt::UserRole).toInt();
+      PaletteCellDescription* pd = &preferences.paletteCellList[idx];
+      Shortcut* s = &pd->shortcut;
+      s->clear();
+      QAction* action = s->action();
+      action->setShortcuts(s->keys());
+
+      for (Palette* p : mscore->getPaletteBox()->palettes()) {
+            for (PaletteCell* c : p->getCells()) {
+                  if (c->id == pd->cell->id) {
+                        c->shortcut = pd->shortcut;
+                        break;
+                        }
+                  }
+            }
+      paletteShortcut->setText(s->keysToString());
+      preferences.dirty = true;
+      }
+
+//---------------------------------------------------------
+//   writeSettings
+//---------------------------------------------------------
+
+void PaletteShortcutManager::writeSettings()
+      {
+      MuseScore::saveGeometry(this);
+      }
+
+//---------------------------------------------------------
+//   readSettings
+//---------------------------------------------------------
+
+void PaletteShortcutManager::readSettings()
+      {
+      MuseScore::restoreGeometry(this);
+      }
+
+}

--- a/mscore/paletteShortcutManager.h
+++ b/mscore/paletteShortcutManager.h
@@ -1,0 +1,59 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//  $Id: palette.cpp 5576 2012-04-24 19:15:22Z wschweer $
+//
+//  Copyright (C) 2011 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENSE.GPL
+//=============================================================================
+
+#ifndef __PALETTE_SHORTCUT_MANAGER_H__
+#define __PALETTE_SHORTCUT_MANAGER_H__
+
+#include "ui_paletteShortcutManager.h"
+#include "preferences.h"
+#include "palette.h"
+
+namespace Ms {
+
+class Shortcut;
+
+//---------------------------------------------------------
+//   PaletteShortcutManager
+//---------------------------------------------------------
+
+class PaletteShortcutManager : public QDialog, public Ui::PaletteShortcutManager {
+      Q_OBJECT
+
+      QMap<QString, Shortcut*> localShortcuts;
+      bool shortcutsChanged;
+
+      void readSettings();
+      virtual void closeEvent(QCloseEvent*);
+      virtual void accept();
+
+   private slots:
+      void definePaletteShortcutClicked();
+      void clearPaletteShortcutClicked();
+      void paletteCellListItemChanged(QListWidgetItem*, QListWidgetItem*);
+
+   signals:
+      void closed(bool);
+
+   public:
+      PaletteShortcutManager(QWidget* parent = 0);
+      void writeSettings();
+      void init();
+      void init1();
+      void setShortcut(PaletteCell* &cell);
+      void clearShortcut(PaletteCell* c);
+      void setIds();
+      };
+
+
+} // namespace Ms
+#endif

--- a/mscore/paletteShortcutManager.ui
+++ b/mscore/paletteShortcutManager.ui
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PaletteShortcutManager</class>
+ <widget class="QDialog" name="PaletteShortcutManager">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>582</width>
+    <height>382</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Palette Shortcut Manager</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1">
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_19">
+        <property name="text">
+         <string>Name:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2" colspan="2">
+       <widget class="QLineEdit" name="paletteCellName">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QLabel" name="label_30">
+        <property name="text">
+         <string>Shortcut:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2" colspan="2">
+       <widget class="QLineEdit" name="paletteShortcut">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="5">
+       <widget class="QTextBrowser" name="paletteCellDescription">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="5">
+       <layout class="QHBoxLayout" name="horizontalLayout_13">
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="definePaletteShortcut">
+          <property name="text">
+           <string>Define Shortcut</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="clearPaletteShortcut">
+          <property name="text">
+           <string>Clear Shortcut</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_17">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QListWidget" name="paletteCellList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="resizeMode">
+      <enum>QListView::Adjust</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>paletteCellName</tabstop>
+  <tabstop>paletteShortcut</tabstop>
+  <tabstop>paletteCellDescription</tabstop>
+  <tabstop>definePaletteShortcut</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>PaletteShortcutManager</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>PaletteShortcutManager</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/mscore/palettebox.cpp
+++ b/mscore/palettebox.cpp
@@ -17,6 +17,7 @@
 #include "preferences.h"
 #include "libmscore/xml.h"
 #include "workspace.h"
+#include "shortcutcapturedialog.h"
 
 namespace Ms {
 
@@ -379,6 +380,7 @@ QList<Palette*> PaletteBox::palettes()const
 
 bool PaletteBox::read(XmlReader& e)
       {
+      preferences.paletteCellList.clear();
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "Palette") {

--- a/mscore/palettebox.h
+++ b/mscore/palettebox.h
@@ -15,12 +15,14 @@
 #define __PALETTE_BOX_H__
 
 #include "paletteBoxButton.h"
+#include "preferences.h"
 
 namespace Ms {
 
 class XmlWriter;
 class XmlReader;
 class Palette;
+class Shortcut;
 
 //---------------------------------------------------------
 //   PaletteBox

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -689,6 +689,7 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       connect(resetShortcut,  SIGNAL(clicked()), SLOT(resetShortcutClicked()));
       connect(saveShortcutList,  SIGNAL(clicked()), SLOT(saveShortcutListClicked()));
       connect(loadShortcutList,  SIGNAL(clicked()), SLOT(loadShortcutListClicked()));
+      connect(showPaletteShortcutManager,  SIGNAL(clicked()), SLOT(showPaletteShortcutManagerClicked()));
       connect(clearShortcut,  SIGNAL(clicked()), SLOT(clearShortcutClicked()));
       connect(defineShortcut, SIGNAL(clicked()), SLOT(defineShortcutClicked()));
       connect(resetToDefault, SIGNAL(clicked()), SLOT(resetAllValues()));
@@ -1160,6 +1161,11 @@ void PreferenceDialog::loadShortcutListClicked()
             prefs.myShortcutPath = loadFileName;
             Shortcut::loadFromNewFile(loadFileName);
             }
+      }
+
+void PreferenceDialog::showPaletteShortcutManagerClicked()
+      {
+      mscore->showPaletteShortcutManager();
       }
 
 //---------------------------------------------------------

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -28,6 +28,7 @@
 namespace Ms {
 
 extern QString mscoreGlobalShare;
+class PaletteCell;
 
 enum class SessionStart : char {
       EMPTY, LAST, NEW, SCORE
@@ -77,6 +78,16 @@ struct PluginDescription {
       bool load;
       Shortcut shortcut;
       QString menuPath;
+      };
+
+//---------------------------------------------------------
+//   PaletteCellDescription
+//---------------------------------------------------------
+
+struct PaletteCellDescription {
+      QString description;
+      Shortcut shortcut;
+      PaletteCell* cell;
       };
 
 //---------------------------------------------------------
@@ -188,6 +199,9 @@ struct Preferences {
       bool dirty;
 
       QList<PluginDescription> pluginList;
+      QList<PaletteCellDescription> paletteCellList;
+      QList<PaletteCellDescription> paletteCellListBasic;
+      QList<PaletteCellDescription> paletteCellListAdv;
 
       bool readPluginList();
       void writePluginList();

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -61,6 +61,7 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       void resetShortcutClicked();
       void saveShortcutListClicked();
       void loadShortcutListClicked();
+      void showPaletteShortcutManagerClicked();
       void clearShortcutClicked();
       void defineShortcutClicked();
       void portaudioApiActivated(int idx);
@@ -92,6 +93,7 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       PreferenceDialog(QWidget* parent);
       ~PreferenceDialog();
       void setPreferences(const Preferences& p);
+      Preferences getPreferences() { return prefs; }
       void updateRemote();
       };
 

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -3991,6 +3991,19 @@
           </widget>
          </item>
          <item>
+          <widget class="QPushButton" name="showPaletteShortcutManager">
+           <property name="accessibleName">
+            <string>Displays the Palette Shortcut Manager</string>
+           </property>
+           <property name="accessibleDescription">
+            <string>Displays the Palette Shortcut Manager</string>
+           </property>
+           <property name="text">
+            <string>Palette Shortcut Manager</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="clearShortcut">
            <property name="accessibleName">
             <string>Clear</string>

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2783,6 +2783,26 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::MAIN_WINDOW,
+         STATE_ALL,
+         "palette-shortcut-manager",
+         QT_TRANSLATE_NOOP("action", "Palette Shortcut Manager..."),
+         QT_TRANSLATE_NOOP("action", "Palette Shortcut Manager"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::ApplicationShortcut
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_ALL,
+         "set-palette-shortcut",
+         QT_TRANSLATE_NOOP("action", "Set palette shortcut"),
+         QT_TRANSLATE_NOOP("action", "Set palette shortcut"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::ApplicationShortcut
+         },
+      {
+         MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_PLAY | STATE_EDIT | STATE_FOTO,
          "inspector",
          QT_TRANSLATE_NOOP("action","Inspector"),

--- a/mscore/shortcut.h
+++ b/mscore/shortcut.h
@@ -139,6 +139,7 @@ class Shortcut {
       QString descr() const;
       QString text() const;
       QString help() const;
+      void setDescr(QString s) { _descr = s.toUtf8(); }
       MsWidget assignedWidget() const { return _assignedWidget; }
       void clear();           //! remove shortcuts
       void reset();           //! reset to buildin

--- a/mscore/shortcutcapturedialog.cpp
+++ b/mscore/shortcutcapturedialog.cpp
@@ -22,7 +22,9 @@
 #include "shortcutcapturedialog.h"
 #include "musescore.h"
 #include "shortcut.h"
-
+#include "prefsdialog.h"
+#include "palette.h"
+#include "palettebox.h"
 namespace Ms {
 
 //---------------------------------------------------------
@@ -136,6 +138,25 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
       bool conflict = false;
       QString msgString;
 
+      QList<Shortcut*> menuShortcuts;
+      QList<QObject*> ol = mscore->getMenuBar()->children();
+      for (QObject* o : ol) {
+            QMenu* menu = qobject_cast<QMenu*>(o);
+            if (!menu)
+                  continue;
+            QString menuName = (menu->objectName());
+            if (menuName == "Format" || menuName == "Debug" || menuName == "")
+                  continue;
+
+            QString s = (menu->objectName()) + " Menu";
+            QString shortcut = Shortcut::getMenuShortcutString(menu);
+            QKeySequence k = Shortcut::keySeqFromString(shortcut, QKeySequence::PortableText); // check seq format
+            Shortcut* sh = new Shortcut(MsWidget::MAIN_WINDOW, -1, s.toUtf8());
+            sh->setDescr(s);
+            sh->addShortcut(k);
+            menuShortcuts.append(sh);
+            }
+
       for (Shortcut* ss : localShortcuts) {
             if (s == ss)
                   continue;
@@ -155,6 +176,77 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
             for (const QKeySequence& ks : ss->keys()) {
                   if (ks == key) {
                         msgString = tr("Shortcut conflicts with %1").arg(ss->descr());
+                        conflict = true;
+                        break;
+                        }
+                  }
+            if (conflict)
+                  break;
+            }
+
+      for (Shortcut* ss : menuShortcuts) {
+            if (s == ss)
+                  continue;
+            if (!(s->state() & ss->state()))    // no conflict if states do not overlap
+                  continue;
+
+            for (const QKeySequence& ks : ss->keys()) {
+                  if (ks == key) {
+                        msgString = tr("Shortcut conflicts with ") + ss->key();
+                        conflict = true;
+                        break;
+                        }
+                  }
+            if (conflict)
+                  break;
+            }
+
+      for (PaletteCellDescription d : preferences.paletteCellList) {
+            Shortcut* ss = &d.shortcut;
+            if (s == ss)
+                  continue;
+            if (!(s->state() & ss->state()))    // no conflict if states do not overlap
+                  continue;
+
+            for (const QKeySequence& ks : ss->keys()) {
+                  if (ks == key) {
+                        msgString = tr("Shortcut conflicts with ") + ss->descr();
+                        conflict = true;
+                        break;
+                        }
+                  }
+            if (conflict)
+                  break;
+            }
+
+      for (PaletteCellDescription d : preferences.paletteCellListBasic) {
+            Shortcut* ss = &d.shortcut;
+            if (s == ss)
+                  continue;
+            if (!(s->state() & ss->state()))    // no conflict if states do not overlap
+                  continue;
+
+            for (const QKeySequence& ks : ss->keys()) {
+                  if (ks == key) {
+                        msgString = tr("Shortcut conflicts with ") + ss->descr();
+                        conflict = true;
+                        break;
+                        }
+                  }
+            if (conflict)
+                  break;
+            }
+
+      for (PaletteCellDescription d : preferences.paletteCellListAdv) {
+            Shortcut* ss = &d.shortcut;
+            if (s == ss)
+                  continue;
+            if (!(s->state() & ss->state()))    // no conflict if states do not overlap
+                  continue;
+
+            for (const QKeySequence& ks : ss->keys()) {
+                  if (ks == key) {
+                        msgString = tr("Shortcut conflicts with ") + ss->descr();
                         conflict = true;
                         break;
                         }

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -209,8 +209,13 @@ void MuseScore::changeWorkspace(QAction* a)
 
 void MuseScore::changeWorkspace(Workspace* p)
       {
+      if (!p->loaded()) {
+            Workspace::currentWorkspace = p;
+            p->read();
+            return;
+            }
       Workspace::currentWorkspace->save();
-      p->read();
+      p->read1();
       Workspace::currentWorkspace = p;
       }
 
@@ -339,29 +344,16 @@ extern QString readRootFile(MQZipReader*, QList<QString>&);
 
 void Workspace::read()
       {
-      if (_path == "Advanced") {
-            mscore->setAdvancedPalette();
-            for (Palette* p : mscore->getPaletteBox()->palettes())
-                  p->setSystemPalette(true);
-            mscore->setNoteInputMenuEntries(MuseScore::advancedNoteInputMenuEntries());
-            mscore->populateNoteInputMenu();
-            return;
-            }
-      if (_path == "Basic") {
-            mscore->setBasicPalette();
-            for (Palette* p : mscore->getPaletteBox()->palettes())
-                  p->setSystemPalette(true);
-            mscore->setNoteInputMenuEntries(MuseScore::basicNoteInputMenuEntries());
-            mscore->populateNoteInputMenu();
-            return;
-            }
       if (_path.isEmpty() || !QFile(_path).exists()) {
             qDebug("cannot read workspace <%s>", qPrintable(_path));
             mscore->setAdvancedPalette();       // set default palette
             return;
             }
       QFileInfo fi(_path);
-      _readOnly = !fi.isWritable();
+      if (_path == "Basic" || _path == "Advanced")
+            _readOnly = true;
+      else
+            _readOnly = !fi.isWritable();
 
       MQZipReader f(_path);
       QList<QString> images;
@@ -390,6 +382,72 @@ void Workspace::read()
                         }
                   }
             }
+      }
+
+//---------------------------------------------------------
+//   read1
+//---------------------------------------------------------
+
+void Workspace::read1()
+      {
+      if (_path == "Advanced") {
+            mscore->setAdvancedPalette();
+            for (Palette* p : mscore->getPaletteBox()->palettes())
+                  p->setSystemPalette(true);
+            mscore->setNoteInputMenuEntries(MuseScore::advancedNoteInputMenuEntries());
+            mscore->populateNoteInputMenu();
+            _loaded = true;
+            return;
+            }
+      if (_path == "Basic") {
+            mscore->setBasicPalette();
+            for (Palette* p : mscore->getPaletteBox()->palettes())
+                  p->setSystemPalette(true);
+            mscore->setNoteInputMenuEntries(MuseScore::basicNoteInputMenuEntries());
+            mscore->populateNoteInputMenu();
+            _loaded = true;
+            return;
+            }
+      if (_path.isEmpty() || !QFile(_path).exists()) {
+            qDebug("cannot read workspace <%s>", qPrintable(_path));
+            mscore->setAdvancedPalette();       // set default palette
+            return;
+            }
+      QFileInfo fi(_path);
+      if (_path == "Basic" || _path == "Advanced")
+            _readOnly = true;
+      else
+            _readOnly = !fi.isWritable();
+
+      MQZipReader f(_path);
+      QList<QString> images;
+      QString rootfile = readRootFile(&f, images);
+      //
+      // load images
+      //
+      for (const QString& s : images)
+            imageStore.add(s, f.fileData(s));
+
+      if (rootfile.isEmpty()) {
+            qDebug("can't find rootfile in: %s", qPrintable(_path));
+            return;
+            }
+
+      QByteArray ba = f.fileData(rootfile);
+      XmlReader e(gscore, ba);
+
+      while (e.readNextStartElement()) {
+            if (e.name() == "museScore") {
+                  while (e.readNextStartElement()) {
+                        if (e.name() == "Workspace")
+                              read(e);
+                        else
+                              e.unknown();
+                        }
+                  }
+            }
+      if (!_loaded)
+            _loaded = true;
       }
 
 void Workspace::read(XmlReader& e)
@@ -439,6 +497,8 @@ void Workspace::read(XmlReader& e)
             mscore->setNoteInputMenuEntries(mscore->allNoteInputMenuEntries());
             mscore->populateNoteInputMenu();
             }
+      if (!_loaded)
+            _loaded = true;
       }
 
 //---------------------------------------------------------
@@ -447,9 +507,35 @@ void Workspace::read(XmlReader& e)
 
 void Workspace::save()
       {
-      if (_readOnly)
-            return;
       PaletteBox* pb = mscore->getPaletteBox();
+      if (_path == "Basic" && pb) {
+            preferences.paletteCellListBasic.clear();
+            for (Palette* p : pb->palettes()) {
+                  for (PaletteCell* cell : p->getCells()) {
+                        PaletteCellDescription pd;
+                        pd.cell = cell;
+                        pd.description = cell->name;
+                        pd.shortcut = cell->shortcut;
+                        pd.shortcut.setDescr(cell->name);
+                        pd.shortcut.setState(STATE_NORMAL | STATE_NOTE_ENTRY);
+                        preferences.paletteCellListBasic.append(pd);
+                        }
+                  }
+            }
+      else if (_path == "Advanced" && pb) {
+            preferences.paletteCellListAdv.clear();
+            for (Palette* p : pb->palettes()) {
+                  for (PaletteCell* cell : p->getCells()) {
+                        PaletteCellDescription pd;
+                        pd.cell = cell;
+                        pd.description = cell->name;
+                        pd.shortcut = cell->shortcut;
+                        pd.shortcut.setDescr(cell->name);
+                        pd.shortcut.setState(STATE_NORMAL | STATE_NOTE_ENTRY);
+                        preferences.paletteCellListAdv.append(pd);
+                        }
+                  }
+            }
       if (pb)
             write();
       }

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -40,6 +40,7 @@ class Workspace : public QObject {
       QString _path;
       bool _dirty;
       bool _readOnly;
+      bool _loaded { false }; // true if the workspace has been loaded once
 
    public slots:
       void setDirty(bool val = true) { _dirty = val;    }
@@ -59,6 +60,7 @@ class Workspace : public QObject {
       void write();
       void read(XmlReader&);
       void read();
+      void read1();
       bool readOnly() const          { return _readOnly; }
       void setReadOnly(bool val)     { _readOnly = val;  }
 
@@ -68,6 +70,7 @@ class Workspace : public QObject {
       static Workspace* createNewWorkspace(const QString& name);
       static bool workspacesRead;
       static void writeBuiltinWorkspace();
+      bool loaded() { return _loaded; }
       };
 }
 #endif


### PR DESCRIPTION
This pull request adds the ability to assign a shortcut to a palette element.
A new dialog (Palette Shortcut Manager) has been added which displays a list of palette elements in the current workspace along with the shortcut assigned to each element. A shortcut can be defined or cleared using the palette shortcut manager. The palette shortcut manager can be accessed from the preferences dialog, or by using a shortcut command.
A shortcut can also be assigned using the palette cell context menu or a shortcut command which adds a shortcut to the currently selected palette element.
Shortcuts are saved, so a shortcut defined in a session can be used in later sessions.