### PR TITLE
fix #108201: Untick 'Show courtesy' for clefs does not work.

### DIFF
--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -148,6 +148,14 @@ void Clef::layout()
                         _clefTypes = staff()->clefType(0);
                   }
 
+            Measure* meas = clefSeg->measure();
+            if (meas && meas->system()) {
+                  auto ml = meas->system()->measures();
+                  bool found = (std::find(ml.begin(), ml.end(), meas) != ml.end());
+                  bool courtesy = (tick == meas->endTick() && (meas == meas->system()->lastMeasure() || !found));
+                  if (courtesy && (!showCourtesy() || !score()->styleB(Sid::genCourtesyClef) || meas->isFinalMeasureOfSection()))
+                        show = false;
+                  }
             // if clef not to show or not compatible with staff group
             if (!show) {
                   setbbox(QRectF());
@@ -450,6 +458,7 @@ bool Clef::setProperty(Pid propertyId, const QVariant& v)
             default:
                   return Element::setProperty(propertyId, v);
             }
+      triggerLayout();
       return true;
       }
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2418,7 +2418,7 @@ void Score::getNextMeasure(LayoutContext& lc)
                               e->layout();
                               }
                         }
-                  else if (segment.isType(SegmentType::TimeSig | SegmentType::Ambitus)) {
+                  else if (segment.isType(SegmentType::TimeSig | SegmentType::Ambitus | SegmentType::HeaderClef)) {
                         Element* e = segment.element(staffIdx * VOICES);
                         if (e)
                               e->layout();

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -870,7 +870,7 @@ void InspectorClef::setElement()
             otherMeas = meas->nextMeasure();                // look for a next measure
       // look for a clef segment in the 'other' measure at the same tick of this clef segment
       if (otherMeas)
-            otherSegm = otherMeas->findSegment(SegmentType::Clef, segmTick);
+            otherSegm = otherMeas->findSegment(SegmentType::Clef | SegmentType::HeaderClef, segmTick);
       // if any 'other' segment found, look for a clef in the same track as this
       if (otherSegm)
             otherClef = toClef(otherSegm->element(clef->track()));


### PR DESCRIPTION
See [#108201: Untick 'Show courtesy' for clefs does not work.](https://musescore.org/en/node/108201)

Summary of changes:
1. Add logic in Clef::layout() to hide a courtesy clef if it should not be shown.
2. Have Clef::setProperty() trigger a layout for properties that are not handled by Element::setProperty().
3. Have Score::getNextMeasure() layout elements belonging to segments of type HeaderClef. Courtesy clefs fall into this category.
4. Allow the inspector to find the 'other' clef by searching for a HeaderClef segment as well as a regular Clef segment.

I noticed that Score::undoChangeClef() uses HeaderClef segments for courtesy clefs. I wonder if HeaderClef segments should only be used for the large clef at the beginning of each system. I also noticed that there is no longer a way to create a clef change at the beginning of a measure without the clef being moved to the previous measure. It is possible to modify Score::undoChangeClef() to bring back this functionality.