### PR TITLE
fix #265183 Piano Roll editor eats %100 CPU for most edits

### DIFF
--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -656,7 +656,6 @@ void PianorollEditor::updateAll()
 
 void PianorollEditor::playlistChanged()
       {
-      startTimer(0);    // delayed update
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
If the PianoRoll editor window had been started during current musescore session, then many basic edits will cause the mscore process to hog 100% of a CPU core.  Simply removing this 'delayed update' will avoid this problem.  I do not know why this delayed update was here.