### PR TITLE
fix #270878: improve restriking

### DIFF
--- a/mscore/exportmidi.cpp
+++ b/mscore/exportmidi.cpp
@@ -289,16 +289,17 @@ bool ExportMidi::write(const QString& name, bool midiExpandRepeats)
                         for (auto i = events.begin(); i != events.end(); ++i) {
                               const NPlayEvent& event = i->second;
 
+                              if (event.discard() == staffIdx + 1 && event.velo() > 0)
+                                    // turn note off so we can restrike it in another track
+                                    track.insert(pauseMap.addPauseTicks(i->first), MidiEvent(ME_NOTEON, channel,
+                                                                     event.pitch(), 0));
+
                               if (event.getOriginatingStaff() != staffIdx)
                                     continue;
 
-                              if (event.discard()) { // ignore noteoff but restrike noteon
-                                    if (event.velo() > 0)
-                                          track.insert(pauseMap.addPauseTicks(i->first), MidiEvent(ME_NOTEON, channel,
-                                                                     event.pitch(), 0));
-                                    else
-                                          continue;
-                                    }
+                              if (event.discard() && event.velo() == 0)
+                                    // ignore noteoff but restrike noteon
+                                    continue;
 
                               char eventPort    = cs->midiPort(event.channel());
                               char eventChannel = cs->midiChannel(event.channel());

--- a/synthesizer/event.h
+++ b/synthesizer/event.h
@@ -236,7 +236,7 @@ class PlayEvent : public MidiCoreEvent {
 class NPlayEvent : public PlayEvent {
       const Note* _note = 0;
       int _origin = -1;
-      bool _discard = false;
+      int _discard = 0;
 
    public:
       NPlayEvent() : PlayEvent() {}
@@ -250,8 +250,8 @@ class NPlayEvent : public PlayEvent {
 
       int getOriginatingStaff() const { return _origin; }
       void setOriginatingStaff(int i) { _origin = i; }
-      void setDiscard(bool d) {_discard = d; }
-      bool discard() const { return _discard; }
+      void setDiscard(int d) { _discard = d; }
+      int discard() const { return _discard; }
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
• hoist the temporary noteoff event created for restriking to the
  same track as the corresponding noteon event
• use the restriking track for the “real” noteoff events

cf. https://musescore.org/en/node/270878

Note that master will need to cherry-pick this **after** https://github.com/musescore/MuseScore/pull/3548 will have been merged in master, but, just like the second commit of that PR, this one will need to be reverted once we switch back from restriking to different-channel assignment.