### PR TITLE
fix #270850: Changes to a score cause all fermatas over a barline to be discarded

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1862,7 +1862,7 @@ void Measure::read(XmlReader& e, int staffIdx)
                               // be reconstructed from measure flags
                               bool endBarLineGenerated = (blt == BarLineType::NORMAL || blt == BarLineType::END_REPEAT
                                     || blt == BarLineType::END_START_REPEAT || blt == BarLineType::START_REPEAT);
-                              setEndBarLineType(blt, endBarLineGenerated, true);
+                              setEndBarLineType(blt, barLine->el()->empty() && endBarLineGenerated, true);
                               }
                         if (!barLine->customSpan()) {
                               Staff* staff = score()->staff(staffIdx);


### PR DESCRIPTION
See [issue 270850](https://musescore.org/en/node/270850). 

Without this change, MuseScore "forgets" that the barline was modified, and so it does not write the barline (thus not writing the fermata) when the file is saved.