### PR TITLE
fix #175216, fix #269114: Crash with shortcut alt+arrow up/down if mo…

### DIFF
--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -197,10 +197,9 @@ Element* Score::upAlt(Element* element)
             Chord* chord = note->chord();
             const std::vector<Note*>& notes = chord->notes();
             auto i = std::find(notes.begin(), notes.end(), note);
-            if (i != notes.begin()) {
-                  ++i;
-                  re = i != notes.end() ? *i : 0;
-                  }
+            ++i;
+            if (i != notes.end())
+                  re = *i;
             else {
                   re = prevTrack(chord);
                   if (re->track() == chord->track())

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -153,10 +153,9 @@ void TieSegment::editDrag(EditData& ed)
             //
             if ((g == Grip::START && isSingleBeginType()) || (g == Grip::END && isSingleEndType())) {
                   Spanner* spanner = tie();
-                  Note* note = toNote(ed.view->elementNear(ed.pos));
-                  if (note && note->isNote()
-                     && ((g == Grip::END && note->tick() > tie()->tick()) || (g == Grip::START && note->tick() < tie()->tick2()))
-                     ) {
+                  Element* e = ed.view->elementNear(ed.pos);
+                  Note* note = (e && e->isNote()) ? toNote(e) : NULL;
+                  if (note && ((g == Grip::END && note->tick() > tie()->tick()) || (g == Grip::START && note->tick() < tie()->tick2()))) {
                         if (g == Grip::END) {
                               Tie* tie = toTie(spanner);
                               if (tie->startNote()->pitch() == note->pitch()

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1904,10 +1904,15 @@ void ScoreView::cmd(const char* s)
             }
       else if (cmd == "up-chord") {
             Element* el = score()->selection().element();
+            Element* oel = el;
             if (el && (el->isNote() || el->isRest()))
                   cmdGotoElement(score()->upAlt(el));
             el = score()->selection().element();
-            while (el->isRest() && toRest(el)->isGap() && el->voice() != 0) {
+            while (el && el->isRest() && toRest(el)->isGap()) {
+                  if (score()->upAlt(el) == el) {
+                        cmdGotoElement(oel);
+                        break;
+                        }
                   el = score()->upAlt(el);
                   cmdGotoElement(el);
                   }
@@ -1918,7 +1923,7 @@ void ScoreView::cmd(const char* s)
             if (el && (el->isNote() || el->isRest()))
                   cmdGotoElement(score()->downAlt(el));
             el = score()->selection().element();
-            while (el->isRest() && toRest(el)->isGap() && el->voice() != 3) {
+            while (el && el->isRest() && toRest(el)->isGap()) {
                   if (score()->downAlt(el) == el) {
                         cmdGotoElement(oel);
                         break;


### PR DESCRIPTION
…re than one element or nothing is selected

Fix other related issues with the up-chord/down-chord commands
Prevent crash when adjusting the grips of ties