### PR TITLE
master palette navigation and template navigation

### DIFF
--- a/mscore/keyedit.h
+++ b/mscore/keyedit.h
@@ -49,6 +49,7 @@ class KeyEditor : public QWidget, Ui::KeyEdit {
       KeyEditor(QWidget* parent = 0);
       bool dirty() const { return _dirty; }
       void save();
+      Palette* getPalette() { return sp; }
       };
 
 

--- a/mscore/masterpalette.cpp
+++ b/mscore/masterpalette.cpp
@@ -36,7 +36,7 @@
 #include "libmscore/note.h"
 #include "libmscore/tremolo.h"
 #include "libmscore/chordline.h"
-
+#include "palettebox.h"
 #include "timedialog.h"
 
 namespace Ms {
@@ -248,6 +248,8 @@ void MasterPalette::closeEvent(QCloseEvent* ev)
             timeDialog->save();
       if (keyEditor->dirty())
             keyEditor->save();
+      PaletteBox* pb = mscore->getPaletteBox();
+      pb->setKeyboardNavigation(false);
       emit closed(false);
       QWidget::closeEvent(ev);
       }
@@ -263,5 +265,132 @@ void MasterPalette::changeEvent(QEvent *event)
             retranslate();
       }
 
+//---------------------------------------------------------
+//   keyPressEvent
+//---------------------------------------------------------
+
+void MasterPalette::keyPressEvent(QKeyEvent *event)
+      {
+      QTreeWidgetItem* currentItem = treeWidget->currentItem();
+      int idx = treeWidget->indexOfTopLevelItem(currentItem);
+      QString s = currentItem->text(0);
+      if (event->key() == Qt::Key_Down) {
+            if (idx >= 0 && idx < treeWidget->topLevelItemCount() - 1) {
+                  selectItem(treeWidget->topLevelItem(idx+1)->text(0));
+                  } 
+            else if (idx == treeWidget->topLevelItemCount() - 1) {
+                  if (!currentItem->isExpanded())
+                        selectItem(treeWidget->topLevelItem(0)->text(0));
+                  else
+                        treeWidget->setCurrentItem(symbolItem->child(0));
+                  }
+            else {
+                  int i;
+                  for (i = 0; i < symbolItem->childCount(); i++) {
+                        if (symbolItem->child(i) == currentItem)
+                              break;
+                        }
+                  if (i < symbolItem->childCount()-1) {
+                        treeWidget->setCurrentItem(symbolItem->child(i+1));
+                        }
+                  else {
+                        selectItem(treeWidget->topLevelItem(0)->text(0));
+                        }
+                  }
+            }
+      else if (event->key() == Qt::Key_Up) {
+            if (idx > 0)
+                  selectItem(treeWidget->topLevelItem(idx-1)->text(0));
+            else if (idx == 0)
+                  selectItem(treeWidget->topLevelItem(treeWidget->topLevelItemCount() - 1)->text(0));
+            else {
+                  int i;
+                  for (i = 0; i < symbolItem->childCount(); i++) {
+                        if (symbolItem->child(i) == currentItem)
+                              break;
+                        }
+                  if (i > 0) {
+                        treeWidget->setCurrentItem(symbolItem->child(i-1));
+                        }
+                  else {
+                        selectItem(treeWidget->topLevelItem(treeWidget->topLevelItemCount() - 1)->text(0));
+                        }
+                }
+            }
+      else if (event->key() == Qt::Key_Right) {
+            QWidget* w = stack->currentWidget();
+            QWidget* ch = w->childAt(1, 1);
+            if (ch) {
+                  Palette* chp = static_cast<Palette*>(ch);
+                  chp->setSelected(0);
+                  chp->update();
+                  chp->setFocus();
+                  }
+            else {
+                  if (stack->currentIndex() == 1) {
+                        KeyEditor* k = static_cast<KeyEditor*>(w);
+                        Palette* p = k->getPalette();
+                        p->setSelected(0);
+                        p->update();
+                        p->setFocus();
+                        }
+                  else if (stack->currentIndex() == 2) {
+                        TimeDialog* t = static_cast<TimeDialog*>(w);
+                        Palette* p = t->getPalette();
+                        p->setSelected(0);
+                        p->update();
+                        p->setFocus();
+                        }
+                  else if (stack->currentIndex() >= 24) {
+                        SymbolDialog* s = static_cast<SymbolDialog*>(w);
+                        Palette* p = s->getPalette();
+                        p->setSelected(0);
+                        p->update();
+                        p->setFocus();
+                        }
+                  }
+            return;
+            }
+      else if (event->key() == Qt::Key_Left) {
+            QWidget* w = stack->currentWidget();
+            QWidget* ch = w->childAt(1, 1);         
+            if (ch) {
+                  Palette* chp = static_cast<Palette*>(ch);
+                  chp->setSelected(chp->size() - 1);
+                  chp->update();
+                  chp->setFocus();
+                  }
+            else {
+                  if (stack->currentIndex() == 1) {
+                        KeyEditor* k = static_cast<KeyEditor*>(w);
+                        Palette* p = k->getPalette();
+                        p->setSelected(p->size() - 1);
+                        p->update();
+                        p->setFocus();
+                        }
+                  else if (stack->currentIndex() == 2) {
+                        TimeDialog* t = static_cast<TimeDialog*>(w);
+                        Palette* p = t->getPalette();
+                        p->setSelected(p->size() - 1);
+                        p->update();
+                        p->setFocus();
+                        }
+                  else if (stack->currentIndex() >= 24) {
+                        SymbolDialog* s = static_cast<SymbolDialog*>(w);
+                        Palette* p = s->getPalette();
+                        p->setSelected(p->size() - 1);
+                        p->update();
+                        p->setFocus();
+                        }
+                  }
+            return;
+            }
+      else if (event->key() == Qt::Key_Enter ||
+               event->key() == Qt::Key_Return) {
+          if (idx == 24)
+                clicked(treeWidget->topLevelItem(idx), 0);
+          }
+      QWidget::keyPressEvent(event);
+      }
 }
 

