### PR TITLE
MusicXml: Import attribute color of element Note.

### DIFF
--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -4280,6 +4280,8 @@ Note* MusicXMLParserPass2::note(const QString& partId,
       Direction stemDir = Direction::AUTO;
       bool noStem = false;
       NoteHead::Group headGroup = NoteHead::Group::HEAD_NORMAL;
+      QColor noteColor = QColor::Invalid;
+      noteColor.setNamedColor(_e.attributes().value("color").toString());
       QColor noteheadColor = QColor::Invalid;
       bool noteheadParentheses = false;
       QString noteheadFilled;
@@ -4519,6 +4521,8 @@ Note* MusicXMLParserPass2::note(const QString& partId,
                   else
                         cr->setBeamMode(Beam::Mode::NONE);
                   cr->setSmall(small);
+                  if (noteColor != QColor::Invalid)
+                      cr->setColor(noteColor);
                   cr->setVisible(printObject);
                   handleDisplayStep(cr, displayStep, displayOctave, noteStartTime.ticks(), _score->spatium());
                   }
@@ -4570,8 +4574,10 @@ Note* MusicXMLParserPass2::note(const QString& partId,
             note = new Note(_score);
             note->setSmall(small);
             note->setHeadGroup(headGroup);
-            if (noteheadColor != QColor::Invalid)
-                  note->setColor(noteheadColor);
+            if (noteColor != QColor::Invalid)
+                note->setColor(noteColor);
+            else if (noteheadColor != QColor::Invalid)
+                note->setColor(noteheadColor);
             note->setVisible(printObject); // TODO also set the stem to invisible
 
             if (noteheadParentheses) {


### PR DESCRIPTION
This should cover the import side of:
https://musescore.org/en/node/268578 MusicXML Import/Export rest colors

I have a very simple test case MusicXml attached, which shows lyrics with the correct colors. A human can easily see if the test succeeds or fails. Perhaps an automated test case could be made out of it, but I do not know how to do that in MuseScore. Perhaps if someone has a relevant example?
 
[NoteColor.xml.txt](https://github.com/musescore/MuseScore/files/1657900/NoteColor.xml.txt)
(.txt extension otherwise GitHub refused it).

