### PR TITLE
Clean up instrument search code

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -422,7 +422,6 @@ void InstrumentsWidget::buildTemplateList()
       {
       // clear search if instrument list is updated
       search->clear();
-      filterInstruments(instrumentList, search->text());
 
       populateInstrumentList(instrumentList);
       populateGenreCombo(instrumentGenreFilter);
@@ -875,25 +874,12 @@ void InstrumentsWidget::on_linkedButton_clicked()
 
 void InstrumentsWidget::on_search_textChanged(const QString &searchPhrase)
       {
-      if (searchPhrase.isEmpty())
-            return;
-
-      filterInstruments(instrumentList, searchPhrase);
       instrumentGenreFilter->blockSignals(true);
       instrumentGenreFilter->setCurrentIndex(0);
       instrumentGenreFilter->blockSignals(false);
+      filterInstruments(instrumentList, searchPhrase);
       }
 
-//---------------------------------------------------------
-//   on_clearSearch_clicked
-//---------------------------------------------------------
-
-void InstrumentsWidget::on_clearSearch_clicked()
-      {
-      search->clear();
-      QString genre = instrumentGenreFilter->currentData().toString();
-      filterInstrumentsByGenre(instrumentList, genre);
-      }
 
 //---------------------------------------------------------
 //   on_instrumentGenreFilter_currentTextChanged

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -132,7 +132,6 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
       void expandOrCollapse(const QModelIndex &);
 
       void on_search_textChanged(const QString &searchPhrase);
-      void on_clearSearch_clicked();
 
       void on_instrumentGenreFilter_currentIndexChanged(int);
       void filterInstrumentsByGenre(QTreeWidget *, QString);

--- a/mscore/instrwidget.ui
+++ b/mscore/instrwidget.ui
@@ -101,18 +101,8 @@
            <property name="placeholderText">
             <string>Search</string>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="clearSearch">
-           <property name="accessibleName">
-            <string>Clear</string>
-           </property>
-           <property name="accessibleDescription">
-            <string>Clear Search box</string>
-           </property>
-           <property name="text">
-            <string>Clear</string>
+           <property name="clearButtonEnabled">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -369,7 +359,6 @@
   <tabstop>instrumentGenreFilter</tabstop>
   <tabstop>instrumentList</tabstop>
   <tabstop>search</tabstop>
-  <tabstop>clearSearch</tabstop>
   <tabstop>addButton</tabstop>
   <tabstop>removeButton</tabstop>
   <tabstop>upButton</tabstop>

--- a/mscore/selectinstr.ui
+++ b/mscore/selectinstr.ui
@@ -63,12 +63,8 @@
        <property name="placeholderText">
         <string>Search</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="clearSearch">
-       <property name="text">
-        <string>Clear</string>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -91,7 +87,6 @@
   <tabstop>instrumentGenreFilter</tabstop>
   <tabstop>instrumentList</tabstop>
   <tabstop>search</tabstop>
-  <tabstop>clearSearch</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/mscore/selinstrument.cpp
+++ b/mscore/selinstrument.cpp
@@ -54,7 +54,6 @@ void SelectInstrument::buildTemplateList()
       {
       // clear search if instrument list is updated
       search->clear();
-      filterInstruments(instrumentList, search->text());
 
       populateInstrumentList(instrumentList);
       populateGenreCombo(instrumentGenreFilter);
@@ -113,21 +112,13 @@ const InstrumentTemplate* SelectInstrument::instrTemplate() const
 
 void SelectInstrument::on_search_textChanged(const QString &searchPhrase)
       {
-      filterInstruments(instrumentList, searchPhrase);
       instrumentGenreFilter->blockSignals(true);
       instrumentGenreFilter->setCurrentIndex(0);
       instrumentGenreFilter->blockSignals(false);
+      filterInstruments(instrumentList, searchPhrase);
       }
 
-//---------------------------------------------------------
-//   on_clearSearch_clicked
-//---------------------------------------------------------
 
-void SelectInstrument::on_clearSearch_clicked()
-      {
-      search->clear();
-      filterInstruments (instrumentList);
-      }
 //---------------------------------------------------------
 //   on_instrumentGenreFilter_currentTextChanged
 //---------------------------------------------------------

--- a/mscore/selinstrument.h
+++ b/mscore/selinstrument.h
@@ -43,7 +43,6 @@ class SelectInstrument : public QDialog, private Ui::SelectInstrument {
       void on_instrumentList_itemDoubleClicked(QTreeWidgetItem* item, int);
 
       void on_search_textChanged(const QString &searchPhrase);
-      void on_clearSearch_clicked();
 
       void on_instrumentGenreFilter_currentIndexChanged(int);
       void filterInstrumentsByGenre(QTreeWidget *, QString);


### PR DESCRIPTION
- Removes the clear button in favor of the builtin clear button functionality in QLineEdit
- Makes the code behave the same in new wizard  and instrument dialog