### PR TITLE
Fix #270433: Crash when pasting a note with an articulation if the final note is split between two measures

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2820,7 +2820,8 @@ void Chord::removeMarkings(bool keepTremolo)
             remove(tremolo());
       if (arpeggio())
             remove(arpeggio());
-      qDeleteAll(graceNotes());
+      graceNotes().clear();
+      articulations().clear();
       for (Note* n : notes()) {
             for (Element* e : n->el())
                   n->remove(e);

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1235,10 +1235,8 @@ void ChordRest::flipLyrics(Lyrics* l)
 
 void ChordRest::removeMarkings(bool /* keepTremolo */)
       {
-      qDeleteAll(el());
-      if (isChord())
-          toChord(this)->articulations().clear();
-      qDeleteAll(lyrics());
+      el().clear();
+      lyrics().clear();
       }
 
 //---------------------------------------------------------

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1237,7 +1237,7 @@ void ChordRest::removeMarkings(bool /* keepTremolo */)
       {
       qDeleteAll(el());
       if (isChord())
-            qDeleteAll(toChord(this)->articulations());
+          toChord(this)->articulations().clear();
       qDeleteAll(lyrics());
       }
 


### PR DESCRIPTION
Issue Reference:
https://musescore.org/en/node/270433#comment-825767

Function Chord::removeMarkings should not delete the Vector but just delete Markings inside. That's the reason caused null reference and application crashed
Old pull request from here #3573