### PR TITLE
Improved plugin support 3.0 

### DIFF
--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -441,6 +441,12 @@ bool Accidental::setProperty(P_ID propertyId, const QVariant& v)
       return true;
       }
 
+void Accidental::supportedProperties(QList<P_ID>& dest, bool writeable)
+      {
+      Element::supportedProperties(dest, writeable);
+      dest << P_ID::SMALL << P_ID::ACCIDENTAL_BRACKET << P_ID::ROLE;
+      }
+
 //---------------------------------------------------------
 //   accessibleInfo
 //---------------------------------------------------------

--- a/libmscore/accidental.h
+++ b/libmscore/accidental.h
@@ -212,6 +212,7 @@ class Accidental : public Element {
 
       virtual QVariant getProperty(P_ID propertyId) const override;
       virtual bool setProperty(P_ID propertyId, const QVariant&) override;
+      virtual void supportedProperties(QList<P_ID>& dest, bool writeable = false) override;
       virtual QVariant propertyDefault(P_ID propertyId) const override;
 
       static AccidentalVal subtype2value(AccidentalType);             // return effective pitch offset

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3401,5 +3401,28 @@ Shape Chord::shape() const
       shape.add(ChordRest::shape());      // add articulation + lyrics
       return shape;
       }
+
+Chord* ChordW::chord()
+      {
+      return dynamic_cast<Chord*>(e);
+      }
+
+QQmlListProperty<ChordW> ChordW::qmlGraceNotes()
+      {
+      _gnotes.clear();
+      for (Chord* c : chord()->_graceNotes) {
+            _gnotes << dynamic_cast<ChordW*>(ElementW::buildWrapper(c));
+            }
+      return QmlListAccess<ChordW>(this, _gnotes);
+      }
+
+QQmlListProperty<NoteW> ChordW::qmlNotes()
+      {
+      _notes.clear();
+      for(Note* n : chord()->notes()) {
+            _notes << dynamic_cast<NoteW*>(ElementW::buildWrapper(n));
+            }
+      return QmlListAccess<NoteW>(this, _notes);
+      }
 }
 

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -19,6 +19,7 @@
 */
 
 #include <functional>
