### PR TITLE
fix #269774: Cannot use the mouse to enter notes on a staff with...

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1144,7 +1144,7 @@ bool Score::getPosition(Position* pos, const QPointF& p, int voice) const
       qreal y           = p.y() - system->pagePos().y();
       for (; pos->staffIdx < nstaves(); ++pos->staffIdx) {
             Staff* st = staff(pos->staffIdx);
-            if (st->invisible() || !st->part()->show())
+            if (!st->part()->show())
                   continue;
             qreal sy2;
             SysStaff* ss = system->staff(pos->staffIdx);
@@ -1153,7 +1153,7 @@ bool Score::getPosition(Position* pos, const QPointF& p, int voice) const
             // find next visible staff
             for (int i = pos->staffIdx + 1; i < nstaves(); ++i) {
                   Staff* st = staff(i);
-                  if (st->invisible() || !st->part()->show())
+                  if (!st->part()->show())
                         continue;
                   nstaff = system->staff(i);
                   break;


### PR DESCRIPTION
... invisible lines.

[Here](https://musescore.org/en/node/269774) is a link to the issue in the tracker.

The mistake comes from confusion about what it means for a staff to be "invisible". It really only means that the lines are invisible, not that the staff should not be shown.