### PR TITLE
Uncomment and fix MusicXML tests

### DIFF
--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -87,6 +87,51 @@ struct TempoPattern {
 // note: findTempoDuration requires the longer patterns to be before the shorter patterns in tp
 
 static const TempoPattern tp[] = {
+      TempoPattern("\uECA5\\s*\uECB7\\s*\uECB7", 1.75/60.0,  TDuration::DurationType::V_QUARTER, 2), // double dotted 1/4
+      TempoPattern("\uECA5\\s*\uECB7",           1.5/60.0,   TDuration::DurationType::V_QUARTER, 1), // dotted 1/4
+      TempoPattern("\uECA5",                     1.0/60.0,   TDuration::DurationType::V_QUARTER),    // 1/4
+      TempoPattern("\uECA3\\s*\uECB7\\s*\uECB7", 1.75/30.0,  TDuration::DurationType::V_HALF, 2),    // double dotted 1/2
+      TempoPattern("\uECA3\\s*\uECB7",           1.5/30.0,   TDuration::DurationType::V_HALF, 1),    // dotted 1/2
+      TempoPattern("\uECA3",                     1.0/30.0,   TDuration::DurationType::V_HALF),       // 1/2
+      TempoPattern("\uECA7\\s*\uECB7\\s*\uECB7", 1.75/120.0, TDuration::DurationType::V_EIGHTH, 2),  // double dotted 1/8
+      TempoPattern("\uECA7\\s*\uECB7",           1.5/120.0,  TDuration::DurationType::V_EIGHTH, 1),  // dotted 1/8
+      TempoPattern("\uECA7",                     1.0/120.0,  TDuration::DurationType::V_EIGHTH),     // 1/8
+      TempoPattern("\uECA2\\s*\uECB7",           1.5/15.0,   TDuration::DurationType::V_WHOLE, 1),   // dotted whole
+      TempoPattern("\uECA2",                     1.0/15.0,   TDuration::DurationType::V_WHOLE),      // whole
+      TempoPattern("\uECA9\\s*\uECB7",           1.5/240.0,  TDuration::DurationType::V_16TH, 1),    // dotted 1/16
+      TempoPattern("\uECA9",                     1.0/240.0,  TDuration::DurationType::V_16TH),       // 1/16
+      TempoPattern("\uECAB\\s*\uECB7",           1.5/480.0,  TDuration::DurationType::V_32ND, 1),    // dotted 1/32
+      TempoPattern("\uECAB",                     1.0/480.0,  TDuration::DurationType::V_32ND),       // 1/32
+      TempoPattern("\uECA1",                     1.0/7.5,    TDuration::DurationType::V_BREVE),      // longa
+      TempoPattern("\uECA0",                     1.0/7.5,    TDuration::DurationType::V_BREVE),      // double whole
+      TempoPattern("\uECAD",                     1.0/960.0,  TDuration::DurationType::V_64TH),       // 1/64
+      TempoPattern("\uECAF",                     1.0/1920.0, TDuration::DurationType::V_128TH),      // 1/128
+      };
+
+//---------------------------------------------------------
+//   findTempoDuration
+//    find the duration part (note + dot) of a tempo text in string s
+//    return the match position or -1 if not found
+//    set len to the match length and dur to the duration value
+//---------------------------------------------------------
+
+int TempoText::findTempoDuration(const QString& s, int& len, TDuration& dur)
+      {
+      len = 0;
+      dur = TDuration();
+      for (const auto& i : tp) {
+            QRegExp re(i.pattern);
+            int pos = re.indexIn(s);
+            if (pos != -1) {
+                  len = re.matchedLength();
+                  dur = i.d;
+                  return pos;
+                  }
+            }
+      return -1;
+      }
+
+static const TempoPattern tpSym[] = {
       TempoPattern("<sym>metNoteQuarterUp</sym>\\s*<sym>metAugmentationDot</sym>\\s*<sym>metAugmentationDot</sym>",                         1.75/60.0, TDuration::DurationType::V_QUARTER, 2), // double dotted 1/4
       TempoPattern("<sym>metNoteQuarterUp</sym>\\s*<sym>metAugmentationDot</sym>",          1.5/60.0,  TDuration::DurationType::V_QUARTER, 1), // dotted 1/4
       TempoPattern("<sym>metNoteQuarterUp</sym>",                                           1.0/60.0,  TDuration::DurationType::V_QUARTER),  // 1/4
@@ -109,40 +154,16 @@ static const TempoPattern tp[] = {
       };
 
 //---------------------------------------------------------
-//   findTempoDuration
-//    find the duration part (note + dot) of a tempo text in string s
-//    return the match position or -1 if not found
-//    set len to the match length and dur to the duration value
-//---------------------------------------------------------
-
-int TempoText::findTempoDuration(const QString& s, int& len, TDuration& dur)
-      {
-      len = 0;
-      dur = TDuration();
-
-      for (const auto& i : tp) {
-            QRegExp re(i.pattern);
-            int pos = re.indexIn(s);
-            if (pos != -1) {
-                  len = re.matchedLength();
-                  dur = i.d;
-                  return pos;
-                  }
-            }
-      return -1;
-      }
-
-//---------------------------------------------------------
 //   duration2tempoTextString
 //    find the tempoText string representation for duration
 //---------------------------------------------------------
 
 QString TempoText::duration2tempoTextString(const TDuration dur)
       {
-      for (const TempoPattern& pa : tp) {
+      for (const TempoPattern& pa : tpSym) {
             if (pa.d == dur) {
                   QString res = pa.pattern;
-                  res.remove("\\s*");
+                  res.replace("\\s*", " ");
                   return res;
                   }
             }

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -4732,7 +4732,7 @@ static void partList(XmlWriter& xml, Score* score, const QList<Part*>& il, MxmlI
             for (int i = 0; i < part->nstaves(); i++) {
                   Staff* st = part->staff(i);
                   if (st) {
-                        for (int j = 0; j < st->bracketLevels(); j++) {
+                        for (int j = 0; j < st->bracketLevels() + 1; j++) {
                               if (st->bracketType(j) != BracketType::NO_BRACKET) {
                                     bracketFound = true;
                                     if (i == 0) {

--- a/mscore/musicxmlfonthandler.cpp
+++ b/mscore/musicxmlfonthandler.cpp
@@ -266,6 +266,8 @@ static QString attribute(bool needed, bool value, QString trueString, QString fa
 
 QString MScoreTextToMXML::updateFormat()
       {
+      if (newFormat.fontFamily() == "ScoreText")
+            newFormat.setFontFamily(musicalTextFont);
       QString res;
       res += attribute(newFormat.bold() != oldFormat.bold(), newFormat.bold(), "font-weight=\"bold\"", "font-weight=\"normal\"");
       res += attribute(newFormat.italic() != oldFormat.italic(), newFormat.italic(), "font-style=\"italic\"", "font-style=\"normal\"");

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -200,7 +200,7 @@ subdirs (
         importmidi
         capella
         biab
-#        musicxml
+        musicxml
         guitarpro
         scripting
 #        testoves


### PR DESCRIPTION
Always better to have uncommented tests :)

So, I tried to uncomment MusicXML tests and face 3 problems:

1. The new implementation of brackets
2. The use of font family "ScoreText" (which looks like a huge hack to me?)
3. The new implementation of SMuFL code point in text, not using `<sym>` anymore but directly the codepoint in the text. This one breaks the parsing of tempo text (`findTempoDuration`) and so it breaks MusicXML export but also the display of tempo text in the status bar, the "follow text" feature for tempo and the new tempo modulation feature. We could rewrite the tempo regexp but are we 100% sure that using the codepoint in the text is better than keeping the `<sym>`? I kind of like that the text is "human readable"