### PR TITLE
fix #271147: Running playback from note input mode leaves phantom note in the score

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2916,9 +2916,8 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
                   showRect.setHeight(r.height());
                   }
             }
-      if (mscore->state() & ScoreState::STATE_NOTE_ENTRY) {
+      if (_score->inputState().noteEntryMode())
             setShadowNote(p);
-            }
 
       if (r.contains(showRect))
             return;


### PR DESCRIPTION
See https://musescore.org/en/node/271147