### PR TITLE
fix #247641: Tremolos between notes corrupted on part creation

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -267,12 +267,12 @@ Chord::Chord(const Chord& c, bool link)
             }
       if (c._tremolo) {
             Tremolo* t = new Tremolo(*(c._tremolo));
-            add(t);
             if (link) {
                   score()->undo(new Link(const_cast<Tremolo*>(c._tremolo), t));
                   if (c._tremolo->twoNotes())
                         t->setChords(0, 0);
                   }
+            add(t);
             }
 
       for (Element* e : c.el()) {


### PR DESCRIPTION
When adding a tremolo to a chord using <a href="https://github.com/musescore/MuseScore/blob/master/libmscore/chord.cpp#L454">void Chord::add(Element* e)</a> the duration of the existing chords is adjusted:
<pre>
                              d  = d.shift(-1);
                              d.setDots(dots);
                              if (tr->chord1())
                                    tr->chord1()->setDurationType(d);
                              if (tr->chord2())
                                    tr->chord2()->setDurationType(d);
</pre>

<a href="https://github.com/musescore/MuseScore/blob/master/libmscore/chord.cpp#L269">Chord::Chord(const Chord& c, bool link)</a> creates a copy of the original tremolo element using
<pre>            Tremolo* t = new Tremolo(*(c._tremolo));</pre>
which will also copy the references to the original chords:
<pre>Tremolo::Tremolo(const Tremolo& t)
   : Element(t)
      {
      setTremoloType(t.tremoloType());
      _chord1  = t.chord1();
      _chord2  = t.chord2();</pre>
The following call to Chord::add(t) therefore once more doubles the duration of the (original) notes, which leads to the corruption in the master score. I don't fully understand why in the part only the second note was doubled.

I delayed the call to add(t) until the reinitialization of the chord pointers of the new tremolo element, which seems to work fine. 