### PR TITLE
prevent layout crash when no visible staffs

### DIFF
--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -378,6 +378,7 @@ void System::layout2()
 
       if (visibleStaves.empty()) {
             qDebug("====no visible staves, staves %d, score staves %d", _staves.size(), score()->nstaves());
+            return;
             }
 
       for (auto i = visibleStaves.begin();; ++i) {


### PR DESCRIPTION
Don't loop over visible staffs if there are no visile staffs.