### PR TITLE
Remove OpenSSL references from kQOAuth

### DIFF
--- a/thirdparty/kQOAuth/CMakeLists.txt
+++ b/thirdparty/kQOAuth/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(kqoauth STATIC
 set_target_properties (
       kqoauth
       PROPERTIES
-         COMPILE_FLAGS "${PCH_INCLUDE} -I ${PROJECT_SOURCE_DIR}/thirdparty/openssl/include -g -Wall -Wextra -Winvalid-pch"
+         COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
 
 xcode_pch(kqoauth all)

--- a/thirdparty/kQOAuth/kqoauthutils.cpp
+++ b/thirdparty/kQOAuth/kqoauthutils.cpp
@@ -24,11 +24,6 @@
 #include <QtDebug>
 #include "kqoauthutils.h"
 
-#include <openssl/pem.h>
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-#include <openssl/evp.h>
-
 
 QString KQOAuthUtils::hmac_sha1(const QString &message, const QString &key)
 {


### PR DESCRIPTION
The code will happily build without OpenSSL.

From @jcowgill via Debian