### PR TITLE
fix #267789: crash on tie with grace note

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1625,14 +1625,24 @@ void Score::cmdAddTie()
                   }
 
             if (noteEntryMode()) {
-                  // set cursor at position after note
-                  _is.setSegment(note->chord()->segment());
-                  _is.moveToNextInputPos();
-                  _is.setLastSegment(_is.segment());
+                  ChordRest* cr = nullptr;
+                  Chord* c = note->chord();
 
-                  if (_is.cr() == 0)
-                        expandVoice();
-                  ChordRest* cr = _is.cr();
+                  // set cursor at position after note
+                  if (c->isGraceBefore()) {
+                        // tie grace note before to main note
+                        cr = static_cast<ChordRest*>(c->parent());
+                        }
+                  else {
+                        // tie to next input position
+                        _is.setSegment(note->chord()->segment());
+                        _is.moveToNextInputPos();
+                        _is.setLastSegment(_is.segment());
+
+                        if (_is.cr() == 0)
+                              expandVoice();
+                        cr = _is.cr();
+                        }
                   if (cr == 0)
                         break;
 
@@ -1672,7 +1682,7 @@ void Score::cmdAddTie()
                               tie->setEndNote(nnote);
                               tie->setTrack(note->track());
                               undoAddElement(tie);
-                              if (!addFlag || nnote->chord() == lastAddedChord) {
+                              if (!addFlag || nnote->chord()->tick() >= lastAddedChord->tick() || nnote->chord()->isGrace()) {
                                     break;
                                     }
                               else {


### PR DESCRIPTION
The code was getting confused over whether it was tying to/from a grace note or normal note.  Quite a few other bad things happen even in cases where there is no crash, when ties involving grace notes happen in note input mode.  My fix here improves the situation greatly and eliminates the crash.

Master will need the same fix but I'm submitted a separate PR to use the proper cast syntax.