### PR TITLE
Right Click Menu 

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # This is not needed for MSVC compilation
 if (NOT MSVC)
-   include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
+include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
 endif (NOT MSVC)
 include (${PROJECT_SOURCE_DIR}/build/CopyFilesMacros.cmake)
 
@@ -435,6 +435,7 @@ add_executable ( ${ExecutableName}
       extension.cpp extension.h
       tourhandler.cpp
       script/script.cpp script/scriptentry.cpp script/testscript.cpp script/recorderwidget.cpp
+      noteeditcontext.cpp noteeditcontext.h
 
       ${COCOABRIDGE}
       ${OMR_FILES}
@@ -501,7 +502,7 @@ if (SOUNDFONT3)
       if (MSVC)
           target_link_libraries(mscore vorbisdll oggdll)
       else (MSVC)
-          target_link_libraries(mscore ${VORBIS_LIB} ${OGG_LIB})
+      target_link_libraries(mscore ${VORBIS_LIB} ${OGG_LIB})
       endif (MSVC)
 endif (SOUNDFONT3)
 
@@ -509,7 +510,7 @@ if (HAS_AUDIOFILE)
       if (MSVC)
          target_link_libraries(mscore audiofile sndfiledll)
       else (MSVC)
-         target_link_libraries(mscore audiofile ${SNDFILE_LIB})
+      target_link_libraries(mscore audiofile ${SNDFILE_LIB})
       endif (MSVC)
 endif (HAS_AUDIOFILE)
 
@@ -595,12 +596,12 @@ if (MINGW)
       install( FILES
          ${MINGW_ROOT}/bin/libgcc_s_seh-1.dll
          DESTINATION bin)
-      install( FILES
+   install( FILES
          ${MINGW_ROOT}/lib/portaudio.dll RENAME libportaudio-x86_64-w64-mingw32.static.dll
          DESTINATION bin)
    else (BUILD_64)
       install( FILES
-         ${MINGW_ROOT}/bin/libgcc_s_dw2-1.dll
+      ${MINGW_ROOT}/bin/libgcc_s_dw2-1.dll
          ${MINGW_ROOT}/lib/portaudio.dll
          DESTINATION bin)
    endif (BUILD_64)
@@ -676,125 +677,125 @@ else (MINGW)
             )
       endif(NOT APPLE AND USE_WEBENGINE)
 
-      target_link_libraries(mscore
-         ${ALSA_LIB}
-         ${QT_LIBRARIES}
-         z
-         ${CMAKE_DL_LIBS}
-         pthread
-         )
+   target_link_libraries(mscore
+      ${ALSA_LIB}
+      ${QT_LIBRARIES}
+      z
+      ${CMAKE_DL_LIBS}
+      pthread
+      )
 
-       if (USE_SYSTEM_FREETYPE)
-            target_link_libraries(mscore freetype)
-       else (USE_SYSTEM_FREETYPE)
-            target_link_libraries(mscore mscore_freetype)
-       endif (USE_SYSTEM_FREETYPE)
+    if (USE_SYSTEM_FREETYPE)
+         target_link_libraries(mscore freetype)
+    else (USE_SYSTEM_FREETYPE)
+         target_link_libraries(mscore mscore_freetype)
+    endif (USE_SYSTEM_FREETYPE)
 
-       if (USE_PORTAUDIO)
-         target_link_libraries(mscore ${PORTAUDIO_LIB})
-       endif (USE_PORTAUDIO)
+    if (USE_PORTAUDIO)
+      target_link_libraries(mscore ${PORTAUDIO_LIB})
+    endif (USE_PORTAUDIO)
 
-       if (USE_PORTMIDI)
-           if (APPLE)
-               set(PORTMIDI_LIB portmidi)
-           else (APPLE)
-               set(PORTMIDI_LIB -lportmidi -lporttime) # Remove -lporttime on RPM-based systems where PortTime is part of PortMidi.
-           endif (APPLE)
-           target_link_libraries(mscore ${PORTMIDI_LIB})
-       endif (USE_PORTMIDI)
+    if (USE_PORTMIDI)
+        if (APPLE)
+            set(PORTMIDI_LIB portmidi)
+        else (APPLE)
+            set(PORTMIDI_LIB -lportmidi -lporttime) # Remove -lporttime on RPM-based systems where PortTime is part of PortMidi.
+        endif (APPLE)
+        target_link_libraries(mscore ${PORTMIDI_LIB})
+    endif (USE_PORTMIDI)
 
-       if (USE_PULSEAUDIO)
-         target_link_libraries(mscore ${PULSEAUDIO_LIBRARY})
-       endif (USE_PULSEAUDIO)
+    if (USE_PULSEAUDIO)
+      target_link_libraries(mscore ${PULSEAUDIO_LIBRARY})
+    endif (USE_PULSEAUDIO)
 
-      set_target_properties (
-         mscore
-         PROPERTIES
-            COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wno-overloaded-virtual -Winvalid-pch"
-         )
+   set_target_properties (
+      mscore
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wno-overloaded-virtual -Winvalid-pch"
+      )
 
-      if (OMR)
-         target_link_libraries(mscore omr poppler)
-         if (OCR)
-               target_link_libraries(mscore tesseract_api)
-         endif (OCR)
-      endif (OMR)
+   if (OMR)
+      target_link_libraries(mscore omr poppler)
+      if (OCR)
+            target_link_libraries(mscore tesseract_api)
+      endif (OCR)
+   endif (OMR)
 
-      if (APPLE)
-        target_link_libraries(mscore ${OsxFrameworks})
-      else (APPLE)
-          target_link_libraries(mscore rt)
-      endif (APPLE)
+   if (APPLE)
+     target_link_libraries(mscore ${OsxFrameworks})
+   else (APPLE)
+       target_link_libraries(mscore rt)
+   endif (APPLE)
 
-      # 'gold' does not use indirect shared libraries for symbol resolution, Linux only
-      if (NOT APPLE)
-         if(USE_JACK)
-            target_link_libraries(mscore ${CMAKE_DL_LIBS})
-         endif(USE_JACK)
-         target_link_libraries(mscore rt)
-      endif (NOT APPLE)
+   # 'gold' does not use indirect shared libraries for symbol resolution, Linux only
+   if (NOT APPLE)
+      if(USE_JACK)
+         target_link_libraries(mscore ${CMAKE_DL_LIBS})
+      endif(USE_JACK)
+      target_link_libraries(mscore rt)
+   endif (NOT APPLE)
 
-      if (APPLE)
-         set_target_properties(mscore
-           PROPERTIES
-              LINK_FLAGS "-stdlib=libc++"
-           )
-        xcode_pch(mscore all)
-        install (TARGETS mscore BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
-        install (FILES data/mscore.icns DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME})
-        install (FILES data/musescoreDocument.icns DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME})
-      else (APPLE)
-        #### PACKAGING for Linux and BSD based systems (more in top-level CMakeLists.txt) ####
-        # Install mscore executable (package maintainers may add "MuseScore" and/or "musescore" aliases that symlink to mscore)
-        install( TARGETS mscore RUNTIME DESTINATION bin )
-        if (LN_EXECUTABLE)
-           add_custom_target(mscore_alias ALL
-               COMMAND echo "Creating symlink alias for mscore executable."
-               COMMAND ${LN_EXECUTABLE} -sf "mscore${MSCORE_INSTALL_SUFFIX}" "musescore${MSCORE_INSTALL_SUFFIX}"
-               COMMAND echo 'Symlink alias: musescore${MSCORE_INSTALL_SUFFIX} -> mscore${MSCORE_INSTALL_SUFFIX}'
-               )
-           install( FILES ${PROJECT_BINARY_DIR}/mscore/musescore${MSCORE_INSTALL_SUFFIX} DESTINATION bin)
-        else (LN_EXECUTABLE)
-           add_custom_target(mscore_alias ALL
-               COMMAND echo "No symlink aliases will be created."
-               VERBATIM
-               )
-        endif (LN_EXECUTABLE)
-        # Install MuseScore icons (use SVGs where possible, but install PNGs as backup for systems that don't support SVG)
-        if (MSCORE_UNSTABLE)
-            set(MSCORE_ICON_BASE ../assets/musescore-icon-square) # Square icons on development builds
-        else (MSCORE_UNSTABLE)
-            set(MSCORE_ICON_BASE ../assets/musescore-icon-round) # Round icons on stable releases
-        endif (MSCORE_UNSTABLE)
-        install(FILES ${MSCORE_ICON_BASE}.svg RENAME mscore${MSCORE_INSTALL_SUFFIX}.svg DESTINATION share/icons/hicolor/scalable/apps)
-        install(FILES ${MSCORE_ICON_BASE}-16.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/16x16/apps)
-        install(FILES ${MSCORE_ICON_BASE}-24.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/24x24/apps)
-        install(FILES ${MSCORE_ICON_BASE}-32.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/32x32/apps)
-        install(FILES ${MSCORE_ICON_BASE}-48.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/48x48/apps)
-        install(FILES ${MSCORE_ICON_BASE}-64.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/64x64/apps)
-        install(FILES ${MSCORE_ICON_BASE}-96.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/96x96/apps)
-        install(FILES ${MSCORE_ICON_BASE}-128.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/128x128/apps)
-        install(FILES ${MSCORE_ICON_BASE}-512.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/512x512/apps)
-        # Install MIME (filetype) icons for each mimetype on Linux
-        install( FILES   ../assets/mscz-icon.svg RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}.svg
-           DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MSCZ files
-        install( FILES   ../assets/mscz-icon-48.png RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}.png
-           DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MSCZ files
-        install( FILES   ../assets/mscx-icon.svg RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}+xml.svg
-           DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MSCX files
-        install( FILES   ../assets/mscx-icon-48.png RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}+xml.png
-           DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MSCX files
-        # use a custom icon for MusicXML files (there isn't a standard icon for MusicXML files)
-        install( FILES   ../assets/mxl-icon.svg RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}.svg
-           DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MXL (compressed MusicXML) files
-        install( FILES   ../assets/mxl-icon-48.png RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}.png
-           DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MXL (compressed MusicXML) files
-        install( FILES   ../assets/xml-icon.svg RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}+xml.svg
-           DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .XML (MusicXML) files
-        install( FILES   ../assets/xml-icon-48.png RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}+xml.png
-           DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .XML (MusicXML) files
-        # Note: Must now run "gtk-update-icon-cache" to set the new icons. This is done in the Makefile.
-      endif (APPLE)
+   if (APPLE)
+      set_target_properties(mscore
+        PROPERTIES
+           LINK_FLAGS "-stdlib=libc++"
+        )
+     xcode_pch(mscore all)
+     install (TARGETS mscore BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
+     install (FILES data/mscore.icns DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME})
+     install (FILES data/musescoreDocument.icns DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME})
+   else (APPLE)
+     #### PACKAGING for Linux and BSD based systems (more in top-level CMakeLists.txt) ####
+     # Install mscore executable (package maintainers may add "MuseScore" and/or "musescore" aliases that symlink to mscore)
+     install( TARGETS mscore RUNTIME DESTINATION bin )
+     if (LN_EXECUTABLE)
+        add_custom_target(mscore_alias ALL
+            COMMAND echo "Creating symlink alias for mscore executable."
+            COMMAND ${LN_EXECUTABLE} -sf "mscore${MSCORE_INSTALL_SUFFIX}" "musescore${MSCORE_INSTALL_SUFFIX}"
+            COMMAND echo 'Symlink alias: musescore${MSCORE_INSTALL_SUFFIX} -> mscore${MSCORE_INSTALL_SUFFIX}'
+            )
+        install( FILES ${PROJECT_BINARY_DIR}/mscore/musescore${MSCORE_INSTALL_SUFFIX} DESTINATION bin)
+     else (LN_EXECUTABLE)
+        add_custom_target(mscore_alias ALL
+            COMMAND echo "No symlink aliases will be created."
+            VERBATIM
+            )
+     endif (LN_EXECUTABLE)
+     # Install MuseScore icons (use SVGs where possible, but install PNGs as backup for systems that don't support SVG)
+     if (MSCORE_UNSTABLE)
+         set(MSCORE_ICON_BASE ../assets/musescore-icon-square) # Square icons on development builds
+     else (MSCORE_UNSTABLE)
+         set(MSCORE_ICON_BASE ../assets/musescore-icon-round) # Round icons on stable releases
+     endif (MSCORE_UNSTABLE)
+     install(FILES ${MSCORE_ICON_BASE}.svg RENAME mscore${MSCORE_INSTALL_SUFFIX}.svg DESTINATION share/icons/hicolor/scalable/apps)
+     install(FILES ${MSCORE_ICON_BASE}-16.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/16x16/apps)
+     install(FILES ${MSCORE_ICON_BASE}-24.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/24x24/apps)
+     install(FILES ${MSCORE_ICON_BASE}-32.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/32x32/apps)
+     install(FILES ${MSCORE_ICON_BASE}-48.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/48x48/apps)
+     install(FILES ${MSCORE_ICON_BASE}-64.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/64x64/apps)
+     install(FILES ${MSCORE_ICON_BASE}-96.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/96x96/apps)
+     install(FILES ${MSCORE_ICON_BASE}-128.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/128x128/apps)
+     install(FILES ${MSCORE_ICON_BASE}-512.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/512x512/apps)
+     # Install MIME (filetype) icons for each mimetype on Linux
+     install( FILES   ../assets/mscz-icon.svg RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}.svg
+        DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MSCZ files
+     install( FILES   ../assets/mscz-icon-48.png RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}.png
+        DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MSCZ files
+     install( FILES   ../assets/mscx-icon.svg RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}+xml.svg
+        DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MSCX files
+     install( FILES   ../assets/mscx-icon-48.png RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}+xml.png
+        DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MSCX files
+     # use a custom icon for MusicXML files (there isn't a standard icon for MusicXML files)
+     install( FILES   ../assets/mxl-icon.svg RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}.svg
+        DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MXL (compressed MusicXML) files
+     install( FILES   ../assets/mxl-icon-48.png RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}.png
+        DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MXL (compressed MusicXML) files
+     install( FILES   ../assets/xml-icon.svg RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}+xml.svg
+        DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .XML (MusicXML) files
+     install( FILES   ../assets/xml-icon-48.png RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}+xml.png
+        DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .XML (MusicXML) files
+     # Note: Must now run "gtk-update-icon-cache" to set the new icons. This is done in the Makefile.
+   endif (APPLE)
    else ( NOT MSVC )
       # Microsoft Visual Studio-specific starts here!
       string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
