### PR TITLE
fix #224781, fix #268293 crash on creation tuplets with small baseLen duration

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4823,6 +4823,11 @@ void ScoreView::cmdTuplet(int n, ChordRest* cr)
       //    Example: an 1/8 has 240 midi ticks, in an 1/8 triplet the note
       //             has a tick duration of 240 / (3/2) = 160 ticks
       //
+      if (fr.denominator() > 128) {
+            delete tuplet;
+            mscore->noteTooShortForTupletDialog();
+            return;
+            }
 
       tuplet->setDuration(f);
       TDuration baseLen(fr);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4797,6 +4797,10 @@ void ScoreView::cmdTuplet(int n, ChordRest* cr)
             return;
             }
 
+      Measure* measure = cr->measure();
+      if (measure && measure->isMMRest())
+            return;
+
       Fraction f(cr->duration());
       int tick    = cr->tick();
       Tuplet* ot  = cr->tuplet();
@@ -4826,7 +4830,6 @@ void ScoreView::cmdTuplet(int n, ChordRest* cr)
 
       tuplet->setTrack(cr->track());
       tuplet->setTick(tick);
-      Measure* measure = cr->measure();
       tuplet->setParent(measure);
 
       if (ot)

--- a/mscore/tupletdialog.cpp
+++ b/mscore/tupletdialog.cpp
@@ -94,6 +94,11 @@ Tuplet* MuseScore::tupletDialog()
             noteTooShortForTupletDialog();
             return 0;
             }
+
+      Measure* measure = cr->measure();
+      if (measure && measure->isMMRest())
+            return 0;
+
       TupletDialog td;
       if (!td.exec())
             return 0;
@@ -123,7 +128,6 @@ Tuplet* MuseScore::tupletDialog()
             return 0;
             }
 
-      Measure* measure = cr->measure();
       tuplet->setParent(measure);
 
       return tuplet;

--- a/mscore/tupletdialog.cpp
+++ b/mscore/tupletdialog.cpp
@@ -118,6 +118,12 @@ Tuplet* MuseScore::tupletDialog()
          qPrintable(tuplet->ratio().print()),
          qPrintable(f.print()));
 
+      if (f.denominator() > 128) {
+            delete tuplet;
+            mscore->noteTooShortForTupletDialog();
+            return 0;
+            }
+
       tuplet->setBaseLen(Fraction(1, f.denominator()));
 
       if (tuplet->baseLen() == TDuration::DurationType::V_INVALID) {


### PR DESCRIPTION
Not sure about the workflow here.

1. First commit could rather be an actual cherry pick of ab28b7e into 2.2
2. Second commit feels like it might be required (or at least in similar form) for master as well, so probably better off making that a PR and then have it merged back?

Side question: currently no tuplet creation is allowed if the baseLen of the tuplet goes beyond 1/128th; I _think/believe_ that this could be a 1/256th for 2.2 and likely a 1/1024th for master?