### PR TITLE
compare duration() of tuplet with calculated duration to see if it…

### DIFF
--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -1093,6 +1093,8 @@ void Tuplet::sanitizeTuplet()
             }
       testDuration = testDuration / ratio();
       testDuration.reduce();
+      if (elements().back()->tick() + elements().back()->actualTicks() - elements().front()->tick() > testDuration.ticks())
+            return;     // this tuplet has missing elements; do not sanitize
       if (!(testDuration == baseLenDuration && baseLenDuration == duration())) {
             Fraction f = testDuration * Fraction(1, ratio().denominator());
             f.reduce();

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -1093,7 +1093,7 @@ void Tuplet::sanitizeTuplet()
             }
       testDuration = testDuration / ratio();
       testDuration.reduce();
-      if ((testDuration - baseLenDuration).reduced().numerator() != 0) {
+      if (!(testDuration == baseLenDuration && baseLenDuration == duration())) {
             Fraction f = testDuration * Fraction(1, ratio().denominator());
             f.reduce();
             Fraction fbl(1, f.denominator());


### PR DESCRIPTION
… needs to be sanitized

#3526 may have fixed some issues with the sanitizeTuplet() function, but it allows tuplets to go unsanitized when testDuration is equal to baseLenDuration, but duration() is incorrect. 