### PR TITLE
fix #255646: crash changing actual duration of only measure

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -736,7 +736,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
             //
             // rewrite all measures up to the next time signature
             //
-            if (fm == score->firstMeasure() && (fm->len() != fm->timesig())) {
+            if (fm == score->firstMeasure() && fm->nextMeasure() && (fm->len() != fm->timesig())) {
                   // handle upbeat
                   undoChangeProperty(fm, P_ID::TIMESIG_NOMINAL, QVariant::fromValue(ns));
                   Measure* m = fm->nextMeasure();


### PR DESCRIPTION
Fix crash by skipping the special handling for pickup measures if there is only one measure - thus treating this case the same as the normal case.