### PR TITLE
Canvas jumping issues

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4078,6 +4078,9 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack)
       {
       if (this != mscore->currentScoreView())
             return;
+      // TODO: change icon, or add panning options
+      if (!mscore->panDuringPlayback())
+            return;
 
       if (score()->layoutMode() == LayoutMode::LINE) {
 
@@ -4112,6 +4115,13 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack)
             if (_continuousPanel->active())
                   marginLeft += _continuousPanel->width() * mag();
 
+            // this code implements "continuous" panning
+            // it could potentially be enabled via more panning options
+            //if (playBack && _cursor) {
+            //      // keep playback cursor pinned at 25%
+            //      xo = -curPosL * mag() + marginLeft + width() * 0.2;
+            //      }
+            //else
             if (round(curPosMagR) > round(width() - marginRight)) {
                   // focus in or beyond right margin
                   // pan to left margin in playback,

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4241,18 +4241,14 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack)
 
       // align to page borders if extends beyond
       Page* page = sys->page();
-      if (!MScore::verticalOrientation()) {
-            if (x < page->x() || r.width() >= page->width())
-                  x = page->x();
-            else if (r.width() < page->width() && r.width() + x > page->width() + page->x())
-                  x = (page->width() + page->x()) - r.width();
-                  }
-      else {
-            if (y < page->y() || r.height() >= page->height())
-                  y = page->y();
-            else if (r.height() < page->height() && r.height() + y > page->height() + page->y())
-                  y = (page->height() + page->y()) - r.height();
-            }
+      if (x < page->x() || r.width() >= page->width())
+            x = page->x();
+      else if (r.width() < page->width() && r.width() + x > page->width() + page->x())
+            x = (page->width() + page->x()) - r.width();
+      if (y < page->y() || r.height() >= page->height())
+            y = page->y();
+      else if (r.height() < page->height() && r.height() + y > page->height() + page->y())
+            y = (page->height() + page->y()) - r.height();
 
       // hack: don't update if we haven't changed the offset
       if (oldX == x && oldY == y)

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4093,9 +4093,15 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack)
             */
 
             qreal xo = 0.0;  // new x offset
-            // at one point, the code used _cursor->rect(), but this only works during note entry or playback
-            // see issue #33391
-            QRectF curPos = el->canvasBoundingRect();
+            QRectF curPos = playBack ? _cursor->rect() : el->canvasBoundingRect();
+            // keep current note in view as well if applicable (note input mode)
+            Element* current = nullptr;
+            if (noteEntryMode()) {
+                  current = score()->selection().cr();
+                  if (current && current != el)
+                        curPos |= current->canvasBoundingRect();
+                  }
+
             qreal curPosR = curPos.right();                    // Position on the canvas
             qreal curPosL = curPos.left();                     // Position on the canvas
             qreal curPosMagR = curPosR * mag() + xoffset(); // Position in the screen
@@ -4107,26 +4113,37 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack)
                   marginLeft += _continuousPanel->width() * mag();
 
             if (round(curPosMagR) > round(width() - marginRight)) {
-                  xo = -curPosL * mag() + marginLeft;
-
-                  // Keeps the score up to the right to avoid blank gap on the right.
-                  qreal scoreEnd = score()->pages().front()->width() * mag() + xo;
-                  if (scoreEnd < width())
-                        xo += width() - scoreEnd;
-
-                  setOffset(xo, yoffset());
-                  update();
+                  // focus in or beyond right margin
+                  // pan to left margin in playback,
+                  // most of the way left in note entry,
+                  // otherwise just enforce right margin
+                  if (playBack)
+                        xo = -curPosL * mag() + marginLeft;
+                  else if (noteEntryMode())
+                        xo = -curPosL * mag() + marginLeft + width() * 0.2;
+                  else
+                        xo = -curPosR * mag() + width() - marginRight;
                   }
             else if (round(curPosMagL) < round(marginLeft) ) {
-                  xo = -curPosR * mag() + width() - marginRight;
-
-                  // Bring back the score to the left to avoid blank gap on the left.
-                  if (xo > 10)
-                        xo = 10;
-
-                  setOffset(xo, yoffset());
-                  update();
+                  // focus in or beyond left margin
+                  // enforce left margin
+                  // (previously we moved canvas all the way right,
+                  // but this made sense only when navigating right-to-left)
+                  xo = -curPosL * mag() + marginLeft;
                   }
+            else {
+                  // focus is within margins, so do nothing
+                  return;
+                  }
+            // avoid empty space on either side of "page"
+            qreal scoreEnd = score()->pages().front()->width() * mag() + xo;
+            if (xo > 10)
+                  xo = 10;
+            else if (scoreEnd < width())
+                  xo += width() - scoreEnd;
+
+            setOffset(xo, yoffset());
+            update();
             return;
             }
 

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2080,7 +2080,7 @@ Shortcut Shortcut::_sc[] = {
          "pan",
          QT_TRANSLATE_NOOP("action","Pan Score"),
          QT_TRANSLATE_NOOP("action","Toggle 'Pan Score'"),
-         QT_TRANSLATE_NOOP("action","Pan score during playback"),
+         QT_TRANSLATE_NOOP("action","Pan score automatically"),
          Icons::pan_ICON,
          Qt::WindowShortcut,
          ShortcutFlags::A_SCORE | ShortcutFlags::A_CHECKABLE | ShortcutFlags::A_CHECKED


### PR DESCRIPTION
We get complaints from time to time about the canvas jumping during note input or other editing operations.  Obviously some of this is intended and good, but there have been a few cases identified where I agree we are doing too much.  See https://musescore.org/en/node/271271 for a recent forum discussion leading to this PR.

This PR is submitted against 2.3 because the whole canvas positioning seems more funamentally broken in master - I think maybe the width of the page in continuous view is wrong and throwing a lot of things off?  But FWIW, the exact same code *does* compile and works as well as can be expected in master as well.

There are a few distinct changes here, separated into three different commits.

The first commit fixes something that is unquestionably a bug, a regression introduced in 2.2 that affects operations near the right margin in page view with vertical stacking of pages.

The second commit makes the canvas positioning more conservative in continuous view.  Previously, any operation near either margin would cause an immediately jump all the way to the other side.  This could make sense in some situations but really doesn't in others, as discussed in the forum post above.  My changes here prevent the score jumping all the way to the right upon an operation near the right margin or all the way left upon an operation near the left margin.  The only big jump I retain is during note entry, where the canvas *will* still reposition to the left when you near the right edge of the screen.  Even here, though, I made it less aggressive, putting the target element 25% from the left edge of the screen rather than 5%.  The idea is to keep more of the previous context in view.  I also amended it to guarantee the previous and current note *both* remain in view, so even if we reduce that 25% back down to 5%, there will still be more context than before.

The final commit is a trial I don't recommend keeping as is, and there is a TODO in the code for this.  Basically, I turned the "Pan score during playback" toggle button into "Pan score", period.  So when disabled, there is *no* automatic canvas positioning whatsoever (at least, none done by adjustCanvasPosition).  Some people swear they want that.  I have my doubts, but I figure, get them a test build to see.

I welcome feedback!  Probably best to discuss the *behavior* in the forum, the *code* here.