### PR TITLE
Fix #271074: transparent image copy paste on Windows 

### DIFF
--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -410,7 +410,14 @@ void ScoreView::fotoContextPopup(QContextMenuEvent* ev)
 
 void ScoreView::fotoModeCopy()
       {
+#if defined(Q_OS_WIN)
+      // See https://bugreports.qt.io/browse/QTBUG-11463
+      // while transparent copy/paste works fine inside musescore,
+      // it does not paste into other programs in Windows though
+      bool transparent = false; // preferences.getBool(PREF_EXPORT_PNG_USETRANSPARENCY);
+#else
       bool transparent = preferences.getBool(PREF_EXPORT_PNG_USETRANSPARENCY);
+#endif
       double convDpi   = preferences.getDouble(PREF_EXPORT_PNG_RESOLUTION);
       double mag       = convDpi / DPI;
 

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -434,14 +434,7 @@ void ScoreView::fotoModeCopy()
       printer.fill(transparent ? 0 : 0xffffffff);
       QPainter p(&printer);
       paintRect(true, p, r, mag);
-#if defined(Q_OS_WIN)
-      // workaround for apparent Qt 5.4 bug; corrupt clipboard when using setImage()
-      QPixmap px;
-      px.convertFromImage(printer);
-      QApplication::clipboard()->setPixmap(px);
-#else
       QApplication::clipboard()->setImage(printer);
-#endif
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
1st commit should probably go to 2.3, even if it doesn't cherry-pick cleanly due to the changes in how preferences are stored, 2nd commit is master only (at least not tested at all with 2.3, instead I just trust the comment about a bug in Qt 5.4)