### PR TITLE
fix #268732: changing barline style to start-repeat in inspector …

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -1153,8 +1153,18 @@ bool BarLine::setProperty(P_ID id, const QVariant& v)
 
 void BarLine::undoChangeProperty(P_ID id, const QVariant& v, PropertyFlags ps)
       {
-      if (id == P_ID::BARLINE_TYPE && segment())
-            undoChangeBarLineType(this, v.value<BarLineType>());
+      if (id == P_ID::BARLINE_TYPE && segment()) {
+            const BarLine* bl = this;
+            BarLineType blType = v.value<BarLineType>();
+            if (blType == BarLineType::START_REPEAT) { // change next measures endBarLine
+                  if (bl->measure()->nextMeasure())
+                        bl = bl->measure()->nextMeasure()->endBarLine();
+                  else
+                        bl = 0;
+                  }
+            if (bl)
+                  undoChangeBarLineType(const_cast<BarLine*>(bl), v.value<BarLineType>());
+            }
       else
             ScoreElement::undoChangeProperty(id, v, ps);
       }


### PR DESCRIPTION
… changes wrong barline.
Since a selected barline belongs to the preceding bar, a change of its barline style to `START_REPEAT` results in creating a "start repeat"-barline on the _preceding_ barline.
**Fix**: 
If a barlines style is changed to `START_REPEAT` and it is not the last measure, the next bar is changed instead. It is not possible to change the style of the last barline to `START_REPEAT`.
