### PR TITLE
fix #232931 for 2.2 - allow break shortcut on selections

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -26,6 +26,7 @@
 #include "segment.h"
 #include "ottava.h"
 #include "spannermap.h"
+#include "layoutbreak.h"
 #include "rehearsalmark.h"
 #include <set>
 
@@ -533,6 +534,7 @@ class Score : public QObject, public ScoreElement {
       void cmdHalfDuration()        { cmdIncDecDuration( 1, 0); }
       void cmdIncDurationDotted()   { cmdIncDecDuration(-1, 1); }
       void cmdDecDurationDotted()   { cmdIncDecDuration( 1, 1); }
+      void cmdToggleLayoutBreak(LayoutBreak::Type);
 
       void addRemoveBreaks(int interval, bool lock);
 

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -361,6 +361,10 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
                   else
                         qDebug("nowhere to place drum note");
                   }
+            else if (element->type() == Element::Type::LAYOUT_BREAK) {
+                  LayoutBreak* breakElement = static_cast<LayoutBreak*>(element);
+                  score->cmdToggleLayoutBreak(breakElement->layoutBreakType());
+                  }
             else if (element->type() == Element::Type::SLUR && addSingle) {
                   viewer->cmdAddSlur();
                   }

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -385,7 +385,6 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
                 || element->type() == Element::Type::MARKER
                 || element->type() == Element::Type::JUMP
                 || element->type() == Element::Type::SPACER
-                || element->type() == Element::Type::LAYOUT_BREAK
                 || element->type() == Element::Type::VBOX
                 || element->type() == Element::Type::HBOX
                 || element->type() == Element::Type::TBOX
@@ -406,6 +405,10 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
                         if (m == last)
                               break;
                         }
+                  }
+            else if (element->type() == Element::Type::LAYOUT_BREAK) {
+                  LayoutBreak* breakElement = static_cast<LayoutBreak*>(element);
+                  score->cmdToggleLayoutBreak(breakElement->layoutBreakType());
                   }
             else if (element->type() == Element::Type::CLEF
                      || element->type() == Element::Type::KEYSIG


### PR DESCRIPTION
Been meaning to do this a while now - a 2.2 port of the code I added for master last fall to allow "Enter" to toggle line breaks with selections other than just barlines.  All we were doing was finding the measure for the barline and toggling the break there; it was trivial to modify the code to find try to find the measure for *any* single selection.  For range selections, I take the last chordrest, so hitting enter on with a measure selected toggle the break on that measure.  With multiple measures selected, the last measure only is toggled.