### PR TITLE
fix a lot of issues related to no sound on mac

### DIFF
--- a/fluid/dsp.cpp
+++ b/fluid/dsp.cpp
@@ -146,7 +146,6 @@ int Voice::dsp_float_interpolate_none(unsigned n)
       Phase dsp_phase = voice->phase;
       Phase dsp_phase_incr; //  end_phase;
       short int *dsp_data = voice->sample->data;
-      float *dsp_buf = voice->dsp_buf;
       auto curSample2AmpInc = Sample2AmpInc.begin();
       qreal dsp_amp_incr = curSample2AmpInc->second;
       unsigned int nextNewAmpInc = curSample2AmpInc->first;
@@ -212,7 +211,6 @@ int Voice::dsp_float_interpolate_linear(unsigned n)
       Phase dsp_phase = voice->phase;
       Phase dsp_phase_incr; // end_phase;
       short int *dsp_data = voice->sample->data;
-      float *dsp_buf = voice->dsp_buf;
       auto curSample2AmpInc = Sample2AmpInc.begin();
       qreal dsp_amp_incr = curSample2AmpInc->second;
       unsigned int nextNewAmpInc = curSample2AmpInc->first;
@@ -352,10 +350,11 @@ int Voice::dsp_float_interpolate_4th_order(unsigned n)
             /* interpolate first sample point (start or loop start) if needed */
             for ( ; dsp_phase_index == start_index && dsp_i < n; dsp_i++) {
                   coeffs = interp_coeff[fluid_phase_fract_to_tablerow (phase)];
-                  dsp_buf[dsp_i] = amp * (coeffs[0] * start_point
-				  + coeffs[1] * dsp_data[dsp_phase_index]
-				  + coeffs[2] * dsp_data[dsp_phase_index+1]
-				  + coeffs[3] * dsp_data[dsp_phase_index+2]);
+                  auto val = amp * (coeffs[0] * start_point
+                                    + coeffs[1] * dsp_data[dsp_phase_index]
+                                    + coeffs[2] * dsp_data[dsp_phase_index+1]
+                                    + coeffs[3] * dsp_data[dsp_phase_index+2]);
+                  dsp_buf[dsp_i] = val;
 
                   /* increment phase and amplitude */
                   phase += dsp_phase_incr;
@@ -368,10 +367,11 @@ int Voice::dsp_float_interpolate_4th_order(unsigned n)
             /* interpolate the sequence of sample points */
             for ( ; dsp_i < n && dsp_phase_index <= end_index; dsp_i++) {
                   coeffs = interp_coeff[fluid_phase_fract_to_tablerow (phase)];
-                  dsp_buf[dsp_i] = amp * (coeffs[0] * dsp_data[dsp_phase_index-1]
-				  + coeffs[1] * dsp_data[dsp_phase_index]
-				  + coeffs[2] * dsp_data[dsp_phase_index+1]
-				  + coeffs[3] * dsp_data[dsp_phase_index+2]);
+                  auto val = amp * (coeffs[0] * dsp_data[dsp_phase_index-1]
+                                   + coeffs[1] * dsp_data[dsp_phase_index]
+                                   + coeffs[2] * dsp_data[dsp_phase_index+1]
+                                   + coeffs[3] * dsp_data[dsp_phase_index+2]);
+                  dsp_buf[dsp_i] = val;
 
                   /* increment phase and amplitude */
                   phase += dsp_phase_incr;
@@ -390,10 +390,11 @@ int Voice::dsp_float_interpolate_4th_order(unsigned n)
             /* interpolate within 2nd to last point */
             for (; dsp_phase_index <= end_index && dsp_i < n; dsp_i++) {
                   coeffs = interp_coeff[fluid_phase_fract_to_tablerow (phase)];
-                  dsp_buf[dsp_i] = amp * (coeffs[0] * dsp_data[dsp_phase_index-1]
-				  + coeffs[1] * dsp_data[dsp_phase_index]
-				  + coeffs[2] * dsp_data[dsp_phase_index+1]
-				  + coeffs[3] * end_point1);
+                  auto val = amp * (coeffs[0] * dsp_data[dsp_phase_index-1]
+                                   + coeffs[1] * dsp_data[dsp_phase_index]
+                                   + coeffs[2] * dsp_data[dsp_phase_index+1]
+                                   + coeffs[3] * end_point1);
+                  dsp_buf[dsp_i] = val;
 
                   /* increment phase and amplitude */
                   phase += dsp_phase_incr;
@@ -408,10 +409,11 @@ int Voice::dsp_float_interpolate_4th_order(unsigned n)
             /* interpolate within the last point */
             for (; dsp_phase_index <= end_index && dsp_i < n; dsp_i++) {
                   coeffs = interp_coeff[fluid_phase_fract_to_tablerow (phase)];
-                  dsp_buf[dsp_i] = amp * (coeffs[0] * dsp_data[dsp_phase_index-1]
-				  + coeffs[1] * dsp_data[dsp_phase_index]
-				  + coeffs[2] * end_point1
-				  + coeffs[3] * end_point2);
+                  auto val = amp * (coeffs[0] * dsp_data[dsp_phase_index-1]
+                                    + coeffs[1] * dsp_data[dsp_phase_index]
+                                    + coeffs[2] * end_point1
+                                    + coeffs[3] * end_point2);
+                  dsp_buf[dsp_i] = val;
 
                   /* increment phase and amplitude */
                   phase += dsp_phase_incr;
@@ -455,7 +457,6 @@ int Voice::dsp_float_interpolate_7th_order(unsigned n)
       Phase dsp_phase = voice->phase;
       Phase dsp_phase_incr; // end_phase;
       short int *dsp_data = voice->sample->data;
-      float *dsp_buf = voice->dsp_buf;
       auto curSample2AmpInc = Sample2AmpInc.begin();
       qreal dsp_amp_incr = curSample2AmpInc->second;
       unsigned int nextNewAmpInc = curSample2AmpInc->first;

--- a/mscore/pa.cpp
+++ b/mscore/pa.cpp
@@ -104,7 +104,8 @@ bool Portaudio::init(bool)
 
       const PaDeviceInfo* di = Pa_GetDeviceInfo(idx);
 
-      if (di == nullptr)
+      //select default output device if no device or device without output channels have been selected
+      if (di == nullptr || di->maxOutputChannels < 1)
             di = Pa_GetDeviceInfo(Pa_GetDefaultOutputDevice());
 
       if (!di)
@@ -118,11 +119,7 @@ bool Portaudio::init(bool)
       out.device           = idx;
       out.channelCount     = 2;
       out.sampleFormat     = paFloat32;
-#ifdef Q_OS_MAC
-      out.suggestedLatency = 0.020;
-#else // on windows, this small latency causes some problem
-      out.suggestedLatency = 0.100;
-#endif
+      out.suggestedLatency = di->defaultLowOutputLatency;
       out.hostApiSpecificStreamInfo = 0;
 
       err = Pa_OpenStream(&stream, 0, &out, double(_sampleRate), 0, 0, paCallback, (void*)this);


### PR DESCRIPTION
If we don't specify framesPerBuffer parameter in Pa_OpenStream, PortAudio will choose (randomly?) the value. In Voice::write, we assume that RestN which initially keeps the value of frames from pa_callback will be bigger than env_data->count. The last is 43 on my Mac (47 on my Ubuntu machine), but default frames count from pa callback on failed MacBook 12" is 39. So, we cannot correctly process all frames and envelop and produce sound, specifically amplitude calculation fails and Voice::write returns under this if statement 'if (volenv_section == FLUID_VOICE_ENVDELAY)'.

So, I hardcoded 630 since it is the value from my Mac. Also I've got 1027 for Ubuntu.