### PR TITLE
fix #195146: rehearsalmark alignment

### DIFF
--- a/libmscore/elementlayout.cpp
+++ b/libmscore/elementlayout.cpp
@@ -235,10 +235,14 @@ bool ElementLayout::readProperties(XmlReader& e)
 
 void ElementLayout::restyle(const ElementLayout& ol, const ElementLayout& nl)
       {
-      if ((ol._align & AlignmentFlags::HMASK) == (_align & AlignmentFlags::HMASK))
+      if ((ol._align & AlignmentFlags::HMASK) == (_align & AlignmentFlags::HMASK)) {
+            _align &= AlignmentFlags::VMASK; // unset all HMASK-flags before setting new flags
             _align |= nl._align & AlignmentFlags::HMASK;
-      if ((ol._align & AlignmentFlags::VMASK) == (_align & AlignmentFlags::VMASK))
+            }
+      if ((ol._align & AlignmentFlags::VMASK) == (_align & AlignmentFlags::VMASK)) {
+            _align &= AlignmentFlags::HMASK; // unset all VMASK-Flags before setting new flags
             _align |= nl._align & AlignmentFlags::VMASK;
+            }
       if (ol._offset == _offset)
             _offset = nl._offset;
       if (_offsetType == ol._offsetType)


### PR DESCRIPTION
After adding a new rehearsalmark by double clicking the palette-element is cloned and restyled. The restyled clone from the palette is always horizontal centered before the restyling. Because of the bitwise OR in the restyle-method it can get centered AND right aligned! That is why I suggest unsetting all HMASK-flags before setting new horizontal-alignment-flags. The same should be right for the VMASK-flags. This fixes the problem descibed here: [https://musescore.org/en/node/195036#comment-706826](https://musescore.org/en/node/195036#comment-706826)