### PR TITLE
fix #269280: Playback when adding an accidental

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1557,6 +1557,7 @@ void Score::changeAccidental(Note* note, AccidentalType accidental)
                   }
             changeAccidental2(ln, pitch, tpc);
             }
+      setPlayNote(true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Works with the palette as well as the toolbar.