### PR TITLE
Meter fix

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -923,11 +923,11 @@ void Seq::process(unsigned framesPerPeriod, float* buffer)
       for (unsigned i = 0; i < framesRemain; ++i) {
             qreal val = *p;
             lv = qMax(lv, qAbs(val));
-            *p++ = val;
+            p++;
 
             val = *p;
             rv = qMax(rv, qAbs(val));
-            *p++ = val;
+            p++;
             }
       meterValue[0] = lv;
       meterValue[1] = rv;

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -926,7 +926,7 @@ void Seq::process(unsigned framesPerPeriod, float* buffer)
             *p++ = val;
 
             val = *p;
-            rv = qMax(lv, qAbs(val));
+            rv = qMax(rv, qAbs(val));
             *p++ = val;
             }
       meterValue[0] = lv;


### PR DESCRIPTION
Please post these on the issue tracker and on github.com 
See my previous post.

lasconic

2017-08-18 17:46 GMT+02:00 Tommaso Cucinotta <tommaso.cucinotta@gmail.com>:

    Hi all,

    if I understand the code well, then the right-channel meter on the synth panel is not really behaving as expected. Wouldn't you need the attached patch ? (0001) Now the two meters show some difference, instead without this patch they look like always aligned (with a few simple scores I'm playing).

    Also, in the same code, why rewriting the buffer contents with the same contents at every cycle ? Looks like unneeded (see 0002)

    Thanks,

            T.