### PR TITLE
Fix #271039: crash when closing score after changing tempo in play panel

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1553,7 +1553,7 @@ void Seq::updateSynthesizerState(int tick1, int tick2)
 
 double Seq::curTempo() const
       {
-      return cs->tempomap()->tempo(playPos->first);
+      return cs ? cs->tempomap()->tempo(playPos->first) : 0.0;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Should go to 2.3 too