### PR TITLE
Default shortcuts for next-element and prev-element

### DIFF
--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -261,6 +261,14 @@
     <seq>Ctrl+Alt+Shift+Left</seq>
     </SC>
   <SC>
+    <key>next-element</key>
+    <seq>Alt+Right</seq>
+    </SC>
+  <SC>
+    <key>prev-element</key>
+    <seq>Alt+Left</seq>
+    </SC>
+  <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
     </SC>


### PR DESCRIPTION
This adds default shortcuts Alt+Right for next-element and Alt+Left for prev-element.