### PR TITLE
255066 musicxml articulations dont play back

### DIFF
--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -651,6 +651,20 @@ InstrumentTemplate* searchTemplate(const QString& name)
       return 0;
       }
 
+//---------------------------------------------------------
+//   searchTemplateForMusicXMLid
+//---------------------------------------------------------
+
+InstrumentTemplate* searchTemplateForMusicXmlId(const QString& mxmlId)
+      {
+      foreach(InstrumentGroup* g, instrumentGroups) {
+            foreach(InstrumentTemplate* it, g->instrumentTemplates) {
+                  if (it->musicXMLid == mxmlId)
+                        return it;
+                  }
+            }
+      return 0;
+      }
 
 //---------------------------------------------------------
 //   linkGenre

--- a/libmscore/instrtemplate.h
+++ b/libmscore/instrtemplate.h
@@ -116,10 +116,12 @@ struct InstrumentGroup {
       };
 
 extern QList<InstrumentGenre *> instrumentGenres;
+extern QList<MidiArticulation> articulation;
 extern QList<InstrumentGroup*> instrumentGroups;
 extern bool loadInstrumentTemplates(const QString& instrTemplates);
 extern bool saveInstrumentTemplates(const QString& instrTemplates);
 extern InstrumentTemplate* searchTemplate(const QString& name);
+extern InstrumentTemplate* searchTemplateForMusicXmlId(const QString& mxmlId);
 
 }     // namespace Ms
 #endif

--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -1769,7 +1769,7 @@ void MusicXMLParserPass1::scorePart()
                   skipLogCurrElem();
             }
 
-      fixupMidiProgram(_drumsets[id]);
+      //fixupMidiProgram(_drumsets[id]); TODO check if still required
 
       Q_ASSERT(_e.isEndElement() && _e.name() == "score-part");
       }
@@ -1956,6 +1956,13 @@ void MusicXMLParserPass1::part()
             _parts[id]._instrList.setInstrument(_firstInstrId, Fraction(0, 1));
 
       // debug: print results
