### PR TITLE
fix #249541: PluginCreator improvements.

### DIFF
--- a/manual/genManual.cpp
+++ b/manual/genManual.cpp
@@ -319,8 +319,14 @@ static void writeOutput()
       //
       QString out;
       addHeader(out);
-      out += "<h2>Score Elements</h2>\n"
-             "<ul>\n";
+      out += "<h2>Score Elements</h2>\n";
+      out += "<h3>Quick Guide</h3>\n";
+      out += "<p>Below are all the various classes you can use."
+             "<br>The main class is <a href='musescore.html'>MuseScore</a>."
+             "<br>Use 'New' to create a skeleton plugin."
+             "<br>Plugins are coded in <a href='http://doc.qt.io/qt-5/qmlapplications.html#what-is-qml'>QML</a>"
+             "</p>\n";
+      out += "<ul>\n";
       qSort(classes);
       foreach(const Class& s, classes) {
             out += QString("<li><a href=\"%1\">%2</a></li>\n")

--- a/mscore/helpBrowser.cpp
+++ b/mscore/helpBrowser.cpp
@@ -152,7 +152,7 @@ HelpBrowser::HelpBrowser(QWidget* parent)
 
       view->document()->setDefaultStyleSheet(
             preferences.isThemeDark() ? cssDark : css);
-
+      view->setOpenExternalLinks(true);
       toolbar->setLayout(bl);
       }
 

--- a/mscore/pluginManager.h
+++ b/mscore/pluginManager.h
@@ -33,6 +33,7 @@ class PluginManager : public QDialog, public Ui::PluginManager {
       Preferences prefs;
 
       void readSettings();
+      void loadList(bool forceRefresh);
 
       virtual void closeEvent(QCloseEvent*);
       virtual void accept();
@@ -42,6 +43,7 @@ class PluginManager : public QDialog, public Ui::PluginManager {
       void clearPluginShortcutClicked();
       void pluginListItemChanged(QListWidgetItem*, QListWidgetItem*);
       void pluginLoadToggled(QListWidgetItem*);
+      void reloadPluginsClicked();
 
    signals:
       void closed(bool);

--- a/mscore/pluginManager.ui
+++ b/mscore/pluginManager.ui
@@ -45,6 +45,16 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="3" colspan="2">
+       <widget class="QLineEdit" name="pluginShortcut">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1" colspan="4">
        <widget class="QLineEdit" name="pluginPath">
         <property name="enabled">
@@ -65,13 +75,10 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="3" colspan="2">
-       <widget class="QLineEdit" name="pluginShortcut">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_23">
+        <property name="text">
+         <string>Path:</string>
         </property>
        </widget>
       </item>
@@ -86,23 +93,6 @@
        <widget class="QTextBrowser" name="pluginDescription">
         <property name="readOnly">
          <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="3">
-       <widget class="QLineEdit" name="pluginName">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_23">
-        <property name="text">
-         <string>Path:</string>
         </property>
        </widget>
       </item>
@@ -133,6 +123,16 @@
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="reloadPlugins">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reload all plugins.&lt;/p&gt;&lt;p&gt;This will re-evaluate all plugins, picking up any changes that may have occured.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Reload Plugins</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer_17">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -147,17 +147,17 @@
         </item>
        </layout>
       </item>
+      <item row="0" column="1" colspan="3">
+       <widget class="QLineEdit" name="pluginName">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
     </widget>
    </item>
    <item row="0" column="0">
@@ -179,6 +179,16 @@
      </property>
      <property name="sortingEnabled">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -1963,13 +1963,18 @@ static void updatePluginList(QList<QString>& pluginPathList, const QString& plug
       }
 #endif
 
-void Preferences::updatePluginList()
+void Preferences::updatePluginList(bool forceRefresh)
       {
 #ifdef SCRIPT_INTERFACE
       QList<QString> pluginPathList;
       pluginPathList.append(dataPath + "/plugins");
       pluginPathList.append(mscoreGlobalShare + "plugins");
       pluginPathList.append(myPluginsPath);
+      if (forceRefresh) {
+            pluginList.clear();
+            QQmlEngine* engine=Ms::MScore::qml();
+            engine->clearComponentCache(); //TODO: Check this doesn't have unwanted side effects.
+            }
 
       foreach(QString pluginPath, pluginPathList) {
             Ms::updatePluginList(pluginPathList, pluginPath, pluginList);

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -191,7 +191,7 @@ struct Preferences {
 
       bool readPluginList();
       void writePluginList();
-      void updatePluginList();
+      void updatePluginList(bool forceRefresh=false);
 
       Preferences();
       void write();

--- a/mscore/qmledit.cpp
+++ b/mscore/qmledit.cpp
@@ -641,7 +641,34 @@ void QmlEdit::keyPressEvent(QKeyEvent* event)
             event->accept();
             return;
             }
+      if (event->modifiers() != Qt::ControlModifier &&
+          (event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return)) {
+            autoIndent();
+            event->accept();
+            return;
+            }
       QPlainTextEdit::keyPressEvent(event);
+      }
+
+//---------------------------------------------------------
+//   autoindent - line new line up with start of previous.
+//---------------------------------------------------------
+void QmlEdit::autoIndent()
+      {
+      QTextCursor c = textCursor();
+      QTextBlock b = c.block();
+      QString line = "";
+      while (line.trimmed() == "" && b.isValid()) // Find last non-blank line to line up on.
+            {
+            line = b.text();
+            b = b.previous();
+            }
+      int indent = 0;
+      c.insertText("\n");
+      while (line[indent] == " ") {
+            indent += 1;
+            c.insertText(" ");
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/qmledit.h
+++ b/mscore/qmledit.h
@@ -36,6 +36,7 @@ class QmlEdit : public QPlainTextEdit {
       void move(QTextCursor::MoveOperation);
       virtual void keyPressEvent(QKeyEvent*);
       void tab();
+      void autoIndent();
 
    private slots:
       void updateLineNumberAreaWidth(int);

--- a/mscore/qmlplugin.h
+++ b/mscore/qmlplugin.h
@@ -36,10 +36,10 @@ extern int updateVersion();
 //   @@ MuseScore
 //   @P menuPath             QString           where the plugin is placed in menu
 //   @P filePath             QString           source file path, without the file name (read only)
-//   @P version              QString
-//   @P description          QString
-//   @P pluginType           QString
-//   @P dockArea             QString
+//   @P version              QString           version of this plugin
+//   @P description          QString           human readable description, displayed in Plugin Manager
+//   @P pluginType           QString           type may be dialog, dock, or not defined.
+//   @P dockArea             QString           where to dock on main screen. left,top,bottom, right(default)
 //   @P requiresScore        bool              whether the plugin requires an existing score to run
 //   @P division             int               number of MIDI ticks for 1/4 note (read only)
 //   @P mscoreVersion        int               complete version number of MuseScore in the form: MMmmuu (read only)


### PR DESCRIPTION
Improved Help - added a very basic guide and external links.
Very simple autoindent implemented in editor - new lines line up with previous lines
"New" includes placeholders for description and version.
Refresh button on PluginManager forces modifications to be picked up
Make plugins stay on top while using Run

Note: incorporates #249631 (PluginCreator SaveAs)