### PR TITLE
271135 visual studio2017port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ vtest/LOG
 vtest/META-INF
 vtest/Thumbnails
 vtest/Pictures
+.vs
+dependencies
 
 # Downloaded files during build process
 MS_General.sf3
@@ -43,3 +45,4 @@ MuseScore_General.sf3
 MuseScore_General-License.md
 MuseScore_General-changelog.txt
 VERSION
+/mscore/data/mscore.aps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ if(POLICY CMP0071)
       cmake_policy(SET CMP0071 OLD)
 endif(POLICY CMP0071)
 
+# Define MINGW for VS, as it appears not to be defined
+if (MSVC)
+   set (MINGW false)
+endif (MSVC)
+
 #  Look for Qt5
 SET(QT_MIN_VERSION    "5.8.0")
 # Include modules
@@ -80,6 +85,11 @@ set(USE_SSE           TRUE)
 set(SCRIPT_INTERFACE  TRUE)
 
 # Disable components not supported on Windows
+if (MSVC)
+      set(WIN_NOT_AVAIL "Not available on Windows")
+      option(BUILD_PULSEAUDIO ${WIN_NOT_AVAIL} OFF)
+      option(BUILD_ALSA ${WIN_NOT_AVAIL} OFF)
+endif (MSVC)
 if (MINGW)
       set(WIN_NOT_AVAIL "Not available on Windows")
       option(BUILD_PULSEAUDIO ${WIN_NOT_AVAIL} OFF)
@@ -94,10 +104,10 @@ if (APPLE)
 endif (APPLE)
 
 # Disable components not supported on Linux/BSD
-if (NOT APPLE AND NOT MINGW)
+if (NOT APPLE AND NOT MINGW AND NOT MSVC)
       set(NIX_NOT_AVAIL "Not available on Linux/BSD")
       #option(BUILD_PORTMIDI "PortMidi disabled on Linux. (It uses ALSA but it's better to use ALSA directly)" OFF)
-endif (NOT APPLE AND NOT MINGW)
+endif (NOT APPLE AND NOT MINGW AND NOT MSVC)
 
 option(AEOLUS        "Enable pipe organ synthesizer"      OFF)
 option(ZERBERUS      "Enable experimental SFZ sampler"    ON)
@@ -161,8 +171,10 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
       endif()
 endif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
-set(CMAKE_CXX_FLAGS_DEBUG   "-g")
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG -DQT_NO_DEBUG")
+if (NOT MSVC)
+   set(CMAKE_CXX_FLAGS_DEBUG   "-g")
+   set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG -DQT_NO_DEBUG")
+endif (NOT MSVC)
 
 if (APPLE)
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -stdlib=libc++ -Wno-inconsistent-missing-override")
@@ -171,16 +183,29 @@ if (APPLE)
    SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
    SET(CMAKE_INSTALL_RPATH "${QT_INSTALL_PREFIX}/lib")
 else (APPLE)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
-   if (MINGW)
-      # -mno-ms-bitfields see #22048
-      set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -mno-ms-bitfields")
-      set(CMAKE_EXE_LINKER_FLAGS "-Wl,--large-address-aware")
-   else (MINGW)
-      set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -fPIC")
-      set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Woverloaded-virtual")
-      set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DQT_NO_DEBUG_OUTPUT")
-   endif (MINGW)
+   if (MSVC)
+   # Set compiler options for VS2017 toolchain.
+   # Note: /D_CRT_SECURE_NO WARNINGS disables warnings when using "non-secure" library functions like sscanf...
+      set(CMAKE_CXX_FLAGS                "/DWIN32 /D_WINDOWS /GR /EHsc /D_UNICODE /DUNICODE /D_CRT_SECURE_NO_WARNINGS /execution-charset:utf-8")
+      if (USE_SSE)
+         # If USE_SSE is set, enable use of SSE instructions to compiler.
+         set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /arch:SSE")
+      endif (USE_SSE)
+      set(CMAKE_CXX_FLAGS_DEBUG         "/MDd /permissive- /std:c++14 /W4 /Zi /Ob0 /Od /RTC1")
+      set(CMAKE_CXX_FLAGS_RELEASE        "/MD /permissive- /std:c++14 /W4 /O2 /Ob2 -DNDEBUG -DQT_NO_DEBUG")
+      set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MD /permissive- /std:c++14 /W4 /Zi /O2 /Ob1 -DNDEBUG -DQT_NO_DEBUG")
+   else (MSVC)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+      if (MINGW)
+         # -mno-ms-bitfields see #22048
+         set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -mno-ms-bitfields")
+         set(CMAKE_EXE_LINKER_FLAGS "-Wl,--large-address-aware")
+      else (MINGW)
+         set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -fPIC")
+         set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Woverloaded-virtual")
+         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DQT_NO_DEBUG_OUTPUT")
+      endif (MINGW)
+   endif (MSVC)
 endif(APPLE)
 
 set(CMAKE_INCLUDE_CURRENT_DIR TRUE)
@@ -207,18 +232,26 @@ if (MSCORE_UNSTABLE)
   SET (MUSESCORE_NAME_VERSION "${MUSESCORE_NAME_VERSION} (${MUSESCORE_VERSION_FULL} unstable)")
 endif (MSCORE_UNSTABLE)
 
-if (MINGW OR APPLE)
+if (MINGW OR MSVC OR APPLE)
   if(MINGW)
+      # Option for MINGW
       SET(Mscore_INSTALL_NAME  "")
       SET(Mscore_SHARE_NAME    "./")
   else(MINGW)
-      SET(Mscore_INSTALL_NAME  "Contents/Resources/")
-      SET(Mscore_SHARE_NAME    "mscore.app/")
+      if (MSVC)
+         # Option for MSVC
+         SET(Mscore_INSTALL_NAME  "")
+         SET(Mscore_SHARE_NAME    "./")
+      else (MSVC)
+         # Option for Apple
+         SET(Mscore_INSTALL_NAME  "Contents/Resources/")
+         SET(Mscore_SHARE_NAME    "mscore.app/")
+      endif (MSVC)
   endif(MINGW)
-else (MINGW OR APPLE)
+else (MINGW OR MSVC OR APPLE)
       SET(Mscore_INSTALL_NAME  "mscore${MSCORE_INSTALL_SUFFIX}-${MUSESCORE_VERSION}/")
       SET(Mscore_SHARE_NAME    "share/")
-endif (MINGW OR APPLE)
+endif (MINGW OR MSVC OR APPLE)
 
 # Download MuseScore SoundFont
 if (DOWNLOAD_SOUNDFONT)
@@ -307,13 +340,13 @@ endif (BUILD_ALSA)
 ## MIDI
 ##
 
-if (APPLE OR MINGW)
+if (APPLE OR MINGW OR MSVC)
       set (HAS_MIDI 1)
-else (APPLE OR MINGW)
+else (APPLE OR MINGW OR MSVC)
       if (USE_ALSA)
             set (HAS_MIDI 1)
       endif (USE_ALSA)
-endif (APPLE OR MINGW)
+endif (APPLE OR MINGW OR MSVC)
 
 ##
 ## PulseAudio
@@ -333,12 +366,12 @@ endif (BUILD_PULSEAUDIO)
 ##
 ## LAME
 ##
-if (APPLE OR MINGW)
+if (APPLE OR MINGW OR MSVC)
       IF (BUILD_LAME)
             include (FindLame)
             set (USE_LAME 1)
       ENDIF (BUILD_LAME)
-else (APPLE OR MINGW)
+else (APPLE OR MINGW OR MSVC)
       IF (BUILD_LAME)
             include (FindLame)
             IF (LAME_FOUND)
@@ -351,14 +384,14 @@ else (APPLE OR MINGW)
       ELSE (BUILD_LAME)
             MESSAGE(STATUS "LAME MP3 support disabled")
       ENDIF (BUILD_LAME)
-endif (APPLE OR MINGW)
+endif (APPLE OR MINGW OR MSVC)
 
 ##
 ## Find JACK >= JACK_MIN_VERSION
 ##
 
 IF(BUILD_JACK)
-     IF(MINGW)
+     IF(MINGW OR MSVC)
            set (USE_JACK 1)
            IF("$ENV{PROCESSOR_ARCHITEW6432}" STREQUAL "")
               IF("$ENV{PROCESSOR_ARCHITECTURE}" STREQUAL "x86")
@@ -381,7 +414,7 @@ IF(BUILD_JACK)
               ENDIF("$ENV{PROCESSOR_ARCHITECTURE}" STREQUAL "x86")
            ENDIF("$ENV{PROCESSOR_ARCHITEW6432}" STREQUAL "")
            MESSAGE("JACK support enabled.")
-     ELSE(MINGW)
+     ELSE(MINGW OR MSVC)
            PKGCONFIG1 (jack ${JACK_MIN_VERSION} JACK_INCDIR JACK_LIBDIR JACK_LIB JACK_CPP)
            IF(JACK_INCDIR)
                  MESSAGE(STATUS "${JACK_LONGNAME} >= ${JACK_MIN_VERSION} found. jack support enabled.")
@@ -390,7 +423,7 @@ IF(BUILD_JACK)
                  MESSAGE(STATUS "${JACK_LONGNAME} >= ${JACK_MIN_VERSION} not found")
                  MESSAGE(SEND_ERROR "Error: JACK support requested (BUILD_JACK=${BUILD_JACK}), but JACK was not found")
            ENDIF(JACK_INCDIR)
-     ENDIF(MINGW)
+     ENDIF(MINGW OR MSVC)
 ELSE(BUILD_JACK)
      MESSAGE(STATUS "${JACK_LONGNAME} support disabled")
 ENDIF(BUILD_JACK)
@@ -401,9 +434,9 @@ ENDIF(BUILD_JACK)
 ##
 
 if (BUILD_PORTAUDIO)
-    if (MINGW)
+    if (MINGW OR MSVC)
         set ( USE_PORTAUDIO 1 )
-    else (MINGW)
+    else (MINGW OR MSVC)
         PKGCONFIG1 (portaudio-2.0 19 PORTAUDIO_INCDIR PORTAUDIO_LIBDIR PORTAUDIO_LIB PORTAUDIO_CPP)
         if (PORTAUDIO_INCDIR)
               message("PortAudio found. PortAudio support enabled. INCDIR ${PORTAUDIO_INCDIR}, LIBDIR ${PORTAUDIO_LIBDIR}, LIB ${PORTAUDIO_LIB}")
@@ -411,7 +444,7 @@ if (BUILD_PORTAUDIO)
         else (PORTAUDIO_INCDIR)
               message(SEND_ERROR "Error: PortAudio support requested (BUILD_PORTAUDIO=${BUILD_PORTAUDIO}), but portaudio-2.0 version 19 was not found (package portaudio19-dev)")
         endif (PORTAUDIO_INCDIR)
-    endif (MINGW)
+    endif (MINGW OR MSVC)
 else (BUILD_PORTAUDIO)
      message(STATUS "PortAudio support disabled")
 endif (BUILD_PORTAUDIO)
@@ -468,11 +501,11 @@ if (APPLE)
       endif (SNDFILE_INCDIR)
    endif(HAS_AUDIOFILE)
 else(APPLE)
-   if(MINGW)
+   if(MINGW OR MSVC)
       set(SNDFILE_LIB sndfile-1)
-   else(MINGW)
+   else(MINGW OR MSVC)
       set(SNDFILE_LIB sndfile)
-   endif(MINGW)
+   endif(MINGW OR MSVC)
    set(OGG_LIB ogg)
    set(VORBIS_LIB vorbis)
 endif(APPLE)
@@ -498,7 +531,7 @@ configure_file (
       ${PROJECT_BINARY_DIR}/config.h
       )
 
-if (NOT MINGW AND NOT APPLE)
+if (NOT MINGW AND NOT MSVC AND NOT APPLE)
     #### PACKAGING for Linux and BSD based systems (more in mscore/CMakeLists.txt) ####
     #
     #     set library search path for runtime linker to load the same
@@ -594,22 +627,28 @@ if (NOT MINGW AND NOT APPLE)
     configure_file(build/Linux+BSD/musescore.xml.in musescore${MSCORE_INSTALL_SUFFIX}.xml)
     install( FILES ${PROJECT_BINARY_DIR}/musescore${MSCORE_INSTALL_SUFFIX}.xml DESTINATION share/mime/packages COMPONENT doc)
     # Note: Must now run "update-mime-database" to apply changes. This is done in the Makefile.
-endif (NOT MINGW AND NOT APPLE)
+endif (NOT MINGW AND NOT MSVC AND NOT APPLE)
 
 #
 #  Create precompiled header file
 #
 
-# all.h is expected in PROJECT_BINARY_DIR by subdirs
-execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/all.h ${PROJECT_BINARY_DIR}/all.h
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-    )
+# all.h is expected in PROJECT_BINARY_DIR by subdirs, except for MSVC
+if (NOT MSVC)
+   execute_process(
+      COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/all.h ${PROJECT_BINARY_DIR}/all.h
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+      )
+endif (NOT MSVC)
 
 precompiled_header(QT_INCLUDES all ${BUILD_PCH})
 
-ADD_CUSTOM_TARGET(mops1 DEPENDS ${PROJECT_BINARY_DIR}/all.h)
-ADD_CUSTOM_TARGET(mops2 DEPENDS ${PCH})
+# MSVC does not require these targets, as all.h is not copied and the
+#   PCH generation is done per-project
+if (NOT MSVC)
+   ADD_CUSTOM_TARGET(mops1 DEPENDS ${PROJECT_BINARY_DIR}/all.h)
+   ADD_CUSTOM_TARGET(mops2 DEPENDS ${PCH})
+endif (NOT MSVC)
 
 ##
 ## Add subdirs
@@ -635,9 +674,9 @@ add_subdirectory(fonttools EXCLUDE_FROM_ALL)
 add_subdirectory(manual)
 add_subdirectory(demos)
 
-if (USE_PORTMIDI AND (MINGW OR APPLE))
+if (USE_PORTMIDI AND (MINGW OR APPLE OR MSVC))
       subdirs (thirdparty/portmidi)
-endif (USE_PORTMIDI AND (MINGW OR APPLE))
+endif (USE_PORTMIDI AND (MINGW OR APPLE OR MSVC))
 
 if (AEOLUS)
       subdirs (aeolus)
@@ -721,3 +760,24 @@ add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/plugins
    COMMAND genManual ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR}
    DEPENDS genManual
    )
+
+
+##
+##  For MSVC: set the startup project to be mscore 
+##     (requires CMake 3.6.3+ to work, but should be benign on other versions
+##      as it is just setting the value for a property).
+##
+if (MSVC)
+   set(VS_STARTUP_PROJECT mscore)
+endif (MSVC)
+
+## TEMP: Display all variables!
+### message(STATUS "===========================================================")
+### message(STATUS "VARIABLES:")
+### message(STATUS "")
+### get_cmake_property(_variableNames VARIABLES)
+### list (SORT _variableNames)
+### foreach (_variableName ${_variableNames})
+###     message(STATUS "${_variableName}=${${_variableName}}")
+### endforeach()
+### message(STATUS "===========================================================")

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,121 @@
+{
+   // See https://go.microsoft.com//fwlink//?linkid=834763 for more information about this file.
+   "configurations": [
+      {
+         "name": "x86-Debug",
+         "generator": "Visual Studio 15 2017",
+         "configurationType": "Debug",
+         "inheritEnvironments": [ "msvc_x86" ],
+         "buildRoot": "${projectDir}\\build.debug", // "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+         "installRoot": "${projectDir}\\win32install", // "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+         "cmakeCommandArgs": "-Wno-deprecated -LA",
+         "variables": [
+            {
+               "name": "CMAKE_BUILD_TYPE",
+               "value": "DEBUG"
+            },
+            {
+               "name": "BUILD_FOR_WINSTORE",
+               "value": "OFF"
+            },
+            {
+               "name": "CMAKE_PREFIX_PATH",
+               "value": "C:\\Qt\\5.9.4\\msvc2015;${projectDir}\\dependencies"
+            },
+            {
+               "name": "CMAKE_LIBRARY_PATH",
+               "value": "${projectDir}\\dependencies\\libx86;${projectDir}\\dependencies\\zlib\\x86\\static\\Release"
+            }
+         ],
+         "buildCommandArgs": "-v",
+         "ctestCommandArgs": ""
+      },
+      {
+         "name": "x86-Release",
+         "generator": "Visual Studio 15 2017",
+         "configurationType": "RelWithDebInfo",
+         "inheritEnvironments": [ "msvc_x86" ],
+         "buildRoot": "${projectDir}\\build.release", // "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+         "installRoot": "${projectDir}\\win32install", // "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+         "cmakeCommandArgs": "-Wno-deprecated",
+         "variables": [
+            {
+               "name": "CMAKE_BUILD_TYPE",
+               "value": "RELEASE"
+            },
+            {
+               "name": "BUILD_FOR_WINSTORE",
+               "value": "OFF"
+            },
+            {
+               "name": "CMAKE_PREFIX_PATH",
+               "value": "C:\\Qt\\5.9.4\\msvc2015;${projectDir}\\dependencies"
+            },
+            {
+               "name": "CMAKE_LIBRARY_PATH",
+               "value": "${projectDir}\\dependencies\\libx86;${projectDir}\\dependencies\\zlib\\x86\\static\\Release"
+            }
+         ],
+         "buildCommandArgs": "-v",
+         "ctestCommandArgs": ""
+      },
+      {
+         "name": "x64-Debug",
+         "generator": "Visual Studio 15 2017 Win64",
+         "configurationType": "Debug",
+         "inheritEnvironments": [ "msvc_x64_x64" ],
+         "buildRoot": "${projectDir}\\build.debug64", // "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+         "installRoot": "${projectDir}\\win64install", // "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+         "cmakeCommandArgs": "-Wno-deprecated",
+         "variables": [
+            {
+               "name": "CMAKE_BUILD_TYPE",
+               "value": "DEBUG"
+            },
+            {
+               "name": "BUILD_FOR_WINSTORE",
+               "value": "OFF"
+            },
+            {
+               "name": "CMAKE_PREFIX_PATH",
+               "value": "C:\\Qt\\5.9.4\\msvc2017_64;${projectDir}\\dependencies"
+            },
+            {
+               "name": "CMAKE_LIBRARY_PATH",
+               "value": "${projectDir}\\dependencies\\libx64;${projectDir}\\dependencies\\zlib\\x64\\static\\Release"
+            }
+         ],
+         "buildCommandArgs": "-v",
+         "ctestCommandArgs": ""
+      },
+      {
+         "name": "x64-Release",
+         "generator": "Ninja",
+         "configurationType": "RelWithDebInfo",
+         "inheritEnvironments": [ "msvc_x64_x64" ],
+         "buildRoot": "${projectDir}\\build.release64", // "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
+         "installRoot": "${projectDir}\\win64install", // "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
+         "cmakeCommandArgs": "-Wno-deprecated",
+         "variables": [
+            {
+               "name": "CMAKE_BUILD_TYPE",
+               "value": "RELEASE"
+            },
+            {
+               "name": "BUILD_FOR_WINSTORE",
+               "value": "OFF"
+            },
+            {
+               "name": "CMAKE_PREFIX_PATH",
+               "value": "C:\\Qt\\5.9.4\\msvc2017_64;${projectDir}\\dependencies"
+            },
+            {
+               "name": "CMAKE_LIBRARY_PATH",
+               "value": "${projectDir}\\dependencies\\libx64;${projectDir}\\dependencies\\zlib\\x64\\static\\Release"
+            }
+         ],
+         "buildCommandArgs": "-v",
+         "ctestCommandArgs": ""
+      }
+   ]
+}

