### PR TITLE
fix #8808: Add option to limit scroll area of the navigator and the score view

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -126,6 +126,7 @@ void Preferences::init()
       portMidiOutputLatencyMilliseconds = 0;
 
       antialiasedDrawing       = true;
+      limitScrollArea          = false;
       sessionStart             = SessionStart::SCORE;
       startScore               = ":/data/My_First_Score.mscz";
       defaultStyleFile         = "";
@@ -268,6 +269,7 @@ void Preferences::write()
       s.setValue("layoutBreakColor",   MScore::layoutBreakColor.name(QColor::NameFormat::HexArgb));
       s.setValue("frameMarginColor",   MScore::frameMarginColor.name(QColor::NameFormat::HexArgb));
       s.setValue("antialiasedDrawing", antialiasedDrawing);
+      s.setValue("limitScrollArea",    limitScrollArea);
       switch(sessionStart) {
             case SessionStart::EMPTY:  s.setValue("sessionStart", "empty"); break;
             case SessionStart::LAST:   s.setValue("sessionStart", "last"); break;
@@ -436,6 +438,7 @@ void Preferences::read()
       MScore::layoutBreakColor   = readColor("layoutBreakColor", MScore::layoutBreakColor);
       MScore::frameMarginColor   = readColor("frameMarginColor", MScore::frameMarginColor);
       antialiasedDrawing      = s.value("antialiasedDrawing", antialiasedDrawing).toBool();
+      limitScrollArea         = s.value("limitScrollArea", limitScrollArea).toBool();
 
       defaultStyleFile         = s.value("defaultStyle", defaultStyleFile).toString();
 
@@ -910,6 +913,7 @@ void PreferenceDialog::updateValues()
 
       alsaFragments->setValue(prefs.alsaFragments);
       drawAntialiased->setChecked(prefs.antialiasedDrawing);
+      limitScrollArea->setChecked(prefs.limitScrollArea);
       switch(prefs.sessionStart) {
             case SessionStart::EMPTY:  emptySession->setChecked(true); break;
             case SessionStart::LAST:   lastSession->setChecked(true); break;
@@ -1393,6 +1397,7 @@ void PreferenceDialog::apply()
       prefs.showStartcenter    = showStartcenter->isChecked();
 
       prefs.antialiasedDrawing = drawAntialiased->isChecked();
+      prefs.limitScrollArea    = limitScrollArea->isChecked();
 
       prefs.useJackTransport   = jackDriver->isChecked() && useJackTransport->isChecked();
       prefs.jackTimebaseMaster = becomeTimebaseMaster->isChecked();

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -121,6 +121,7 @@ struct Preferences {
       int portMidiOutputLatencyMilliseconds;
 
       bool antialiasedDrawing;
+      bool limitScrollArea;
       SessionStart sessionStart;
       QString startScore;
       QString defaultStyleFile;

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -1123,6 +1123,40 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <spacer>
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="limitScrollArea">
+            <property name="toolTip">
+             <string>Limit the scroll area to the edges of the score</string>
+            </property>
+            <property name="whatsThis">
+             <string>If this is checked, scrolling will stop at the edge of the score.</string>
+            </property>
+            <property name="accessibleName">
+             <string>Limit scroll area to page borders</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>If this is checked, scrolling will stop at the edge of the score.</string>
+            </property>
+            <property name="text">
+             <string>Limit scroll area to page borders</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -4279,6 +4313,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>printShortcuts</tabstop>
   <tabstop>resetToDefault</tabstop>
   <tabstop>buttonBox</tabstop>
+  <tabstop>limitScrollArea</tabstop>
   <tabstop>drawAntialiased</tabstop>
   <tabstop>proximity</tabstop>
  </tabstops>


### PR DESCRIPTION
This provides the option that was suggested by Isaac Weiss in [#8808: Add option to limit scroll area of the navigator and the score view](https://musescore.org/en/node/8808), and again by polarbreeze in [Add view mode that pins the page location in the window](https://musescore.org/en/node/270435). See also [#68966: Disable horizontal scrolling when zoomed to page width](https://musescore.org/en/node/68966) for more discussion about why many users would appreciate this, and why others would not want to have this enabled.

I have added a checkbox in the Canvas tab of the Preferences dialog which reads "Limit scroll area to page borders". If checked,
- Scrolling will stop at the edge of the score.
- If the left and right edges are both visible, the score will be kept centered horizontally in the score view.
- If the top and bottom edges are both visible, the score will be kept centered vertically in the score view.

This option is off by default, which means those who do not want this feature are not affected by it.