### PR TITLE
fix #270408: visual tracking of colliding notes

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -166,7 +166,7 @@ static void playNote(EventMap* events, const Note* note, int channel, int pitch,
       NPlayEvent ev(ME_NOTEON, channel, pitch, velo);
       ev.setOriginatingStaff(staffIdx);
       ev.setTuning(note->tuning());
-      ev.setNote(note);
+      ev.notes.push_back(note);
       events->insert(std::pair<int, NPlayEvent>(onTime, ev));
       ev.setVelo(0);
       events->insert(std::pair<int, NPlayEvent>(offTime, ev));

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -510,9 +510,9 @@ void Seq::playEvent(const NPlayEvent& event, unsigned framePos)
       int type = event.type();
       if (type == ME_NOTEON) {
             bool mute;
-            const Note* note = event.note();
 
-            if (note) {
+            if (!event.notes.empty()) {
+                  const Note* note = event.notes[0];
                   Instrument* instr = note->staff()->part()->instrument(note->chord()->tick());
                   const Channel* a = instr->channel(note->subchannel());
                   mute = a->mute || a->soloMute;
@@ -1486,20 +1486,18 @@ void Seq::heartBeatTimeout()
                         break;
             const NPlayEvent& n = guiPos->second;
             if (n.type() == ME_NOTEON) {
-                  const Note* note1 = n.note();
-                  if (n.velo()) {
+                  for (auto it = n.notes.cbegin(); it != n.notes.cend(); ++it) {
+                        const Note* note1 = *it;
                         while (note1) {
-                              note1->setMark(true);
-                              markedNotes.append(note1);
+                              if (n.velo()) {
+                                    note1->setMark(true);
+                                    markedNotes.append(note1);
+                                    }
+                              else {
+                                    note1->setMark(false);
+                                    markedNotes.removeOne(note1);
+                                    }
                               r |= note1->canvasBoundingRect();
-                              note1 = note1->tieFor() ? note1->tieFor()->endNote() : 0;
-                              }
-                        }
-                  else {
-                        while (note1) {
-                              note1->setMark(false);
-                              r |= note1->canvasBoundingRect();
-                              markedNotes.removeOne(note1);
                               note1 = note1->tieFor() ? note1->tieFor()->endNote() : 0;
                               }
                         }

--- a/synthesizer/event.cpp
+++ b/synthesizer/event.cpp
@@ -377,31 +377,44 @@ void EventList::insert(const Event& e)
 
 void EventMap::fixupMIDI()
       {
-      unsigned short nowPlaying[_highestChannel + 1][128 /* notes */];
-      int originatingTrack[_highestChannel + 1][128 /* notes */];
+      /* track info for each of the 128 possible MIDI notes */
+      struct channelInfo {
+            /* which event the first ME_NOTEON came from */
+            NPlayEvent *event[128];
+            /* how often is the note on right now? */
+            unsigned short nowPlaying[128];
+            };
+
+      /* track info for each channel (on the heap, 0-initialised) */
+      struct channelInfo *info = (struct channelInfo *)calloc(_highestChannel + 1, sizeof(struct channelInfo));
+
       auto it = begin();
-
-      memset(nowPlaying, 0, (_highestChannel + 1) * 128 * sizeof(unsigned short));
-
       while (it != end()) {
             bool discard = false;
 
             /* ME_NOTEOFF is never emitted, no need to check for it */
             if (it->second.type() == ME_NOTEON) {
-                  unsigned short np = nowPlaying[it->second.channel()][it->second.pitch()];
+                  unsigned short np = info[it->second.channel()].nowPlaying[it->second.pitch()];
                   if (it->second.velo() == 0) {
                         /* already off or still playing? */
                         if (np == 0 || --np > 0)
                               discard = true;
-                        else
+                        else {
                               /* hoist NOTEOFF to same track as NOTEON */
-                              it->second.setOriginatingStaff(originatingTrack[it->second.channel()][it->second.pitch()]);
+                              it->second.setOriginatingStaff(info[it->second.channel()].event[it->second.pitch()]->getOriginatingStaff());
+                              /* copy linked Notes */
+                              it->second.notes = info[it->second.channel()].event[it->second.pitch()]->notes;
+                              }
                         }
-                  else if (++np > 1)
-                        discard = true; /* already playing */
+                  else if (++np > 1) {
+                        /* already playing */
+                        discard = true;
+                        /* carry over the corresponding score notes */
+                        info[it->second.channel()].event[it->second.pitch()]->notes.insert(info[it->second.channel()].event[it->second.pitch()]->notes.end(), it->second.notes.begin(), it->second.notes.end());
+                        }
                   else
-                        originatingTrack[it->second.channel()][it->second.pitch()] = it->second.getOriginatingStaff();
-                  nowPlaying[it->second.channel()][it->second.pitch()] = np;
+                        info[it->second.channel()].event[it->second.pitch()] = &(it->second);
+                  info[it->second.channel()].nowPlaying[it->second.pitch()] = np;
                   }
 
             if (discard)
@@ -409,6 +422,8 @@ void EventMap::fixupMIDI()
             else
                   ++it;
             }
+
+            free((void *)info);
       }
 
 }

--- a/synthesizer/event.h
+++ b/synthesizer/event.h
@@ -234,7 +234,7 @@ class PlayEvent : public MidiCoreEvent {
 //---------------------------------------------------------
 
 class NPlayEvent : public PlayEvent {
-      const Note* _note = 0;
+      std::vector<const Note*> _notes;
       int _origin = -1;
 
    public:
@@ -243,8 +243,9 @@ class NPlayEvent : public PlayEvent {
          : PlayEvent(t, c, a, b) {}
       NPlayEvent(const MidiCoreEvent& e) : PlayEvent(e) {}
       NPlayEvent(BeatType beatType);
-      const Note* note() const       { return _note; }
-      void setNote(const Note* v)    { _note = v; }
+
+      std::vector<const Note*> notes;
+
       int getOriginatingStaff() const { return _origin; }
       void setOriginatingStaff(int i) { _origin = i; }
       };


### PR DESCRIPTION
Carry over `const Note*` values of `discard`ed `ME_NOTEON` events to their nōn-discarded counterparts

https://musescore.org/en/node/270408