### PR TITLE
Fix #270783

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -167,6 +167,8 @@ static void playNote(EventMap* events, const Note* note, int channel, int pitch,
       ev.setOriginatingStaff(staffIdx);
       ev.setTuning(note->tuning());
       ev.setNote(note);
+      if (offTime < onTime)
+            offTime = onTime;
       events->insert(std::pair<int, NPlayEvent>(onTime, ev));
       ev.setVelo(0);
       events->insert(std::pair<int, NPlayEvent>(offTime, ev));

--- a/synthesizer/event.cpp
+++ b/synthesizer/event.cpp
@@ -396,7 +396,7 @@ void EventMap::fixupMIDI()
             if (it->second.type() == ME_NOTEON) {
                   unsigned short np = info[it->second.channel()].nowPlaying[it->second.pitch()];
                   if (it->second.velo() == 0) {
-                        /* already off or still playing? */
+                        /* already off (should not happen) or still playing? */
                         if (np == 0 || --np > 0)
                               discard = true;
                         else {


### PR DESCRIPTION
Ensure we *always* send the note on event before the corresponding note off event.

Fix as discussed on IRC. It is safe because `std::multimap` keeps the ordering.

Fixes https://musescore.org/en/node/270783 and should be included in `v2.2.1`.

After https://github.com/musescore/MuseScore/pull/3548 will have been applied, this should cherry-pick cleanly on master, too.