### PR TITLE
Ignore project files created by Qt-Creator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ win32build
 win32install
 build.xcode
 applebuild
+/*.config
+/*.creator
+/*.files
+/*.includes
 *.user
 *.qm
 share/manual/en


### PR DESCRIPTION
see
https://musescore.org/de/node/98621/revisions/387414/view#Qt-Creator-IDE---method-2

Should primarily go to master, won't harm for 2.2 (but 2.2 is the branch I am working in currently on this PC)