### PR TITLE
AlsaDriver::write() avail=0 avoid CPU hog w/ sleep

### DIFF
--- a/mscore/alsa.cpp
+++ b/mscore/alsa.cpp
@@ -540,6 +540,7 @@ void AlsaDriver::write(int n, float* l, float* r)
                   }
             else if (avail >= n)
                   break;
+            usleep(1000); // sleep 1 ms when avail = 0 to avoid infinite loop hogging a CPU.
             }
       if (mmappedInterface) {
             playInit(n);


### PR DESCRIPTION
In AlsaDriver::write() would eat a lot of CPU from infinite loop when snd_pcm_avail_update() returns 0.

Note I haven't made an issue report...my forum posting is: https://musescore.org/en/node/270130