### PR TITLE
fix #8808: Add option to limit scroll area of the navigator and the score view

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -172,6 +172,23 @@ void ScoreView::resizeEvent(QResizeEvent* /*ev*/)
       if (_magIdx != MagIdx::MAG_FREE)
             setMag(mscore->getMag(this));
       emit sizeChanged();
+
+      // The score may need to be repositioned now.
+      // So figure out how far it needs to move in each direction...
+      int dx = 0, dy = 0;
+      constraintCanvas(&dx, &dy);
+
+      if (dx == 0 && dy == 0)
+            return;
+
+      // ...and adjust its position accordingly.
+      _matrix.setMatrix(_matrix.m11(), _matrix.m12(), _matrix.m13(), _matrix.m21(),
+         _matrix.m22(), _matrix.m23(), _matrix.dx()+dx, _matrix.dy()+dy, _matrix.m33());
+      imatrix = _matrix.inverted();
+
+      scroll(dx, dy, QRect(0, 0, width(), height()));
+      emit viewRectChanged();
+      emit offsetChanged(_matrix.dx(), _matrix.dy());
       }
 
 //---------------------------------------------------------

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -144,6 +144,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_CANVAS_FG_WALLPAPER,                          Preference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/paper5.png")).absoluteFilePath())},
             {PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING,               Preference(true)},
             {PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY,               Preference(6)},
+            {PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA,                Preference(false)},
             {PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION,            Preference(false)},
             {PREF_UI_APP_STARTUP_CHECKUPDATE,                      Preference(checkUpdateStartup)},
             {PREF_UI_APP_STARTUP_SHOWNAVIGATOR,                    Preference(false)},

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -154,6 +154,7 @@ enum class MusicxmlExportBreaks : char {
 #define PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING              "ui/canvas/misc/antialiasedDrawing"
 #define PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY              "ui/canvas/misc/selectionProximity"
 #define PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION           "ui/canvas/scroll/verticalOrientation"
+#define PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA               "ui/canvas/scroll/limitScrollArea"
 #define PREF_UI_APP_STARTUP_CHECKUPDATE                     "ui/application/startup/checkUpdate"
 #define PREF_UI_APP_STARTUP_SHOWNAVIGATOR                   "ui/application/startup/showNavigator"
 #define PREF_UI_APP_STARTUP_SHOWPLAYPANEL                   "ui/application/startup/showPlayPanel"

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -352,6 +352,7 @@ void PreferenceDialog::updateValues(bool useDefaultValues)
 
       alsaFragments->setValue(preferences.getInt(PREF_IO_ALSA_FRAGMENTS));
       drawAntialiased->setChecked(preferences.getBool(PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING));
+      limitScrollArea->setChecked(preferences.getBool(PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA));
       switch(preferences.sessionStart()) {
             case SessionStart::EMPTY:  emptySession->setChecked(true); break;
             case SessionStart::LAST:   lastSession->setChecked(true); break;
@@ -888,6 +889,7 @@ void PreferenceDialog::apply()
       preferences.setPreference(PREF_UI_CANVAS_FG_WALLPAPER, fgWallpaper->text());
       preferences.setPreference(PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING, drawAntialiased->isChecked());
       preferences.setPreference(PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY, proximity->value());
+      preferences.setPreference(PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA, limitScrollArea->isChecked());
       preferences.setPreference(PREF_UI_THEME_ICONWIDTH, iconWidth->value());
       preferences.setPreference(PREF_UI_THEME_ICONHEIGHT, iconHeight->value());
 

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -1040,6 +1040,40 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <spacer>
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="limitScrollArea">
+            <property name="toolTip">
+             <string>Limit the scroll area to the edges of the score</string>
+            </property>
+            <property name="whatsThis">
+             <string>If this is checked, scrolling will stop at the edge of the score.</string>
+            </property>
+            <property name="accessibleName">
+             <string>Limit scroll area to page borders</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>If this is checked, scrolling will stop at the edge of the score.</string>
+            </property>
+            <property name="text">
+             <string>Limit scroll area to page borders</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -4275,6 +4309,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>printShortcuts</tabstop>
   <tabstop>resetToDefault</tabstop>
   <tabstop>buttonBox</tabstop>
+  <tabstop>limitScrollArea</tabstop>
   <tabstop>drawAntialiased</tabstop>
   <tabstop>proximity</tabstop>
  </tabstops>

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1295,13 +1295,23 @@ void ScoreView::constraintCanvas (int* dxx, int* dyy)
                                          lastPage->width() * mag(),
                                          lastPage->height() * mag());
             QRectF pagesRect = firstPageRect.united(lastPageRect).translated(offsetPt);
-            qreal hmargin = this->width() * 0.75;
-            qreal vmargin = this->height() * 0.75;
-            pagesRect.adjust(-hmargin, -vmargin, hmargin, vmargin);
+            bool limitScrollArea = preferences.getBool(PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA);
+            if (!limitScrollArea) {
+                  qreal hmargin = this->width() * 0.75;
+                  qreal vmargin = this->height() * 0.75;
+                  pagesRect.adjust(-hmargin, -vmargin, hmargin, vmargin);
+                  }
             QRectF toPagesRect = pagesRect.translated(dx, dy);
 
-            // move right
-            if (dx > 0) {
+            if (limitScrollArea && pagesRect.width() <= width()) {
+                  if (score()->layoutMode() == LayoutMode::LINE)
+                        // keep score fixed in place horizontally
+                        dx = 0;
+                  else
+                        // center horizontally on screen
+                        dx = (width() - pagesRect.width()) / 2 - pagesRect.left();
+                  }
+            else if (dx > 0) { // move right
                   if (toPagesRect.right() > rect.right() && toPagesRect.left() > rect.left()) {
                         if(pagesRect.width() <= rect.width()) {
                               dx = rect.right() - pagesRect.right();
@@ -1322,8 +1332,15 @@ void ScoreView::constraintCanvas (int* dxx, int* dyy)
                         }
                   }
 
-            // move down
-            if (dy > 0) {
+            if (limitScrollArea && pagesRect.height() <= height()) {
+                  if (score()->layoutMode() == LayoutMode::LINE)
+                        // keep score fixed in place vertically
+                        dy = 0;
+                  else
+                        // center vertically on screen
+                        dy = (height() - pagesRect.height()) / 2 - pagesRect.top();
+                  }
+            else if (dy > 0) { // move down
                   if (toPagesRect.bottom() > rect.bottom() && toPagesRect.top() > rect.top()) {
                         if (pagesRect.height() <= rect.height()) {
                               dy = rect.bottom() - pagesRect.bottom();


### PR DESCRIPTION
Just like #3644, but rewritten for the master branch.