### PR TITLE
Fix gate time for note with multiple articulations

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -674,7 +674,7 @@ void Instrument::updateGateTime(int* gateTime, int /*channelIdx*/, const QString
       {
       for (const MidiArticulation& a : _articulation) {
             if (a.name == name) {
-                  *gateTime = a.gateTime;
+                  *gateTime = *gateTime * a.gateTime / 100;
                   break;
                   }
             }


### PR DESCRIPTION
Now, the gate time of note with multi articulations is determined by 'last' articulation only.

So...

1. The length of a note with sforzato and staccato is 50%.
2. The length of a note with staccato and sforzato is 100%.

But I think 'order of articulations' should be meaningless for a user.
This change respects all gate time of articulations (This formula is from before 2d727fbb4672df4f48cb3e43d3b7438add6586d9 ).
