### PR TITLE
fix #269952: allowed new templates to be shown in new wizard w/o restart

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -480,8 +480,11 @@ MasterScore* MuseScore::getNewFile()
       {
       if (!newWizard)
             newWizard = new NewWizard(this);
-      else
+      else {
+            newWizard->updateTemplate();
             newWizard->restart();
+            }
+
       if (newWizard->exec() != QDialog::Accepted)
             return 0;
       int measures            = newWizard->measures();

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -358,6 +358,24 @@ QString NewWizardPage4::templatePath() const
       }
 
 //---------------------------------------------------------
+//   setTemplateLayout
+//---------------------------------------------------------
+
+void NewWizardPage4::setTemplateLayout()
+      {
+      QDir dir(mscoreGlobalShare + "/templates");
+      QFileInfoList fil = dir.entryInfoList(QDir::NoDotAndDotDot | QDir::Readable | QDir::Dirs | QDir::Files, QDir::Name);
+      if(fil.isEmpty()){
+          fil.append(QFileInfo(QFile(":data/Empty_Score.mscz")));
+          }
+
+      QDir myTemplatesDir(preferences.getString(PREF_APP_PATHS_MYTEMPLATES));
+      fil.append(myTemplatesDir.entryInfoList(QDir::NoDotAndDotDot | QDir::Readable | QDir::Dirs | QDir::Files, QDir::Name));
+
+      templateFileBrowser->setScores(fil);
+      }
+
+//---------------------------------------------------------
 //   NewWizardPage5
 //---------------------------------------------------------
 

--- a/mscore/newwizard.h
+++ b/mscore/newwizard.h
@@ -145,6 +145,7 @@ class NewWizardPage4 : public QWizardPage {
       virtual bool isComplete() const override;
       QString templatePath() const;
       virtual void initializePage();
+      void setTemplateLayout();
       };
 
 //---------------------------------------------------------
@@ -193,6 +194,7 @@ class NewWizard : public QWizard {
       enum Page { Invalid = -1, Type, Instruments, Template, Keysig, Timesig};
 
       QString templatePath() const       { return p4->templatePath(); }
+      void updateTemplate()              { p4->setTemplateLayout();  }
       int measures() const               { return p3->measures();    }
       Fraction timesig() const           { return p3->timesig();     }
       void createInstruments(Score* s)   { p2->createInstruments(s); }


### PR DESCRIPTION
readded the template page when opening a NewFileWizard so that it reiterated over the template file folder each time to generate any new templates being saved