### PR TITLE
fix #268717: Raising pitch diatonically is not working properly

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -728,7 +728,8 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Diatonic pitch up"),
          0,
          Icons::Invalid_ICON,
-         Qt::WindowShortcut
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CMD
          },
       {
          MsWidget::SCORE_TAB,


### PR DESCRIPTION
This fixes [issue #268717](https://musescore.org/en/node/268717).

Without this line in mscore/shortcut.cpp, the test on line 4681 of mscore/musescore.cpp returns false, and Score::update() never gets called.

Note: Lowering a pitch diatonically works as it should.