### PR TITLE
fix #270433 Crash when pasting a note with articulation if the final note is split between two measures

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2821,6 +2821,9 @@ void Chord::removeMarkings(bool keepTremolo)
       if (arpeggio())
             remove(arpeggio());
       qDeleteAll(graceNotes());
+	  for(Articulation* a : articulations() ){
+            remove(a);
+      }
       for (Note* n : notes()) {
             for (Element* e : n->el())
                   n->remove(e);

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2823,7 +2823,7 @@ void Chord::removeMarkings(bool keepTremolo)
       qDeleteAll(graceNotes());
       for(Articulation* a : articulations()) {
             remove(a);
-      	    }
+      	}
       for (Note* n : notes()) {
             for (Element* e : n->el())
                   n->remove(e);

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2821,9 +2821,9 @@ void Chord::removeMarkings(bool keepTremolo)
       if (arpeggio())
             remove(arpeggio());
       qDeleteAll(graceNotes());
-	  for(Articulation* a : articulations() ){
+      for(Articulation* a : articulations()) {
             remove(a);
-      }
+      	    }
       for (Note* n : notes()) {
             for (Element* e : n->el())
                   n->remove(e);

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2820,10 +2820,7 @@ void Chord::removeMarkings(bool keepTremolo)
             remove(tremolo());
       if (arpeggio())
             remove(arpeggio());
-      qDeleteAll(graceNotes());
-      for(Articulation* a : articulations()) {
-            remove(a);
-      	}
+      graceNotes().clear();
       for (Note* n : notes()) {
             for (Element* e : n->el())
                   n->remove(e);

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1235,10 +1235,10 @@ void ChordRest::flipLyrics(Lyrics* l)
 
 void ChordRest::removeMarkings(bool /* keepTremolo */)
       {
-      qDeleteAll(el());
+      el().clear();
       if (isChord())
-            qDeleteAll(toChord(this)->articulations());
-      qDeleteAll(lyrics());
+            toChord(this)->articulations().clear();
+      lyrics().clear();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
There was a reference to a deleted articulation but its trace (marking) wasn't actually deleted and it was causing a segmentation fault. I added a loop to properly delete the articulation markings.