### PR TITLE
fix #269998: Tuplets numbers, when creating parts, obey first to the …

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -348,6 +348,7 @@ static void cloneTuplets(ChordRest* ocr, ChordRest* ncr, Tuplet* ot, TupletMap& 
             nt = static_cast<Tuplet*>(ot->linkedClone());
             nt->setTrack(track);
             nt->setParent(m);
+            nt->setScore(ncr->score());
             tupletMap.add(ot, nt);
 
             Tuplet* nt1 = nt;
@@ -357,6 +358,7 @@ static void cloneTuplets(ChordRest* ocr, ChordRest* ncr, Tuplet* ot, TupletMap& 
                         nt = static_cast<Tuplet*>(ot->tuplet()->linkedClone());
                         nt->setTrack(track);
                         nt->setParent(m);
+                        nt->setScore(ncr->score());
                         tupletMap.add(ot->tuplet(), nt);
                         }
                   nt->add(nt1);
@@ -529,7 +531,7 @@ void cloneStaves(Score* oscore, Score* score, const QList<int>& map)
                                     Tuplet* ot = ocr->tuplet();
 
                                     if (ot)
-                                          cloneTuplets(ocr, ncr, ot, tupletMap, m, track);
+                                          cloneTuplets(ocr, ncr, ot, tupletMap, nm, track);
 
                                     if (oe->type() == Element::Type::CHORD) {
                                           Chord* och = static_cast<Chord*>(ocr);

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -61,10 +61,8 @@ Tuplet::Tuplet(const Tuplet& t)
       _p1           = t._p1;
       _p2           = t._p2;
 
-      if (t._number)
-            _number = new Text(*t._number);
-      else
-            _number = 0;
+     // recreated on layout
+     _number = 0;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
…scaling in main score instead of the default parts scaling