### PR TITLE
fix #267721: added iteration over selected elements when clicking bar…

### DIFF
--- a/mscore/inspector/inspectorBarline.cpp
+++ b/mscore/inspector/inspectorBarline.cpp
@@ -127,13 +127,16 @@ void InspectorBarLine::setElement()
 
 void InspectorBarLine::presetDefaultClicked()
       {
-      BarLine* bl = toBarLine(inspector->element());
-      Score* score = bl->score();
+      Score* score = inspector->element()->score();
       score->startCmd();
 
-      bl->undoResetProperty(P_ID::BARLINE_SPAN);
-      bl->undoResetProperty(P_ID::BARLINE_SPAN_FROM);
-      bl->undoResetProperty(P_ID::BARLINE_SPAN_TO);
+      BarLine* bl;
+      for (Element* e : *inspector->el()) {
+            bl = toBarLine(e);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN, bl->propertyDefault(P_ID::BARLINE_SPAN).toBool());
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN_FROM, bl->propertyDefault(P_ID::BARLINE_SPAN_FROM).toInt());
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN_TO, bl->propertyDefault(P_ID::BARLINE_SPAN_FROM).toInt());
+            }
 
       score->endCmd();
       }
@@ -144,13 +147,16 @@ void InspectorBarLine::presetDefaultClicked()
 
 void InspectorBarLine::presetTick1Clicked()
       {
-      BarLine* bl = toBarLine(inspector->element());
-      Score* score = bl->score();
+      Score* score = inspector->element()->score();
       score->startCmd();
 
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN, false);
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN_FROM, BARLINE_SPAN_TICK1_FROM);
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN_TO,   BARLINE_SPAN_TICK1_TO);
+      BarLine* bl;
+      for (Element* e : *inspector->el()) {
+            bl = toBarLine(e);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN, false);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN_FROM, BARLINE_SPAN_TICK1_FROM);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN_TO, BARLINE_SPAN_TICK1_TO);
+            }
 
       score->endCmd();
       }
@@ -161,13 +167,16 @@ void InspectorBarLine::presetTick1Clicked()
 
 void InspectorBarLine::presetTick2Clicked()
       {
-      BarLine* bl = toBarLine(inspector->element());
-      Score* score = bl->score();
+      Score* score = inspector->element()->score();
       score->startCmd();
 
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN, false);
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN_FROM, BARLINE_SPAN_TICK2_FROM);
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN_TO,   BARLINE_SPAN_TICK2_TO);
+      BarLine* bl;
+      for (Element* e : *inspector->el()) {
+            bl = toBarLine(e);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN, false);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN_FROM, BARLINE_SPAN_TICK2_FROM);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN_TO, BARLINE_SPAN_TICK2_TO);
+            }
 
       score->endCmd();
       }
@@ -178,14 +187,17 @@ void InspectorBarLine::presetTick2Clicked()
 
 void InspectorBarLine::presetShort1Clicked()
       {
-      BarLine* bl = toBarLine(inspector->element());
-      Score* score = bl->score();
+      Score* score = inspector->element()->score();
       score->startCmd();
 
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN, false);
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN_FROM, BARLINE_SPAN_SHORT1_FROM);
-      int shortDelta = bl->staff() ? (bl->staff()->lines(bl->tick()) - 5) * 2 : 0;
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN_TO,   BARLINE_SPAN_SHORT1_TO + shortDelta);
+      BarLine* bl;
+      for (Element* e : *inspector->el()) {
+            bl = toBarLine(e);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN, false);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN_FROM, BARLINE_SPAN_SHORT1_FROM);
+            int shortDelta = bl->staff() ? (bl->staff()->lines(bl->tick()) - 5) * 2 : 0;
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN_TO, BARLINE_SPAN_SHORT1_TO + shortDelta);
+            }
 
       score->endCmd();
       }
@@ -196,14 +208,17 @@ void InspectorBarLine::presetShort1Clicked()
 
 void InspectorBarLine::presetShort2Clicked()
       {
-      BarLine* bl = toBarLine(inspector->element());
-      Score* score = bl->score();
+      Score* score = inspector->element()->score();
       score->startCmd();
 
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN, false);
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN_FROM, BARLINE_SPAN_SHORT2_FROM);
-      int shortDelta = bl->staff() ? (bl->staff()->lines(bl->tick()) - 5) * 2 : 0;
-      bl->undoChangeProperty(P_ID::BARLINE_SPAN_TO,   BARLINE_SPAN_SHORT2_TO + shortDelta);
+      BarLine* bl;
+      for (Element* e : *inspector->el()) {
+            bl = toBarLine(e);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN, false);
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN_FROM, BARLINE_SPAN_SHORT2_FROM);
+            int shortDelta = bl->staff() ? (bl->staff()->lines(bl->tick()) - 5) * 2 : 0;
+            bl->undoChangeProperty(P_ID::BARLINE_SPAN_TO, BARLINE_SPAN_SHORT2_TO + shortDelta);
+            }
 
       score->endCmd();
       }

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -344,7 +344,13 @@ void InspectorBase::valueChanged(int idx, bool reset)
 
       Score* score  = inspector->element()->score();
 
-      score->startCmd();
+      bool alreadyActive = false;
+      if (!score->undoStack()->active()) {
+            score->startCmd();
+      } else {
+            alreadyActive = true;
+      }
+
       for (Element* e : *inspector->el()) {
             for (int i = 0; i < ii.parent; ++i)
                   e = e->parent();
@@ -362,7 +368,8 @@ void InspectorBase::valueChanged(int idx, bool reset)
             }
       inspector->setInspectorEdit(true);
       checkDifferentValues(ii);
-      score->endCmd();
+      if (!alreadyActive)
+            score->endCmd();
       inspector->setInspectorEdit(false);
       postInit();
 


### PR DESCRIPTION
…line presets. Since the barline presets change three properties in the same time (span, spanFrom, spanTo) they should be combines in one undo-step. But in InspectorBase::valueChanged score->startCmd() and score->endCmd() are called for every single property change. That is why parenthesizing the three undoChangeProperty-calls with score->startCmd() / score->endCmd() was (for me) only possible by adding a flag in InspectorBase::valueChanged that tests if the undoStack is already active.