### PR TITLE
fix #178591, fix #85401: ottava palette not consistent on doubleclick

### DIFF
--- a/libmscore/ottava.cpp
+++ b/libmscore/ottava.cpp
@@ -171,7 +171,7 @@ void OttavaSegment::styleChanged()
 Ottava::Ottava(Score* s)
    : TextLine(s)
       {
-      _numbersOnly        = score()->styleB(StyleIdx::ottavaNumbersOnly);
+      _numbersOnly = score()->styleB(StyleIdx::ottavaNumbersOnly);
       setOttavaType(Type::OTTAVA_8VA);
       setLineWidth(score()->styleS(StyleIdx::ottavaLineWidth));
       setLineStyle(Qt::PenStyle(score()->styleI(StyleIdx::ottavaLineStyle)));
@@ -181,10 +181,16 @@ Ottava::Ottava(Score* s)
 Ottava::Ottava(const Ottava& o)
    : TextLine(o)
       {
-      _numbersOnly = o._numbersOnly;
-      _pitchShift  = o._pitchShift;
+      _ottavaType = o._ottavaType;
+      _numbersOnly = score()->styleB(StyleIdx::ottavaNumbersOnly);
+      numbersOnlyStyle = o.numbersOnlyStyle;
+      lineWidthStyle = o.lineWidthStyle;
       lineStyleStyle = o.lineStyleStyle;
-      setOttavaType(o._ottavaType);
+      beginTextStyle = o.beginTextStyle;
+      continueTextStyle = o.continueTextStyle;
+      setBeginText(o.beginText());
+      setContinueText(o.continueText());
+      _pitchShift  = o._pitchShift;
       }
 
 //---------------------------------------------------------
@@ -411,13 +417,9 @@ QVariant Ottava::propertyDefault(P_ID propertyId) const
             case P_ID::CONTINUE_TEXT:
                   {
                   const OttavaDefault* def = &ottavaDefault[int(_ottavaType)];
-                  SymId id = _numbersOnly ? def->numbersOnlyId : def->id;
-                  QString s;
-                  if (symIsValid(id))
-                        s = QString("<sym>%1</sym>").arg(Sym::id2name(id));
-                  else
-                        s = _numbersOnly ? def->numbersOnlyName : def->name;
-                  return s;
+                  const char* symId;
+                  symId = _numbersOnly ? Sym::id2name(def->numbersOnlyId) : Sym::id2name(def->id);
+                  return QString("<sym>%1</sym>").arg(symId);
                   }
 
             case P_ID::END_TEXT:

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -513,6 +513,7 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
                   for (int i = sel.staffStart(); i < endStaff; ++i) {
                         Spanner* spanner = static_cast<Spanner*>(element->clone());
                         spanner->setScore(score);
+                        spanner->styleChanged();
                         score->cmdAddSpanner(spanner, i, startSegment, endSegment);
                         }
                   }

--- a/mtest/guitarpro/ottava1.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava1.gpx-ref.mscx
@@ -434,6 +434,7 @@
           <Ottava id="7">
             <subtype>8va</subtype>
             <lid>29</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>6</lid>
@@ -468,6 +469,7 @@
           <Ottava id="8">
             <subtype>8vb</subtype>
             <lid>30</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>12</lid>
@@ -488,6 +490,7 @@
           <Ottava id="10">
             <subtype>15ma</subtype>
             <lid>31</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>15</lid>
@@ -508,6 +511,7 @@
           <Ottava id="12">
             <subtype>15mb</subtype>
             <lid>32</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>18</lid>
@@ -579,6 +583,7 @@
           <Ottava id="9">
             <subtype>8va</subtype>
             <lid>29</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>6</lid>
@@ -609,6 +614,7 @@
           <Ottava id="11">
             <subtype>8vb</subtype>
             <lid>30</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>12</lid>
@@ -626,6 +632,7 @@
           <Ottava id="13">
             <subtype>15ma</subtype>
             <lid>31</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>15</lid>
@@ -643,6 +650,7 @@
           <Ottava id="15">
             <subtype>15mb</subtype>
             <lid>32</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>18</lid>

--- a/mtest/guitarpro/ottava2.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava2.gpx-ref.mscx
@@ -618,6 +618,7 @@
           <Ottava id="4">
             <subtype>8va</subtype>
             <lid>31</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>6</lid>
@@ -649,6 +650,7 @@
           <Ottava id="5">
             <subtype>8vb</subtype>
             <lid>32</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>12</lid>
@@ -762,6 +764,7 @@
           <Ottava id="6">
             <subtype>8va</subtype>
             <lid>31</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>6</lid>
@@ -792,6 +795,7 @@
           <Ottava id="7">
             <subtype>8vb</subtype>
             <lid>32</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>12</lid>

--- a/mtest/guitarpro/ottava4.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava4.gpx-ref.mscx
@@ -630,6 +630,7 @@
           <Ottava id="6">
             <subtype>8va</subtype>
             <lid>31</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>6</lid>
@@ -661,6 +662,7 @@
           <Ottava id="7">
             <subtype>8vb</subtype>
             <lid>32</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>12</lid>
@@ -774,6 +776,7 @@
           <Ottava id="8">
             <subtype>8va</subtype>
             <lid>31</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>6</lid>
@@ -804,6 +807,7 @@
           <Ottava id="9">
             <subtype>8vb</subtype>
             <lid>32</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>12</lid>
@@ -1063,6 +1067,7 @@
           <Ottava id="10">
             <subtype>8va</subtype>
             <lid>53</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>37</lid>
@@ -1094,6 +1099,7 @@
           <Ottava id="11">
             <subtype>8vb</subtype>
             <lid>54</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>41</lid>
@@ -1207,6 +1213,7 @@
           <Ottava id="12">
             <subtype>8va</subtype>
             <lid>53</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>37</lid>
@@ -1237,6 +1244,7 @@
           <Ottava id="13">
             <subtype>8vb</subtype>
             <lid>54</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>41</lid>

--- a/mtest/guitarpro/ottava5.gpx-ref.mscx
+++ b/mtest/guitarpro/ottava5.gpx-ref.mscx
@@ -783,6 +783,7 @@
           <Ottava id="6">
             <subtype>8va</subtype>
             <lid>30</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>21</lid>
@@ -872,6 +873,7 @@
           <Ottava id="7">
             <subtype>8va</subtype>
             <lid>30</lid>
+            <lineWidth>0.1</lineWidth>
             </Ottava>
           <Chord>
             <lid>21</lid>


### PR DESCRIPTION
added styleChanged()-call when adding an ottava by doubleclicking, removed the use of non <sym> texts for default palette elements, changed the way the ottava-constructor (which is called when cloning the palette object) copies the object-properties