### PR TITLE
fix #195891: score information too big for small screens

### DIFF
--- a/mscore/uploadscoredialog.cpp
+++ b/mscore/uploadscoredialog.cpp
@@ -69,15 +69,15 @@ UploadScoreDialog::UploadScoreDialog(LoginManager* loginManager)
                            .arg("</a>"));
       QFont font = licenseHelp->font();
       font.setPointSize(8);
+      font.setItalic(true);
       licenseHelp->setFont(font);
+      font.setItalic(false);
 
       privateHelp->setText(tr("Respect the %1community guidelines%2. Only make your scores accessible to anyone with permission from the right holders.")
                            .arg("<a href=\"https://musescore.com/community-guidelines\">")
                            .arg("</a>"));
       privateHelp->setFont(font);
 
-      tagsHelp->setText(tr("Use a comma to separate the tags"));
-      tagsHelp->setFont(font);
       uploadAudioHelp->setFont(font);
       QString urlHelp = QString("https://musescore.org/redirect/handbook?chapter=upload-score-audio&locale=%1&utm_source=desktop&utm_medium=save-online&utm_content=%2&utm_term=upload-score-audio&utm_campaign=MuseScore%3")
          .arg(mscore->getLocaleISOCode())
@@ -93,7 +93,7 @@ UploadScoreDialog::UploadScoreDialog(LoginManager* loginManager)
       connect(updateExistingCb, SIGNAL(toggled(bool)), changes, SLOT(setVisible(bool)));
 
       connect(buttonBox,   SIGNAL(clicked(QAbstractButton*)), SLOT(buttonBoxClicked(QAbstractButton*)));
-      chkSignoutOnExit->setVisible(false);
+      chkSignoutOnExit->setVisible(false); // currently unused, so hide it
       _loginManager = loginManager;
       connect(_loginManager, SIGNAL(uploadSuccess(QString, QString, QString)), this, SLOT(uploadSuccess(QString, QString, QString)));
       connect(_loginManager, SIGNAL(uploadError(QString)), this, SLOT(uploadError(QString)));
