### PR TITLE
Fix #209596: Screencapture + Copy + Transparency issue

### DIFF
--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -402,8 +402,7 @@ void ScoreView::fotoContextPopup(QContextMenuEvent* ev)
 
 void ScoreView::fotoModeCopy()
       {
-      // oowriter wants transparent==false
-      bool transparent = false; // preferences.pngTransparent;
+      bool transparent = preferences.pngTransparent;
       double convDpi   = preferences.pngResolution;
       double mag       = convDpi / DPI;
 


### PR DESCRIPTION
Applies to master and 2.2.
Seems to be a remnant of some pretty old restriction that no longer exists, but I'm not really sure here.