### PR TITLE
Fix #268465: image capture: no file saved when selected rectangle is 'negative'

### DIFF
--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -630,9 +630,9 @@ void ScoreView::fotoContextPopup(QContextMenuEvent* ev)
             return;
       QString cmd(a->data().toString());
       if (cmd == "print")
-            saveFotoAs(true, _foto->rect());
+            saveFotoAs(true, _foto->rect().normalized());
       else if (cmd == "screenshot")
-            saveFotoAs(false, _foto->rect());
+            saveFotoAs(false, _foto->rect().normalized());
       else if (cmd == "copy")
             ;
       else if (cmd == "set-res") {
@@ -688,7 +688,7 @@ void ScoreView::fotoModeCopy()
       double convDpi   = preferences.pngResolution;
       double mag       = convDpi / DPI;
 
-      QRectF r(_foto->rect());
+      QRectF r(_foto->rect().normalized());
 
       int w = lrint(r.width()  * mag);
       int h = lrint(r.height() * mag);


### PR DESCRIPTION
The 3 lines I changed in this PR were inspired by a recent change for master in 1bed5f4