### PR TITLE
fix #270532 Select All type TEXT by SubType

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3027,6 +3027,11 @@ void Score::selectSimilar(Element* e, bool sameStaff)
                   pattern.subtype = -1; // hack
             else
                   pattern.subtype = e->subtype();
+            pattern.subtypeValid = true;
+            }
+      else if (type == ElementType::TEXT) {
+            pattern.subtype = e->subtype();
+            pattern.subtypeValid = true;
             }
       pattern.staffStart = sameStaff ? e->staffIdx() : -1;
       pattern.staffEnd = sameStaff ? e->staffIdx() + 1 : -1;
@@ -3058,6 +3063,10 @@ void Score::selectSimilarInRange(Element* e)
                   pattern.subtype = -1; //hack
             else
                   pattern.subtype = e->subtype();
+            pattern.subtypeValid = true;
+            }
+      else if (type == ElementType::TEXT) {
+            pattern.subtype = e->subtype();
             pattern.subtypeValid = true;
             }
       pattern.staffStart = selection().staffStart();

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2416,6 +2416,7 @@ int TextBase::subtype() const
             case SubStyle::POET:
             case SubStyle::FRAME:
             case SubStyle::INSTRUMENT_EXCERPT:
+            case SubStyle::MEASURE_NUMBER:
                   return int(subStyle());
             default: return -1;
             }
@@ -2438,6 +2439,7 @@ QString TextBase::subtypeName() const
             case SubStyle::POET:
             case SubStyle::FRAME:
             case SubStyle::INSTRUMENT_EXCERPT:
+            case SubStyle::MEASURE_NUMBER:
                   rez = subStyleUserName(subStyle());
                   break;
             default: rez = "";

--- a/mscore/inspector/inspectorText.cpp
+++ b/mscore/inspector/inspectorText.cpp
@@ -36,7 +36,7 @@ InspectorText::InspectorText(QWidget* parent)
       f.subStyle->clear();
       for (auto ss : { SubStyleId::FRAME, SubStyleId::TITLE, SubStyleId::SUBTITLE,SubStyleId::COMPOSER,
          SubStyleId::POET, SubStyleId::INSTRUMENT_EXCERPT,
-         SubStyleId::TRANSLATOR, SubStyleId::HEADER, SubStyleId::FOOTER, SubStyleId::USER1, SubStyleId::USER2 } )
+         SubStyleId::TRANSLATOR, SubStyleId::HEADER, SubStyleId::FOOTER, SubStyleId::USER1, SubStyleId::USER2, SubStyleId::MEASURE_NUMBER } )
             {
             f.subStyle->addItem(subStyleUserName(ss), int(ss));
             }


### PR DESCRIPTION
This is to prevent user unintentionally selecting the text element of tuplet numbers when selecting all measure number text (or title text, or composer text, etc.).  That can cause problems since it is not possible to select the text element of tuplet numbers in any other way, so changes to tuplet text couldn't easily be reverted.

I'm fixing this by having Score::selectSimilar() and Score::selectSimilarInRange() select TEXT elements by subtype, that way selecting all of a particular subtype of text won't select text of all other subtypes.

Additionally I'm making sure inspector is aware of the MEASURE_NUMBER subtype by populating MEASURE_NUMBER in the subtype combobox.