### PR TITLE
fix #166016 slur on grace after wrong

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4487,6 +4487,11 @@ void ScoreView::cmdAddSlur()
                   return;
             if (firstNote == lastNote)
                   lastNote = 0;
+            else if (firstNote->chord()->isGraceAfter()) {
+                  Note* tmp = firstNote;
+                  firstNote = lastNote;
+                  lastNote = tmp;
+                  }
             cmdAddSlur(firstNote, lastNote);
             }
       }


### PR DESCRIPTION
The algorithm for finding the first and last note of the selection ends up with the two notes reversed. This happens only if a gracenote after is part of the selection. So I decided to test for this case and simply commute the two values.