### PR TITLE
backport to 2.2: fix #196771 : Regroup Rhythms deletes various elements

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3178,19 +3178,17 @@ void Chord::sortNotes()
 
 Chord* Chord::nextTiedChord(bool backwards, bool sameSize)
       {
-      Segment* nextSeg = segment();
-      ChordRest* nextCR = 0;
-      do    {
-            nextSeg = backwards ? nextSeg->prev1(Segment::Type::ChordRest) : nextSeg->next1(Segment::Type::ChordRest);
-            if (!nextSeg)
-                  return 0; // nothing to tie to
-            nextCR = nextSeg->cr(track());
-            } while (nextCR == 0); // nextCR = 0 when CR in another voice overlaps
-      if (!nextCR->isChord())
-            return 0; // can't tie to a rest
+      Segment* nextSeg = backwards ? segment()->prev1(Segment::Type::ChordRest) : segment()->next1(Segment::Type::ChordRest);
+      if (!nextSeg)
+            return 0;
+      ChordRest* nextCR = nextSeg->nextChordRest(track(), backwards);
+      if (!nextCR || !nextCR->isChord())
+            return 0;
       Chord* next = static_cast<Chord*>(nextCR);
       if (sameSize && notes().size() != next->notes().size())
             return 0; // sizes don't match so some notes can't be tied
+      if (tuplet() != next->tuplet())
+            return 0; // next chord belongs to a different tuplet
       for (Note* n : _notes) {
             Tie* tie = backwards ? n->tieBack() : n->tieFor();
             if (!tie)

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1528,7 +1528,8 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                               lastRest = cr;
                               }
                         int restTicks = lastRest->tick() + lastRest->duration().ticks() - curr->tick();
-                        seg = setNoteRest(seg, curr->track(), NoteVal(), Fraction::fromTicks(restTicks), MScore::Direction::AUTO, true);
+                        if (restTicks > curr->duration().ticks())
+                              seg = setNoteRest(seg, curr->track(), NoteVal(), Fraction::fromTicks(restTicks), MScore::Direction::AUTO, true);
                         }
                   else {
                         // combine tied chords
@@ -1539,51 +1540,127 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                               }
                         if (!lastTiedChord)
                               lastTiedChord = chord;
-                        int numNotes = chord->notes().size();
-                        int pitches[numNotes];
-                        Tie* tieBack[numNotes];
-                        Tie* tieFor[numNotes];
-                        for (int i = 0; i < numNotes; i++) {
-                              Note* n = chord->notes()[i];
-                              Note* nn = lastTiedChord->notes()[i];
-                              pitches[i] = n->pitch();
-                              tieBack[i] = n->tieBack();
-                              tieFor[i] = nn->tieFor();
-                              n->setTieBack(0);
-                              nn->setTieFor(0);
-                              }
                         int noteTicks = lastTiedChord->tick() + lastTiedChord->duration().ticks() - chord->tick();