@@ -997,8 +998,8 @@ endif (APPLE)
 
 # MSVC does not depend on mops1 & mops2 for PCH
 if (NOT MSVC)
-   ADD_DEPENDENCIES(${ExecutableName} mops1)
-   ADD_DEPENDENCIES(${ExecutableName} mops2)
+ADD_DEPENDENCIES(${ExecutableName} mops1)
+ADD_DEPENDENCIES(${ExecutableName} mops2)
 endif (NOT MSVC)
 
 add_library(

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -330,8 +330,8 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                         r.translate(0.0, -m->spatium());
                         }
                   if (r.contains(editData.startMove)) {
-                        _score->select(m, st, staffIdx);
-                        _score->setUpdateAll();
+                  _score->select(m, st, staffIdx);
+                  _score->setUpdateAll();
                         clickOffElement = false;
                         }
                   else
@@ -396,12 +396,14 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                   break;
 
             case ViewState::NOTE_ENTRY:
+                  if (ev->button() == Qt::LeftButton) {
                   _score->startCmd();
                   _score->putNote(editData.startMove, ev->modifiers() & Qt::ShiftModifier, ev->modifiers() & Qt::ControlModifier);
                   _score->endCmd();
                   if (_score->inputState().cr())
                         adjustCanvasPosition(_score->inputState().cr(), false);
                   shadowNote->setVisible(false);
+                  }
                   break;
 
             case ViewState::EDIT: {
@@ -468,8 +470,8 @@ void ScoreView::mouseMoveEvent(QMouseEvent* me)
 
       switch (state) {
             case ViewState::NORMAL:
-                   if (!drag)
-                        return;
+                        if (!drag)
+                              return;
                   if (!editData.element && (me->modifiers() & Qt::ShiftModifier))
                         changeState(ViewState::LASSO);
                   else if (editData.element && !(me->modifiers()) && editData.element->isMovable())
@@ -702,6 +704,24 @@ void ScoreView::contextMenuEvent(QContextMenuEvent* ev)
       QPoint gp          = ev->globalPos();
       editData.startMove = toLogical(ev->pos());
       Element* e         = elementNear(editData.startMove);
+      InputState& is = _score->inputState();
+
+      if (is.noteEntryMode()) {
+            noteEntryPopup(gp);
+            QCursor::setPos(gp);
+            return;
+            }
+      else if(e){
+            if( e->isNote() && !(e->selected())){
+            //editData.element = e;
+            e->score()->select(e, SelectType::SINGLE, -1);
+            noteEntryPopup(gp);
+            QCursor::setPos(gp);
+            return;
+            }
+      }
+
+
       if (e) {
             if (!e->selected()) {
                   // bool control = (ev->modifiers() & Qt::ControlModifier) ? true : false;
@@ -723,6 +743,10 @@ void ScoreView::contextMenuEvent(QContextMenuEvent* ev)
                   popup->addAction(getAction("edit-style"));
                   popup->addAction(getAction("page-settings"));
                   popup->addAction(getAction("load-style"));
+
+                  popup->addSeparator();
+                  popup->addAction(getAction("note-input"));
+
                   _score->update();
                   popup->popup(gp);
                   }

--- a/mscore/noteeditcontext.cpp
+++ b/mscore/noteeditcontext.cpp
@@ -1,0 +1,112 @@
+
+#include "globals.h"
+#include "noteeditcontext.h"
+#include "preferences.h"
+#include "shortcut.h"
+#include "musescore.h"
+#include "libmscore/element.h"
+#include "libmscore/mscore.h"
+
+namespace Ms {
+
+NoteEditContext::NoteEditContext(QWidget *parent)
+    : QWidget(parent)
+    {
+
+    entryContextToolbar = new QToolBar();
+    entryContextToolbar->setObjectName("entry-tools");
+
+    QToolBar* firstRowBar = new QToolBar();
+    QToolBar* secondRowBar = new QToolBar();
+    QToolBar* thirdRowBar = new QToolBar();
+
+    QWidget* contxtToolbarWdg = new QWidget;
+    QVBoxLayout *contxtToolbarLayout = new QVBoxLayout;
+
+
+	static const char* row1[] = {
+                       "note-input",  "pad-rest", "", "pad-dot", "pad-dotdot", "",
+                       "sharp2", "sharp", "nat", "flat", "flat2"
+                       };
+
+    static const char* row2[] = {
+                       "pad-note-128", "pad-note-64", "pad-note-32", "pad-note-16",
+                       "pad-note-8", "pad-note-4", "pad-note-2", "pad-note-1", "note-breve", "note-longa",
+                       };
+
+
+    static const char* row3[] = {
+                       "repitch", "tie", "flip", ""
+                       };
+
+    for (auto s : row1) {
+          if (!*s)
+                        firstRowBar->addSeparator();
+                  else
+                        firstRowBar->addAction(getAction(s));
+                  }
+
+    for (auto s : row2) {
+                  if (!*s)
+                        secondRowBar->addSeparator();
+                  else
+                        secondRowBar->addAction(getAction(s));
+                  }
+
+    for (auto s : row3) {
+          if (!*s)
+                        thirdRowBar->addSeparator();
+          else
+                thirdRowBar->addAction(getAction(s));
+                  }
+
+    contxtToolbarLayout->addWidget(firstRowBar);
+    contxtToolbarLayout->addWidget(secondRowBar);
+    contxtToolbarLayout->addWidget(thirdRowBar);
+    contxtToolbarWdg->setLayout(contxtToolbarLayout);
+
+    static const char* vbsh { "QToolButton:checked, QToolButton:pressed { color: white;}" };
+
+    //QVector<QAction*> actionArray;
+
+    for (int i = 0; i < VOICES; ++i) {
+          QToolButton* tb = new QToolButton(this);
+          if (preferences.globalStyle() == MuseScoreStyleType::LIGHT_FUSION)
+                tb->setStyleSheet(vbsh);
+          tb->setToolButtonStyle(Qt::ToolButtonTextOnly);
+          QPalette p(tb->palette());
+          p.setColor(QPalette::Base, MScore::selectColor[i]);
+          tb->setPalette(p);
+          QAction* a = getAction(voiceActions[i]);
+          a->setCheckable(true);
+          actionArray.append(a);
+          tb->setDefaultAction(a);
+          tb->setFocusPolicy(Qt::ClickFocus);
+          thirdRowBar->addWidget(tb);
+          }
+
+    entryContextToolbar->addWidget(contxtToolbarWdg);
+    entryContextMenu = new QMenu(this);
+
+    QWidgetAction* noteAction = new QWidgetAction(entryContextMenu);
+    noteAction->setDefaultWidget(entryContextToolbar);
+    entryContextMenu->addAction(noteAction);
+
+    for (int i = 0; i < actionArray.count(); i++)
+          connect(actionArray[i], SIGNAL(triggered()),  entryContextMenu, SLOT(close()));
+
+    connect(firstRowBar, SIGNAL(actionTriggered(QAction*)), entryContextMenu, SLOT(close()));
+    connect(secondRowBar, SIGNAL(actionTriggered(QAction*)), entryContextMenu, SLOT(close()));
+    connect(thirdRowBar, SIGNAL(actionTriggered(QAction*)), entryContextMenu, SLOT(close()));
+    }
+
+    NoteEditContext::~NoteEditContext(){
+
+    }
+
+    void NoteEditContext::open(const QPoint& pos)
+    {
+       entryContextMenu->exec(pos);
+    }
+
+}

--- a/mscore/noteeditcontext.h
+++ b/mscore/noteeditcontext.h
@@ -1,0 +1,36 @@
+#ifndef __NOTEEDITCONTEXT_H__
+#define __NOTEEDITCONTEXT_H__
+
+#include "globals.h"
+#include "libmscore/element.h"
+#include "libmscore/durationtype.h"
+#include "libmscore/mscore.h"
+#include "libmscore/mscoreview.h"
+#include "libmscore/pos.h"
+
+namespace Ms {
+
+    class NoteEditContext : public QWidget {
+        Q_OBJECT
+
+        QToolBar* entryContextToolbar;
+        QToolBar* firstRowBar;
+        QToolBar* secondRowBar;
+        QToolBar* thirdRowBar;
+
+        QMenu* entryContextMenu;
+
+        QWidget* contextToolbarWdg;
+        QVBoxLayout* contextToolbarLayout;
+
+        QVector<QAction*> actionArray;
+
+    public:
+        NoteEditContext(QWidget* parent = 0);
+        ~NoteEditContext();
+        void open(const QPoint& pos);
+
+    };
+}
+
+#endif // NOTEEDITCONTEXT_H

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -22,6 +22,7 @@
 #include "measureproperties.h"
 #include "musescore.h"
 #include "navigator.h"
+#include "noteeditcontext.h"
 #include "preferences.h"
 #include "scoretab.h"
 #include "seq.h"
@@ -158,6 +159,7 @@ ScoreView::ScoreView(QWidget* parent)
       _curLoopOut = new PositionCursor(this);
       _curLoopOut->setType(CursorType::LOOP_OUT);
 
+      noteEditContextMenu = new NoteEditContext(this);
       if (converterMode)      // HACK
             return;
 
@@ -258,6 +260,12 @@ ScoreView::~ScoreView()
       delete shadowNote;
       }
 
+
+void ScoreView::noteEntryPopup(const QPoint& pos)
+      {
+      noteEditContextMenu->open(pos);//entryContextMenu->exec(pos);
+      }
+
 //---------------------------------------------------------
 //   objectPopup
 //    the menu can be extended by Elements with
@@ -317,6 +325,8 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
       popup->addSeparator();
       popup->addAction("Debugger")->setData("list");
 #endif
+      popup->addAction(getAction("note-input"));
+      popup->addSeparator();
 
       a = popup->exec(pos);
       if (a == 0)
@@ -417,6 +427,8 @@ void ScoreView::measurePopup(QContextMenuEvent* ev, Measure* obj)
 #ifndef NDEBUG
       popup->addAction("Object Debugger")->setData("list");
 #endif
+      popup->addAction(getAction("note-input"));
+      popup->addSeparator();
 
       a = popup->exec(gpos);
       if (a == 0)

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -46,6 +46,7 @@ class Tuplet;
 class FretDiagram;
 class Bend;
 class TremoloBar;
+class NoteEditContext;
 
 #ifdef Q_OS_MAC
 #define CONTROL_MODIFIER Qt::AltModifier
@@ -144,6 +145,7 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       void objectPopup(const QPoint&, Element*);
       void measurePopup(QContextMenuEvent* ev, Measure*);
+      void noteEntryPopup(const QPoint&);
 
       void saveChord(XmlWriter&);
 
@@ -243,6 +245,8 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       void endLasso();
       Element* getDropTarget(EditData&);
+
+      void initNoteEditPopup();
 
    private slots:
       void posChanged(POS pos, unsigned tick);
@@ -406,6 +410,9 @@ class ScoreView : public QWidget, public MuseScoreView {
       void updateGrips();
       bool moveWhenInactive() const { return _moveWhenInactive; }
       bool moveWhenInactive(bool move) { bool m = _moveWhenInactive; _moveWhenInactive = move; return m; }
+
+      NoteEditContext* noteEditContextMenu;
+
       };
 
 } // namespace Ms


### PR DESCRIPTION
+ Implemented the right click context menu for note entry mode
+ Added right click menu in note edit mode to be able to do modifications on the spot.

There is a discussion going on here https://musescore.org/en/node/269001 and here https://github.com/musescore/MuseScore/pull/3535 about the possible ways to implement the right click menu.

This commit is the implementation of the version described here: https://musescore.org/en/node/99536. Since a lot has changed on the master branch since the original pull request https://github.com/musescore/MuseScore/pull/2401 from 2016, I did a reimplementation based on the actual master branch.

Additionally in this version the described menu also opens up if you right click on a  notehead in "note edit mode" Right clicking on a selected note in the "note edit mode" opens up the normal menu which lets you cut, copy, paste, delete etc.

(If you would like to try this version of right click menu without building the master branch, I have build an evaluation version based on MusesScore 2.2. You can download it here: https://bitbucket.org/19JoHo66/musescoretestversions/downloads/ and place it in your MuseScore2.2 installation folder. Please keep in mind, that this version is only intended for the evaluation and testing of the right click menu)