### PR TITLE
fix #269404: The ending text of a text line now incorporates the user…

### DIFF
--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -296,7 +296,9 @@ void TextLineSegment::layout1()
       bbox().setRect(x1, y1, x2 - x1, y2 - y1);
       // set end text position and extend bbox
       if (_endText) {
-            _endText->setPos(bbox().right(), 0);
+
+            // up to 2.2(.1) was setting y to constant 0 here via setPos
+            _endText->setUserXoffset(bbox().right());
             bbox() |= _endText->bbox().translated(_endText->pos());
             }
       }


### PR DESCRIPTION
…-defined vertical placement. This should be helpful in being more precise while forming custom lines with arrows/hooks/etc. from special characters of a font.

setUserXOffset(qreal); seems to fundamentally be doing the same action as setPos(qreal,qureal) with the difference being that there is only a change in the X positioning . If we were confined to setPos() only, there would need be an explicit reference to the y position of the _endText, but instead the code had a constant of 0! No wonder it didn't set properly. Took a while to figure out the problem, but once this was seen it was glaringly obvious. 