### PR TITLE
Fixed most of clang warnings

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -61,12 +61,13 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType)
                                     e->score()->undo(new ChangeProperty(e, P_ID::GENERATED, false, PropertyFlags::NOSTYLE));
                                     }
                               else {
-                                    BarLine* bl = new BarLine(bl->score());
-                                    bl->setBarLineType(barType);
-                                    bl->setParent(segment);
-                                    bl->setTrack(0);
-                                    bl->setSpanStaff(bl->score()->nstaves());
-                                    bl->score()->undo(new AddElement(bl));
+                                    auto score = bl->score();
+                                    BarLine* newBl = new BarLine(score);
+                                    newBl->setBarLineType(barType);
+                                    newBl->setParent(segment);
+                                    newBl->setTrack(0);
+                                    newBl->setSpanStaff(score->nstaves());
+                                    newBl->score()->undo(new AddElement(newBl));
                                     }
                               }
                         }

--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -1721,7 +1721,7 @@ bool ChordList::read(const QString& name)
             qDebug("ChordList::read failed: <%s>", qPrintable(path));
             return false;
             }
-      XmlReader e(0, &f);
+      XmlReader e(&f);
       docName = f.fileName();
 
       while (e.readNextStartElement()) {

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2443,7 +2443,7 @@ void Score::cmdExplode()
                   int track = (srcStaff + i) * VOICES;
                   ChordRest* cr = toChordRest(firstCRSegment->element(track));
                   if (cr) {
-                        XmlReader e(this, srcSelection.mimeData());
+                        XmlReader e(srcSelection.mimeData());
                         e.setPasteMode(true);
                         pasteStaff(e, cr->segment(), cr->staffIdx());
                         }

--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -1594,7 +1594,7 @@ bool FiguredBass::readConfigFile(const QString& fileName)
             qDebug("FiguredBass::read failed: <%s>", qPrintable(path));
             return false;
             }
-      XmlReader e(0, &f);
+      XmlReader e(&f);
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {
                   // QString version = e.attribute(QString("version"));

--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -598,7 +598,7 @@ bool loadInstrumentTemplates(const QString& instrTemplates)
             return false;
             }
 
-      XmlReader e(0, &qf);
+      XmlReader e(&qf);
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {
                   while (e.readNextStartElement()) {

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -830,7 +830,7 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view)
             }
       if ((_selection.isSingle() || _selection.isList()) && ms->hasFormat(mimeSymbolFormat)) {
             QByteArray data(ms->data(mimeSymbolFormat));
-            XmlReader e(this, data);
+            XmlReader e(data);
             QPointF dragOffset;
             Fraction duration(1, 4);
             ElementType type = Element::readType(e, &dragOffset, &duration);
@@ -893,7 +893,7 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view)
                   QByteArray data(ms->data(mimeStaffListFormat));
                   if (MScore::debugMode)
                         qDebug("paste <%s>", data.data());
-                  XmlReader e(this, data);
+                  XmlReader e(data);
                   e.setPasteMode(true);
                   if (!pasteStaff(e, cr->segment(), cr->staffIdx()))
                         return;
@@ -926,7 +926,7 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view)
                   QByteArray data(ms->data(mimeSymbolListFormat));
                   if (MScore::debugMode)
                         qDebug("paste <%s>", data.data());
