### PR TITLE
fix #269998: Dotted rhythms within tuplets

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1051,7 +1051,12 @@ QList<Fraction> Score::splitGapToMeasureBoundaries(ChordRest* cr, Fraction gap)
       if (tuplet) {
             if (tuplet->tuplet())
                   return flist; // do no deal with nested tuplets
-            Fraction rest = Fraction::fromTicks(tuplet->tick() + tuplet->duration().ticks() - cr->segment()->tick()) * tuplet->ratio();
+            Fraction rest = tuplet->elementsDuration();
+            for (DurationElement* de : tuplet->elements()) {
+                  if (de == cr)
+                        break;
+                  rest -= de->duration();
+                  }
             if (rest < gap)
                   qDebug("does not fit in tuplet");
             else

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -285,11 +285,12 @@ Rest* Score::setRest(int tick, int track, Fraction l, bool useDots, Tuplet* tupl
             //
             Fraction f;
             if (tuplet) {
-                  int ticks = (tuplet->tick() + tuplet->actualTicks()) - tick;
-
-                  f = Fraction::fromTicks(ticks);
-                  for (Tuplet* t = tuplet; t; t = t->tuplet())
-                        f *= t->ratio();
+                  f = tuplet->baseLen().fraction() * tuplet->ratio().numerator();
+                  for (DurationElement* de : tuplet->elements()) {
+                        if (de->tick() >= tick)
+                              break;
+                        f -= de->duration();
+                        }
                   //
                   // restrict to tuplet len
                   //


### PR DESCRIPTION
See [issue 269998](https://musescore.org/en/node/269998).
This was recently merged into the 2.2 branch. Here is the patch for the master branch.