### PR TITLE
Fix errors in mscore.1 manpage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,7 +512,7 @@ if (NOT MINGW AND NOT APPLE)
                        build/rm-empty-dirs              DESTINATION bin COMPONENT portable ${SCRIPT_PERMS})
       install(FILES    build/Linux+BSD/portable/qt.conf DESTINATION bin COMPONENT portable)
     else (${MSCORE_INSTALL_SUFFIX} MATCHES "portable")
-      set(MAN_PORTABLE '.\"') # comment out lines in man page that are only relevent to the portable version
+      set(MAN_PORTABLE .\\\") # comment out lines in man page that are only relevent to the portable version
     endif (${MSCORE_INSTALL_SUFFIX} MATCHES "portable")
     # install desktop file (perform variable substitution first)
     configure_file(build/Linux+BSD/mscore.desktop.in mscore${MSCORE_INSTALL_SUFFIX}.desktop)

--- a/build/Linux+BSD/mscore.1.in
+++ b/build/Linux+BSD/mscore.1.in
@@ -69,6 +69,7 @@ For help with the full MuseScore program see:
 These pages cover the topics in this manual and may be more up-to-date:
 
 <https://musescore.org/handbook/command-line-options-0>
+.br
 <https://musescore.org/handbook/revert-factory-settings-0>
 
 .SH OPTIONS


### PR DESCRIPTION
CMake doesn't support single quotes, so the old value of MAN_PORTABLE was
causing errors. Insert manual line break to help groff displaying a long line.

From @jcowgill via Debian