### PR TITLE
Fix #269901: fixed segmentation fault within piano roll editor

### DIFF
--- a/mscore/pianoview.cpp
+++ b/mscore/pianoview.cpp
@@ -535,10 +535,12 @@ void PianoView::updateNotes()
       SegmentType st = SegmentType::ChordRest;
       for (Segment* s = staff->score()->firstSegment(st); s; s = s->next1(st)) {
             for (int track = startTrack; track < endTrack; ++track) {
-                  Chord* chord = static_cast<Chord*>(s->element(track));
-                  if (chord == 0 || chord->type() != ElementType::CHORD)
-                        continue;
-                  addChord(chord);
+                  Element* e = s->element(track);
+                  if (e && e->isChord()) {
+                        Chord* chord = toChord(e);
+                        if (chord != 0)
+                              addChord(chord);
+                        }
                   }
             }
       for (int i = 0; i < 3; ++i)


### PR DESCRIPTION
Before: was casting Rest objects as Chords and then callling addChord on them -> caused segmentation fault.  Also noticed that when looping through segments, code was converting to Chord and adding it even if the Element* was the nullptr.

I added a check to make sure that the Element exists first, and then another check to make sure that it is not a Rest.

After: Piano Roll Editor opens correctly when right clicking an empty measure (no notes are displayed on the editor) and also when there are chords to display in the editor.