--- a/aeolus/CMakeLists.txt
+++ b/aeolus/CMakeLists.txt
@@ -40,11 +40,19 @@ add_library (aeolus STATIC
       ${INCS}
       )
 
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       aeolus
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      aeolus
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE} ${PCH_FORCE_USE}"
+      )
+endif (NOT MSVC)   
 
 install(DIRECTORY
       stops

--- a/all.cpp
+++ b/all.cpp
@@ -1,0 +1,24 @@
+//=============================================================================
+//  MusE
+//  Linux Music Score Editor
+//  $Id: allqt.h,v 1.24 2006/03/02 17:08:30 wschweer Exp $
+//
+//  Copyright (C) 2004-2011 Werner Schweer (ws@seh.de)
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+// MSVC requires a cpp compilable file to create pre-compiled headers.
+
+// No need to include all.h, as it is force-included.
+// #include "all.h"

--- a/all.h
+++ b/all.h
@@ -54,6 +54,12 @@
 #include <functional>
 #include <memory>
 
+// Disable warning C4127: conditional expression is constant in VS2017 (generated in header file qvector.h)
+#if (defined (_MSCVER) || defined (_MSC_VER))
+   #pragma warning ( push )
+   #pragma warning ( disable: 4127)
+#endif
+
 #include <QtGui>
 #include <QLoggingCategory>
 #include <QModelIndex>

--- a/all.h
+++ b/all.h
@@ -29,6 +29,12 @@
 
 #if defined __cplusplus
 
+#if (defined (_MSCVER) || defined (_MSC_VER))
+   // Define to opt-in to deprecated features (bind2nd, mem_fun) removed in VS2017 c++17 mode.
+   #undef _HAS_AUTO_PTR_ETC
+   #define _HAS_AUTO_PTR_ETC 1
+#endif
+
 #include <stdio.h>
 #include <limits.h>
 #include <map>
@@ -36,7 +42,13 @@
 #include <set>
 #include <errno.h>
 #include <fcntl.h>
-#include <unistd.h>
+// VStudio does not have <unistd.h>, <io.h> & <process.h> replace many functions from it...
+#if (defined (_MSCVER) || defined (_MSC_VER))
+   #include <io.h>
+   #include <process.h>
+#else
+   #include <unistd.h>
+#endif
 #include <math.h>
 #include <array>
 #include <functional>
@@ -191,6 +203,12 @@
 #define Q_ASSERT_X(a,b,c)
 #undef Q_ASSERT
 #define Q_ASSERT(a)
+#endif
+
+#if (defined (_MSCVER) || defined (_MSC_VER))
+   // Undefined problematic #def'd macros in Microsoft headers
+   #undef STRING_NONE
+   #undef small
 #endif
 
 #endif  // __cplusplus

--- a/audiofile/CMakeLists.txt
+++ b/audiofile/CMakeLists.txt
@@ -18,20 +18,41 @@ else (APPLE)
         set(INCS "")
 endif (APPLE)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (audiofile STATIC
-      ${PROJECT_BINARY_DIR}/all.h
+      ${_all_h_file}
       ${PCH}
       audiofile.cpp
       )
-set_target_properties (
+
+if (NOT MSVC)
+   set_target_properties (
       audiofile
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      audiofile
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(audiofile all)
 
-ADD_DEPENDENCIES(audiofile mops1)
-ADD_DEPENDENCIES(audiofile mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( audiofile )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(audiofile mops1)
+   ADD_DEPENDENCIES(audiofile mops2)
+endif (NOT MSVC)
 
 

--- a/awl/CMakeLists.txt
+++ b/awl/CMakeLists.txt
@@ -20,6 +20,12 @@
 
 include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (
       awl STATIC
       aslider.cpp
@@ -40,19 +46,33 @@ add_library (
       knob.h midipanknob.h mslider.h panknob.h pitchedit.h pitchlabel.h
       poslabel.h slider.h utils.h volknob.h volslider.h
       )
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       awl
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      awl
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(awl all)
 
-ADD_DEPENDENCIES(awl mops1 mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( awl )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(awl mops1 mops2)
+endif (NOT MSVC)
 
 add_library (
       awlplugin SHARED
-      ${PROJECT_BINARY_DIR}/all.h
+      ${_all_h_file}
       awlplugin.cpp
       aslider.cpp
       knob.cpp
@@ -74,11 +94,20 @@ add_library (
 #
 # We cannot use our precompiled headers because of -fPIC
 #
-set_target_properties(awlplugin
+if (NOT MSVC)
+   set_target_properties(awlplugin
       PROPERTIES
       COMPILE_FLAGS
          "-fPIC -D_GNU_SOURCE -D_REENTRANT -DHAVE_CONFIG_H -DQT_PLUGIN -DQT_SHARED -DQT_NO_DEBUG -include ${PROJECT_SOURCE_DIR}/all.h"
       )
+else (NOT MSVC)
+   # x86 archictecture does not support position-independent code, the -fPIC option is not relevant for this processor.
+   set_target_properties (
+      awlplugin
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE} -D_GNU_SOURCE -D_REENTRANT -DHAVE_CONFIG_H -DQT_PLUGIN -DQT_SHARED -DQT_NO_DEBUG"
+      )
+endif (NOT MSVC)   
 
 # Don't install awlplugin on default
 #install( TARGETS awlplugin DESTINATION ${designerPlugins}/plugins/designer/ )

--- a/awl/aslider.cpp
+++ b/awl/aslider.cpp
@@ -302,7 +302,8 @@ QString AccessibleAbstractSlider::text(QAccessible::Text t) const
             default:
                   return QString();
             }
-      return QString();
+      // Eliminate "unreachable code" 
+      // return QString();
       }
 
 void AccessibleAbstractSlider::valueChanged(double, int)

--- a/awl/knob.cpp
+++ b/awl/knob.cpp
@@ -261,11 +261,11 @@ void Knob::paintEvent(QPaintEvent* /*ev*/)
       if (_center) {
             if (points)
                   delete points;
-            qreal x = ar.width() / 2 + ar.x();
-            qreal y = ar.y() - _markSize - _scaleWidth/2;
-            points = new QPainterPath(QPointF(x - markSize2, y));
-            points->lineTo(x + markSize2, y);
-            points->lineTo(x, _markSize + y);
+            qreal x3 = ar.width() / 2 + ar.x();
+            qreal y3 = ar.y() - _markSize - _scaleWidth/2;
+            points = new QPainterPath(QPointF(x3 - markSize2, y3));
+            points->lineTo(x3 + markSize2, y3);
+            points->lineTo(x3, _markSize + y3);
             points->closeSubpath();
             p.drawPath(*points);
             }

--- a/awl/mslider.cpp
+++ b/awl/mslider.cpp
@@ -188,24 +188,24 @@ void MeterSlider::paintEvent(QPaintEvent* ev)
       p.setPen(QPen(Qt::white, 2));
 
       for (int i = 0; i < _channel; ++i) {
-            int h = mh - (lrint(fast_log10(meterval[i]) * -20.0f * mh / range));
-            if (h < 0)
-                  h = 0;
-            else if (h > mh)
-                  h = mh;
+            int h1 = mh - (lrint(fast_log10(meterval[i]) * -20.0f * mh / range));
+            if (h1 < 0)
+                  h1 = 0;
+            else if (h1 > mh)
+                  h1 = mh;
 
-            p.drawPixmap(x, y1 + mh - h, mw, h,      onPm,  0, mh - h, mw, h);
-            p.drawPixmap(x, y1,          mw, mh - h, offPm, 0, 0,      mw, mh - h);
+            p.drawPixmap(x, y1 + mh - h1, mw, h1,      onPm,  0, mh - h1, mw, h1);
+            p.drawPixmap(x, y1,           mw, mh - h1, offPm, 0, 0,       mw, mh - h1);
 
             //---------------------------------------------------
             //    draw peak line
             //---------------------------------------------------
 
-            h = mh - (lrint(fast_log10(meterPeak[i]) * -20.0f * mh / range));
-            if (h > mh)
-                  h = mh;
-            if (h > 0)
-                p.drawLine(x, y3 - h, x + mw, y3 - h);
+            h1 = mh - (lrint(fast_log10(meterPeak[i]) * -20.0f * mh / range));
+            if (h1 > mh)
+                  h1 = mh;
+            if (h1 > 0)
+                p.drawLine(x, y3 - h1, x + mw, y3 - h1);
 
             x += mw;
             }

--- a/awl/slider.cpp
+++ b/awl/slider.cpp
@@ -101,8 +101,8 @@ void Slider::updateKnob()
     	int kw  = _sliderSize.width();
       points->moveTo(0.0, 0.0);
       if (orient == Qt::Vertical) {
-      	int kh  = _sliderSize.height();
-            int kh2  = kh / 2;
+      	   int kh1  = _sliderSize.height();
+            int kh2  = kh1 / 2;
             points->lineTo(kw, -kh2);
             points->lineTo(kw, kh2);
             }

--- a/build/CopyFilesMacros.cmake
+++ b/build/CopyFilesMacros.cmake
@@ -1,0 +1,45 @@
+# Code from: https://cmake.org/pipermail/cmake/2009-March/027892.html
+
+MACRO(COPY_FILE_IF_CHANGED in_file out_file target)
+    IF(${in_file} IS_NEWER_THAN ${out_file})    
+    #    message("COpying file: ${in_file} to: ${out_file}")
+    	ADD_CUSTOM_COMMAND (
+    		TARGET     ${target}
+    		POST_BUILD
+    		COMMAND    ${CMAKE_COMMAND}
+    		ARGS       -E copy ${in_file} ${out_file}
+    	)
+	ENDIF(${in_file} IS_NEWER_THAN ${out_file})
+ENDMACRO(COPY_FILE_IF_CHANGED)
+
+
+MACRO(COPY_FILE_INTO_DIRECTORY_IF_CHANGED in_file out_dir target)
+	GET_FILENAME_COMPONENT(file_name ${in_file} NAME)
+	COPY_FILE_IF_CHANGED(${in_file} ${out_dir}/${file_name}
+${target})	
+ENDMACRO(COPY_FILE_INTO_DIRECTORY_IF_CHANGED)
+
+
+#Copies all the files from in_file_list into the out_dir. 
+# sub-trees are ignored (files are stored in same out_dir)
+MACRO(COPY_FILES_INTO_DIRECTORY_IF_CHANGED in_file_list out_dir target)
+    FOREACH(in_file ${in_file_list})
+		COPY_FILE_INTO_DIRECTORY_IF_CHANGED(${in_file}
+${out_dir} ${target})
+	ENDFOREACH(in_file)	
+ENDMACRO(COPY_FILES_INTO_DIRECTORY_IF_CHANGED)
+
+
+#Copy all files and directories in in_dir to out_dir. 
+# Subtrees remain intact.
+MACRO(COPY_DIRECTORY_IF_CHANGED in_dir out_dir target)
+    #message("Copying directory ${in_dir}")
+    FILE(GLOB_RECURSE in_file_list ${in_dir}/*)
+	FOREACH(in_file ${in_file_list})
+	    if(NOT ${in_file} MATCHES ".*/CVS.*")
+    		STRING(REGEX REPLACE ${in_dir} ${out_dir} out_file
+${in_file})
+    		COPY_FILE_IF_CHANGED(${in_file} ${out_file} ${target})
+    	endif(NOT ${in_file} MATCHES ".*/CVS.*")
+	ENDFOREACH(in_file)	
+ENDMACRO(COPY_DIRECTORY_IF_CHANGED)

--- a/build/CreatePrecompiledHeader.cmake
+++ b/build/CreatePrecompiledHeader.cmake
@@ -29,20 +29,47 @@ macro( precompiled_header includes header_name build_pch)
         # Prepare the compile flags var for passing to GCC
         separate_arguments( compile_flags )
 
-        set (PCH_HEADER "${PROJECT_BINARY_DIR}/${header_name}.h")
-        set (PCH_INCLUDE "-include ${PCH_HEADER}")
+        if (NOT MSVC)
+            set (PCH_HEADER "${PROJECT_BINARY_DIR}/${header_name}.h")
+            set (PCH_INCLUDE "-include ${PCH_HEADER}")
+        else (NOT MSVC)
+            set (PCH_HEADERNAME "${header_name}")
+            set (PCH_HEADER "${PROJECT_SOURCE_DIR}/${header_name}.h")
+            set (PCH_INCLUDE "/FI${PCH_HEADER}")
+            set (PCH_CPP "${PROJECT_SOURCE_DIR}/${header_name}.cpp")
+        endif (NOT MSVC)
 
         if( ${build_pch} )
-            set (PCH ${PROJECT_BINARY_DIR}/${header_name}.h.gch)
-            add_custom_command(
-             OUTPUT ${PROJECT_BINARY_DIR}/${header_name}.h.gch
-             COMMAND ${CMAKE_CXX_COMPILER} -x c++-header -g  ${compile_flags} -o ${header_name}.h.gch ${header_name}.h
-             DEPENDS ${PROJECT_BINARY_DIR}/${header_name}.h
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             VERBATIM
-             )
+            if(NOT MSVC)
+               set (PCH ${PROJECT_BINARY_DIR}/${header_name}.h.gch)
+               add_custom_command(
+                  OUTPUT ${PROJECT_BINARY_DIR}/${header_name}.h.gch
+                  COMMAND ${CMAKE_CXX_COMPILER} -x c++-header -g  ${compile_flags} -o ${header_name}.h.gch ${header_name}.h
+                  DEPENDS ${PROJECT_BINARY_DIR}/${header_name}.h
+                  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+                  VERBATIM
+                  )
+            else (NOT MSVC)
+               SET (PCH "")
+               # For MSVC: instead of creating pre-compiled headers here, we just set variables, and create the PCH in another macro.
+               # NOTE: MSVC is picky about PCH: it is difficult to share them amongst different projects (almost impossible).
+               #       By default, if a PCH file was created by another project, it gets deleted before attempting compilation.
+               #       Best solution would be to create PCH-files per project (per subdir).list (REMOVE_DUPLICATES compile_flags)
+               # set (PCH ${PROJECT_BINARY_DIR}/${header_name}.pch)
+               
+               # set (PCH_FORCE_USE "/Fp${PCH} /Yu${PCH_HEADER}")
+               # set (PCH_FORCE_USE "")     # Temp -> do not use precompiled headers, not working right now!
+               #add_custom_command(
+               #   OUTPUT ${PROJECT_BINARY_DIR}/${header_name}.pch
+               #   COMMAND ${CMAKE_CXX_COMPILER} ${compile_flags} /c /Yc${header_name}.h /Fp${header_name}.pch ${header_name}.cpp
+               #   DEPENDS ${PROJECT_BINARY_DIR}/${header_name}.h ${PROJECT_BINARY_DIR}/${header_name}.cpp
+               #   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+               #   VERBATIM
+               #   )
+            endif (NOT MSVC)
         else ( ${build_pch} )
             message(STATUS "No precompiled header")
+            set (PCH_FORCE_USE "")
         endif( ${build_pch} )
     endif()
 endmacro()
@@ -59,4 +86,41 @@ macro( xcode_pch target_name header_name )
             XCODE_ATTRIBUTE_GCC_PRECOMPILE_PREFIX_HEADER "YES"
         )
     endif()
+endmacro()
+
+# VStudio PCH support. Has to be called *AFTER* the target is created.
+# "target_name" - the target for which PCH are being added
+# The header name needs not be specified, it must have been specified in the call to 
+#   the precompiled_header() macro (sets the variables PCH_HEADERNAME, PCH_HEADER, PCH_INCLUDE, PCH_CPP)
+#  [[ "header_name" - the name of the PCH header, without the extension; "all" or something similar;
+#                  note that *the source file compiling the header* needs to have the same name ]]
+macro( vstudio_pch target_name )
+    if( MSVC )
+        # Prepare paths and filenames
+        message(STATUS "Preparing pre-compiled headers for ${target_name}")
+        set(_pch_path "${CMAKE_CURRENT_BINARY_DIR}/${target_name}_pch")
+        make_directory("${_pch_path}")
+        set(_pch_file "${_pch_path}/${PCH_HEADERNAME}.pch")
+        set(_pch_force_use "/Fp${_pch_file} /Yu${PCH_HEADER}")
+
+        # Set precompiled-header option for all files in the project
+        get_target_property(_flgs ${target_name} COMPILE_FLAGS)
+        set(_flgs "${_flgs} ${_pch_force_use}")
+        set_target_properties( ${target_name}
+           PROPERTIES
+              COMPILE_FLAGS "${_flgs}"
+           )
+
+        # Add the pre-compiled headers cpp file to the source and set properties to force pch creation
+        target_sources(
+            ${target_name}
+            PUBLIC ${PCH_CPP}
+            )  
+        
+        set_source_files_properties(
+            ${PCH_CPP}
+            PROPERTIES
+               COMPILE_FLAGS "/Yc"
+            ) 
+    endif( MSVC )
 endmacro()

--- a/build/FindQt5.cmake
+++ b/build/FindQt5.cmake
@@ -18,13 +18,13 @@ set(_components
     LinguistTools
     Help
   )
-if (NOT MINGW)
+if (NOT MINGW AND NOT MSVC)
   set(_components
     ${_components}
     WebEngine
     WebEngineCore
     WebEngineWidgets)
-endif()
+endif(NOT MINGW AND NOT MSVC)
 foreach(_component ${_components})
   find_package(Qt5${_component})
   list(APPEND QT_LIBRARIES ${Qt5${_component}_LIBRARIES})

--- a/build/UsePkgConfig1.cmake
+++ b/build/UsePkgConfig1.cmake
@@ -9,7 +9,7 @@
 # if pkg-config was NOT found or the specified software package doesn't exist, the
 # variable will be empty when the function returns, otherwise they will contain the respective information
 #
-IF (NOT MINGW)
+IF (NOT MINGW AND NOT MSVC)
   FIND_PROGRAM(PKGCONFIG_EXECUTABLE NAMES pkg-config PATHS ${PATH} /usr/bin /usr/local/bin )
 
   MACRO(PKGCONFIG1 _package _minVersion _include_DIR _link_DIR _link_FLAGS _cflags)
@@ -43,5 +43,5 @@ IF (NOT MINGW)
   ENDMACRO(PKGCONFIG1 _include_DIR _link_DIR _link_FLAGS _cflags)
 
   MARK_AS_ADVANCED(PKGCONFIG_EXECUTABLE)
-ENDIF (NOT MINGW)
+ENDIF (NOT MINGW AND NOT MSVC)
 

--- a/build/gch.cmake
+++ b/build/gch.cmake
@@ -19,11 +19,13 @@
 #=============================================================================
 
 
-SET_SOURCE_FILES_PROPERTIES(
-   ${PCH}
-   ${PROJECT_BINARY_DIR}/all.h
-   PROPERTIES GENERATED 1
-   )
+if (NOT MSVC)
+   SET_SOURCE_FILES_PROPERTIES(
+      ${PCH}
+      ${PROJECT_BINARY_DIR}/all.h
+      PROPERTIES GENERATED 1
+      )
+endif (NOT MSVC)
 
 
 

--- a/bww2mxml/CMakeLists.txt
+++ b/bww2mxml/CMakeLists.txt
@@ -35,7 +35,15 @@ add_library(bww STATIC
    writer.cpp
    )
 
-if (NOT MINGW AND NOT APPLE)
+if (MSVC)
+   set_target_properties (
+      bww
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (MSVC)
+
+if (NOT MINGW AND NOT APPLE AND NOT MSVC)
    add_executable(bww2mxml
       ${INCS}
       lexer.cpp
@@ -57,10 +65,15 @@ if (NOT MINGW AND NOT APPLE)
       )
    ADD_DEPENDENCIES(bww2mxml mops1)
    ADD_DEPENDENCIES(bww2mxml mops2)
-endif (NOT MINGW AND NOT APPLE)
+endif (NOT MINGW AND NOT APPLE AND NOT MSVC)
 
 xcode_pch(bww all)
 
-ADD_DEPENDENCIES(bww mops1)
-ADD_DEPENDENCIES(bww mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( bww )
 
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(bww mops1)
+   ADD_DEPENDENCIES(bww mops2)
+endif (NOT MSVC)

--- a/bww2mxml/parser.cpp
+++ b/bww2mxml/parser.cpp
@@ -711,13 +711,13 @@ namespace Bww {
   {
     qDebug() << "Parser::parseGraces() value:" << qPrintable(lex.symValue());
 
-    const QString type = "32";
+    const QString c_type = "32";
     const int dots = 0;
     QStringList graces = lex.symValue().split(" ");
     for (int i = 0; i < graces.size(); ++i)
     {
       const QString beam = graceBeam(graces.size(), i);
-      NoteDescription noteDesc(graces.at(i), beam, type, dots, false, false, ST_NONE, true);
+      NoteDescription noteDesc(graces.at(i), beam, c_type, dots, false, false, ST_NONE, true);
       if (measures.isEmpty())
       {
         errorHandler("cannot append note: no measure");

--- a/effects/CMakeLists.txt
+++ b/effects/CMakeLists.txt
@@ -26,10 +26,16 @@ QT5_WRAP_UI (ui_headers
       compressor/compressor_gui.ui
       )
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (effects STATIC
       ${ui_headers}
       ${qrc_effects_files}
-      ${PROJECT_BINARY_DIR}/all.h
+      ${_all_h_file}
       ${PCH}
       effect.cpp
       effectgui.cpp
@@ -41,14 +47,29 @@ add_library (effects STATIC
       compressor/compressorgui.cpp
       ${INCS}
       )
-set_target_properties (
+
+if (NOT MSVC)
+   set_target_properties (
       effects
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      effects
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(effects all)
 
-ADD_DEPENDENCIES(effects mops1)
-ADD_DEPENDENCIES(effects mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( effects )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(effects mops1)
+   ADD_DEPENDENCIES(effects mops2)
+endif (NOT MSVC)   
 

--- a/effects/compressor/compressor.cpp
+++ b/effects/compressor/compressor.cpp
@@ -76,8 +76,8 @@ static inline float f_max(float x, float a)
 
 static inline void round_to_zero(volatile float *f)
       {
-      *f += 1e-18;
-      *f -= 1e-18;
+      *f += 1e-18f;
+      *f -= 1e-18f;
       }
 
 // Linearly interpolate [ = a * (1 - f) + b * f]

--- a/effects/zita1/zita.cpp
+++ b/effects/zita1/zita.cpp
@@ -29,7 +29,7 @@ enum {
       };
 
 static const std::vector<ParDescr> pd = {
-      { R_DELAY, "delay", false,  0.02,        0.100,          0.04  },
+      { R_DELAY, "delay", false,  0.02f,       0.100f,       0.04f },
       { R_XOVER, "xover", true,   logf(50.0),  logf(1000.0), 200.0 },
       { R_RTLOW, "rtlow", true,   logf(1.0),   logf(8.0),    3.0   },
       { R_RTMID, "rtmid", true,   logf(1.0),   logf(8.0),    2.0   },

--- a/effects/zita1/zitagui.cpp
+++ b/effects/zita1/zitagui.cpp
@@ -67,8 +67,8 @@ ZitaEffectGui::ZitaEffectGui(ZitaReverb* effect, QWidget* parent)
 
 void ZitaEffectGui::updateValues()
       {
-      for (Rotary& r : rotary) {
-            r.value = effect()->value(r.id);
+      for (Rotary& rot : rotary) {
+            rot.value = effect()->value(rot.id);
             }
       update();
       }
@@ -135,10 +135,10 @@ void ZitaEffectGui::paintEvent(QPaintEvent*)
             x += pix.width();
             }
       p.setBrush(QColor(0x3f, 0x3f, 0x3f));
-      for (const Rotary& r : rotary) {
+      for (const Rotary& rot : rotary) {
             p.save();
-            p.translate(r.x + 11.5, r.y + 11.5);
-            p.rotate(r.value * 270.0 - 225);
+            p.translate(rot.x + 11.5, rot.y + 11.5);
+            p.rotate(rot.value * 270.0 - 225);
             p.drawRect(QRectF(-2, -2, 11.5 + 2, 4));
             p.restore();
             }

--- a/fluid/CMakeLists.txt
+++ b/fluid/CMakeLists.txt
@@ -32,8 +32,14 @@ endif (SOUNDFONT3)
 
 QT5_WRAP_UI (fluidUi fluid_gui.ui)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (fluid STATIC
-      ${PROJECT_BINARY_DIR}/all.h
+      ${_all_h_file}
       ${PCH}
       ${fluidUi}
       fluidgui.cpp
@@ -42,14 +48,28 @@ add_library (fluid STATIC
       ${SF3_SRC}
       ${INCS}
       )
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       fluid
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      fluid
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(fluid all)
 
-ADD_DEPENDENCIES(fluid mops1)
-ADD_DEPENDENCIES(fluid mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( fluid )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(fluid mops1)
+   ADD_DEPENDENCIES(fluid mops2)
+endif (NOT MSVC)   
 

--- a/fluid/fluid.cpp
+++ b/fluid/fluid.cpp
@@ -148,7 +148,7 @@ void Fluid::play(const PlayEvent& event)
                   //
                   // process note off
                   //
-                  foreach (Voice* v, activeVoices) {
+                  for (Voice* v : activeVoices) {
                         if (v->ON() && (v->chan == ch) && (v->key == key))
                               v->noteoff();
                         }
@@ -168,7 +168,7 @@ void Fluid::play(const PlayEvent& event)
                    * several voice processes, for example a stereo sample.  Don't
                    * release those...
                    */
-                  foreach(Voice* v, activeVoices) {
+                  for(Voice* v : activeVoices) {
                         if (v->isPlaying() && (v->chan == ch) && (v->key == key) && (v->get_id() != noteid))
                               v->noteoff();
                         }
@@ -204,7 +204,7 @@ void Fluid::play(const PlayEvent& event)
 
 void Fluid::damp_voices(int chan)
       {
-      foreach(Voice* v, activeVoices) {
+      for(Voice* v : activeVoices) {
             if ((v->chan == chan) && v->SUSTAINED())
                   v->noteoff();
             }
@@ -216,7 +216,7 @@ void Fluid::damp_voices(int chan)
 
 void Fluid::allNotesOff(int chan)
       {
-      foreach(Voice* v, activeVoices) {
+      for(Voice* v : activeVoices) {
             if (chan == -1 || v->chan == chan)
                   v->noteoff();
             }
@@ -230,7 +230,7 @@ void Fluid::allNotesOff(int chan)
 
 void Fluid::allSoundsOff(int chan)
       {
-      foreach(Voice* v, activeVoices) {
+      for(Voice* v : activeVoices) {
             if (chan == -1 || v->chan == chan)
                   v->off();
             }
@@ -245,9 +245,9 @@ void Fluid::allSoundsOff(int chan)
 
 void Fluid::system_reset()
       {
-      foreach(Voice* v, activeVoices)
+      for(Voice* v : activeVoices)
             v->off();
-      foreach(Channel* c, channel)
+      for(Channel* c : channel)
             c->reset();
       }
 
@@ -259,7 +259,7 @@ void Fluid::system_reset()
  */
 void Fluid::modulate_voices(int chan, bool is_cc, int ctrl)
       {
-      foreach(Voice* v, activeVoices) {
+      for(Voice* v : activeVoices) {
             if (v->chan == chan)
                   v->modulate(is_cc, ctrl);
             }
@@ -274,7 +274,7 @@ void Fluid::modulate_voices(int chan, bool is_cc, int ctrl)
  */
 void Fluid::modulate_voices_all(int chan)
       {
-      foreach(Voice* v, activeVoices) {
+      for(Voice* v : activeVoices) {
             if (v->chan == chan)
                   v->modulate_all();
             }
@@ -344,18 +344,18 @@ void Fluid::program_change(int chan, int prognum)
                   preset = find_preset(0, 0);
             }
 
-      unsigned sfont_id = preset? preset->sfont->id() : 0;
-      c->setSfontnum(sfont_id);
+      unsigned sfont_idl = preset? preset->sfont->id() : 0;
+      c->setSfontnum(sfont_idl);
       c->setPreset(preset);
       }
 
 /*
  * fluid_synth_get_program
  */
-void Fluid::get_program(int chan, unsigned* sfont_id, unsigned* bank_num, unsigned* preset_num)
+void Fluid::get_program(int chan, unsigned* sfont_idl, unsigned* bank_num, unsigned* preset_num)
       {
       Channel* c       = channel[chan];
-      *sfont_id        = c->getSfontnum();
+      *sfont_idl       = c->getSfontnum();
       *bank_num        = c->getBanknum();
       *preset_num      = c->getPrognum();
       }
@@ -364,17 +364,17 @@ void Fluid::get_program(int chan, unsigned* sfont_id, unsigned* bank_num, unsign
 //   program_select
 //---------------------------------------------------------
 
-bool Fluid::program_select(int chan, unsigned sfont_id, unsigned bank_num, unsigned preset_num)
+bool Fluid::program_select(int chan, unsigned sfont_idl, unsigned bank_num, unsigned preset_num)
       {
       Channel* c     = channel[chan];
-      Preset* preset = get_preset(sfont_id, bank_num, preset_num);
+      Preset* preset = get_preset(sfont_idl, bank_num, preset_num);
       if (preset == 0) {
-            qDebug("There is no preset with bank number %d and preset number %d in SoundFont %d", bank_num, preset_num, sfont_id);
+            qDebug("There is no preset with bank number %d and preset number %d in SoundFont %d", bank_num, preset_num, sfont_idl);
             return false;
             }
 
       /* inform the channel of the new bank and program number */
-      c->setSfontnum(sfont_id);
+      c->setSfontnum(sfont_idl);
       c->setBanknum(bank_num);
       c->setPrognum(preset_num);
       c->setPreset(preset);
@@ -398,7 +398,7 @@ void Fluid::update_presets()
 void Fluid::process(unsigned len, float* out, float* effect1, float* effect2)
       {
       if (mutex.tryLock()) {
-            foreach (Voice* v, activeVoices)
+            for (Voice* v : activeVoices)
                   v->write(len, out, effect1, effect2);
             mutex.unlock();
             }
@@ -417,7 +417,7 @@ void Fluid::free_voice_by_kill()
       float this_voice_prio;
       Voice* best_voice = 0;
 
-      foreach(Voice* v, activeVoices) {
+      for(Voice* v : activeVoices) {
             /* Determine, how 'important' a voice is.
              * Start with an arbitrary number */
             this_voice_prio = 10000.;
@@ -533,7 +533,7 @@ void Fluid::start_voice(Voice* voice)
 
             /* Kill all notes on the same channel with the same exclusive class */
 
-            foreach(Voice* existing_voice, activeVoices) {
+            for(Voice* existing_voice : activeVoices) {
                   /* Existing voice does not play? Leave it alone. */
                   if (!existing_voice->isPlaying())
                         continue;
@@ -596,7 +596,7 @@ void Fluid::updatePatchList()
 QStringList Fluid::soundFonts() const
       {
       QStringList sf;
-      foreach (SFont* f, sfonts)
+      for (SFont* f : sfonts)
             sf.append(QFileInfo(f->get_name()).fileName());
       return sf;
       }
@@ -614,11 +614,11 @@ bool Fluid::loadSoundFonts(const QStringList& sl)
             return true;
             }
       QMutexLocker locker(&mutex);
-      foreach(Voice* v, activeVoices)
+      for(Voice* v : activeVoices)
             v->off();
-      foreach(Channel* c, channel)
+      for(Channel* c : channel)
             c->reset();
-      foreach (SFont* sf, sfonts)
+      for (SFont* sf : sfonts)
             sfunload(sf->id());
       locker.unlock();
       bool ok = true;
@@ -633,7 +633,7 @@ bool Fluid::loadSoundFonts(const QStringList& sl)
             QString path;
             QFileInfo fis(s);
             QString fileName = fis.fileName();
-            foreach (const QFileInfo& fi, l) {
+            for (const QFileInfo& fi : l) {
                   if (fi.fileName() == fileName) {
                         path = fi.absoluteFilePath();
                         break;
@@ -675,7 +675,7 @@ bool Fluid::addSoundFont(const QString& s)
 bool Fluid::removeSoundFont(const QString& s)
       {
       QMutexLocker locker(&mutex);
-      foreach(Voice* v, activeVoices)
+      for(Voice* v : activeVoices)
             v->off();
       SFont* sf = get_sfont_by_name(s);
       sfunload(sf->id());
@@ -742,7 +742,7 @@ bool Fluid::sfunload(int id)
 
 SFont* Fluid::get_sfont_by_id(int id)
       {
-      foreach(SFont* sf, sfonts) {
+      for(SFont* sf : sfonts) {
             if (sf->id() == id)
                   return sf;
             }
@@ -755,7 +755,7 @@ SFont* Fluid::get_sfont_by_id(int id)
 
 SFont* Fluid::get_sfont_by_name(const QString& name)
       {
-      foreach(SFont* sf, sfonts) {
+      for(SFont* sf : sfonts) {
             if (QFileInfo(sf->get_name()).fileName() == name)
                   return sf;
             }
@@ -770,7 +770,7 @@ SFont* Fluid::get_sfont_by_name(const QString& name)
 
 void Fluid::set_interp_method(int chan, int interp_method)
       {
-      foreach(Channel* c, channel) {
+      for(Channel* c : channel) {
             if (chan < 0 || c->getNum() == chan)
                   c->setInterpMethod(interp_method);
             }
@@ -783,7 +783,7 @@ void Fluid::set_interp_method(int chan, int interp_method)
 void Fluid::set_gen(int chan, int param, float value)
       {
       channel[chan]->setGen(param, value, 0);
-      foreach(Voice* v, activeVoices) {
+      for(Voice* v : activeVoices) {
             if (v->chan == chan)
                   v->set_param(param, value, 0);
             }
@@ -817,7 +817,7 @@ void Fluid::set_gen2(int chan, int param, float value, int absolute, int normali
       float v = (normalized)? fluid_gen_scale(param, value) : value;
       channel[chan]->setGen(param, v, absolute);
 
-      foreach(Voice* vo, activeVoices) {
+      for(Voice* vo : activeVoices) {
             if (vo->chan == chan)
                   vo->set_param(param, v, absolute);
             }
@@ -842,7 +842,7 @@ SynthesizerGroup Fluid::state() const
       g.setName(name());
 
       QStringList sfl = soundFonts();
-      foreach (QString sf, sfl)
+      for (QString sf : sfl)
             g.push_back(IdValue(0, sf));
 
       return g;
@@ -871,7 +871,7 @@ bool Fluid::setState(const SynthesizerGroup& sp)
 static void collectFiles(QFileInfoList* l, const QString& path)
       {
       QDir dir(path);
-      foreach (const QFileInfo& s, dir.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot)) {
+      for (const QFileInfo& s : dir.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot)) {
             if (path == s.absoluteFilePath())
                   return;
 
@@ -896,7 +896,7 @@ QFileInfoList Fluid::sfFiles()
       QStringList pl = preferences.getString(PREF_APP_PATHS_MYSOUNDFONTS).split(";");
       pl.prepend(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("sound")).absoluteFilePath());
 
-      foreach (const QString& s, pl) {
+      for (const QString& s : pl) {
             QString ss(s);
             if (!s.isEmpty() && s[0] == '~')
                   ss = QDir::homePath() + s.mid(1);

--- a/fluid/mod.cpp
+++ b/fluid/mod.cpp
@@ -322,19 +322,19 @@ void Mod::dump() const
       {
       const Mod* mod = this;
 
-      int src1     = mod->src1;
-      int dest     = mod->dest;
-      int src2     = mod->src2;
-      int flags1   = mod->flags1;
-      int flags2   = mod->flags2;
-      float amount = (float)mod->amount;
+      int lsrc1     = mod->src1;
+      int ldest     = mod->dest;
+      int lsrc2     = mod->src2;
+      int lflags1   = mod->flags1;
+      int lflags2   = mod->flags2;
+      float lamount = (float)mod->amount;
 
       printf("Src: ");
       if (flags1 & FLUID_MOD_CC){
-            printf("MIDI CC=%i",src1);
+            printf("MIDI CC=%i",lsrc1);
             }
       else {
-            switch(src1){
+            switch(lsrc1){
                   case FLUID_MOD_NONE:
                         printf("None");
                         break;
@@ -357,19 +357,19 @@ void Mod::dump() const
                         printf("Pitch Wheel sens");
                         break;
                   default:
-                        printf("(unknown: %i)", src1);
+                        printf("(unknown: %i)", lsrc1);
                   } /* switch src1 */
             }; /* if not CC */
-      if (flags1 & FLUID_MOD_NEGATIVE)
+      if (lflags1 & FLUID_MOD_NEGATIVE)
             printf("- ");
       else
             {printf("+ ");};
-      if (flags1 & FLUID_MOD_BIPOLAR)
+      if (lflags1 & FLUID_MOD_BIPOLAR)
             printf("bip ");
       else
             printf("unip ");
       printf("-> ");
-      switch(dest){
+      switch(ldest){
             case GEN_FILTERQ:
                   printf("Q");
                   break;
@@ -398,10 +398,10 @@ void Mod::dump() const
                   printf("att");
                   break;
             default:
-                  printf("dest %i", dest);
+                  printf("dest %i", ldest);
                   break;
             } /* switch dest */
-      printf(", amount %f flags %i src2 %i flags2 %i\n",amount, flags1, src2, flags2);
+      printf(", amount %f flags %i src2 %i flags2 %i\n",lamount, lflags1, lsrc2, lflags2);
       }
 
 }

--- a/fluid/sfont.cpp
+++ b/fluid/sfont.cpp
@@ -57,14 +57,14 @@ SFont::SFont(Fluid* f)
 
 SFont::~SFont()
       {
-      foreach(Sample* s, sample)
+      for(Sample* s : sample)
             delete s;
-      foreach(Preset* p, presets)
+      for(Preset* p : presets)
             delete p;
-      foreach(unsigned char* p, infos)
+      for(unsigned char* p : infos)
             delete[] p;
-      foreach(Instrument* i, instruments) {
-//            foreach(Zone* z, i->zones)
+      for(Instrument* i : instruments) {
+//            for(Zone* z : i->zones)
 //                  delete z;
             delete i;
             }
@@ -80,12 +80,12 @@ bool SFont::read(const QString& s)
       if (!load())
             return false;
 
-      foreach(Instrument* i, instruments) {
+      for(Instrument* i : instruments) {
             if (!i->import_sfont())
                   return false;
             }
 
-      foreach(Preset* p, presets) {
+      for(Preset* p : presets) {
             if (!p->importSfont())
                   return false;
             }
@@ -125,7 +125,7 @@ Preset::Preset(SFont* s)
 Preset::~Preset()
       {
       delete _global_zone;
-      foreach(Zone* z, zones)
+      for(Zone* z : zones)
             delete z;
       }
 
@@ -142,15 +142,15 @@ void Preset::loadSamples()
             Instrument* i = _global_zone->instrument;
             if (i->global_zone && i->global_zone->sample)
                   i->global_zone->sample->load();
-            foreach(Zone* iz, i->zones)
+            for(Zone* iz : i->zones)
                   iz->sample->load();
             }
 
-      foreach(Zone* z, zones) {
+      for(Zone* z : zones) {
             Instrument* i = z->instrument;
             if (i->global_zone && i->global_zone->sample)
                   i->global_zone->sample->load();
-            foreach(Zone* iz, i->zones)
+            for(Zone* iz : i->zones)
                   iz->sample->load();
             }
       if (locked)
@@ -169,7 +169,7 @@ bool Preset::noteon(Fluid* synth, unsigned id, int chan, int key, int vel, doubl
       Zone* global_preset_zone = global_zone();
 
       /* run thru all the zones of this preset */
-      foreach (Zone* preset_zone, zones) {
+      for (Zone* preset_zone : zones) {
             /* check if the note falls into the key and velocity range of this
                preset */
             if (preset_zone->inside_range(key, vel)) {
@@ -178,7 +178,7 @@ bool Preset::noteon(Fluid* synth, unsigned id, int chan, int key, int vel, doubl
                   Zone* global_inst_zone = inst->get_global_zone();
 
                   /* run thru all the zones of this instrument */
-                  foreach(Zone* inst_zone, inst->get_zone()) {
+                  for(Zone* inst_zone : inst->get_zone()) {
                         /* make sure this instrument zone has a valid sample */
                         Sample* sample = inst_zone->get_sample();
                         if (sample == 0 || sample->inRom())
@@ -221,28 +221,28 @@ bool Preset::noteon(Fluid* synth, unsigned id, int chan, int key, int vel, doubl
                               int mod_list_count = 0;
 
                               if (global_inst_zone){
-                                    foreach(Mod* mod, global_inst_zone->modlist)
-                                          mod_list[mod_list_count++] = mod;
+                                    for(Mod* mod1 : global_inst_zone->modlist)
+                                          mod_list[mod_list_count++] = mod1;
                                     }
 
                               /* local instrument zone, modulators.
                                * Replace modulators with the same definition in the list:
                                * SF 2.01 page 69, 'bullet' 8
                                */
-                              foreach(Mod* mod, inst_zone->modlist) {
+                              for(Mod* mod1 : inst_zone->modlist) {
 	                              /* 'Identical' modulators will be deleted by setting their
 	                               *  list entry to 0.  The list length is known, 0
 	                               *  entries will be ignored later.  SF2.01 section 9.5.1
                                      *  page 69, 'bullet' 3 defines 'identical'.  */
 
                                     for (int i = 0; i < mod_list_count; i++){
-                                          if (mod_list[i] && test_identity(mod, mod_list[i])){
+                                          if (mod_list[i] && test_identity(mod1, mod_list[i])){
                                                 mod_list[i] = 0;
 	                                          }
 	                                    }
 
                                     /* Finally add the new modulator to to the list. */
-                                    mod_list[mod_list_count++] = mod;
+                                    mod_list[mod_list_count++] = mod1;
                                     }
 
                               /* Add instrument modulators (global / local) to the voice. */
@@ -298,21 +298,21 @@ bool Preset::noteon(Fluid* synth, unsigned id, int chan, int key, int vel, doubl
                                * list. */
                               mod_list_count = 0;
                               if (global_preset_zone){
-                                    foreach(Mod* mod, global_preset_zone->modlist)
-                                          mod_list[mod_list_count++] = mod;
+                                    for(Mod* mod1 : global_preset_zone->modlist)
+                                          mod_list[mod_list_count++] = mod1;
                                     }
 
                               /* Process the modulators of the local preset zone.  Kick
                                * out all identical modulators from the global preset zone
                                * (SF 2.01 page 69, second-last bullet) */
 
-                              foreach(Mod* mod, preset_zone->modlist) {
+                              for(Mod* mod1 : preset_zone->modlist) {
                                     for (int i = 0; i < mod_list_count; i++) {
-                                          if (mod_list[i] && test_identity(mod,mod_list[i]))
+                                          if (mod_list[i] && test_identity(mod1,mod_list[i]))
                                                 mod_list[i] = 0;
                                           }
                                     /* Finally add the new modulator to the list. */
-                                    mod_list[mod_list_count++] = mod;
+                                    mod_list[mod_list_count++] = mod1;
                                     }
 
                               /* Add preset modulators (global / local) to the voice. */
@@ -352,7 +352,7 @@ bool Preset::importSfont()
             name = QString("Bank%1,Preset%2").arg(bank).arg(num);
 
       int idx = 0;
-      foreach(Zone* zone, zones) {
+      for(Zone* zone : zones) {
             // zone->name = QString("%1/%2").arg(name).arg(idx);
             if (!zone->importZone())
                   return false;
@@ -370,7 +370,7 @@ bool Preset::importSfont()
 bool Instrument::import_sfont()
       {
       int idx = 0;
-      foreach(Zone* zone, zones) {
+      for(Zone* zone : zones) {
             if (!zone->importZone())
                   return false;
             if ((idx == 0) && (zone->get_sample() == 0))
@@ -404,11 +404,11 @@ Zone::Zone()
 
 Zone::~Zone()
       {
-      foreach(Mod* m, modlist)
+      for(Mod* m : modlist)
             delete m;
-      foreach(SFGen* p, gen)
+      for(SFGen* p : gen)
             delete p;
-      foreach(SFMod* p, mod)
+      for(SFMod* p : mod)
             delete p;
       }
 
@@ -433,7 +433,7 @@ Instrument::Instrument()
 Instrument::~Instrument()
       {
       delete global_zone;
-      foreach(Zone* z, zones)
+      for(Zone* z : zones)
             delete z;
       }
 
@@ -443,7 +443,7 @@ Instrument::~Instrument()
 
 bool Zone::importZone()
       {
-      foreach (SFGen* sfgen, gen) {
+      for (SFGen* sfgen : gen) {
             switch (sfgen->id) {
                   case GEN_KEYRANGE:
                         keylo = sfgen->amount.range.lo;
@@ -463,7 +463,7 @@ bool Zone::importZone()
             }
 
       // Import the modulators (only SF2.1 and higher)
-      foreach(SFMod* mod_src, mod) {
+      for(SFMod* mod_src : mod) {
             Mod* mod_dest = new Mod;
             int type;
             // mod_dest->next = 0; /* pointer to next modulator, this is the end of the list now.*/
@@ -1035,7 +1035,7 @@ void SFont::load_pbag (int size)
       if (size % SFBAGSIZE || size == 0)	/* size is multiple of SFBAGSIZE? */
             throw(QString("Preset bag chunk size is invalid"));
 
-      foreach(Preset* p, presets) {
+      for(Preset* p : presets) {
             for (int i = 0; i < p->zones.size(); ++i) {
 	            if ((size -= SFBAGSIZE) < 0)
 	                  throw(QString("1:Preset bag chunk size mismatch"));
@@ -1095,8 +1095,8 @@ void SFont::load_pbag (int size)
 
 void SFont::load_pmod (int size)
       {
-      foreach (Preset* p, presets) {
-            foreach(Zone* p2, p->zones) {
+      for (Preset* p : presets) {
+            for(Zone* p2 : p->zones) {
                   for (int i = 0; i < p2->mod.size(); ++i) {
 	                  if ((size -= SFMODSIZE) < 0)
 		                  throw(QString("Preset modulator chunk size mismatch"));
@@ -1168,7 +1168,7 @@ static int gen_validp (int gen)
 
 static SFGen* gen_inlist (int gen, const QList<SFGen*>& genlist)
       {
-      foreach(SFGen* p, genlist) {
+      for(SFGen* p : genlist) {
             if (p == 0)
                   break;
             if (gen == p->id)
@@ -1199,7 +1199,7 @@ static void sfont_zone_delete (QList<Zone*>* l, Zone * zone)
 
 void SFont::load_pgen (int size)
       {
-      foreach(Preset* p, presets) {
+      for(Preset* p : presets) {
             bool gzone          = false;
             bool discarded      = false;
 
@@ -1216,7 +1216,8 @@ void SFont::load_pgen (int size)
 		                  throw(QString("1:Preset generator chunk size mismatch"));
 
 	                  unsigned short genid = READW();
-                        SFGenAmount genval;
+                     SFGenAmount    genval;
+                     genval.uword = 0;          // Initialize to prevent "potentially uninitialized local variable" warning in VS.
 	                  if (genid == Gen_KeyRange) {  /* nothing precedes */
 		                  if (level == 0) {
 		                        level = 1;
@@ -1369,7 +1370,7 @@ void SFont::load_ibag(int size)
       if (size % SFBAGSIZE || size == 0)	/* size is multiple of SFBAGSIZE? */
             throw(QString("Instrumentrument bag chunk size is invalid"));
 
-      foreach(Instrument* in, instruments) {
+      for(Instrument* in : instruments) {
             int n = in->zones.size();
             for (int i = 0; i < n; ++i) {
 	            if ((size -= SFBAGSIZE) < 0) {
@@ -1427,8 +1428,8 @@ void SFont::load_ibag(int size)
 /* instrument modulator loader */
 void SFont::load_imod(int size)
       {
-      foreach(Instrument* i, instruments) {
-            foreach(Zone* p2, i->zones) {
+      for(Instrument* i : instruments) {
+            for(Zone* p2 : i->zones) {
                   for (int k = 0; k < p2->mod.size(); ++k) {
                         if ((size -= SFMODSIZE) < 0)
                               throw(QString("Instrumentrument modulator chunk size mismatch"));
@@ -1462,7 +1463,7 @@ void SFont::load_imod(int size)
 
 void SFont::load_igen (int size)
       {
-      foreach(Instrument* instr, instruments) {
+      for(Instrument* instr : instruments) {
             bool gzone     = false;
             bool discarded = false;
 
@@ -1478,6 +1479,7 @@ void SFont::load_igen (int size)
                         SFGen* dup = 0;
                         bool skip = false;
                         bool drop = false;
+                        genval.uword = 0;          // Initialize to prevent "potentially uninitialized local variable" warning in VS.
                         if ((size -= SFGENSIZE) < 0)
                               throw(QString("IGEN chunk size mismatch"));
 
@@ -1651,8 +1653,8 @@ void SFont::load_shdr (int size)
 
 void SFont::fixup_pgen()
       {
-      foreach(Preset* p, presets) {
-            foreach(Zone* z, p->zones) {
+      for(Preset* p : presets) {
+            for(Zone* z : p->zones) {
                   if (z->instIdx) {        // load instrument #
                         z->instrument = instruments[z->instIdx-1];
                         if (!z->instrument)
@@ -1665,8 +1667,8 @@ void SFont::fixup_pgen()
 /* "fixup" (sample # -> sample ptr) sample references in instrument list */
 void SFont::fixup_igen()
       {
-      foreach(Instrument* p, instruments) {
-            foreach(Zone* z, p->zones) {
+      for(Instrument* p : instruments) {
+            for(Zone* z : p->zones) {
                   if (z->sampIdx) {
                         z->sample = sample[z->sampIdx - 1];
                         if (!z->sample)

--- a/fluid/voice.cpp
+++ b/fluid/voice.cpp
@@ -41,7 +41,7 @@ namespace FluidS {
  * 16 bits => 96+4=100 dB dynamic range => 0.00001
  * 0.00001 * 2 is approximately 0.00003 :)
  */
-#define FLUID_NOISE_FLOOR 0.00003
+#define FLUID_NOISE_FLOOR 0.00003f
 
 /* these should be the absolute minimum that FluidSynth can deal with */
 #define FLUID_MIN_LOOP_SIZE 2
@@ -925,7 +925,7 @@ void Voice::update_param(int _gen)
       float y;
       unsigned int count;
       // Alternate attenuation scale used by EMU10K1 cards when setting the attenuation at the preset or instrument level within the SoundFont bank.
-      static const float ALT_ATTENUATION_SCALE = 0.4;
+      static const float ALT_ATTENUATION_SCALE = 0.4f;
 
       double gain = 1.0 / 32768.0f;
       switch (_gen) {

--- a/fluid/voice.cpp
+++ b/fluid/voice.cpp
@@ -1444,8 +1444,8 @@ void Voice::noteoff()
                   */
                   if (volenv_val > 0) {
                         float lfo = modlfo_val * -modlfo_to_vol;
-                        float amp = volenv_val * pow (10.0, lfo / -200);
-                        float env_value = - ((-200 * log (amp) / log (10.0) - lfo) / 960.0 - 1);
+                        float ampl = volenv_val * pow (10.0, lfo / -200);
+                        float env_value = - ((-200 * log (ampl) / log (10.0) - lfo) / 960.0 - 1);
                         fluid_clip (env_value, 0.0, 1.0);
                         volenv_val = env_value;
                         }

--- a/fonttools/CMakeLists.txt
+++ b/fonttools/CMakeLists.txt
@@ -19,5 +19,14 @@ add_executable(
       )
 
 target_link_libraries(genft ${QT_LIBRARIES} -lfreetype)
-set_target_properties(genft PROPERTIES COMPILE_FLAGS "-I/usr/include/freetype2 -g -Wall -Wextra -Winvalid-pch")
+
+if (NOT MSVC)
+   set_target_properties(genft PROPERTIES COMPILE_FLAGS "-I/usr/include/freetype2 -g -Wall -Wextra -Winvalid-pch")
+else (NOT MSVC)
+   set_target_properties (
+      genft
+      PROPERTIES
+         COMPILE_FLAGS ""     # Might be enough, have to check if a forced directory or forced include is needed.
+      )
+endif (NOT MSVC)   
 

--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -15,13 +15,16 @@
       set (LIB_SCRIPT_FILES plugins.cpp)
 #endif (SCRIPT_INTERFACE)
 
-add_custom_command(
-   OUTPUT ${PROJECT_BINARY_DIR}/all.h
-   COMMAND ${CMAKE_COMMAND}
-   ARGS -E copy ${PROJECT_SOURCE_DIR}/all.h ${PROJECT_BINARY_DIR}/all.h
-   DEPENDS ${PROJECT_SOURCE_DIR}/all.h
-   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-   )
+# MSVC does not depend on copying all.h to the binary directory
+if (NOT MSVC)
+   add_custom_command(
+      OUTPUT ${PROJECT_BINARY_DIR}/all.h
+      COMMAND ${CMAKE_COMMAND}
+      ARGS -E copy ${PROJECT_SOURCE_DIR}/all.h ${PROJECT_BINARY_DIR}/all.h
+      DEPENDS ${PROJECT_SOURCE_DIR}/all.h
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+      )
+endif (NOT MSVC)
 
 if (APPLE)
         file(GLOB_RECURSE INCS "*.h")
@@ -29,9 +32,15 @@ else (APPLE)
         set(INCS "")
 endif (APPLE)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (
       libmscore STATIC
-      ${PROJECT_BINARY_DIR}/all.h
+      ${_all_h_file}
       ${INCS}
       ${LIB_SCRIPT_FILES}
       types.h
@@ -79,23 +88,37 @@ add_library (
 ##
 
 set(COVERAGE_OPTIONS "")
-if (NOT APPLE AND NOT MINGW AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
+if (NOT APPLE AND NOT MINGW AND NOT MSVC AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
    if (COVERAGE)
       set(COVERAGE_OPTIONS "-O0 --coverage")
       set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)
       target_link_libraries(libmscore gcov)
    endif (COVERAGE)
-endif (NOT APPLE AND NOT MINGW AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
+endif (NOT APPLE AND NOT MINGW AND NOT MSVC AND CMAKE_BUILD_TYPE MATCHES "DEBUG")
 
 
 
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       libmscore
       PROPERTIES
          COMPILE_FLAGS "-g ${PCH_INCLUDE} -Wall -Wextra -Winvalid-pch -Woverloaded-virtual ${COVERAGE_OPTIONS}"
       )
+else (NOT MSVC)
+   set_target_properties (
+      libmscore
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(libmscore all)
 
-ADD_DEPENDENCIES(libmscore mops1)
-ADD_DEPENDENCIES(libmscore mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( libmscore )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(libmscore mops1)
+   ADD_DEPENDENCIES(libmscore mops2)
+endif (NOT MSVC)   

--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -302,8 +302,8 @@ void Accidental::layout()
       if (_bracket != AccidentalBracket::NONE) {
             SymId id = _bracket == AccidentalBracket::PARENTHESIS ? SymId::accidentalParensRight : SymId::accidentalBracketRight;
             x = r.x()+r.width();
-            SymElement e(id, x);
-            el.append(e);
+            SymElement e1(id, x);
+            el.append(e1);
             r |= symBbox(id).translated(x, 0.0);
             }
       setbbox(r);

--- a/libmscore/ambitus.cpp
+++ b/libmscore/ambitus.cpp
@@ -564,7 +564,8 @@ void Ambitus::updateRange()
       int   lastTrack   = firstTrack + VOICES-1;
       int   pitchTop    = -1000;
       int   pitchBottom = 1000;
-      int   tpcTop, tpcBottom;
+      int   tpcTop      = 0;  // Initialized to prevent warning
+      int   tpcBottom   = 0;  // Initialized to prevent warning
       int   trk;
       Measure* meas     = segment()->measure();
       Segment* segm     = meas->findSegment(SegmentType::ChordRest, segment()->tick());

--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -54,8 +54,8 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType)
                               }
                         }
                   else if (segmentType == SegmentType::BeginBarLine) {
-                        Segment* segment = m->undoGetSegmentR(SegmentType::BeginBarLine, 0);
-                        for (Element* e : segment->elist()) {
+                        Segment* segment1 = m->undoGetSegmentR(SegmentType::BeginBarLine, 0);
+                        for (Element* e : segment1->elist()) {
                               if (e) {
                                     e->score()->undo(new ChangeProperty(e, Pid::BARLINE_TYPE, QVariant::fromValue(barType), PropertyFlags::NOSTYLE));
                                     e->score()->undo(new ChangeProperty(e, Pid::GENERATED, false, PropertyFlags::NOSTYLE));
@@ -64,7 +64,7 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType)
                                     auto score = bl->score();
                                     BarLine* newBl = new BarLine(score);
                                     newBl->setBarLineType(barType);
-                                    newBl->setParent(segment);
+                                    newBl->setParent(segment1);
                                     newBl->setTrack(0);
                                     newBl->setSpanStaff(score->nstaves());
                                     newBl->score()->undo(new AddElement(newBl));
@@ -320,20 +320,20 @@ void BarLine::drawDots(QPainter* painter, qreal x) const
       {
       qreal _spatium = spatium();
 
-      qreal y1;
-      qreal y2;
+      qreal y1l;
+      qreal y2l;
       if (parent() == 0) {    // for use in palette
-            y1 = 2.0 * _spatium;
-            y2 = 3.0 * _spatium;
+            y1l = 2.0 * _spatium;
+            y2l = 3.0 * _spatium;
             }
       else {
             Staff* staff  = score()->staff(staffIdx());
             StaffType* st = staff->staffType(tick());
-            y1            = st->doty1() * _spatium + 0.5 * score()->spatium() * mag();
-            y2            = st->doty2() * _spatium + 0.5 * score()->spatium() * mag();
+            y1l           = st->doty1() * _spatium + 0.5 * score()->spatium() * mag();
+            y2l           = st->doty2() * _spatium + 0.5 * score()->spatium() * mag();
             }
-      drawSymbol(SymId::repeatDot, painter, QPointF(x, y1));
-      drawSymbol(SymId::repeatDot, painter, QPointF(x, y2));
+      drawSymbol(SymId::repeatDot, painter, QPointF(x, y1l));
+      drawSymbol(SymId::repeatDot, painter, QPointF(x, y2l));
       }
 
 //---------------------------------------------------------
@@ -566,7 +566,8 @@ printf("may drop\n");
                && segment()
                && segment()->isEndBarLineType());
             }
-      return false;
+      // Prevent unreachable code warning 
+      // return false;
       }
 
 //---------------------------------------------------------
@@ -1254,8 +1255,8 @@ QString BarLine::accessibleExtraInfo() const
                   if (e->type() == ElementType::JUMP)
                         rez= QString("%1 %2").arg(rez).arg(e->screenReaderInfo());
                   if (e->type() == ElementType::MARKER) {
-                        const Marker* m = toMarker(e);
-                        if (m->markerType() == Marker::Type::FINE)
+                        const Marker* m1 = toMarker(e);
+                        if (m1->markerType() == Marker::Type::FINE)
                               rez = QString("%1 %2").arg(rez).arg(e->screenReaderInfo());
                         }
 

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1655,7 +1655,13 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
       qreal x1 = crl[0]->stemPosX() + crl[0]->pageX() - pageX();
 
       int baseLevel = 0;      // beam level that covers all notes of beam
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       int crBase[n];          // offset of beam level 0 for each chord
+#else
+      // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+      //    heap allocation is slow, an optimization might be used.
+      std::vector<int> crBase(n);
+#endif
       bool growDown = _up;
 
       for (int beamLevel = 0; beamLevel < beamLevels; ++beamLevel) {

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -214,13 +214,13 @@ void Beam::draw(QPainter* painter) const
             d = M_PI/6.0;
       double ww = lw2 / sin(M_PI_2 - atan(d));
 
-      for (const QLineF* bs : beamSegments) {
+      for (const QLineF* bs1 : beamSegments) {
             painter->drawPolygon(
                QPolygonF({
-                  QPointF(bs->x1(), bs->y1() - ww),
-                  QPointF(bs->x2(), bs->y2() - ww),
-                  QPointF(bs->x2(), bs->y2() + ww),
-                  QPointF(bs->x1(), bs->y1() + ww),
+                  QPointF(bs1->x1(), bs1->y1() - ww),
+                  QPointF(bs1->x2(), bs1->y2() - ww),
+                  QPointF(bs1->x2(), bs1->y2() + ww),
+                  QPointF(bs1->x1(), bs1->y1() + ww),
                   }),
             Qt::OddEvenFill);
             }
@@ -1623,9 +1623,9 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                         if (!cr->isChord())
                               continue;
                         Chord* c = toChord(cr);
-                        bool _up = c->up();
-                        qreal y = (_up ? c->upNote() : c->downNote())->pagePos().y();
-                        if (_up)
+                        bool _up1 = c->up();
+                        qreal y = (_up1 ? c->upNote() : c->downNote())->pagePos().y();
+                        if (_up1)
                               yUpMin = qMin(y, yUpMin);
                         else
                               yDownMax = qMax(y, yDownMax);

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -843,7 +843,8 @@ QVariant ChordRest::propertyDefault(Pid propertyId) const
             default:
                   return DurationElement::propertyDefault(propertyId);
             }
-      triggerLayout();
+      // Prevent unreachable code warning 
+      // triggerLayout();
       }
 
 //---------------------------------------------------------

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -999,8 +999,15 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                         if (noteTicks > chord->duration().ticks()) {
                               // store start/end note for backward/forward ties ending/starting on the group of notes being rewritten
                               int numNotes = chord->notes().size();
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
                               Note* tieBack[numNotes];
                               Note* tieFor[numNotes];
+#else
+                              // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+                              //    heap allocation is slow, an optimization might be used.
+                              std::vector<Note *> tieBack(numNotes);
+                              std::vector<Note *> tieFor(numNotes);
+#endif
                               for (int i = 0; i < numNotes; i++) {
                                     Note* n = chord->notes()[i];
                                     Note* nn = lastTiedChord->notes()[i];

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -309,7 +309,7 @@ QColor Element::curColor(const Element* proxy) const
                   int red = originalColor.red();
                   int green = originalColor.green();
                   int blue = originalColor.blue();
-                  float tint = .6;  // Between 0 and 1. Higher means lighter, lower means darker
+                  float tint = .6f;  // Between 0 and 1. Higher means lighter, lower means darker
                   return QColor(red + tint * (255 - red), green + tint * (255 - green), blue + tint * (255 - blue));
                   }
             }

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -95,7 +95,7 @@ FretDiagram* FretDiagram::fromString(Score* score, const QString &s)
       int barreString = -1;
       for (int i = 0; i < s.size(); i++) {
             QChar c = s.at(i);
-            if (c == 'X' or c == 'O')
+            if (c == 'X' || c == 'O')
                   fd->setMarker(i, c.unicode());
             else if (c == '-' && barreString == -1) {
                   fd->setBarre(1);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1570,8 +1570,15 @@ void Score::respace(std::vector<ChordRest*>* elements)
       qreal x1       = cr1->segment()->pos().x();
       qreal x2       = cr2->segment()->pos().x();
 
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       qreal width[n-1];
       int ticksList[n-1];
+#else
+      // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+      //    heap allocation is slow, an optimization might be used.
+      std::vector<qreal> width(n-1);
+      std::vector<int> ticksList(n-1);
+#endif
       int minTick = 100000;
 
       for (int i = 0; i < n-1; ++i) {

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -186,7 +186,12 @@ const char* toString(Direction val)
             case Direction::UP:   return "up";
             case Direction::DOWN: return "down";
             }
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       __builtin_unreachable();
+#else
+      // The MSVC __assume() optimizer hint is similar, though not identical, to __builtin_unreachable()
+      __assume(0);
+#endif
       }
 
 //---------------------------------------------------------

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -429,7 +429,16 @@ bool MasterScore::saveFile()
 #ifdef Q_OS_WIN
             QFileInfo fileBackup(dir, backupName);
             QString backupNativePath = QDir::toNativeSeparators(fileBackup.absoluteFilePath());
+#if (defined (_MSCVER) || defined (_MSC_VER))
+   #if (defined (UNICODE))
+            SetFileAttributes((LPCTSTR)backupNativePath.unicode(), FILE_ATTRIBUTE_HIDDEN);
+   #else
+            // Use byte-based Windows function
             SetFileAttributes((LPCTSTR)backupNativePath.toLocal8Bit(), FILE_ATTRIBUTE_HIDDEN);
+   #endif
+#else
+            SetFileAttributes((LPCTSTR)backupNativePath.toLocal8Bit(), FILE_ATTRIBUTE_HIDDEN);
+#endif
 #endif
             }
       else {

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -303,11 +303,11 @@ void Score::readStaff(XmlReader& e)
                         else {
                               // this is a multi measure rest
                               // always preceded by the first measure it replaces
-                              Measure* m = e.lastMeasure();
+                              Measure* m1 = e.lastMeasure();
 
-                              if (m) {
-                                    m->setMMRest(measure);
-                                    measure->setTick(m->tick());
+                              if (m1) {
+                                    m1->setMMRest(measure);
+                                    measure->setTick(m1->tick());
                                     }
                               }
                         }
@@ -588,15 +588,15 @@ bool Score::saveCompressedFile(QIODevice* f, QFileInfo& info, bool onlySelection
             int n = masterScore()->omr()->numPages();
             for (int i = 0; i < n; ++i) {
                   QString path = QString("OmrPages/page%1.png").arg(i+1);
-                  QBuffer cbuf;
+                  QBuffer cbuf1;
                   OmrPage* page = masterScore()->omr()->page(i);
                   const QImage& image = page->image();
-                  if (!image.save(&cbuf, "PNG")) {
+                  if (!image.save(&cbuf1, "PNG")) {
                         MScore::lastError = tr("save file: cannot save image (%1x%2)").arg(image.width(), image.height());
                         return false;
                         }
-                  uz.addFile(path, cbuf.data());
-                  cbuf.close();
+                  uz.addFile(path, cbuf1.data());
+                  cbuf1.close();
                   }
             }
 #endif
@@ -809,10 +809,10 @@ Score::FileError MasterScore::loadCompressedMsc(QIODevice* io, bool ignoreVersio
             int n = masterScore()->omr()->numPages();
             for (int i = 0; i < n; ++i) {
                   QString path = QString("OmrPages/page%1.png").arg(i+1);
-                  QByteArray dbuf = uz.fileData(path);
+                  QByteArray dbuf1 = uz.fileData(path);
                   OmrPage* page = masterScore()->omr()->page(i);
                   QImage image;
-                  if (image.loadFromData(dbuf, "PNG")) {
+                  if (image.loadFromData(dbuf1, "PNG")) {
                         page->setImage(image);
                         }
                   else
@@ -824,8 +824,8 @@ Score::FileError MasterScore::loadCompressedMsc(QIODevice* io, bool ignoreVersio
       //  read audio
       //
       if (audio()) {
-            QByteArray dbuf = uz.fileData("audio.ogg");
-            audio()->setData(dbuf);
+            QByteArray dbuf1 = uz.fileData("audio.ogg");
+            audio()->setData(dbuf1);
             }
       return retval;
       }
@@ -1129,8 +1129,8 @@ void Score::writeSegments(XmlWriter& xml, int strack, int etrack,
                                     }
                               }
                         }
-                  for (Element* e : segment->annotations()) {
-                        if (e->track() != track || e->generated() || (e->systemFlag() && !writeSystemElements))
+                  for (Element* e1 : segment->annotations()) {
+                        if (e1->track() != track || e1->generated() || (e1->systemFlag() && !writeSystemElements))
                               continue;
                         if (needTick) {
                               // xml.tag("tick", segment->tick() - xml.tickDiff);
@@ -1139,7 +1139,7 @@ void Score::writeSegments(XmlWriter& xml, int strack, int etrack,
                               xml.setCurTick(segment->tick());
                               needTick = false;
                               }
-                        e->write(xml);
+                        e1->write(xml);
                         }
                   Measure* m = segment->measure();
                   // don't write spanners for multi measure rests

--- a/libmscore/stringdata.cpp
+++ b/libmscore/stringdata.cpp
@@ -150,7 +150,13 @@ void StringData::fretChords(Chord * chord) const
       bFretting = true;
 
       // we need to keep track of string allocation
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       int bUsed[strings()];                    // initially all strings are available
+#else
+      // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+      //    heap allocation is slow, an optimization might be used.
+      std::vector<int> bUsed(strings());
+#endif
       for(nString=0; nString<strings(); nString++)
             bUsed[nString] = 0;
       // we also need the notes sorted in order of string (from highest to lowest) and then pitch

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -171,7 +171,13 @@ void System::layoutSystem(qreal xo1)
             columns = qMax(columns, c);
             }
 
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       qreal bracketWidth[columns];
+#else
+      // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+      //    heap allocation is slow, an optimization might be used.
+      std::vector<qreal> bracketWidth(columns);
+#endif
       for (int i = 0; i < columns; ++i)
             bracketWidth[i] = 0.0;
 

--- a/libmscore/text.cpp
+++ b/libmscore/text.cpp
@@ -2916,7 +2916,16 @@ bool TextBase::edit(EditData& ed)
       if (hexState >= 0) {
             if (ed.modifiers == (Qt::ControlModifier | Qt::ShiftModifier | Qt::KeypadModifier)) {
                   switch (ed.key) {
-                        case Qt::Key_0 ... Qt::Key_9:
+                        case Qt::Key_0:
+                        case Qt::Key_1:
+                        case Qt::Key_2:
+                        case Qt::Key_3:
+                        case Qt::Key_4:
+                        case Qt::Key_5:
+                        case Qt::Key_6:
+                        case Qt::Key_7:
+                        case Qt::Key_8:
+                        case Qt::Key_9:
                               s = QChar::fromLatin1(ed.key);
                               ++hexState;
                               wasHex = true;
@@ -2927,7 +2936,12 @@ bool TextBase::edit(EditData& ed)
                   }
             else if (ed.modifiers == (Qt::ControlModifier | Qt::ShiftModifier)) {
                   switch (ed.key) {
-                        case Qt::Key_A ... Qt::Key_F:
+                        case Qt::Key_A:
+                        case Qt::Key_B:
+                        case Qt::Key_C:
+                        case Qt::Key_D:
+                        case Qt::Key_E:
+                        case Qt::Key_F:
                               s = QChar::fromLatin1(ed.key);
                               ++hexState;
                               wasHex = true;

--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -11,6 +11,8 @@
 #  the file LICENSE.GPL
 #=============================================================================
 
+include (${PROJECT_SOURCE_DIR}/build/CopyFilesMacros.cmake)
+
 include_directories(
       ${PROJECT_BINARY_DIR}
       ${PROJECT_SOURCE_DIR}
@@ -18,14 +20,22 @@ include_directories(
 
 if (APPLE)
         file(GLOB_RECURSE INCS "*.h")
+        set(GETOPT_REPLACE "")
 else (APPLE)
         set(INCS "")
+        if (MSVC)
+            set(GETOPT_REPLACE "getopt/getopt.c")
+            include_directories("getopt")
+        else (MSVC)
+            set(GETOPT_REPLACE "")
+        endif (MSVC)
 endif (APPLE)
 
 add_executable(
       genManual
       ${INCS}
       genManual.cpp
+      ${GETOPT_REPLACE}
       )
 target_link_libraries(
       genManual
@@ -39,11 +49,25 @@ set_target_properties (
       COMPILE_FLAGS "-include all.h -D TESTROOT=\\\\\"${PROJECT_SOURCE_DIR}\\\\\" -g -Wall -Wextra"
       )
 else(APPLE)
-set_target_properties (
-      genManual
-      PROPERTIES
-      COMPILE_FLAGS "-include all.h -D TESTROOT=\\\"${PROJECT_SOURCE_DIR}\\\" -g -Wall -Wextra"
-      )
+   if (NOT MSVC)
+      set_target_properties (
+         genManual
+         PROPERTIES
+         COMPILE_FLAGS "-include all.h -D TESTROOT=\\\"${PROJECT_SOURCE_DIR}\\\" -g -Wall -Wextra"
+         )
+   else (NOT MSVC)
+      set_target_properties (
+         genManual
+         PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE} -D TESTROOT=\\\"${PROJECT_SOURCE_DIR}\\\" -DSTATIC_GETOPT"
+         )
+
+      # Copy DLL dependencies to .EXE DIRECTORY
+      list(APPEND dlls_to_copy_m  "${QT_INSTALL_PREFIX}/bin/Qt5Core.dll" )
+      set( output_dir_for_dlls_m "$<TARGET_FILE_DIR:genManual>")
+      COPY_FILES_INTO_DIRECTORY_IF_CHANGED( "${dlls_to_copy_m}" ${output_dir_for_dlls_m}  genManual)
+
+   endif (NOT MSVC)
 endif(APPLE)
 
 ADD_DEPENDENCIES(genManual mops1)

--- a/manual/genManual.cpp
+++ b/manual/genManual.cpp
@@ -116,7 +116,7 @@ static void parseClass(const QString& name, const QString& in)
 
       bool parseClassDescription = true;
 
-      foreach(const QString& s, sl) {
+      for(const QString& s : sl) {
             if (re.indexIn(s, 0) != -1) {             //@P
                   parseClassDescription = false;
                   Prop p;
@@ -254,14 +254,14 @@ static QString linkClass(const QString& in)
 
 static void writeOutput()
       {
-      foreach(const Class& cl, classes) {
+      for(const Class& cl : classes) {
             QString out;
             addHeader(out);
             out += QString("<h3>%1</h3>\n").arg(cl.name);
 
             if (!cl.parent.isEmpty()) {
                   // show parent only if its part of the exported classes
-                  foreach(const Class& lcl, classes) {
+                  for(const Class& lcl : classes) {
                         if (lcl.name == cl.parent) {
                               QString path = cl.parent.toLower();
                               out += QString("<div class=\"class-inherit\">inherits <a href=\"%1.html\">%2</a></div>\n").arg(path).arg(cl.parent);
@@ -271,7 +271,7 @@ static void writeOutput()
                   }
             if (!cl.description.isEmpty()) {
                   out += "<div class=\"class-description\">\n";
-                  foreach(const QString& s, cl.description) {
+                  for(const QString& s : cl.description) {
                         out += s.simplified().replace("\\brief ", "");
                         out += "\n";
                         }
@@ -283,7 +283,7 @@ static void writeOutput()
             if (!cl.procs.isEmpty()) {
                   out += "<h4>Methods</h4>\n";
                   out += "<div class=\"methods\">\n";
-                  foreach(const Proc& p, cl.procs) {
+                  for(const Proc& p : cl.procs) {
                         out += "<div class=\"method\">\n";
                         out += linkClass(p.type) + " ";
 
@@ -297,7 +297,7 @@ static void writeOutput()
                         out += "</div>\n";
                         if (!p.description.isEmpty()) {
                               out += "<div class=\"method-description\">\n";
-                              foreach(const QString& s, p.description) {
+                              for(const QString& s : p.description) {
                                     out += s.simplified();
                                     out += "<br/>\n";
                                     }
@@ -311,7 +311,7 @@ static void writeOutput()
                   out += "<div class=\"properties\">\n";
                   out += "<table>\n";
                   int count = 1;
-                  foreach(const Prop& m, cl.props) {
+                  for(const Prop& m : cl.props) {
                         out += QString("<tr class=\"prop-%1\">") .arg( (count & 1) ? "odd" : "even");
                         out += QString("<td class=\"prop-name\">%1</td>"
                                "<td class=\"prop-type\">%2</td>"
@@ -348,7 +348,7 @@ static void writeOutput()
              "</p>\n";
       out += "<ul>\n";
       qSort(classes);
-      foreach(const Class& s, classes) {
+      for(const Class& s : classes) {
             out += QString("<li><a href=\"%1\">%2</a></li>\n")
                     .arg(s.name.toLower() + ".html").arg(s.name);
             }
@@ -369,10 +369,10 @@ static void writeOutput()
 //   copyAssets
 //---------------------------------------------------------
 
-static void copyAssets(QString& srcPath, QString& dstPath)
+static void copyAssets(QString& lSrcPath, QString& lDstPath)
       {
-      QString assetDstPath = dstPath + "/plugins/";
-      QString assetSrcPath = srcPath + "/manual/";
+      QString assetDstPath = lDstPath + "/plugins/";
+      QString assetSrcPath = lSrcPath + "/manual/";
 //      QStringList files = {"manual.css", "manual-dark.css", "mscore.png" };
       QStringList files = {"mscore.png" };
 
@@ -446,10 +446,10 @@ int main(int argc, char* argv[])
       filter << "*.h";
       QStringList fl = libdir.entryList(filter, QDir::Files);
 
-      foreach(QString f, fl)
+      for(QString f : fl)
             files << "libmscore/" + f;
 
-      foreach(const QString& s, files) {
+      for(const QString& s : files) {
             QString infile = srcPath + "/" + s;
             QFile inFile(infile);
             if (!inFile.open(QIODevice::ReadOnly)) {

--- a/manual/genManual.cpp
+++ b/manual/genManual.cpp
@@ -12,6 +12,13 @@
 
 #include <stdio.h>
 #include <QString>
+// Load replacement for getopt() for VS
+#if (defined (_MSCVER) || defined (_MSC_VER))
+   #define STATIC_GETOPT 1
+   #undef _UNICODE
+   #include "getopt/getopt.h"
+#endif
+
 
 QString srcPath;
 QString dstPath;

--- a/manual/getopt/README.md
+++ b/manual/getopt/README.md
@@ -15,3 +15,5 @@ original licence, Oxford Nanopore Technologies does not take any liability
 or warranty whatsoever.
 
 Building the Release and Debug DLL is done via the Microsoft Visual Studio IDE.
+
+Original CodeProject article: https://www.codeproject.com/KB/cpp/getopt4win.aspx?msg=3987371

--- a/manual/getopt/README.md
+++ b/manual/getopt/README.md
@@ -1,0 +1,17 @@
+getopt-win32
+============
+Full getopt Port for Unicode and Multibyte Microsoft Visual C or C++
+
+GitHub: nanoporetech/getopt-win32
+
+This repository's branch "original" is a copy of
+
+<https://www.codeproject.com/KB/cpp/getopt4win/getopt_mb_uni_vc10.zip>
+
+originally released by its author Ludvik Jerabek in 2012 under LGPLv3.
+Its sole purpose is to publish the changes made by Oxford Nanopore
+Technologies available in the current branch. In accordance with the
+original licence, Oxford Nanopore Technologies does not take any liability
+or warranty whatsoever.
+
+Building the Release and Debug DLL is done via the Microsoft Visual Studio IDE.

--- a/manual/getopt/getopt.c
+++ b/manual/getopt/getopt.c
@@ -1,0 +1,976 @@
+/* Getopt for Microsoft C
+This code is a modification of the Free Software Foundation, Inc.
+Getopt library for parsing command line argument the purpose was
+to provide a Microsoft Visual C friendly derivative. This code
+provides functionality for both Unicode and Multibyte builds.
+
+Date: 02/03/2011 - Ludvik Jerabek - Initial Release
+Version: 1.0
+Comment: Supports getopt, getopt_long, and getopt_long_only
+and POSIXLY_CORRECT environment flag
+License: LGPL
+
+Revisions:
+
+02/03/2011 - Ludvik Jerabek - Initial Release
+02/20/2011 - Ludvik Jerabek - Fixed compiler warnings at Level 4
+07/05/2011 - Ludvik Jerabek - Added no_argument, required_argument, optional_argument defs
+08/03/2011 - Ludvik Jerabek - Fixed non-argument runtime bug which caused runtime exception
+08/09/2011 - Ludvik Jerabek - Added code to export functions for DLL and LIB
+02/15/2012 - Ludvik Jerabek - Fixed _GETOPT_THROW definition missing in implementation file
+08/01/2012 - Ludvik Jerabek - Created separate functions for char and wchar_t characters so single dll can do both unicode and ansi
+10/15/2012 - Ludvik Jerabek - Modified to match latest GNU features
+06/19/2015 - Ludvik Jerabek - Fixed maximum option limitation caused by option_a (255) and option_w (65535) structure val variable
+
+**DISCLAIMER**
+THIS MATERIAL IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING, BUT Not LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, OR NON-INFRINGEMENT. SOME JURISDICTIONS DO NOT ALLOW THE
+EXCLUSION OF IMPLIED WARRANTIES, SO THE ABOVE EXCLUSION MAY NOT
+APPLY TO YOU. IN NO EVENT WILL I BE LIABLE TO ANY PARTY FOR ANY
+DIRECT, INDIRECT, SPECIAL OR OTHER CONSEQUENTIAL DAMAGES FOR ANY
+USE OF THIS MATERIAL INCLUDING, WITHOUT LIMITATION, ANY LOST
+PROFITS, BUSINESS INTERRUPTION, LOSS OF PROGRAMS OR OTHER DATA ON
+YOUR INFORMATION HANDLING SYSTEM OR OTHERWISE, EVEN If WE ARE
+EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+*/
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <malloc.h>
+#include "getopt.h"
+
+#ifdef __cplusplus
+	#define _GETOPT_THROW throw()
+#else
+	#define _GETOPT_THROW
+#endif
+
+int optind = 1;
+int opterr = 1;
+int optopt = '?';
+enum ENUM_ORDERING { REQUIRE_ORDER, PERMUTE, RETURN_IN_ORDER };
+
+//
+//
+//		Ansi structures and functions follow
+// 
+//
+
+static struct _getopt_data_a
+{
+	int optind;
+	int opterr;
+	int optopt;
+	char *optarg;
+	int __initialized;
+	char *__nextchar;
+	enum ENUM_ORDERING __ordering;
+	int __posixly_correct;
+	int __first_nonopt;
+	int __last_nonopt;
+} getopt_data_a;
+char *optarg_a;
+
+static void exchange_a(char **argv, struct _getopt_data_a *d)
+{
+	int bottom = d->__first_nonopt;
+	int middle = d->__last_nonopt;
+	int top = d->optind;
+	char *tem;
+	while (top > middle && middle > bottom)
+	{
+		if (top - middle > middle - bottom)
+		{
+			int len = middle - bottom;
+			register int i;
+			for (i = 0; i < len; i++)
+			{
+				tem = argv[bottom + i];
+				argv[bottom + i] = argv[top - (middle - bottom) + i];
+				argv[top - (middle - bottom) + i] = tem;
+			}
+			top -= len;
+		}
+		else
+		{
+			int len = top - middle;
+			register int i;
+			for (i = 0; i < len; i++)
+			{
+				tem = argv[bottom + i];
+				argv[bottom + i] = argv[middle + i];
+				argv[middle + i] = tem;
+			}
+			bottom += len;
+		}
+	}
+	d->__first_nonopt += (d->optind - d->__last_nonopt);
+	d->__last_nonopt = d->optind;
+}
+static const char *_getopt_initialize_a (const char *optstring, struct _getopt_data_a *d, int posixly_correct)
+{
+	d->__first_nonopt = d->__last_nonopt = d->optind;
+	d->__nextchar = NULL;
+	d->__posixly_correct = posixly_correct | !!getenv("POSIXLY_CORRECT");
+	if (optstring[0] == '-')
+	{
+		d->__ordering = RETURN_IN_ORDER;
+		++optstring;
+	}
+	else if (optstring[0] == '+')
+	{
+		d->__ordering = REQUIRE_ORDER;
+		++optstring;
+	}
+	else if (d->__posixly_correct)
+		d->__ordering = REQUIRE_ORDER;
+	else
+		d->__ordering = PERMUTE;
+	return optstring;
+}
+int _getopt_internal_r_a (int argc, char *const *argv, const char *optstring, const struct option_a *longopts, int *longind, int long_only, struct _getopt_data_a *d, int posixly_correct)
+{
+	int print_errors = d->opterr;
+	if (argc < 1)
+		return -1;
+	d->optarg = NULL;
+	if (d->optind == 0 || !d->__initialized)
+	{
+		if (d->optind == 0)
+			d->optind = 1;
+		optstring = _getopt_initialize_a (optstring, d, posixly_correct);
+		d->__initialized = 1;
+	}
+	else if (optstring[0] == '-' || optstring[0] == '+')
+		optstring++;
+	if (optstring[0] == ':')
+		print_errors = 0;
+	if (d->__nextchar == NULL || *d->__nextchar == '\0')
+	{
+		if (d->__last_nonopt > d->optind)
+			d->__last_nonopt = d->optind;
+		if (d->__first_nonopt > d->optind)
+			d->__first_nonopt = d->optind;
+		if (d->__ordering == PERMUTE)
+		{
+			if (d->__first_nonopt != d->__last_nonopt && d->__last_nonopt != d->optind)
+				exchange_a ((char **) argv, d);
+			else if (d->__last_nonopt != d->optind)
+				d->__first_nonopt = d->optind;
+			while (d->optind < argc && (argv[d->optind][0] != '-' || argv[d->optind][1] == '\0'))
+				d->optind++;
+			d->__last_nonopt = d->optind;
+		}
+		if (d->optind != argc && !strcmp(argv[d->optind], "--"))
+		{
+			d->optind++;
+			if (d->__first_nonopt != d->__last_nonopt && d->__last_nonopt != d->optind)
+				exchange_a((char **) argv, d);
+			else if (d->__first_nonopt == d->__last_nonopt)
+				d->__first_nonopt = d->optind;
+			d->__last_nonopt = argc;
+			d->optind = argc;
+		}
+		if (d->optind == argc)
+		{
+			if (d->__first_nonopt != d->__last_nonopt)
+				d->optind = d->__first_nonopt;
+			return -1;
+		}
+		if ((argv[d->optind][0] != '-' || argv[d->optind][1] == '\0'))
+		{
+			if (d->__ordering == REQUIRE_ORDER)
+				return -1;
+			d->optarg = argv[d->optind++];
+			return 1;
+		}
+		d->__nextchar = (argv[d->optind] + 1 + (longopts != NULL && argv[d->optind][1] == '-'));
+	}
+	if (longopts != NULL && (argv[d->optind][1] == '-' || (long_only && (argv[d->optind][2] || !strchr(optstring, argv[d->optind][1])))))
+	{
+		char *nameend;
+		unsigned int namelen;
+		const struct option_a *p;
+		const struct option_a *pfound = NULL;
+		struct option_list
+		{
+			const struct option_a *p;
+			struct option_list *next;
+		} *ambig_list = NULL;
+		int exact = 0;
+		int indfound = -1;
+		int option_index;
+		for (nameend = d->__nextchar; *nameend && *nameend != '='; nameend++);
+		namelen = (unsigned int)(nameend - d->__nextchar);
+		for (p = longopts, option_index = 0; p->name; p++, option_index++)
+			if (!strncmp(p->name, d->__nextchar, namelen))
+			{
+				if (namelen == (unsigned int)strlen(p->name))
+				{
+					pfound = p;
+					indfound = option_index;
+					exact = 1;
+					break;
+				}
+				else if (pfound == NULL)
+				{
+					pfound = p;
+					indfound = option_index;
+				}
+				else if (long_only || pfound->has_arg != p->has_arg || pfound->flag != p->flag || pfound->val != p->val)
+				{
+					struct option_list *newp = (struct option_list*)alloca(sizeof(*newp));
+					newp->p = p;
+					newp->next = ambig_list;
+					ambig_list = newp;
+				}
+			}
+			if (ambig_list != NULL && !exact)
+			{
+				if (print_errors)
+				{
+					struct option_list first;
+					first.p = pfound;
+					first.next = ambig_list;
+					ambig_list = &first;
+					fprintf (stderr, "%s: option '%s' is ambiguous; possibilities:", argv[0], argv[d->optind]);
+					do
+					{
+						fprintf (stderr, " '--%s'", ambig_list->p->name);
+						ambig_list = ambig_list->next;
+					}
+					while (ambig_list != NULL);
+					fputc ('\n', stderr);
+				}
+				d->__nextchar += strlen(d->__nextchar);
+				d->optind++;
+				d->optopt = 0;
+				return '?';
+			}
+			if (pfound != NULL)
+			{
+				option_index = indfound;
+				d->optind++;
+				if (*nameend)
+				{
+					if (pfound->has_arg)
+						d->optarg = nameend + 1;
+					else
+					{
+						if (print_errors)
+						{
+							if (argv[d->optind - 1][1] == '-')
+							{
+								fprintf(stderr, "%s: option '--%s' doesn't allow an argument\n",argv[0], pfound->name);
+							}
+							else
+							{
+								fprintf(stderr, "%s: option '%c%s' doesn't allow an argument\n",argv[0], argv[d->optind - 1][0],pfound->name);
+							}
+						}
+						d->__nextchar += strlen(d->__nextchar);
+						d->optopt = pfound->val;
+						return '?';
+					}
+				}
+				else if (pfound->has_arg == 1)
+				{
+					if (d->optind < argc)
+						d->optarg = argv[d->optind++];
+					else
+					{
+						if (print_errors)
+						{
+							fprintf(stderr,"%s: option '--%s' requires an argument\n",argv[0], pfound->name);
+						}
+						d->__nextchar += strlen(d->__nextchar);
+						d->optopt = pfound->val;
+						return optstring[0] == ':' ? ':' : '?';
+					}
+				}
+				d->__nextchar += strlen(d->__nextchar);
+				if (longind != NULL)
+					*longind = option_index;
+				if (pfound->flag)
+				{
+					*(pfound->flag) = pfound->val;
+					return 0;
+				}
+				return pfound->val;
+			}
+			if (!long_only || argv[d->optind][1] == '-' || strchr(optstring, *d->__nextchar) == NULL)
+			{
+				if (print_errors)
+				{
+					if (argv[d->optind][1] == '-')
+					{
+						fprintf(stderr, "%s: unrecognized option '--%s'\n",argv[0], d->__nextchar);
+					}
+					else
+					{
+						fprintf(stderr, "%s: unrecognized option '%c%s'\n",argv[0], argv[d->optind][0], d->__nextchar);
+					}
+				}
+				d->__nextchar = (char *)"";
+				d->optind++;
+				d->optopt = 0;
+				return '?';
+			}
+	}
+	{
+		char c = *d->__nextchar++;
+		char *temp = (char*)strchr(optstring, c);
+		if (*d->__nextchar == '\0')
+			++d->optind;
+		if (temp == NULL || c == ':' || c == ';')
+		{
+			if (print_errors)
+			{
+				fprintf(stderr, "%s: invalid option -- '%c'\n", argv[0], c);
+			}
+			d->optopt = c;
+			return '?';
+		}
+		if (temp[0] == 'W' && temp[1] == ';')
+		{
+			char *nameend;
+			const struct option_a *p;
+			const struct option_a *pfound = NULL;
+			int exact = 0;
+			int ambig = 0;
+			int indfound = 0;
+			int option_index;
+			if (longopts == NULL)
+				goto no_longs;
+			if (*d->__nextchar != '\0')
+			{
+				d->optarg = d->__nextchar;
+				d->optind++;
+			}
+			else if (d->optind == argc)
+			{
+				if (print_errors)
+				{
+					fprintf(stderr,"%s: option requires an argument -- '%c'\n",argv[0], c);
+				}
+				d->optopt = c;
+				if (optstring[0] == ':')
+					c = ':';
+				else
+					c = '?';
+				return c;
+			}
+			else
+				d->optarg = argv[d->optind++];
+			for (d->__nextchar = nameend = d->optarg; *nameend && *nameend != '='; nameend++);
+			for (p = longopts, option_index = 0; p->name; p++, option_index++)
+				if (!strncmp(p->name, d->__nextchar, nameend - d->__nextchar))
+				{
+					if ((unsigned int) (nameend - d->__nextchar) == strlen(p->name))
+					{
+						pfound = p;
+						indfound = option_index;
+						exact = 1;
+						break;
+					}
+					else if (pfound == NULL)
+					{
+						pfound = p;
+						indfound = option_index;
+					}
+					else if (long_only || pfound->has_arg != p->has_arg || pfound->flag != p->flag || pfound->val != p->val)
+						ambig = 1;
+				}
+				if (ambig && !exact)
+				{
+					if (print_errors)
+					{
+						fprintf(stderr, "%s: option '-W %s' is ambiguous\n",argv[0], d->optarg);
+					}
+					d->__nextchar += strlen(d->__nextchar);
+					d->optind++;
+					return '?';
+				}
+				if (pfound != NULL)
+				{
+					option_index = indfound;
+					if (*nameend)
+					{
+						if (pfound->has_arg)
+							d->optarg = nameend + 1;
+						else
+						{
+							if (print_errors)
+							{
+								fprintf(stderr, "%s: option '-W %s' doesn't allow an argument\n",argv[0], pfound->name);
+							}
+							d->__nextchar += strlen(d->__nextchar);
+							return '?';
+						}
+					}
+					else if (pfound->has_arg == 1)
+					{
+						if (d->optind < argc)
+							d->optarg = argv[d->optind++];
+						else
+						{
+							if (print_errors)
+							{
+								fprintf(stderr, "%s: option '-W %s' requires an argument\n",argv[0], pfound->name);
+							}
+							d->__nextchar += strlen(d->__nextchar);
+							return optstring[0] == ':' ? ':' : '?';
+						}
+					}
+					else
+						d->optarg = NULL;
+					d->__nextchar += strlen(d->__nextchar);
+					if (longind != NULL)
+						*longind = option_index;
+					if (pfound->flag)
+					{
+						*(pfound->flag) = pfound->val;
+						return 0;
+					}
+					return pfound->val;
+				}
+no_longs:
+				d->__nextchar = NULL;
+				return 'W';
+		}
+		if (temp[1] == ':')
+		{
+			if (temp[2] == ':')
+			{
+				if (*d->__nextchar != '\0')
+				{
+					d->optarg = d->__nextchar;
+					d->optind++;
+				}
+				else
+					d->optarg = NULL;
+				d->__nextchar = NULL;
+			}
+			else
+			{
+				if (*d->__nextchar != '\0')
+				{
+					d->optarg = d->__nextchar;
+					d->optind++;
+				}
+				else if (d->optind == argc)
+				{
+					if (print_errors)
+					{
+						fprintf(stderr,"%s: option requires an argument -- '%c'\n",argv[0], c);
+					}
+					d->optopt = c;
+					if (optstring[0] == ':')
+						c = ':';
+					else
+						c = '?';
+				}
+				else
+					d->optarg = argv[d->optind++];
+				d->__nextchar = NULL;
+			}
+		}
+		return c;
+	}
+}
+int _getopt_internal_a (int argc, char *const *argv, const char *optstring, const struct option_a *longopts, int *longind, int long_only, int posixly_correct)
+{
+	int result;
+	getopt_data_a.optind = optind;
+	getopt_data_a.opterr = opterr;
+	result = _getopt_internal_r_a (argc, argv, optstring, longopts,longind, long_only, &getopt_data_a,posixly_correct);
+	optind = getopt_data_a.optind;
+	optarg_a = getopt_data_a.optarg;
+	optopt = getopt_data_a.optopt;
+	return result;
+}
+int getopt_a (int argc, char *const *argv, const char *optstring) _GETOPT_THROW
+{
+	return _getopt_internal_a (argc, argv, optstring, (const struct option_a *) 0, (int *) 0, 0, 0);
+}
+int getopt_long_a (int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index) _GETOPT_THROW
+{
+	return _getopt_internal_a (argc, argv, options, long_options, opt_index, 0, 0);
+}
+int getopt_long_only_a (int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index) _GETOPT_THROW
+{
+	return _getopt_internal_a (argc, argv, options, long_options, opt_index, 1, 0);
+}
+int _getopt_long_r_a (int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index, struct _getopt_data_a *d)
+{
+	return _getopt_internal_r_a (argc, argv, options, long_options, opt_index,0, d, 0);
+}
+int _getopt_long_only_r_a (int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index, struct _getopt_data_a *d)
+{
+	return _getopt_internal_r_a (argc, argv, options, long_options, opt_index, 1, d, 0);
+}
+
+//
+//
+//	Unicode Structures and Functions
+// 
+//
+
+static struct _getopt_data_w
+{
+	int optind;
+	int opterr;
+	int optopt;
+	wchar_t *optarg;
+	int __initialized;
+	wchar_t *__nextchar;
+	enum ENUM_ORDERING __ordering;
+	int __posixly_correct;
+	int __first_nonopt;
+	int __last_nonopt;
+} getopt_data_w;
+wchar_t *optarg_w;
+
+static void exchange_w(wchar_t **argv, struct _getopt_data_w *d)
+{
+	int bottom = d->__first_nonopt;
+	int middle = d->__last_nonopt;
+	int top = d->optind;
+	wchar_t *tem;
+	while (top > middle && middle > bottom)
+	{
+		if (top - middle > middle - bottom)
+		{
+			int len = middle - bottom;
+			register int i;
+			for (i = 0; i < len; i++)
+			{
+				tem = argv[bottom + i];
+				argv[bottom + i] = argv[top - (middle - bottom) + i];
+				argv[top - (middle - bottom) + i] = tem;
+			}
+			top -= len;
+		}
+		else
+		{
+			int len = top - middle;
+			register int i;
+			for (i = 0; i < len; i++)
+			{
+				tem = argv[bottom + i];
+				argv[bottom + i] = argv[middle + i];
+				argv[middle + i] = tem;
+			}
+			bottom += len;
+		}
+	}
+	d->__first_nonopt += (d->optind - d->__last_nonopt);
+	d->__last_nonopt = d->optind;
+}
+static const wchar_t *_getopt_initialize_w (const wchar_t *optstring, struct _getopt_data_w *d, int posixly_correct)
+{
+	d->__first_nonopt = d->__last_nonopt = d->optind;
+	d->__nextchar = NULL;
+	d->__posixly_correct = posixly_correct | !!_wgetenv(L"POSIXLY_CORRECT");
+	if (optstring[0] == L'-')
+	{
+		d->__ordering = RETURN_IN_ORDER;
+		++optstring;
+	}
+	else if (optstring[0] == L'+')
+	{
+		d->__ordering = REQUIRE_ORDER;
+		++optstring;
+	}
+	else if (d->__posixly_correct)
+		d->__ordering = REQUIRE_ORDER;
+	else
+		d->__ordering = PERMUTE;
+	return optstring;
+}
+int _getopt_internal_r_w (int argc, wchar_t *const *argv, const wchar_t *optstring, const struct option_w *longopts, int *longind, int long_only, struct _getopt_data_w *d, int posixly_correct)
+{
+	int print_errors = d->opterr;
+	if (argc < 1)
+		return -1;
+	d->optarg = NULL;
+	if (d->optind == 0 || !d->__initialized)
+	{
+		if (d->optind == 0)
+			d->optind = 1;
+		optstring = _getopt_initialize_w (optstring, d, posixly_correct);
+		d->__initialized = 1;
+	}
+	else if (optstring[0] == L'-' || optstring[0] == L'+')
+		optstring++;
+	if (optstring[0] == L':')
+		print_errors = 0;
+	if (d->__nextchar == NULL || *d->__nextchar == L'\0')
+	{
+		if (d->__last_nonopt > d->optind)
+			d->__last_nonopt = d->optind;
+		if (d->__first_nonopt > d->optind)
+			d->__first_nonopt = d->optind;
+		if (d->__ordering == PERMUTE)
+		{
+			if (d->__first_nonopt != d->__last_nonopt && d->__last_nonopt != d->optind)
+				exchange_w((wchar_t **) argv, d);
+			else if (d->__last_nonopt != d->optind)
+				d->__first_nonopt = d->optind;
+			while (d->optind < argc && (argv[d->optind][0] != L'-' || argv[d->optind][1] == L'\0'))
+				d->optind++;
+			d->__last_nonopt = d->optind;
+		}
+		if (d->optind != argc && !wcscmp(argv[d->optind], L"--"))
+		{
+			d->optind++;
+			if (d->__first_nonopt != d->__last_nonopt && d->__last_nonopt != d->optind)
+				exchange_w((wchar_t **) argv, d);
+			else if (d->__first_nonopt == d->__last_nonopt)
+				d->__first_nonopt = d->optind;
+			d->__last_nonopt = argc;
+			d->optind = argc;
+		}
+		if (d->optind == argc)
+		{
+			if (d->__first_nonopt != d->__last_nonopt)
+				d->optind = d->__first_nonopt;
+			return -1;
+		}
+		if ((argv[d->optind][0] != L'-' || argv[d->optind][1] == L'\0'))
+		{
+			if (d->__ordering == REQUIRE_ORDER)
+				return -1;
+			d->optarg = argv[d->optind++];
+			return 1;
+		}
+		d->__nextchar = (argv[d->optind] + 1 + (longopts != NULL && argv[d->optind][1] == L'-'));
+	}
+	if (longopts != NULL && (argv[d->optind][1] == L'-' || (long_only && (argv[d->optind][2] || !wcschr(optstring, argv[d->optind][1])))))
+	{
+		wchar_t *nameend;
+		unsigned int namelen;
+		const struct option_w *p;
+		const struct option_w *pfound = NULL;
+		struct option_list
+		{
+			const struct option_w *p;
+			struct option_list *next;
+		} *ambig_list = NULL;
+		int exact = 0;
+		int indfound = -1;
+		int option_index;
+		for (nameend = d->__nextchar; *nameend && *nameend != L'='; nameend++);
+		namelen = (unsigned int)(nameend - d->__nextchar);
+		for (p = longopts, option_index = 0; p->name; p++, option_index++)
+			if (!wcsncmp(p->name, d->__nextchar, namelen))
+			{
+				if (namelen == (unsigned int)wcslen(p->name))
+				{
+					pfound = p;
+					indfound = option_index;
+					exact = 1;
+					break;
+				}
+				else if (pfound == NULL)
+				{
+					pfound = p;
+					indfound = option_index;
+				}
+				else if (long_only || pfound->has_arg != p->has_arg || pfound->flag != p->flag || pfound->val != p->val)
+				{
+					struct option_list *newp = (struct option_list*)alloca(sizeof(*newp));
+					newp->p = p;
+					newp->next = ambig_list;
+					ambig_list = newp;
+				}
+			}
+			if (ambig_list != NULL && !exact)
+			{
+				if (print_errors)
+				{						
+					struct option_list first;
+					first.p = pfound;
+					first.next = ambig_list;
+					ambig_list = &first;
+					fwprintf(stderr, L"%s: option '%s' is ambiguous; possibilities:", argv[0], argv[d->optind]);
+					do
+					{
+						fwprintf (stderr, L" '--%s'", ambig_list->p->name);
+						ambig_list = ambig_list->next;
+					}
+					while (ambig_list != NULL);
+					fputwc (L'\n', stderr);
+				}
+				d->__nextchar += wcslen(d->__nextchar);
+				d->optind++;
+				d->optopt = 0;
+				return L'?';
+			}
+			if (pfound != NULL)
+			{
+				option_index = indfound;
+				d->optind++;
+				if (*nameend)
+				{
+					if (pfound->has_arg)
+						d->optarg = nameend + 1;
+					else
+					{
+						if (print_errors)
+						{
+							if (argv[d->optind - 1][1] == L'-')
+							{
+								fwprintf(stderr, L"%s: option '--%s' doesn't allow an argument\n",argv[0], pfound->name);
+							}
+							else
+							{
+								fwprintf(stderr, L"%s: option '%c%s' doesn't allow an argument\n",argv[0], argv[d->optind - 1][0],pfound->name);
+							}
+						}
+						d->__nextchar += wcslen(d->__nextchar);
+						d->optopt = pfound->val;
+						return L'?';
+					}
+				}
+				else if (pfound->has_arg == 1)
+				{
+					if (d->optind < argc)
+						d->optarg = argv[d->optind++];
+					else
+					{
+						if (print_errors)
+						{
+							fwprintf(stderr,L"%s: option '--%s' requires an argument\n",argv[0], pfound->name);
+						}
+						d->__nextchar += wcslen(d->__nextchar);
+						d->optopt = pfound->val;
+						return optstring[0] == L':' ? L':' : L'?';
+					}
+				}
+				d->__nextchar += wcslen(d->__nextchar);
+				if (longind != NULL)
+					*longind = option_index;
+				if (pfound->flag)
+				{
+					*(pfound->flag) = pfound->val;
+					return 0;
+				}
+				return pfound->val;
+			}
+			if (!long_only || argv[d->optind][1] == L'-' || wcschr(optstring, *d->__nextchar) == NULL)
+			{
+				if (print_errors)
+				{
+					if (argv[d->optind][1] == L'-')
+					{
+						fwprintf(stderr, L"%s: unrecognized option '--%s'\n",argv[0], d->__nextchar);
+					}
+					else
+					{
+						fwprintf(stderr, L"%s: unrecognized option '%c%s'\n",argv[0], argv[d->optind][0], d->__nextchar);
+					}
+				}
+				d->__nextchar = (wchar_t *)L"";
+				d->optind++;
+				d->optopt = 0;
+				return L'?';
+			}
+	}
+	{
+		wchar_t c = *d->__nextchar++;
+		wchar_t *temp = (wchar_t*)wcschr(optstring, c);
+		if (*d->__nextchar == L'\0')
+			++d->optind;
+		if (temp == NULL || c == L':' || c == L';')
+		{
+			if (print_errors)
+			{
+				fwprintf(stderr, L"%s: invalid option -- '%c'\n", argv[0], c);
+			}
+			d->optopt = c;
+			return L'?';
+		}
+		if (temp[0] == L'W' && temp[1] == L';')
+		{
+			wchar_t *nameend;
+			const struct option_w *p;
+			const struct option_w *pfound = NULL;
+			int exact = 0;
+			int ambig = 0;
+			int indfound = 0;
+			int option_index;
+			if (longopts == NULL)
+				goto no_longs;
+			if (*d->__nextchar != L'\0')
+			{
+				d->optarg = d->__nextchar;
+				d->optind++;
+			}
+			else if (d->optind == argc)
+			{
+				if (print_errors)
+				{
+					fwprintf(stderr,L"%s: option requires an argument -- '%c'\n",argv[0], c);
+				}
+				d->optopt = c;
+				if (optstring[0] == L':')
+					c = L':';
+				else
+					c = L'?';
+				return c;
+			}
+			else
+				d->optarg = argv[d->optind++];
+			for (d->__nextchar = nameend = d->optarg; *nameend && *nameend != L'='; nameend++);
+			for (p = longopts, option_index = 0; p->name; p++, option_index++)
+				if (!wcsncmp(p->name, d->__nextchar, nameend - d->__nextchar))
+				{
+					if ((unsigned int) (nameend - d->__nextchar) == wcslen(p->name))
+					{
+						pfound = p;
+						indfound = option_index;
+						exact = 1;
+						break;
+					}
+					else if (pfound == NULL)
+					{
+						pfound = p;
+						indfound = option_index;
+					}
+					else if (long_only || pfound->has_arg != p->has_arg || pfound->flag != p->flag || pfound->val != p->val)
+						ambig = 1;
+				}
+				if (ambig && !exact)
+				{
+					if (print_errors)
+					{
+						fwprintf(stderr, L"%s: option '-W %s' is ambiguous\n",argv[0], d->optarg);
+					}
+					d->__nextchar += wcslen(d->__nextchar);
+					d->optind++;
+					return L'?';
+				}
+				if (pfound != NULL)
+				{
+					option_index = indfound;
+					if (*nameend)
+					{
+						if (pfound->has_arg)
+							d->optarg = nameend + 1;
+						else
+						{
+							if (print_errors)
+							{
+								fwprintf(stderr, L"%s: option '-W %s' doesn't allow an argument\n",argv[0], pfound->name);
+							}
+							d->__nextchar += wcslen(d->__nextchar);
+							return L'?';
+						}
+					}
+					else if (pfound->has_arg == 1)
+					{
+						if (d->optind < argc)
+							d->optarg = argv[d->optind++];
+						else
+						{
+							if (print_errors)
+							{
+								fwprintf(stderr, L"%s: option '-W %s' requires an argument\n",argv[0], pfound->name);
+							}
+							d->__nextchar += wcslen(d->__nextchar);
+							return optstring[0] == L':' ? L':' : L'?';
+						}
+					}
+					else
+						d->optarg = NULL;
+					d->__nextchar += wcslen(d->__nextchar);
+					if (longind != NULL)
+						*longind = option_index;
+					if (pfound->flag)
+					{
+						*(pfound->flag) = pfound->val;
+						return 0;
+					}
+					return pfound->val;
+				}
+no_longs:
+				d->__nextchar = NULL;
+				return L'W';
+		}
+		if (temp[1] == L':')
+		{
+			if (temp[2] == L':')
+			{
+				if (*d->__nextchar != L'\0')
+				{
+					d->optarg = d->__nextchar;
+					d->optind++;
+				}
+				else
+					d->optarg = NULL;
+				d->__nextchar = NULL;
+			}
+			else
+			{
+				if (*d->__nextchar != L'\0')
+				{
+					d->optarg = d->__nextchar;
+					d->optind++;
+				}
+				else if (d->optind == argc)
+				{
+					if (print_errors)
+					{
+						fwprintf(stderr,L"%s: option requires an argument -- '%c'\n",argv[0], c);
+					}
+					d->optopt = c;
+					if (optstring[0] == L':')
+						c = L':';
+					else
+						c = L'?';
+				}
+				else
+					d->optarg = argv[d->optind++];
+				d->__nextchar = NULL;
+			}
+		}
+		return c;
+	}
+}
+int _getopt_internal_w (int argc, wchar_t *const *argv, const wchar_t *optstring, const struct option_w *longopts, int *longind, int long_only, int posixly_correct)
+{
+	int result;
+	getopt_data_w.optind = optind;
+	getopt_data_w.opterr = opterr;
+	result = _getopt_internal_r_w (argc, argv, optstring, longopts,longind, long_only, &getopt_data_w,posixly_correct);
+	optind = getopt_data_w.optind;
+	optarg_w = getopt_data_w.optarg;
+	optopt = getopt_data_w.optopt;
+	return result;
+}
+int getopt_w (int argc, wchar_t *const *argv, const wchar_t *optstring) _GETOPT_THROW
+{
+	return _getopt_internal_w (argc, argv, optstring, (const struct option_w *) 0, (int *) 0, 0, 0);
+}
+int getopt_long_w (int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW
+{
+	return _getopt_internal_w (argc, argv, options, long_options, opt_index, 0, 0);
+}
+int getopt_long_only_w (int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW
+{
+	return _getopt_internal_w (argc, argv, options, long_options, opt_index, 1, 0);
+}
+int _getopt_long_r_w (int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index, struct _getopt_data_w *d)
+{
+	return _getopt_internal_r_w (argc, argv, options, long_options, opt_index,0, d, 0);
+}
+int _getopt_long_only_r_w (int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index, struct _getopt_data_w *d)
+{
+	return _getopt_internal_r_w (argc, argv, options, long_options, opt_index, 1, d, 0);
+}

--- a/manual/getopt/getopt.h
+++ b/manual/getopt/getopt.h
@@ -1,0 +1,136 @@
+/* Getopt for Microsoft C
+This code is a modification of the Free Software Foundation, Inc.
+Getopt library for parsing command line argument the purpose was
+to provide a Microsoft Visual C friendly derivative. This code
+provides functionality for both Unicode and Multibyte builds.
+
+Date: 02/03/2011 - Ludvik Jerabek - Initial Release
+Version: 1.0
+Comment: Supports getopt, getopt_long, and getopt_long_only
+and POSIXLY_CORRECT environment flag
+License: LGPL
+
+Revisions:
+
+02/03/2011 - Ludvik Jerabek - Initial Release
+02/20/2011 - Ludvik Jerabek - Fixed compiler warnings at Level 4
+07/05/2011 - Ludvik Jerabek - Added no_argument, required_argument, optional_argument defs
+08/03/2011 - Ludvik Jerabek - Fixed non-argument runtime bug which caused runtime exception
+08/09/2011 - Ludvik Jerabek - Added code to export functions for DLL and LIB
+02/15/2012 - Ludvik Jerabek - Fixed _GETOPT_THROW definition missing in implementation file
+08/01/2012 - Ludvik Jerabek - Created separate functions for char and wchar_t characters so single dll can do both unicode and ansi
+10/15/2012 - Ludvik Jerabek - Modified to match latest GNU features
+06/19/2015 - Ludvik Jerabek - Fixed maximum option limitation caused by option_a (255) and option_w (65535) structure val variable
+
+**DISCLAIMER**
+THIS MATERIAL IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING, BUT Not LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, OR NON-INFRINGEMENT. SOME JURISDICTIONS DO NOT ALLOW THE
+EXCLUSION OF IMPLIED WARRANTIES, SO THE ABOVE EXCLUSION MAY NOT
+APPLY TO YOU. IN NO EVENT WILL I BE LIABLE TO ANY PARTY FOR ANY
+DIRECT, INDIRECT, SPECIAL OR OTHER CONSEQUENTIAL DAMAGES FOR ANY
+USE OF THIS MATERIAL INCLUDING, WITHOUT LIMITATION, ANY LOST
+PROFITS, BUSINESS INTERRUPTION, LOSS OF PROGRAMS OR OTHER DATA ON
+YOUR INFORMATION HANDLING SYSTEM OR OTHERWISE, EVEN If WE ARE
+EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+*/
+#ifndef __GETOPT_H_
+	#define __GETOPT_H_
+
+	#ifdef _GETOPT_API
+		#undef _GETOPT_API
+	#endif
+
+	#if defined(EXPORTS_GETOPT) && defined(STATIC_GETOPT)
+		#error "The preprocessor definitions of EXPORTS_GETOPT and STATIC_GETOPT can only be used individually"
+	#elif defined(STATIC_GETOPT)
+		#pragma message("Warning static builds of getopt violate the Lesser GNU Public License")
+		#define _GETOPT_API
+	#elif defined(EXPORTS_GETOPT)
+		#pragma message("Exporting getopt library")
+		#define _GETOPT_API __declspec(dllexport)
+	#else
+		#pragma message("Importing getopt library")
+		#define _GETOPT_API __declspec(dllimport)
+	#endif
+
+	// Change behavior for C\C++
+	#ifdef __cplusplus
+		#define _BEGIN_EXTERN_C extern "C" {
+		#define _END_EXTERN_C }
+		#define _GETOPT_THROW throw()
+	#else
+		#define _BEGIN_EXTERN_C
+		#define _END_EXTERN_C
+		#define _GETOPT_THROW
+	#endif
+
+	// Standard GNU options
+	#define	null_argument		0	/*Argument Null*/
+	#define	no_argument			0	/*Argument Switch Only*/
+	#define required_argument	1	/*Argument Required*/
+	#define optional_argument	2	/*Argument Optional*/	
+
+	// Shorter Options
+	#define ARG_NULL	0	/*Argument Null*/
+	#define ARG_NONE	0	/*Argument Switch Only*/
+	#define ARG_REQ		1	/*Argument Required*/
+	#define ARG_OPT		2	/*Argument Optional*/
+
+	#include <string.h>
+	#include <wchar.h>
+
+_BEGIN_EXTERN_C
+
+	extern _GETOPT_API int optind;
+	extern _GETOPT_API int opterr;
+	extern _GETOPT_API int optopt;
+
+	// Ansi
+	struct option_a
+	{
+		const char* name;
+		int has_arg;
+		int *flag;
+		int val;
+	};
+	extern _GETOPT_API char *optarg_a;
+	extern _GETOPT_API int getopt_a(int argc, char *const *argv, const char *optstring) _GETOPT_THROW;
+	extern _GETOPT_API int getopt_long_a(int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index) _GETOPT_THROW;
+	extern _GETOPT_API int getopt_long_only_a(int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index) _GETOPT_THROW;
+
+	// Unicode
+	struct option_w
+	{
+		const wchar_t* name;
+		int has_arg;
+		int *flag;
+		int val;
+	};
+	extern _GETOPT_API wchar_t *optarg_w;
+	extern _GETOPT_API int getopt_w(int argc, wchar_t *const *argv, const wchar_t *optstring) _GETOPT_THROW;
+	extern _GETOPT_API int getopt_long_w(int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW;
+	extern _GETOPT_API int getopt_long_only_w(int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW;	
+	
+_END_EXTERN_C
+
+	#undef _BEGIN_EXTERN_C
+	#undef _END_EXTERN_C
+	#undef _GETOPT_THROW
+	#undef _GETOPT_API
+
+	#ifdef _UNICODE
+		#define getopt getopt_w
+		#define getopt_long getopt_long_w
+		#define getopt_long_only getopt_long_only_w
+		#define option option_w
+		#define optarg optarg_w
+	#else
+		#define getopt getopt_a
+		#define getopt_long getopt_long_a
+		#define getopt_long_only getopt_long_only_a
+		#define option option_a
+		#define optarg optarg_a
+	#endif
+#endif  // __GETOPT_H_

--- a/midi/CMakeLists.txt
+++ b/midi/CMakeLists.txt
@@ -18,21 +18,42 @@ else (APPLE)
       set(INCS "")
 endif (APPLE)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (midi STATIC
-      ${PROJECT_BINARY_DIR}/all.h
+      ${_all_h_file}
       ${PCH}
       midifile.cpp
       midiinstrument.cpp
       )
-set_target_properties (
+
+if (NOT MSVC)
+   set_target_properties (
       midi
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      midi
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(midi all)
 
-ADD_DEPENDENCIES(midi mops1)
-ADD_DEPENDENCIES(midi mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( midi )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(midi mops1)
+   ADD_DEPENDENCIES(midi mops2)
+endif (NOT MSVC)   
 
 

--- a/midi/midifile.cpp
+++ b/midi/midifile.cpp
@@ -429,10 +429,23 @@ void MidiFile::writeLong(int i)
 
 void MidiFile::skip(qint64 len)
       {
+      // Note: if MS is updated to use Qt 5.10, this can be implemented with QIODevice::skip(), which should be more efficient
+      //       as bytes do not need to be moved around.
       if (len <= 0)
             return;
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       char tmp[len];
       read(tmp, len);
+#else
+      const int tmp_size = 256;  // Size of fixed-length temporary buffer. MSVC does not support VLA.
+      char tmp[tmp_size];
+      while(len > tmp_size) {
+            read(tmp, len);
+            len -= tmp_size;
+            }
+      // Now len is <= tmp_size, last read fits in the buffer.
+      read(tmp, tmp_size);
+#endif
       }
 
 /*---------------------------------------------------------

--- a/midi/midifile.cpp
+++ b/midi/midifile.cpp
@@ -293,7 +293,9 @@ bool MidiFile::read(QIODevice* in)
                   break;
             default:
                   throw(QString("midi file format %1 not implemented").arg(_format));
-                  return false;
+
+                  // Prevent "unreachable code" warning 
+                  // return false;
             }
       return true;
       }
@@ -721,9 +723,9 @@ void MidiTrack::mergeNoteOnOffAndFindMidiType(MidiType *mt)
                               ++ii;
                               bool found = false;
                               for (; ii != _events.end(); ++ii) {
-                                    MidiEvent& ev = ii->second;
-                                    if (ev.type() == ME_CONTROLLER) {
-                                          if (ev.controller() == CTRL_LDATA) {
+                                    MidiEvent& ev1 = ii->second;
+                                    if (ev1.type() == ME_CONTROLLER) {
+                                          if (ev1.controller() == CTRL_LDATA) {
                                                 // handle later
                                                 found = true;
                                                 }

--- a/miditools/CMakeLists.txt
+++ b/miditools/CMakeLists.txt
@@ -12,19 +12,34 @@
 
 add_executable (smf2xml smf2xml.cpp xmlwriter.cpp midifile.cpp)
 
-set_target_properties(smf2xml
+if (NOT MSVC)
+   set_target_properties(smf2xml
       PROPERTIES COMPILE_FLAGS "-g -Wall -Wextra"
       )
+else (NOT MSVC)
+   set_target_properties (smf2xml
+      PROPERTIES COMPILE_FLAGS ""
+      )
+endif (NOT MSVC)   
+
 target_link_libraries(smf2xml
       ${QT_LIBRARIES}
       )
 
 add_executable (xml2smf xml2smf.cpp xmlreader.cpp midifile.cpp)
 
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       xml2smf
       PROPERTIES COMPILE_FLAGS "-g -Wall -Wextra"
       )
+else (NOT MSVC)
+   set_target_properties (
+      xml2smf
+      PROPERTIES COMPILE_FLAGS ""
+      )
+endif (NOT MSVC)   
+
 target_link_libraries(xml2smf
       ${QT_LIBRARIES}
       )

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -17,7 +17,11 @@
 #  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #=============================================================================
 
-include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
+# This is not needed for MSVC compilation
+if (NOT MSVC)
+   include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
+endif (NOT MSVC)
+include (${PROJECT_SOURCE_DIR}/build/CopyFilesMacros.cmake)
 
 SET_SOURCE_FILES_PROPERTIES(revision.h PROPERTIES GENERATED TRUE)
 
@@ -160,11 +164,16 @@ endif (APPLE)
 set (AUDIO "")
 if (MINGW)
       set (resource_file ${PROJECT_BINARY_DIR}/resfile.o)
-else (MINGW)
+endif (MINGW)
+if (MSVC)
+      # MSVC recognizes a *.rc file and will invoke the resource compiler to link it
+      set (resource_file ${PROJECT_SOURCE_DIR}/mscore/data/mscore.rc)
+endif ( MSVC )
+if ( NOT MINGW AND NOT MSVC )
       if (USE_ALSA)
             set (AUDIO ${AUDIO} alsa.cpp)
       endif (USE_ALSA)
-endif (MINGW)
+endif ( NOT MINGW AND NOT MSVC )
 
 if (USE_PORTAUDIO)
       set (AUDIO ${AUDIO} pa.cpp)
@@ -229,10 +238,16 @@ else (APPLE)
       set(COCOABRIDGE "")
 endif (APPLE)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_executable ( ${ExecutableName}
       ${qrc_files}
       ${ui_headers}
-      ${PROJECT_BINARY_DIR}/all.h
+      ${_all_h_file}
       ${PCH}
       ${resource_file}
       ${INCS}
@@ -378,11 +393,11 @@ if (USE_SYSTEM_FREETYPE)
       target_link_libraries(mscore ${FREETYPE_LIBRARIES})
 endif (USE_SYSTEM_FREETYPE)
 
-if (MINGW)
+if (MINGW OR MSVC)
       set(MSCORE_OUTPUT_NAME ${MUSESCORE_NAME})
 elseif (MSCORE_INSTALL_SUFFIX)
       set(MSCORE_OUTPUT_NAME "${ExecutableName}${MSCORE_INSTALL_SUFFIX}")
-endif (MINGW)
+endif (MINGW OR MSVC)
 
 # If MSCORE_OUTPUT_NAME is set (e.g, when cmake is called by the user), the output executable will be
 # called MSCORE_OUTPUT_NAME instead of 'mscore'. This can be used to have MuseScore stable and unstable
@@ -437,7 +452,7 @@ if (MINGW)
       ${PROJECT_BINARY_DIR}/resfile.o
       PROPERTIES generated true
       )
-   string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
+   string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
    # Windows: Add -mconsole to LINK_FLAGS to get a console window for debug output
    if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
      set_target_properties( mscore
@@ -540,125 +555,291 @@ if (MINGW)
       REGEX ".*QtWebkit.*" EXCLUDE)
 
 else (MINGW)
-   target_link_libraries(mscore
-      ${ALSA_LIB}
-      ${QT_LIBRARIES}
-      z
-      ${CMAKE_DL_LIBS}
-      pthread
-      )
+   if ( NOT MSVC )
+      target_link_libraries(mscore
+         ${ALSA_LIB}
+         ${QT_LIBRARIES}
+         z
+         ${CMAKE_DL_LIBS}
+         pthread
+         )
 
-    if (USE_SYSTEM_FREETYPE)
-         target_link_libraries(mscore freetype)
-    else (USE_SYSTEM_FREETYPE)
-         target_link_libraries(mscore mscore_freetype)
-    endif (USE_SYSTEM_FREETYPE)
+       if (USE_SYSTEM_FREETYPE)
+            target_link_libraries(mscore freetype)
+       else (USE_SYSTEM_FREETYPE)
+            target_link_libraries(mscore mscore_freetype)
+       endif (USE_SYSTEM_FREETYPE)
 
-    if (USE_PORTAUDIO)
-      target_link_libraries(mscore ${PORTAUDIO_LIB})
-    endif (USE_PORTAUDIO)
+       if (USE_PORTAUDIO)
+         target_link_libraries(mscore ${PORTAUDIO_LIB})
+       endif (USE_PORTAUDIO)
 
-    if (USE_PORTMIDI)
-        if (APPLE)
-            set(PORTMIDI_LIB portmidi)
-        else (APPLE)
-            set(PORTMIDI_LIB -lportmidi -lporttime) # Remove -lporttime on RPM-based systems where PortTime is part of PortMidi.
-        endif (APPLE)
-        target_link_libraries(mscore ${PORTMIDI_LIB})
-    endif (USE_PORTMIDI)
+       if (USE_PORTMIDI)
+           if (APPLE)
+               set(PORTMIDI_LIB portmidi)
+           else (APPLE)
+               set(PORTMIDI_LIB -lportmidi -lporttime) # Remove -lporttime on RPM-based systems where PortTime is part of PortMidi.
+           endif (APPLE)
+           target_link_libraries(mscore ${PORTMIDI_LIB})
+       endif (USE_PORTMIDI)
 
-    if (USE_PULSEAUDIO)
-      target_link_libraries(mscore ${PULSEAUDIO_LIBRARY})
-    endif (USE_PULSEAUDIO)
+       if (USE_PULSEAUDIO)
+         target_link_libraries(mscore ${PULSEAUDIO_LIBRARY})
+       endif (USE_PULSEAUDIO)
 
-   set_target_properties (
-      mscore
-      PROPERTIES
-         COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wno-overloaded-virtual -Winvalid-pch"
-      )
+      set_target_properties (
+         mscore
+         PROPERTIES
+            COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wno-overloaded-virtual -Winvalid-pch"
+         )
 
-   if (OMR)
-      target_link_libraries(mscore omr poppler)
-      if (OCR)
-            target_link_libraries(mscore tesseract_api)
-      endif (OCR)
-   endif (OMR)
+      if (OMR)
+         target_link_libraries(mscore omr poppler)
+         if (OCR)
+               target_link_libraries(mscore tesseract_api)
+         endif (OCR)
+      endif (OMR)
 
-   if (APPLE)
-     target_link_libraries(mscore ${OsxFrameworks})
-   else (APPLE)
-       target_link_libraries(mscore rt)
-   endif (APPLE)
+      if (APPLE)
+        target_link_libraries(mscore ${OsxFrameworks})
+      else (APPLE)
+          target_link_libraries(mscore rt)
+      endif (APPLE)
 
-   # 'gold' does not use indirect shared libraries for symbol resolution, Linux only
-   if (NOT APPLE)
-      if(USE_JACK)
-         target_link_libraries(mscore ${CMAKE_DL_LIBS})
-      endif(USE_JACK)
-      target_link_libraries(mscore rt)
-   endif (NOT APPLE)
+      # 'gold' does not use indirect shared libraries for symbol resolution, Linux only
+      if (NOT APPLE)
+         if(USE_JACK)
+            target_link_libraries(mscore ${CMAKE_DL_LIBS})
+         endif(USE_JACK)
+         target_link_libraries(mscore rt)
+      endif (NOT APPLE)
 
-   if (APPLE)
-      set_target_properties(mscore
-        PROPERTIES
-           LINK_FLAGS "-stdlib=libc++"
-        )
-     xcode_pch(mscore all)
-     install (TARGETS mscore BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
-     install (FILES data/mscore.icns DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME})
-     install (FILES data/musescoreDocument.icns DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME})
-   else (APPLE)
-     #### PACKAGING for Linux and BSD based systems (more in top-level CMakeLists.txt) ####
-     # Install mscore executable (package maintainers may add "MuseScore" and/or "musescore" aliases that symlink to mscore)
-     install( TARGETS mscore RUNTIME DESTINATION bin )
-     if (LN_EXECUTABLE)
-        add_custom_target(mscore_alias ALL
-            COMMAND echo "Creating symlink alias for mscore executable."
-            COMMAND ${LN_EXECUTABLE} -sf "mscore${MSCORE_INSTALL_SUFFIX}" "musescore${MSCORE_INSTALL_SUFFIX}"
-            COMMAND echo 'Symlink alias: musescore${MSCORE_INSTALL_SUFFIX} -> mscore${MSCORE_INSTALL_SUFFIX}'
-            )
-        install( FILES ${PROJECT_BINARY_DIR}/mscore/musescore${MSCORE_INSTALL_SUFFIX} DESTINATION bin)
-     else (LN_EXECUTABLE)
-        add_custom_target(mscore_alias ALL
-            COMMAND echo "No symlink aliases will be created."
-            VERBATIM
-            )
-     endif (LN_EXECUTABLE)
-     # Install MuseScore icons (use SVGs where possible, but install PNGs as backup for systems that don't support SVG)
-     if (MSCORE_UNSTABLE)
-         set(MSCORE_ICON_BASE ../assets/musescore-icon-square) # Square icons on development builds
-     else (MSCORE_UNSTABLE)
-         set(MSCORE_ICON_BASE ../assets/musescore-icon-round) # Round icons on stable releases
-     endif (MSCORE_UNSTABLE)
-     install(FILES ${MSCORE_ICON_BASE}.svg RENAME mscore${MSCORE_INSTALL_SUFFIX}.svg DESTINATION share/icons/hicolor/scalable/apps)
-     install(FILES ${MSCORE_ICON_BASE}-16.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/16x16/apps)
-     install(FILES ${MSCORE_ICON_BASE}-24.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/24x24/apps)
-     install(FILES ${MSCORE_ICON_BASE}-32.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/32x32/apps)
-     install(FILES ${MSCORE_ICON_BASE}-48.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/48x48/apps)
-     install(FILES ${MSCORE_ICON_BASE}-64.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/64x64/apps)
-     install(FILES ${MSCORE_ICON_BASE}-96.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/96x96/apps)
-     install(FILES ${MSCORE_ICON_BASE}-128.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/128x128/apps)
-     install(FILES ${MSCORE_ICON_BASE}-512.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/512x512/apps)
-     # Install MIME (filetype) icons for each mimetype on Linux
-     install( FILES   ../assets/mscz-icon.svg RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}.svg
-        DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MSCZ files
-     install( FILES   ../assets/mscz-icon-48.png RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}.png
-        DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MSCZ files
-     install( FILES   ../assets/mscx-icon.svg RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}+xml.svg
-        DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MSCX files
-     install( FILES   ../assets/mscx-icon-48.png RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}+xml.png
-        DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MSCX files
-     # use a custom icon for MusicXML files (there isn't a standard icon for MusicXML files)
-     install( FILES   ../assets/mxl-icon.svg RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}.svg
-        DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MXL (compressed MusicXML) files
-     install( FILES   ../assets/mxl-icon-48.png RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}.png
-        DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MXL (compressed MusicXML) files
-     install( FILES   ../assets/xml-icon.svg RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}+xml.svg
-        DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .XML (MusicXML) files
-     install( FILES   ../assets/xml-icon-48.png RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}+xml.png
-        DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .XML (MusicXML) files
-     # Note: Must now run "gtk-update-icon-cache" to set the new icons. This is done in the Makefile.
-   endif (APPLE)
+      if (APPLE)
+         set_target_properties(mscore
+           PROPERTIES
+              LINK_FLAGS "-stdlib=libc++"
+           )
+        xcode_pch(mscore all)
+        install (TARGETS mscore BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
+        install (FILES data/mscore.icns DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME})
+        install (FILES data/musescoreDocument.icns DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME})
+      else (APPLE)
+        #### PACKAGING for Linux and BSD based systems (more in top-level CMakeLists.txt) ####
+        # Install mscore executable (package maintainers may add "MuseScore" and/or "musescore" aliases that symlink to mscore)
+        install( TARGETS mscore RUNTIME DESTINATION bin )
+        if (LN_EXECUTABLE)
+           add_custom_target(mscore_alias ALL
+               COMMAND echo "Creating symlink alias for mscore executable."
+               COMMAND ${LN_EXECUTABLE} -sf "mscore${MSCORE_INSTALL_SUFFIX}" "musescore${MSCORE_INSTALL_SUFFIX}"
+               COMMAND echo 'Symlink alias: musescore${MSCORE_INSTALL_SUFFIX} -> mscore${MSCORE_INSTALL_SUFFIX}'
+               )
+           install( FILES ${PROJECT_BINARY_DIR}/mscore/musescore${MSCORE_INSTALL_SUFFIX} DESTINATION bin)
+        else (LN_EXECUTABLE)
+           add_custom_target(mscore_alias ALL
+               COMMAND echo "No symlink aliases will be created."
+               VERBATIM
+               )
+        endif (LN_EXECUTABLE)
+        # Install MuseScore icons (use SVGs where possible, but install PNGs as backup for systems that don't support SVG)
+        if (MSCORE_UNSTABLE)
+            set(MSCORE_ICON_BASE ../assets/musescore-icon-square) # Square icons on development builds
+        else (MSCORE_UNSTABLE)
+            set(MSCORE_ICON_BASE ../assets/musescore-icon-round) # Round icons on stable releases
+        endif (MSCORE_UNSTABLE)
+        install(FILES ${MSCORE_ICON_BASE}.svg RENAME mscore${MSCORE_INSTALL_SUFFIX}.svg DESTINATION share/icons/hicolor/scalable/apps)
+        install(FILES ${MSCORE_ICON_BASE}-16.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/16x16/apps)
+        install(FILES ${MSCORE_ICON_BASE}-24.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/24x24/apps)
+        install(FILES ${MSCORE_ICON_BASE}-32.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/32x32/apps)
+        install(FILES ${MSCORE_ICON_BASE}-48.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/48x48/apps)
+        install(FILES ${MSCORE_ICON_BASE}-64.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/64x64/apps)
+        install(FILES ${MSCORE_ICON_BASE}-96.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/96x96/apps)
+        install(FILES ${MSCORE_ICON_BASE}-128.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/128x128/apps)
+        install(FILES ${MSCORE_ICON_BASE}-512.png RENAME mscore${MSCORE_INSTALL_SUFFIX}.png DESTINATION share/icons/hicolor/512x512/apps)
+        # Install MIME (filetype) icons for each mimetype on Linux
+        install( FILES   ../assets/mscz-icon.svg RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}.svg
+           DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MSCZ files
+        install( FILES   ../assets/mscz-icon-48.png RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}.png
+           DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MSCZ files
+        install( FILES   ../assets/mscx-icon.svg RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}+xml.svg
+           DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MSCX files
+        install( FILES   ../assets/mscx-icon-48.png RENAME application-x-musescore${MSCORE_INSTALL_SUFFIX}+xml.png
+           DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MSCX files
+        # use a custom icon for MusicXML files (there isn't a standard icon for MusicXML files)
+        install( FILES   ../assets/mxl-icon.svg RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}.svg
+           DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .MXL (compressed MusicXML) files
+        install( FILES   ../assets/mxl-icon-48.png RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}.png
+           DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .MXL (compressed MusicXML) files
+        install( FILES   ../assets/xml-icon.svg RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}+xml.svg
+           DESTINATION share/icons/hicolor/scalable/mimetypes) # SVG icon for .XML (MusicXML) files
+        install( FILES   ../assets/xml-icon-48.png RENAME application-vnd.recordare.musicxml${MSCORE_INSTALL_SUFFIX}+xml.png
+           DESTINATION share/icons/hicolor/48x48/mimetypes) # PNG icon for .XML (MusicXML) files
+        # Note: Must now run "gtk-update-icon-cache" to set the new icons. This is done in the Makefile.
+      endif (APPLE)
+   else ( NOT MSVC )
+      # Microsoft Visual Studio-specific starts here!
+      string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
+
+      # Create list of directories to search for libraries
+      foreach (item ${CMAKE_LIBRARY_PATH})
+         string( APPEND all_library_paths " /LIBPATH:${item}" )
+      endforeach()
+
+      # Windows: Add -mconsole to LINK_FLAGS to get a console window for debug output
+      if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
+        set_target_properties( mscore
+           PROPERTIES
+              COMPILE_FLAGS "${PCH_INCLUDE} ${QT_DEFINITIONS} -DQT_SVG_LIB -DQT_GUI_LIB -DQT_XML_LIB -DQT_CORE_LIB"
+              LINK_FLAGS    "/LIBPATH:${QT_INSTALL_PREFIX}/lib ${all_library_paths}"
+              #LINK_FLAGS "-mwindows -mconsole -L ${QT_INSTALL_PREFIX}/lib"
+           )
+      else(CMAKE_BUILD_TYPE MATCHES "DEBUG")
+        set_target_properties( mscore
+           PROPERTIES
+              COMPILE_FLAGS "${PCH_INCLUDE} ${QT_DEFINITIONS} -DQT_SVG_LIB -DQT_GUI_LIB -DQT_XML_LIB -DQT_CORE_LIB"
+              LINK_FLAGS    "/LIBPATH:${QT_INSTALL_PREFIX}/lib ${all_library_paths}"
+              # LINK_FLAGS "-Wl,-S -mwindows -L ${QT_INSTALL_PREFIX}/lib"
+           )
+      endif(CMAKE_BUILD_TYPE MATCHES "DEBUG")
+
+      target_link_libraries(mscore
+         portaudio
+         portmidi
+         winmm
+         mscore_freetype
+         zlibstat
+         )
+
+      if (OMR)
+         target_link_libraries(mscore omr poppler)
+         if (OCR)
+               target_link_libraries(mscore tesseract_api)
+         endif (OCR)
+      endif (OMR)
+
+      # Use pre-compiled headers
+      vstudio_pch( mscore )
+
+      # Copy DLL dependencies to .EXE DIRECTORY
+      list(APPEND dlls_to_copy 
+                  "${QT_INSTALL_PREFIX}/bin/Qt5Core.dll"  "${QT_INSTALL_PREFIX}/bin/Qt5Gui.dll"  "${QT_INSTALL_PREFIX}/bin/Qt5Help.dll"
+                  "${QT_INSTALL_PREFIX}/bin/Qt5Network.dll"  "${QT_INSTALL_PREFIX}/bin/Qt5PrintSupport.dll"
+                  "${QT_INSTALL_PREFIX}/bin/Qt5Qml.dll"  "${QT_INSTALL_PREFIX}/bin/Qt5Quick.dll"  "${QT_INSTALL_PREFIX}/bin/Qt5Sql.dll"
+                  "${QT_INSTALL_PREFIX}/bin/Qt5Svg.dll"  "${QT_INSTALL_PREFIX}/bin/Qt5Widgets.dll"  "${QT_INSTALL_PREFIX}/bin/Qt5Xml.dll"
+                  "${QT_INSTALL_PREFIX}/bin/Qt5XmlPatterns.dll"
+                  )
+      set(CMAKE_FIND_LIBRARY_PREFIX "")
+      set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+      find_library( dll_lame        NAMES "lame_enc.dll"       PATHS ${CMAKE_LIBRARY_PATH} )
+      find_library( dll_ogg         NAMES "libogg.dll"         PATHS ${CMAKE_LIBRARY_PATH} )
+      find_library( dll_sndfile     NAMES "libsndfile-1.dll"   PATHS ${CMAKE_LIBRARY_PATH} )
+      find_library( dll_vorbis      NAMES "libvorbis.dll"      PATHS ${CMAKE_LIBRARY_PATH} )
+      find_library( dll_vorbisfile  NAMES "libvorbisfile.dll"  PATHS ${CMAKE_LIBRARY_PATH} )
+      find_library( dll_portaudio   NAMES "portaudio.dll"      PATHS ${CMAKE_LIBRARY_PATH} )
+
+      list(APPEND dlls_to_copy ${dll_lame} ${dll_ogg} ${dll_sndfile} ${dll_vorbis} ${dll_vorbisfile} ${dll_portaudio})
+      set( output_dir_for_dlls "$<TARGET_FILE_DIR:mscore>")
+
+      COPY_FILES_INTO_DIRECTORY_IF_CHANGED( "${dlls_to_copy}" ${output_dir_for_dlls}  mscore)
+      ###add_custom_command (TARGET mscore POST_BUILD
+      ###      # Copy Qt5 dependencies to .exe directory
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Core.dll           ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Gui.dll            ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Help.dll           ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Network.dll        ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5PrintSupport.dll   ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Qml.dll            ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Quick.dll          ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Sql.dll            ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Svg.dll            ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Widgets.dll        ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Xml.dll            ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5XmlPatterns.dll    ${PROJECT_BINARY_DIR}
+      ###
+      ###      # Copy other dependencies to .EXE directory
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Core.dll   ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Core.dll   ${PROJECT_BINARY_DIR}
+      ###      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${QT_INSTALL_PREFIX}/bin/Qt5Core.dll   ${PROJECT_BINARY_DIR}
+      ###
+      ###
+      ###
+      ###      COMMENT "Copying libraries to output directory" VERBATIM)
+
+
+
+
+      # Keep dependencies in alphabetical order. Changes made to this list
+      # might need to be made in "build/Linux+BSD/portable/copy-libs" too.
+      get_filename_component(COMPILER_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
+      get_filename_component (MINGW_ROOT ${COMPILER_DIR} DIRECTORY)
+      foreach (QtLibrary ${QT_LIBRARIES})
+         message("Library ${QtLibrary}")
+         # always use release libs
+         set_target_properties(${QtLibrary} PROPERTIES MAP_IMPORTED_CONFIG_DEBUG "RELEASE")
+         get_target_property(QtSharedLibrary ${QtLibrary} LOCATION_RELEASE)
+         if (EXISTS ${QtSharedLibrary})
+             list (APPEND QtInstallLibraries ${QtSharedLibrary})
+         endif (EXISTS ${QtSharedLibrary})
+      endforeach (QtLibrary ${QT_LIBRARIES})
+      list(REMOVE_DUPLICATES QtInstallLibraries)
+      
+      target_link_libraries(mscore ${QT_LIBRARIES})
+      
+      ### MINGW stuff that will need to be converted for MSVC...
+      #####install( TARGETS mscore RUNTIME DESTINATION bin )
+      #####
+      #####install( FILES
+      #####   ${MINGW_ROOT}/bin/libgcc_s_dw2-1.dll
+      #####   ${MINGW_ROOT}/bin/libstdc++-6.dll
+      #####   ${MINGW_ROOT}/bin/libwinpthread-1.dll
+      #####   ${MINGW_ROOT}/lib/libogg.dll
+      #####   ${MINGW_ROOT}/lib/libsndfile-1.dll
+      #####   ${MINGW_ROOT}/lib/libvorbis.dll
+      #####   ${MINGW_ROOT}/lib/libvorbisfile.dll
+      #####   ${MINGW_ROOT}/lib/portaudio.dll
+      #####   ${MINGW_ROOT}/opt/bin/libeay32.dll
+      #####   ${MINGW_ROOT}/opt/bin/ssleay32.dll
+      #####   ${QtInstallLibraries}
+      #####   ${PROJECT_SOURCE_DIR}/build/qt.conf
+      #####   DESTINATION bin)
+      #####
+      #####install (FILES
+      #####   ${MINGW_ROOT}/lib/lame_enc.dll
+      #####   DESTINATION bin
+      #####   OPTIONAL)
+      #####
+      ##### install(FILES
+      #####   ${QT_INSTALL_PREFIX}/plugins/iconengines/qsvgicon.dll
+      #####   DESTINATION bin/iconengines)
+      #####
+      ##### install(FILES
+      #####   ${QT_INSTALL_PREFIX}/plugins/imageformats/qjpeg.dll
+      #####   ${QT_INSTALL_PREFIX}/plugins/imageformats/qsvg.dll
+      #####   ${QT_INSTALL_PREFIX}/plugins/imageformats/qtiff.dll
+      #####   DESTINATION bin/imageformats)
+      #####
+      ##### install(FILES
+      #####   ${QT_INSTALL_PREFIX}/plugins/platforms/qwindows.dll
+      #####   DESTINATION bin/platforms)
+      #####
+      ##### install(FILES
+      #####   ${QT_INSTALL_PREFIX}/plugins/printsupport/windowsprintersupport.dll
+      #####   DESTINATION bin/printsupport)
+      #####
+      ##### install(FILES
+      #####   ${QT_INSTALL_PREFIX}/plugins/sqldrivers/qsqlite.dll
+      #####   DESTINATION bin/sqldrivers)
+      #####
+      ##### install(DIRECTORY
+      #####   ${QT_INSTALL_PREFIX}/qml
+      #####   DESTINATION .
+      #####   REGEX ".*d\\.dll" EXCLUDE
+      #####   REGEX ".*QtGraphicalEffects.*" EXCLUDE
+      #####   REGEX ".*QtMultimedia.*" EXCLUDE
+      #####   REGEX ".*QtSensors.*" EXCLUDE
+      #####   REGEX ".*QtTest.*" EXCLUDE
+      #####   REGEX ".*QtWebkit.*" EXCLUDE)
+      
+   endif ( NOT MSVC )
 endif (MINGW)
 
 if (APPLE)
@@ -688,6 +869,8 @@ if (APPLE)
       REGEX ".*_debug\\.dylib" EXCLUDE)
 endif (APPLE)
 
-ADD_DEPENDENCIES(${ExecutableName} mops1)
-ADD_DEPENDENCIES(${ExecutableName} mops2)
-
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(${ExecutableName} mops1)
+   ADD_DEPENDENCIES(${ExecutableName} mops2)
+endif (NOT MSVC)

--- a/mscore/bb.cpp
+++ b/mscore/bb.cpp
@@ -113,7 +113,13 @@ bool BBFile::read(const QString& name)
       int idx = 0;
       _version = a[idx++];
       switch(_version) {
-            case 0x43 ... 0x49:
+            case 0x43:
+            case 0x44:
+            case 0x45:
+            case 0x46:
+            case 0x47:
+            case 0x48:
+            case 0x49:
                   break;
             default:
                   qDebug("BB: unknown file version %02x", _version);

--- a/mscore/capella.cpp
+++ b/mscore/capella.cpp
@@ -1412,7 +1412,14 @@ void TextObj::read()
       {
       BasicRectObj::read();
       unsigned size = cap->readUnsigned();
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       char txt[size+1];
+#else
+      // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+      //    heap allocation is slow, an optimization might be used.
+      std::vector<char> vtxt(size+1);
+      char* txt = vtxt.data();
+#endif
       cap->read(txt, size);
       txt[size] = 0;
       text = QString(txt);
@@ -1496,7 +1503,14 @@ void MetafileObj::read()
       {
       BasicRectObj::read();
       unsigned size = cap->readUnsigned();
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       char enhMetaFileBits[size];
+#else
+      // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+      //    heap allocation is slow, an optimization might be used.
+      std::vector<char> vEnhMetaFileBits(size);
+      char* enhMetaFileBits = vEnhMetaFileBits.data();
+#endif
       cap->read(enhMetaFileBits, size);
       // qDebug("MetaFileObj::read %d bytes", size);
       }
@@ -2210,7 +2224,7 @@ void Capella::readStaveLayout(CapStaffLayout* sl, int idx)
             uchar iMin = readByte();
             Q_UNUSED(iMin);
             uchar n    = readByte();
-            Q_ASSERT (n > 0 and iMin + n <= 128);
+            Q_ASSERT (n > 0 && iMin + n <= 128);
             f->read(sl->soundMapIn, n);
             curPos += n;
             }
@@ -2218,7 +2232,7 @@ void Capella::readStaveLayout(CapStaffLayout* sl, int idx)
             unsigned char iMin = readByte();
             Q_UNUSED(iMin);
             unsigned char n    = readByte();
-            Q_ASSERT (n > 0 and iMin + n <= 128);
+            Q_ASSERT (n > 0 && iMin + n <= 128);
             f->read(sl->soundMapOut, n);
             curPos += n;
             }

--- a/mscore/driver.cpp
+++ b/mscore/driver.cpp
@@ -10,6 +10,13 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#if (defined (_MSCVER) || defined (_MSC_VER))
+// Include stdint.h and #define _STDINT_H to prevent <systemdeps.h> from redefining types
+// #undef UNICODE to force LoadLibrary to use the char-based implementation instead of the wchar_t one.
+#include <stdint.h>
+#define _STDINT_H 1  
+#endif
+
 #include "config.h"
 #include "preferences.h"
 #include "driver.h"

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -1041,8 +1041,13 @@ const StyleWidget& EditStyle::styleWidget(Sid idx) const
             if (sw.idx == idx)
                   return sw;
             }
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       __builtin_unreachable();
-      }
+#else
+      // The MSVC __assume() optimizer hint is similar, though not identical, to __builtin_unreachable()
+      __assume(0);
+#endif
+   }
 
 //---------------------------------------------------------
 //   valueChanged

--- a/mscore/importgtp-gp6.cpp
+++ b/mscore/importgtp-gp6.cpp
@@ -2506,7 +2506,14 @@ void GuitarPro6::readGpif(QByteArray* data)
                   continue;
             const StringData* sd = instr->stringData();
             if (sd) {
-                  int tuning[sd->strings()];
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+               int tuning[sd->strings()];
+#else
+               // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+               //    heap allocation is slow, an optimization might be used.
+               std::vector<int> vTuning(sd->strings());
+               int* tuning = vTuning.data();
+#endif
                   int frets   = sd->frets();
                   int strings;
                   for (strings = 0; strings < sd->strings(); strings++) {

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -677,7 +677,13 @@ void InstrumentsWidget::on_upButton_clicked()
                   // Qt looses the QComboBox set into StaffListItem's when they are re-inserted into the tree:
                   // get the currently selected staff type of each combo and re-insert
                   int numOfStaffListItems = item->childCount();
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
                   int staffIdx[numOfStaffListItems];
+#else
+                  // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+                  //    heap allocation is slow, an optimization might be used.
+                  std::vector<int> staffIdx(numOfStaffListItems);
+#endif
                   for (int itemIdx=0; itemIdx < numOfStaffListItems; ++itemIdx)
                         staffIdx[itemIdx] = (static_cast<StaffListItem*>(item->child(itemIdx)))->staffTypeIdx();
                   // do not consider hidden ones
@@ -760,7 +766,13 @@ void InstrumentsWidget::on_downButton_clicked()
                   // Qt looses the QComboBox set into StaffListItem's when they are re-inserted into the tree:
                   // get the currently selected staff type of each combo and re-insert
                   int numOfStaffListItems = item->childCount();
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
                   int staffIdx[numOfStaffListItems];
+#else
+                  // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+                  //    heap allocation is slow, an optimization might be used.
+                  std::vector<int> staffIdx(numOfStaffListItems);
+#endif
                   int itemIdx;
                   for (itemIdx=0; itemIdx < numOfStaffListItems; ++itemIdx)
                         staffIdx[itemIdx] = (static_cast<StaffListItem*>(item->child(itemIdx)))->staffTypeIdx();

--- a/mscore/jackaudio.cpp
+++ b/mscore/jackaudio.cpp
@@ -18,6 +18,13 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
+#if (defined (_MSCVER) || defined (_MSC_VER))
+// Include stdint.h and #define _STDINT_H to prevent <systemdeps.h> from redefining types
+// #undef UNICODE to force LoadLibrary to use the char-based implementation instead of the wchar_t one.
+#include <stdint.h>
+#define _STDINT_H 1  
+#endif
+
 #include "jackaudio.h"
 #include "musescore.h"
 #include "libmscore/mscore.h"
@@ -397,7 +404,14 @@ int JackAudio::processAudio(jack_nframes_t frames, void* p)
                   }
             }
       if (l && r) {
-            float buffer[frames * 2];
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+         float buffer[frames * 2];
+#else
+         // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+         //    heap allocation is slow, an optimization might be used.
+         std::vector<float> vBuffer(frames * 2);
+         float* buffer = vBuffer.data();
+#endif
             audio->seq->process((unsigned)frames, buffer);
             float* sp = buffer;
             for (unsigned i = 0; i < frames; ++i) {
@@ -407,7 +421,14 @@ int JackAudio::processAudio(jack_nframes_t frames, void* p)
             }
       else {
             // JACK MIDI only
-            float buffer[frames * 2];
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+         float buffer[frames * 2];
+#else
+            // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+            //    heap allocation is slow, an optimization might be used.
+         std::vector<float> vBuffer(frames * 2);
+         float* buffer = vBuffer.data();
+#endif
             audio->seq->process((unsigned)frames, buffer);
             }
       return 0;

--- a/mscore/mididriver.h
+++ b/mscore/mididriver.h
@@ -25,7 +25,7 @@
 #ifndef __MIDIDRIVER_H__
 #define __MIDIDRIVER_H__
 
-#if not defined(Q_OS_WIN)
+#if !defined(Q_OS_WIN)
 #include <poll.h>
 #endif
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1349,7 +1349,7 @@ MuseScore::MuseScore()
       menuHelp->addAction(aboutMusicXMLAction);
 
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
-#if not defined(FOR_WINSTORE)
+#if !defined(FOR_WINSTORE)
       checkForUpdateAction = menuHelp->addAction("", this, SLOT(checkForUpdate()));
 #endif
 #endif
@@ -5754,8 +5754,15 @@ bool MuseScore::saveMp3(Score* score, const QString& name)
                               break;
                         int n = f - playTime;
                         if (n) {
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
                               float bu[n * 2];
                               memset(bu, 0, sizeof(float) * 2 * n);
+#else
+                              // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+                              //    heap allocation is slow, an optimization might be used.
+                              std::vector<float> vBu(n * 2, 0);   // Default initialized, memset() not required.
+                              float* bu = vBu.data();
+#endif
 
                               synti->process(n, bu);
                               float* sp = bu;
@@ -5776,8 +5783,15 @@ bool MuseScore::saveMp3(Score* score, const QString& name)
                               }
                         }
                   if (frames) {
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
                         float bu[frames * 2];
                         memset(bu, 0, sizeof(float) * 2 * frames);
+#else
+                        // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+                        //    heap allocation is slow, an optimization might be used.
+                        std::vector<float> vBu(frames * 2, 0);   // Default initialized, memset() not required.
+                        float* bu = vBu.data();
+#endif
                         synti->process(frames, bu);
                         float* sp = bu;
                         for (unsigned i = 0; i < frames; ++i) {

--- a/mscore/resourceManager.cpp
+++ b/mscore/resourceManager.cpp
@@ -65,7 +65,13 @@ void ResourceManager::displayLanguages()
 
       int row = 0;
       int col = 0;
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       QPushButton* updateButtons[rowCount];
+#else
+      // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+      //    heap allocation is slow, an optimization might be used.
+      std::vector<QPushButton*> updateButtons(rowCount);
+#endif
       QPushButton* temp;
       languagesTable->verticalHeader()->show();
 

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -936,9 +936,15 @@ void Timeline::drawGrid(int global_rows, int global_cols)
       int x_pos = 0;
 
       //Create stagger array if collapsed_meta is false
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
       int stagger_arr[num_metas];
       for (unsigned int row = 0; row < num_metas; row++)
-            stagger_arr[row] = 0;
+         stagger_arr[row] = 0;
+#else
+      // MSVC does not support VLA. Replace with std::vector. If profiling determines that the
+      //    heap allocation is slow, an optimization might be used.
+      std::vector<int> stagger_arr(num_metas, 0);  // Default initialized, loop not required
+#endif
 
       bool no_key = true;
       std::get<4>(repeat_info) = false;

--- a/omr/CMakeLists.txt
+++ b/omr/CMakeLists.txt
@@ -29,9 +29,15 @@ if (OCR)
       set (OCR_SRC ocr.cpp)
 endif (OCR)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (
       omr STATIC
-      ${PROJECT_BINARY_DIR}/all.h
+      ${_all_h_file}
       ${PCH}
       omrview.cpp pdf.cpp omrpage.cpp
       skew.cpp utils.cpp
@@ -39,14 +45,28 @@ add_library (
       ${OCR_SRC}
       )
 
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       omr
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch -Wno-unused-private-field"
       )
+else (NOT MSVC)
+   set_target_properties (
+      omr
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"    # TODO: Add disabling of unused private field warning?
+      )
+endif (NOT MSVC)   
 
 xcode_pch(omr all)
 
-ADD_DEPENDENCIES(omr mops1)
-ADD_DEPENDENCIES(omr mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( omr )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(omr mops1)
+   ADD_DEPENDENCIES(omr mops2)
+endif (NOT MSVC)   
 

--- a/omr/importpdf.cpp
+++ b/omr/importpdf.cpp
@@ -278,10 +278,10 @@ Score::FileError importPdf(MasterScore* score, const QString& path)
 
       OmrState state;
       state.score = score;
-      foreach (OmrPage* omrPage, omr->pages()) {
-            OmrStaff staff = omrPage->systems().last().staves().first();
+      for (OmrPage* omrPage1 : omr->pages()) {
+            OmrStaff staff = omrPage1->systems().last().staves().first();
             qreal top = staff.top()/omr->spatium();
-            state.importPdfPage(omrPage, top);
+            state.importPdfPage(omrPage1, top);
             }
 
       //---create bracket

--- a/omr/omr.cpp
+++ b/omr/omr.cpp
@@ -89,7 +89,7 @@ void Omr::write(XmlWriter& xml) const
       xml.tag("path", _path);
       xml.tag("spatium", _spatium);
       xml.tag("dpmm", _dpmm);
-      foreach(OmrPage* page, _pages) {
+      for(OmrPage* page : _pages) {
             page->write(xml);
             }
       xml.etag();
@@ -200,12 +200,12 @@ bool Omr::omrActions(int &ID, int page)
             int n = _doc->numPages();
             printf("readPdf: %d pages\n", n);
             for (int i = 0; i < n; ++i) {
-                  OmrPage* page = new OmrPage(this);
+                  OmrPage* page1 = new OmrPage(this);
                   QImage image = _doc->page(i);
                   if (image.isNull())
                         return false;
-                  page->setImage(image);
-                  _pages.append(page);
+                  page1->setImage(image);
+                  _pages.append(page1);
                   }
 
             _spatium = 15.0; //constant spatium, image will be rescaled according to this parameter

--- a/omr/omrpage.cpp
+++ b/omr/omrpage.cpp
@@ -427,12 +427,12 @@ void OmrPage::readBarLines()
                         int nx = 0;
                         SymId nsym = SymId::noSym;
                         OmrChord chord;
-                        foreach(OmrNote* n, staff.notes()) {
-                              int x = n->x();
+                        for(OmrNote* n1 : staff.notes()) {
+                              int x = n1->x();
                               if (x >= m.x2())
                                     break;
                               if (x >= m.x1() && x < m.x2()) {
-                                    if (qAbs(x - nx) > int(_spatium / 2) || (nsym != n->sym)) {
+                                    if (qAbs(x - nx) > int(_spatium / 2) || (nsym != n1->sym)) {
                                           if (!chord.notes.isEmpty()) {
                                                 SymId sym = chord.notes.front()->sym;
                                                 if (sym == SymId::noteheadBlack)
@@ -444,8 +444,8 @@ void OmrPage::readBarLines()
                                                 }
                                           }
                                     nx = x;
-                                    nsym = n->sym;
-                                    chord.notes.append(n);
+                                    nsym = n1->sym;
+                                    chord.notes.append(n1);
                                     }
                               }
                         if (!chord.notes.isEmpty()) {
@@ -991,8 +991,8 @@ void OmrSystem::searchNotes()
             // detect collisions
             //
             int fuzz = int(_page->spatium()) / 2;
-            foreach(OmrNote* n, r->notes()) {
-                  foreach(OmrNote* m, r->notes()) {
+            for(OmrNote* n : r->notes()) {
+                  for(OmrNote* m : r->notes()) {
                         if (m == n)
                               continue;
                         if (intersectFuzz(*m, *n, fuzz)) {
@@ -1027,7 +1027,7 @@ void OmrSystem::searchNotes(int *note_labels, int ran)
             //
             // save detected note horizontal positions into note_labels
             //
-            foreach(OmrNote* n, r->notes()) {
+            for(OmrNote* n : r->notes()) {
                   QPoint p = n->center();
                   int h_cent = p.x();
                   for(int h = h_cent - ran; h <= h_cent + ran; h++){
@@ -1309,7 +1309,7 @@ void OmrPage::deSkew()
       uint* db = new uint[wl * h];
       memset(db, 0, wl * h * sizeof(uint));
 
-      foreach(const QRect& r, _slices) {
+      for(const QRect& r : _slices) {
             double rot = skew(r);
             if (qAbs(rot) < 0.1) {
                   memcpy(db + wl * r.y(), scanLine(r.y()), wl * r.height() * sizeof(uint));
@@ -1575,12 +1575,12 @@ void OmrPage::getStaffLines()
 
       QList<Lv> staveTop;
       int staffHeight = _spatium * 6;
-      foreach (Lv a, lv) {
+      for (Lv a : lv) {
             if (a.val < 500)   // MAGIC to avoid false positives
                   continue;
             int line = a.line;
             bool ok = true;
-            foreach (Lv b, staveTop) {
+            for (Lv b : staveTop) {
                   if ((line > (b.line - staffHeight)) && (line < (b.line + staffHeight))) {
                         ok = false;
                         break;
@@ -1590,7 +1590,7 @@ void OmrPage::getStaffLines()
                   staveTop.append(a);
             }
       qSort(staveTop.begin(), staveTop.end(), sortLvStaves);
-      foreach (Lv a, staveTop) {
+      for (Lv a : staveTop) {
             staves.append(OmrStaff(cropL * 32, a.line, (wordsPerLine() - cropL - cropR) * 32, _spatium * 4));
             }
       }
@@ -1644,9 +1644,9 @@ void OmrSystem::searchNotes(QList<OmrNote*>* noteList, int x1, int x2, int y, in
       int n = notePeaks.size();
       for (int i = 0; i < n; ++i) {
             OmrNote* note = new OmrNote;
-            int hh = pattern->h();
-            int hw = pattern->w();
-            note->setRect(notePeaks[i].x, y - hh / 2, hw, hh);
+            int hh1 = pattern->h();
+            int hw1 = pattern->w();
+            note->setRect(notePeaks[i].x, y - hh1 / 2, hw1, hh1);
             note->line = line;
             note->sym = pattern->id();
             note->prob = notePeaks[i].val;
@@ -1688,7 +1688,7 @@ void OmrPage::write(XmlWriter& xml) const
       xml.tag("cropR", cropR);
       xml.tag("cropT", cropT);
       xml.tag("cropB", cropB);
-      foreach(const QRect& r, staves)
+      for(const QRect& r : staves)
             xml.tag("staff", QRectF(r));
       xml.etag();
       }

--- a/omr/omrview.cpp
+++ b/omr/omrview.cpp
@@ -131,7 +131,7 @@ void OmrView::paintEvent(QPaintEvent* event)
       rr.adjust(-1, -1, 2, 2);
 
       QList<Tile*> nl;
-      foreach(Tile* t, usedTiles) {
+      for(Tile* t : usedTiles) {
             if (t->r.intersects(rr))
                   nl.append(t);
             else
@@ -198,7 +198,7 @@ void OmrView::paintEvent(QPaintEvent* event)
 
       int minPage = 9000;
       int maxPage = 0;
-      foreach(const Tile* t, usedTiles) {
+      for(const Tile* t : usedTiles) {
             p.drawPixmap(t->r, t->pm);
             if (t->pageNo < minPage)
                   minPage = t->pageNo;
@@ -211,36 +211,36 @@ void OmrView::paintEvent(QPaintEvent* event)
             p.translate(w * pageNo, 0);
             if (_showLines) {
                   p.setPen(QPen(QColor(255, 0, 0, 80), 1.0));
-                  foreach(QLine l, page->sl())
+                  for(QLine l : page->sl())
                         p.drawLine(QLineF(l.x1()+.5, l.y1()+.5, l.x2()+.5, l.y2()+.5));
                   }
             if (_showSlices) {
-                  foreach(const QRect r, page->slices())
-                        p.fillRect(r, QBrush(QColor(0, 100, 100, 50)));
+                  for(const QRect r1 : page->slices())
+                        p.fillRect(r1, QBrush(QColor(0, 100, 100, 50)));
                   }
 
             if (_showStaves) {
-                  foreach(const OmrSystem& s, page->systems()) {       // staves
-                        foreach(const OmrStaff& r, s.staves())
-                              p.fillRect(r, QBrush(QColor(0, 0, 100, 50)));
+                  for(const OmrSystem& s : page->systems()) {       // staves
+                        for(const OmrStaff& r1 : s.staves())
+                              p.fillRect(r1, QBrush(QColor(0, 0, 100, 50)));
                         }
                   }
 
-            foreach (const OmrSystem& system, page->systems()) {
+            for (const OmrSystem& system : page->systems()) {
                   if (_showBarlines) {
                         p.setPen(QPen(Qt::blue, 3.0));
-                        foreach(const QLineF& l, system.barLines)
-                            for(int w = 0; w < 10; w++)
-                              p.drawLine(l.x1()+w, l.y1(), l.x2()+w, l.y2() ); //add width to barline
+                        for(const QLineF& l : system.barLines)
+                            for(int w1 = 0; w1 < 10; w1++)
+                              p.drawLine(l.x1()+w1, l.y1(), l.x2()+w1, l.y2() ); //add width to barline
                         }
 
-                  foreach (const OmrStaff& staff, system.staves()) {
-                        foreach (const OmrNote* n, staff.notes()) {
-                            if (n->sym == SymId::noteheadBlack)
+                  for (const OmrStaff& staff : system.staves()) {
+                        for (const OmrNote* n1 : staff.notes()) {
+                            if (n1->sym == SymId::noteheadBlack)
                                     p.setPen(QPen(QColor(255, 0, 0), 2.0));
                               else
                                     p.setPen(QPen(QColor(0, 0, 255), 2.0));
-                              p.drawRect(*n);
+                              p.drawRect(*n1);
                               }
                         }
                   }
@@ -252,8 +252,8 @@ void OmrView::paintEvent(QPaintEvent* event)
             p.setBrush(QColor(0, 0, 50, 50));
             QPen pen(QColor(0, 0, 255));
             // always 2 pixel width
-            qreal w = 2.0 / p.matrix().m11();
-            pen.setWidthF(w);
+            qreal w1 = 2.0 / p.matrix().m11();
+            pen.setWidthF(w1);
             p.setPen(pen);
             p.drawRect(_foto);
             }

--- a/synthesizer/CMakeLists.txt
+++ b/synthesizer/CMakeLists.txt
@@ -18,22 +18,42 @@ else (APPLE)
       set(INCS "")
 endif (APPLE)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (synthesizer STATIC
-      ${PROJECT_BINARY_DIR}/all.h
+      ${_all_h_file}
       ${PCH}
       msynthesizer.cpp
       event.cpp
       synthesizergui.cpp
       ${INCS}
       )
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       synthesizer
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      synthesizer
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(synthesizer all)
 
-ADD_DEPENDENCIES(synthesizer mops1)
-ADD_DEPENDENCIES(synthesizer mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( synthesizer )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(synthesizer mops1)
+   ADD_DEPENDENCIES(synthesizer mops2)
+endif (NOT MSVC)   
 

--- a/synthesizer/event.cpp
+++ b/synthesizer/event.cpp
@@ -200,7 +200,9 @@ bool MidiCoreEvent::isChannelEvent() const
             default:
                   return false;
             }
-      return false;
+
+      // Prevent "unreachable code" warning.
+      // return false;
       }
 
 //---------------------------------------------------------

--- a/synthesizer/msynthesizer.cpp
+++ b/synthesizer/msynthesizer.cpp
@@ -199,8 +199,12 @@ void MasterSynthesizer::setEffect(int ab, int idx)
             return;
             }
       lock2 = true;
-      while (lock1)
-            sleep(1);
+      while(lock1)
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+         sleep(1);
+#else
+         Sleep(1000);      // MS-equivalent function, time in ms instead of seconds.
+#endif
       _effect[ab] = _effectList[ab][idx];
       lock2 = false;
       }

--- a/synthesizer/msynthesizer.h
+++ b/synthesizer/msynthesizer.h
@@ -33,7 +33,7 @@ class Xml;
 class MasterSynthesizer : public QObject {
       Q_OBJECT
 
-      float _gain             { 0.1   };     // -20dB
+      float _gain             { 0.1f  };     // -20dB
       float _boost            { 10.0  };     // +20dB
       double _masterTuning    { 440.0 };
 

--- a/thirdparty/beatroot/CMakeLists.txt
+++ b/thirdparty/beatroot/CMakeLists.txt
@@ -12,13 +12,26 @@ add_library (
       Agent.cpp
   )
 
-set_target_properties( beatroot
-   PROPERTIES
-      COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
-   )
+if (NOT MSVC)
+   set_target_properties( beatroot
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
+      )
+else (NOT MSVC)
+   set_target_properties ( beatroot
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(beatroot all)
 
-ADD_DEPENDENCIES(beatroot mops1)
-ADD_DEPENDENCIES(beatroot mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( beatroot )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(beatroot mops1)
+   ADD_DEPENDENCIES(beatroot mops2)
+endif (NOT MSVC)
 

--- a/thirdparty/diff/CMakeLists.txt
+++ b/thirdparty/diff/CMakeLists.txt
@@ -26,21 +26,40 @@ else (APPLE)
         set(INCS "")
 endif (APPLE)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library(diff_match_patch STATIC
    diff_match_patch.cpp
-   ${PROJECT_BINARY_DIR}/all.h
+   ${_all_h_file}
    ${PCH}
    ${INCS}
    )
 
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       diff_match_patch
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      diff_match_patch
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(diff_match_patch all)
 
-ADD_DEPENDENCIES(diff_match_patch mops1)
-ADD_DEPENDENCIES(diff_match_patch mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( diff_match_patch )
 
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(diff_match_patch mops1)
+   ADD_DEPENDENCIES(diff_match_patch mops2)
+endif (NOT MSVC)

--- a/thirdparty/diff/diff_match_patch.cpp
+++ b/thirdparty/diff/diff_match_patch.cpp
@@ -137,7 +137,7 @@ QString Patch::toString() {
   text = QString("@@ -") + coords1 + QString(" +") + coords2
       + QString(" @@\n");
   // Escape the body of the patch with %xx notation.
-  foreach (Diff aDiff, diffs) {
+  for (Diff aDiff : diffs) {
     switch (aDiff.operation) {
       case INSERT:
         text += QString('+');
@@ -349,7 +349,7 @@ QList<Diff> diff_match_patch::diff_lineMode(QString text1, QString text2,
             pointer.previous();
             pointer.remove();
           }
-          foreach(Diff newDiff,
+          for(Diff newDiff :
               diff_main(text_delete, text_insert, false, deadline)) {
             pointer.insert(newDiff);
           }
@@ -1212,7 +1212,7 @@ int diff_match_patch::diff_xIndex(const QList<Diff> &diffs, int loc) {
   int last_chars1 = 0;
   int last_chars2 = 0;
   Diff lastDiff;
-  foreach(Diff aDiff, diffs) {
+  for(Diff aDiff : diffs) {
     if (aDiff.operation != INSERT) {
       // Equality or deletion.
       chars1 += aDiff.text.length();
@@ -1242,7 +1242,7 @@ QString diff_match_patch::diff_prettyHtml(const QList<Diff> &diffs) {
   QString html;
   QString text;
   int i = 0;
-  foreach(Diff aDiff, diffs) {
+  for(Diff aDiff : diffs) {
     text = aDiff.text;
     text.replace("&", "&amp;").replace("<", "&lt;")
         .replace(">", "&gt;").replace("\n", "&para;<br/>");
@@ -1269,7 +1269,7 @@ QString diff_match_patch::diff_prettyHtml(const QList<Diff> &diffs) {
 
 QString diff_match_patch::diff_text1(const QList<Diff> &diffs) {
   QString text;
-  foreach(Diff aDiff, diffs) {
+  for(Diff aDiff : diffs) {
     if (aDiff.operation != INSERT) {
       text += aDiff.text;
     }
@@ -1280,7 +1280,7 @@ QString diff_match_patch::diff_text1(const QList<Diff> &diffs) {
 
 QString diff_match_patch::diff_text2(const QList<Diff> &diffs) {
   QString text;
-  foreach(Diff aDiff, diffs) {
+  for(Diff aDiff : diffs) {
     if (aDiff.operation != DELETE) {
       text += aDiff.text;
     }
@@ -1293,7 +1293,7 @@ int diff_match_patch::diff_levenshtein(const QList<Diff> &diffs) {
   int levenshtein = 0;
   int insertions = 0;
   int deletions = 0;
-  foreach(Diff aDiff, diffs) {
+  for(Diff aDiff : diffs) {
     switch (aDiff.operation) {
       case INSERT:
         insertions += aDiff.text.length();
@@ -1316,7 +1316,7 @@ int diff_match_patch::diff_levenshtein(const QList<Diff> &diffs) {
 
 QString diff_match_patch::diff_toDelta(const QList<Diff> &diffs) {
   QString text;
-  foreach(Diff aDiff, diffs) {
+  for(Diff aDiff : diffs) {
     switch (aDiff.operation) {
       case INSERT: {
         QString encoded = QString(QUrl::toPercentEncoding(aDiff.text,
@@ -1347,7 +1347,7 @@ QList<Diff> diff_match_patch::diff_fromDelta(const QString &text1,
   QList<Diff> diffs;
   int pointer = 0;  // Cursor in text1
   QStringList tokens = delta.split("\t");
-  foreach(QString token, tokens) {
+  for(QString token : tokens) {
     if (token.isEmpty()) {
       // Blank tokens are ok (from a trailing \t).
       continue;
@@ -1647,7 +1647,7 @@ QList<Patch> diff_match_patch::patch_make(const QString &text1,
   // context info.
   QString prepatch_text = text1;
   QString postpatch_text = text1;
-  foreach(Diff aDiff, diffs) {
+  for(Diff aDiff : diffs) {
     if (patch.diffs.isEmpty() && aDiff.operation != EQUAL) {
       // A new patch starts here.
       patch.start1 = char_count1;
@@ -1713,9 +1713,9 @@ QList<Patch> diff_match_patch::patch_make(const QString &text1,
 
 QList<Patch> diff_match_patch::patch_deepCopy(QList<Patch> &patches) {
   QList<Patch> patchesCopy;
-  foreach(Patch aPatch, patches) {
+  for(Patch aPatch : patches) {
     Patch patchCopy = Patch();
-    foreach(Diff aDiff, aPatch.diffs) {
+    for(Diff aDiff : aPatch.diffs) {
       Diff diffCopy = Diff(aDiff.operation, aDiff.text);
       patchCopy.diffs.append(diffCopy);
     }
@@ -1750,7 +1750,7 @@ QPair<QString, QVector<bool> > diff_match_patch::patch_apply(
   // has an effective expected position of 22.
   int delta = 0;
   QVector<bool> results(patchesCopy.size());
-  foreach(Patch aPatch, patchesCopy) {
+  for(Patch aPatch : patchesCopy) {
     int expected_loc = aPatch.start2 + delta;
     QString text1 = diff_text1(aPatch.diffs);
     int start_loc;
@@ -1801,7 +1801,7 @@ QPair<QString, QVector<bool> > diff_match_patch::patch_apply(
         } else {
           diff_cleanupSemanticLossless(diffs);
           int index1 = 0;
-          foreach(Diff aDiff, aPatch.diffs) {
+          for(Diff aDiff : aPatch.diffs) {
             if (aDiff.operation != EQUAL) {
               int index2 = diff_xIndex(diffs, index1);
               if (aDiff.operation == INSERT) {
@@ -1995,7 +1995,7 @@ void diff_match_patch::patch_splitMax(QList<Patch> &patches) {
 
 QString diff_match_patch::patch_toText(const QList<Patch> &patches) {
   QString text;
-  foreach(Patch aPatch, patches) {
+  for(Patch aPatch : patches) {
     text.append(aPatch.toString());
   }
   return text;
@@ -2065,7 +2065,9 @@ QList<Patch> diff_match_patch::patch_fromText(const QString &textline) {
       } else {
         // WTF?
         throw QString("Invalid patch mode '%1' in: %2").arg(sign).arg(line);
-        return QList<Patch>();
+
+        // Eliminate "unreachable code" warning
+        // return QList<Patch>();
       }
       text.removeFirst();
     }

--- a/thirdparty/freetype/CMakeLists.txt
+++ b/thirdparty/freetype/CMakeLists.txt
@@ -188,7 +188,7 @@ add_library(mscore_freetype
   ${BASE_SRCS}
 )
 
-if (MSVC)
-  set_target_properties(freetype PROPERTIES
-    COMPILE_FLAGS /Fd"$(IntDir)$(TargetName).pdb")
-endif ()
+###-###if (MSVC)
+###-###  set_target_properties(freetype PROPERTIES
+###-###    COMPILE_FLAGS /Fd"$(IntDir)$(TargetName).pdb")
+###-###endif ()

--- a/thirdparty/freetype/src/base/ftobjs.c
+++ b/thirdparty/freetype/src/base/ftobjs.c
@@ -4706,9 +4706,10 @@
 #ifdef FT_CONFIG_OPTION_PIC
   Fail:
     ft_pic_container_destroy( library );
-#endif
+
     FT_FREE( library );
     return error;
+#endif
   }
 
 

--- a/thirdparty/freetype/src/base/ftoutln.c
+++ b/thirdparty/freetype/src/base/ftoutln.c
@@ -938,7 +938,8 @@
       FT_Fixed   l_in, l_out, l_anchor = 0, l, q, d;
       FT_Int     i, j, k;
 
-
+      anchor.x = anchor.y = 0;      // Prevent "potentially unitialized local variable" warning in VS.
+      in.x = in.y = 0;              // Prevent "potentially unitialized local variable" warning in VS.
       l_in = 0;
       last = outline->contours[c];
 

--- a/thirdparty/freetype/src/truetype/ttgload.c
+++ b/thirdparty/freetype/src/truetype/ttgload.c
@@ -1655,6 +1655,10 @@
         FT_SubGlyph  subglyph;
 
         FT_Outline  outline;
+        // #if (defined (_MSCVER) || defined (_MSC_VER))
+        // Initialize outline to prevent "potentially uninitialized local variable" warning
+        outline = (FT_Outline) { .n_contours = 0, .n_points = 0, .points = NULL, .tags = NULL, .contours = NULL, .flags = 0 };
+
         FT_Vector*  points   = NULL;
         char*       tags     = NULL;
         short*      contours = NULL;

--- a/thirdparty/kQOAuth/CMakeLists.txt
+++ b/thirdparty/kQOAuth/CMakeLists.txt
@@ -26,25 +26,45 @@ else (APPLE)
         set(INCS "")
 endif (APPLE)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library(kqoauth STATIC
    kqoauthauthreplyserver.cpp
    kqoauthrequest.cpp
    kqoauthrequest_xauth.cpp
    kqoauthmanager.cpp
    kqoauthutils.cpp
-   ${PROJECT_BINARY_DIR}/all.h
+   ${_all_h_file}
    ${PCH}
    ${INCS}
    )
 
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       kqoauth
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -I ${PROJECT_SOURCE_DIR}/thirdparty/openssl/include -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      kqoauth
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE} /I${PROJECT_SOURCE_DIR}/thirdparty/openssl/include"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(kqoauth all)
 
-ADD_DEPENDENCIES(kqoauth mops1)
-ADD_DEPENDENCIES(kqoauth mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( kqoauth )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(kqoauth mops1)
+   ADD_DEPENDENCIES(kqoauth mops2)
+endif (NOT MSVC)   
 

--- a/thirdparty/kQOAuth/kqoauthrequest.cpp
+++ b/thirdparty/kQOAuth/kqoauthrequest.cpp
@@ -265,7 +265,8 @@ bool KQOAuthRequestPrivate::validateRequest() const {
     }
 
     // We should not come here.
-    return false;
+    // Prevent "unreachable code" warning.
+    // return false;
 }
 
 //////////// Public implementation ////////////////

--- a/thirdparty/ofqf/CMakeLists.txt
+++ b/thirdparty/ofqf/CMakeLists.txt
@@ -26,21 +26,41 @@ else (APPLE)
         set(INCS "")
 endif (APPLE)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library(ofqf STATIC
-   ${PROJECT_BINARY_DIR}/all.h
+   ${_all_h_file}
    ${PCH}
    ${INCS}
    qoscclient.cpp qoscserver.cpp qosctypes.cpp
    )
 
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       ofqf
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      ofqf
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(ofqf all)
 
-ADD_DEPENDENCIES(ofqf mops1)
-ADD_DEPENDENCIES(ofqf mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( ofqf )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(ofqf mops1)
+   ADD_DEPENDENCIES(ofqf mops2)
+endif (NOT MSVC)   
 

--- a/thirdparty/ofqf/qoscserver.cpp
+++ b/thirdparty/ofqf/qoscserver.cpp
@@ -88,7 +88,7 @@ void QOscServer::readyRead()
         		            args += data[ i++ ];
                   i++; //move one byte more!
         			    if ( ! args.isEmpty() ) {
-        				        QList<QVariant> list;
+        				        QList<QVariant> list1;
         				        foreach( QChar type, args ) {
         					            while ( i%4 != 0 ) ++i;
         					            //qDebug() << i << "\ttrying to convert to" << type;
@@ -112,13 +112,13 @@ void QOscServer::readyRead()
                               //qDebug() << " got" << value;
         
                               if ( args.size() > 1 )
-                                    list.append( value );
+                                    list1.append( value );
                               else
                                     arguments = value;
                               }
         
                               if ( args.size() > 1 )
-                                    arguments = list;
+                                    arguments = list1;
                         }
         		      }
         		      qDebug() << "path seems to be" << path << "args are" << args << ":" << arguments;

--- a/thirdparty/poppler/CMakeLists.txt
+++ b/thirdparty/poppler/CMakeLists.txt
@@ -139,7 +139,20 @@ else (APPLE)
    if (MINGW)
       set (POPPLER_COMPILE_FLAGS "-O2 -Wall -Wextra -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-but-set-variable -Wno-format -std=c++11")
    else (MINGW)
-      set (POPPLER_COMPILE_FLAGS "-O2 -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-but-set-variable -std=c++11")
+      if (NOT MSVC)
+         set (POPPLER_COMPILE_FLAGS "-O2 -Wno-write-strings -ansi -Wnon-virtual-dtor -Woverloaded-virtual -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-but-set-variable -std=c++11")
+      else (NOT MSVC)
+         # For MSVC:
+         # -O2: controls optimization, not compatible with global options
+         # -ansi & -std=c++11 -> gloablly set /std:c++14 should take care.
+         # -Wno-write-strings    -> ???
+         # -Wno-unused-parameter -> Warning C4100: 'identifier' : unreferenced formal parameter
+         # -Wnon-virtual-dtor    -> /Wall enabled all warnings, no need to enable particularly (Warning C4265: 'classname': class has virtual functions, but destructor is not virtual\n instances of this class may not be destructed correctly)
+         # -Woverloaded-virtual  -> /Wall enabled all warnings, no need to enable particularly
+         # -Wno-missing-field-initializers -> ???
+         # -Wno-unused-but-set-variable -> Warning C4189: 'identifier': local variable is initialized but not referenced
+         set (POPPLER_COMPILE_FLAGS "/wd4100 /wd4189")
+      endif (NOT MSVC)
    endif(MINGW)
 endif(APPLE)
 

--- a/thirdparty/poppler/config.h
+++ b/thirdparty/poppler/config.h
@@ -51,7 +51,10 @@
 /* #undef HAVE_FSEEK64 */
 
 /* Define to 1 if fseeko (and presumably ftello) exists and is declared. */
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+// MSVC does not have fseeko/ftello. Might be uncommented if an implementation is added.
 #define HAVE_FSEEKO 1
+#endif
 
 /* Define to 1 if you have the `ftell64' function. */
 /* #undef HAVE_FTELL64 */
@@ -152,7 +155,10 @@
 /* #undef HAVE_TIFFIO_H */
 
 /* Define to 1 if you have the <unistd.h> header file. */
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+   // MSVC does not have <unistd.h>. Might be uncommented if an implementation is added.
 #define HAVE_UNISTD_H 1
+#endif
 
 /* Define to 1 if you have the <zlib.h> header file. */
 #define HAVE_ZLIB_H 1
@@ -280,3 +286,10 @@
 
 /* Define for large files, on AIX-style hosts. */
 /* #undef _LARGE_FILES */
+
+#if (defined (_MSCVER) || defined (_MSC_VER))
+   // Undefine UNICODE for MSVC to get the char-based library functions
+   #ifdef UNICODE
+   #undef UNICODE
+   #endif
+#endif

--- a/thirdparty/poppler/poppler/PSOutputDev.cc
+++ b/thirdparty/poppler/poppler/PSOutputDev.cc
@@ -48,6 +48,7 @@
 #include <signal.h>
 #include <math.h>
 #include <limits.h>
+#include <algorithm>       // Required for std::min() & std::max()  (on MSVC, and per-standard)
 #include "goo/GooString.h"
 #include "goo/GooList.h"
 #include "goo/GooHash.h"

--- a/thirdparty/poppler/poppler/poppler-config.h
+++ b/thirdparty/poppler/poppler/poppler-config.h
@@ -86,8 +86,15 @@
 #endif
 
 /* Defines if gettimeofday is available on your system */
-#ifndef HAVE_GETTIMEOFDAY
-#define HAVE_GETTIMEOFDAY 1
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+   // MSVC does not have time of day
+   #ifndef HAVE_GETTIMEOFDAY
+   #define HAVE_GETTIMEOFDAY 1
+   #endif
+#else
+   #ifdef HAVE_GETTIMEOFDAY
+   #undef HAVE_GETTIMEOFDAY
+   #endif
 #endif
 
 /* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
@@ -179,10 +186,11 @@ char * strtok_r (char *s, const char *delim, char **save_ptr);
 #define GCC_PRINTF_FORMAT(fmt_index, va_index)
 #endif
 
-#if defined(_MSC_VER)
-#define fmax(a, b) std::max(a, b)
-#define fmin(a, b) std::min(a, b)
-#endif
+// Causes compilation errors with Visual Studio 17, and fmax/fmin are available
+//#if defined(_MSC_VER)
+//#define fmax(a, b) std::max(a, b)
+//#define fmin(a, b) std::min(a, b)
+//#endif
 
 
 #endif /* POPPLER_CONFIG_H */

--- a/thirdparty/portmidi/pm_common/portmidi.c
+++ b/thirdparty/portmidi/pm_common/portmidi.c
@@ -6,6 +6,19 @@
 #include "pminternal.h"
 #include <assert.h>
 
+#if (!defined(Q_UNUSED))
+/* Define Q_UNUSED macro to suppress warnings about unreferenced parameters. This definition is the same
+   as the one in the Qt headers, copied since this file does not include those headers.*/
+#define Q_UNUSED(x) (void)x;
+#endif
+
+#if (defined(_MSCVER) || defined(_MSC_VER))
+/* Suppress warnings:
+      C4018: signed/unsigned mismatch in comparison
+      C4244: narrowing conversion, possible loss of data */
+#pragma warning(disable : 4018 4244)
+#endif
+
 #define MIDI_CLOCK      0xf8
 #define MIDI_ACTIVE     0xfe
 #define MIDI_STATUS_MASK 0x80
@@ -154,40 +167,64 @@ const PmDeviceInfo* Pm_GetDeviceInfo( PmDeviceID id ) {
 
 /* pm_success_fn -- "noop" function pointer */
 PmError pm_success_fn(PmInternal *midi) {
-    return pmNoError;
+   Q_UNUSED(midi);
+
+   return pmNoError;
 }
 
 /* none_write -- returns an error if called */
 PmError none_write_short(PmInternal *midi, PmEvent *buffer) {
-    return pmBadPtr;
+   Q_UNUSED(midi);
+   Q_UNUSED(buffer);
+
+   return pmBadPtr;
 }
 
 /* pm_fail_timestamp_fn -- placeholder for begin_sysex and flush */
 PmError pm_fail_timestamp_fn(PmInternal *midi, PmTimestamp timestamp) {
-    return pmBadPtr;
+   Q_UNUSED(midi);
+   Q_UNUSED(timestamp);
+
+   return pmBadPtr;
 }
 
 PmError none_write_byte(PmInternal *midi, unsigned char byte, 
                         PmTimestamp timestamp) {
-    return pmBadPtr;
+   Q_UNUSED(midi);
+   Q_UNUSED(byte);
+   Q_UNUSED(timestamp);
+
+   return pmBadPtr;
 }
 
 /* pm_fail_fn -- generic function, returns error if called */
 PmError pm_fail_fn(PmInternal *midi) {
-    return pmBadPtr;
+   Q_UNUSED(midi);
+
+   return pmBadPtr;
 }
 
 static PmError none_open(PmInternal *midi, void *driverInfo) {
-    return pmBadPtr;
+   Q_UNUSED(midi);
+   Q_UNUSED(driverInfo);
+
+   return pmBadPtr;
 }
 static void none_get_host_error(PmInternal * midi, char * msg, unsigned int len) {
-    strcpy(msg, "");
+   Q_UNUSED(midi);
+   Q_UNUSED(len);
+
+   strcpy(msg, "");
 }
 static unsigned int none_has_host_error(PmInternal * midi) {
-    return FALSE;
+   Q_UNUSED(midi);
+
+   return FALSE;
 }
 PmTimestamp none_synchronize(PmInternal *midi) {
-    return 0;
+   Q_UNUSED(midi);
+
+   return 0;
 }
 
 #define none_abort pm_fail_fn
@@ -347,11 +384,11 @@ int Pm_Read(PortMidiStream *stream, PmEvent *buffer, long length) {
     }
 
     while (n < length) {
-        PmError err = Pm_Dequeue(midi->queue, buffer++);
-        if (err == pmBufferOverflow) {
+        PmError err1 = Pm_Dequeue(midi->queue, buffer++);
+        if (err1 == pmBufferOverflow) {
             /* ignore the data we have retreived so far */
             return pm_errmsg(pmBufferOverflow);
-        } else if (err == 0) { /* empty queue */
+        } else if (err1 == 0) { /* empty queue */
             break;
         }
         n++;
@@ -585,12 +622,12 @@ PmError Pm_WriteSysEx(PortMidiStream *stream, PmTimestamp when,
                 buffer_size = BUFLEN;
                 /* optimization: maybe we can just copy bytes */
                 if (midi->fill_base) {
-                    PmError err;
+                    PmError err1;
                     while (*(midi->fill_offset_ptr) < midi->fill_length) {
                         midi->fill_base[(*midi->fill_offset_ptr)++] = *msg;
                         if (*msg++ == MIDI_EOX) {
-                            err = pm_end_sysex(midi);
-                            if (err != pmNoError) return pm_errmsg(err);
+                            err1 = pm_end_sysex(midi);
+                            if (err1 != pmNoError) return pm_errmsg(err1);
                             goto end_of_sysex;
                         }
                     }

--- a/thirdparty/portmidi/pm_win/pmwin.c
+++ b/thirdparty/portmidi/pm_win/pmwin.c
@@ -92,7 +92,9 @@ PmDeviceID Pm_GetDefaultOutputDeviceID() {
         }
     }
     return pmNoDevice;
-    return 0;
+
+    // Prevent "unreachable code" warning
+    // return 0;
 }
 
 #include "stdio.h"

--- a/thirdparty/portmidi/pm_win/pmwinmm.c
+++ b/thirdparty/portmidi/pm_win/pmwinmm.c
@@ -7,6 +7,11 @@
     #define _WIN32_WINNT 0x0500
 #endif
 
+// Undefine UNICODE to get the char-based library functions
+#ifdef UNICODE
+#undef UNICODE
+#endif
+
 #include "windows.h"
 #include "mmsystem.h"
 #include "portmidi.h"

--- a/thirdparty/portmidi/pm_win/pmwinmm.c
+++ b/thirdparty/portmidi/pm_win/pmwinmm.c
@@ -162,7 +162,12 @@ general MIDI device queries
 static void pm_winmm_general_inputs()
 {
     UINT i;
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
     WORD wRtn;
+#else
+    // The result type is MMRESULT in MSVC. Keeping it as WORD generated a "possible loss of data" warning
+    MMRESULT wRtn;
+#endif
     midi_num_inputs = midiInGetNumDevs();
     midi_in_caps = (MIDIINCAPS *) pm_alloc(sizeof(MIDIINCAPS) * 
                                            midi_num_inputs);
@@ -189,8 +194,13 @@ static void pm_winmm_general_inputs()
 
 static void pm_winmm_mapper_input()
 {
-    WORD wRtn;
-    /* Note: if MIDIMAPPER opened as input (documentation implies you
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+   WORD wRtn;
+#else
+   // The result type is MMRESULT in MSVC. Keeping it as WORD generated a "possible loss of data" warning
+   MMRESULT wRtn;
+#endif
+   /* Note: if MIDIMAPPER opened as input (documentation implies you
         can, but current system fails to retrieve input mapper
         capabilities) then you still should retrieve some formof
         setup info. */
@@ -229,8 +239,13 @@ static void pm_winmm_general_outputs()
 
 static void pm_winmm_mapper_output()
 {
-    WORD wRtn;
-    /* Note: if MIDIMAPPER opened as output (pseudo MIDI device
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+   WORD wRtn;
+#else
+   // The result type is MMRESULT in MSVC. Keeping it as WORD generated a "possible loss of data" warning
+   MMRESULT wRtn;
+#endif
+   /* Note: if MIDIMAPPER opened as output (pseudo MIDI device
         maps device independent messages into device dependant ones,
         via NT midimapper program) you still should get some setup info */
     wRtn = midiOutGetDevCaps((UINT) MIDIMAPPER, (LPMIDIOUTCAPS)
@@ -272,7 +287,10 @@ static void winmm_get_host_error(PmInternal * midi, char * msg, UINT len)
     /* precondition: midi != NULL */
     midiwinmm_node * m = (midiwinmm_node *) midi->descriptor;
     char *hdr1 = "Host error: ";
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+    /* This variable generates a not-referenced warning in MSVC */
     char *hdr2 = "Host callback error: ";
+#endif
 
     msg[0] = 0; /* initialize result string to empty */
 
@@ -542,6 +560,9 @@ static PmError allocate_input_buffer(HMIDIIN h, long buffer_len)
 
 static PmError winmm_in_open(PmInternal *midi, void *driverInfo)
 {
+#if (defined (_MSCVER) || defined (_MSC_VER))
+    UNREFERENCED_PARAMETER(driverInfo);
+#endif
     DWORD dwDevice;
     int i = midi->device_id;
     int max_sysex_len = midi->buffer_len * 4;
@@ -641,13 +662,17 @@ static PmError winmm_in_close(PmInternal *midi)
     midiwinmm_type m = (midiwinmm_type) midi->descriptor;
     if (!m) return pmBadPtr;
     /* device to close */
-    if (pm_hosterror = midiInStop(m->handle.in)) {
+    pm_hosterror = midiInStop(m->handle.in);
+    if (pm_hosterror) {
         midiInReset(m->handle.in); /* try to reset and close port */
         midiInClose(m->handle.in);
-    } else if (pm_hosterror = midiInReset(m->handle.in)) {
-        midiInClose(m->handle.in); /* best effort to close midi port */
     } else {
-        pm_hosterror = midiInClose(m->handle.in);
+        pm_hosterror = midiInReset(m->handle.in);
+        if(pm_hosterror) {
+            midiInClose(m->handle.in); /* best effort to close midi port */
+        } else {
+            pm_hosterror = midiInClose(m->handle.in);
+        }
     }
     midi->descriptor = NULL;
     DeleteCriticalSection(&m->lock);
@@ -695,7 +720,10 @@ static void FAR PASCAL winmm_in_callback(
             in [ms] from when midiInStart called.
            each message is expanded to include the status byte */
 
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+        /* This variable generates a "local variable not referenced" warning in MSVC. */
         long new_driver_time = dwParam2;
+#endif
 
         if ((dwParam1 & 0x80) == 0) {
             /* not a status byte -- ignore it. This happened running the
@@ -787,7 +815,10 @@ begin midi output implementation
 static int add_to_buffer(midiwinmm_type m, LPMIDIHDR hdr,
                          unsigned long delta, unsigned long msg)
 {
-    unsigned long *ptr = (unsigned long *)
+#if (defined (_MSCVER) || defined (_MSC_VER))
+    UNREFERENCED_PARAMETER(m);
+#endif
+   unsigned long *ptr = (unsigned long *)
                          (hdr->lpData + hdr->dwBytesRecorded);
     *ptr++ = delta; /* dwDeltaTime */
     *ptr++ = 0;     /* dwStream */
@@ -817,7 +848,10 @@ static PmTimestamp pm_time_get(midiwinmm_type m)
 
 static PmError winmm_out_open(PmInternal *midi, void *driverInfo)
 {
-    DWORD dwDevice;
+#if (defined (_MSCVER) || defined (_MSC_VER))
+    UNREFERENCED_PARAMETER(driverInfo);
+#endif
+   DWORD dwDevice;
     int i = midi->device_id;
     midiwinmm_type m;
     MIDIPROPTEMPO propdata;
@@ -886,7 +920,10 @@ static PmError winmm_out_open(PmInternal *midi, void *driverInfo)
         if (output_buffer_len < MIN_SIMPLE_SYSEX_LEN)
             output_buffer_len = MIN_SIMPLE_SYSEX_LEN;
     } else {
-        long dur = 0;
+#if (!defined (_MSCVER) && !defined (_MSC_VER))
+       /* This variable generates a "local variable not referenced" warning in MSVC. */
+       long dur = 0;
+#endif
         num_buffers = max(midi->buffer_len, midi->latency / 2);
         if (num_buffers < MIN_STREAM_BUFFERS)
             num_buffers = MIN_STREAM_BUFFERS;
@@ -1005,7 +1042,10 @@ static PmError winmm_out_abort(PmInternal *midi)
 
 static PmError winmm_write_flush(PmInternal *midi, PmTimestamp timestamp)
 {
-    midiwinmm_type m = (midiwinmm_type) midi->descriptor;
+#if (defined (_MSCVER) || defined (_MSC_VER))
+    UNREFERENCED_PARAMETER(timestamp);
+#endif
+   midiwinmm_type m = (midiwinmm_type) midi->descriptor;
     assert(m);
     if (m->hdr) {
         m->error = midiOutPrepareHeader(m->handle.out, m->hdr, 
@@ -1321,7 +1361,11 @@ static void CALLBACK winmm_out_callback(HMIDIOUT hmo, UINT wMsg,
 static void CALLBACK winmm_streamout_callback(HMIDIOUT hmo, UINT wMsg,
         DWORD dwInstance, DWORD dwParam1, DWORD dwParam2)
 {
-    PmInternal *midi = (PmInternal *) dwInstance;
+#if (defined (_MSCVER) || defined (_MSC_VER))
+    UNREFERENCED_PARAMETER(dwParam2);
+    UNREFERENCED_PARAMETER(hmo);
+#endif
+   PmInternal *midi = (PmInternal *) dwInstance;
     midiwinmm_type m = (midiwinmm_type) midi->descriptor;
     LPMIDIHDR hdr = (LPMIDIHDR) dwParam1;
     int err;

--- a/thirdparty/portmidi/porttime/porttime.c
+++ b/thirdparty/portmidi/porttime/porttime.c
@@ -1,3 +1,9 @@
 /* porttime.c -- portable API for millisecond timer */
 
 /* There is no machine-independent implementation code to put here */
+
+#if (defined (_MSCVER) || defined (_MSC_VER))
+/* Suppress warnings:
+      C4206: nonstandard extension used: translation unit is empty */
+#pragma warning(disable : 4206)
+#endif

--- a/thirdparty/portmidi/porttime/ptwinmm.c
+++ b/thirdparty/portmidi/porttime/ptwinmm.c
@@ -17,7 +17,13 @@ static PtCallback *time_callback;
 void CALLBACK winmm_time_callback(UINT uID, UINT uMsg, DWORD dwUser, 
                                   DWORD dw1, DWORD dw2)
 {
-    (*time_callback)(Pt_Time(), (void *) dwUser);
+#if (defined (_MSCVER) || defined (_MSC_VER))
+   UNREFERENCED_PARAMETER(uID);
+   UNREFERENCED_PARAMETER(uMsg);
+   UNREFERENCED_PARAMETER(dw1);
+   UNREFERENCED_PARAMETER(dw2);
+#endif
+   (*time_callback)(Pt_Time(), (void *) dwUser);
 }
  
 

--- a/thirdparty/qzip/CMakeLists.txt
+++ b/thirdparty/qzip/CMakeLists.txt
@@ -19,21 +19,42 @@ else (APPLE)
         set(INCS "")
 endif (APPLE)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library(qzip STATIC
    qzip.cpp
-   ${PROJECT_BINARY_DIR}/all.h
+   ${_all_h_file}
    ${PCH}
    ${INCS}
    )
 
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       qzip
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      qzip
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+      include_directories("${PROJECT_SOURCE_DIR}/dependencies/include/zlib")
+endif (NOT MSVC)   
 
 xcode_pch(qzip all)
 
-ADD_DEPENDENCIES(qzip mops1)
-ADD_DEPENDENCIES(qzip mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( qzip )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(qzip mops1)
+   ADD_DEPENDENCIES(qzip mops2)
+endif (NOT MSVC)   
 

--- a/thirdparty/qzip/qzip.cpp
+++ b/thirdparty/qzip/qzip.cpp
@@ -47,7 +47,7 @@
 
 #include <zlib.h>
 
-#if defined(Q_OS_WIN) or defined(Q_OS_ANDROID)
+#if (defined(Q_OS_WIN) || defined(Q_OS_ANDROID))
 #  undef S_IFREG
 #  define S_IFREG 0100000
 #  ifndef S_IFDIR

--- a/thirdparty/qzip/qzip.cpp
+++ b/thirdparty/qzip/qzip.cpp
@@ -506,10 +506,10 @@ void MQZipReaderPrivate::scanFiles()
 
     // find EndOfDirectory header
     int i = 0;
-    int start_of_directory = -1;
+    int start_of_directory1 = -1;
     int num_dir_entries = 0;
     EndOfDirectory eod;
-    while (start_of_directory == -1) {
+    while (start_of_directory1 == -1) {
         int pos = device->size() - sizeof(EndOfDirectory) - i;
         if (pos < 0 || i > 65535) {
             qWarning() << "QZip: EndOfDirectory not found";
@@ -524,16 +524,16 @@ void MQZipReaderPrivate::scanFiles()
     }
 
     // have the eod
-    start_of_directory = readUInt(eod.dir_start_offset);
+    start_of_directory1 = readUInt(eod.dir_start_offset);
     num_dir_entries = readUShort(eod.num_dir_entries);
-    ZDEBUG("start_of_directory at %d, num_dir_entries=%d", start_of_directory, num_dir_entries);
+    ZDEBUG("start_of_directory at %d, num_dir_entries=%d", start_of_directory1, num_dir_entries);
     int comment_length = readUShort(eod.comment_length);
     if (comment_length != i)
         qWarning() << "QZip: failed to parse zip file.";
     comment = device->read(qMin(comment_length, i));
 
 
-    device->seek(start_of_directory);
+    device->seek(start_of_directory1);
     for (i = 0; i < num_dir_entries; ++i) {
         FileHeader header;
         int read = device->read((char *) &header.h, sizeof(MCentralFileHeader));

--- a/thirdparty/rtf2html/CMakeLists.txt
+++ b/thirdparty/rtf2html/CMakeLists.txt
@@ -25,9 +25,15 @@ else (APPLE)
         set(INCS "")
 endif (APPLE)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (
   rtf2html STATIC
-  ${PROJECT_BINARY_DIR}/all.h
+  ${_all_h_file}
   ${INCS}
   fmt_opts.cpp
   rtf2html.cpp
@@ -35,13 +41,26 @@ add_library (
   rtf_table.cpp
   )
 
-set_target_properties( rtf2html
-   PROPERTIES
-      COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
-   )
+if (NOT MSVC)
+   set_target_properties( rtf2html
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
+      )
+else (NOT MSVC)
+   set_target_properties ( rtf2html
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(rtf2html all)
 
-ADD_DEPENDENCIES(rtf2html mops1)
-ADD_DEPENDENCIES(rtf2html mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( rtf2html )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(rtf2html mops1)
+   ADD_DEPENDENCIES(rtf2html mops2)
+endif (NOT MSVC)   
 

--- a/thirdparty/rtf2html/rtf2html.cpp
+++ b/thirdparty/rtf2html/rtf2html.cpp
@@ -148,8 +148,8 @@ QString rtf2html(const QString& iString)
                      {
                      case '\\':
                      {
-                        rtf_keyword kw(++buf_in);
-                        if (kw.keyword()==rtf_keyword::rkw_title)
+                        rtf_keyword kw1(++buf_in);
+                        if (kw1.keyword()==rtf_keyword::rkw_title)
                            in_title=true;
                         break;
                      }
@@ -170,17 +170,17 @@ QString rtf2html(const QString& iString)
                      {
                      case '\\':
                      {
-                        rtf_keyword kw(++buf_in);
-                        switch (kw.keyword())
+                        rtf_keyword kw1(++buf_in);
+                        switch (kw1.keyword())
                         {
                         case rtf_keyword::rkw_red:
-                           clr.r=kw.parameter();
+                           clr.r=kw1.parameter();
                            break;
                         case rtf_keyword::rkw_green:
-                           clr.g=kw.parameter();
+                           clr.g=kw1.parameter();
                            break;
                         case rtf_keyword::rkw_blue:
-                           clr.b=kw.parameter();
+                           clr.b=kw1.parameter();
                            break;
                         default:
                            break;
@@ -212,20 +212,20 @@ QString rtf2html(const QString& iString)
                      {
                      case '\\':
                      {
-                        rtf_keyword kw(++buf_in);
-                        if (kw.is_control_char() && kw.control_char()=='*')
+                        rtf_keyword kw1(++buf_in);
+                        if (kw1.is_control_char() && kw1.control_char()=='*')
                            skip_group(buf_in);
                         else
-                           switch (kw.keyword())
+                           switch (kw1.keyword())
                            {
                            case rtf_keyword::rkw_f:
-                              font_num=kw.parameter();
+                              font_num=kw1.parameter();
                               break;
                            case rtf_keyword::rkw_fprq:
-                              fnt.pitch=kw.parameter();
+                              fnt.pitch=kw1.parameter();
                               break;
                            case rtf_keyword::rkw_fcharset:
-                              fnt.charset=kw.parameter();
+                              fnt.charset=kw1.parameter();
                               break;
                            case rtf_keyword::rkw_fnil:
                               fnt.family=font::ff_none;

--- a/thirdparty/rtf2html/rtf_keyword.h
+++ b/thirdparty/rtf2html/rtf_keyword.h
@@ -1,6 +1,8 @@
-#ifndef __RTF_KEYWORD_H__#define __RTF_KEYWORD_H__
+#ifndef __RTF_KEYWORD_H__
+#define __RTF_KEYWORD_H__
 
-#include "config.h"
+
+#include "config.h"
 #include <string>
 #include <map>
 #include <ctype.h>

--- a/thirdparty/singleapp/src/CMakeLists.txt
+++ b/thirdparty/singleapp/src/CMakeLists.txt
@@ -20,21 +20,41 @@
 
 include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (
   qtsingleapp STATIC
-  ${PROJECT_BINARY_DIR}/all.h
+  ${_all_h_file}
   ${PCH}
   qtsingleapplication.cpp
   qtlocalpeer.cpp
   )
 
-set_target_properties (
-  qtsingleapp
-  PROPERTIES
-  COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
-  )
+if (NOT MSVC)
+   set_target_properties (
+      qtsingleapp
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
+      )
+else (NOT MSVC)
+   set_target_properties (
+      qtsingleapp
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(qtsingleapp all)
 
-ADD_DEPENDENCIES(qtsingleapp mops1)
-ADD_DEPENDENCIES(qtsingleapp mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( qtsingleapp )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(qtsingleapp mops1)
+   ADD_DEPENDENCIES(qtsingleapp mops2)
+endif (NOT MSVC)   

--- a/thirdparty/xmlstream/CMakeLists.txt
+++ b/thirdparty/xmlstream/CMakeLists.txt
@@ -26,11 +26,19 @@ add_library(xmlstream STATIC
    ${INCS}
    )
 
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       xmlstream
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      xmlstream
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE} ${PCH_FORCE_USE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(xmlstream all)
 

--- a/zerberus/CMakeLists.txt
+++ b/zerberus/CMakeLists.txt
@@ -14,6 +14,12 @@ include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
 
 QT5_WRAP_UI (zerberusUi zerberus_gui.ui)
 
+if (NOT MSVC)
+   set(_all_h_file "${PROJECT_BINARY_DIR}/all.h")
+else (NOT MSVC)
+   set(_all_h_file "${PROJECT_SOURCE_DIR}/all.h")
+endif (NOT MSVC)
+
 add_library (zerberus STATIC
       ${zerberusUi}
       channel.cpp
@@ -23,19 +29,33 @@ add_library (zerberus STATIC
       zerberus.cpp
       zone.cpp
       zerberusgui.cpp
-      ${PROJECT_BINARY_DIR}/all.h
+      ${_all_h_file}
       ${PCH}
       ${INCS}
       )
 
-set_target_properties (
+if (NOT MSVC)
+   set_target_properties (
       zerberus
       PROPERTIES
          COMPILE_FLAGS "${PCH_INCLUDE} -g -Wall -Wextra -Winvalid-pch"
       )
+else (NOT MSVC)
+   set_target_properties (
+      zerberus
+      PROPERTIES
+         COMPILE_FLAGS "${PCH_INCLUDE}"
+      )
+endif (NOT MSVC)   
 
 xcode_pch(zerberus all)
 
-ADD_DEPENDENCIES(zerberus mops1)
-ADD_DEPENDENCIES(zerberus mops2)
+# Use MSVC pre-compiled headers
+vstudio_pch( zerberus )
+
+# MSVC does not depend on mops1 & mops2 for PCH
+if (NOT MSVC)
+   ADD_DEPENDENCIES(zerberus mops1)
+   ADD_DEPENDENCIES(zerberus mops2)
+endif (NOT MSVC)   
 

--- a/zerberus/channel.cpp
+++ b/zerberus/channel.cpp
@@ -30,8 +30,8 @@ Channel::Channel(Zerberus* ms, int i)
       _instrument = 0;
       _gain       = 1.0;
       _midiVolume = 1.0;
-      _panLeftGain  = cosf(M_PI_2 * 64.0/126.0);
-      _panRightGain = sinf(M_PI_2 * 64.0/126.0);
+      _panLeftGain  = cosf(static_cast<float>(M_PI_2 * 64.0/126.0));
+      _panRightGain = sinf(static_cast<float>(M_PI_2 * 64.0/126.0));
       memset(ctrl, 0, 128 * sizeof(char));
       ctrl[Ms::CTRL_EXPRESSION] = 127;
       }

--- a/zerberus/instrument.cpp
+++ b/zerberus/instrument.cpp
@@ -141,12 +141,12 @@ bool ZInstrument::loadFromDir(const QString& s)
             printf("cannot load orchestra.xml in <%s>\n", qPrintable(s));
             return false;
             }
-      QByteArray buf = f.readAll();
-      if (buf.isEmpty()) {
+      QByteArray buff = f.readAll();
+      if (buff.isEmpty()) {
             printf("Instrument::loadFromFile: orchestra.xml is empty\n");
             return false;
             }
-      return read(buf, 0, s);
+      return read(buff, 0, s);
       }
 
 //---------------------------------------------------------
@@ -166,12 +166,12 @@ bool ZInstrument::loadFromFile(const QString& path)
             printf("Instrument::load: %s not found\n", qPrintable(path));
             return false;
             }
-      QByteArray buf = uz.fileData("orchestra.xml");
-      if (buf.isEmpty()) {
+      QByteArray buff = uz.fileData("orchestra.xml");
+      if (buff.isEmpty()) {
             printf("Instrument::loadFromFile: orchestra.xml not found\n");
             return false;
             }
-      return read(buf, &uz, QString());
+      return read(buff, &uz, QString());
       }
 
 //---------------------------------------------------------
@@ -179,9 +179,9 @@ bool ZInstrument::loadFromFile(const QString& path)
 //    read orchestra
 //---------------------------------------------------------
 
-bool ZInstrument::read(const QByteArray& buf, MQZipReader* /*uz*/, const QString& /*path*/)
+bool ZInstrument::read(const QByteArray& buff, MQZipReader* /*uz*/, const QString& /*path*/)
       {
-      Ms::XmlReader e(buf);
+      Ms::XmlReader e(buff);
       while (e.readNextStartElement()) {
             if (e.name() == "MuseSynth") {
                   while (e.readNextStartElement()) {

--- a/zerberus/sfz.cpp
+++ b/zerberus/sfz.cpp
@@ -519,15 +519,15 @@ bool ZInstrument::loadSfz(const QString& s)
       for (int i = 0;i < 128; i++)
             c.set_cc[i] = -1;
 
-      int idx = 0;
+      int idx0 = 0;
       bool inBlockComment = false;
       // preprocessor
-      while(idx < fileContents.size()) {
+      while(idx0 < fileContents.size()) {
             QRegularExpression findWithSpaces("\"(.+)\"");
             QRegularExpression comment("//.*$");
             QRegularExpression trailingSpacesOrTab("^[\\s\\t]*");
             QRegularExpressionMatch foundWithSpaces;
-            QString curLine = fileContents[idx];
+            QString curLine = fileContents[idx0];
             QString curLineCopy = curLine;
             bool nextIsImportant = false;
             int idxBlockComment = 0;
@@ -564,7 +564,7 @@ bool ZInstrument::loadSfz(const QString& s)
 
             curLine = curLine.remove(comment);
             curLine.remove(trailingSpacesOrTab);
-            fileContents[idx] = curLine;
+            fileContents[idx0] = curLine;
 
             if (curLine.startsWith("#define")) {
                   QStringList define = curLine.split(" ");
@@ -573,7 +573,7 @@ bool ZInstrument::loadSfz(const QString& s)
                         c.defines.insert(std::pair<QString, QString>(define[1], define[2]));
                   else if(foundWithSpaces.hasMatch())
                         c.defines.insert(std::pair<QString, QString>(define[1], foundWithSpaces.captured(1)));
-                  fileContents.removeAt(idx);
+                  fileContents.removeAt(idx0);
                   }
             else if (curLine.startsWith("#include")) {
                   foundWithSpaces = findWithSpaces.match(curLine);
@@ -590,17 +590,17 @@ bool ZInstrument::loadSfz(const QString& s)
 
                         int offset = 1;
                         for (QString newFileLine : newFileContents) {
-                              fileContents.insert(idx+offset, newFileLine);
+                              fileContents.insert(idx0+offset, newFileLine);
                               offset++;
                               }
 
-                        fileContents.removeAt(idx);
+                        fileContents.removeAt(idx0);
                         }
                   }
             else if (curLine.isEmpty())
-                  fileContents.removeAt(idx);
+                  fileContents.removeAt(idx0);
             else
-                  idx++;
+                  idx0++;
             }
 
       int total = fileContents.size();
@@ -615,9 +615,9 @@ bool ZInstrument::loadSfz(const QString& s)
       bool globMode = false;
       zerberus->setLoadProgress(0);
 
-      for (int idx = 0; idx < fileContents.size(); idx++) {
-            QString curLine = fileContents[idx];
-            zerberus->setLoadProgress(((qreal) idx * 100) /  (qreal) total);
+      for (int idx1 = 0; idx1 < fileContents.size(); idx1++) {
+            QString curLine = fileContents[idx1];
+            zerberus->setLoadProgress(((qreal) idx1 * 100) /  (qreal) total);
 
             if (zerberus->loadWasCanceled())
                   return false;
@@ -676,8 +676,8 @@ bool ZInstrument::loadSfz(const QString& s)
                         }
                   else
                         ei = curLine.size();
-                  QString s = curLine.mid(si, ei-si);
-                  r.readOp(match.captured(1), s, c);
+                  QString str = curLine.mid(si, ei-si);
+                  r.readOp(match.captured(1), str, c);
                   }
             }
 

--- a/zerberus/voice.h
+++ b/zerberus/voice.h
@@ -16,6 +16,11 @@
 #include <cstdint>
 #include <math.h>
 
+// Disable warning C4201: nonstandard extension used: nameless struct/union in VS2017
+#if (defined (_MSCVER) || defined (_MSC_VER))
+      #pragma warning ( disable: 4201)
+#endif
+
 class Channel;
 struct Zone;
 class Sample;

--- a/zerberus/zerberus.cpp
+++ b/zerberus/zerberus.cpp
@@ -69,9 +69,9 @@ Zerberus::~Zerberus()
             i->setRefCount(i->refCount() - 1);
             if (i->refCount() <= 0) {
                   delete i;
-                  auto it = find(globalInstruments.begin(), globalInstruments.end(), i);
-                  if (it != globalInstruments.end())
-                        globalInstruments.erase(it);
+                  auto it1 = find(globalInstruments.begin(), globalInstruments.end(), i);
+                  if (it1 != globalInstruments.end())
+                        globalInstruments.erase(it1);
                   }
             }
       for (Channel* c : _channel)
@@ -335,17 +335,17 @@ bool Zerberus::removeSoundFont(const QString& s)
                               _channel[k]->setInstrument(0);
                         }
                   if (!instruments.empty()) {
-                        for (int i = 0; i < MAX_CHANNEL; ++i) {
-                              if (_channel[i]->instrument() == 0)
-                                    _channel[i]->setInstrument(instruments.front());
+                        for (int ii = 0; ii < MAX_CHANNEL; ++ii) {
+                              if (_channel[ii]->instrument() == 0)
+                                    _channel[ii]->setInstrument(instruments.front());
                               }
                         }
                   i->setRefCount(i->refCount() - 1);
                   if (i->refCount() <= 0) {
-                        auto it = find(globalInstruments.begin(), globalInstruments.end(), i);
-                        if (it == globalInstruments.end())
+                        auto it1 = find(globalInstruments.begin(), globalInstruments.end(), i);
+                        if (it1 == globalInstruments.end())
                               return false;
-                        globalInstruments.erase(it);
+                        globalInstruments.erase(it1);
                         delete i;
                         }
                   return true;
@@ -454,6 +454,9 @@ bool Zerberus::loadInstrument(const QString& s)
             }
       catch (std::bad_alloc& a) {
             qDebug("Unable to allocate memory when loading Zerberus soundfont %s", qPrintable(s));
+
+            // Prevent "Unreferenced local variable" warning for a
+            Q_UNUSED(a);
             }
       catch (...) {
             }

--- a/zerberus/zerberusgui.cpp
+++ b/zerberus/zerberusgui.cpp
@@ -158,8 +158,8 @@ void ZerberusGui::loadSfz() {
 
      QStringList sl;
      for (int i = 0; i < files->count(); ++i) {
-           QListWidgetItem* item = files->item(i);
-           sl.append(item->text());
+           QListWidgetItem* item1 = files->item(i);
+           sl.append(item1->text());
            }
 
       if (sl.contains(sfPath)) {


### PR DESCRIPTION
This is the initial work on porting MuseScore to the Visual Studio 2017 toolchain.

The current status: the project is using the CMake build system, and creates the solution and projects for Visual Studio 2017. The solution compiles and links with no errors, but with lots of warnings:
Project awl: 8 warnings
Project bww: 1 warning
Project libmscore: 259 warnings
Project mscore: 330 warnings
Project poppler: 660 warnings
All the other projects compile with no warnings.
When trying to execute the resulting program, an exception is triggered early in the initialization process (line 343 - libmscore/style.cpp, the QVariant::fromValue<Direction>() method is throwing an exception. All QVariant::fromValue() invocations for the enum Align work flawlessly. The only difference I've noticed is that for Ms::Align, Q_DECLARE_METATYPE(Ms::Align) is invoked in elementlayout.h, whereas for Direction this is not used, and Q_ENUM_NS(Direction) is. Could this be the source of the problem? ).

I have created separately a document with the build instructions for Visual Studio 2017, as well as a file containing the required dependencies, which I'm including here, The build instructions for VS2017 should be published alongside the instructions for other platforms.

[dependencies.zip](https://github.com/musescore/MuseScore/files/1945534/dependencies.zip)
[Compile Instructions MuseScore VS2017.docx](https://github.com/musescore/MuseScore/files/1945583/Compile.Instructions.MuseScore.VS2017.docx)
