### PR TITLE
fix #268122: Missing naturals when switching key

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -17,6 +17,7 @@
 #include "measure.h"
 #include "segment.h"
 #include "score.h"
+#include "system.h"
 #include "undo.h"
 #include "xml.h"
 
@@ -140,7 +141,8 @@ void KeySig::layout()
 
 
       // Don't repeat naturals if shown in courtesy
-      if (prevMeasure && prevMeasure->findSegment(SegmentType::KeySigAnnounce, segment()->tick())
+      if (measure() && measure()->system() && measure() == measure()->system()->firstMeasure()
+          && prevMeasure && prevMeasure->findSegment(SegmentType::KeySigAnnounce, segment()->tick())
           && !segment()->isKeySigAnnounceType())
             naturalsOn = false;
       if (track() == -1)

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3499,6 +3499,13 @@ void Measure::addSystemHeader(bool isFirstSystem)
                               }
                         if (disable)
                               kSegment->setEnabled(false);
+                        else {
+                              Element* e = kSegment->element(track);
+                              if (e && e->isKeySig()) {
+                                    KeySig* keysig = toKeySig(e);
+                                    keysig->layout();
+                                    }
+                              }
                         }
                   }
 


### PR DESCRIPTION
See https://musescore.org/en/node/268122.