### PR TITLE
fix #113846: Regression—shadow note appears in note entry with keyboard or piano keyboard

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -358,6 +358,7 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                   _score->endCmd();
                   if (_score->inputState().cr())
                         adjustCanvasPosition(_score->inputState().cr(), false);
+                  shadowNote->setVisible(false);
                   break;
 
             case ViewState::EDIT: {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1688,6 +1688,7 @@ void ScoreView::cmd(const char* s)
       {
       const QByteArray cmd(s);
 
+      shadowNote->setVisible(false);
       if (MScore::debugMode)
             qDebug("ScoreView::cmd <%s>", s);
 
@@ -2916,9 +2917,8 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
                   showRect.setHeight(r.height());
                   }
             }
-      if (mscore->state() & ScoreState::STATE_NOTE_ENTRY) {
+      if (shadowNote->visible())
             setShadowNote(p);
-            }
 
       if (r.contains(showRect))
             return;
@@ -4326,7 +4326,8 @@ void ScoreView::updateContinuousPanel()
 
 void ScoreView::updateShadowNotes()
       {
-      setShadowNote(shadowNote->pos());
+      if (shadowNote->visible())
+            setShadowNote(shadowNote->pos());
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/113846.

As an added bonus, this also fixes [issue 271147](https://musescore.org/en/node/271147) for free, making #3621 unnecessary if this is to be merged.