+      /*
+      qDebug("instrument map:");
+      for (auto& instr: _parts[id]._instrList) {
+            qDebug("%s %s", qPrintable(instr.first.print()), qPrintable(instr.second));
+            }
+      */
+
       /*
       qDebug("voiceMapperStats: new staff");
       VoiceList& vl = _parts[id].voicelist;

--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -1722,11 +1722,9 @@ void MusicXMLParserPass1::scorePart()
                   // It is displayed by default, but can be suppressed (print-object=”no”)
                   // As of MusicXML 3.0, formatting is deprecated, with part-name in plain text
                   // and the formatted version in the part-name-display element
-                  bool doLong = !(_e.attributes().value("print-object") == "no");
+                  _parts[id].setPrintName(!(_e.attributes().value("print-object") == "no"));
                   QString name = _e.readElementText();
-                  _partMap[id]->setPartName(name);
-                  if (doLong)
-                        _partMap[id]->setLongName(name);
+                  _parts[id].setName(name);
                   }
             else if (_e.name() == "part-name-display") {
                   // TODO
@@ -1737,9 +1735,9 @@ void MusicXMLParserPass1::scorePart()
                   // It is displayed by default, but can be suppressed (print-object=”no”)
                   // As of MusicXML 3.0, formatting is deprecated, with part-name in plain text
                   // and the formatted version in the part-abbreviation-display element
+                  _parts[id].setPrintAbbr(!(_e.attributes().value("print-object") == "no"));
                   QString name = _e.readElementText();
-                  if (!(_e.attributes().value("print-object") == "no"))
-                        _partMap[id]->setPlainShortName(name);
+                  _parts[id].setAbbr(name);
                   }
             else if (_e.name() == "part-abbreviation-display")
                   _e.skipCurrentElement();  // skip but don't log
@@ -1805,9 +1803,6 @@ void MusicXMLParserPass1::scoreInstrument(const QString& partId)
                   // but used only internally
                   if (_drumsets[partId].contains(instrId))
                         _drumsets[partId][instrId].name = instrName;
-                  // try to prevent an empty track name
-                  if (_partMap[partId]->partName() == "")
-                        _partMap[partId]->setPartName(instrName);
                   }
             else if (_e.name() == "instrument-sound") {
                   QString instrSound = _e.readElementText();
@@ -1956,6 +1951,8 @@ void MusicXMLParserPass1::part()
             _parts[id]._instrList.setInstrument(_firstInstrId, Fraction(0, 1));
 
       // debug: print results
+      //qDebug("%s", qPrintable(_parts[id].toString()));
+
       /*
       qDebug("instrument map:");
       for (auto& instr: _parts[id]._instrList) {
@@ -2129,7 +2126,7 @@ void MusicXMLParserPass1::attributes(const QString& partId)
             else if (_e.name() == "divisions")
                   divisions();
             else if (_e.name() == "staff-details")
-                  staffDetails(partId);
+                  _e.skipCurrentElement(); // skip but don't log
             else if (_e.name() == "staves")
                   staves(partId);
             else if (_e.name() == "time")
@@ -2298,165 +2295,6 @@ void MusicXMLParserPass1::divisions()
       _divs = _e.readElementText().toInt();
       if (!(_divs > 0))
             _logger->logError("illegal divisions", &_e);
-      }
-
-//---------------------------------------------------------
-//   setStaffLines
-//---------------------------------------------------------
-
-/**
- Set stafflines and barline span for a single staff
- */
-
-static void setStaffLines(Score* score, int staffIdx, int stafflines)
-      {
-      score->staff(staffIdx)->setLines(0, stafflines);
-      score->staff(staffIdx)->setBarLineTo(0);  // default
-      }
-
-//---------------------------------------------------------
-//   staffDetails
-//---------------------------------------------------------
-
-/**
- Parse the /score-partwise/part/measure/attributes/staff-details node.
- */
-
-void MusicXMLParserPass1::staffDetails(const QString& partId)
-      {
-      Q_ASSERT(_e.isStartElement() && _e.name() == "staff-details");
-      _logger->logDebugTrace("MusicXMLParserPass1::staffDetails", &_e);
-
-      Part* part = getPart(partId);
-      Q_ASSERT(part);
-      int staves = part->nstaves();
-
-      QString number = _e.attributes().value("number").toString();
-      int n = 1; // default
-      if (number != "") {
-            n = number.toInt();
-            if (n <= 0 || n > staves) {
-                  _logger->logError(QString("invalid staff-details number %1").arg(number), &_e);
-                  n = 1;
-                  }
-            }
-      n--;        // make zero-based
-
-      int staffIdx = _score->staffIdx(part) + n;
-
-      StringData* t = 0;
-      if (_score->staff(staffIdx)->isTabStaff(0)) {
-            t = new StringData;
-            t->setFrets(25);       // sensible default
-            }
-
-      int staffLines = 0;
-      while (_e.readNextStartElement()) {
-            if (_e.name() == "staff-lines") {
-                  // save staff lines for later
-                  staffLines = _e.readElementText().toInt();
-                  // for a TAB staff also resize the string table and init with zeroes
-                  if (t) {
-                        if (0 < staffLines)
-                              t->stringList() = QVector<instrString>(staffLines).toList();
-                        else
-                              _logger->logError(QString("illegal staff-lines %1").arg(staffLines), &_e);
-                        }
-                  }
-            else if (_e.name() == "staff-tuning")
-                  staffTuning(t);
-            else
-                  skipLogCurrElem();
-            }
-
-      if (staffLines > 0) {
-            setStaffLines(_score, staffIdx, staffLines);
-            }
-
-      if (t) {
-            Instrument* i = part->instrument();
-            i->setStringData(*t);
-            }
-      }
-
-//---------------------------------------------------------
-//   MusicXMLStepAltOct2Pitch
-//---------------------------------------------------------
-
-/**
- Convert MusicXML \a step (0=C, 1=D, etc.) / \a alter / \a octave to midi pitch.
- Note: same code is in pass 1 and in pass 2.
- TODO: combine
- */
-
-static int MusicXMLStepAltOct2Pitch(int step, int alter, int octave)
-      {
-      //                       c  d  e  f  g  a   b
-      static int table[7]  = { 0, 2, 4, 5, 7, 9, 11 };
-      if (step < 0 || step > 6) {
-            qDebug("MusicXMLStepAltOct2Pitch: illegal step %d", step);
-            return -1;
-            }
-      int pitch = table[step] + alter + (octave+1) * 12;
-
-      if (pitch < 0)
-            pitch = -1;
-      if (pitch > 127)
-            pitch = -1;
-
-      return pitch;
-      }
-
-//---------------------------------------------------------
-//   staffTuning
-//---------------------------------------------------------
-
-/**
- Parse the /score-partwise/part/measure/attributes/staff-details/staff-tuning node.
- */
-
-void MusicXMLParserPass1::staffTuning(StringData* t)
-      {
-      Q_ASSERT(_e.isStartElement() && _e.name() == "staff-tuning");
-      _logger->logDebugTrace("MusicXMLParserPass1::staffTuning", &_e);
-
-      // ignore <staff-tuning> if not a TAB staff
-      if (!t) {
-            _logger->logError("<staff-tuning> on non-TAB staff", &_e);
-            skipLogCurrElem();
-            return;
-            }
-
-      int line   = _e.attributes().value("line").toInt();
-      int step   = 0;
-      int alter  = 0;
-      int octave = 0;
-      while (_e.readNextStartElement()) {
-            if (_e.name() == "tuning-alter")
-                  alter = _e.readElementText().toInt();
-            else if (_e.name() == "tuning-octave")
-                  octave = _e.readElementText().toInt();
-            else if (_e.name() == "tuning-step") {
-                  QString strStep = _e.readElementText();
-                  int pos = QString("CDEFGAB").indexOf(strStep);
-                  if (strStep.size() == 1 && pos >=0 && pos < 7)
-                        step = pos;
-                  else
-                        _logger->logError(QString("invalid step '%1'").arg(strStep), &_e);
-                  }
-            else
-                  skipLogCurrElem();
-            }
-
-      if (0 < line && line <= t->stringList().size()) {
-            int pitch = MusicXMLStepAltOct2Pitch(step, alter, octave);
-            if (pitch >= 0)
-                  t->stringList()[line - 1].pitch = pitch;
-            else
-                  _logger->logError(QString("invalid string %1 tuning step/alter/oct %2/%3/%4")
-                                    .arg(line).arg(step).arg(alter).arg(octave), &_e);
-            }
-
       }
 
 //---------------------------------------------------------

