### PR TITLE
Solve memory leak chord found by Cppcheck

### DIFF
--- a/mtest/libmscore/note/tst_note.cpp
+++ b/mtest/libmscore/note/tst_note.cpp
@@ -312,6 +312,7 @@ void TestNote::note()
       QCOMPARE(n->veloType(), Note::ValueType::OFFSET_VAL);
       delete n;
 
+      delete chord;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
The pointer chord (returned by new ...) is correctly deleted when reaching
the function's end. But the object of class Ms::Chord itself is not destroyed
due to its creation through new... and must therefore be properly deleted manually.
This error was found by Cppcheck 1.83.