--- a/mscore/masterpalette.h
+++ b/mscore/masterpalette.h
@@ -55,6 +55,7 @@ class MasterPalette : public QWidget, Ui::MasterPalette
       MasterPalette(QWidget* parent = 0);
       void selectItem(const QString& s);
       QString selectedItem();
+      virtual void keyPressEvent(QKeyEvent *event) override;
       };
 
 } // namespace Ms

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -37,6 +37,7 @@
 #include "selectionwindow.h"
 #include "palette.h"
 #include "palettebox.h"
+#include "masterpalette.h"
 #include "libmscore/part.h"
 #include "libmscore/drumset.h"
 #include "libmscore/instrtemplate.h"

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -723,6 +723,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       static Palette* newLinesPalette(PaletteType);
       static Palette* newFretboardDiagramPalette();
 
+      MasterPalette* getMasterPalette() {return masterPalette; }
       Inspector* inspector()           { return _inspector; }
       PluginCreator* pluginCreator()   { return _pluginCreator; }
       ScoreView* currentScoreView() const { return cv; }
@@ -731,6 +732,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void showHelp(QString);
       void showContextHelp();
       void showHelp(const QUrl&);
+      Startcenter* getStartCenter() { return startcenter; }
+      NewWizard* getNewWizard() { return newWizard; }
 
       void registerPlugin(PluginDescription*);
       void unregisterPlugin(PluginDescription*);

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -314,6 +314,8 @@ NewWizardPage4::NewWizardPage4(QWidget* parent)
 void NewWizardPage4::initializePage()
       {
       templateFileBrowser->show();
+      templateFileBrowser->selectFirst();
+      templateFileBrowser->update();
       path.clear();
       }
 
@@ -379,6 +381,7 @@ NewWizardPage5::NewWizardPage5(QWidget* parent)
       sp->setSelectable(true);
       sp->setDisableDoubleClick(true);
       sp->setSelected(14);
+      sp->setNewScoreWizardFlag(true);
       PaletteScrollArea* sa = new PaletteScrollArea(sp);
       QVBoxLayout* l1 = new QVBoxLayout;
       l1->addWidget(sa);

--- a/mscore/newwizard.h
+++ b/mscore/newwizard.h
@@ -145,6 +145,7 @@ class NewWizardPage4 : public QWizardPage {
       virtual bool isComplete() const override;
       QString templatePath() const;
       virtual void initializePage();
+      ScoreBrowser* getTemplateFileBrowser() { return templateFileBrowser; }
       };
 
 //---------------------------------------------------------
