### PR TITLE
fix #228531: Courtesy clefs don't appear on lines ending in repeat barlines

### DIFF
--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -191,8 +191,8 @@ void Clef::layout()
                         !courtesy
                         // or, if courtesy clef: show if score has courtesy clefs on
                         || ( score()->styleB(StyleIdx::genCourtesyClef)
-                              // AND measure is not at the end of a repeat or of a section
-                              && !( (meas->repeatFlags() & Repeat::END) || meas->isFinalMeasureOfSection() )
+                              // AND measure is not at the end of a section
+                              && !meas->isFinalMeasureOfSection()
                               // AND this clef has courtesy clef turned on
                               && showCourtesy() );
                   bHide |= !showClef;


### PR DESCRIPTION
See [#228531: Courtesy clefs don't appear on lines ending in repeat barlines](https://musescore.org/en/node/228531).

While I understand the reasoning behind hiding a courtesy clef if it comes at the end of a repeat, the example in the bug report shows why this is not the correct thing to do. After all, it is easy to hide a courtesy clef if it should not be shown. It is much harder to show a courtesy clef if MuseScore wants to hide it.