--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -1672,23 +1672,6 @@ static const InstrumentTemplate* findInstrument(const QString& instrSound)
       }
 
 //---------------------------------------------------------
-//   fixupMidiProgram
-//---------------------------------------------------------
-
-static void fixupMidiProgram(MusicXMLDrumset& drumset)
-      {
-      for (auto& instr : drumset) {
-            if (instr.midiProgram < 0 && instr.sound != "") {
-                  const InstrumentTemplate* templ = findInstrument(instr.sound);
-                  if (templ) {
-                        const int prog = templ->channel.at(0).program;
-                        instr.midiProgram = prog;
-                        }
-                  }
-            }
-      }
-
-//---------------------------------------------------------
 //   scorePart
 //---------------------------------------------------------
 
@@ -1766,8 +1749,6 @@ void MusicXMLParserPass1::scorePart()
             else
                   skipLogCurrElem();
             }
-
-      //fixupMidiProgram(_drumsets[id]); TODO check if still required
 
       Q_ASSERT(_e.isEndElement() && _e.name() == "score-part");
       }

--- a/mscore/importmxmlpass1.h
+++ b/mscore/importmxmlpass1.h
@@ -88,8 +88,6 @@ public:
       void clef(const QString& partId);
       void time();
       void divisions();
-      void staffDetails(const QString& partId);
-      void staffTuning(StringData* t);
       void staves(const QString& partId);
       void direction(const QString& partId, const Fraction cTime);
       void directionType(const Fraction cTime, QList<MxmlOctaveShiftDesc>& starts, QList<MxmlOctaveShiftDesc>& stops);
