### PR TITLE
fix #270458: Re-Pitch a note to a rest.

### DIFF
--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -69,6 +69,8 @@ void MuseScore::updateInputState(Score* score)
       {
       InputState& is = score->inputState();
       if (is.noteEntryMode()) {
+            if (is.usingNoteEntryMethod(NoteEntryMethod::REPITCH))
+                  is.setDuration(is.cr()->durationType());
             Staff* staff = score->staff(is.track() / VOICES);
             switch (staff->staffType(is.tick())->group()) {
                   case StaffGroup::STANDARD:


### PR DESCRIPTION
See [issue 270458](https://musescore.org/en/node/270458).