### PR TITLE
Fix #271505: Allow user to set mode along with key signature

### DIFF
--- a/libmscore/key.h
+++ b/libmscore/key.h
@@ -56,7 +56,14 @@ enum class KeyMode {
       UNKNOWN = -1,
       NONE,
       MAJOR,
-      MINOR
+      MINOR,
+      DORIAN,
+      PHRYGIAN,
+      LYDIAN,
+      MIXOLYDIAN,
+      AEOLIAN,
+      IONIAN,
+      LOCRIAN
       };
 
 static inline bool operator< (Key a, Key b) { return static_cast<int>(a) < static_cast<int>(b); }

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -382,9 +382,16 @@ void KeySig::write(XmlWriter& xml) const
             xml.tag("accidental", int(_sig.key()));
             }
       switch (_sig.mode()) {
-            case KeyMode::NONE:     xml.tag("mode", "none"); break;
-            case KeyMode::MAJOR:    xml.tag("mode", "major"); break;
-            case KeyMode::MINOR:    xml.tag("mode", "minor"); break;
+            case KeyMode::NONE:       xml.tag("mode", "none"); break;
+            case KeyMode::MAJOR:      xml.tag("mode", "major"); break;
+            case KeyMode::MINOR:      xml.tag("mode", "minor"); break;
+            case KeyMode::DORIAN:     xml.tag("mode", "dorian"); break;
+            case KeyMode::PHRYGIAN:   xml.tag("mode", "phrygian"); break;
+            case KeyMode::LYDIAN:     xml.tag("mode", "lydian"); break;
+            case KeyMode::MIXOLYDIAN: xml.tag("mode", "mixolydian"); break;
+            case KeyMode::AEOLIAN:    xml.tag("mode", "aeolian"); break;
+            case KeyMode::IONIAN:     xml.tag("mode", "ionian"); break;
+            case KeyMode::LOCRIAN:    xml.tag("mode", "locrian"); break;
             case KeyMode::UNKNOWN:
             default:
                   ;
@@ -450,6 +457,20 @@ void KeySig::read(XmlReader& e)
                         _sig.setMode(KeyMode::MAJOR);
                   else if (m == "minor")
                         _sig.setMode(KeyMode::MINOR);
+                  else if (m == "dorian")
+                        _sig.setMode(KeyMode::DORIAN);
+                  else if (m == "phrygian")
+                        _sig.setMode(KeyMode::PHRYGIAN);
+                  else if (m == "lydian")
+                        _sig.setMode(KeyMode::LYDIAN);
+                  else if (m == "mixolydian")
+                        _sig.setMode(KeyMode::MIXOLYDIAN);
+                  else if (m == "aeolian")
+                        _sig.setMode(KeyMode::AEOLIAN);
+                  else if (m == "ionian")
+                        _sig.setMode(KeyMode::IONIAN);
+                  else if (m == "locrian")
+                        _sig.setMode(KeyMode::LOCRIAN);
                   else
                         _sig.setMode(KeyMode::UNKNOWN);
                   }
@@ -551,6 +572,15 @@ void KeySig::undoSetShowCourtesy(bool v)
       }
 
 //---------------------------------------------------------
+//   undoSetMode
+//---------------------------------------------------------
+
+void KeySig::undoSetMode(KeyMode v)
+      {
+      undoChangeProperty(Pid::KEYSIG_MODE, int(v));
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 
@@ -559,6 +589,7 @@ QVariant KeySig::getProperty(Pid propertyId) const
       switch (propertyId) {
             case Pid::KEY:           return int(key());
             case Pid::SHOW_COURTESY: return int(showCourtesy());
+            case Pid::KEYSIG_MODE:   return int(mode());
             default:
                   return Element::getProperty(propertyId);
             }
@@ -581,6 +612,11 @@ bool KeySig::setProperty(Pid propertyId, const QVariant& v)
                         return false;
                   setShowCourtesy(v.toBool());
                   break;
+            case Pid::KEYSIG_MODE:
+                  if (generated())
+                        return false;
+                  setMode(KeyMode(v.toInt()));
+                  break;
             default:
                   if (!Element::setProperty(propertyId, v))
                         return false;
@@ -600,6 +636,7 @@ QVariant KeySig::propertyDefault(Pid id) const
       switch (id) {
             case Pid::KEY:               return int(Key::INVALID);
             case Pid::SHOW_COURTESY:     return true;
+            case Pid::KEYSIG_MODE:       return int(KeyMode::UNKNOWN);
             default:
                   return Element::propertyDefault(id);
             }

--- a/libmscore/keysig.h
+++ b/libmscore/keysig.h
@@ -67,6 +67,10 @@ class KeySig final : public Element {
       void setShowCourtesy(bool v)        { _showCourtesy = v;    }
       void undoSetShowCourtesy(bool v);
 
+      KeyMode mode() const                { return _sig.mode(); }
+      void setMode(KeyMode v)             { _sig.setMode(v); }
+      void undoSetMode(KeyMode v);
+
       void setHideNaturals(bool hide)     { _hideNaturals = hide; }
 
       QVariant getProperty(Pid propertyId) const;

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -53,12 +53,13 @@ struct PropertyMetaData {
 static constexpr PropertyMetaData propertyList[] = {
       { Pid::SUBTYPE,                 false, "subtype",               P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "subtype")          },
       { Pid::SELECTED,                false, "selected",              P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "selected")         },
-      { Pid::GENERATED,               false,  "generated",            P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "generated")        },
+      { Pid::GENERATED,               false, "generated",             P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "generated")        },
       { Pid::COLOR,                   false, "color",                 P_TYPE::COLOR,               DUMMY_QT_TRANSLATE_NOOP("propertyName", "color")            },
       { Pid::VISIBLE,                 false, "visible",               P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "visible")          },
       { Pid::Z,                       false, "z",                     P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "z")                },
       { Pid::SMALL,                   false, "small",                 P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "small")            },
       { Pid::SHOW_COURTESY,           false, "showCourtesySig",       P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "show courtesy")    },
