### PR TITLE
fix #271325: Adjusting a note outside the range of a piano causes a crash when the piano keyboard is visible.

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4284,6 +4284,7 @@ void MuseScore::showPianoKeyboard(bool on)
             }
       if (on) {
             _pianoTools->show();
+            _pianoTools->changeSelection(currentScore()->selection());
             }
       else {
             if (_pianoTools)

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -191,10 +191,12 @@ void HPiano::changeSelection(Selection selection)
             key->setHighlighted(false);
             key->setSelected(false);
             }
-      for (Note* n : selection.uniqueNotes()) {
-            keys[n->pitch() - _firstKey]->setSelected(true);
+      for (Note* n : selection.noteList()) {
+            if (n->pitch() >= _firstKey && n->pitch() <= _lastKey)
+                  keys[n->pitch() - _firstKey]->setSelected(true);
             for (Note* other : n->chord()->notes())
-                  keys[other->pitch() - _firstKey]->setHighlighted(true);
+                  if (other->pitch() >= _firstKey && other->pitch() <= _lastKey)
+                        keys[other->pitch() - _firstKey]->setHighlighted(true);
             }
       for (PianoKeyItem* key : keys)
             key->update();


### PR DESCRIPTION
See https://musescore.org/en/node/271325.