### PR TITLE
Fix #125121: Formula determining octave number affecting split staff

### DIFF
--- a/awl/utils.cpp
+++ b/awl/utils.cpp
@@ -59,7 +59,7 @@ QString pitch2string(int v)
       {
       if (v < 0 || v > 127)
             return QString("----");
-      int octave = (v / 12) - 2;
+      int octave = (v / 12) - 1;
       QString o;
       o.sprintf("%d", octave);
       int i = v % 12;


### PR DESCRIPTION
Octave formula subtracted 2 which made middle C have a octave number of C3, though it should be C4, caused the SplitStaff UI to display the wrong number

Reopened a new pull request with single commit