### PR TITLE
fix #269280: Playback when adding an accidental

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1524,6 +1524,7 @@ void Score::changeAccidental(AccidentalType idx)
       {
       foreach(Note* note, selection().noteList())
             changeAccidental(note, idx);
+      setPlayNote(true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See [issue #269280](https://musescore.org/en/node/269280).