### PR TITLE
fix #255551 Allow user to change color of playback cursor

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -76,6 +76,7 @@ void Preferences::init()
       fgWallpaper        = (QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/paper5.png")).absoluteFilePath());
       fgColor.setNamedColor("#f9f9f9");
       pianoHlColor.setNamedColor("#1259d0");
+      cursorColor.setNamedColor("#1259d0");
       iconHeight         = 24;
       iconWidth          = 28;
 
@@ -235,6 +236,7 @@ void Preferences::write()
       s.setValue("dropColor",          MScore::dropColor.name(QColor::NameFormat::HexArgb));
       s.setValue("defaultColor",       MScore::defaultColor.name(QColor::NameFormat::HexArgb));
       s.setValue("pianoHlColor",       pianoHlColor.name(QColor::NameFormat::HexArgb));
+      s.setValue("cursorColor",        cursorColor.name(QColor::NameFormat::HexArgb));
       s.setValue("enableMidiInput",    enableMidiInput);
       s.setValue("realtimeDelay",      realtimeDelay);
       s.setValue("playNotes",          playNotes);
@@ -408,6 +410,7 @@ void Preferences::read()
       MScore::defaultColor    = readColor("defaultColor", MScore::defaultColor);
       MScore::dropColor       = readColor("dropColor",    MScore::dropColor);
       pianoHlColor            = readColor("pianoHlColor", pianoHlColor);
+      cursorColor             = readColor("cursorColor", cursorColor);
 
       enableMidiInput         = s.value("enableMidiInput", enableMidiInput).toBool();
       realtimeDelay           = s.value("realtimeDelay", realtimeDelay).toInt();
@@ -852,6 +855,7 @@ void PreferenceDialog::updateValues()
             fgColorLabel->setPixmap(new QPixmap(fgWallpaper->text()));
             }
 
+      cursorColorLabel->setColor(prefs.cursorColor);
       iconWidth->setValue(prefs.iconWidth);
       iconHeight->setValue(prefs.iconHeight);
 
@@ -1375,7 +1379,7 @@ void PreferenceDialog::apply()
 
       prefs.iconWidth      = iconWidth->value();
       prefs.iconHeight     = iconHeight->value();
-
+      prefs.cursorColor    = cursorColorLabel->color();
       prefs.bgUseColor     = bgColorButton->isChecked();
       prefs.fgUseColor     = fgColorButton->isChecked();
       prefs.enableMidiInput = enableMidiInput->isChecked();

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -92,6 +92,7 @@ struct Preferences {
       int iconHeight, iconWidth;
       QColor dropColor;
       QColor pianoHlColor;
+      QColor cursorColor;
       bool enableMidiInput;
       int realtimeDelay;
       bool playNotes;         // play notes on click

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -2619,6 +2619,48 @@
          </property>
         </spacer>
        </item>
+       <item row="2" column="0">
+        <widget class="QGroupBox" name="groupBox_14">
+         <property name="title">
+          <string>Playback</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Cursor color:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Awl::ColorLabel" name="cursorColorLabel">
+              <property name="focusPolicy">
+               <enum>Qt::StrongFocus</enum>
+              </property>
+              <property name="accessibleName">
+               <string>Select playback cursor color</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>Opens a dialog for selecting the playback cursor color</string>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::Box</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tabIO">

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -557,7 +557,7 @@ void ScoreView::moveCursor(int tick)
       if (s == 0)
             return;
 
-      QColor c(MScore::selectColor[0]);
+      QColor c(preferences.cursorColor);
       c.setAlpha(50);
       _cursor->setColor(c);
       _cursor->setTick(tick);


### PR DESCRIPTION
Not sure if the Score-tab is the correct place for this setting. See image.
![image](https://user-images.githubusercontent.com/983237/32521125-9e39069e-c412-11e7-94aa-9668c6b77405.png)

Maybe there should be an own tab for colors? Or a completely different solution?