### PR TITLE
fix #269870 SVG bugfix & unify page print function

### DIFF
--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -262,7 +262,8 @@ class Element : public ScoreElement {
       virtual int subtype() const                 { return -1; }  // for select gui
 
       virtual void draw(QPainter*) const {}
-      void drawAt(QPainter*p, const QPointF& pt) const { p->translate(pt); draw(p); p->translate(-pt);}
+      void drawAt(QPainter* p, const QPointF& pt) const { p->translate(pt); draw(p); p->translate(-pt);}
+      void drawAtPagePos(QPainter* p) const { drawAt(p, pagePos()); }
 
       virtual void writeProperties(XmlWriter& xml) const;
       virtual bool readProperties(XmlReader&);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -744,7 +744,7 @@ class Score : public QObject, ScoreElement {
       bool saveCompressedFile(QIODevice*, QFileInfo&, bool onlySelection, bool createThumbnail = true);
       bool exportFile();
 
-      void print(QPainter* printer, int page);
+      void print(QPaintDevice* paintDevice, QPainter* painter, int pageNumber);
       ChordRest* getSelectedChordRest() const;
       QSet<ChordRest*> getSelectedChordRests() const;
       void getSelectedChordRest2(ChordRest** cr1, ChordRest** cr2) const;

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -501,12 +501,12 @@ QImage Score::createThumbnail()
       double pr = MScore::pixelRatio;
       MScore::pixelRatio = 1.0;
 
-      QPainter p(&pm);
-      p.setRenderHint(QPainter::Antialiasing, true);
-      p.setRenderHint(QPainter::TextAntialiasing, true);
-      p.scale(mag, mag);
-      print(&p, 0);
-      p.end();
+      QPainter painter(&pm);
+      painter.setRenderHint(QPainter::Antialiasing, true);
+      painter.setRenderHint(QPainter::TextAntialiasing, true);
+      painter.scale(mag, mag);
+      print(0, &painter, 0);
+      painter.end();
 
       MScore::pixelRatio = pr;
 
@@ -933,31 +933,6 @@ Score::FileError MasterScore::read1(XmlReader& e, bool ignoreVersionError)
                   e.unknown();
             }
       return FileError::FILE_CORRUPTED;
-      }
-
-//---------------------------------------------------------
-//   print
-//---------------------------------------------------------
-
-void Score::print(QPainter* painter, int pageNo)
-      {
-      _printing  = true;
-      MScore::pdfPrinting = true;
-      Page* page = pages().at(pageNo);
-      QRectF fr  = page->abbox();
-
-      QList<Element*> ell = page->items(fr);
-      qStableSort(ell.begin(), ell.end(), elementLessThan);
-      for (const Element* e : ell) {
-            if (!e->visible())
-                  continue;
-            painter->save();
-            painter->translate(e->pagePos());
-            e->draw(painter);
-            painter->restore();
-            }
-      MScore::pdfPrinting = false;
-      _printing = false;
       }
 
 //---------------------------------------------------------

--- a/libmscore/stafflines.cpp
+++ b/libmscore/stafflines.cpp
@@ -121,6 +121,20 @@ void StaffLines::draw(QPainter* painter) const
       }
 
 //---------------------------------------------------------
+//   drawMultipleMeasures
+//   - used to optimize SVG and PDF files by reducing number of elements.
+//   - additionalLength after this measure to the last measure of a contiguous connected series of measures.
+//   - draws a horizontal line from x1 to x2 + additionalLength at y1.
+//---------------------------------------------------------
+
+void StaffLines::drawMultipleMeasures(QPainter* painter, qreal additionalLength) const
+      {
+      painter->setPen(QPen(curColor(), lw, Qt::SolidLine, Qt::FlatCap));
+      for (int i = 0; i < lines.size(); ++i)
+            painter->drawLine(lines[i].x1(), lines[i].y1(), lines[i].x2() + additionalLength, lines[i].y1());
+      }
+
+//---------------------------------------------------------
 //   y1
 //---------------------------------------------------------
 

