### PR TITLE
fix 267602: layout jump with naturals in keysig

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2137,7 +2137,7 @@ qreal Score::cautionaryWidth(Measure* m, bool& hasCourtesy)
       if (showCourtesy && ns) {
             TimeSig* ts = static_cast<TimeSig*>(ns->element(0));
             if (ts && ts->showCourtesySig()) {
-                  qreal leftMargin  = point(styleS(StyleIdx::timesigLeftMargin));
+                  qreal leftMargin = point(styleS(StyleIdx::timesigLeftMargin));
                   Segment* s = m->findSegment(Segment::Type::TimeSigAnnounce, tick);
                   if (s && s->element(0)) {
                         w = static_cast<TimeSig*>(s->element(0))->width() + leftMargin;
@@ -2274,9 +2274,14 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
                         firstMeasure = m;
                         addSystemHeader(m, isFirstSystem);
                         ww = m->minWidth2();
+                        if (MScore::debugMode)
+                              qDebug("measure %d: ww after minWidth2 = %f", m->no(), ww);
                         }
-                  else
+                  else {
                         ww = m->minWidth1();
+                        if (MScore::debugMode)
+                              qDebug("measure %d: ww after minWidth1 = %f", m->no(), ww);
+                        }
 
                   Segment* s = m->last();
                   if ((s->segmentType() == Segment::Type::EndBarLine) && s->element(0)) {
@@ -2297,10 +2302,14 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
                                     - BarLine::layoutWidth(this, ot, mag);
                               }
                         }
+                  if (MScore::debugMode)
+                        qDebug("measure %d: ww after BarLine = %f", m->no(), ww);
                   qreal stretch = m->userStretch() * measureSpacing;
                   if (stretch < 1.0)
                         stretch = 1.0;
                   ww            *= stretch;
+                  if (MScore::debugMode)
+                        qDebug("measure %d: ww after stretch = %f", m->no(), ww);
                   cautionaryW   = cautionaryWidth(m, hasCourtesy) * stretch;
 
                   // if measure does not already have courtesy elements,
@@ -2308,17 +2317,21 @@ bool Score::layoutSystem(qreal& minWidth, qreal systemWidth, bool isFirstSystem,
                   // (if measure *does* already have courtesy elements, these are included in width already)
                   if (!hasCourtesy)
                         ww += cautionaryW;
+                  if (MScore::debugMode)
+                        qDebug("measure %d: ww after cautionaryWidth = %f", m->no(), ww);
 
                   if (ww < minMeasureWidth)
                         ww = minMeasureWidth;
                   isFirstMeasure = false;
-                  //qDebug("measure %d: ww %f + minWidth %f = %f", m->no(), ww, minWidth, ww + minWidth);
+                  if (MScore::debugMode)
+                        qDebug("measure %d: ww %f + minWidth %f = %f", m->no(), ww, minWidth, ww + minWidth);
                   }
 
             // collect at least one measure
             bool empty = system->measures().isEmpty();
             if (!empty && (minWidth + ww > systemWidth)) {
-                  //qDebug("=== does not fit: systemWidth = %f", systemWidth);
+                  if (MScore::debugMode)
+                        qDebug("=== does not fit: systemWidth = %f", systemWidth);
                   curMeasure->setSystem(oldSystem);
                   continueFlag = false;
                   break;


### PR DESCRIPTION
As per analysis in issue report:

If a measure with a keysig involving naturals is just barely too wide to fit at the end of a system, we can get into a "layout jump situation as we push the measure to the next system where it no longer needs the naturals (they are in the courtesy signature), and we now think it fits on the previous system, so we move it back, and keep going back and forth on every layout.

Fix is conceptually simply - when calculating size of measure to see if it will fit (meaning it is on same system as previous measure), be sure to generate the natural.  Somewhat tricky because the courtesy signatures have not been generated yet and are thus not reliable to look at, so I have tweaked the code to not rely on the actual courtesy signature.  I also fixed it so no naturals appear after a mid-system horziontal frame if the courtesy keysig is present and shows the naturals.  Related bug https://musescore.org/en/node/251706 is also fixed here.

Same fix should apply to master, but current naturals in keysigs appear completely broken, not sure why.  For now this fix is submitted on 2.2 only.

Testing welcome!