### PR TITLE
fix the pasting of lyrics

### DIFF
--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -20,6 +20,12 @@
 
 namespace Ms {
 
+#ifdef Q_OS_MAC
+#define CONTROL_MODIFIER Qt::AltModifier
+#else
+#define CONTROL_MODIFIER Qt::ControlModifier
+#endif
+
 #ifndef VOICES
 #define VOICES 4
 #endif
@@ -123,7 +129,7 @@ class EditData {
 
       ElementEditData* getData(const Element*) const;
       void addData(ElementEditData*);
-      bool control() const  { return modifiers & Qt::ControlModifier; }
+      bool control() const  { return modifiers & CONTROL_MODIFIER; }
       bool shift() const    { return modifiers & Qt::ShiftModifier; }
       bool isStartEndGrip() { return curGrip == Grip::START || curGrip == Grip::END; }
       };

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -19,6 +19,7 @@
 #include "xml.h"
 #include "staff.h"
 #include "segment.h"
+#include "undo.h"
 
 namespace Ms {
 
@@ -403,14 +404,16 @@ void Lyrics::paste(EditData& ed)
       QStringList hyph = sl[0].split("-");
       bool minus = false;
       bool underscore = false;
+      score()->startCmd();
+
       if(hyph.length() > 1) {
-            insertText(ed, hyph[0]);
+            score()->undo(new InsertText(cursor(ed), hyph[0]), &ed);
             hyph.removeFirst();
             sl[0] =  hyph.join("-");
             minus = true;
             }
       else if (sl.length() > 1 && sl[1] == "-") {
-            insertText(ed, sl[0]);
+            score()->undo(new InsertText(cursor(ed), sl[0]), &ed);
             sl.removeFirst();
             sl.removeFirst();
             minus = true;
@@ -423,26 +426,24 @@ void Lyrics::paste(EditData& ed)
             }
       else if (sl[0].contains("_")) {
             int p = sl[0].indexOf("_");
-            insertText(ed, sl[0].left(p));
+            score()->undo(new InsertText(cursor(ed), sl[0]), &ed);
             sl[0] = sl[0].mid(p + 1);
             if (sl[0].isEmpty())
                   sl.removeFirst();
             underscore = true;
             }
       else if (sl.length() > 1 && sl[1] == "_") {
-            insertText(ed, sl[0]);
+            score()->undo(new InsertText(cursor(ed), sl[0]), &ed);
             sl.removeFirst();
             sl.removeFirst();
             underscore = true;
             }
       else {
-            insertText(ed, sl[0]);
+            score()->undo(new InsertText(cursor(ed), sl[0]), &ed);
             sl.removeFirst();
             }
 
-      layout();
-      score()->setLayoutAll();
-      score()->update();
+      score()->endCmd();
       txt = sl.join(" ");
 
       QApplication::clipboard()->setText(txt, mode);


### PR DESCRIPTION
[This pull request](https://github.com/musescore/MuseScore/pull/3423) was recently merged into master to allow for the pasting of lyrics in version 3.0. Unfortunately, it didn't quite work. This fixes the pasting of lyrics, makes the action undoable, and reenables the use of option+space on a Mac to insert a (non-breaking) space in a lyric.