-                  XmlReader e(this, data);
+                  XmlReader e(data);
                   pasteSymbols(e, cr);
                   }
             }

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1054,7 +1054,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   while (e.readNextStartElement()) {
                         const QStringRef& tag(e.name());
                         if (tag == "subtype") {
-                              BarLineType t;
+                              BarLineType t = BarLineType::NORMAL;
                               switch (e.readInt()) {
                                     default:
                                     case 0:

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1132,7 +1132,6 @@ static void readVolta(XmlReader& e, Volta* volta)
 static void readPedal(XmlReader& e, Pedal* pedal)
       {
       while (e.readNextStartElement()) {
-            const QStringRef& tag(e.name());
             if (!readTextLineProperties(e, pedal))
                   e.unknown();
             }
@@ -1251,7 +1250,6 @@ static void readTrill(XmlReader& e, Trill* t)
 static void readTextLine(XmlReader& e, TextLineBase* tlb)
       {
       while (e.readNextStartElement()) {
-            const QStringRef& tag(e.name());
             if (!readTextLineProperties(e, tlb))
                   e.unknown();
             }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1842,7 +1842,7 @@ MasterScore* MasterScore::clone()
 
       buffer.close();
 
-      XmlReader r(this, buffer.buffer());
+      XmlReader r(buffer.buffer());
       MasterScore* score = new MasterScore(style());
       score->read1(r, true);
 

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -721,7 +721,7 @@ QString readRootFile(MQZipReader* uz, QList<QString>& images)
             return rootfile;
             }
 
-      XmlReader e(0, cbuf);
+      XmlReader e(cbuf);
 
       while (e.readNextStartElement()) {
             if (e.name() != "container") {
@@ -786,7 +786,7 @@ Score::FileError MasterScore::loadCompressedMsc(QIODevice* io, bool ignoreVersio
                         }
                   }
             }
-      XmlReader e(this, dbuf);
+      XmlReader e(dbuf);
       e.setDocName(masterScore()->fileInfo()->completeBaseName());
 
       FileError retval = read1(e, ignoreVersionError);
@@ -842,7 +842,7 @@ Score::FileError MasterScore::loadMsc(QString name, QIODevice* io, bool ignoreVe
       if (name.endsWith(".mscz"))
             return loadCompressedMsc(io, ignoreVersionError);
       else {
-            XmlReader r(this, io);
+            XmlReader r(io);
             return read1(r, ignoreVersionError);
             }
       }

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -1205,7 +1205,7 @@ bool StaffType::readConfigFile(const QString& fileName)
             return false;
             }
 
-      XmlReader e(0, &f);
+      XmlReader e(&f);
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {
                   while (e.readNextStartElement()) {

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -1570,7 +1570,7 @@ bool MStyle::readProperties(XmlReader& e)
 
 bool MStyle::load(QFile* qf)
       {
-      XmlReader e(0, qf);
+      XmlReader e(qf);
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {
                   QString version = e.attribute("version");

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2550,7 +2550,7 @@ bool TextBase::validateText(QString& s)
                   d.append(c);
             }
       QString ss = "<data>" + d + "</data>\n";
-      XmlReader xml(0, ss);
+      XmlReader xml(ss);
       while (xml.readNextStartElement())
             ; // qDebug("  token %d <%s>", int(xml.tokenType()), qPrintable(xml.name().toString()));
       if (xml.error() == QXmlStreamReader::NoError) {

--- a/libmscore/xml.h
+++ b/libmscore/xml.h
@@ -43,7 +43,6 @@ struct SpannerValues {
 //---------------------------------------------------------
 
 class XmlReader : public QXmlStreamReader {
-      Score* _score;
       QString docName;  // used for error reporting
 
       // Score read context (for read optimizations):
@@ -66,10 +65,10 @@ class XmlReader : public QXmlStreamReader {
       QMultiMap<int, int> _tracks;
 
    public:
-      XmlReader(Score* s, QFile* f) : QXmlStreamReader(f), _score(s), docName(f->fileName()) {}
-      XmlReader(Score* s, const QByteArray& d, const QString& st = QString()) : QXmlStreamReader(d), _score(s), docName(st)  {}
-      XmlReader(Score* s, QIODevice* d, const QString& st = QString()) : QXmlStreamReader(d), _score(s), docName(st) {}
-      XmlReader(Score* s, const QString& d, const QString& st = QString()) : QXmlStreamReader(d), _score(s), docName(st) {}
+      XmlReader(QFile* f) : QXmlStreamReader(f), docName(f->fileName()) {}
+      XmlReader(const QByteArray& d, const QString& st = QString()) : QXmlStreamReader(d), docName(st)  {}
+      XmlReader(QIODevice* d, const QString& st = QString()) : QXmlStreamReader(d), docName(st) {}
+      XmlReader(const QString& d, const QString& st = QString()) : QXmlStreamReader(d), docName(st) {}
 
       bool hasAccidental;                     // used for userAccidental backward compatibility
       void unknown();

--- a/mscore/capxml.cpp
+++ b/mscore/capxml.cpp
@@ -1192,7 +1192,7 @@ Score::FileError importCapXml(MasterScore* score, const QString& name)
             }
 
       QByteArray dbuf = uz.fileData("score.xml");
-      XmlReader e(score, dbuf);
+      XmlReader e(dbuf);
       e.setDocName(name);
       Capella cf;
 

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -213,7 +213,7 @@ void ScoreView::dragEnterEvent(QDragEnterEvent* event)
             if (MScore::debugMode)
                   qDebug("ScoreView::dragEnterEvent Symbol: <%s>", a.data());
 
-            XmlReader e(_score, a);
+            XmlReader e(a);
             editData.dragOffset = QPoint();
             Fraction duration;  // dummy
             ElementType type = Element::readType(e, &editData.dragOffset, &duration);
@@ -728,7 +728,7 @@ void ScoreView::dropEvent(QDropEvent* event)
             }
       else if (etype == ElementType::MEASURE_LIST || etype == ElementType::STAFF_LIST) {
             _score->startCmd();
-            XmlReader xml(_score, data);
+            XmlReader xml(data);
             System* s = measure->system();
             int idx   = s->y2staff(pos.y());
             if (idx != -1) {

--- a/mscore/editdrumset.cpp
+++ b/mscore/editdrumset.cpp
@@ -365,7 +365,7 @@ void EditDrumset::load()
       if (!fp.open(QIODevice::ReadOnly))
             return;
 
-      XmlReader e(0, &fp);
+      XmlReader e(&fp);
       nDrumset.clear();
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {

--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -229,7 +229,7 @@ void ExampleView::dragEnterEvent(QDragEnterEvent* event)
 
 // qDebug("ExampleView::dragEnterEvent Symbol: <%s>", a.data());
 
-            XmlReader e(score(), a);
+            XmlReader e(a);
             QPointF dragOffset;
             Fraction duration;  // dummy
             ElementType type = Element::readType(e, &dragOffset, &duration);

--- a/mscore/harmonyedit.cpp
+++ b/mscore/harmonyedit.cpp
@@ -511,7 +511,7 @@ void HarmonyCanvas::dragEnterEvent(QDragEnterEvent* event)
       if (data->hasFormat(mimeSymbolFormat)) {
             QByteArray a = data->data(mimeSymbolFormat);
 
-            XmlReader e(gscore, a);
+            XmlReader e(a);
 
             QPointF dragOffset;
             Fraction duration;

--- a/mscore/importgtp.h
+++ b/mscore/importgtp.h
@@ -323,8 +323,6 @@ class GuitarPro3 : public GuitarPro1 {
 
 class GuitarPro4 : public GuitarPro {
 	std::vector<int> curDynam;
-	//int curDynam{ -1 };
-	int curTuple{ 0 };
 	std::vector<int> tupleKind;
       void readInfo();
       bool readNote(int string, int staffIdx, Note* note);

--- a/mscore/importptb.cpp
+++ b/mscore/importptb.cpp
@@ -956,7 +956,7 @@ void PowerTab::ptSection::copyTracks(ptTrack* track)
                   beat->isRest = rt.is_rest;
                   beat->tuplet = rt.triplet;
                   if (!rt.is_rest) {
-                        auto diagram = track->diagramMap.find({ signature->second.key, signature->second.formula, signature->second.formula_mod });
+                        auto diagram = track->diagramMap.find({ {signature->second.key, signature->second.formula, signature->second.formula_mod} });
                         for (unsigned int string = 0; string < diagram->second.frets.size(); ++string) {
                               int fret = diagram->second.frets[string];
                               if (fret >= 0xFE) {

--- a/mscore/importptb.h
+++ b/mscore/importptb.h
@@ -339,10 +339,8 @@ class PowerTab {
 
             int               staves{ 0 };
 
-            int               _tick{ 0 };
             ptTrack*          curTrack;
             int               staffInc{ 0 };
-            Measure*          incMeasure{ nullptr };
             char              lastPart{ 0 };
 
             ptSection*        cur_section;

--- a/mscore/keyedit.cpp
+++ b/mscore/keyedit.cpp
@@ -194,7 +194,7 @@ void KeyCanvas::dragEnterEvent(QDragEnterEvent* event)
       if (data->hasFormat(mimeSymbolFormat)) {
             QByteArray a = data->data(mimeSymbolFormat);
 
-            XmlReader e(gscore, a);
+            XmlReader e(a);
 
             QPointF dragOffset;
             Fraction duration;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4055,7 +4055,7 @@ bool MuseScore::restoreSession(bool always)
             qDebug("Cannot open session file <%s>", qPrintable(f.fileName()));
             return false;
             }
-      XmlReader e(0, &f);
+      XmlReader e(&f);
       int tab = 0;
       int idx = -1;
       bool cleanExit = false;

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -407,7 +407,7 @@ static void applyDrop(Score* score, ScoreView* viewer, Element* target, Element*
             // use same code path as drag&drop
 
             QByteArray a = e->mimeData(QPointF());
-            XmlReader e(gscore, a);
+            XmlReader e(a);
             Fraction duration;  // dummy
             QPointF dragOffset;
             ElementType type = Element::readType(e, &dragOffset, &duration);
@@ -492,7 +492,7 @@ void Palette::applyPaletteElement(PaletteCell* cell)
                   int idx = cr1->staffIdx();
 
                   QByteArray a = element->mimeData(QPointF());
-                  XmlReader e(gscore, a);
+                  XmlReader e(a);
                   Fraction duration;  // dummy
                   QPointF dragOffset;
                   ElementType type = Element::readType(e, &dragOffset, &duration);
@@ -1253,7 +1253,7 @@ void Palette::write(XmlWriter& xml) const
 
 bool Palette::read(QFile* qf)
       {
-      XmlReader e(gscore, qf);
+      XmlReader e(qf);
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {
                   QString version = e.attribute("version");
@@ -1295,7 +1295,7 @@ bool Palette::read(const QString& p)
 
       QByteArray ba = f.fileData("META-INF/container.xml");
 
-      XmlReader e(gscore, ba);
+      XmlReader e(ba);
       // extract first rootfile
       QString rootfile = "";
       QList<QString> images;
@@ -1810,7 +1810,7 @@ void Palette::dropEvent(QDropEvent* event)
             }
       else if (data->hasFormat(mimeSymbolFormat)) {
             QByteArray data(event->mimeData()->data(mimeSymbolFormat));
-            XmlReader xml(gscore, data);
+            XmlReader xml(data);
             QPointF dragOffset;
             Fraction duration;
             ElementType type = Element::readType(xml, &dragOffset, &duration);

--- a/mscore/pluginManager.cpp
+++ b/mscore/pluginManager.cpp
@@ -71,7 +71,7 @@ bool PluginManager::readPluginList()
             qDebug("Cannot open plugins file <%s>", qPrintable(f.fileName()));
             return false;
             }
-      XmlReader e(0, &f);
+      XmlReader e(&f);
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {
                   while (e.readNextStartElement()) {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1604,7 +1604,7 @@ void ScoreView::normalSwap()
       if (mimeType == mimeStaffListFormat) { // determine size of clipboard selection
             int tickLen = 0, staves = 0;
             QByteArray data(ms->data(mimeStaffListFormat));
-            XmlReader e(_score, data);
+            XmlReader e(data);
             e.readNextStartElement();
             if (e.name() == "StaffList") {
                   tickLen         = e.intAttribute("len", 0);
@@ -3964,7 +3964,7 @@ void ScoreView::cmdRepeatSelection()
       QApplication::clipboard()->setMimeData(mimeData);
 
       QByteArray data(mimeData->data(mimeType));
-      XmlReader xml(_score, data);
+      XmlReader xml(data);
       xml.setPasteMode(true);
 
       int dStaff = selection.staffStart();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3972,7 +3972,7 @@ void Shortcut::load()
       if (MScore::debugMode)
             qDebug("read shortcuts from <%s>", qPrintable(f.fileName()));
 
-      XmlReader e(0, &f);
+      XmlReader e(&f);
 
       while (e.readNextStartElement()) {
             if (e.name() == "Shortcuts") {
@@ -4037,7 +4037,7 @@ static QList<Shortcut1> loadShortcuts(QString fileLocation)
             QMessageBox::critical(0, QObject::tr("Load Shortcuts"), QObject::tr("Can't load shortcuts file: %1").arg(strerror(errno)));
             return list;
             }
-      XmlReader e(0, &f);
+      XmlReader e(&f);
       while (e.readNextStartElement()) {
             if (e.name() == "Shortcuts") {
                   while (e.readNextStartElement()) {

--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -291,7 +291,7 @@ void SynthControl::recallButtonClicked()
             qDebug("cannot read synthesizer settings <%s>", qPrintable(s));
             return;
             }
-      XmlReader e(0, &f);
+      XmlReader e(&f);
       while (e.readNextStartElement()) {
             if (e.name() == "Synthesizer")
                   state.read(e);

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -375,7 +375,7 @@ void Workspace::read()
             }
 
       QByteArray ba = f.fileData(rootfile);
-      XmlReader e(gscore, ba);
+      XmlReader e(ba);
 
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {

--- a/mtest/testutils.cpp
+++ b/mtest/testutils.cpp
@@ -90,7 +90,7 @@ Element* MTest::writeReadElement(Element* element)
 // printf("===read <%s>===\n", element->name());
 // printf("%s\n", buffer.buffer().data());
 
-      XmlReader e(element->score(), buffer.buffer());
+      XmlReader e(buffer.buffer());
       e.readNextStartElement();
       QString tag(e.name().toString());
 // printf("read tag %s\n", qPrintable(tag));

--- a/synthesizer/msynthesizer.cpp
+++ b/synthesizer/msynthesizer.cpp
@@ -45,7 +45,7 @@ void MasterSynthesizer::init()
             setState(defaultState);
             return;
             }
-      XmlReader e(0, &f);
+      XmlReader e(&f);
       while (e.readNextStartElement()) {
             if (e.name() == "Synthesizer")
                   state.read(e);

--- a/zerberus/instrument.cpp
+++ b/zerberus/instrument.cpp
@@ -181,7 +181,7 @@ bool ZInstrument::loadFromFile(const QString& path)
 
 bool ZInstrument::read(const QByteArray& buf, MQZipReader* /*uz*/, const QString& /*path*/)
       {
-      Ms::XmlReader e(0, buf);
+      Ms::XmlReader e(buf);
       while (e.readNextStartElement()) {
             if (e.name() == "MuseSynth") {
                   while (e.readNextStartElement()) {


### PR DESCRIPTION
- removed obsolete Score* _score from XmlReader
- removed not used variables
- added braces for initializer list
- fixed using similar var names in one scope