### PR TITLE
fix #271717: Match the default tempo in New Score Wizard

### DIFF
--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -393,7 +393,7 @@ NewWizardPage5::NewWizardPage5(QWidget* parent)
       _tempo = new QDoubleSpinBox;
       _tempo->setAccessibleName(tr("Beats per minute"));
       _tempo->setRange(20.0, 400.0);
-      _tempo->setValue(100.0);
+      _tempo->setValue(120.0);
       _tempo->setDecimals(1);
       QHBoxLayout* l2 = new QHBoxLayout;
       l2->addWidget(bpm);


### PR DESCRIPTION
fixes https://musescore.org/en/node/271717