### PR TITLE
fix #267569 numeric overflow causes MusicXML import crash

### DIFF
--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -2727,8 +2727,10 @@ void MusicXMLParserPass1::duration(Fraction& dura)
       dura.set(0, 0);  // invalid unless set correctly
       int intDura = _e.readElementText().toInt();
       if (intDura > 0) {
-            if (_divs > 0)
+            if (_divs > 0) {
                   dura.set(intDura, 4 * _divs);
+                  dura.reduce(); // prevent overflow in later Fraction operations
+                  }
             else
                   _logger->logError("illegal or uninitialized divisions", &_e);
             }

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -4832,8 +4832,10 @@ void MusicXMLParserPass2::duration(Fraction& dura)
       dura.set(0, 0);        // invalid unless set correctly
       int intDura = _e.readElementText().toInt();
       if (intDura > 0) {
-            if (_divs > 0)
+            if (_divs > 0) {
                   dura.set(intDura, 4 * _divs);
+                  dura.reduce(); // prevent overflow in later Fraction operations
+                  }
             else
                   _logger->logError(QString("illegal or uninitialized divisions (%1)").arg(_divs), &_e);
             }


### PR DESCRIPTION
Prevent numeric overflow on MusicXML import by keeping Fractions reduced. Also to be synced to 2.2-dev.

Notes:
- on master b7d51c8 this is sufficient to successfully import the file attached to #267534
- on master 2c391b6 the same file causes a new and unrelated crash (still to be investigated)
- IMHO, this should be merged anyway
