### PR TITLE
Fix #270433: Crash when pasting a note with an articulation if the final note is split between two measures

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1237,7 +1237,7 @@ void ChordRest::removeMarkings(bool /* keepTremolo */)
       {
       qDeleteAll(el());
       if (isChord())
-            qDeleteAll(toChord(this)->articulations());
+          toChord(this)->articulations().clear();
       qDeleteAll(lyrics());
       }
 


### PR DESCRIPTION
Issue Reference:
https://musescore.org/en/node/270433#comment-825767

Function Chord::removeMarkings should not delete the Vector but just delete Markings inside.  That's the reason caused null reference and application crashed 