### PR TITLE
fixes #257631 Crash in layout with TieSegments

### DIFF
--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -675,7 +675,7 @@ void Tie::layoutFor(System* system)
 
       fixupSegments(n);
       TieSegment* segment = segmentAt(0);
-      segment->setParent(system);
+      segment->setSystem(system); // Needed to populate System.spannerSegments
       segment->layoutSegment(sPos.p1, sPos.p2);
       segment->setSpannerSegmentType(sPos.system1 != sPos.system2 ? SpannerSegmentType::BEGIN : SpannerSegmentType::SINGLE);
       }
@@ -692,7 +692,7 @@ void Tie::layoutBack(System* system)
 
       fixupSegments(2);
       TieSegment* segment = segmentAt(1);
-      segment->setParent(system);
+      segment->setSystem(system);
 
       qreal x;
       Segment* seg = endNote()->chord()->segment()->prev();


### PR DESCRIPTION
Musescore 3.0 crashing during layout changes with TieSegments.

Ties were not being added correctly to Systems, and thus were not being correctly unlinked when parent Systems were deleted.