@@ -207,6 +208,7 @@ class NewWizard : public QWizard {
       double tempo() const                { return p5->tempo();       }
       bool createTempo() const            { return p5->createTempo(); }
       bool emptyScore() const;
+      ScoreBrowser* getTemplateFileBrowser() { return p4->getTemplateFileBrowser(); }
       };
 
 

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -45,6 +45,7 @@
 #include "libmscore/slur.h"
 #include "paletteBoxButton.h"
 #include "palettebox.h"
+#include "masterpalette.h"
 
 namespace Ms {
 
@@ -687,6 +688,8 @@ void PaletteScrollArea::keyPressEvent(QKeyEvent* event)
       {
       QWidget* w = this->widget();
       Palette* p = static_cast<Palette*>(w);
+      bool newScoreWizard = p->newScoreWizardFlag();
+
       if (event->key() == Qt::Key_Right) {
             int i = p->getSelectedIdx();
             if (i == -1)
@@ -710,6 +713,29 @@ void PaletteScrollArea::keyPressEvent(QKeyEvent* event)
                   p->setSelected(p->size()-1);
 
             p->update();
+            }
+      else if ((event->key() == Qt::Key_Down || event->key() == Qt::Key_Up)
+               && !newScoreWizard) {
+            p->setCurrentIdx(-1);
+            if (p->name() == "Time Signatures")
+                  p->setSelected(2);
+            else
+                  p->setSelected(-1);
+            update();
+            MasterPalette* mp = mscore->getMasterPalette();
+            mp->setFocus();
+            mp->keyPressEvent(event);
+            }
+      else if ((event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return)
+               && !newScoreWizard) {
+            Score* score = mscore->currentScore();
+            if (score == 0)
+                  return;
+            const Selection& sel = score->selection();
+            if (sel.isNone())
+                  return;
+            // apply currently selected palette symbol to selected score elements
+            p->applyPaletteElement(p->cellAt(p->getSelectedIdx()));
             }
       QScrollArea::keyPressEvent(event);
       }

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -129,6 +129,7 @@ class Palette : public QWidget {
 
       bool _moreElements;
       bool _showContextMenu { true };
+      bool newScoreWizard { false };  // true if it is in new score wizard
 
       virtual void paintEvent(QPaintEvent*) override;
       virtual void mousePressEvent(QMouseEvent*) override;
@@ -137,7 +138,6 @@ class Palette : public QWidget {
       virtual void leaveEvent(QEvent*) override;
       virtual bool event(QEvent*) override;
       virtual void resizeEvent(QResizeEvent*) override;
-      void applyPaletteElement(PaletteCell* cell);
 
       virtual void dragEnterEvent(QDragEnterEvent*) override;
       virtual void dragMoveEvent(QDragMoveEvent*) override;
@@ -166,6 +166,7 @@ class Palette : public QWidget {
       void nextPaletteElement();
       void prevPaletteElement();
       void applyPaletteElement();
+      void applyPaletteElement(PaletteCell* p);
       PaletteCell* append(Element*, const QString& name, QString tag = QString(),
          qreal mag = 1.0);
       PaletteCell* add(int idx, Element*, const QString& name,
@@ -215,9 +216,12 @@ class Palette : public QWidget {
       void setCurrentIdx(int i) { currentIdx = i; }
       bool isFilterActive() { return filterActive == true; }
       QList<PaletteCell*> getDragCells() { return dragCells; }
+      QList<PaletteCell*>getCells() { return cells; }
       virtual int heightForWidth(int) const;
       virtual QSize sizeHint() const;
       int idx(const QPoint&) const;
+      bool newScoreWizardFlag() { return newScoreWizard; }
+      void setNewScoreWizardFlag(bool v) { newScoreWizard = v; }
       };
 
 

--- a/mscore/scoreBrowser.cpp
+++ b/mscore/scoreBrowser.cpp
@@ -1,4 +1,4 @@
-//=============================================================================
+﻿//=============================================================================
 //  MuseScore
 //  Music Composition & Notation
 //
@@ -14,6 +14,7 @@
 #include "musescore.h"
 #include "icons.h"
 #include "libmscore/score.h"
+#include "startcenter.h"
 
 namespace Ms {
 
@@ -65,6 +66,7 @@ ScoreBrowser::ScoreBrowser(QWidget* parent)
       _noMatchedScoresLabel = new QLabel(tr("There are no templates matching the current search."));
       _noMatchedScoresLabel->setHidden(true);
       scoreList->layout()->addWidget(_noMatchedScoresLabel);
+      setFocusPolicy(Qt::StrongFocus);
       connect(preview, SIGNAL(doubleClicked(QString)), SIGNAL(scoreActivated(QString)));
       if (!_showPreview)
             preview->setVisible(false);
@@ -94,8 +96,9 @@ ScoreListWidget* ScoreBrowser::createScoreList()
       sl->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
       sl->setLayoutMode(QListView::SinglePass);
       sl->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
+      sl->setAcceptDrops(true);
       if (!_showPreview)
-            sl->setSelectionMode(QAbstractItemView::NoSelection);
+            sl->setSelectionMode(QAbstractItemView::SingleSelection);
 
       connect(sl, SIGNAL(itemClicked(QListWidgetItem*)),   this, SLOT(scoreChanged(QListWidgetItem*)), Qt::QueuedConnection);
       connect(sl, SIGNAL(itemActivated(QListWidgetItem*)), SLOT(setScoreActivated(QListWidgetItem*)));
@@ -177,6 +180,7 @@ void ScoreBrowser::setScores(QFileInfoList& s)
       scoreLists.clear();
 
       QVBoxLayout* l = static_cast<QVBoxLayout*>(scoreList->layout());
+      scoreList->setAcceptDrops(true);
       while (l->count())
             l->removeItem(l->itemAt(0));
 
@@ -252,9 +256,13 @@ void ScoreBrowser::selectFirst()
       ScoreListWidget* w = scoreLists.front();
       if (w->count() == 0)
             return;
+      for (ScoreListWidget* s : scoreLists) {
+            s->setCurrentRow(-1);
+            }
       ScoreItem* item = static_cast<ScoreItem*>(w->item(0));
       w->setCurrentItem(item);
       preview->setScore(item->info());
+      emit scoreSelected(item->info().filePath());
       }
 
 //---------------------------------------------------------
@@ -341,6 +349,180 @@ void ScoreBrowser::setScoreActivated(QListWidgetItem* val)
       {
       ScoreItem* item = static_cast<ScoreItem*>(val);
       emit scoreActivated(item->info().filePath());
+      }
+
+//---------------------------------------------------------
+//   focusNextPrevChild
+//---------------------------------------------------------
+
+bool ScoreBrowser::focusNextPrevChild(bool next)
+      {
+      Q_UNUSED(next);
+      return false; // disable tab action during template navigation
+      }
+
+void ScoreListWidget::keyPressEvent(QKeyEvent* event)
+      {
+      int idx = mscore->getNewWizard()->getTemplateFileBrowser()->getScoreLists().indexOf(this);
+      if (idx == 7)
+            setCurrentRow(-1);
+      mscore->getNewWizard()->getTemplateFileBrowser()->keyPressEvent(event);
+      }
+
+//---------------------------------------------------------
+//   keyPressEvent
+//---------------------------------------------------------
+
+void ScoreBrowser::keyPressEvent(QKeyEvent* event)
+      {
+      QWidget* wFocus = QApplication::focusWidget();
+      if (wFocus == 0)
+            return;
+      const char* classname = wFocus->metaObject()->className();
+      if (strcmp(classname, "Ms::ScoreBrowser") != 0) {
+            this->setFocus();
+            //return;
+            }
+      ScoreBrowser* sc = static_cast<ScoreBrowser*>(wFocus);
+      if (!sc)
+            return;
+      int s = this->scoreLists.size();
+      if (s == 1) { // if focus is on start center
+          if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) {
+                Startcenter* sc = mscore->getStartCenter();
+                sc->newScoreOnEnter();
+                return;
+                }
+      }
+      ScoreListWidget* currentWidget = scoreLists.front();
+      int index = -1, idx = -1;
+      for (int i = 0; i < scoreLists.size(); i++) {
+            ScoreListWidget* w = scoreLists[i];
+            if (w->currentRow() != -1) {
+                  currentWidget = w;
+                  idx = i;
+                  index = w->currentRow();
+            }
+      }
+      ScoreItem* current = static_cast<ScoreItem*>(currentWidget->currentItem());
+      if (event->key() == Qt::Key_Right) {
+            ScoreItem* item;
+            if (index == -1) {
+                  item = static_cast<ScoreItem*>(currentWidget->item(0));
+                  currentWidget->setCurrentItem(item);
+                  currentWidget->setCurrentRow(0);
+                  }
+            else if (index < currentWidget->count() - 1){
+                  item = static_cast<ScoreItem*>(currentWidget->item(index + 1));
+                  currentWidget->setCurrentItem(item);
+                  currentWidget->setCurrentRow(index + 1);
+                  }
+            else {
+                  if (idx < scoreLists.size() - 1) {
+                        ScoreListWidget* next = scoreLists[idx + 1];
+                        item = static_cast<ScoreItem*>(next->item(0));
+                        currentWidget->setCurrentRow(-1);
+                        next->setCurrentItem(item);
+                        next->setCurrentRow(0);
+                        }
+                  else {
+                        item = static_cast<ScoreItem*>(scoreLists.front()->item(0));
+                        currentWidget->setCurrentRow(-1);
+                        scoreLists.front()->setCurrentItem(item);
+                        scoreLists.front()->setCurrentRow(0);
+                        }
+                  }
+
+
+            preview->setScore(item->info());
+            emit scoreSelected(item->info().filePath());
+            return;
+            }
+      else if (event->key() == Qt::Key_Left) {
+            ScoreItem* item;
+            if (index == -1) {
+                  item = static_cast<ScoreItem*>(currentWidget->item(0));
+                  currentWidget->setCurrentItem(item);
+                  currentWidget->setCurrentRow(0);
+                  }
+            else if (index > 0) {
+                  item = static_cast<ScoreItem*>(currentWidget->item(index - 1));
+                  currentWidget->setCurrentItem(item);
+                  currentWidget->setCurrentRow(index - 1);
+                  }
+            else {
+                  if (idx > 0) {
+                        ScoreListWidget* prev = scoreLists[idx - 1];
+                        item = static_cast<ScoreItem*>(prev->item(prev->count() - 1));
+                        currentWidget->setCurrentRow(-1);
+                        prev->setCurrentItem(item);
+                        prev->setCurrentRow(prev->count() - 1);
+                        currentWidget->update();
+                        prev->update();
+                        }
+                  else {
+                        item = static_cast<ScoreItem*>(scoreLists.back()->item(scoreLists.back()->count() - 1));
+                        currentWidget->setCurrentRow(-1);
+                        scoreLists.back()->setCurrentItem(item);
+                        scoreLists.back()->setCurrentRow(scoreLists.back()->count() - 1);
+                        }
+                  }
+            preview->setScore(item->info());
+            emit scoreSelected(item->info().filePath());
+            return;
+            }
+      else if (event->key() == Qt::Key_Tab) {
+            NewWizard* nw = mscore->getNewWizard();
+            if (nw->button(QWizard::CancelButton)->hasFocus()) {
+                  nw->button(QWizard::CancelButton)->clearFocus();
+                  nw->button(QWizard::BackButton)->setFocus();
+                  }
+            else if (nw->button(QWizard::BackButton)->hasFocus()) {
+                  nw->button(QWizard::BackButton)->clearFocus();
+                  nw->button(QWizard::NextButton)->setFocus();
+                  }
+            else if (nw->button(QWizard::NextButton)->hasFocus()) {
+                  nw->button(QWizard::NextButton)->clearFocus();
+                  nw->button(QWizard::FinishButton)->setFocus();
+                  }
+            else if (nw->button(QWizard::FinishButton)->hasFocus()) {
+                  nw->button(QWizard::FinishButton)->clearFocus();
+                  }
+            else {
+                  nw->button(QWizard::CancelButton)->setFocus();
+                  }
+            return;
+            }
+    else if (event->key() == Qt::Key_Backtab) {
+            NewWizard* nw = mscore->getNewWizard();
+            if (nw->button(QWizard::CancelButton)->hasFocus()) {
+                  nw->button(QWizard::CancelButton)->clearFocus();
+                  }
+            else if (nw->button(QWizard::BackButton)->hasFocus()) {
+                  nw->button(QWizard::BackButton)->clearFocus();
+                  nw->button(QWizard::CancelButton)->setFocus();
+                  }
+            else if (nw->button(QWizard::NextButton)->hasFocus()) {
+                  nw->button(QWizard::NextButton)->clearFocus();
+                  nw->button(QWizard::BackButton)->setFocus();
+                  }
+            else if (nw->button(QWizard::FinishButton)->hasFocus()) {
+                  nw->button(QWizard::FinishButton)->clearFocus();
+                  nw->button(QWizard::NextButton)->setFocus();
+                  }
+            else {
+                  nw->button(QWizard::FinishButton)->setFocus();
+                  }
+            return;
+            }
+      else if (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return) {
+            if (!current)
+                  return;
+            scoreChanged(current);
+            setScoreActivated(current);
+            return;
+            }
+      QWidget::keyPressEvent(event);
       }
 
 }

--- a/mscore/scoreBrowser.h
+++ b/mscore/scoreBrowser.h
@@ -33,6 +33,8 @@ class ScoreListWidget : public QListWidget
 
       virtual QSize sizeHint() const override;
 
+   protected:
+      virtual void keyPressEvent(QKeyEvent* event) override;
    public:
       ScoreListWidget(QWidget* parent = 0) : QListWidget(parent) {}
       int cellWidth() const { return CELLW; }
@@ -69,6 +71,9 @@ class ScoreBrowser : public QWidget, public Ui::ScoreBrowser
       void scoreSelected(QString);
       void scoreActivated(QString);
 
+   protected:
+      virtual bool focusNextPrevChild(bool next) override;
+
    public:
       ScoreBrowser(QWidget* parent = 0);
       void setScores(QFileInfoList&);
@@ -78,6 +83,8 @@ class ScoreBrowser : public QWidget, public Ui::ScoreBrowser
       void setBoldTitle(bool bold) { _boldTitle = bold; }
       void setShowCustomCategory(bool showCustomCategory) { _showCustomCategory = showCustomCategory; }
       void filter(const QString&);
+      virtual void keyPressEvent(QKeyEvent *event) override;
+      QList<ScoreListWidget*> getScoreLists() { return scoreLists; }
       };
 }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1959,7 +1959,7 @@ void ScoreView::cmd(const char* s)
       else if (cmd == "prev-element") {
             Element* el = score()->selection().element();
             if (!el && !score()->selection().elements().isEmpty())
-                el = score()->selection().elements().last();
+                  el = score()->selection().elements().last();
 
             if (el)
                   cmdGotoElement(score()->prevElement());

--- a/mscore/startcenter.cpp
+++ b/mscore/startcenter.cpp
@@ -47,6 +47,7 @@ Startcenter::Startcenter()
       setBackgroundRole(QPalette::Base);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
       setWindowModality(Qt::ApplicationModal);
+      this->setFocusPolicy(Qt::StrongFocus);
       connect(recentPage,  &ScoreBrowser::scoreActivated, this, &Startcenter::loadScore);
       connect(openScore, SIGNAL(clicked()), this, SLOT(openScoreClicked()));
       connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
@@ -148,6 +149,15 @@ void Startcenter::writeSettings()
 void Startcenter::readSettings()
       {
       MuseScore::restoreGeometry(this);
+      }
+
+//---------------------------------------------------------
+//   newScoreOnEnter
+//---------------------------------------------------------
+
+void Startcenter::newScoreOnEnter()
+      {
+      newScore();
       }
 
 #if 0

--- a/mscore/startcenter.h
+++ b/mscore/startcenter.h
@@ -107,6 +107,7 @@ class Startcenter : public AbstractDialog, public Ui::Startcenter
       void updateRecentScores();
       void writeSettings();
       void readSettings();
+      void newScoreOnEnter();
       };
 }
 #endif

--- a/mscore/symboldialog.h
+++ b/mscore/symboldialog.h
@@ -52,6 +52,7 @@ class SymbolDialog : public QWidget, Ui::SymbolDialogBase {
 
    public:
       SymbolDialog(const QString&, QWidget* parent = 0);
+      Palette* getPalette() { return sp; }
       };
 }
 

--- a/mscore/timedialog.h
+++ b/mscore/timedialog.h
@@ -49,6 +49,7 @@ class TimeDialog : public QWidget, Ui::TimeDialogBase {
       TimeDialog(QWidget* parent = 0);
       bool dirty() const { return _dirty; }
       void save();
+      Palette* getPalette() { return sp; }
       };
 }
 


### PR DESCRIPTION
The master palette can be navigated using the up and down arrow keys. Pressing left or right arrow keys shifts focus to the palette. The palette elements can be traversed using the left and right arrow keys. A palette element can be applied by pressing Enter. When focus is on the palette, pressing up or down accesses the next or previous palette.
The templates in the new score wizard can be navigated using the left and right arrow keys.