### PR TITLE
Fix lupdate step to not put all translations into all ts files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,6 +639,8 @@ include(Packaging)
 add_custom_target(lupdate
    COMMAND ${PROJECT_SOURCE_DIR}/build/gen-qt-projectfile ${PROJECT_SOURCE_DIR} > mscore.pro
    COMMAND Qt5::lupdate ${PROJECT_BINARY_DIR}/mscore.pro
+   COMMAND ${PROJECT_SOURCE_DIR}/build/gen-instruments-projectfile ${PROJECT_SOURCE_DIR}/share/instruments > instruments.pro
+   COMMAND Qt5::lupdate ${PROJECT_BINARY_DIR}/instruments.pro
    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
    )
 

--- a/build/gen-instruments-projectfile
+++ b/build/gen-instruments-projectfile
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "TRANSLATIONS = \\"
+uis=`find $1/../../share/locale/ -name "instruments_*.ts"`
+for a in $uis; do
+      echo "    " $a \\;
+      done
+echo
+
+echo "HEADERS = \\"
+uis=`find $1 -name "*.h"`
+for a in $uis; do
+      echo "    " $a \\;
+      done
+echo
+echo

--- a/build/gen-instruments-projectfile.bat
+++ b/build/gen-instruments-projectfile.bat
@@ -1,0 +1,16 @@
+@echo off
+
+set OLD_DIR=%CD%
+
+echo TRANSLATIONS = \
+for /r %1/../../share/locale/ %%a in (instruments_*.ts) do echo     %%a \
+echo.
+
+cd /d %1
+
+echo HEADERS= \
+for /r %1 %%a in (*.h) do echo     %%a \
+echo.
+echo.
+
+cd /d %OLD_DIR%

--- a/build/gen-qt-projectfile
+++ b/build/gen-qt-projectfile
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "TRANSLATIONS = \\"
-uis=`find $1/share/locale/ -name "*.ts"`
+uis=`find $1/share/locale/ -name "mscore_*.ts"`
 for a in $uis; do
       echo "    " $a \\;
       done
@@ -16,10 +16,6 @@ echo
 
 echo "SOURCES = \\"
 uis=`find $1 -name "*.cpp"`
-for a in $uis; do
-      echo "    " $a \\;
-      done
-uis=`find $1/share/instruments -name "*.h"`
 for a in $uis; do
       echo "    " $a \\;
       done

--- a/build/gen-qt-projectfile.bat
+++ b/build/gen-qt-projectfile.bat
@@ -3,7 +3,7 @@
 set OLD_DIR=%CD%
 
 echo TRANSLATIONS = \
-for /r %1/share/locale/ %%a in (*.ts) do echo     %%a \
+for /r %1/share/locale/ %%a in (mscore_*.ts) do echo     %%a \
 echo.
 
 cd /d %1
@@ -14,7 +14,6 @@ echo.
 
 echo SOURCES = \
 for /r %1 %%a in (*.cpp) do echo     %%a \
-for /r %1/share/instruments %%a in (*.h) do echo     %%a \
 echo.
 echo.
 

--- a/share/instruments/README.md
+++ b/share/instruments/README.md
@@ -2,7 +2,7 @@ Translation of the instrument list
 ---
 
 * `generateTs.py` parses `instruments.xml` and creates a fake `instrumentsxml.h` file
-* gen-qt-projectfile creates a pro file for the translations, so we can run lupdate (to create/update the TS files) and lrelease on it (to generate the QM files)
+* gen-instruments-projectfile creates a pro file for the translations, so we can run lupdate (to create/update the TS files) and lrelease on it (to generate the QM files)
 * the QM files are loaded by MuseScore and the instruments are translated when the instruments.xml file is loaded
 
 If instruments.xml is modified


### PR DESCRIPTION
but put mscore translations into mscore_\*.ts only, instruments translations into instruments_\*.ts only and don't run lupdate against qt_\*.ts at all.
The latter seems to have been done wrongly since quite a while, the former since PR #3272 , 41b7906 (master) and d1b606e (2.2)
So this should go into master and 2.2.