-                        Segment* newSeg = setNoteRest(seg, curr->track(), NoteVal(pitches[0]), Fraction::fromTicks(noteTicks), MScore::Direction::AUTO, true);
-                        for (seg = seg->prev1()->next1(Segment::Type::ChordRest);;seg = seg->next1(Segment::Type::ChordRest)) {
-                              ChordRest* cr = seg->cr(track);
-                              if (!cr)
-                                    continue; // voice is empty here
-                              Chord* newChord = static_cast<Chord*>(cr);
-                              Note* n = newChord->notes().front();
-                              undoRemoveElement(n);
+                        if (noteTicks > chord->duration().ticks()) {
+                              // store start/end note for backward/forward ties ending/starting on the group of notes being rewritten
+                              int numNotes = chord->notes().size();
+                              Note* tieBack[numNotes];
+                              Note* tieFor[numNotes];
                               for (int i = 0; i < numNotes; i++) {
-                                    NoteVal nval = NoteVal(pitches[i]);
-                                    n = addNote(newChord, nval);
-                                    if (tieBack[i]) {
-                                          n->setTieBack(tieBack[i]);
-                                          tieBack[i]->setEndNote(n);
+                                    Note* n = chord->notes()[i];
+                                    Note* nn = lastTiedChord->notes()[i];
+                                    if (n->tieBack())
+                                          tieBack[i] = n->tieBack()->startNote();
+                                    else
                                           tieBack[i] = 0;
+                                    if (nn->tieFor())
+                                          tieFor[i] = nn->tieFor()->endNote();
+                                    else
+                                          tieFor[i] = 0;
+                                    }
+                              int tick      = seg->tick();
+                              int track     = chord->track();
+                              Fraction sd   = Fraction::fromTicks(noteTicks);
+                              Tie* tie      = 0;
+                              Segment* segment = seg;
+                              ChordRest* cr = static_cast<ChordRest*>(segment->element(track));
+                              Chord* nchord = static_cast<Chord*>(chord->clone());
+                              for (int i = 0; i < numNotes; i++) { // strip ties from cloned chord
+                                    Note* n = nchord->notes()[i];
+                                    n->setTieFor(0);
+                                    n->setTieBack(0);
+                                    }
+                              Chord* startChord = nchord;
+                              Measure* measure = 0;
+                              bool firstpart = true;
+                              for (;;) {
+                                    if (track % VOICES)
+                                          expandVoice(segment, track);
+                                    // the returned gap ends at the measure boundary or at tuplet end
+                                    Fraction dd = makeGap(segment, track, sd, cr->tuplet());
+                                    if (dd.isZero())
+                                          break;
+                                    measure = segment->measure();
+                                    QList<TDuration> dl = toRhythmicDurationList(dd, false, segment->rtick(), sigmap()->timesig(tick).nominal(), measure, 1);
+                                    int n = dl.size();
+                                    for (int i = 0; i < n; ++i) {
+                                          const TDuration& d = dl[i];
+                                          Chord* nchord2 = static_cast<Chord*>(nchord->clone());
+                                          if (!firstpart)
+                                                nchord2->removeMarkings(true);
+                                          nchord2->setDurationType(d);
+                                          nchord2->setDuration(d.fraction());
+                                          QList<Note*> nl1 = nchord->notes();
+                                          QList<Note*> nl2 = nchord2->notes();
+                                          if (!firstpart)
+                                                for (unsigned j = 0; j < nl1.size(); ++j) {
+                                                      tie = new Tie(this);
+                                                      tie->setStartNote(nl1[j]);
+                                                      tie->setEndNote(nl2[j]);
+                                                      tie->setTrack(track);
+                                                      nl1[j]->setTieFor(tie);
+                                                      nl2[j]->setTieBack(tie);
+                                                      }
+                                          undoAddCR(nchord2, measure, tick);
+                                          segment = nchord2->segment();
+                                          tick += nchord2->actualTicks();
+                                          nchord = nchord2;
+                                          firstpart = false;
                                           }
-                                    if (seg != newSeg) {
-                                          Tie* tie = new Tie(this);
-                                          n->setTieFor(tie);
-                                          tie->setStartNote(n);
-                                          tie->setEndNote(n);
-                                          tie->setTrack(n->track());
-                                          tieBack[i] = tie;
-                                          }
-                                    else if (tieFor[i]) {
-                                          n->setTieFor(tieFor[i]);
-                                          tieFor[i]->setStartNote(n);
+                                    sd -= dd;
+                                    if (sd.isZero())
+                                          break;
+                                    Segment* nseg = tick2segment(tick, false, Segment::Type::ChordRest);
+                                    if (nseg == 0)
+                                          break;
+                                    segment = nseg;
+                                    cr = static_cast<ChordRest*>(segment->element(track));
+                                    if (cr == 0) {
+                                          if (track % VOICES)
+                                                cr = addRest(segment, track, TDuration(TDuration::DurationType::V_MEASURE), 0);
+                                          else
+                                                break;
                                           }
                                     }
-                              if (seg == newSeg)
-                                    break;
+                              if (_is.slur()) {
+                                    // extend slur
+                                    _is.slur()->undoChangeProperty(P_ID::SPANNER_TICKS, nchord->tick() - _is.slur()->tick());
+                                    for (ScoreElement* e : _is.slur()->linkList()) {
+                                          Slur* slur = static_cast<Slur*>(e);
+                                          for (ScoreElement* ee : nchord->linkList()) {
+                                                Element* e = static_cast<Element*>(ee);
+                                                if (e->score() == slur->score() && e->track() == slur->track2()) {
+                                                      slur->score()->undo(new ChangeSpannerElements(slur, slur->startElement(), e));
+                                                      break;
+                                                      }
+                                                }
+                                          }
+                                    }
+                              // recreate previously stored pending ties
+                              for (int i = 0; i < numNotes; i++) {
+                                    Note* n = startChord->notes()[i];
+                                    Note* nn = nchord->notes()[i];
+                                    if (tieBack[i]) {
+                                          tie = new Tie(this);
+                                          tie->setStartNote(tieBack[i]);
+                                          tie->setEndNote(n);
+                                          tie->setTrack(track);
+                                          n->setTieBack(tie);
+                                          tieBack[i]->setTieFor(tie);
+                                          undoAddElement(tie);
+                                          }
+                                    if (tieFor[i]) {
+                                          tie = new Tie(this);
+                                          tie->setStartNote(nn);
+                                          tie->setEndNote(tieFor[i]);
+                                          tie->setTrack(track);
+                                          n->setTieFor(tie);
+                                          tieFor[i]->setTieBack(tie);
+                                          undoAddElement(tie);
+                                          }
+                                    }
+                              if (tie) // at least one tie was created
+                                    connectTies();
                               }
                         }
                   }

--- a/mtest/libmscore/rhythmicGrouping/groupArticulationsTies-ref.mscx
+++ b/mtest/libmscore/rhythmicGrouping/groupArticulationsTies-ref.mscx
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <page-layout>
+        <page-height>1683.36</page-height>
+        <page-width>1190.88</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Beam id="1">
+          <l1>19</l1>
+          <l2>20</l2>
+          </Beam>
+        <Tuplet id="1">
+          <normalNotes>2</normalNotes>
+          <actualNotes>3</actualNotes>
+          <baseNote>eighth</baseNote>
+          <Number>
+            <style>Tuplet</style>
+            <text>3</text>
+            </Number>
+          </Tuplet>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
+            <Tie id="2">
+              </Tie>
+            <pitch>72</pitch>
+            <tpc>26</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <Tie id="3">
+              </Tie>
+            <endSpanner id="2"/>
+            <pitch>72</pitch>
+            <tpc>26</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>eighth</durationType>
+          <Note>
+            <endSpanner id="3"/>
+            <pitch>72</pitch>
+            <tpc>26</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>eighth</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="2">
+        <Chord>
+          <durationType>half</durationType>
+          <Articulation>
+            <subtype>fermata</subtype>
+            </Articulation>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>quarter</durationType>
+          </Rest>
+        <tick>2400</tick>
+        <Chord>
+          <track>1</track>
+          <durationType>quarter</durationType>
+          <Note>
+            <track>1</track>
+            <pitch>64</pitch>
+            <tpc>18</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <track>1</track>
+          <durationType>quarter</durationType>
+          <Note>
+            <track>1</track>
+            <pitch>64</pitch>
+            <tpc>18</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="3">
+        <Chord>
+          <durationType>eighth</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <dots>1</dots>
+          <durationType>quarter</durationType>
+          <Articulation>
+            <subtype>sforzato</subtype>
+            <timeStretch>0.1</timeStretch>
+            <pos x="0.788281" y="-0.996094"/>
+            </Articulation>
+          <Lyrics>
+            <text>lyrics</text>
+            </Lyrics>
+          <Note>
+            <Accidental>
+              <subtype>double flat</subtype>
+              </Accidental>
+            <Tie id="4">
+              </Tie>
+            <pitch>72</pitch>
+            <tpc>2</tpc>
+            </Note>
+          </Chord>
+        <Beam id="2">
+          <l1>18</l1>
+          <l2>19</l2>
+          </Beam>
+        <Tuplet id="2">
+          <normalNotes>2</normalNotes>
+          <actualNotes>3</actualNotes>
+          <baseNote>eighth</baseNote>
+          <Number>
+            <style>Tuplet</style>
+            <text>3</text>
+            </Number>
+          </Tuplet>
+        <Chord>
+          <Tuplet>2</Tuplet>
+          <durationType>eighth</durationType>
+          <Articulation>
+            <subtype>staccato</subtype>
+            <timeStretch>0.1</timeStretch>
+            </Articulation>
+          <Beam>2</Beam>
+          <Note>
+            <endSpanner id="4"/>
+            <pitch>72</pitch>
+            <tpc>2</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>2</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>2</Beam>
+          <Note>
+            <Accidental>
+              <subtype>natural</subtype>
+              </Accidental>
+            <pitch>74</pitch>
+            <tpc>16</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>2</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>2</Beam>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>quarter</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="4">
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <Tie id="5">
+              </Tie>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>32nd</durationType>
+          <Note>
+            <endSpanner id="5"/>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Rest>
+          <dots>1</dots>
+          <durationType>16th</durationType>
+          </Rest>
+        <Rest>
+          <durationType>eighth</durationType>
+          </Rest>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/rhythmicGrouping/groupArticulationsTies.mscx
+++ b/mtest/libmscore/rhythmicGrouping/groupArticulationsTies.mscx
@@ -1,0 +1,380 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <page-layout>
+        <page-height>1683.36</page-height>
+        <page-width>1190.88</page-width>
+        <page-margins type="even">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        <page-margins type="odd">
+          <left-margin>56.6929</left-margin>
+          <right-margin>56.6929</right-margin>
+          <top-margin>56.6929</top-margin>
+          <bottom-margin>113.386</bottom-margin>
+          </page-margins>
+        </page-layout>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <clef staff="2">F</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure number="1">
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Beam id="1">
+          <l1>19</l1>
+          <l2>20</l2>
+          </Beam>
+        <Tuplet id="1">
+          <normalNotes>2</normalNotes>
+          <actualNotes>3</actualNotes>
+          <baseNote>eighth</baseNote>
+          <Number>
+            <style>Tuplet</style>
+            <text>3</text>
+            </Number>
+          </Tuplet>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
+            <Tie id="2">
+              </Tie>
+            <pitch>72</pitch>
+            <tpc>26</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <Tie id="3">
+              </Tie>
+            <endSpanner id="2"/>
+            <pitch>72</pitch>
+            <tpc>26</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>eighth</durationType>
+          <Note>
+            <endSpanner id="3"/>
+            <pitch>72</pitch>
+            <tpc>26</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>eighth</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="2">
+        <Chord>
+          <durationType>eighth</durationType>
+          <Articulation>
+            <subtype>fermata</subtype>
+            </Articulation>
+          <Note>
+            <Tie id="4">
+              </Tie>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <Tie id="5">
+              </Tie>
+            <endSpanner id="4"/>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>eighth</durationType>
+          <Articulation>
+            <subtype>staccato</subtype>
+            <timeStretch>0.1</timeStretch>
+            </Articulation>
+          <Lyrics>
+            <text>Disappearing</text>
+            </Lyrics>
+          <Note>
+            <endSpanner id="5"/>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>quarter</durationType>
+          </Rest>
+        <tick>2400</tick>
+        <Chord>
+          <track>1</track>
+          <durationType>quarter</durationType>
+          <Note>
+            <track>1</track>
+            <pitch>64</pitch>
+            <tpc>18</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <track>1</track>
+          <durationType>quarter</durationType>
+          <Note>
+            <track>1</track>
+            <pitch>64</pitch>
+            <tpc>18</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      <Measure number="3">
+        <Beam id="2">
+          <l1>17</l1>
+          <l2>16</l2>
+          </Beam>
+        <Chord>
+          <durationType>eighth</durationType>
+          <Beam>2</Beam>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>eighth</durationType>
+          <Articulation>
+            <subtype>sforzato</subtype>
+            <timeStretch>0.1</timeStretch>
+            <pos x="0.788281" y="-0.996094"/>
+            </Articulation>
+          <Beam>2</Beam>
+          <Lyrics>
+            <text>lyrics</text>
+            </Lyrics>
+          <Note>
+            <Accidental>
+              <subtype>double flat</subtype>
+              </Accidental>
+            <Tie id="6">
+              </Tie>
+            <pitch>72</pitch>
+            <tpc>2</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <Tie id="7">
+              </Tie>
+            <endSpanner id="6"/>
+            <pitch>72</pitch>
+            <tpc>2</tpc>
+            </Note>
+          </Chord>
+        <Beam id="3">
+          <l1>18</l1>
+          <l2>19</l2>
+          </Beam>
+        <Tuplet id="2">
+          <normalNotes>2</normalNotes>
+          <actualNotes>3</actualNotes>
+          <baseNote>eighth</baseNote>
+          <Number>
+            <style>Tuplet</style>
+            <text>3</text>
+            </Number>
+          </Tuplet>
+        <Chord>
+          <Tuplet>2</Tuplet>
+          <durationType>eighth</durationType>
+          <Articulation>
+            <subtype>staccato</subtype>
+            <timeStretch>0.1</timeStretch>
+            </Articulation>
+          <Beam>3</Beam>
+          <Note>
+            <endSpanner id="7"/>
+            <pitch>72</pitch>
+            <tpc>2</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>2</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>3</Beam>
+          <Note>
+            <Accidental>
+              <subtype>natural</subtype>
+              </Accidental>
+            <pitch>74</pitch>
+            <tpc>16</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>2</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>3</Beam>
+          <Note>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>quarter</durationType>
+          </Rest>
+        </Measure>
+      <Measure number="4">
+        <Chord>
+          <durationType>quarter</durationType>
+          <Note>
+            <Tie id="8">
+              </Tie>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <durationType>32nd</durationType>
+          <Note>
+            <endSpanner id="8"/>
+            <pitch>72</pitch>
+            <tpc>14</tpc>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>32nd</durationType>
+          </Rest>
+        <Rest>
+          <durationType>16th</durationType>
+          </Rest>
+        <Rest>
+          <durationType>eighth</durationType>
+          </Rest>
+        <Rest>
+          <durationType>half</durationType>
+          </Rest>
+        <BarLine>
+          <subtype>end</subtype>
+          <span>1</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/rhythmicGrouping/tst_rhythmicGrouping.cpp
+++ b/mtest/libmscore/rhythmicGrouping/tst_rhythmicGrouping.cpp
@@ -31,12 +31,13 @@ class TestRhythmicGrouping : public QObject, public MTest
 
    private slots:
       void initTestCase();
-      void group8ths44()            { group("group8ths4-4.mscx",        "group8ths4-4-ref.mscx");      }
-      void group8thsSimple()        { group("group8thsSimple.mscx",     "group8thsSimple-ref.mscx");   }
-      void group8thsCompound()      { group("group8thsCompound.mscx",   "group8thsCompound-ref.mscx"); }
-      void groupSubbeats()          { group("groupSubbeats.mscx",       "groupSubbeats-ref.mscx");     }
-      void groupVoices()            { group("groupVoices.mscx",         "groupVoices-ref.mscx");       }
-      void groupConflicts()         { group("groupConflicts.mscx",      "groupConflicts-ref.mscx", 1); } // only group 1st staff
+      void group8ths44()             { group("group8ths4-4.mscx",           "group8ths4-4-ref.mscx");      }
+      void group8thsSimple()         { group("group8thsSimple.mscx",        "group8thsSimple-ref.mscx");   }
+      void group8thsCompound()       { group("group8thsCompound.mscx",      "group8thsCompound-ref.mscx"); }
+      void groupSubbeats()           { group("groupSubbeats.mscx",          "groupSubbeats-ref.mscx");     }
+      void groupVoices()             { group("groupVoices.mscx",            "groupVoices-ref.mscx");       }
+      void groupConflicts()          { group("groupConflicts.mscx",         "groupConflicts-ref.mscx", 1); } // only group 1st staff
+      void groupArticulationsTies()  { group("groupArticulationsTies.mscx", "groupArticulationsTies-ref.mscx"); } // test for articulations and forward/backward ties
 
       };
 


### PR DESCRIPTION
Backporting PR #3552 into the 2.2 branch.

- Fix merge conflicts
- Replace 3.X concepts with 2.X equivalents:
  - Use `QList` instead of `std:vector`
  - Use `static_cast<Element*>(e)` instead of `toElement(e)`
  - Use `Segment::Type` instead of `SegmentType`, etc
- Recreate test cases in older MSCX format