### PR TITLE
Fix #243656: Warnings/Errors from lupdate

### DIFF
--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -424,7 +424,7 @@ QQmlEngine* MScore::qml()
             qmlRegisterType<FileIO, 1>  ("FileIO",    3, 0, "FileIO");
             //-----------mscore bindings
             qmlRegisterUncreatableMetaObject(Ms::staticMetaObject, "MuseScore", 3, 0, "Ms", enumErr);
-//            qmlRegisterUncreatableType<Direction>("MuseScore", 3, 0, "Direction", tr(enumErr));
+//            qmlRegisterUncreatableType<Direction>("MuseScore", 3, 0, "Direction", QObject::tr(enumErr));
 
             qmlRegisterType<MScore>     ("MuseScore", 3, 0, "MScore");
             qmlRegisterType<MsScoreView>("MuseScore", 3, 0, "ScoreView");
@@ -464,7 +464,7 @@ QQmlEngine* MScore::qml()
 
 
             //classed enumerations
-            qmlRegisterUncreatableType<MSQE_StyledPropertyListIdx>("MuseScore", 1, 0, "StyledPropertyListIdx", tr("You can't create an enum"));
+            qmlRegisterUncreatableType<MSQE_StyledPropertyListIdx>("MuseScore", 1, 0, "StyledPropertyListIdx", QObject::tr("You can't create an enum"));
             qmlRegisterUncreatableType<MSQE_BarLineType>("MuseScore", 1, 0, "BarLineType", enumErr);
 
             //-----------virtual classes

--- a/mscore/editdrumset.cpp
+++ b/mscore/editdrumset.cpp
@@ -92,7 +92,7 @@ EditDrumset::EditDrumset(const Drumset* ds, QWidget* parent)
 
       updateList();
 
-      noteHead->addItem(tr("invalid"));
+      noteHead->addItem(QObject::tr("invalid"));
       for (auto g : noteHeadNames)
             noteHead->addItem(NoteHead::group2userName(g), int(g));
 

--- a/mscore/inspector/inspectorTextLine.cpp
+++ b/mscore/inspector/inspectorTextLine.cpp
@@ -24,9 +24,9 @@ namespace Ms {
 void populateHookType(QComboBox* b)
       {
       b->clear();
-      b->addItem(b->tr("None"), int(HookType::NONE));
-      b->addItem(b->tr("90°"), int(HookType::HOOK_90));
-      b->addItem(b->tr("45°"), int(HookType::HOOK_45));
+      b->addItem(b->QObject::tr("None"), int(HookType::NONE));
+      b->addItem(b->QObject::tr("90°"), int(HookType::HOOK_90));
+      b->addItem(b->QObject::tr("45°"), int(HookType::HOOK_45));
       }
 
 //---------------------------------------------------------
@@ -36,10 +36,10 @@ void populateHookType(QComboBox* b)
 void populateTextPlace(QComboBox* b)
       {
       b->clear();
-      b->addItem(b->tr("Auto"),  int(PlaceText::AUTO));
-      b->addItem(b->tr("Above"), int(PlaceText::ABOVE));
-      b->addItem(b->tr("Below"), int(PlaceText::BELOW));
-      b->addItem(b->tr("Left"),  int(PlaceText::LEFT));
+      b->addItem(b->QObject::tr("Auto"),  int(PlaceText::AUTO));
+      b->addItem(b->QObject::tr("Above"), int(PlaceText::ABOVE));
+      b->addItem(b->QObject::tr("Below"), int(PlaceText::BELOW));
+      b->addItem(b->QObject::tr("Left"),  int(PlaceText::LEFT));
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
All but one, which I can't figure out:
 [.../MuseScore/libmscore/durationtype.cpp:787](https://github.com/musescore/MuseScore/blob/ae60d402c38c60941dbb37848baeb991ef314699/libmscore/durationtype.cpp#L787): Qualifying with unknown namespace/class ::TDuration

Not sure how much of this, if anything, would apply to 2.2 too.