### PR TITLE
fix #269404: (MS-2.3) - Effective user-defined vertical alignment reg…

### DIFF
--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -296,7 +296,10 @@ void TextLineSegment::layout1()
       bbox().setRect(x1, y1, x2 - x1, y2 - y1);
       // set end text position and extend bbox
       if (_endText) {
-            _endText->setPos(bbox().right(), 0);
+            // Set _endText's position horizontally related to the dimensions of the previously formed rectangle.
+            // Previously, this was performed while 'zeroing' the vertical alignment, hence the bug of
+            // non-effect regarding the user-defined end-text's vertical alignment
+            _endText->setUserXoffset(bbox().right());
             bbox() |= _endText->bbox().translated(_endText->pos());
             }
       }


### PR DESCRIPTION
…arding the ending text of a line

As related to https://musescore.org/en/node/269404

This simple fix should be helpful in allowing the user to be more precise while forming custom lines with arrows/hooks/etc. from special characters of a font.

Thanks again to _Joachim Schmitz_ for the responses.

**Note**:
_setUserXOffset(qreal)_ is fundamentally doing the same action as _setPos(qreal, qreal)_ with the difference being that there is only a change in the X positioning. If we were confined to setPos() only as with the original code, there would need be an explicit reference to the y position of the _endText, but instead of providing the variable for this (whatever that might be) the code had a constant of 0! No wonder it didn't respond to user-defined settings.

**2nd Attempt**: 
Originally did this with 2.2.1 but found that the 2.3-branch had removed the file _libmscore/textlinebase.cpp_ and had incorporated the class into one _libmscore/textline.cpp_ (interestingly the master branch has it back again...). So here it is with the 2.3-branch

**Correction**: textlinebase.cpp seems to only be in master and this error was from, I think, an inappropriate rebasing. What threw me off also was from rebasing I had a 2.2.1 textline.cpp file and a master textlinebase.cpp file in the same folder. It seemed like there was duplicate code, but taking a peek at a fresh copy of the branches, this is not the case.  Amateur ramblings of course, but why not, at least for now? 