### PR TITLE
fix #269024: Enable alignment of verse numbers in version 3.0

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -299,23 +299,21 @@ void Lyrics::layout1()
             QRegularExpression punctuationPattern("(^[\\d\\W]*)([^\\d\\W].*?)([\\d\\W]*$)", QRegularExpression::UseUnicodePropertiesOption);
             QRegularExpressionMatch punctuationMatch = punctuationPattern.match(s);
             if (punctuationMatch.hasMatch()) {
-#if 0 // TODO::ws
                   // leading and trailing punctuation
                   QString lp = punctuationMatch.captured(1);
                   QString tp = punctuationMatch.captured(3);
                   // actual lyric
                   //QString actualLyric = punctuationMatch.captured(2);
-                  Text leading(*this);
+                  Lyrics leading(*this);
                   leading.setPlainText(lp);
-                  leading.layout1();
-                  Text trailing(*this);
+                  toText(&leading)->layout1();
+                  Lyrics trailing(*this);
                   trailing.setPlainText(tp);
-                  trailing.layout1();
+                  toText(&trailing)->layout1();
                   leftAdjust = leading.width();
                   centerAdjust = leading.width() - trailing.width();
                   if (!lp.isEmpty() && lp[0].isDigit())
                         hasNumber = true;
-#endif
                   }
             }
 


### PR DESCRIPTION
In version 2.x, verse numbers line up automatically, but this is disabled in version 3.0. These changes enable verse number alignment in 3.0.