### PR TITLE
fix compiler warning reg. comparison between signed and unsigned integer expressions

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1593,7 +1593,7 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                                           QList<Note*> nl1 = nchord->notes();
                                           QList<Note*> nl2 = nchord2->notes();
                                           if (!firstpart)
-                                                for (unsigned j = 0; j < nl1.size(); ++j) {
+                                                for (int j = 0; j < nl1.size(); ++j) {
                                                       tie = new Tie(this);
                                                       tie->setStartNote(nl1[j]);
                                                       tie->setEndNote(nl2[j]);


### PR DESCRIPTION
Warning got introduced with aeaa2ee, for "fix #196771 : Regroup Rhythms deletes various elements". Somewhat surprisingly [QList::size()](http://doc.qt.io/qt-5/qlist.html#size) seems to return `int` rather than some unsigned type like `size_t`. The corresponding fix for master uses `std::vector`, the size method for that does seem to return `unsigned` (actually: `size_type`) 