### PR TITLE
Make use of the non-breaking space character

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -418,7 +418,8 @@ void Lyrics::paste(MuseScoreView* scoreview)
       QClipboard::Mode mode = QClipboard::Selection;
 #endif
       QString txt = QApplication::clipboard()->text(mode);
-      QStringList sl = txt.split(QRegExp("\\s+"), QString::SkipEmptyParts);
+      QString regex = QString("[^\\S") + QChar(0xa0) + QChar(0x202F) + "]+";
+      QStringList sl = txt.split(QRegExp(regex), QString::SkipEmptyParts);
       if (sl.isEmpty())
             return;
 

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -26,6 +26,12 @@
 
 namespace Ms {
 
+#ifdef Q_OS_MAC
+#define CONTROL_MODIFIER Qt::AltModifier
+#else
+#define CONTROL_MODIFIER Qt::ControlModifier
+#endif
+
 static const qreal subScriptSize   = 0.6;
 static const qreal subScriptOffset = 0.5;       // of x-height
 static const qreal superScriptOffset = -.9;      // of x-height
@@ -1810,8 +1816,14 @@ bool Text::edit(MuseScoreView*, Grip, int key, Qt::KeyboardModifiers modifiers, 
                         break;
 
                   case Qt::Key_Tab:
-                  case Qt::Key_Space:
                         s = " ";
+                        modifiers = 0;
+                        break;
+                  case Qt::Key_Space:
+                        if (modifiers & CONTROL_MODIFIER)
+                              s = QString(QChar(0xa0)); // non-breaking space
+                        else
+                              s = " ";
                         modifiers = 0;
                         break;
 


### PR DESCRIPTION
See [issue #268842](https://musescore.org/en/node/268842).