+#include <QQmlListProperty>
 #include "chordrest.h"
 
 namespace Ms {
@@ -58,9 +59,24 @@ enum class PlayEventType : char    {
 //   @P stemDirection Direction       the stem slash of the chord (acciaccatura) if any (read only)
 //---------------------------------------------------------
 
-class Chord : public ChordRest {
-      Q_GADGET
+class ChordW : public ChordRestW {
+      Q_OBJECT
+      Q_PROPERTY(QQmlListProperty<Ms::ChordW> graceNotes READ qmlGraceNotes)
+      Q_PROPERTY(QQmlListProperty<Ms::NoteW>  notes      READ qmlNotes)
+private:
+      QVector<ChordW*> _gnotes;
+      QVector<NoteW*>  _notes;
+public:
+      ChordW() : ChordRestW() {}
+      ChordW(ScoreElement* _e) : ChordRestW(_e) {}
+      Chord* chord();
+      QQmlListProperty<ChordW> qmlGraceNotes();
+      QQmlListProperty<NoteW>  qmlNotes();
+      };
 
+class Chord : public ChordRest {
+      friend class ChordW;
+      Q_GADGET
       Q_PROPERTY(Ms::Beam* beam                         READ beam)
 //      Q_PROPERTY(QQmlListProperty<Ms::Chord> graceNotes READ qmlGraceNotes)
       Q_PROPERTY(Ms::Hook* hook                         READ hook)

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1109,6 +1109,16 @@ bool ChordRest::setProperty(P_ID propertyId, const QVariant& v)
       return true;
       }
 
+void ChordRest::supportedProperties(QList<P_ID>& dest, bool writeable)
+      {
+      DurationElement::supportedProperties(dest, writeable);
+      if (writeable) {
+            dest << P_ID::SMALL << P_ID::BEAM_MODE << P_ID::STAFF_MOVE << P_ID::DURATION_TYPE << P_ID::VISIBLE;
+            } else {
+            dest << P_ID::SMALL << P_ID::BEAM_MODE << P_ID::STAFF_MOVE << P_ID::DURATION_TYPE;
+            }
+      }
+
 //---------------------------------------------------------
 //   propertyDefault
 //---------------------------------------------------------
@@ -1232,7 +1242,7 @@ void ChordRest::processSiblings(std::function<void(Element*)> func)
 //---------------------------------------------------------
 
 Element* ChordRest::nextArticulationOrLyric(Element* e)
-      {  
+      {
       auto i = std::find(_articulations.begin(), _articulations.end(), e);
       if (i != _articulations.end()) {
             if (i != _articulations.end()-1) {
@@ -1290,23 +1300,23 @@ Element* ChordRest::prevArticulationOrLyric(Element* e)
 Element* ChordRest::nextElement()
       {
       Element* e = score()->selection().element();
-            if (!e && !score()->selection().elements().isEmpty())
-                  e = score()->selection().elements().first();
+      if (!e && !score()->selection().elements().isEmpty())
+            e = score()->selection().elements().first();
       switch (e->type()) {
             case ElementType::ARTICULATION:
-            case ElementType::LYRICS: {                  
+            case ElementType::LYRICS: {
                   Element* next = nextArticulationOrLyric(e);
                   if (next)
                         return next;
                   else
                         break;
                   }
-            default: {                  
+            default: {
                   if (!_articulations.empty())
                         return _articulations[0];
                   else if (!_lyrics.empty())
-                        return _lyrics[0];                
-                  else 
+                        return _lyrics[0];
+                  else
                         break;
                   }
             }
@@ -1321,8 +1331,8 @@ Element* ChordRest::nextElement()
 Element* ChordRest::prevElement()
       {
       Element* e = score()->selection().element();
-            if (!e && !score()->selection().elements().isEmpty())
-                  e = score()->selection().elements().last();
+      if (!e && !score()->selection().elements().isEmpty())
+            e = score()->selection().elements().last();
       switch (e->type()) {
             case ElementType::ARTICULATION:
             case ElementType::LYRICS: {
@@ -1334,9 +1344,9 @@ Element* ChordRest::prevElement()
                               return static_cast<Chord*>(this)->lastElementBeforeSegment();
                         }
                   // fall through
-                  }           
+                  }
             default: {
-                  break;                 
+                  break;
                   }
             }
       int staffId = e->staffIdx();
@@ -1517,6 +1527,11 @@ void ChordRest::removeMarkings(bool /* keepTremolo */)
       qDeleteAll(el());
       qDeleteAll(articulations());
       qDeleteAll(lyrics());
+      }
+
+ChordRest* ChordRestW::chordrest()
+      {
+      return dynamic_cast<ChordRest*>(e);
       }
 
 }

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -47,6 +47,14 @@ enum class SegmentType;
 //   @P durationType  int
 //   @P small         bool           small chord/rest
 //-------------------------------------------------------------------
+class ChordRestW : public DurationElementW {
+      Q_OBJECT
+
+   public:
+      ChordRestW() : DurationElementW() {}
+      ChordRestW(ScoreElement* _e) : DurationElementW(_e) {}
+      ChordRest* chordrest();
+      };
 
 class ChordRest : public DurationElement {
       Q_GADGET
@@ -170,6 +178,7 @@ class ChordRest : public DurationElement {
 
       virtual QVariant getProperty(P_ID propertyId) const override;
       virtual bool setProperty(P_ID propertyId, const QVariant&) override;
+      virtual void supportedProperties(QList<P_ID>& dest, bool writeable = false) override;
       virtual QVariant propertyDefault(P_ID) const override;
       bool isGrace() const;
       bool isGraceBefore() const;

--- a/libmscore/cursor.h
+++ b/libmscore/cursor.h
@@ -12,6 +12,7 @@
 
 #ifndef __CURSOR_H__
 #define __CURSOR_H__
+#include <QVariant>
 
 namespace Ms {
 
@@ -39,18 +40,27 @@ class ElementW : public QObject {
       Q_PROPERTY(int       type READ type)
       Q_PROPERTY(QString   name READ name)
       Q_PROPERTY(int       tick READ tick)
-
+      Q_PROPERTY(QVariantList readProperties   READ supportedRead)
+      Q_PROPERTY(QVariantList writeProperties READ supportedWrite)
+   protected:
       ScoreElement* e;
+      QVariantList supportedProperties(bool writeable);
+      QVariantList supportedRead() {return supportedProperties(false);}
+      QVariantList supportedWrite() {return supportedProperties(true);}
 
    public slots:
 
    public:
       ElementW(ScoreElement* _e) : QObject() { e = _e; }
       ElementW() {}
+      ~ElementW();
       QString name() const;
       int type() const;
       int tick() const;
       Q_INVOKABLE QVariant get(const QString& s) const;
+      Q_INVOKABLE void set(const QString& s, const QVariant& value);
+      Element* element();
+      static ElementW* buildWrapper(ScoreElement* _e);
       };
 
 //---------------------------------------------------------
@@ -59,7 +69,7 @@ class ElementW : public QObject {
 //   @P staffIdx  int           current staff (track / 4)
 //   @P voice     int           current voice (track % 4)
 //   @P filter    enum          segment type filter
-//   @P element   Ms::ElementW*  current element at track, read only
+//   @P element   Ms::Element*  current element at track, read only
 //   @P segment   Ms::Segment*  current segment, read only
 //   @P measure   Ms::Measure*  current measure, read only
 //   @P tick      int           midi tick position, read only
@@ -74,7 +84,6 @@ class Cursor : public QObject {
       Q_PROPERTY(int staffIdx   READ staffIdx  WRITE setStaffIdx)
       Q_PROPERTY(int voice      READ voice     WRITE setVoice)
       Q_PROPERTY(int filter     READ filter    WRITE setFilter)
-
       Q_PROPERTY(int tick         READ tick)
       Q_PROPERTY(double time      READ time)
 
@@ -133,6 +142,7 @@ class Cursor : public QObject {
       Q_INVOKABLE bool next();
       Q_INVOKABLE bool nextMeasure();
       Q_INVOKABLE void add(Ms::Element*);
+      Q_INVOKABLE void add(Ms::ElementW*);
 
       Q_INVOKABLE void addNote(int pitch);
 

--- a/libmscore/duration.cpp
+++ b/libmscore/duration.cpp
@@ -179,5 +179,31 @@ bool DurationElement::setProperty(P_ID propertyId, const QVariant& v)
       return true;
       }
 
+void DurationElement::supportedProperties(QList<P_ID>& dest, bool writeable)
+      {
+      Element::supportedProperties(dest, writeable);
+      dest << P_ID::DURATION;
+      }
+
+DurationElement* DurationElementW::durationElement()
+      {
+      return dynamic_cast<DurationElement*>(e);
+      }
+
+FractionWrapper*DurationElementW::durationW()
+      {
+      return durationElement()->durationW();
+      }
+
+void DurationElementW::setDurationW(FractionWrapper* f)
+      {
+      durationElement()->setDurationW(f);
+      }
+
+FractionWrapper*DurationElementW::globalDurW()
+      {
+      return durationElement()->globalDurW();
+      }
+
 }
 

--- a/libmscore/duration.h
+++ b/libmscore/duration.h
@@ -15,6 +15,7 @@
 
 #include "config.h"
 #include "element.h"
+#include "cursor.h"
 #include "durationtype.h"
 
 namespace Ms {
@@ -31,7 +32,23 @@ class Spanner;
 //   @P globalDuration Fraction  played duration
 //---------------------------------------------------------
 
+#ifdef SCRIPT_INTERFACE
+class DurationElementW : public ElementW {
+      Q_OBJECT
+      Q_PROPERTY(FractionWrapper* duration READ durationW WRITE setDurationW)
+      Q_PROPERTY(FractionWrapper* globalDuration READ globalDurW)
+   public:
+      DurationElementW() : ElementW() {}
+      DurationElementW(ScoreElement* _e) : ElementW(_e) {}
+      DurationElement* durationElement();
+      FractionWrapper* durationW();
+      void setDurationW(FractionWrapper* f);
+      FractionWrapper* globalDurW();
+      };
+#endif
+
 class DurationElement : public Element {
+      friend class DurationElementW;
       Fraction _duration;
       Tuplet* _tuplet;
 
@@ -69,6 +86,7 @@ class DurationElement : public Element {
 
       virtual QVariant getProperty(P_ID propertyId) const override;
       virtual bool setProperty(P_ID propertyId, const QVariant&) override;
+      virtual void supportedProperties(QList<P_ID>& dest, bool writeable = false) override;
       };
 
 

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1117,6 +1117,13 @@ bool Element::setProperty(P_ID propertyId, const QVariant& v)
       return true;
       }
 
+void Element::supportedProperties(QList<P_ID>& dest, bool writeable)
+      {
+      ScoreElement::supportedProperties(dest, writeable);
+      dest << P_ID::TRACK << P_ID::GENERATED << P_ID::COLOR << P_ID::VISIBLE << P_ID::SELECTED << P_ID::USER_OFF << P_ID::PLACEMENT
+           << P_ID::AUTOPLACE << P_ID::Z <<P_ID::SYSTEM_FLAG;
+      }
+
 //---------------------------------------------------------
 //   propertyDefault
 //---------------------------------------------------------

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -137,6 +137,7 @@ class EditData {
 //-------------------------------------------------------------------
 
 class Element : public ScoreElement {
+      friend class ElementW;
       Q_GADGET
       Q_ENUMS(Placement)
 
@@ -165,7 +166,6 @@ class Element : public ScoreElement {
       mutable QRectF _bbox;       ///< Bounding box relative to _pos + _userOff
                                   ///< valid after call to layout()
       uint _tag;                  ///< tag bitmask
-
    public:
       Element(Score* s = 0);
       Element(const Element&);
@@ -412,6 +412,7 @@ class Element : public ScoreElement {
 
       virtual QVariant getProperty(P_ID) const override;
       virtual bool setProperty(P_ID, const QVariant&) override;
+      virtual void supportedProperties(QList<P_ID>& dest, bool writeable = false) override;
       virtual QVariant propertyDefault(P_ID) const override;
       virtual void initSubStyle(SubStyle);
 

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -434,10 +434,14 @@ QQmlEngine* MScore::qml()
             qmlRegisterType<Cursor>     ("MuseScore", 3, 0, "Cursor");
             qmlRegisterType<ElementW>   ("MuseScore", 3, 0, "Element");
             qRegisterMetaType<ElementW*>("ElementWrapper*");
+            qmlRegisterType<TimeSigW>   ("MuseScore", 3, 0, "TimeSig");
+            qmlRegisterType<SegmentW>   ("MuseScore", 3, 0, "Segment");
+            qmlRegisterType<ChordW>     ("MuseScore", 3, 0, "Chord");
+            qRegisterMetaType<ChordW*>  ("ChordW*");
+            qmlRegisterType<NoteW>      ("MuseScore", 3, 0, "Note");
+            qRegisterMetaType<NoteW*>   ("NoteW*");
+
 #if 0
-            qmlRegisterType<Segment>    ("MuseScore", 1, 0, "Segment");
-            qmlRegisterType<Chord>      ("MuseScore", 1, 0, "Chord");
-            qmlRegisterType<Note>       ("MuseScore", 1, 0, "Note");
             qmlRegisterType<NoteHead>   ("MuseScore", 1, 0, "NoteHead");
             qmlRegisterType<Accidental> ("MuseScore", 1, 0, "Accidental");
             qmlRegisterType<Rest>       ("MuseScore", 1, 0, "Rest");
@@ -446,7 +450,6 @@ QQmlEngine* MScore::qml()
             qmlRegisterType<Part>       ("MuseScore", 1, 0, "Part");
             qmlRegisterType<Staff>      ("MuseScore", 1, 0, "Staff");
             qmlRegisterType<Harmony>    ("MuseScore", 1, 0, "Harmony");
-            qmlRegisterType<TimeSig>    ("MuseScore", 1, 0, "TimeSig");
             qmlRegisterType<KeySig>     ("MuseScore", 1, 0, "KeySig");
             qmlRegisterType<Slur>       ("MuseScore", 1, 0, "Slur");
             qmlRegisterType<Tie>        ("MuseScore", 1, 0, "Tie");

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2542,6 +2542,15 @@ bool Note::setProperty(P_ID propertyId, const QVariant& v)
       return true;
       }
 
+void Note::supportedProperties(QList<P_ID>& dest, bool writeable)
+      {
+      Element::supportedProperties(dest, writeable);
+      dest << P_ID::PITCH << P_ID::TPC1 << P_ID::TPC2 << P_ID::SMALL << P_ID::MIRROR_HEAD << P_ID::DOT_POSITION << P_ID::HEAD_GROUP
+           << P_ID::VELO_OFFSET << P_ID::TUNING << P_ID::FRET << P_ID::STRING << P_ID::GHOST << P_ID::HEAD_TYPE << P_ID::VELO_TYPE
+           << P_ID::PLAY << P_ID::LINE << P_ID::FIXED << P_ID::FIXED_LINE;
+      if (writeable) dest << P_ID::VISIBLE;
+      }
+
 //---------------------------------------------------------
 //   undoSetFret
 //---------------------------------------------------------
@@ -2906,11 +2915,11 @@ Element* Note::nextElement()
                   }
             case ElementType::TIE_SEGMENT: {
                   if (!_spannerFor.empty()) {
-                      for (auto i : _spannerFor) {
-                            if (i->type() == ElementType::GLISSANDO)
-                                  return i->spannerSegments().front();
-                                  }
-                            }
+                        for (auto i : _spannerFor) {
+                              if (i->type() == ElementType::GLISSANDO)
+                                    return i->spannerSegments().front();
+                              }
+                        }
                   Chord* c = chord();
                   return c->nextElement();
                   }
@@ -3024,7 +3033,7 @@ Element* Note::lastElementBeforeSegment()
             return _tieFor->frontSegment();
             }
       else if (!_el.empty()) {
-              return _el.back();
+            return _el.back();
             }
       /*else if (_accidental) {
             return _accidental;
@@ -3141,7 +3150,7 @@ AccidentalType Note::accidentalType() const
 void Note::setAccidentalType(AccidentalType type)
       {
       if (score())
-      	score()->changeAccidental(this, type);
+            score()->changeAccidental(this, type);
       }
 
 //---------------------------------------------------------
@@ -3158,4 +3167,22 @@ Shape Note::shape() const
       return shape;
       }
 
+ElementW*NoteW::accidental()
+      {
+      return ElementW::buildWrapper(note()->accidental());
+      }
+
+Note* NoteW::note()
+      {
+      return dynamic_cast<Note*>(e);
+      }
+
+QQmlListProperty<ElementW> NoteW::qmlDots()
+      {
+      _dots.clear();
+      for(NoteDot* d : note()->_dots) {
+            _dots << ElementW::buildWrapper(d);
+            }
+      return QmlListAccess<ElementW>(this,_dots);
+      }
 }

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -17,7 +17,8 @@
  \file
  Definition of classes Note and NoteHead.
 */
-
+#include <QObject>
+#include <QQmlListProperty>
 #include "element.h"
 #include "symbol.h"
 #include "noteevent.h"
@@ -25,6 +26,7 @@
 #include "shape.h"
 #include "tremolo.h"
 #include "key.h"
+#include "cursor.h"
 
 namespace Ms {
 
@@ -203,7 +205,22 @@ static const int INVALID_LINE = -10000;
 //   @P veloType         enum (Note.OFFSET_VAL, Note.USER_VAL)
 //---------------------------------------------------------------------------------------
 
+class NoteW : public ElementW {
+      Q_OBJECT
+      Q_PROPERTY(QQmlListProperty<Ms::ElementW>  dots READ qmlDots)
+      Q_PROPERTY(Ms::ElementW*             accidental READ accidental)
+private:
+      QVector<ElementW*> _dots;
+      ElementW* accidental();
+public:
+      NoteW() : ElementW() {}
+      NoteW(ScoreElement* _e) : ElementW(_e) {}
+      Note* note();
+      QQmlListProperty<ElementW> qmlDots();
+      };
+
 class Note : public Element {
+      friend class NoteW;
       Q_GADGET
       Q_PROPERTY(Ms::Accidental*                accidental        READ accidental)
       Q_PROPERTY(int                            accidentalType    READ qmlAccidentalType  WRITE qmlSetAccidentalType)
@@ -494,6 +511,7 @@ class Note : public Element {
 
       virtual QVariant getProperty(P_ID propertyId) const override;
       virtual bool setProperty(P_ID propertyId, const QVariant&) override;
+      virtual void supportedProperties(QList<P_ID>& dest, bool writeable = false) override;
       virtual QVariant propertyDefault(P_ID) const override;
 
       bool mark() const               { return _mark;   }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1639,6 +1639,12 @@ Segment* Score::lastSegment() const
       return m ? m->last() : 0;
       }
 
+ElementW* Score::lastSegmentW() const
+      {
+      Segment* result = lastSegment();
+      return ElementW::buildWrapper(result);
+      }
+
 //---------------------------------------------------------
 //   utick2utime
 //---------------------------------------------------------
@@ -2017,7 +2023,7 @@ bool Score::appendScore(Score* score, bool addPageBreak, bool addSectionBreak)
 
 void Score::splitStaff(int staffIdx, int splitPoint)
       {
-//      qDebug("split staff %d point %d", staffIdx, splitPoint);
+      //      qDebug("split staff %d point %d", staffIdx, splitPoint);
 
       //
       // create second staff
@@ -2413,7 +2419,7 @@ void Score::cmdRemoveStaff(int staffIdx)
                               }
                         }
                   else // linked staff in the same score
-                       sameScoreLinkedStaff = staff;
+                        sameScoreLinkedStaff = staff;
                   }
             if (sameScoreLinkedStaff)
                   s->score()->undo(new UnlinkStaff(sameScoreLinkedStaff, s)); // once should be enough
@@ -2566,27 +2572,27 @@ void Score::padToggle(Pad n)
                   break;
             case Pad::DOTDOT:
                   if ((_is.duration().dots() == 2)
-                     || (_is.duration() == TDuration::DurationType::V_512TH)
-                     || (_is.duration() == TDuration::DurationType::V_1024TH))
+                      || (_is.duration() == TDuration::DurationType::V_512TH)
+                      || (_is.duration() == TDuration::DurationType::V_1024TH))
                         _is.setDots(0);
                   else
                         _is.setDots(2);
                   break;
             case Pad::DOT3:
                   if ((_is.duration().dots() == 3)
-                     || (_is.duration() == TDuration::DurationType::V_256TH)
-                     || (_is.duration() == TDuration::DurationType::V_512TH)
-                     || (_is.duration() == TDuration::DurationType::V_1024TH))
+                      || (_is.duration() == TDuration::DurationType::V_256TH)
+                      || (_is.duration() == TDuration::DurationType::V_512TH)
+                      || (_is.duration() == TDuration::DurationType::V_1024TH))
                         _is.setDots(0);
                   else
                         _is.setDots(3);
                   break;
             case Pad::DOT4:
                   if ((_is.duration().dots() == 4)
-                     || (_is.duration() == TDuration::DurationType::V_128TH)
-                     || (_is.duration() == TDuration::DurationType::V_256TH)
-                     || (_is.duration() == TDuration::DurationType::V_512TH)
-                     || (_is.duration() == TDuration::DurationType::V_1024TH))
+                      || (_is.duration() == TDuration::DurationType::V_128TH)
+                      || (_is.duration() == TDuration::DurationType::V_256TH)
+                      || (_is.duration() == TDuration::DurationType::V_512TH)
+                      || (_is.duration() == TDuration::DurationType::V_1024TH))
                         _is.setDots(0);
                   else
                         _is.setDots(4);
@@ -2690,7 +2696,7 @@ void Score::select(Element* e, SelectType type, int staffIdx)
             }
       if (MScore::debugMode)
             qDebug("select element <%s> type %d(state %d) staff %d",
-               e ? e->name() : "", int(type), int(selection().state()), e ? e->staffIdx() : -1);
+                   e ? e->name() : "", int(type), int(selection().state()), e ? e->staffIdx() : -1);
 
       switch (type) {
             case SelectType::SINGLE:
@@ -2800,9 +2806,9 @@ void Score::selectRange(Element* e, int staffIdx)
             int etick = tick + m->ticks();
             activeTrack = staffIdx * VOICES;
             if (_selection.isNone()
-               || (_selection.isList() && !_selection.isSingle())) {
-                        if (_selection.isList())
-                              deselectAll();
+                || (_selection.isList() && !_selection.isSingle())) {
+                  if (_selection.isList())
+                        deselectAll();
                   _selection.setRange(m->tick2segment(tick),
                                       m == lastMeasure() ? 0 : m->last(),
                                       staffIdx,
@@ -2829,8 +2835,8 @@ void Score::selectRange(Element* e, int staffIdx)
                               startSegment = m->tick2segment(tick);
                               if (etick <= oetick)
                                     endSegment = cr->nextSegmentAfterCR(SegmentType::ChordRest
-                                                                                    | SegmentType::EndBarLine
-                                                                                    | SegmentType::Clef);
+                                                                        | SegmentType::EndBarLine
+                                                                        | SegmentType::Clef);
 
                               }
                         int staffStart = staffIdx;
@@ -2942,7 +2948,7 @@ void Score::collectMatch(void* data, Element* e)
             return;
 
       if ((p->staffStart != -1)
-         && ((p->staffStart > e->staffIdx()) || (p->staffEnd <= e->staffIdx())))
+          && ((p->staffStart > e->staffIdx()) || (p->staffEnd <= e->staffIdx())))
             return;
 
       if (p->voice != -1 && p->voice != e->voice())
@@ -2983,7 +2989,7 @@ void Score::collectNoteMatch(void* data, Element* e)
       if (p->duration.type() != TDuration::DurationType::V_INVALID && p->duration != n->chord()->actualDurationType())
             return;
       if ((p->staffStart != -1)
-         && ((p->staffStart > e->staffIdx()) || (p->staffEnd <= e->staffIdx())))
+          && ((p->staffStart > e->staffIdx()) || (p->staffEnd <= e->staffIdx())))
             return;
       if (p->voice != -1 && p->voice != e->voice())
             return;
@@ -3124,8 +3130,8 @@ void Score::lassoSelectEnd()
             }
       if (noteRestCount > 0) {
             endSegment = endCR->nextSegmentAfterCR(SegmentType::ChordRest
-               | SegmentType::EndBarLine
-               | SegmentType::Clef);
+                                                   | SegmentType::EndBarLine
+                                                   | SegmentType::Clef);
             _selection.setRange(startSegment, endSegment, startStaff, endStaff+1);
             if (!_selection.isRange())
                   _selection.setState(SelState::RANGE);
@@ -3146,7 +3152,7 @@ void Score::addLyrics(int tick, int staffIdx, const QString& txt)
       Segment* seg     = measure->findSegment(SegmentType::ChordRest, tick);
       if (seg == 0) {
             qDebug("no segment found for lyrics<%s> at tick %d",
-               qPrintable(txt), tick);
+                   qPrintable(txt), tick);
             return;
             }
 
@@ -3165,7 +3171,7 @@ void Score::addLyrics(int tick, int staffIdx, const QString& txt)
             }
       if (!lyricsAdded) {
             qDebug("no chord/rest for lyrics<%s> at tick %d, staff %d",
-               qPrintable(txt), tick, staffIdx);
+                   qPrintable(txt), tick, staffIdx);
             }
       }
 
@@ -4244,7 +4250,7 @@ void Score::setStyle(const MStyle& s)
 //---------------------------------------------------------
 
 MasterScore::MasterScore()
-   : Score()
+      : Score()
       {
       _tempomap    = new TempoMap;
       _sigmap      = new TimeSigMap();
@@ -4276,7 +4282,7 @@ MasterScore::MasterScore()
       }
 
 MasterScore::MasterScore(const MStyle& s)
-   : MasterScore{}
+      : MasterScore{}
       {
       _movements = new Movements;
       _movements->push_back(this);
@@ -4432,7 +4438,7 @@ bool Score::isTopScore() const
 //---------------------------------------------------------
 
 Movements::Movements()
-   : std::vector<MasterScore*>()
+      : std::vector<MasterScore*>()
       {
       _undo = new UndoStack();
       }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -26,6 +26,7 @@
 #include "spannermap.h"
 #include "layoutbreak.h"
 #include "property.h"
+#include "segment.h"
 
 namespace Ms {
 
@@ -353,7 +354,7 @@ class Score : public QObject, ScoreElement {
       Q_PROPERTY(int                            keysig            READ keysig)
       Q_PROPERTY(Ms::Measure*                   lastMeasure       READ lastMeasure)
       Q_PROPERTY(Ms::Measure*                   lastMeasureMM     READ lastMeasureMM)
-      Q_PROPERTY(Ms::Segment*                   lastSegment       READ lastSegment)
+      Q_PROPERTY(Ms::ElementW*                  lastSegment       READ lastSegmentW)
       Q_PROPERTY(int                            lyricCount        READ lyricCount)
       Q_PROPERTY(int                            nmeasures         READ nmeasures)
       Q_PROPERTY(int                            npages            READ npages)
@@ -942,6 +943,7 @@ class Score : public QObject, ScoreElement {
       Segment* firstSegment(SegmentType s) const;
       Segment* firstSegmentMM(SegmentType s) const;
       Segment* lastSegment() const;
+      ElementW* lastSegmentW() const;
 
       void connectTies(bool silent=false);
 

--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -131,6 +131,7 @@ ScoreElement::ScoreElement(const ScoreElement& se)
       {
       _score = se._score;
       _links = 0;
+      elementWrapper = 0;
       }
 
 //---------------------------------------------------------
@@ -145,6 +146,10 @@ ScoreElement::~ScoreElement()
                   delete _links;
                   _links = 0;
                   }
+            }
+      if (elementWrapper) {
+            delete elementWrapper;
+            elementWrapper = 0;
             }
       }
 
@@ -237,6 +242,16 @@ void ScoreElement::writeProperty(XmlWriter& xml, P_ID id) const
             }
       else
             xml.tag(id, getProperty(id), propertyDefault(id));
+      }
+
+//---------------------------------------------------------
+//  supportedProperties - get a list of supported properties.
+//---------------------------------------------------------
+
+void ScoreElement::supportedProperties(QList<P_ID>& dest, bool writeable)
+      {
+      Q_UNUSED(writeable); // If writeable=true, return only properties that are supported by setproperty, otherwise getproperty.
+      dest.clear();
       }
 
 //---------------------------------------------------------