--- a/libmscore/stafflines.h
+++ b/libmscore/stafflines.h
@@ -30,6 +30,7 @@ class StaffLines final : public Element {
       virtual ElementType type() const override     { return ElementType::STAFF_LINES; }
       virtual void layout() override;
       virtual void draw(QPainter*) const override;
+      void drawMultipleMeasures(QPainter* painter, qreal additionalLength) const;
       virtual QPointF pagePos() const override;    ///< position in page coordinates
       virtual QPointF canvasPos() const override;  ///< position in page coordinates
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -845,7 +845,7 @@ Measure* System::lastMeasure() const
 //   prevMeasure
 //---------------------------------------------------------
 
-MeasureBase* System::prevMeasure(const MeasureBase* m) const
+MeasureBase* System::prevMeasureBase(const MeasureBase* m) const
       {
       if (m == ml.front())
             return 0;
@@ -856,7 +856,7 @@ MeasureBase* System::prevMeasure(const MeasureBase* m) const
 //   nextMeasure
 //---------------------------------------------------------
 
-MeasureBase* System::nextMeasure(const MeasureBase* m) const
+MeasureBase* System::nextMeasureBase(const MeasureBase* m) const
       {
       if (m == ml.back())
             return 0;

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -132,8 +132,8 @@ class System final : public Element {
       Measure* lastMeasure() const;
       int endTick() const;
 
-      MeasureBase* prevMeasure(const MeasureBase*) const;
-      MeasureBase* nextMeasure(const MeasureBase*) const;
+      MeasureBase* prevMeasureBase(const MeasureBase*) const;
+      MeasureBase* nextMeasureBase(const MeasureBase*) const;
 
       qreal leftMargin() const    { return _leftMargin; }
       VBox* vbox() const;

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -94,23 +94,15 @@ extern bool savePositions(Score*, const QString& name, bool segments);
 extern MasterSynthesizer* synti;
 
 //---------------------------------------------------------
-//   paintElement(s)
+//   paintElements
 //---------------------------------------------------------
 
-static void paintElement(QPainter& p, const Element* e)
-      {
-      QPointF pos(e->pagePos());
-      p.translate(pos);
-      e->draw(&p);
-      p.translate(-pos);
-      }
-
-static void paintElements(QPainter& p, const QList<Element*>& el)
+static void paintElements(QPainter* p, const QList<Element*>& el)
       {
       for (Element* e : el) {
             if (!e->visible())
                   continue;
-            paintElement(p, e);
+            e->drawAt(p, e->pagePos());
             }
       }
 
@@ -223,6 +215,89 @@ static bool readScoreError(const QString& name, Score::FileError error, bool ask
             }
       return false;
       }
+
+
+//---------------------------------------------------------
+//   print
+//---------------------------------------------------------
+
+void Score::print(QPaintDevice* paintDevice, QPainter* painter, int pageNumber)
+      {
+      _printing  = true;
+      MScore::pdfPrinting = true;
+      Page* page = pages().at(pageNumber);
+
+      // 1st pass: Group contiguous staff lines together into single longer lines to be printed once (to reduce element count in PDF & SVG files)
+      for (System* system : page->systems()) {
+            for (int i = 0; i < system->staves()->size(); i++) {
+
+                  // ignore staves that won't be drawn
+                  if (score()->staff(i)->invisible() || !score()->staff(i)->show() ||
+                      system->staves()->isEmpty() || !system->staff(i)->show())
+                        continue;
+
+                  StaffLines* firstSL = 0;
+                  qreal additionalLength = 0.0;
+                  for (MeasureBase* mb = system->firstMeasure(); mb != 0; mb = mb->nextMeasureMM()) {
+
+                        if (mb->isMeasure() && static_cast<Measure*>(mb)->visible(i)) {
+                              if (firstSL)
+                                    additionalLength += static_cast<Measure*>(mb)->width();
+                              else {
+                                    firstSL = static_cast<Measure*>(mb)->staffLines(i);
+                                    additionalLength = 0.0;
+                                    }
+                              }
+
+                        // draw staff lines only when reaching a break in staff lines
+                        if (firstSL &&
+                            !(system->nextMeasureBase(mb) &&
+                              system->nextMeasureBase(mb)->isMeasure() &&
+                              static_cast<Measure*>(system->nextMeasureBase(mb))->visible(i))
+                            ) {
+                              painter->translate(firstSL->pagePos());
+                              firstSL->drawMultipleMeasures(painter, additionalLength);
+                              painter->translate(-firstSL->pagePos());
+
+                              firstSL = 0; // indicate that a break in staff lines has occurred.
+                              }
+
+                        if (system->nextMeasureBase(mb) == 0)
+                              break;
+                        }
+                  }
+            }
+
+      // 2nd pass: print the remaining elements other than staff lines
+      QList<Element*> pel = page->elements();
+      qStableSort(pel.begin(), pel.end(), elementLessThan);
+      ElementType eType;
+      for (const Element* e : pel) {
+            // Always exclude invisible elements
+            if (!e->visible())
+                  continue;
+
+            eType = e->type();
+            switch (eType) { // In future sub-type code, this switch() grows, and eType gets used
+            case ElementType::STAFF_LINES : // Handled in the 1st pass above
+                  continue; // Exclude from 2nd pass
+                  break;
+            default:
+                  break;
+            } // switch(eType)
+
+            // Set the Element pointer inside SvgGenerator/SvgPaintEngine
+            if (MScore::svgPrinting)
+                  static_cast<SvgGenerator*>(paintDevice)->setElement(e);
+
+            // Paint it
+            e->drawAtPagePos(painter);
+            }
+
+      MScore::pdfPrinting = false;
+      _printing = false;
+      }
+
 
 //---------------------------------------------------------
 //   checkDirty
@@ -1549,6 +1624,8 @@ void MuseScore::printFile()
             MScore::pixelRatio = 1.0 / mag;
             p.scale(mag, mag);
 
+            cs->setPrinting(true);
+
             int fromPage = printerDev.fromPage() - 1;
             int toPage   = printerDev.toPage() - 1;
             if (fromPage < 0)
@@ -1563,12 +1640,13 @@ void MuseScore::printFile()
                               printerDev.newPage();
                         firstPage = false;
 
-                        cs->print(&p, n);
+                        cs->print(&printerDev, &p, n);
                         if ((copy + 1) < printerDev.numCopies())
                               printerDev.newPage();
                         }
                   }
             p.end();
+            cs->setPrinting(false);
             MScore::pixelRatio = pr;
             }
 
