### PR TITLE
Follow macOS platform conventions for window title and dirty state

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -426,7 +426,7 @@ bool MuseScore::saveFile(MasterScore* score)
             return false;
             }
       score->setCreated(false);
-      setWindowTitle(QString(MUSESCORE_NAME_VERSION) + ": " + score->fileInfo()->completeBaseName());
+      updateWindowTitle(score);
       int idx = scoreList.indexOf(score->masterScore());
       tab1->setTabText(idx, score->fileInfo()->completeBaseName());
       if (tab2)
@@ -1864,7 +1864,7 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy, const QString& path, const QStr
 
             if (rv && !saveCopy) {
                   cs->masterScore()->fileInfo()->setFile(fn);
-                  setWindowTitle(QString(MUSESCORE_NAME_VERSION) + ": " + cs->title());
+                  updateWindowTitle(cs);
                   cs->undoStack()->setClean();
                   dirtyChanged(cs);
                   cs->setCreated(false);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1920,7 +1920,8 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
             magChanged(midx);
             }
 
-      setWindowTitle(MUSESCORE_NAME_VERSION ": " + cs->title());
+      updateWindowTitle(cs);
+      setWindowModified(cs->dirty());
 
       QAction* a = getAction("concert-pitch");
       a->setChecked(cs->styleB(Sid::concertPitch));
@@ -3719,6 +3720,9 @@ void MuseScore::dirtyChanged(Score* s)
       tab1->setTabText(idx, label);
       if (tab2)
             tab2->setTabText(idx, label);
+#ifdef Q_OS_MAC
+      setWindowModified(score->dirty());
+#endif
       }
 
 //---------------------------------------------------------
@@ -5491,6 +5495,22 @@ void MuseScore::restoreGeometry(QWidget *const qw)
             qw->restoreGeometry(settings.value(objectName).toByteArray());
             settings.endGroup();
             }
+      }
+
+void MuseScore::updateWindowTitle(Score* score)
+      {
+#ifdef Q_OS_MAC
+      if (score->created()) {
+            setWindowTitle(score->title());
+            setWindowFilePath(QString());
+            }
+      else {
+            setWindowTitle(QString());
+            setWindowFilePath(score->masterScore()->fileInfo()->absoluteFilePath());
+            }
+#else
+      setWindowTitle(MUSESCORE_NAME_VERSION ": " + score->title());
+#endif
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -773,6 +773,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       static void saveGeometry(QWidget const*const qw);
       static void restoreGeometry(QWidget*const qw);
+
+      void updateWindowTitle(Score* score);
       };
 
 extern MuseScore* mscore;


### PR DESCRIPTION
This results in the window title displaying just the filename (including the
extension) and not the application name, as per platform convention.
To the left of the filename, an icon is displayed. This icon is draggable and
behaves as if you were dragging the file in Finder. It can also be right-
clicked to view the path hierarchy. This is not displayed when there is no
path for the current file (imported or created scores).

Additionally, the window's dirty state is kept synchronized with the current
tab. When the document is dirty, this results in a dot in the close button and
the window icon turning grey.