### PR TITLE
Fix numerous reports of missing all.h during compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,11 +584,8 @@ endif (NOT MINGW AND NOT APPLE)
 #
 
 # all.h is expected in PROJECT_BINARY_DIR by subdirs
-add_custom_command(
-    OUTPUT ${PROJECT_BINARY_DIR}/all.h
-    COMMAND ${CMAKE_COMMAND}
-    ARGS -E copy ${PROJECT_SOURCE_DIR}/all.h ${PROJECT_BINARY_DIR}/all.h
-    DEPENDS ${PROJECT_SOURCE_DIR}/all.h
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/all.h ${PROJECT_BINARY_DIR}/all.h
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     )
 if (NOT MINGW)


### PR DESCRIPTION
When disabling PCH, the all.h copying code is no longer run before
AUTOMOC=caused *_autogen targets, so we must run it earlier.

From Debian

Note: I do not know CMake well, so I’d appreciate it if someone could review it before merging,
and test it on Linux with PCH, and on Windows and Mac OSX (which I do not have access to).