@@ -1995,7 +2073,7 @@ bool MuseScore::savePdf(Score* cs, const QString& saveName)
             if (!firstPage)
                   pdfWriter.newPage();
             firstPage = false;
-            cs->print(&p, n);
+            cs->print(0, &p, n);
             }
       p.end();
       cs->setPrinting(false);
@@ -2060,7 +2138,7 @@ bool MuseScore::savePdf(QList<Score*> cs, const QString& saveName)
                   if (!firstPage)
                         pdfWriter.newPage();
                   firstPage = false;
-                  s->print(&p, n);
+                  s->print(0, &p, n);
                   }
             //reset score
             s->setPrinting(false);
@@ -2457,16 +2535,16 @@ bool MuseScore::savePng(Score* score, const QString& name, bool screenshot, bool
             double mag = convDpi / DPI;
             MScore::pixelRatio = 1.0 / mag;
 
-            QPainter p(&printer);
-            p.setRenderHint(QPainter::Antialiasing, true);
-            p.setRenderHint(QPainter::TextAntialiasing, true);
-            p.scale(mag, mag);
+            QPainter painter(&printer);
+            painter.setRenderHint(QPainter::Antialiasing, true);
+            painter.setRenderHint(QPainter::TextAntialiasing, true);
+            painter.scale(mag, mag);
             if (trimMargin >= 0)
-                  p.translate(-r.topLeft());
+                  painter.translate(-r.topLeft());
 
             QList<Element*> pel = page->elements();
             qStableSort(pel.begin(), pel.end(), elementLessThan);
-            paintElements(p, pel);
+            paintElements(&painter, pel);
 
             if (format == QImage::Format_Indexed8) {
                   //convert to grayscale & respect alpha
@@ -2641,8 +2719,8 @@ bool MuseScore::saveSvg(Score* score, const QString& saveName)
       double pr = MScore::pixelRatio;
       for (int pageNumber = 0; pageNumber < pages; ++pageNumber) {
             Page* page = pl.at(pageNumber);
-            SvgGenerator printer;
-            printer.setTitle(pages > 1 ? QString("%1 (%2)").arg(title).arg(pageNumber + 1) : title);
+            SvgGenerator paintDev;
+            paintDev.setTitle(pages > 1 ? QString("%1 (%2)").arg(title).arg(pageNumber + 1) : title);
 
             QString fileName(saveName);
             if (fileName.endsWith(".svg"))
@@ -2672,7 +2750,7 @@ bool MuseScore::saveSvg(Score* score, const QString& saveName)
                               continue;
                         }
                   }
-            printer.setFileName(fileName);
+            paintDev.setFileName(fileName);
 
             QRectF r;
             if (trimMargin >= 0) {
@@ -2683,89 +2761,19 @@ bool MuseScore::saveSvg(Score* score, const QString& saveName)
                   r = page->abbox();
             qreal w = r.width();
             qreal h = r.height();
-            printer.setSize(QSize(w, h));
-            printer.setViewBox(QRectF(0, 0, w, h));
-            QPainter p(&printer);
+            paintDev.setSize(QSize(w, h));
+            paintDev.setViewBox(QRectF(0, 0, w, h));
+            QPainter p(&paintDev);
             p.setRenderHint(QPainter::Antialiasing, true);
             p.setRenderHint(QPainter::TextAntialiasing, true);
             if (trimMargin >= 0 && score->npages() == 1)
                   p.translate(-r.topLeft());
-            MScore::pixelRatio = DPI / printer.logicalDpiX();
+            MScore::pixelRatio = DPI / paintDev.logicalDpiX();
             if (trimMargin >= 0)
-                   p.translate(-r.topLeft());
-            // 1st pass: StaffLines
-            for  (System* s : page->systems()) {
-                  for (int i = 0, n = s->staves()->size(); i < n; i++) {
-                        if (score->staff(i)->invisible() || !score->staff(i)->show())
-                              continue;  // ignore invisible staves
-                        if (s->staves()->isEmpty() || !s->staff(i)->show())
-                              continue;
+                  p.translate(-r.topLeft());
 
-                        // The goal here is to draw SVG staff lines more efficiently.
-                        // MuseScore draws staff lines by measure, but for SVG they can
-                        // generally be drawn once for each system. This makes a big
-                        // difference for scores that scroll horizontally on a single
-                        // page. But there are exceptions to this rule:
-                        //
-                        //   ~ One (or more) invisible measure(s) in a system/staff ~
-                        //   ~ One (or more) elements of type HBOX or VBOX          ~
-                        //
-                        // In these cases the SVG staff lines for the system/staff
-                        // are drawn by measure.
-                        //
-                        bool byMeasure = false;
-                        for (MeasureBase* mb = s->firstMeasure(); mb != 0; mb = s->nextMeasure(mb)) {
-                              if (mb->isHBox() || mb->isVBox() || !toMeasure(mb)->visible(i)) {
-                                    byMeasure = true;
-                                    break;
-                                    }
-                              }
-                        if (byMeasure) { // Draw visible staff lines by measure
-                              for (MeasureBase* mb = s->firstMeasure(); mb != 0; mb = s->nextMeasure(mb)) {
-                                    if (mb->type() != ElementType::HBOX
-                                     && mb->type() != ElementType::VBOX
-                                     && static_cast<Measure*>(mb)->visible(i)) {
-                                          StaffLines* sl = toMeasure(mb)->staffLines(i);
-                                          printer.setElement(sl);
-                                          paintElement(p, sl);
-                                          }
-                                    }
-                              }
-                        else { // Draw staff lines once per system
-                              StaffLines* firstSL = s->firstMeasure()->staffLines(i)->clone();
-                              StaffLines*  lastSL =  s->lastMeasure()->staffLines(i);
-                              firstSL->bbox().setRight(lastSL->bbox().right()
-                                                    +  lastSL->pagePos().x()
-                                                    - firstSL->pagePos().x());
-                              printer.setElement(firstSL);
-                              paintElement(p, firstSL);
-                              }
-                        }
-                  }
-            // 2nd pass: the rest of the elements
-            QList<Element*> pel = page->elements();
-            qStableSort(pel.begin(), pel.end(), elementLessThan);
-            ElementType eType;
-            for (const Element* e : pel) {
-                  // Always exclude invisible elements
-                  if (!e->visible())
-                        continue;
+            score->print(&paintDev, &p, pageNumber);
 
-                  eType = e->type();
-                  switch (eType) { // In future sub-type code, this switch() grows, and eType gets used
-                  case ElementType::STAFF_LINES : // Handled in the 1st pass above
-                        continue; // Exclude from 2nd pass
-                        break;
-                  default:
-                        break;
-                  } // switch(eType)
-
-                  // Set the Element pointer inside SvgGenerator/SvgPaintEngine
-                  printer.setElement(e);
-
-                  // Paint it
-                  paintElement(p, e);
-                  }
             p.end(); // Writes MuseScore SVG file to disk, finally
             }
 


### PR DESCRIPTION
<del>printing a page follows same code strucutre regardless of SVG, PDF,
thumbnail, etc.  This unifies the code between these print modes a
bit, and that helps out with keeping consistent behavior in the output.
Previously there was a bug with SVG output because it was trying to use
an optimization whereby staff lines were extended if all systems in a
measure were visible and weren't broken by frames.  However, that
optimization had a mistake, whereby only the first measure of staff
lines was drawn.  By unifying the print function, then also PDF can
benefit from the optimization.  I've also improved the optimizatino a
bit to also handle all continuous measures even if the entire staff is
unbroken.  I still need to investigate a bug with MMRests, though.</del>