### PR TITLE
Fix #235516: support .musicxml file extension

### DIFF
--- a/build/Linux+BSD/musescore.xml.in
+++ b/build/Linux+BSD/musescore.xml.in
@@ -12,7 +12,7 @@
   </mime-type>
   <mime-type type="application/vnd.recordare.musicxml@MSCORE_INSTALL_SUFFIX@">
     <!-- http://www.musicxml.com/for-developers/musicxml-dtd/ -->
-    <_comment>MusicXML file</_comment>
+    <_comment>compressed MusicXML file</_comment>
     <sub-class-of type="application/zip"/>
 <!-- Note: a custom icon is used for MusicXML files. You can change this below -->
 <!--  <icon name="application-x-musescore"/> Uncomment to use MuseScore file icon -->
@@ -36,5 +36,23 @@
       </match>
     </magic>
     <glob pattern="*.xml" weight="40"/>
+  </mime-type>
+  <mime-type type="application/vnd.recordare.musicxml@MSCORE_INSTALL_SUFFIX@+xml">
+        <!-- http://www.musicxml.com/for-developers/musicxml-dtd/ -->
+        <_comment>uncompressed MusicXML file</_comment>
+        <sub-class-of type="application/xml"/>
+        <!--  <icon name="application-x-musescore"/> Uncomment to use MuseScore file icon -->
+        <!--  <generic-icon name="audio-x-generic"/> Uncomment to use generic audio file icon -->
+        <magic>
+              <match type="string" value="&lt;?xml" offset="0">
+                    <match type="string" value="score-partwise" offset="0:128"/>
+                    <match type="string" value="score-timewise" offset="0:128"/>
+              </match>
+              <match type="string" value="&lt;!--" offset="0">
+                    <match type="string" value="score-partwise" offset="0:128"/>
+                    <match type="string" value="score-timewise" offset="0:128"/>
+              </match>
+        </magic>
+        <glob pattern="*.musicxml" weight="40"/>
   </mime-type>
 </mime-info>

--- a/build/MacOSXBundleInfo.plist.in
+++ b/build/MacOSXBundleInfo.plist.in
@@ -103,10 +103,28 @@
 		</dict>
 		<dict>
 			<key>CFBundleTypeName</key>
-			<string>MusicXML File</string>
+			<string>Uncompressed MusicXML File</string>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>xml</string>
+			</array>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>application/vnd.recordare.musicxml+xml</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSTypeIsPackage</key>
+			<false/>
+			<key>NSPersistentStoreTypeKey</key>
+			<string>XML</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Uncompressed MusicXML File</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>musicxml</string>
 			</array>
 			<key>CFBundleTypeMIMETypes</key>
 			<array>

--- a/build/packaging/WIX.template.in
+++ b/build/packaging/WIX.template.in
@@ -89,8 +89,9 @@
             <!-- Extend to the "open with" list + Win7 jump menu pinning  -->
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mscz" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mscx" Value="" Type="string" />
-            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mxl" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".xml" Value="" Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".musicxml" Value="" Type="string" />
+            <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".mxl" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".cap" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".capx" Value="" Type="string" />
             <RegistryValue Root="$(var.RegistryRoot)" Key="SOFTWARE\Classes\Applications\$(var.ExeKey)\SupportedTypes" Name=".bww" Value="" Type="string" />

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -269,22 +269,22 @@ void MuseScore::loadFiles()
       {
       QStringList files = getOpenScoreNames(
 #ifdef OMR
-         tr("All Supported Files") + " (*.mscz *.mscx *.xml *.mxl *.mid *.midi *.kar *.md *.mgu *.MGU *.sgu *.SGU *.cap *.capx *.pdf *.ove *.scw *.bww *.GTP *.GP3 *.GP4 *.GP5 *.GPX);;" +
+         tr("All Supported Files") + " (*.mscz *.mscx *.mxl *.musicxml *.xml *.mid *.midi *.kar *.md *.mgu *.sgu *.cap *.capx *.pdf *.ove *.scw *.bww *.gtp *.gp3 *.gp4 *.gp5 *.gpx);;" +
 #else
-         tr("All Supported Files") + " (*.mscz *.mscx *.xml *.mxl *.mid *.midi *.kar *.md *.mgu *.MGU *.sgu *.SGU *.cap *.capx *.ove *.scw *.bww *.GTP *.GP3 *.GP4 *.GP5 *.GPX);;" +
+         tr("All Supported Files") + " (*.mscz *.mscx *.mxl *.musicxml *.xml *.mid *.midi *.kar *.md *.mgu *.sgu *.cap *.capx *.ove *.scw *.bww *.gtp *.gp3 *.gp4 *.gp5 *.gpx);;" +
 #endif
          tr("MuseScore Files") + " (*.mscz *.mscx);;" +
-         tr("MusicXML Files") + " (*.xml *.mxl);;" +
+         tr("MusicXML Files") + " (*.mxl *.musicxml *.xml);;" +
          tr("MIDI Files") + " (*.mid *.midi *.kar);;" +
          tr("Muse Data Files") + " (*.md);;" +
          tr("Capella Files") + " (*.cap *.capx);;" +
-         tr("BB Files <experimental>") + " (*.mgu *.MGU *.sgu *.SGU);;" +
+         tr("BB Files <experimental>") + " (*.mgu *.sgu);;" +
 #ifdef OMR
          tr("PDF Files <experimental OMR>") + " (*.pdf);;" +
 #endif
          tr("Overture / Score Writer Files <experimental>") + " (*.ove *.scw);;" +
          tr("Bagpipe Music Writer Files <experimental>") + " (*.bww);;" +
-         tr("Guitar Pro") + " (*.GTP *.GP3 *.GP4 *.GP5 *.GPX)",
+         tr("Guitar Pro") + " (*.gtp *.gp3 *.gp4 *.gp5 *.gpx)",
          tr("Load Score")
          );
       for (const QString& s : files)
@@ -1601,8 +1601,8 @@ void MuseScore::exportFile()
       fl.append(tr("MP3 Audio") + " (*.mp3)");
 #endif
       fl.append(tr("Standard MIDI File") + " (*.mid)");
-      fl.append(tr("MusicXML File") + " (*.xml)");
       fl.append(tr("Compressed MusicXML File") + " (*.mxl)");
+      fl.append(tr("Uncompressed MusicXML File") + " (*.musicxml)");
       fl.append(tr("Uncompressed MuseScore File") + " (*.mscx)");
 
       QString saveDialogTitle = tr("Export");
@@ -1677,8 +1677,8 @@ bool MuseScore::exportParts()
       fl.append(tr("MP3 Audio") + " (*.mp3)");
 #endif
       fl.append(tr("Standard MIDI File") + " (*.mid)");
-      fl.append(tr("MusicXML File") + " (*.xml)");
       fl.append(tr("Compressed MusicXML File") + " (*.mxl)");
+      fl.append(tr("Uncompressed MusicXML File") + " (*.musicxml)");
       fl.append(tr("MuseScore File") + " (*.mscz)");
       fl.append(tr("Uncompressed MuseScore File") + " (*.mscx)");
 
@@ -1846,8 +1846,8 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy, const QString& path, const QStr
                   writeSessionFile(false);
                   }
             }
