### PR TITLE
fix #240831, fix #267689: crash on editing arpeggios, spacers, brackets and stems

### DIFF
--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -326,6 +326,7 @@ QPointF Arpeggio::gripAnchor(Grip n) const
 
 void Arpeggio::startEdit(EditData& ed)
       {
+      Element::startEdit(ed);
       ed.grips   = 2;
       ed.curGrip = Grip::END;
       undoPushProperty(P_ID::ARP_USER_LEN1);

--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -275,6 +275,7 @@ void Bracket::draw(QPainter* painter) const
 
 void Bracket::startEdit(EditData& ed)
       {
+      Element::startEdit(ed);
       ed.grips   = 1;
       ed.curGrip = Grip::START;
       }

--- a/libmscore/chordline.cpp
+++ b/libmscore/chordline.cpp
@@ -380,6 +380,7 @@ void ChordLine::updateGrips(EditData& ed) const
 
 void ChordLine::startEdit(EditData& ed)
       {
+      Element::startEdit(ed);
       if (_straight) {
             ed.curGrip = Grip(0);
             ed.grips   = 1;

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1812,8 +1812,7 @@ bool Element::edit(EditData& ed)
 void Element::startEditDrag(EditData& ed)
       {
       ElementEditData* eed = ed.getData(this);
-      if (eed)
-            eed->pushProperty(P_ID::USER_OFF);
+      eed->pushProperty(P_ID::USER_OFF);
       }
 
 //---------------------------------------------------------

--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -570,6 +570,7 @@ QVariant Image::propertyDefault(P_ID id) const
 
 void Image::startEdit(EditData& ed)
       {
+      Element::startEdit(ed);
       ed.grips   = 2;
       ed.curGrip = Grip(1);
       }

--- a/libmscore/lasso.cpp
+++ b/libmscore/lasso.cpp
@@ -106,6 +106,7 @@ void Lasso::updateGrips(EditData& ed) const
 
 void Lasso::startEdit(EditData& ed)
       {
+      Element::startEdit(ed);
       ed.grips   = 8;
       ed.curGrip = Grip(7);
       }

--- a/libmscore/spacer.cpp
+++ b/libmscore/spacer.cpp
@@ -122,6 +122,7 @@ void Spacer::spatiumChanged(qreal ov, qreal nv)
 
 void Spacer::startEdit(EditData& ed)
       {
+      Element::startEdit(ed);
       ed.grips   = 1;
       ed.curGrip = Grip::START;
       }

--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -239,6 +239,7 @@ void Stem::updateGrips(EditData& ed) const
 
 void Stem::startEdit(EditData& ed)
       {
+      Element::startEdit(ed);
       ed.grips   = 1;
       ed.curGrip = Grip::START;
       undoPushProperty(P_ID::USER_LEN);

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -786,6 +786,7 @@ bool Tuplet::isEditable() const
 
 void Tuplet::startEdit(EditData& ed)
       {
+      Element::startEdit(ed);
       ed.grips   = 2;
       ed.curGrip = Grip::END;
       }

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -31,6 +31,7 @@ namespace Ms {
 
 void FotoLasso::startEdit(EditData& ed)
       {
+      Element::startEdit(ed);
       ed.grips   = 8;
       ed.curGrip = Grip(0);
       QRectF view = ((ScoreView*)ed.view)->toLogical(QRect(0.0, 0.0, ed.view->geometry().width(), ed.view->geometry().height()));


### PR DESCRIPTION
Added required call of the super startEdit() method to initialize ElementEditData for further usage in startEditDrag.
Removed nullptr check since it is actually useful to have crashes on master to find incorrect program states, but not just avoid occasional crashes.