### PR TITLE
fix #234781: Selection with Ctrl+click is broken by clicking on the canvas

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2777,14 +2777,10 @@ void Score::selectAdd(Element* e)
                                       m == lastMeasure() ? 0 : m->last(),
                                       0,
                                       nstaves());
+                  setUpdateAll();
+                  selState = SelState::RANGE;
+                  _selection.updateSelectedElements();
                   }
-            else {
-                  select(0, SelectType::SINGLE, 0);
-                  return;
-                  }
-            setUpdateAll();
-            selState = SelState::RANGE;
-            _selection.updateSelectedElements();
             }
       else { // None or List
             addRefresh(e->abbox());

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -297,7 +297,7 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                   _score->select(m, st, staffIdx);
                   _score->setUpdateAll();
                   }
-            else
+            else if (st != SelectType::ADD)
                   _score->deselectAll();
             }
       _score->update();


### PR DESCRIPTION
See [issue 234781](https://musescore.org/en/node/234781).

This will prevent the selection from being cleared when the user clicks on a measure or the canvas.