@@ -110,6 +108,7 @@ public:
       int trackForPart(const QString& id) const;
       bool hasPart(const QString& id) const;
       Part* getPart(const QString& id) const { return _partMap.value(id); }
+      MusicXmlPart getMusicXmlPart(const QString& id) const { return _parts.value(id); }
       MusicXMLDrumset getDrumset(const QString& id) const { return _drumsets.value(id); }
       void setDrumsetDefault(const QString& id, const QString& instrId, const NoteHead::Group hg, const int line, const Direction sd);
       MusicXmlInstrList getInstrList(const QString id) const;

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -1739,7 +1739,7 @@ void MusicXMLParserPass2::part()
 
       // set the parts first instrument
       QString instrId = _pass1.getInstrList(id).instrument(Fraction(0, 1));
-      // LVICHECK setFirstInstrument(_pass1.getPart(id), id, instrId, mxmlDrumset);
+      setFirstInstrument(_logger, &_e, _pass1.getPart(id), id, instrId, mxmlDrumset);
 
       // set the part name
       auto mxmlPart = _pass1.getMusicXmlPart(id);

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -412,13 +412,14 @@ static bool hasDrumset(const MusicXMLDrumset& mxmlDrumset)
       while (ii.hasNext()) {
             ii.next();
             // debug: dump the drumset
-            qDebug("hasDrumset: instrument: %s %s", qPrintable(ii.key()), qPrintable(ii.value().toString()));
+            //qDebug("hasDrumset: instrument: %s %s", qPrintable(ii.key()), qPrintable(ii.value().toString()));
             int pitch = ii.value().pitch;
             if (0 <= pitch && pitch <= 127) {
                   res = true;
                   }
             }
 
+      /*
       for (const auto& instr : mxmlDrumset) {
             // MusicXML elements instrument-name, midi-program, instrument-sound, virtual-library, virtual-name
             // in a shell script use "mscore ... 2>&1 | grep GREP_ME | cut -d' ' -f3-" to extract
@@ -430,6 +431,7 @@ static bool hasDrumset(const MusicXMLDrumset& mxmlDrumset)
                    qPrintable(instr.virtName)
                    );
             }
+       */
 
       return res;
       }
@@ -481,10 +483,12 @@ static Instrument createInstrument(const MusicXMLDrumInstrument& mxmlInstr)
             it = Ms::searchTemplateForMusicXmlId(mxmlInstr.sound);
             }
 
