### PR TITLE
fix #251301: wrong octave in status display for transposing instruments

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -767,7 +767,7 @@ int Note::tpc() const
 QString Note::tpcUserName(bool explicitAccidental) const
       {
       QString pitchName = tpc2name(tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
-      QString octaveName = QString::number((pitch() / 12) - 1);
+      QString octaveName = QString::number((epitch() / 12) - 1);
       return pitchName + (explicitAccidental ? " " : "") + octaveName;
       }
 


### PR DESCRIPTION
See https://musescore.org/en/node/251301.