### PR TITLE
Fix typos in translatable texts

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1778,7 +1778,7 @@ Shortcut Shortcut::_sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_PLAY,
          "toggle-selection-window",
          QT_TRANSLATE_NOOP("action","Selection Filter"),
-         QT_TRANSLATE_NOOP("action","Toogle 'Selection Filter'"),
+         QT_TRANSLATE_NOOP("action","Toggle 'Selection Filter'"),
          0,
          Icons::Invalid_ICON,
          Qt::ApplicationShortcut
@@ -1823,7 +1823,7 @@ Shortcut Shortcut::_sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
          "toggle-fileoperations",
          QT_TRANSLATE_NOOP("action","File Operations"),
-         QT_TRANSLATE_NOOP("action","Toogle 'File Operations' toolbar")
+         QT_TRANSLATE_NOOP("action","Toggle 'File Operations' toolbar")
          },
       {
          MsWidget::MAIN_WINDOW,
@@ -1851,7 +1851,7 @@ Shortcut Shortcut::_sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT ,
          "toggle-noteinput",
          QT_TRANSLATE_NOOP("action","Note Input"),
-         QT_TRANSLATE_NOOP("action","Toogle 'Note Input' toolbar")
+         QT_TRANSLATE_NOOP("action","Toggle 'Note Input' toolbar")
          },
       {
          MsWidget::MAIN_WINDOW,


### PR DESCRIPTION
Now trat string freeze is over. Not needed for master, got fixed there in f8abc0bd (or rather: got changed there without those typos)