### PR TITLE
Set focus on palette search box on pressing F9

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4633,6 +4633,24 @@ void MuseScore::cmd(QAction* a)
                QString("Command %1 not valid in current state").arg(cmdn));
             return;
             }
+      if (cmdn == "toggle-palette") {
+            showPalette(a->isChecked());
+            PaletteBox* pb = mscore->getPaletteBox();
+            QLineEdit* sb = pb->searchBox();
+            if (a->isChecked()) {
+                  lastFocusWidget = QApplication::focusWidget();
+                  sb->setFocus();
+                  if (pb->noSelection())
+                        pb->setKeyboardNavigation(false);
+                  else
+                        pb->setKeyboardNavigation(true);
+                  }
+            else {
+                  if (lastFocusWidget)
+                        lastFocusWidget->setFocus();
+                  }
+            return;
+            }
       if (cmdn == "palette-search") {
             PaletteBox* pb = getPaletteBox();
             QLineEdit* sb = pb->searchBox();
@@ -4891,8 +4909,6 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             undoRedo(true);
       else if (cmd == "redo")
             undoRedo(false);
-      else if (cmd == "toggle-palette")
-            showPalette(a->isChecked());
       else if (cmd == "startcenter")
             showStartcenter(a->isChecked());
       else if (cmd == "inspector")

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -329,6 +329,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       PaletteBox* paletteBox         { 0 };
       Inspector* _inspector          { 0 };
       OmrPanel* omrPanel             { 0 };
+      QWidget* lastFocusWidget       { 0 };
 
       QPushButton* showMidiImportButton {0};
 


### PR DESCRIPTION
On opening the palette by pressing F9, the palette search box gets focus. On closing the palette by pressing F9 again, focus returns to the widget that had focus previously.