### PR TITLE
fix #269508: The figured bass crashes if first the selected measure...

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1739,7 +1739,6 @@ void ScoreView::cmd(const char* s)
                   }
             }
       else if (cmd == "figured-bass") {
-            changeState(ViewState::NOTE_ENTRY);
             FiguredBass* fb = _score->addFiguredBass();
             if (fb) {
                   startEditMode(fb);


### PR DESCRIPTION
... is empty

[Here](https://musescore.org/en/node/269508) is a link to the issue in the tracker.

Comparing this code with version 2.2, it is clear that the intent was to change _out of_ note entry mode. But there is really no need to change the state here at all.