### PR TITLE
fix #195146: After adding a rehearsalmark by double clicking the pale…

### DIFF
--- a/libmscore/elementlayout.cpp
+++ b/libmscore/elementlayout.cpp
@@ -236,8 +236,10 @@ bool ElementLayout::readProperties(XmlReader& e)
 void ElementLayout::restyle(const ElementLayout& ol, const ElementLayout& nl)
       {
       if ((ol._align & AlignmentFlags::HMASK) == (_align & AlignmentFlags::HMASK))
+            _align &= AlignmentFlags::VMASK; // unset all HMASK-flags before setting new flags
             _align |= nl._align & AlignmentFlags::HMASK;
       if ((ol._align & AlignmentFlags::VMASK) == (_align & AlignmentFlags::VMASK))
+            _align &= AlignmentFlags::HMASK; // unset all VMASK-Flags before setting new flags
             _align |= nl._align & AlignmentFlags::VMASK;
       if (ol._offset == _offset)
             _offset = nl._offset;


### PR DESCRIPTION
…tte-element is cloned and restyled. The restyled clone is always horizontal centered. Because of the bitwise OR in the restyle-method it can get centered AND right aligned! That is why I suggest unsetting all HMASK-flags before setting new horizontal-alignment-flags. The same should be right for the VMASK-flags. This fixes the problem descibed: [https://musescore.org/en/node/195036#comment-706826](https://musescore.org/en/node/195036#comment-706826)