--- a/libmscore/scoreElement.h
+++ b/libmscore/scoreElement.h
@@ -14,6 +14,7 @@
 #define __SCORE_ELEMENT_H__
 
 #include "types.h"
+#include "cursor.h"
 
 namespace Ms {
 
@@ -148,14 +149,16 @@ struct ElementName {
 //---------------------------------------------------------
 
 class ScoreElement {
+      friend class ElementW;
       Q_GADGET
       Score* _score;
 
    protected:
       LinkedElements* _links { 0 };
+      ElementW* elementWrapper = 0;
 
    public:
-      ScoreElement(Score* s) : _score(s)   {}
+      ScoreElement(Score* s) : _score(s)   {elementWrapper = 0;}
       ScoreElement(const ScoreElement& se);
       virtual ~ScoreElement();
 
@@ -176,6 +179,7 @@ class ScoreElement {
       virtual PropertyFlags propertyFlags(P_ID) const;
       virtual void setPropertyFlags(P_ID, PropertyFlags) {}
       virtual StyleIdx getPropertyStyle(P_ID) const;
+      virtual void supportedProperties(QList<P_ID>& dest, bool writeable = false);
 
       void undoChangeProperty(P_ID id, const QVariant&, PropertyFlags ps);
       void undoChangeProperty(P_ID id, const QVariant&);

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -39,6 +39,11 @@
 
 namespace Ms {
 
+Segment* SegmentW::segment()
+      {
+      return dynamic_cast<Segment*>(element());
+      }
+
 //---------------------------------------------------------
 //   subTypeName
 //---------------------------------------------------------
@@ -830,6 +835,12 @@ QVariant Segment::getProperty(P_ID propertyId) const
             default:
                   return Element::getProperty(propertyId);
             }
+      }
+
+void Segment::supportedProperties(QList<P_ID>& dest, bool writeable)
+      {
+      Element::supportedProperties(dest, writeable);
+      dest << P_ID::TICK << P_ID::LEADING_SPACE;
       }
 
 //---------------------------------------------------------

--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -16,6 +16,7 @@
 #include "element.h"
 #include "shape.h"
 #include "mscore.h"
+#include "cursor.h"
 
 namespace Ms {
 
@@ -80,6 +81,13 @@ constexpr bool operator& (const SegmentType t1, const SegmentType t2) {
 //   @P segmentType     enum (Segment.All, .Ambitus, .BarLine, .Breath, .ChordRest, .Clef, .EndBarLine, .Invalid, .KeySig, .KeySigAnnounce, .StartRepeatBarLine, .TimeSig, .TimeSigAnnounce)
 //   @P tick            int               midi tick position (read only)
 //------------------------------------------------------------------------
+
+class SegmentW : public ElementW {
+public:
+      SegmentW() {};
+      SegmentW(ScoreElement* _e) : ElementW(_e) {}
+      Segment* segment();
+      };
 
 class Segment : public Element {
       Q_GADGET
@@ -214,6 +222,7 @@ class Segment : public Element {
 
       virtual QVariant getProperty(P_ID propertyId) const;
       virtual bool setProperty(P_ID propertyId, const QVariant&);
+      virtual void supportedProperties(QList<P_ID>& dest, bool writeable) override;
       virtual QVariant propertyDefault(P_ID) const;
 
       bool operator<(const Segment&) const;

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2573,6 +2573,7 @@ bool Text::validateText(QString& s)
 
 void Text::inputTransition(QInputMethodEvent* ie)
       {
+      Q_UNUSED(ie); // Remove annoying warning message.
 #if 0
       // remove preedit string
       int n = preEdit.size();

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -23,6 +23,14 @@
 
 namespace Ms {
 
+void TimeSigW::setSig(int numerator, int denominator, int st)
+      {
+      if (e) {
+            static_cast<TimeSig *>(e)->setSig(Fraction(numerator, denominator),
+                                              static_cast<TimeSigType>(st));
+            }
+      }
+
 //---------------------------------------------------------
 //   TimeSig
 //    Constructs an invalid time signature element.
@@ -456,6 +464,13 @@ bool TimeSig::setProperty(P_ID propertyId, const QVariant& v)
       score()->setLayoutAll();      // TODO
       setGenerated(false);
       return true;
+      }
+
+void TimeSig::supportedProperties(QList<P_ID>& dest, bool writeable)
+      {
+      Element::supportedProperties(dest, writeable);
+      dest << P_ID::SHOW_COURTESY << P_ID::NUMERATOR_STRING << P_ID::DENOMINATOR_STRING << P_ID::GROUPS
+           << P_ID::TIMESIG << P_ID::TIMESIG_GLOBAL << P_ID::TIMESIG_STRETCH << P_ID::TIMESIG_TYPE << P_ID::SCALE;
       }
 
 //---------------------------------------------------------

--- a/libmscore/timesig.h
+++ b/libmscore/timesig.h
@@ -17,6 +17,7 @@
 #include "sig.h"
 #include "mscore.h"
 #include "groups.h"
+#include "cursor.h"
 
 namespace Ms {
 
@@ -35,8 +36,25 @@ enum class TimeSigType : char {
 
 //---------------------------------------------------------------------------------------
 //   @@ TimeSig
-///    This class represents a time signature.
+///   This class represents a time signature.
+//   void setSig(int numerator, int denominator, int type) Type 0=NORMAL 1=FOUR_FOUR 2=ALLA_BREVE
+//
+//   @P *denominator         int           (read only)
+//   @P *denominatorStretch  int           (read only)
+//   @P *denominatorString   string        text of denominator
+//   @P *numerator           int           (read only)
+//   @P *numeratorStretch    int           (read only)
+//   @P *numeratorString     string        text of numerator
 //---------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------
+
+class TimeSigW : public ElementW {
+      Q_OBJECT
+   public:
+      TimeSigW() {};
+      TimeSigW(ScoreElement* _e) : ElementW() {e = _e;}
+      Q_INVOKABLE void setSig(int numerator, int denominator, int st=static_cast<int>(TimeSigType::NORMAL)); // Compatible with older versions
+      };
 
 class TimeSig : public Element {
       Q_GADGET
@@ -116,6 +134,7 @@ class TimeSig : public Element {
 
       virtual QVariant getProperty(P_ID propertyId) const override;
       virtual bool setProperty(P_ID propertyId, const QVariant&) override;
+      virtual void supportedProperties(QList<P_ID>& dest, bool writeable = false) override;
       virtual QVariant propertyDefault(P_ID id) const override;
       virtual StyleIdx getPropertyStyle(P_ID id) const override;
       virtual void styleChanged() override;

--- a/mscore/qmlplugin.cpp
+++ b/mscore/qmlplugin.cpp
@@ -101,7 +101,7 @@ void QmlPlugin::closeScore(Ms::Score* score)
 //   newElement
 //---------------------------------------------------------
 
-Ms::Element* QmlPlugin::newElement(int t)
+Ms::ElementW* QmlPlugin::newElement(int t)
       {
       Score* score = curScore();
       if (score == 0)
@@ -109,16 +109,15 @@ Ms::Element* QmlPlugin::newElement(int t)
       Element* e = Element::create(ElementType(t), score);
       // tell QML not to garbage collect this score
 //TODO      Ms::MScore::qml()->setObjectOwnership(e, QQmlEngine::CppOwnership);
-      return e;
+      return ElementW::buildWrapper(e);
       }
 
 //---------------------------------------------------------
 //   newScore
 //---------------------------------------------------------
 
-Score* QmlPlugin::newScore(const QString& /*name*/, const QString& /*part*/, int /*measures*/)
+Score* QmlPlugin::newScore(const QString& name, const QString& part, int measures)
       {
-#if 0 // TODO
       if (msc->currentScore())
             msc->currentScore()->endCmd();
       MasterScore* score = new MasterScore(MScore::defaultStyle());
@@ -133,8 +132,6 @@ Score* QmlPlugin::newScore(const QString& /*name*/, const QString& /*part*/, int
       QQmlEngine::setObjectOwnership(score, QQmlEngine::CppOwnership);
       score->startCmd();
       return score;
-#endif
-      return 0;
       }
 
 //---------------------------------------------------------

--- a/mscore/qmlplugin.h
+++ b/mscore/qmlplugin.h
@@ -17,6 +17,7 @@
 
 #ifdef SCRIPT_INTERFACE
 #include "libmscore/mscore.h"
+#include "libmscore/cursor.h"
 
 namespace Ms {
 
@@ -116,7 +117,7 @@ class QmlPlugin : public QQuickItem {
       QQmlListProperty<Score> scores();
 
       Q_INVOKABLE Ms::Score* newScore(const QString& name, const QString& part, int measures);
-      Q_INVOKABLE Ms::Element* newElement(int);
+      Q_INVOKABLE Ms::ElementW* newElement(int);
       Q_INVOKABLE void cmd(const QString&);
       Q_INVOKABLE Ms::MsProcess* newQProcess();
       Q_INVOKABLE bool writeScore(Ms::Score*, const QString& name, const QString& ext);

--- a/mtest/libmscore/note/tst_note.cpp
+++ b/mtest/libmscore/note/tst_note.cpp
@@ -533,7 +533,7 @@ void TestNote::LongNoteAfterShort_183746() {
       std::vector<Note*> nl = static_cast<Note*>(e)->tiedNotes();
       QVERIFY(nl.size() >= 3); // the breve must be divided across at least 3 measures
       for (Note* n : nl)
-            totalTicks += static_cast<Chord*>(n->parent())->durationTypeTicks();
+            totalTicks += static_cast<Ms::Chord*>(n->parent())->durationTypeTicks();
       QVERIFY(totalTicks == TDuration(TDuration::DurationType::V_BREVE).ticks()); // total duration same as a breve
       }
 

--- a/mtest/scripting/p1.log.ref
+++ b/mtest/scripting/p1.log.ref
@@ -7,12 +7,12 @@ found:Chord (85) at 0
   beamMode:0
   small:false
   stemDirection:AUTO
-  duration:
+  duration:1/4
 found:Rest (24) at 480
 found:Chord (85) at 960
   durationType:
   beamMode:0
   small:false
   stemDirection:AUTO
-  duration:
+  duration:1/2
 found:BarLine (11) at 1920

--- a/mtest/scripting/p1.qml
+++ b/mtest/scripting/p1.qml
@@ -23,7 +23,7 @@ MuseScore {
                             log2("  small:",         e.get("small"));
                             log2("  stemDirection:", e.get("stem_direction"));
 
-                            log2("  duration:", e.duration);
+                            log2("  duration:", e.duration.numerator + "/" +e.duration.denominator);
 //                            log2("    numerator:",   e.duration.numerator);
 //                            log2("    denominator:", e.duration.denominator);
 //                            log2("    ticks:",       e.duration.ticks);

--- a/share/plugins/colornotes.qml
+++ b/share/plugins/colornotes.qml
@@ -16,7 +16,7 @@ import QtQuick 2.2
 import MuseScore 3.0
 
 MuseScore {
-      version:  "1.0"
+      version:  "1.1"
       description: qsTr("This plugin colors notes in the selection depending on their pitch as per the Boomwhackers convention")
       menuPath: "Plugins.Notes.Color Notes"
 
@@ -46,7 +46,7 @@ MuseScore {
             var endStaff;
             var endTick;
             var fullScore = false;
-            if (!cursor.segment) { // no selection
+            if (!cursor.segment()) { // no selection
                   fullScore = true;
                   startStaff = 0; // start with 1st staff
                   endStaff = curScore.nstaves - 1; // and end with last
@@ -74,16 +74,16 @@ MuseScore {
                         if (fullScore)
                               cursor.rewind(0) // if no selection, beginning of score
 
-                        while (cursor.segment && (fullScore || cursor.tick < endTick)) {
-                              if (cursor.element && cursor.element.type === Element.CHORD) {
-                                    var graceChords = cursor.element.graceNotes;
+                        while (cursor.segment() && (fullScore || cursor.tick < endTick)) {
+                              if (cursor.element() && cursor.element().type === Ms.CHORD) {
+                                    var graceChords = cursor.element().graceNotes;
                                     for (var i = 0; i < graceChords.length; i++) {
                                           // iterate through all grace chords
                                           var graceNotes = graceChords[i].notes;
                                           for (var j = 0; j < graceNotes.length; j++)
                                                 func(graceNotes[j]);
                                     }
-                                    var notes = cursor.element.notes;
+                                    var notes = cursor.element().notes;
                                     for (var k = 0; k < notes.length; k++) {
                                           var note = notes[k];
                                           func(note);
@@ -96,24 +96,19 @@ MuseScore {
       }
 
       function colorNote(note) {
-            if (note.color == black)
-                  note.color = colors[note.pitch % 12];
+            var pitch = note.get("pitch");
+            var color = note.get("color");
+            var newcolor;
+            if (color == black) 
+                  newcolor = colors[pitch % 12];
             else
-                  note.color = black;
+                  newcolor = black;
 
-            if (note.accidental) {
-                  if (note.accidental.color == black)
-                        note.accidental.color = colors[note.pitch % 12];
-                  else
-                        note.accidental.color = black;
-                  }
-
+            note.set("color", newcolor);
+            if (note.accidental) note.accidental.set("color",newcolor);
             for (var i = 0; i < note.dots.length; i++) {
                   if (note.dots[i]) {
-                        if (note.dots[i].color == black)
-                              note.dots[i].color = colors[note.pitch % 12];
-                        else
-                              note.dots[i].color = black;
+                        note.dots[i].set("color",newcolor);
                         }
                   }
          }

--- a/share/plugins/proplist.qml
+++ b/share/plugins/proplist.qml
@@ -1,0 +1,23 @@
+import QtQuick 2.0
+import MuseScore 3.0
+
+MuseScore {
+      menuPath: "Plugins.propList"
+      description: "Demonstrates use of get, set, readProperties and writeProperties"
+      version: "1.0"
+      onRun: {
+            console.log("Proplist Started")
+            var score = curScore;
+            var sig=newElement(Ms.TIMESIG);
+            console.log("new sig = "+sig);
+            sig.set("color","red");
+            var list = sig.readProperties;  // All readable properties.
+            console.log("new list = "+list)
+            for(var i=0; i<list.length; i++) {
+              console.log(list[i]+"="+sig.get(list[i]));
+            }
+            list = sig.writeProperties; // All writeable properties. May be identical to readProperties
+            console.log("Writable properties: "+list);
+            Qt.quit()
+            }
+      }

--- a/share/plugins/random.qml
+++ b/share/plugins/random.qml
@@ -1,8 +1,8 @@
 import QtQuick 2.1
-import MuseScore 1.0
+import MuseScore 3.0
 
 MuseScore {
-      version:  "2.1"
+      version:  "3.0"
       description: "Create random score."
       menuPath: "Plugins.random"
       requiresScore: false
@@ -26,7 +26,7 @@ MuseScore {
             var key         = 3;
 
             var score = newScore("Random.mscz", "piano", measures);
-
+            console.log("Score="+score);
             score.addText("title", "==Random==");
             score.addText("subtitle", "subtitle");
 
@@ -35,7 +35,7 @@ MuseScore {
 
             cursor.rewind(0);
 
-            var ts = newElement(Element.TIMESIG);
+            var ts = newElement(Ms.TIMESIG);
             ts.setSig(numerator, denominator);
             cursor.add(ts);
 

--- a/share/plugins/view.qml
+++ b/share/plugins/view.qml
@@ -2,7 +2,7 @@ import QtQuick 2.0
 import MuseScore 1.0
 
 MuseScore {
-      version: "1.0"
+      version: "3.0"
       description: "Demo plugin to demonstrate the use of a ScoreView"
       menuPath: "Plugins.ScoreView"
       pluginType: "dialog"


### PR DESCRIPTION
Modified timesig help

Implemented TimeSig wrapper so random.qml would work.

Modified timesig help

* Improved support for MuseScore 3.0 plugins
* Added a "set" to ElementW for setting properties.
* Added a buildWrapper static function to allow different wrapper descendants.
* Converted "random.qml" to work with MuseScore 3.0
* Added a TimeSigW class to support added features required to manipulate TimeSig
* Added support for lists of valid property names for use with "get" and "set"

colornotes.qml now works with Musescore 3.0

* Improved support for MuseScore 3.0 plugins
* Added a "set" to ElementW for setting properties.
* Added a buildWrapper static function to allow different wrapper descendants.
* Converted "random.qml" to work with MuseScore 3.0
* Added a TimeSigW class to support added features required to manipulate TimeSig
* Added support for lists of valid property names for use with "get" and "set"
* Modified timesig help
colornotes.qml and random.qml now works with Musescore 3.0
Added proplist.qml to demonstrate readProperties and writeProperties

Formatting and Indenting tidy up.

Sorted out cursor.element()  call, fixed elementWrapper linking.

Fixed some merging problems.