### PR TITLE
tolerate empty CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,7 +621,7 @@ subdirs(
       )
 #      thirdparty/xmlstream
 
-string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
+string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
 if (APPLE AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
 # With xcode, we need to have all the targets in the same project
 add_subdirectory(mtest)

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -437,7 +437,7 @@ if (MINGW)
       ${PROJECT_BINARY_DIR}/resfile.o
       PROPERTIES generated true
       )
-   string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
+   string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
    # Windows: Add -mconsole to LINK_FLAGS to get a console window for debug output
    if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
      set_target_properties( mscore


### PR DESCRIPTION
as per Joachim's request, I prepared this pull request, tolerating an empty string for
CMAKE_BUILD_TYPE, something happening for example when compiling with QtCreator the first times.