### PR TITLE
A small readme change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# MuseScore: Music notation and composition software
+![MuseScore](mscore/data/musescore_logo_full.png)    
+ Music notation and composition software
+
+[![Travis CI](https://secure.travis-ci.org/musescore/MuseScore.svg)](https://travis-ci.org/musescore/MuseScore)
+[![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
 
 MuseScore is an open source and free music notation software.
 For support, contribution, bug reports, visit [MuseScore.org](https://musescore.org). Fork and make pull requests!
@@ -20,7 +24,6 @@ For support, contribution, bug reports, visit [MuseScore.org](https://musescore.
 * [MuseScore Homepage](https://musescore.org)
 * [MuseScore Git workflow instructions](https://musescore.org/en/developers-handbook/git-workflow).
 * [How to compile MuseScore?](https://musescore.org/en/developers-handbook/compilation)
-* Build status: [![Build Status](https://secure.travis-ci.org/musescore/MuseScore.svg)](https://travis-ci.org/musescore/MuseScore)
 
 ## License
 MuseScore is licensed under GPL version 2.0. See LICENSE.GPL in the same directory.


### PR DESCRIPTION
Just a few tweaks to make the Travis CI rating and license more accessible. It also puts the main Musescore logo front and center.