+      /*
       qDebug("sound '%s' it %p trackname '%s' program %d",
              qPrintable(mxmlInstr.sound), it,
              it ? qPrintable(it->trackName) : "",
              mxmlInstr.midiProgram);
+       */
 
       if (it) {
             // initialize from template with matching MusicXmlId
@@ -520,7 +524,7 @@ static void setFirstInstrument(MxmlLogger* logger, const QXmlStreamReader* const
                                const QString& instrId, const MusicXMLDrumset& mxmlDrumset)
       {
       if (mxmlDrumset.size() > 0) {
-            qDebug("setFirstInstrument: initial instrument '%s'", qPrintable(instrId));
+            //qDebug("setFirstInstrument: initial instrument '%s'", qPrintable(instrId));
             MusicXMLDrumInstrument mxmlInstr;
             if (instrId == "")
                   mxmlInstr = mxmlDrumset.first();

--- a/mscore/importmxmlpass2.h
+++ b/mscore/importmxmlpass2.h
@@ -144,6 +144,8 @@ public:
       void fermata(ChordRest* cr);
       void tuplet(MusicXmlTupletDesc& tupletDesc);
       void doEnding(const QString& partId, Measure* measure, const QString& number, const QString& type, const QString& text);
+      void staffDetails(const QString& partId);
+      void staffTuning(StringData* t);
       void skipLogCurrElem();
 
       // part specific data interface functions

--- a/mscore/importxmlfirstpass.cpp
+++ b/mscore/importxmlfirstpass.cpp
@@ -39,7 +39,8 @@ Fraction MusicXmlPart::measureDuration(int i) const
 QString MusicXmlPart::toString() const
       {
       QString res;
-      res = QString("part id '%1' name '%2'\n").arg(id).arg(name);
+      res = QString("part id '%1' name '%2' print %3 abbr '%4' print %5\n")
+            .arg(id).arg(name).arg(printName).arg(abbr).arg(printAbbr);
 
       for (VoiceList::const_iterator i = voicelist.constBegin(); i != voicelist.constEnd(); ++i) {
             res += QString("voice %1 map staff data %2\n")

--- a/mscore/importxmlfirstpass.h
+++ b/mscore/importxmlfirstpass.h
@@ -48,9 +48,20 @@ public:
       int octaveShift(const int staff, const Fraction f) const;
       void addOctaveShift(const int staff, const int shift, const Fraction f);
       void calcOctaveShifts();
+      void setName(QString nm) { name = nm; }
+      QString getName() const { return name; }
+      void setPrintName(bool b) { printName = b; }
+      bool getPrintName() const { return printName; }
+      void setAbbr(QString ab) { abbr = ab; }
+      QString getAbbr() const { return abbr; }
+      void setPrintAbbr(bool b) { printAbbr = b; }
+      bool getPrintAbbr() const { return printAbbr; }
 private:
       QString id;
       QString name;
+      bool printName = true;
+      QString abbr;
+      bool printAbbr = true;
       QStringList measureNumbers;             // MusicXML measure number attribute
       QList<Fraction> measureDurations;       // duration in fraction for every measure
       QVector<MusicXmlOctaveShiftList> octaveShifts; // octave shift list for every staff

--- a/mtest/musicxml/io/testInstrumentSound.xml
+++ b/mtest/musicxml/io/testInstrumentSound.xml
@@ -131,6 +131,11 @@
           <sign>G</sign>
           <line>2</line>
           </clef>
+        <transpose>
+          <diatonic>0</diatonic>
+          <chromatic>0</chromatic>
+          <octave-change>-1</octave-change>
+          </transpose>
         </attributes>
       <note>
         <pitch>

--- a/mtest/musicxml/io/testInstrumentSound_ref.xml
+++ b/mtest/musicxml/io/testInstrumentSound_ref.xml
@@ -129,6 +129,11 @@
           <sign>G</sign>
           <line>2</line>
           </clef>
+        <transpose>
+          <diatonic>0</diatonic>
+          <chromatic>0</chromatic>
+          <octave-change>-1</octave-change>
+          </transpose>
         </attributes>
       <note>
         <pitch>

--- a/mtest/musicxml/io/testVirtualInstruments.xml
+++ b/mtest/musicxml/io/testVirtualInstruments.xml
@@ -18,9 +18,7 @@
     <miscellaneous>
       <miscellaneous-field name="description">
         Sibelius 7.1.3 (direct export) uses virtual instruments and leaves out
-        the MIDI information. For a drumset, this means the required staff line
-        to program mapping is missing. The drum part cannot be imported as a
-        percussion staff, instead a standard staff is used.
+        the MIDI information. Unrecognized instruments will use MIDI program 1.
         </miscellaneous-field>
       </miscellaneous>
     </identification>

--- a/mtest/musicxml/io/testVirtualInstruments_ref.xml
+++ b/mtest/musicxml/io/testVirtualInstruments_ref.xml
@@ -26,6 +26,7 @@
       <midi-device id="P1-I1" port="1"></midi-device>
       <midi-instrument id="P1-I1">
         <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
         <volume>78.7402</volume>
         <pan>0</pan>
         </midi-instrument>
@@ -52,7 +53,8 @@
         </score-instrument>
       <midi-device id="P3-I1" port="1"></midi-device>
       <midi-instrument id="P3-I1">
-        <midi-channel>3</midi-channel>
+        <midi-channel>5</midi-channel>
+        <midi-program>1</midi-program>
         <volume>78.7402</volume>
         <pan>0</pan>
         </midi-instrument>


### PR DESCRIPTION
Add articulations to instruments at MusicXML import, either the defaults, or the set defined in the instrument with matching sound id.
Required cleanup of the instrument handling code and moving some code from pass 1 to pass 2.