### PR TITLE
fix #270803 messed playback for specific sounds

### DIFF
--- a/fluid/voice.cpp
+++ b/fluid/voice.cpp
@@ -673,7 +673,7 @@ void Voice::write(unsigned n, float* out, float* reverb, float* chorus)
                   _cachedFrames = 0;
                   }
             
-            static const unsigned requiredNumberOfFramesToGenerateEnvelope = FLUID_VOICE_ENVLAST * volenv_data[FLUID_VOICE_ENVDELAY].count;
+            const unsigned requiredNumberOfFramesToGenerateEnvelope = FLUID_VOICE_ENVLAST * volenv_data[FLUID_VOICE_ENVDELAY].count;
             const unsigned framesToGenerateData = std::max(leftBufferFramesToFill, requiredNumberOfFramesToGenerateEnvelope);
             if (generateDataForDSPChain(framesToGenerateData)) {
                   auto interpolationRes = interpolateGeneratedDSPData(framesToGenerateData);


### PR DESCRIPTION
The reason was not updated minimal frames count and desync between different voices in playback as a result.