### PR TITLE
add property 'play repeats' to jump elements, for 2.2

### DIFF
--- a/libmscore/jump.cpp
+++ b/libmscore/jump.cpp
@@ -45,6 +45,7 @@ Jump::Jump(Score* s)
       setFlags(ElementFlag::MOVABLE | ElementFlag::SELECTABLE);
       setTextStyleType(TextStyleType::REPEAT_RIGHT);
       setLayoutToParentWidth(true);
+      _playRepeats = false;
       }
 
 //---------------------------------------------------------
@@ -100,6 +101,8 @@ void Jump::read(XmlReader& e)
                   _playUntil = e.readElementText();
             else if (tag == "continueAt")
                   _continueAt = e.readElementText();
+            else if (tag == "playRepeats")
+                  _playRepeats = e.readBool();
             else if (!Text::readProperties(e))
                   e.unknown();
             }
@@ -117,6 +120,7 @@ void Jump::write(Xml& xml) const
       xml.tag("jumpTo", _jumpTo);
       xml.tag("playUntil", _playUntil);
       xml.tag("continueAt", _continueAt);
+      xml.tag("playRepeats", _playRepeats);
       xml.etag();
       }
 
@@ -160,6 +164,8 @@ QVariant Jump::getProperty(P_ID propertyId) const
                   return playUntil();
             case P_ID::CONTINUE_AT:
                   return continueAt();
+            case P_ID::PLAY_REPEATS:
+                  return playRepeats();
             default:
                   break;
             }
@@ -182,12 +188,16 @@ bool Jump::setProperty(P_ID propertyId, const QVariant& v)
             case P_ID::CONTINUE_AT:
                   setContinueAt(v.toString());
                   break;
+            case P_ID::PLAY_REPEATS:
+                  setPlayRepeats(v.toInt());
+                  break;
             default:
                   if (!Text::setProperty(propertyId, v))
                         return false;
                   break;
             }
       score()->setLayoutAll(true);
+      score()->setPlaylistDirty();
       return true;
       }
 
@@ -202,6 +212,9 @@ QVariant Jump::propertyDefault(P_ID propertyId) const
             case P_ID::PLAY_UNTIL:
             case P_ID::CONTINUE_AT:
                   return QString("");
+
+            case P_ID::PLAY_REPEATS:
+                  return false;
 
             default:
                   break;

--- a/libmscore/jump.h
+++ b/libmscore/jump.h
@@ -41,6 +41,7 @@ class Jump : public Text {
       QString _jumpTo;
       QString _playUntil;
       QString _continueAt;
+      bool _playRepeats;
 
    public:
       enum class Type : char {
@@ -76,6 +77,8 @@ class Jump : public Text {
       void undoSetJumpTo(const QString& s);
       void undoSetPlayUntil(const QString& s);
       void undoSetContinueAt(const QString& s);
+      bool playRepeats() const             { return _playRepeats; }
+      void setPlayRepeats(bool val)        { _playRepeats = val;  }
 
       virtual bool systemFlag() const override      { return true;        }
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -237,6 +237,7 @@ static const PropertyData propertyList[] = {
       { P_ID::FRET_FRETS,          false, "frets",                 P_TYPE::INT },
       { P_ID::FRET_BARRE,          false, "barre",                 P_TYPE::INT },
       { P_ID::FRET_OFFSET,         false, "fretOffset",            P_TYPE::INT },
+      { P_ID::PLAY_REPEATS,        false, "playRepeats",           P_TYPE::BOOL},
 
       { P_ID::END,                 false, "",                      P_TYPE::INT }
       };

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -230,6 +230,7 @@ enum class P_ID : unsigned char {
       FRET_FRETS,
       FRET_BARRE,
       FRET_OFFSET,
+      PLAY_REPEATS,
       END
       };
 

--- a/mscore/inspector/inspectorJump.cpp
+++ b/mscore/inspector/inspectorJump.cpp
@@ -29,14 +29,15 @@ InspectorJump::InspectorJump(QWidget* parent)
       j.setupUi(addWidget());
 
       iList = {
-            { P_ID::COLOR,              0, false, b.color,      b.resetColor      },
-            { P_ID::VISIBLE,            0, false, b.visible,    b.resetVisible    },
-            { P_ID::USER_OFF,           0, false, b.offsetX,    b.resetX          },
-            { P_ID::USER_OFF,           1, false, b.offsetY,    b.resetY          },
-            { P_ID::TEXT_STYLE_TYPE,    0, 0,     t.style,      t.resetStyle      },
-            { P_ID::JUMP_TO,            0, false, j.jumpTo,     j.resetJumpTo     },
-            { P_ID::PLAY_UNTIL,         0, false, j.playUntil,  j.resetPlayUntil  },
-            { P_ID::CONTINUE_AT,        0, false, j.continueAt, j.resetContinueAt }
+            { P_ID::COLOR,              0, false, b.color,       b.resetColor       },
+            { P_ID::VISIBLE,            0, false, b.visible,     b.resetVisible     },
+            { P_ID::USER_OFF,           0, false, b.offsetX,     b.resetX           },
+            { P_ID::USER_OFF,           1, false, b.offsetY,     b.resetY           },
+            { P_ID::TEXT_STYLE_TYPE,    0, 0,     t.style,       t.resetStyle       },
+            { P_ID::JUMP_TO,            0, false, j.jumpTo,      j.resetJumpTo      },
+            { P_ID::PLAY_UNTIL,         0, false, j.playUntil,   j.resetPlayUntil   },
+            { P_ID::CONTINUE_AT,        0, false, j.continueAt,  j.resetContinueAt  },
+            { P_ID::PLAY_REPEATS,       0, false, j.playRepeats, j.resetPlayRepeats }
             };
 
       mapSignals();

--- a/mscore/inspector/inspector_jump.ui
+++ b/mscore/inspector/inspector_jump.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>340</width>
-    <height>124</height>
+    <width>356</width>
+    <height>163</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -158,6 +158,30 @@
        </property>
        <property name="accessibleName">
         <string>Reset 'Continue at' value</string>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="../musescore.qrc">
+         <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="QCheckBox" name="playRepeats">
+       <property name="text">
+        <string>Play repeats</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QToolButton" name="resetPlayRepeats">
+       <property name="toolTip">
+        <string>Reset to default</string>
+       </property>
+       <property name="accessibleName">
+        <string>Reset 'Play repeats' value</string>
        </property>
        <property name="text">
         <string notr="true"/>


### PR DESCRIPTION
Cherry picking @wschweer's a95613e from master onto 2.2 and hope it doesn't create bad conflicts with @jeetee's #3371
Score using this property opened in older 2.x versions would of course not show nor playback this, they will simply ignore it, tested with 2.1 and 2.0(.0).