### PR TITLE
#46046 Add tint to highlighted non-visible notes

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -315,7 +315,8 @@ QColor Element::curColor(const Element* proxy) const
                   int red = originalColor.red();
                   int green = originalColor.green();
                   int blue = originalColor.blue();
-                  return QColor(red + .75 * (255-red), green + .75 * (255-green), blue + .75 *(255-blue));
+                  float tint = .6;  // Between 0 and 1. Higher means lighter, lower means darker
+                  return QColor(red + tint * (255-red), green + tint * (255-green), blue + tint *(255-blue));
                   }
             }
       if (!proxy->visible())

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -304,10 +304,19 @@ QColor Element::curColor(const Element* proxy) const
             marked = note->mark();
             }
       if (proxy->selected() || marked ) {
+            QColor originalColor;
             if (track() == -1)
-                  return MScore::selectColor[0];
+                  originalColor = MScore::selectColor[0];
             else
-                  return MScore::selectColor[voice()];
+                  originalColor = MScore::selectColor[voice()];
+            if (proxy->visible())
+                  return originalColor;
+            else {
+                  int red = originalColor.red();
+                  int green = originalColor.green();
+                  int blue = originalColor.blue();
+                  return QColor(red + .75 * (255-red), green + .75 * (255-green), blue + .75 *(255-blue));
+                  }
             }
       if (!proxy->visible())
             return Qt::gray;

--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -364,10 +364,8 @@ void HairpinSegment::draw(QPainter* painter) const
       TextLineBaseSegment::draw(painter);
 
       QColor color;
-      if (selected() && !(score() && score()->printing()))
-            color = (track() > -1) ? MScore::selectColor[voice()] : MScore::selectColor[0];
-      else if (!hairpin()->visible())     // || !hairpin()->lineVisible()
-            color = Qt::gray;
+      if ((selected() && !(score() && score()->printing())) || !hairpin()->visible())
+            color = curColor();
       else
             color = hairpin()->lineColor();
       QPen pen(color, point(hairpin()->lineWidth()), hairpin()->lineStyle());

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -1178,13 +1178,7 @@ void Text::drawSelection(QPainter* p, const QRectF& r) const
 
 QColor Text::textColor() const
       {
-      if (score() && !score()->printing()) {
-            if (selected())
-                  return (track() > -1) ? MScore::selectColor[voice()] : MScore::selectColor[0];
-            if (!visible())
-                  return Qt::gray;
-            }
-      return color();
+      return curColor();
       }
 
 //---------------------------------------------------------

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -76,10 +76,8 @@ void TextLineBaseSegment::draw(QPainter* painter) const
 
       // color for line (text color comes from the text properties)
       QColor color;
-      if (selected() && !(score() && score()->printing()))
-            color = (track() > -1) ? MScore::selectColor[voice()] : MScore::selectColor[0];
-      else if (!tl->visible() || !tl->lineVisible())
-            color = Qt::gray;
+      if ((selected() && !(score() && score()->printing())) || !tl->visible() || !tl->lineVisible())
+            color = curColor();
       else
             color = tl->lineColor();
 


### PR DESCRIPTION
For addressing https://musescore.org/en/node/46046

What it looks like:
![screenshot_015](https://user-images.githubusercontent.com/153674/31847123-1ebb6aae-b5dc-11e7-94cb-8f29c8d96bef.png)

This is my first contribution to this project, so apologies if I missed a step or some due diligence.
