### PR TITLE
fix #268713: Start repeat barline added twice

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1870,7 +1870,7 @@ void Measure::read(XmlReader& e, int staffIdx)
             else if (tag == "BarLine") {
                   BarLine* barLine = new BarLine(score());
                   barLine->setTrack(e.track());
-
+                  barLine->read(e);
                   //
                   //  StartRepeatBarLine: at rtick == 0, always BarLineType::START_REPEAT
                   //  BarLine:            in the middle of a measure, has no semantic
@@ -1895,9 +1895,8 @@ void Measure::read(XmlReader& e, int staffIdx)
                   if (barLine) {
                         segment = getSegmentR(st, t);
                         segment->add(barLine);
+                        barLine->layout();
                         }
-                  barLine->read(e);
-                  barLine->layout();
                   }
             else if (tag == "Chord") {
                   Chord* chord = new Chord(score());


### PR DESCRIPTION
The condition `barLine->barLineType() == BarLineType::START_REPEAT` never got true, because the default for the new created object is `BarLineType::NORMAL` and `barLine->read(e)` was executed after checking the conditions. 
Since now the lines `delete barline` and `barLine = 0` can potentially get executed, I had to move  `barLine->layout()` into the conditional executed block.