### PR TITLE
Corrected polish translation mistake

### DIFF
--- a/share/locale/mscore_pl.ts
+++ b/share/locale/mscore_pl.ts
@@ -16135,7 +16135,7 @@ Chcesz go zastąpić?</translation>
     <message>
         <location filename="../../mscore/transposedialog.ui" line="32"/>
         <source>By Key</source>
-        <translation>Przez klucz</translation>
+        <translation>Do tonacji</translation>
     </message>
     <message>
         <location filename="../../mscore/transposedialog.ui" line="57"/>


### PR DESCRIPTION
The word 'klucz' means 'key', but in music it means 'clef'. The correct
translation for 'key' is 'tonacja'.