+      { Pid::KEYSIG_MODE,             false, "keysig_mode",           P_TYPE::KEYMODE,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "show courtesy")    },
       { Pid::LINE_TYPE,               false, "lineType",              P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "line type")        },
       { Pid::PITCH,                   true,  "pitch",                 P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "pitch")            },
 
@@ -159,13 +160,13 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::VELO_CHANGE_SPEED,       true,  "veloChangeSpeed",       P_TYPE::CHANGE_SPEED,        DUMMY_QT_TRANSLATE_NOOP("propertyName", "velocity change speed")  },
       { Pid::DYNAMIC_TYPE,            true,  "subtype",               P_TYPE::DYNAMIC_TYPE,        DUMMY_QT_TRANSLATE_NOOP("propertyName", "dynamic type")     },
       { Pid::DYNAMIC_RANGE,           true,  "dynType",               P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "dynamic range")    },
+//100
       { Pid::SINGLE_NOTE_DYNAMICS,    true,  "singleNoteDynamics",    P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "single note dynamics")   },
       { Pid::PLACEMENT,               false, "placement",             P_TYPE::PLACEMENT,           DUMMY_QT_TRANSLATE_NOOP("propertyName", "placement")        },
       { Pid::VELOCITY,                false, "velocity",              P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "velocity")         },
       { Pid::JUMP_TO,                 true,  "jumpTo",                P_TYPE::STRING,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "jump to")          },
       { Pid::PLAY_UNTIL,              true,  "playUntil",             P_TYPE::STRING,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "play until")       },
       { Pid::CONTINUE_AT,             true,  "continueAt",            P_TYPE::STRING,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "continue at")       },
-//100
       { Pid::LABEL,                   true,  "label",                 P_TYPE::STRING,              DUMMY_QT_TRANSLATE_NOOP("propertyName", "label")            },
       { Pid::MARKER_TYPE,             true,  0,                       P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "marker type")      },
       { Pid::ARP_USER_LEN1,           false, 0,                       P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "length 1")         },
@@ -271,6 +272,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::FRAME_WIDTH,             false, "frameWidth",            P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "frame width")      },
       { Pid::FRAME_PADDING,           false, "framePadding",          P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "frame padding")    },
       { Pid::FRAME_ROUND,             false, "frameRound",            P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "frame round")      },
+//200
       { Pid::FRAME_FG_COLOR,          false, "frameFgColor",          P_TYPE::COLOR,               DUMMY_QT_TRANSLATE_NOOP("propertyName", "frame foreground color") },
       { Pid::FRAME_BG_COLOR,          false, "frameBgColor",          P_TYPE::COLOR,               DUMMY_QT_TRANSLATE_NOOP("propertyName", "frame background color") },
       { Pid::SIZE_SPATIUM_DEPENDENT,  false, "sizeIsSpatiumDependent",P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "spatium dependent font") },
@@ -675,6 +677,31 @@ QString propertyToString(Pid id, QVariant value, bool mscx)
             case P_TYPE::STRING:
             case P_TYPE::FRACTION:
                   return value.toString();