@@ -211,7 +211,7 @@ void UploadScoreDialog::display()
             if (sl.length() > 0) {
                   QString nidString = sl.last();
                   bool ok;
-			int nid = nidString.toInt(&ok);
+                  int nid = nidString.toInt(&ok);
                   if (ok) {
                          _nid = nid;
                          _loginManager->getScore(nid);
@@ -233,6 +233,10 @@ void UploadScoreDialog::onGetScoreSuccess(const QString &t, const QString &desc,
       // file with score info
       title->setText(t);
       description->setPlainText(desc);
+      QScreen* screen      = QGuiApplication::primaryScreen();
+      const QSize screenSize = screen->availableVirtualSize();
+      if (screenSize.height() / guiScaling < 768)
+            description->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContentsOnFirstShow);
       cbPrivate->setChecked(priv);
       // publicdomain used to be an option. Not anymore. Remap to CC0
       QString lice = lic;
@@ -243,6 +247,8 @@ void UploadScoreDialog::onGetScoreSuccess(const QString &t, const QString &desc,
       license->setCurrentIndex(lIndex);
       tags->setText(tag);
       changes->clear();
+      if (screenSize.height() / guiScaling < 800)
+            changes->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContentsOnFirstShow);
       updateExistingCb->setChecked(true);
       updateExistingCb->setVisible(true);
       linkToScore->setText(tr("[%1Link%2]")

--- a/mscore/uploadscoredialog.ui
+++ b/mscore/uploadscoredialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>615</width>
-    <height>644</height>
+    <height>492</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,17 +17,8 @@
    <bool>true</bool>
   </property>
   <layout class="QFormLayout" name="formLayout_2">
-   <property name="fieldGrowthPolicy">
-    <enum>QFormLayout::FieldsStayAtSizeHint</enum>
-   </property>
-   <property name="verticalSpacing">
-    <number>12</number>
-   </property>
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
      <item>
       <widget class="QLabel" name="label_3">
        <property name="text">
@@ -44,7 +35,7 @@
         </font>
        </property>
        <property name="text">
-        <string>USERNAME</string>
+        <string notr="true" extracomment="Placeholder, gets set programatically">USERNAME</string>
        </property>
       </widget>
      </item>
@@ -79,12 +70,6 @@
    </item>
    <item row="1" column="0" colspan="2">
     <layout class="QVBoxLayout" name="verticalLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="sizeConstraint">
-      <enum>QLayout::SetMaximumSize</enum>
-     </property>
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <property name="spacing">
@@ -92,23 +77,13 @@
        </property>
        <item>
         <widget class="QLabel" name="lblTitle">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
          <property name="text">
           <string>Title:</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="title">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
+        <widget class="QLineEdit" name="title"/>
        </item>
       </layout>
      </item>
@@ -125,49 +100,30 @@
         </widget>
        </item>
        <item>
-        <widget class="QPlainTextEdit" name="description">
-         <property name="locale">
-          <locale language="English" country="UnitedStates"/>
-         </property>
-         <property name="plainText">
-          <string notr="true"/>
-         </property>
-        </widget>
+        <widget class="QPlainTextEdit" name="description"/>
        </item>
       </layout>
      </item>
      <item>
       <layout class="QFormLayout" name="formLayout">
-       <property name="fieldGrowthPolicy">
-        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-       </property>
-       <property name="labelAlignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="horizontalSpacing">
-        <number>6</number>
-       </property>
        <property name="verticalSpacing">
         <number>0</number>
        </property>
        <item row="0" column="0" colspan="2">
         <widget class="QCheckBox" name="cbPrivate">
          <property name="text">
-          <string>Make this score private</string>
+          <string>Keep this score private</string>
          </property>
         </widget>
        </item>
        <item row="1" column="0" colspan="2">
         <widget class="QLabel" name="privateHelp">
          <property name="text">
-          <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+          <string notr="true" extracomment="Placeholder, gets set and translated programatically">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Respect the &lt;/span&gt;&lt;a href=&quot;https://musescore.com/community-guidelines&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#0000ff;&quot;&gt;community guidelines&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;. Only make your scores accessible to anyone with permission from the right holders.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -179,9 +135,6 @@ p, li { white-space: pre-wrap; }
        </item>
        <item row="5" column="0">
         <widget class="QLabel" name="lblLicense">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -200,11 +153,7 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item row="5" column="1">
-        <widget class="QComboBox" name="license">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-        </widget>
+        <widget class="QComboBox" name="license"/>
        </item>
        <item row="6" column="1">
         <widget class="QLabel" name="licenseHelp">
@@ -215,20 +164,13 @@ p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://redirect.musescore.com/help/license&quot;&gt;&lt;span style=&quot; font-style:italic; text-decoration: underline; color:#0000ff;&quot;&gt;What does this mean?&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
          <property name="openExternalLinks">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item row="7" column="0">
-        <widget class="QLabel" name="label_spacer_2">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
+        <widget class="QLabel" name="label_spacer_2"/>
        </item>
        <item row="8" column="0">
         <widget class="QLabel" name="lblTag">
@@ -247,20 +189,10 @@ p, li { white-space: pre-wrap; }
          <property name="text">
           <string>Tags:</string>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
         </widget>
        </item>
        <item row="8" column="1">
-        <widget class="QLineEdit" name="tags">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
+        <widget class="QLineEdit" name="tags"/>
        </item>
        <item row="9" column="1">
         <widget class="QLabel" name="tagsHelp">
@@ -275,18 +207,10 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item row="10" column="0">
-        <widget class="QLabel" name="label_spacer_3">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
+        <widget class="QLabel" name="label_spacer_3"/>
        </item>
        <item row="4" column="0">
-        <widget class="QLabel" name="label_spacer">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
+        <widget class="QLabel" name="label_spacer"/>
        </item>
       </layout>
      </item>
@@ -314,9 +238,6 @@ p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Render the score with the current synth settings, and upload it to MuseScore.com. &lt;/span&gt;&lt;a href=&quot;https://musescore.com/community-guidelines&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#0000ff;&quot;&gt;More help.&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
          <property name="wordWrap">
           <bool>true</bool>
          </property>
@@ -332,14 +253,14 @@ p, li { white-space: pre-wrap; }
        <item row="0" column="0">
         <widget class="QCheckBox" name="updateExistingCb">
          <property name="text">
-          <string>Update the existing score</string>
+          <string>Update existing score</string>
          </property>
         </widget>
        </item>
        <item row="0" column="1">
         <widget class="QLabel" name="linkToScore">
          <property name="text">
-          <string notr="true" extracomment="Hyperlink, gets set/unset programatically">Link</string>
+          <string notr="true" extracomment="Hyperlink, gets set/unset programatically">[Link]</string>
          </property>
          <property name="openExternalLinks">
           <bool>true</bool>
@@ -350,6 +271,9 @@ p, li { white-space: pre-wrap; }
      </item>
      <item>
       <layout class="QVBoxLayout" name="vlChanges">
+       <property name="spacing">
+        <number>0</number>
+       </property>
        <item>
         <widget class="QLabel" name="lblChanges">
          <property name="text">
@@ -358,7 +282,7 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item>
-        <widget class="QTextEdit" name="changes"/>
+        <widget class="QPlainTextEdit" name="changes"/>
        </item>
       </layout>
      </item>
@@ -366,14 +290,8 @@ p, li { white-space: pre-wrap; }
    </item>
    <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
and some simplifications and minor corrections to the dialog.

Meant as a possible alternative to #3260, but making the dialog smaller only when running on a too small screen