### PR TITLE
Fix a crash in Timeline::numToStaff(int)

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -2620,7 +2620,7 @@ Staff* Timeline::numToStaff(int staff)
       if (!_score)
             return 0;
       QList<Staff*> staves = _score->staves();
-      if (staves.size() >= staff && staff >= 0)
+      if (staves.size() > staff && staff >= 0)
             return staves.at(staff);
       else
             return 0;


### PR DESCRIPTION
This is my first PR so I start with something small. I ran into a crash in this function, when passed 0 while there are 0 staves (might not happen usually but…). A simple equals sign that shouldn’t be there.