-      else if (ext == "xml") {
-            // save as MusicXML *.xml file
+      else if (ext == "musicxml") {
+            // save as MusicXML *.musicxml file
             rv = saveXml(cs, fn);
             }
       else if (ext == "mxl") {
@@ -2120,6 +2120,7 @@ Score::FileError readScore(MasterScore* score, QString name, bool ignoreVersionE
                   };
             static const ImportDef imports[] = {
                   { "xml",  &importMusicXml           },
+                  { "musicxml", &importMusicXml       },
                   { "mxl",  &importCompressedMusicXml },
                   { "mid",  &importMidi               },
                   { "midi", &importMidi               },

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2602,7 +2602,7 @@ static bool doConvert(Score* cs, QString fn, QString plugin = "")
                   return false;
             return true;
             }
-      else if (fn.endsWith(".xml")) {
+      else if (fn.endsWith(".xml") || fn.endsWith(".musicxml")) {
             rv = saveXml(cs, fn);
             }
       else if (fn.endsWith(".mxl")) {

--- a/mscore/startcenter.cpp
+++ b/mscore/startcenter.cpp
@@ -249,7 +249,8 @@ void MyWebView::link(const QUrl& url)
       {
       QString path(url.path());
       QFileInfo fi(path);
-      if (fi.suffix() == "mscz" || fi.suffix() == "xml" || fi.suffix() == "mxl") {
+      if (fi.suffix() == "mscz" || fi.suffix() == "xml"
+          || fi.suffix() == "musicxml" || fi.suffix() == "mxl") {
             mscore->loadFile(url);
             QAction* a = getAction("startcenter");
             a->setChecked(false);

--- a/mscore/webpage.cpp
+++ b/mscore/webpage.cpp
@@ -197,7 +197,8 @@ void MyWebView::link(const QUrl& url)
       {
       QString path(url.path());
       QFileInfo fi(path);
-      if (fi.suffix() == "mscz" || fi.suffix() == "xml" || fi.suffix() == "mxl")
+      if (fi.suffix() == "mscz" || fi.suffix() == "xml"
+          || fi.suffix() == "musicxml" || fi.suffix() == "mxl")
             mscore->loadFile(url);
       else if(url.host().startsWith("connect."))
             load(QNetworkRequest(url));

--- a/mtest/testutils.cpp
+++ b/mtest/testutils.cpp
@@ -160,7 +160,7 @@ MasterScore* MTest::readCreatedScore(const QString& name)
       else if (csl == "pdf")
             rv = importPdf(score, name);
 #endif
-      else if (csl == "xml")
+      else if (csl == "xml" || csl == "musicxml")
             rv = importMusicXml(score, name);
       else if (csl == "gp3" || csl == "gp4" || csl == "gp5" || csl == "gpx")
             rv = importGTP(score, name);


### PR DESCRIPTION
Choice to label .musicxml files as "MusicXML 3.1+" is debatable, as is allowing exporting with that extension; also, uncertain how to make sure that extension is associated with MuseScore on Windows.

While at it, also making extensions listed in load dialog all lowercase.