### PR TITLE
fix #269271: crash on drag'n'drop brackets to a score

### DIFF
--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -397,7 +397,8 @@ bool Bracket::edit(EditData& ed)
 
 QVariant Bracket::getProperty(P_ID id) const
       {
-      return _bi->getProperty(id);
+      auto prop = _bi->getProperty(id);
+      return prop.isValid() ? prop : Element::getProperty(id);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Added correct check for Bracket properties.
Previous implementation processed only BracketItem properties, but general Element properties were ignored.