### PR TITLE
fix #140256: Regression: no key signatures at beginning of systems if…

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3489,7 +3489,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
                   kSegment->setEnabled(true);
                   }
             else {
-                  if (kSegment) {
+                  if (kSegment && staff->isPitchedStaff(tick())) {
                         // do not disable user modified keysigs
                         bool disable = true;
                         for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {


### PR DESCRIPTION
… any instrument is unpitched percussion

See https://musescore.org/en/node/140256.