+            case P_TYPE::KEYMODE:
+                  switch (KeyMode(value.toInt())) {
+                        case KeyMode::NONE:
+                              return "none";
+                        case KeyMode::MAJOR:
+                              return "major";
+                        case KeyMode::MINOR:
+                              return "minor";
+                        case KeyMode::DORIAN:
+                              return "dorian";
+                        case KeyMode::PHRYGIAN:
+                              return "phrygian";
+                        case KeyMode::LYDIAN:
+                              return "lydian";
+                        case KeyMode::MIXOLYDIAN:
+                              return "mixolydian";
+                        case KeyMode::AEOLIAN:
+                              return "aeolian";
+                        case KeyMode::IONIAN:
+                              return "ionian";
+                        case KeyMode::LOCRIAN:
+                              return "locrian";
+                        default:
+                              return "unknown";
+                        }
             case P_TYPE::ORNAMENT_STYLE:
                   switch (MScore::OrnamentStyle(value.toInt())) {
                         case MScore::OrnamentStyle::BAROQUE:

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -68,6 +68,7 @@ enum class Pid {
       Z,
       SMALL,
       SHOW_COURTESY,
+      KEYSIG_MODE,
       LINE_TYPE,
       PITCH,
 
@@ -373,7 +374,7 @@ enum class P_TYPE : char {
       INT_LIST,
       GLISSANDO_STYLE,
       BARLINE_TYPE,
-      HEAD_TYPE,         // enum class Notehead::Type
+      HEAD_TYPE,        // enum class Notehead::Type
       HEAD_GROUP,       // enum class Notehead::Group
       ZERO_INT,         // displayed with offset +1
       FONT,
@@ -382,7 +383,8 @@ enum class P_TYPE : char {
       CHANGE_METHOD,    // enum class VeloChangeMethod (for single notedynamics)
       CHANGE_SPEED,     // enum class Dynamic::Speed
       CLEF_TYPE,        // enum class ClefType
-      DYNAMIC_TYPE      // enum class Dynamic::Type
+      DYNAMIC_TYPE,     // enum class Dynamic::Type
+      KEYMODE,          // enum class KeyMode
       };
 
 extern QVariant readProperty(Pid type, XmlReader& e);

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1753,10 +1753,17 @@ void ExportMusicXml::keysig(const KeySig* ks, ClefType ct, int staff, bool visib
             // traditional key signature
             _xml.tag("fifths", static_cast<int>(kse.key()));
             switch (kse.mode()) {
-                  case KeyMode::NONE:     _xml.tag("mode", "none"); break;
-                  case KeyMode::MAJOR:    _xml.tag("mode", "major"); break;
-                  case KeyMode::MINOR:    _xml.tag("mode", "minor"); break;
-                  case KeyMode::UNKNOWN:
+                  case KeyMode::NONE:       _xml.tag("mode", "none"); break;
+                  case KeyMode::MAJOR:      _xml.tag("mode", "major"); break;
+                  case KeyMode::MINOR:      _xml.tag("mode", "minor"); break;
+                  case KeyMode::DORIAN:     _xml.tag("mode", "dorian"); break;
+                  case KeyMode::PHRYGIAN:   _xml.tag("mode", "phrygian"); break;
+                  case KeyMode::LYDIAN:     _xml.tag("mode", "lydian"); break;
+                  case KeyMode::MIXOLYDIAN: _xml.tag("mode", "mixolydian"); break;
+                  case KeyMode::AEOLIAN:    _xml.tag("mode", "aeolian"); break;
+                  case KeyMode::IONIAN:     _xml.tag("mode", "ionian"); break;
+                  case KeyMode::LOCRIAN:    _xml.tag("mode", "locrian"); break;
+                  case KeyMode::UNKNOWN:    // fall thru
                   default:
                         if (kse.custom())
                               _xml.tag("mode", "none");

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -3453,15 +3453,26 @@ void MusicXMLParserPass2::key(const QString& partId, Measure* measure, const Fra
                         key.setCustom(true);
                         key.setMode(KeyMode::NONE);
                         }
-                  else if (m == "major") {
+                  else if (m == "major")
                         key.setMode(KeyMode::MAJOR);
-                        }
-                  else if (m == "minor") {
+                  else if (m == "minor")
                         key.setMode(KeyMode::MINOR);
-                        }
-                  else {
+                  else if (m == "dorian")
+                        key.setMode(KeyMode::DORIAN);
+                  else if (m == "phrygian")
+                        key.setMode(KeyMode::PHRYGIAN);
+                  else if (m == "lydian")
+                        key.setMode(KeyMode::LYDIAN);
+                  else if (m == "mixolydian")
+                        key.setMode(KeyMode::MIXOLYDIAN);
+                  else if (m == "aeolian")
+                        key.setMode(KeyMode::AEOLIAN);
+                  else if (m == "ionian")
+                        key.setMode(KeyMode::IONIAN);
+                  else if (m == "locrian")
+                        key.setMode(KeyMode::LOCRIAN);
+                  else
                         _logger->logError(QString("Unsupported mode '%1'").arg(m), &_e);
-                        }
                   }
             else if (_e.name() == "cancel")
                   skipLogCurrElem();  // TODO ??

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -797,11 +797,23 @@ InspectorKeySig::InspectorKeySig(QWidget* parent)
             { Pid::LEADING_SPACE,  1, s.leadingSpace,  s.resetLeadingSpace  },
             { Pid::SHOW_COURTESY,  0, k.showCourtesy,  k.resetShowCourtesy  },
 //          { Pid::SHOW_NATURALS,  0, k.showNaturals,  k.resetShowNaturals  }
+            { Pid::KEYSIG_MODE,    0, k.keysigMode,    k.resetKeysigMode    }
             };
       const std::vector<InspectorPanel> ppList = {
             { s.title, s.panel },
             { k.title, k.panel }
             };
+      k.keysigMode->clear();
+      k.keysigMode->addItem(tr("Unknown"),    int(KeyMode::UNKNOWN));
+      k.keysigMode->addItem(tr("None"),       int(KeyMode::NONE));
+      k.keysigMode->addItem(tr("Major"),      int(KeyMode::MAJOR));
+      k.keysigMode->addItem(tr("Minor"),      int(KeyMode::MINOR));
+      k.keysigMode->addItem(tr("Dorian"),     int(KeyMode::DORIAN));
+      k.keysigMode->addItem(tr("Phrygian"),   int(KeyMode::PHRYGIAN));
+      k.keysigMode->addItem(tr("Lydian"),     int(KeyMode::LYDIAN));
+      k.keysigMode->addItem(tr("Mixolydian"), int(KeyMode::MIXOLYDIAN));
+      k.keysigMode->addItem(tr("Ionian"),     int(KeyMode::IONIAN));
+      k.keysigMode->addItem(tr("Locrian"),    int(KeyMode::LOCRIAN));
       mapSignals(iiList, ppList);
       }
 
@@ -809,8 +821,11 @@ void InspectorKeySig::setElement()
       {
       InspectorElementBase::setElement();
       KeySig* ks = toKeySig(inspector->element());
-      if (ks->generated())
+      if (ks->generated()) {
             k.showCourtesy->setEnabled(false);
+            k.keysigModeLabel->setEnabled(false);
+            k.keysigMode->setEnabled(false);
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspector_hairpin.ui
+++ b/mscore/inspector/inspector_hairpin.ui
@@ -458,12 +458,22 @@
         </property>
         <item>
          <property name="text">
-          <string>Crescendo</string>
+          <string notr="true">Crescendo</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Decrescendo</string>
+          <string notr="true">Decrescendo</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">Crescendo Line</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">Decrescendo Line</string>
          </property>
         </item>
        </widget>

--- a/mscore/inspector/inspector_keysig.ui
+++ b/mscore/inspector/inspector_keysig.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>157</width>
-    <height>79</height>
+    <width>200</width>
+    <height>81</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -77,33 +77,96 @@
        <number>3</number>
       </property>
       <item row="0" column="0">
-       <widget class="QCheckBox" name="showCourtesy">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::TabFocus</enum>
-        </property>
-        <property name="text">
-         <string>Show courtesy</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="Ms::ResetButton" name="resetShowCourtesy" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Show courtesy' value</string>
-        </property>
-       </widget>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="1" column="0">
+         <widget class="QLabel" name="keysigModeLabel">
+          <property name="text">
+           <string>Key signature mode:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="keysigMode">
+          <property name="accessibleName">
+           <string>Key signature mode</string>
+          </property>
+          <item>
+           <property name="text">
+            <string notr="true">Unknown</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">None</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">Major</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">Minor</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">Dorian</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">Lydian</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">Mixolydian</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">Aeolian</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">Ionian</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string notr="true">Locrian</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="Ms::ResetButton" name="resetKeysigMode" native="true">
+          <property name="accessibleName">
+           <string>Reset 'Key signature mode' value</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="Ms::ResetButton" name="resetShowCourtesy" native="true">
+          <property name="accessibleName">
+           <string>Reset 'Show courtesy' value</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0" colspan="2">
+         <widget class="QCheckBox" name="showCourtesy">
+          <property name="focusPolicy">
+           <enum>Qt::TabFocus</enum>
+          </property>
+          <property name="text">
+           <string>Show courtesy</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -121,6 +184,7 @@
  <tabstops>
   <tabstop>title</tabstop>
   <tabstop>showCourtesy</tabstop>
+  <tabstop>keysigMode</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
MusicXML im- and export of all possible key signatur modes.
Make these availble to the UI, via the Key Signature Inspector. (WIP, it doesn't quite work yet, any idea why?)