### PR TITLE
Fix svg drawing for staff line optimization

### DIFF
--- a/libmscore/stafflines.cpp
+++ b/libmscore/stafflines.cpp
@@ -111,6 +111,45 @@ void StaffLines::layout()
       }
 
 //---------------------------------------------------------
+//   layout for svg printing
+//---------------------------------------------------------
+
+void StaffLines::layoutWithoutMeasureWidth()
+    {
+        Staff* s = staff();
+        qreal _spatium = spatium();
+        qreal dist = _spatium;
+        setPos(QPointF(0.0, 0.0));
+        int _lines;
+        if (s) {
+            setMag(s->mag(measure()->tick()));
+            setColor(s->color());
+            StaffType* st = s->staffType(measure()->tick());
+            dist         *= st->lineDistance().val();
+            _lines        = st->lines();
+            rypos()       = st->yoffset().val() * _spatium;
+            if (_lines == 1)
+                rypos() = 2 * _spatium;
+        }
+        else {
+            _lines = 5;
+            setColor(MScore::defaultColor);
+        }
+        qreal w = bbox().width();
+        lw      = score()->styleS(StyleIdx::staffLineWidth).val() * _spatium;
+        qreal x1 = pos().x();
+        qreal x2 = x1 + w;
+        qreal y  = pos().y();
+        bbox().setRect(x1, -lw*.5 + y, w, (_lines-1) * _spatium + lw);
+
+        lines.clear();
+        for (int i = 0; i < _lines; ++i) {
+            lines.push_back(QLineF(x1, y, x2, y));
+            y += dist;
+        }
+    }
+
+//---------------------------------------------------------
 //   draw
 //---------------------------------------------------------
 

--- a/libmscore/stafflines.h
+++ b/libmscore/stafflines.h
@@ -31,6 +31,7 @@ class StaffLines : public Element {
       virtual StaffLines* clone() const override    { return new StaffLines(*this); }
       virtual ElementType type() const override   { return ElementType::STAFF_LINES; }
       virtual void layout() override;
+      virtual void layoutWithoutMeasureWidth();
       virtual void draw(QPainter*) const override;
       virtual QPointF pagePos() const override;    ///< position in page coordinates
       virtual QPointF canvasPos() const override;  ///< position in page coordinates

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2709,6 +2709,7 @@ bool MuseScore::saveSvg(Score* score, const QString& saveName)
                               firstSL->bbox().setRight(lastSL->bbox().right()
                                                     +  lastSL->pagePos().x()
                                                     - firstSL->pagePos().x());
+                              firstSL->layoutWithoutMeasureWidth();
                               printer.setElement(firstSL);
                               paintElement(p, firstSL);
                               }


### PR DESCRIPTION
Not certain if this is the best way to fix it, but I noticed on master branch that when saving as SVG the staff lines are only drawn for the first measure if byMeasure is false. This occurs because the layout function for staff lines no longer respects the change in bounding box size instead always using the measure width to determine the sizing. 