### PR TITLE
Fix a crash in ScoreBrowser on systems with single-click items activation turned on

### DIFF
--- a/all.h
+++ b/all.h
@@ -136,6 +136,7 @@
 #include <QFontComboBox>
 #include <QApplication>
 #include <QStatusBar>
+#include <QStyle>
 #include <QStylePainter>
 #include <QStyleOptionButton>
 #include <QHeaderView>

--- a/mscore/scoreBrowser.cpp
+++ b/mscore/scoreBrowser.cpp
@@ -97,7 +97,7 @@ ScoreListWidget* ScoreBrowser::createScoreList()
       if (!_showPreview)
             sl->setSelectionMode(QAbstractItemView::NoSelection);
 
-      connect(sl, SIGNAL(itemClicked(QListWidgetItem*)),   this, SLOT(scoreChanged(QListWidgetItem*)), Qt::QueuedConnection);
+      connect(sl, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(scoreClicked(QListWidgetItem*)), Qt::QueuedConnection);
       connect(sl, SIGNAL(itemActivated(QListWidgetItem*)), SLOT(setScoreActivated(QListWidgetItem*)));
       scoreLists.append(sl);
       return sl;
@@ -311,13 +311,20 @@ void ScoreBrowser::filter(const QString &searchString)
 }
 
 //---------------------------------------------------------
-//   scoreChanged
+//   scoreClicked
 //---------------------------------------------------------
 
-void ScoreBrowser::scoreChanged(QListWidgetItem* current)
+void ScoreBrowser::scoreClicked(QListWidgetItem* current)
       {
       if (!current)
             return;
+
+      if (style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick)) {
+            // Qt will consider this click an item activation.
+            // Just let it happen.
+            return;
+            }
+
       ScoreItem* item = static_cast<ScoreItem*>(current);
       if (!_showPreview)
             emit scoreActivated(item->info().filePath());

--- a/mscore/scoreBrowser.h
+++ b/mscore/scoreBrowser.h
@@ -61,7 +61,7 @@ class ScoreBrowser : public QWidget, public Ui::ScoreBrowser
       ScoreItem* genScoreItem(const QFileInfo&, ScoreListWidget*);
 
    private slots:
-      void scoreChanged(QListWidgetItem*);
+      void scoreClicked(QListWidgetItem*);
       void setScoreActivated(QListWidgetItem*);
 
    signals:


### PR DESCRIPTION
After starting up MuseScore by default shows a screen suggesting user to create new score or open one of the recently used. On systems with Qt configured to activate items on single click (which is the case for most of GNU/Linux distributions with KDE desktop installed) clicking on any item of the shown list leads to a crash. When configuring system to turn off that behavior crash does not happen anymore.

I didn't manage to find anything like this in the issue tracker, but I happened to experience this issue, so I propose a patch to resolve it.

This patch contains two changes:
1. Added a check on whether the single click activation behavior is turned on to prevent operating on possibly deleted `ScoreItem` object's data (which actually led to a crash) and double-emitting `scoreActivated()` signal.
2. Renamed `scoreChanged` private slot to `scoreClicked` to make its purpose more clear to code reader. This part is obviously not critical, so feel free to ask me to undo this if you consider this unneeded.