### PR TITLE
Fixes for paste of note onto rest

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -779,7 +779,7 @@ Element* ChordRest::drop(EditData& data)
                   nval.headGroup = note->headGroup();
                   nval.fret = note->fret();
                   nval.string = note->string();
-                  score()->setNoteRest(segment(), track(), nval, data.duration, Direction::AUTO);
+                  score()->setNoteRest(segment(), track(), nval, duration(), Direction::AUTO);
                   delete e;
                   }
                   break;

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -775,6 +775,7 @@ Element* ChordRest::drop(EditData& data)
                   Note* note = static_cast<Note*>(e);
                   NoteVal nval;
                   nval.pitch = note->pitch();
+                  nval.tpc1 = note->tpc1();
                   nval.headGroup = note->headGroup();
                   nval.fret = note->fret();
                   nval.string = note->string();


### PR DESCRIPTION
Currently we allow individual notes to be pasted on top of either other notes or rests, but the semantics are slightly different depending on the destination.  We preserve tpc when pasting onto a note, and we use the destination's duration.  When pasting onto a rest, however, we calculate a new tpc from the pitch (based on the key), and we use the source's duration.  This PR fixes both of these issues:

https://musescore.org/en/node/248611
https://musescore.org/en/node/107231

To be honest, only the tpc issue strikes me as an actual bug - I can see legitimate reasons why the current behavior might sense for some use cases regarding duration.  But it was requested and was easy enough to change.  I made these two separate commits in case we decide to merge only one, or wish to revert one later.