### PR TITLE
fix #252201: playback holds during section break

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2362,7 +2362,7 @@ void Score::getNextMeasure(LayoutContext& lc)
       //  implement section break rest
       //
       if (measure->sectionBreak() && measure->pause() != 0.0)
-            setPause(measure->endTick()-1, measure->pause());
+            setPause(measure->endTick(), measure->pause());
 
       //
       // calculate accidentals and note lines,

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -178,7 +178,7 @@ void MeasureBase::remove(Element* el)
                         break;
                   case LayoutBreak::SECTION:
                         setSectionBreak(false);
-                        score()->setPause(endTick()-1, 0);
+                        score()->setPause(endTick(), 0);
                         score()->setLayoutAll();
                         break;
                   case LayoutBreak::NOBREAK:

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -395,7 +395,7 @@ void Score::fixTicks()
             //  implement section break rest
             //
             if (isMaster() && m->sectionBreak() && m->pause() != 0.0)
-                  setPause(m->tick() + m->ticks() - 1, m->pause());
+                  setPause(m->tick() + m->ticks(), m->pause());
 
             //
             // implement fermata as a tempo change


### PR DESCRIPTION
This fixes the problems caused by PR #3229, and is a nicer solution to the bug it was intended to fix. (Now MIDI tempo changes occur on ticks ending in 0 rather than ending in 9.)

@lasconic, don't merge this just yet because the tests didn't fail ;)

Seriously, this should have broken the tests but it didn't so I need to investigate further.