### PR TITLE
Fixed crash in #268357

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3154,7 +3154,7 @@ System* Score::collectSystem(LayoutContext& lc)
             std::vector<Spanner*> spanner;
             for (auto interval : spanners) {
                   Spanner* sp = interval.value;
-                  if (sp->tick() < etick && sp->tick2() > stick) {
+                  if (sp->tick() < etick && sp->tick2() >= stick) {
                         if (sp->isSlur())
                               spanner.push_back(sp);
                         }


### PR DESCRIPTION
First note (tick == tick2 == 0) was not processed correctly during slur spanners calculations. It led to not setting layoutSystem for the created slur.