### PR TITLE
fix #270990: Unable to add fermatas to bar lines

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4278,7 +4278,9 @@ void Score::undoAddElement(Element* element)
                         Segment* segment = toSegment(element->parent());
                         int tick         = segment->tick();
                         Measure* m       = score->tick2measure(tick);
-                        Segment* seg     = m->undoGetSegment(SegmentType::ChordRest, tick);
+                        if ((segment->segmentType() == SegmentType::EndBarLine) && (m->tick() == tick))
+                              m = m->prevMeasure();
+                        Segment* seg     = m->undoGetSegment(segment->segmentType(), tick);
                         ne->setTrack(ntrack);
                         ne->setParent(seg);
                         undo(new AddElement(ne));

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3484,9 +3484,8 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             Measure* m = toMeasure(mb);
             m->layoutMeasureNumber();
             for (Segment* s = m->first(); s; s = s->next()) {
-                  if (!s->isChordRestType())
-                        continue;
-                  sl.push_back(s);
+                  if (s->isChordRestType() || !s->annotations().empty())
+                        sl.push_back(s);
                   }
             }
 

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1054,7 +1054,7 @@ static void readChord(Measure* m, Chord* chord, XmlReader& e)
                   chord->add(note);
                   }
             else if (tag == "Attribute" || tag == "Articulation") {
-                  Element* el = readArticulation(chord, e);
+                  Element* el = readArticulation(chord->score(), e);
                   if (el->isFermata()) {
                         if (!chord->segment())
                               chord->setParent(m->getSegment(SegmentType::ChordRest, e.tick()));
@@ -1087,7 +1087,7 @@ static void readRest(Measure* m, Rest* rest, XmlReader& e)
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "Attribute" || tag == "Articulation") {
-                  Element* el = readArticulation(rest, e);
+                  Element* el = readArticulation(rest->score(), e);
                   if (el->isFermata()) {
                         if (!rest->segment())
                               rest->setParent(m->getSegment(SegmentType::ChordRest, e.tick()));

--- a/libmscore/read206.h
+++ b/libmscore/read206.h
@@ -65,7 +65,7 @@ class PageFormat {
       qreal oddRightMargin() const        { return _size.width() - _printableWidth - _oddLeftMargin;  }
       };
 
-extern Element* readArticulation(ChordRest*, XmlReader&);
+extern Element* readArticulation(Score*, XmlReader&);
 extern void readAccidental206(Accidental*, XmlReader&);
 extern void setPageFormat(MStyle*, const PageFormat&);
 extern void initPageFormat(MStyle*, PageFormat*);


### PR DESCRIPTION
See [issue 270990](https://musescore.org/en/node/270990).

Prior to this patch, Fermatas could only be children of Segments of type SegmentType::ChordRest. This patch allows Fermatas to also be children of Segments of type SegmentType::EndBarLine.