### PR TITLE
Fix #208006: Add built-in MP3 support for Windows

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -425,6 +425,7 @@ if (MINGW)
             ${CROSS}/lib/libvorbis.dll
             ${CROSS}/lib/libvorbisfile.dll
             ${CROSS}/lib/portaudio.dll
+            ${CROSS}/lib/lame_enc.dll
             ${CROSS}/opt/bin/libeay32.dll
             ${CROSS}/opt/bin/ssleay32.dll
             ${CROSSQT}/bin/icudt53.dll


### PR DESCRIPTION
expects lame_enc.dll (from https://lame.buanzo.org/#lamewindl) to be found at the same place as libogg.dll, libsndfile-1.dll, libvorbis.dll, libvorbisfile.dll and portaudio.dll

AppVeyor build expected to fail, lame_enc.dll needs to get added to http://utils.musescore.org.s3.amazonaws.com/musescore_dependencies_win32.7z first

Not sure, we may want to use the same approach for master too, at least until there's MP3 support in libsndfile?