### PR TITLE
fix #270958: Fermata not centered on measure rest, and not following horizontal offset

### DIFF
--- a/libmscore/fermata.cpp
+++ b/libmscore/fermata.cpp
@@ -197,7 +197,12 @@ void Fermata::layout()
             return;
             }
 
-      qreal x = score()->noteHeadWidth() * staff()->mag(0) * .5;
+      qreal x = 0.0;
+      Element* e = s->element(track());
+      if (e)
+            x = e->x() + e->width() * staff()->mag(0) * .5;
+      else
+            x = score()->noteHeadWidth() * staff()->mag(0) * .5;
       qreal y = placeAbove() ? styleP(Sid::fermataPosAbove) : styleP(Sid::fermataPosBelow) + staff()->height();
 
       setPos(QPointF(x, y));


### PR DESCRIPTION
See [issue 270958](https://musescore.org/en/node/270958).

This makes sure that the fermata is centered over the element in the segment to which it belongs.