### PR TITLE
fix #153691: drumtools palette not closing when switching between files

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3238,7 +3238,7 @@ void MuseScore::changeState(ScoreState val)
 
       if (_sstate == STATE_FOTO)
             updateInspector();
-      if (_sstate == STATE_NOTE_ENTRY_STAFF_DRUM)
+      if (_sstate != STATE_NOTE_ENTRY_STAFF_DRUM)
             showDrumTools(0, 0);
 
       switch (val) {


### PR DESCRIPTION
Fixed logic error on calling the showdrumtools function to hide the drumtool palette (wasn't being called before)