### PR TITLE
Adds an advanced preferences tab to prefsdialog

### DIFF
--- a/all.h
+++ b/all.h
@@ -32,7 +32,6 @@
 #include <stdio.h>
 #include <limits.h>
 #include <map>
-#include <unordered_map>
 #include <set>
 #include <errno.h>
 #include <fcntl.h>

--- a/all.h
+++ b/all.h
@@ -31,7 +31,6 @@
 
 #include <stdio.h>
 #include <limits.h>
-#include <float.h>
 #include <map>
 #include <unordered_map>
 #include <set>

--- a/all.h
+++ b/all.h
@@ -31,6 +31,7 @@
 
 #include <stdio.h>
 #include <limits.h>
+#include <float.h>
 #include <map>
 #include <unordered_map>
 #include <set>

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -348,6 +348,7 @@ add_executable ( ${ExecutableName}
       toolbarEditor.cpp toolbarEditor.h
       abstractdialog.cpp abstractdialog.h
       toolbuttonmenu.cpp
+      preferenceslistwidget.cpp preferenceslistwidget.h
 
       ${COCOABRIDGE}
       ${OMR_FILES}

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5934,8 +5934,7 @@ void MuseScore::updateUiStyleAndTheme()
       qApp->setStyleSheet(css);
 
       genIcons();
-
-      // TODO update gui so icons are correct?
+      Shortcut::refreshIcons();
       }
 }
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -479,6 +479,15 @@ void MuseScore::preferencesChanged()
       {
       updateExternalValuesFromPreferences();
 
+      setPlayRepeats(MScore::playRepeats);
+      getAction("pan")->setChecked(MScore::panPlayback);
+      getAction("follow")->setChecked(preferences.getBool(PREF_APP_PLAYBACK_FOLLOWSONG));
+      getAction("midi-on")->setEnabled(preferences.getBool(PREF_IO_MIDI_ENABLEINPUT));
+      getAction("toggle-statusbar")->setChecked(preferences.getBool(PREF_UI_APP_SHOWSTATUSBAR));
+      _statusBar->setVisible(preferences.getBool(PREF_UI_APP_SHOWSTATUSBAR));
+
+      MuseScore::updateUiStyleAndTheme();
+
       QString fgWallpaper = preferences.getString(PREF_UI_CANVAS_FG_WALLPAPER);
       for (int i = 0; i < tab1->count(); ++i) {
             ScoreView* canvas = tab1->view(i);
@@ -524,8 +533,21 @@ void MuseScore::preferencesChanged()
       transportTools->setEnabled(!noSeq && seq && seq->isRunning());
       playId->setEnabled(!noSeq && seq && seq->isRunning());
 
-      getAction("midi-on")->setEnabled(preferences.getBool(PREF_IO_MIDI_ENABLEINPUT));
-      _statusBar->setVisible(preferences.getBool(PREF_UI_APP_SHOWSTATUSBAR));
+      // change workspace
+      if (preferences.getString(PREF_APP_WORKSPACE) != Workspace::currentWorkspace->name()) {
+            Workspace* workspace = 0;
+            for (Workspace* w: Workspace::workspaces()) {
+                  if (w->name() == preferences.getString(PREF_APP_WORKSPACE)) {
+                        workspace = w;
+                        break;
+                        }
+                  }
+
+            if (workspace != 0) {
+                  mscore->changeWorkspace(workspace);
+                  mscore->getPaletteBox()->updateWorkspaces();
+                  }
+            }
 
       delete newWizard;
       newWizard = 0;
@@ -4855,6 +4877,18 @@ void MuseScore::updateUndoRedo()
       a->setEnabled(cs ? cs->undoStack()->canRedo() : false);
       }
 
+
+void MuseScore::setPlayRepeats(bool repeat)
+      {
+      getAction("repeat")->setChecked(repeat);
+      preferences.setPreference(PREF_APP_PLAYBACK_PLAYREPEATS, repeat);
+      MScore::playRepeats = repeat;
+      if (cs) {
+            cs->updateRepeatList(repeat);
+            emit cs->playlistChanged();
+            }
+      }
+
 //---------------------------------------------------------
 //   cmd
 //---------------------------------------------------------
@@ -5072,13 +5106,8 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             }
       else if (cmd == "print")
             printFile();
-      else if (cmd == "repeat") {
-            preferences.setPreference(PREF_APP_PLAYBACK_PLAYREPEATS, a->isChecked());
-            if (cs) {
-                  cs->updateRepeatList(preferences.getBool(PREF_APP_PLAYBACK_PLAYREPEATS));
-                  emit cs->playlistChanged();
-                  }
-            }
+      else if (cmd == "repeat")
+            setPlayRepeats(a->isChecked());
       else if (cmd == "pan")
             MScore::panPlayback = !MScore::panPlayback;
       else if (cmd == "show-invisible")
@@ -5860,6 +5889,54 @@ bool MuseScore::saveMp3(Score* score, const QString& name)
       return true;
 #endif
       }
+
+void MuseScore::updateUiStyleAndTheme()
+      {
+      // set UI Theme
+      QApplication::setStyle(QStyleFactory::create("Fusion"));
+
+      QString wd      = QString("%1/%2").arg(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)).arg(QCoreApplication::applicationName());
+      // set UI Color Palette
+      QPalette p(QApplication::palette());
+      QString jsonPaletteFilename = preferences.isThemeDark() ? "palette_dark_fusion.json" : "palette_light_fusion.json";;
+      QFile jsonPalette(QString(":/themes/%1").arg(jsonPaletteFilename));
+      // read from Documents TODO: remove this
+      if (QFile::exists(QString("%1/%2").arg(wd, "ms_palette.json")))
+            jsonPalette.setFileName(QString("%1/%2").arg(wd, "ms_palette.json"));
+      if (jsonPalette.open(QFile::ReadOnly | QFile::Text)) {
+            QJsonDocument d = QJsonDocument::fromJson(jsonPalette.readAll());
+            QJsonObject o = d.object();
+            QMetaEnum metaEnum = QMetaEnum::fromType<QPalette::ColorRole>();
+            for (int i = 0; i < metaEnum.keyCount(); ++i) {
+                  QJsonValue v = o.value(metaEnum.valueToKey(i));
+                  if (!v.isUndefined())
+                        p.setColor(static_cast<QPalette::ColorRole>(metaEnum.value(i)), QColor(v.toString()));
+                  }
+            }
+      QApplication::setPalette(p);
+
+      // set UI Style
+      QString css;
+      QString styleFilename = preferences.isThemeDark() ? "style_dark_fusion.css" : "style_light_fusion.css";
+      QFile fstyle(QString(":/themes/%1").arg(styleFilename));
+      // read from Documents TODO: remove this
+      if (QFile::exists(QString("%1/%2").arg(wd, "ms_style.css")))
+            fstyle.setFileName(QString("%1/%2").arg(wd, "ms_style.css"));
+      if (fstyle.open(QFile::ReadOnly | QFile::Text)) {
+            QTextStream in(&fstyle);
+            css = in.readAll();
+            }
+
+      css.replace("$voice1-bgcolor", MScore::selectColor[0].name(QColor::HexRgb));
+      css.replace("$voice2-bgcolor", MScore::selectColor[1].name(QColor::HexRgb));
+      css.replace("$voice3-bgcolor", MScore::selectColor[2].name(QColor::HexRgb));
+      css.replace("$voice4-bgcolor", MScore::selectColor[3].name(QColor::HexRgb));
+      qApp->setStyleSheet(css);
+
+      genIcons();
+
+      // TODO update gui so icons are correct?
+      }
 }
 
 using namespace Ms;
@@ -6200,46 +6277,7 @@ int main(int argc, char* av[])
             }
 
       if (!converterMode && !pluginMode) {
-
-            // set UI Theme
-            QApplication::setStyle(QStyleFactory::create("Fusion"));
-
-            QString wd      = QString("%1/%2").arg(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)).arg(QCoreApplication::applicationName());
-            // set UI Color Palette
-            QPalette p(QApplication::palette());
-            QString jsonPaletteFilename = preferences.isThemeDark() ? "palette_dark_fusion.json" : "palette_light_fusion.json";;
-            QFile jsonPalette(QString(":/themes/%1").arg(jsonPaletteFilename));
-            // read from Documents TODO: remove this
-            if (QFile::exists(QString("%1/%2").arg(wd, "ms_palette.json")))
-                  jsonPalette.setFileName(QString("%1/%2").arg(wd, "ms_palette.json"));
-            if (jsonPalette.open(QFile::ReadOnly | QFile::Text)) {
-                  QJsonDocument d = QJsonDocument::fromJson(jsonPalette.readAll());
-                  QJsonObject o = d.object();
-                  QMetaEnum metaEnum = QMetaEnum::fromType<QPalette::ColorRole>();
-                  for (int i = 0; i < metaEnum.keyCount(); ++i) {
-                        QJsonValue v = o.value(metaEnum.valueToKey(i));
-                        if (!v.isUndefined())
-                              p.setColor(static_cast<QPalette::ColorRole>(metaEnum.value(i)), QColor(v.toString()));
-                        }
-                  }
-            QApplication::setPalette(p);
-
-            // set UI Style
-            QString css;
-            QString styleFilename = preferences.isThemeDark() ? "style_dark_fusion.css" : "style_light_fusion.css";
-            QFile fstyle(QString(":/themes/%1").arg(styleFilename));
-            // read from Documents TODO: remove this
-            if (QFile::exists(QString("%1/%2").arg(wd, "ms_style.css")))
-                  fstyle.setFileName(QString("%1/%2").arg(wd, "ms_style.css"));
-            if (fstyle.open(QFile::ReadOnly | QFile::Text)) {
-                  QTextStream in(&fstyle);
-                  css = in.readAll();
-                  }
-            css.replace("$voice1-bgcolor", MScore::selectColor[0].name(QColor::HexRgb));
-            css.replace("$voice2-bgcolor", MScore::selectColor[1].name(QColor::HexRgb));
-            css.replace("$voice3-bgcolor", MScore::selectColor[2].name(QColor::HexRgb));
-            css.replace("$voice4-bgcolor", MScore::selectColor[3].name(QColor::HexRgb));
-            qApp->setStyleSheet(css);
+            MuseScore::updateUiStyleAndTheme();
             }
       else
             noSeq = true;

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -459,6 +459,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       void updateViewModeCombo();
       void switchLayoutMode(LayoutMode);
+      void setPlayRepeats(bool repeat);
 
    private slots:
       void cmd(QAction* a, const QString& cmd);
@@ -768,6 +769,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       void setNoteInputMenuEntries(std::list<const char*> l)         { _noteInputMenuEntries = l; }
       void populateNoteInputMenu();
+      static void updateUiStyleAndTheme();
 
       void showError();
 

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -21,10 +21,12 @@
 #include "libmscore/style.h"
 #include "libmscore/mscore.h"
 #include "preferences.h"
+#include <sstream>
 
 namespace Ms {
 
 Preferences preferences;
+
 
 void Preferences::init(bool storeInMemoryOnly)
       {
@@ -71,103 +73,103 @@ void Preferences::init(bool storeInMemoryOnly)
 
       _allPreferences.insert(
       {
-            {PREF_APP_AUTOSAVE_AUTOSAVETIME,                       Preference(2 /* minutes */)},
-            {PREF_APP_AUTOSAVE_USEAUTOSAVE,                        Preference(true)},
-            {PREF_APP_PATHS_INSTRUMENTLIST1,                       Preference(":/data/instruments.xml")},
-            {PREF_APP_PATHS_INSTRUMENTLIST2,                       Preference("")},
-            {PREF_APP_PATHS_MYIMAGES,                              Preference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("images_directory", "Images"))).absoluteFilePath())},
-            {PREF_APP_PATHS_MYPLUGINS,                             Preference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("plugins_directory", "Plugins"))).absoluteFilePath())},
-            {PREF_APP_PATHS_MYSCORES,                              Preference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("scores_directory", "Scores"))).absoluteFilePath())},
-            {PREF_APP_PATHS_MYSOUNDFONTS,                          Preference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("soundfonts_directory", "SoundFonts"))).absoluteFilePath())},
-            {PREF_APP_PATHS_MYSHORTCUTS,                           Preference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("shortcuts_directory", "Shortcuts"))).absoluteFilePath())},
-            {PREF_APP_PATHS_MYSTYLES,                              Preference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("styles_directory", "Styles"))).absoluteFilePath())},
-            {PREF_APP_PATHS_MYTEMPLATES,                           Preference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("templates_directory", "Templates"))).absoluteFilePath())},
-            {PREF_APP_PLAYBACK_FOLLOWSONG,                         Preference(true)},
-            {PREF_APP_PLAYBACK_PANPLAYBACK,                        Preference(true)},
-            {PREF_APP_PLAYBACK_PLAYREPEATS,                        Preference(true)},
-            {PREF_APP_USESINGLEPALETTE,                            Preference(false)},
-            {PREF_APP_STARTUP_SESSIONSTART,                        Preference(QVariant::fromValue(SessionStart::SCORE))},
-            {PREF_APP_STARTUP_STARTSCORE,                          Preference(":/data/My_First_Score.mscz")},
-            {PREF_APP_WORKSPACE,                                   Preference("Basic")},
-            {PREF_EXPORT_AUDIO_SAMPLERATE,                         Preference(44100)},
-            {PREF_EXPORT_MP3_BITRATE,                              Preference(128)},
-            {PREF_EXPORT_MUSICXML_EXPORTBREAKS,                    Preference(QVariant::fromValue(MusicxmlExportBreaks::ALL))},
-            {PREF_EXPORT_MUSICXML_EXPORTLAYOUT,                    Preference(true)},
-            {PREF_EXPORT_PDF_DPI,                                  Preference(300)},
-            {PREF_EXPORT_PNG_RESOLUTION,                           Preference(300.0)},
-            {PREF_EXPORT_PNG_USETRANSPARENCY,                      Preference(true)},
-            {PREF_IMPORT_GUITARPRO_CHARSET,                        Preference("UTF-8")},
-            {PREF_IMPORT_MUSICXML_IMPORTBREAKS,                    Preference(true)},
-            {PREF_IMPORT_MUSICXML_IMPORTLAYOUT,                    Preference(true)},
-            {PREF_IMPORT_OVERTURE_CHARSET,                         Preference("GBK")},
-            {PREF_IMPORT_STYLE_STYLEFILE,                          Preference("")},
-            {PREF_IO_ALSA_DEVICE,                                  Preference("default")},
-            {PREF_IO_ALSA_FRAGMENTS,                               Preference(3)},
-            {PREF_IO_ALSA_PERIODSIZE,                              Preference(1024)},
-            {PREF_IO_ALSA_SAMPLERATE,                              Preference(48000)},
-            {PREF_IO_ALSA_USEALSAAUDIO,                            Preference(defaultUseAlsaAudio)},
-            {PREF_IO_JACK_REMEMBERLASTCONNECTIONS,                 Preference(true)},
-            {PREF_IO_JACK_TIMEBASEMASTER,                          Preference(false)},
-            {PREF_IO_JACK_USEJACKAUDIO,                            Preference(defaultUseJackAudio)},
-            {PREF_IO_JACK_USEJACKMIDI,                             Preference(false)},
-            {PREF_IO_JACK_USEJACKTRANSPORT,                        Preference(false)},
-            {PREF_IO_MIDI_ADVANCEONRELEASE,                        Preference(true)},
-            {PREF_IO_MIDI_ENABLEINPUT,                             Preference(true)},
-            {PREF_IO_MIDI_EXPANDREPEATS,                           Preference(true)},
-            {PREF_IO_MIDI_EXPORTRPNS,                              Preference(false)},
-            {PREF_IO_MIDI_REALTIMEDELAY,                           Preference(750 /* ms */)},
-            {PREF_IO_MIDI_SHORTESTNOTE,                            Preference(MScore::division/4)},
-            {PREF_IO_MIDI_SHOWCONTROLSINMIXER,                     Preference(false)},
-            {PREF_IO_MIDI_USEREMOTECONTROL,                        Preference(false)},
-            {PREF_IO_OSC_PORTNUMBER,                               Preference(5282)},
-            {PREF_IO_OSC_USEREMOTECONTROL,                         Preference(false)},
-            {PREF_IO_PORTAUDIO_DEVICE,                             Preference(-1)},
-            {PREF_IO_PORTAUDIO_USEPORTAUDIO,                       Preference(defaultUsePortAudio)},
-            {PREF_IO_PORTMIDI_INPUTBUFFERCOUNT,                    Preference(100)},
-            {PREF_IO_PORTMIDI_INPUTDEVICE,                         Preference("")},
-            {PREF_IO_PORTMIDI_OUTPUTBUFFERCOUNT,                   Preference(65536)},
-            {PREF_IO_PORTMIDI_OUTPUTDEVICE,                        Preference("")},
-            {PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS,           Preference(0)},
-            {PREF_IO_PULSEAUDIO_USEPULSEAUDIO,                     Preference(defaultUsePulseAudio)},
-            {PREF_SCORE_CHORD_PLAYONADDNOTE,                       Preference(true)},
-            {PREF_SCORE_MAGNIFICATION,                             Preference(1.0)},
-            {PREF_SCORE_NOTE_PLAYONCLICK,                          Preference(true)},
-            {PREF_SCORE_NOTE_DEFAULTPLAYDURATION,                  Preference(300 /* ms */)},
-            {PREF_SCORE_NOTE_WARNPITCHRANGE,                       Preference(true)},
-            {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    Preference("")},
-            {PREF_SCORE_STYLE_PARTSTYLEFILE,                       Preference("")},
-            {PREF_UI_CANVAS_BG_USECOLOR,                           Preference(true)},
-            {PREF_UI_CANVAS_FG_USECOLOR,                           Preference(true)},
-            {PREF_UI_CANVAS_BG_COLOR,                              Preference(QColor("#dddddd"))},
-            {PREF_UI_CANVAS_FG_COLOR,                              Preference(QColor("#f9f9f9"))},
-            {PREF_UI_CANVAS_BG_WALLPAPER,                          Preference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/background1.png")).absoluteFilePath())},
-            {PREF_UI_CANVAS_FG_WALLPAPER,                          Preference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/paper5.png")).absoluteFilePath())},
-            {PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING,               Preference(true)},
-            {PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY,               Preference(6)},
-            {PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA,                Preference(false)},
-            {PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION,            Preference(false)},
-            {PREF_UI_APP_STARTUP_CHECKUPDATE,                      Preference(checkUpdateStartup)},
-            {PREF_UI_APP_STARTUP_SHOWNAVIGATOR,                    Preference(false)},
-            {PREF_UI_APP_STARTUP_SHOWPLAYPANEL,                    Preference(false)},
-            {PREF_UI_APP_STARTUP_SHOWSPLASHSCREEN,                 Preference(true)},
-            {PREF_UI_APP_STARTUP_SHOWSTARTCENTER,                  Preference(true)},
-            {PREF_UI_APP_GLOBALSTYLE,                              Preference(QVariant::fromValue(MuseScoreStyleType::LIGHT_FUSION))},
-            {PREF_UI_APP_LANGUAGE,                                 Preference("system")},
-            {PREF_UI_APP_RASTER_HORIZONTAL,                        Preference(2)},
-            {PREF_UI_APP_RASTER_VERTICAL,                          Preference(2)},
-            {PREF_UI_APP_SHOWSTATUSBAR,                            Preference(true)},
-            {PREF_UI_APP_USENATIVEDIALOGS,                         Preference(nativeDialogs)},
-            {PREF_UI_PIANO_HIGHLIGHTCOLOR,                         Preference(QColor("#1259d0"))},
-            {PREF_UI_SCORE_NOTE_DROPCOLOR,                         Preference(QColor("#1778db"))},
-            {PREF_UI_SCORE_DEFAULTCOLOR,                           Preference(QColor("#000000"))},
-            {PREF_UI_SCORE_FRAMEMARGINCOLOR,                       Preference(QColor("#5999db"))},
-            {PREF_UI_SCORE_LAYOUTBREAKCOLOR,                       Preference(QColor("#5999db"))},
-            {PREF_UI_SCORE_VOICE1_COLOR,                           Preference(QColor("#1259d0"))},    // blue
-            {PREF_UI_SCORE_VOICE2_COLOR,                           Preference(QColor("#009234"))},    // green
-            {PREF_UI_SCORE_VOICE3_COLOR,                           Preference(QColor("#c04400"))},    // orange
-            {PREF_UI_SCORE_VOICE4_COLOR,                           Preference(QColor("#70167a"))},    // purple
-            {PREF_UI_THEME_ICONWIDTH,                              Preference(28)},
-            {PREF_UI_THEME_ICONHEIGHT,                             Preference(24)}
+            {PREF_APP_AUTOSAVE_AUTOSAVETIME,                       new IntPreference(2 /* minutes */, false)},
+            {PREF_APP_AUTOSAVE_USEAUTOSAVE,                        new BoolPreference(true, false)},
+            {PREF_APP_PATHS_INSTRUMENTLIST1,                       new StringPreference(":/data/instruments.xml", false)},
+            {PREF_APP_PATHS_INSTRUMENTLIST2,                       new StringPreference("", false)},
+            {PREF_APP_PATHS_MYIMAGES,                              new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("images_directory", "Images"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYPLUGINS,                             new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("plugins_directory", "Plugins"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYSCORES,                              new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("scores_directory", "Scores"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYSOUNDFONTS,                          new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("soundfonts_directory", "SoundFonts"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYSHORTCUTS,                           new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("shortcuts_directory", "Shortcuts"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYSTYLES,                              new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("styles_directory", "Styles"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYTEMPLATES,                           new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("templates_directory", "Templates"))).absoluteFilePath(), false)},
+            {PREF_APP_PLAYBACK_FOLLOWSONG,                         new BoolPreference(true)},
+            {PREF_APP_PLAYBACK_PANPLAYBACK,                        new BoolPreference(true)},
+            {PREF_APP_PLAYBACK_PLAYREPEATS,                        new BoolPreference(true)},
+            {PREF_APP_USESINGLEPALETTE,                            new BoolPreference(false)},
+            {PREF_APP_STARTUP_SESSIONSTART,                        new EnumPreference(QVariant::fromValue(SessionStart::SCORE), false)},
+            {PREF_APP_STARTUP_STARTSCORE,                          new StringPreference(":/data/My_First_Score.mscz", false)},
+            {PREF_APP_WORKSPACE,                                   new StringPreference("Basic")},
+            {PREF_EXPORT_AUDIO_SAMPLERATE,                         new IntPreference(44100, false)},
+            {PREF_EXPORT_MP3_BITRATE,                              new IntPreference(128, false)},
+            {PREF_EXPORT_MUSICXML_EXPORTBREAKS,                    new EnumPreference(QVariant::fromValue(MusicxmlExportBreaks::ALL), false)},
+            {PREF_EXPORT_MUSICXML_EXPORTLAYOUT,                    new BoolPreference(true, false)},
+            {PREF_EXPORT_PDF_DPI,                                  new IntPreference(300, false)},
+            {PREF_EXPORT_PNG_RESOLUTION,                           new DoublePreference(300.0, false)},
+            {PREF_EXPORT_PNG_USETRANSPARENCY,                      new BoolPreference(true, false)},
+            {PREF_IMPORT_GUITARPRO_CHARSET,                        new StringPreference("UTF-8", false)},
+            {PREF_IMPORT_MUSICXML_IMPORTBREAKS,                    new BoolPreference(true, false)},
+            {PREF_IMPORT_MUSICXML_IMPORTLAYOUT,                    new BoolPreference(true, false)},
+            {PREF_IMPORT_OVERTURE_CHARSET,                         new StringPreference("GBK", false)},
+            {PREF_IMPORT_STYLE_STYLEFILE,                          new StringPreference("", false)},
+            {PREF_IO_ALSA_DEVICE,                                  new StringPreference("default", false)},
+            {PREF_IO_ALSA_FRAGMENTS,                               new IntPreference(3, false)},
+            {PREF_IO_ALSA_PERIODSIZE,                              new IntPreference(1024, false)},
+            {PREF_IO_ALSA_SAMPLERATE,                              new IntPreference(48000, false)},
+            {PREF_IO_ALSA_USEALSAAUDIO,                            new BoolPreference(defaultUseAlsaAudio, false)},
+            {PREF_IO_JACK_REMEMBERLASTCONNECTIONS,                 new BoolPreference(true, false)},
+            {PREF_IO_JACK_TIMEBASEMASTER,                          new BoolPreference(false, false)},
+            {PREF_IO_JACK_USEJACKAUDIO,                            new BoolPreference(defaultUseJackAudio, false)},
+            {PREF_IO_JACK_USEJACKMIDI,                             new BoolPreference(false, false)},
+            {PREF_IO_JACK_USEJACKTRANSPORT,                        new BoolPreference(false, false)},
+            {PREF_IO_MIDI_ADVANCEONRELEASE,                        new BoolPreference(true, false)},
+            {PREF_IO_MIDI_ENABLEINPUT,                             new BoolPreference(true, false)},
+            {PREF_IO_MIDI_EXPANDREPEATS,                           new BoolPreference(true, false)},
+            {PREF_IO_MIDI_EXPORTRPNS,                              new BoolPreference(false, false)},
+            {PREF_IO_MIDI_REALTIMEDELAY,                           new IntPreference(750 /* ms */, false)},
+            {PREF_IO_MIDI_SHORTESTNOTE,                            new IntPreference(MScore::division/4, false)},
+            {PREF_IO_MIDI_SHOWCONTROLSINMIXER,                     new BoolPreference(false, false)},
+            {PREF_IO_MIDI_USEREMOTECONTROL,                        new BoolPreference(false, false)},
+            {PREF_IO_OSC_PORTNUMBER,                               new IntPreference(5282, false)},
+            {PREF_IO_OSC_USEREMOTECONTROL,                         new BoolPreference(false, false)},
+            {PREF_IO_PORTAUDIO_DEVICE,                             new IntPreference(-1, false)},
+            {PREF_IO_PORTAUDIO_USEPORTAUDIO,                       new BoolPreference(defaultUsePortAudio, false)},
+            {PREF_IO_PORTMIDI_INPUTBUFFERCOUNT,                    new IntPreference(100)},
+            {PREF_IO_PORTMIDI_INPUTDEVICE,                         new StringPreference("")},
+            {PREF_IO_PORTMIDI_OUTPUTBUFFERCOUNT,                   new IntPreference(65536)},
+            {PREF_IO_PORTMIDI_OUTPUTDEVICE,                        new StringPreference("")},
+            {PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS,           new IntPreference(0)},
+            {PREF_IO_PULSEAUDIO_USEPULSEAUDIO,                     new BoolPreference(defaultUsePulseAudio, false)},
+            {PREF_SCORE_CHORD_PLAYONADDNOTE,                       new BoolPreference(true, false)},
+            {PREF_SCORE_MAGNIFICATION,                             new DoublePreference(1.0, false)},
+            {PREF_SCORE_NOTE_PLAYONCLICK,                          new BoolPreference(true, false)},
+            {PREF_SCORE_NOTE_DEFAULTPLAYDURATION,                  new IntPreference(300 /* ms */, false)},
+            {PREF_SCORE_NOTE_WARNPITCHRANGE,                       new BoolPreference(true, false)},
+            {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},
+            {PREF_SCORE_STYLE_PARTSTYLEFILE,                       new StringPreference("", false)},
+            {PREF_UI_CANVAS_BG_USECOLOR,                           new BoolPreference(true, false)},
+            {PREF_UI_CANVAS_FG_USECOLOR,                           new BoolPreference(true, false)},
+            {PREF_UI_CANVAS_BG_COLOR,                              new ColorPreference(QColor("#dddddd"), false)},
+            {PREF_UI_CANVAS_FG_COLOR,                              new ColorPreference(QColor("#f9f9f9"), false)},
+            {PREF_UI_CANVAS_BG_WALLPAPER,                          new StringPreference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/background1.png")).absoluteFilePath(), false)},
+            {PREF_UI_CANVAS_FG_WALLPAPER,                          new StringPreference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/paper5.png")).absoluteFilePath(), false)},
+            {PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING,               new BoolPreference(true, false)},
+            {PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY,               new IntPreference(6, false)},
+            {PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA,                new BoolPreference(false, false)},
+            {PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION,            new BoolPreference(false, false)},
+            {PREF_UI_APP_STARTUP_CHECKUPDATE,                      new BoolPreference(checkUpdateStartup, false)},
+            {PREF_UI_APP_STARTUP_SHOWNAVIGATOR,                    new BoolPreference(false, false)},
+            {PREF_UI_APP_STARTUP_SHOWPLAYPANEL,                    new BoolPreference(false, false)},
+            {PREF_UI_APP_STARTUP_SHOWSPLASHSCREEN,                 new BoolPreference(true, false)},
+            {PREF_UI_APP_STARTUP_SHOWSTARTCENTER,                  new BoolPreference(true, false)},
+            {PREF_UI_APP_GLOBALSTYLE,                              new EnumPreference(QVariant::fromValue(MuseScoreStyleType::LIGHT_FUSION), false)},
+            {PREF_UI_APP_LANGUAGE,                                 new StringPreference("system", false)},
+            {PREF_UI_APP_RASTER_HORIZONTAL,                        new IntPreference(2)},
+            {PREF_UI_APP_RASTER_VERTICAL,                          new IntPreference(2)},
+            {PREF_UI_APP_SHOWSTATUSBAR,                            new BoolPreference(true)},
+            {PREF_UI_APP_USENATIVEDIALOGS,                         new BoolPreference(nativeDialogs)},
+            {PREF_UI_PIANO_HIGHLIGHTCOLOR,                         new ColorPreference(QColor("#1259d0"))},
+            {PREF_UI_SCORE_NOTE_DROPCOLOR,                         new ColorPreference(QColor("#1778db"))},
+            {PREF_UI_SCORE_DEFAULTCOLOR,                           new ColorPreference(QColor("#000000"))},
+            {PREF_UI_SCORE_FRAMEMARGINCOLOR,                       new ColorPreference(QColor("#5999db"))},
+            {PREF_UI_SCORE_LAYOUTBREAKCOLOR,                       new ColorPreference(QColor("#5999db"))},
+            {PREF_UI_SCORE_VOICE1_COLOR,                           new ColorPreference(QColor("#1259d0"))},    // blue
+            {PREF_UI_SCORE_VOICE2_COLOR,                           new ColorPreference(QColor("#009234"))},    // green
+            {PREF_UI_SCORE_VOICE3_COLOR,                           new ColorPreference(QColor("#c04400"))},    // orange
+            {PREF_UI_SCORE_VOICE4_COLOR,                           new ColorPreference(QColor("#70167a"))},    // purple
+            {PREF_UI_THEME_ICONWIDTH,                              new IntPreference(28, false)},
+            {PREF_UI_THEME_ICONHEIGHT,                             new IntPreference(24, false)}
             });
 
       _initialized = true;
@@ -178,11 +180,11 @@ void Preferences::save()
       settings()->sync();
       }
 
-QVariant Preferences::defaultValue(const QString key) const
+QVariant Preferences::defaultValue(const std::string key) const
       {
       checkIfKeyExists(key);
-      auto pref = _allPreferences.find(key.toStdString());
-      return pref->second.defaultValue();
+      auto pref = _allPreferences.find(key);
+      return pref->second->defaultValue();
       }
 
 QSettings* Preferences::settings() const
@@ -195,39 +197,39 @@ QSettings* Preferences::settings() const
       return _settings;
       }
 
-QVariant Preferences::get(const QString key) const
+QVariant Preferences::get(const std::string key) const
       {
-      auto pref = _inMemorySettings.find(key.toStdString());
+      auto pref = _inMemorySettings.find(key);
 
       if (_storeInMemoryOnly)
             return (pref != _inMemorySettings.end()) ? pref->second : QVariant(); // invalid QVariant returned when not found
       else if (pref != _inMemorySettings.end()) // if there exists a temporary value stored "in memory" return this value
             return pref->second;
       else
-            return settings()->value(key);
+            return settings()->value(QString(key.c_str()));
       }
 
-void Preferences::set(const QString key, QVariant value, bool temporary)
+void Preferences::set(const std::string key, QVariant value, bool temporary)
       {
       if (_storeInMemoryOnly || temporary)
-            _inMemorySettings[key.toStdString()] = value;
+            _inMemorySettings[key] = value;
       else
-            settings()->setValue(key, value);
+            settings()->setValue(QString(key.c_str()), value);
       }
 
-void Preferences::remove(const QString key)
+void Preferences::remove(const std::string key)
       {
       // remove both preference stored "in memory" and in QSettings
-      _inMemorySettings.erase(key.toStdString());
-      settings()->remove(key);
+      _inMemorySettings.erase(key);
+      settings()->remove(QString(key.c_str()));
       }
 
-bool Preferences::has(const QString key) const
+bool Preferences::has(const std::string key) const
       {
-      return _inMemorySettings.count(key.toStdString()) > 0 || settings()->contains(key);
+      return _inMemorySettings.count(key) > 0 || settings()->contains(QString(key.c_str()));
       }
 
-QVariant Preferences::preference(const QString key) const
+QVariant Preferences::preference(const std::string key) const
       {
       checkIfKeyExists(key);
       QVariant pref = get(key);
@@ -239,13 +241,33 @@ QVariant Preferences::preference(const QString key) const
             return pref;
       }
 
-void Preferences::checkIfKeyExists(const QString key) const
+bool Preferences::checkIfKeyExists(const std::string key) const
       {
-      auto pref = _allPreferences.find(key.toStdString());
+      auto pref = _allPreferences.find(key);
       if (pref == _allPreferences.end()) {
-            qWarning("Preference not found: %s", key.toStdString().c_str());
+            qWarning("Preference not found: %s", key.c_str());
             Q_ASSERT(pref != _allPreferences.end());
             }
+      return pref != _allPreferences.end();
+      }
+
+QMetaType::Type Preferences::type(const std::string key) const
+      {
+      auto pref = _allPreferences.find(key);
+      if (pref != _allPreferences.end())
+            return pref->second->type();
+      else {
+            return QMetaType::UnknownType;
+            }
+      }
+
+bool Preferences::checkType(const std::string key, QMetaType::Type t) const
+      {
+      if (type(key) != t) {
+            qWarning("Preference is not of correct type: %s", key.c_str());
+            Q_ASSERT(type(key) == QMetaType::Bool);
+            }
+      return type(key) == t;
       }
 
 Preferences::Preferences()
@@ -254,23 +276,24 @@ Preferences::Preferences()
 
 Preferences::~Preferences()
       {
+      // clean up _allPreferences
+      for (auto item : _allPreferences)
+            delete item.second;
+
       if (_settings) {
             delete _settings;
             }
       }
 
-void Preferences::setReturnDefaultValues(bool returnDefaultValues)
+bool Preferences::getBool(const std::string key) const
       {
-      _returnDefaultValues = returnDefaultValues;
-      }
-
-bool Preferences::getBool(const QString key) const
-      {
+      checkType(key, QMetaType::Bool);
       return preference(key).toBool();
       }
 
-QColor Preferences::getColor(const QString key) const
+QColor Preferences::getColor(const std::string key) const
       {
+      checkType(key, QMetaType::QColor);
       QVariant v = preference(key);
       if (v.type() == QVariant::Color)
             return v.value<QColor>();
@@ -281,30 +304,33 @@ QColor Preferences::getColor(const QString key) const
             }
       }
 
-QString Preferences::getString(const QString key) const
+QString Preferences::getString(const std::string key) const
       {
+      checkType(key, QMetaType::QString);
       return preference(key).toString();
       }
 
-int Preferences::getInt(const QString key) const
+int Preferences::getInt(const std::string key) const
       {
+      checkType(key, QMetaType::Int);
       QVariant v = preference(key);
       bool ok;
       int pref = v.toInt(&ok);
       if (!ok) {
-            qWarning("Can not convert preference %s to int. Returning default value.", key.toStdString().c_str());
+            qWarning("Can not convert preference %s to int. Returning default value.", key.c_str());
             return defaultValue(key).toInt();
             }
       return pref;
 }
 
-double Preferences::getDouble(const QString key) const
+double Preferences::getDouble(const std::string key) const
       {
+      checkType(key, QMetaType::Double);
       QVariant v = preference(key);
       bool ok;
       double pref = v.toDouble(&ok);
       if (!ok) {
-            qWarning("Can not convert preference %s to double. Returning default value.", key.toStdString().c_str());
+            qWarning("Can not convert preference %s to double. Returning default value.", key.c_str());
             return defaultValue(key).toDouble();
             }
       return pref;
@@ -330,19 +356,19 @@ bool Preferences::isThemeDark() const
       return globalStyle() == MuseScoreStyleType::DARK_FUSION;
       }
 
-void Preferences::revertToDefaultValue(const QString key)
+void Preferences::revertToDefaultValue(const std::string key)
       {
       set(key, defaultValue(key));
       }
 
 
-void Preferences::setPreference(const QString key, QVariant value)
+void Preferences::setPreference(const std::string key, QVariant value)
       {
       checkIfKeyExists(key);
-      set(key, value, false);
+      set(key, value);
       }
 
-void Preferences::setTemporaryPreference(const QString key, QVariant value)
+void Preferences::setTemporaryPreference(const std::string key, QVariant value)
       {
       // note: this function should not call checkIfKeyExists() because it may be
       // called before init() which is ok since the preference is only stored "in memory"
@@ -352,7 +378,9 @@ void Preferences::setTemporaryPreference(const QString key, QVariant value)
 MidiRemote Preferences::midiRemote(int recordId) const
       {
       MidiRemote remote;
-      QString baseKey = QString(PREF_IO_MIDI_REMOTE) + QString("%1%2%3").arg("/").arg(recordId).arg("/");
+      std::stringstream ss;
+      ss << PREF_IO_MIDI_REMOTE << "/" << recordId << "/";
+      std::string baseKey = ss.str();
 
       if (has(baseKey + "type")) {
             remote.type = MidiRemoteType(get(baseKey + "type").toInt());
@@ -367,16 +395,82 @@ MidiRemote Preferences::midiRemote(int recordId) const
 
 void Preferences::updateMidiRemote(int recordId, MidiRemoteType type, int data)
       {
-      QString baseKey = QString(PREF_IO_MIDI_REMOTE) + QString("%1%2%3").arg("/").arg(recordId).arg("/");
+      std::stringstream ss;
+      ss << PREF_IO_MIDI_REMOTE << "/" << recordId << "/";
+      std::string baseKey = ss.str();
+
       set(baseKey + "type", static_cast<int>(type));
       set(baseKey + "data", data);
       }
 
 void Preferences::clearMidiRemote(int recordId)
       {
-      QString baseKey = QString(PREF_IO_MIDI_REMOTE) + QString("%1%2").arg("/").arg(recordId);
+      std::stringstream ss;
+      ss << PREF_IO_MIDI_REMOTE << "/" << recordId;
+      std::string baseKey = ss.str();
       remove(baseKey);
       }
+
+
+Preference::Preference(QVariant defaultValue, QMetaType::Type type, bool showInAdvancedList)
+      : _defaultValue(defaultValue),
+        _showInAdvancedList(showInAdvancedList),
+        _type(type)
+      {}
+
+IntPreference::IntPreference(int defaultValue, bool showInAdvancedList)
+      : Preference(defaultValue, QMetaType::Int, showInAdvancedList)
+      {}
+
+void IntPreference::accept(std::string key, PreferenceVisitor& v)
+      {
+      v.visit(key, this);
+      }
+
+DoublePreference::DoublePreference(double defaultValue, bool showInAdvancedList)
+      : Preference(defaultValue, QMetaType::Double, showInAdvancedList)
+      {}
+
+void DoublePreference::accept(std::string key, PreferenceVisitor& v)
+      {
+      v.visit(key, this);
+      }
+
+BoolPreference::BoolPreference(bool defaultValue, bool showInAdvancedList)
+      : Preference(defaultValue, QMetaType::Bool, showInAdvancedList)
+      {}
+
+void BoolPreference::accept(std::string key, PreferenceVisitor& v)
+      {
+      v.visit(key, this);
+      }
+
+StringPreference::StringPreference(QString defaultValue, bool showInAdvancedList)
+      : Preference(defaultValue, QMetaType::QString, showInAdvancedList)
+      {}
+
+void StringPreference::accept(std::string key, PreferenceVisitor& v)
+      {
+      v.visit(key, this);
+      }
+
+ColorPreference::ColorPreference(QColor defaultValue, bool showInAdvancedList)
+      : Preference(defaultValue, QMetaType::QColor, showInAdvancedList)
+      {}
+
+void ColorPreference::accept(std::string key, PreferenceVisitor& v)
+      {
+      v.visit(key, this);
+      }
+
+EnumPreference::EnumPreference(QVariant defaultValue, bool showInAdvancedList)
+      : Preference(defaultValue, QMetaType::User, showInAdvancedList)
+      {}
+
+void EnumPreference::accept(std::string, PreferenceVisitor&)
+      {
+      }
+
 
 
 } // namespace Ms

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -200,43 +200,44 @@ class Preference {
       QVariant defaultValue() const {return _defaultValue;}
       bool showInAdvancedList() const {return _showInAdvancedList;}
       QMetaType::Type type() {return _type;}
-      virtual void accept(std::string key, PreferenceVisitor&) = 0;
+      virtual void accept(QString key, PreferenceVisitor&) = 0;
       };
 
 class IntPreference : public Preference {
    public:
       IntPreference(int defaultValue, bool showInAdvancedList = true);
-      virtual void accept(std::string key, PreferenceVisitor&);
+      virtual void accept(QString key, PreferenceVisitor&);
       };
 
 class DoublePreference : public Preference {
    public:
       DoublePreference(double defaultValue, bool showInAdvancedList = true);
-      virtual void accept(std::string key, PreferenceVisitor&);
+      virtual void accept(QString key, PreferenceVisitor&);
       };
 
 class BoolPreference : public Preference {
    public:
       BoolPreference(bool defaultValue, bool showInAdvancedList = true);
-      virtual void accept(std::string key, PreferenceVisitor&);
+      virtual void accept(QString key, PreferenceVisitor&);
       };
 
 class StringPreference: public Preference {
    public:
       StringPreference(QString defaultValue, bool showInAdvancedList = true);
-      virtual void accept(std::string key, PreferenceVisitor&);
+      virtual void accept(QString key, PreferenceVisitor&);
       };
 
 class ColorPreference: public Preference {
    public:
       ColorPreference(QColor defaultValue, bool showInAdvancedList = true);
-      virtual void accept(std::string key, PreferenceVisitor&);
+      virtual void accept(QString key, PreferenceVisitor&);
       };
 
+// Support for EnumPreference is currently not fully implemented
 class EnumPreference: public Preference {
    public:
       EnumPreference(QVariant defaultValue, bool showInAdvancedList = true);
-      virtual void accept(std::string, PreferenceVisitor&);
+      virtual void accept(QString, PreferenceVisitor&);
       };
 
 //---------------------------------------------------------
@@ -245,7 +246,7 @@ class EnumPreference: public Preference {
 
 class Preferences {
    public:
-      typedef std::unordered_map<std::string, Preference*> prefs_map_t;
+      typedef QHash<QString, Preference*> prefs_map_t;
 
    private:
 
@@ -255,7 +256,7 @@ class Preferences {
       prefs_map_t _allPreferences;
       // used for storing preferences in memory when _storeInMemoryOnly is true
       // and for storing temporary preferences
-      std::unordered_map<std::string, QVariant> _inMemorySettings;
+      QHash<QString, QVariant> _inMemorySettings;
       bool _storeInMemoryOnly = false;
       bool _returnDefaultValues = false;
       bool _initialized = false;
@@ -264,15 +265,15 @@ class Preferences {
       QSettings* settings() const;
       // the following functions must be used to access and change a preference
       // instead of using QSettings directly
-      QVariant get(const std::string key) const;
-      bool has(const std::string key) const;
-      void set(const std::string key, QVariant value, bool temporary = false);
-      void remove(const std::string key);
+      QVariant get(const QString key) const;
+      bool has(const QString key) const;
+      void set(const QString key, QVariant value, bool temporary = false);
+      void remove(const QString key);
 
-      QVariant preference(const std::string key) const;
-      QMetaType::Type type(const std::string key) const;
-      bool checkIfKeyExists(const std::string key) const;
-      bool checkType(const std::string key, QMetaType::Type t) const;
+      QVariant preference(const QString key) const;
+      QMetaType::Type type(const QString key) const;
+      bool checkIfKeyExists(const QString key) const;
+      bool checkType(const QString key, QMetaType::Type t) const;
 
    public:
       Preferences();
@@ -285,21 +286,21 @@ class Preferences {
       const prefs_map_t& allPreferences() const {return _allPreferences;}
 
       // general getters
-      QVariant defaultValue(const std::string key) const;
-      bool getBool(const std::string key) const;
-      QColor getColor(const std::string key) const;
-      QString getString(const std::string key) const;
-      int getInt(const std::string key) const;
-      double getDouble(const std::string key) const;
+      QVariant defaultValue(const QString key) const;
+      bool getBool(const QString key) const;
+      QColor getColor(const QString key) const;
+      QString getString(const QString key) const;
+      int getInt(const QString key) const;
+      double getDouble(const QString key) const;
 
       // general setters
-      void revertToDefaultValue(const std::string key);
-      void setPreference(const std::string key, QVariant value);
+      void revertToDefaultValue(const QString key);
+      void setPreference(const QString key, QVariant value);
 
       // A temporary preference is stored "in memory" only and not written to file.
       // If there is both a "normal" preference and a temporary preference with the same
       // key the temporary preference is used
-      void setTemporaryPreference(const std::string key, QVariant value);
+      void setTemporaryPreference(const QString key, QVariant value);
 
       /*
        * Some preferences like enums and structs/classes are not easily read using the general set/get methods
@@ -311,7 +312,7 @@ class Preferences {
       bool isThemeDark() const;
 
       template<typename T>
-      void setCustomPreference(const std::string key, T t)
+      void setCustomPreference(const QString key, T t)
             {
             set(key, QVariant::fromValue<T>(t));
             }
@@ -344,11 +345,11 @@ inline QDataStream &operator>>(QDataStream &in, T &val)
 
 class PreferenceVisitor {
    public:
-      virtual void visit(std::string key, IntPreference*) = 0;
-      virtual void visit(std::string key, DoublePreference*) = 0;
-      virtual void visit(std::string key, BoolPreference*) = 0;
-      virtual void visit(std::string key, StringPreference*) = 0;
-      virtual void visit(std::string key, ColorPreference*) = 0;
+      virtual void visit(QString key, IntPreference*) = 0;
+      virtual void visit(QString key, DoublePreference*) = 0;
+      virtual void visit(QString key, BoolPreference*) = 0;
+      virtual void visit(QString key, StringPreference*) = 0;
+      virtual void visit(QString key, ColorPreference*) = 0;
       };
 
 

--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -39,10 +39,8 @@ PreferencesListWidget::PreferencesListWidget(QWidget* parent)
 
 void PreferencesListWidget::loadPreferences()
       {
-      for (auto item : preferences.allPreferences()) {
-
-            std::string key = item.first;
-            Preference* pref = item.second;
+      for (QString key : preferences.allPreferences().keys()) {
+            Preference* pref = preferences.allPreferences().value(key);
 
             if (pref->showInAdvancedList()) {
                   // multiple dispatch using Visitor pattern, see overloaded visit() methods
@@ -53,8 +51,8 @@ void PreferencesListWidget::loadPreferences()
 
 void PreferencesListWidget::updatePreferences()
       {
-      for (auto item : preferenceItems)
-            item.second->update();
+      for (PreferenceItem* item : preferenceItems.values())
+            item->update();
       }
 
 void PreferencesListWidget::addPreference(PreferenceItem* item)
@@ -64,31 +62,31 @@ void PreferencesListWidget::addPreference(PreferenceItem* item)
       preferenceItems[item->name()] = item;
       }
 
-void PreferencesListWidget::visit(std::string key, IntPreference*)
+void PreferencesListWidget::visit(QString key, IntPreference*)
       {
       IntPreferenceItem* item = new IntPreferenceItem(key);
       addPreference(item);
       }
 
-void PreferencesListWidget::visit(std::string key, DoublePreference*)
+void PreferencesListWidget::visit(QString key, DoublePreference*)
       {
       DoublePreferenceItem* item = new DoublePreferenceItem(key);
       addPreference(item);
       }
 
-void PreferencesListWidget::visit(std::string key, BoolPreference*)
+void PreferencesListWidget::visit(QString key, BoolPreference*)
       {
       BoolPreferenceItem* item = new BoolPreferenceItem(key);
       addPreference(item);
       }
 
-void PreferencesListWidget::visit(std::string key, StringPreference*)
+void PreferencesListWidget::visit(QString key, StringPreference*)
       {
       StringPreferenceItem* item = new StringPreferenceItem(key);
       addPreference(item);
       }
 
-void PreferencesListWidget::visit(std::string key, ColorPreference*)
+void PreferencesListWidget::visit(QString key, ColorPreference*)
       {
       ColorPreferenceItem* item = new ColorPreferenceItem(key);
       addPreference(item);
@@ -101,7 +99,7 @@ std::vector<QString> PreferencesListWidget::save()
             PreferenceItem* item = static_cast<PreferenceItem*>(topLevelItem(i));
             if (item->isModified()) {
                   item->save();
-                  changedPreferences.push_back(QString::fromStdString(item->name()));
+                  changedPreferences.push_back(item->name());
                   }
             }
 
@@ -116,10 +114,10 @@ PreferenceItem::PreferenceItem()
 {
 }
 
-PreferenceItem::PreferenceItem(std::string name)
+PreferenceItem::PreferenceItem(QString name)
       : _name(name)
       {
-      setText(0, QString::fromStdString(name));
+      setText(0, name);
       setSizeHint(0, QSize(0, 25));
       }
 
@@ -132,7 +130,7 @@ void PreferenceItem::save(QVariant value)
 //   ColorPreferenceItem
 //---------------------------------------------------------
 
-ColorPreferenceItem::ColorPreferenceItem(std::string name)
+ColorPreferenceItem::ColorPreferenceItem(QString name)
       : PreferenceItem(name),
         _initialValue(preferences.getColor(name)),
         _editor(new Awl::ColorLabel)
@@ -169,7 +167,7 @@ bool ColorPreferenceItem::isModified() const
 //   IntPreferenceItem
 //---------------------------------------------------------
 
-IntPreferenceItem::IntPreferenceItem(std::string name)
+IntPreferenceItem::IntPreferenceItem(QString name)
       : PreferenceItem(name),
         _initialValue(preferences.getInt(name))
 {
@@ -207,7 +205,7 @@ bool IntPreferenceItem::isModified() const
 //   DoublePreferenceItem
 //---------------------------------------------------------
 
-DoublePreferenceItem::DoublePreferenceItem(std::string name)
+DoublePreferenceItem::DoublePreferenceItem(QString name)
       : PreferenceItem(name),
         _initialValue(preferences.getDouble(name)),
         _editor(new QDoubleSpinBox)
@@ -245,7 +243,7 @@ bool DoublePreferenceItem::isModified() const
 //   BoolPreferenceItem
 //---------------------------------------------------------
 
-BoolPreferenceItem::BoolPreferenceItem(std::string name)
+BoolPreferenceItem::BoolPreferenceItem(QString name)
       : PreferenceItem(name),
         _initialValue(preferences.getBool(name)),
         _editor(new QCheckBox)
@@ -280,7 +278,7 @@ bool BoolPreferenceItem::isModified() const
 //   StringPreferenceItem
 //---------------------------------------------------------
 
-StringPreferenceItem::StringPreferenceItem(std::string name)
+StringPreferenceItem::StringPreferenceItem(QString name)
       : PreferenceItem(name),
         _initialValue(preferences.getString(name)),
         _editor(new QLineEdit)

--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -1,0 +1,316 @@
+//=============================================================================
+//  MuseScore
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2002-2017 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "preferenceslistwidget.h"
+
+namespace Ms {
+
+
+PreferencesListWidget::PreferencesListWidget(QWidget* parent)
+      : QTreeWidget(parent)
+      {
+      setRootIsDecorated(false);
+      setHeaderLabels(QStringList() << tr("Preference") << tr("Value"));
+      header()->setStretchLastSection(false);
+      header()->setSectionResizeMode(0, QHeaderView::Stretch);
+      setAccessibleName(tr("Advanced preferences"));
+      setAccessibleDescription(tr("Access to more advanced preferences"));
+      setAlternatingRowColors(true);
+      setSortingEnabled(true);
+      sortByColumn(0, Qt::AscendingOrder);
+      setAllColumnsShowFocus(true);
+      }
+
+void PreferencesListWidget::loadPreferences()
+      {
+      for (auto item : preferences.allPreferences()) {
+
+            std::string key = item.first;
+            Preference* pref = item.second;
+
+            if (pref->showInAdvancedList()) {
+                  // multiple dispatch using Visitor pattern, see overloaded visit() methods
+                  pref->accept(key, *this);
+                  }
+            }
+      }
+
+void PreferencesListWidget::updatePreferences()
+      {
+      for (auto item : preferenceItems)
+            item.second->update();
+      }
+
+void PreferencesListWidget::addPreference(PreferenceItem* item)
+      {
+      addTopLevelItem(item);
+      setItemWidget(item, PREF_VALUE_COLUMN, item->editor());
+      preferenceItems[item->name()] = item;
+      }
+
+void PreferencesListWidget::visit(std::string key, IntPreference*)
+      {
+      IntPreferenceItem* item = new IntPreferenceItem(key);
+      addPreference(item);
+      }
+
+void PreferencesListWidget::visit(std::string key, DoublePreference*)
+      {
+      DoublePreferenceItem* item = new DoublePreferenceItem(key);
+      addPreference(item);
+      }
+
+void PreferencesListWidget::visit(std::string key, BoolPreference*)
+      {
+      BoolPreferenceItem* item = new BoolPreferenceItem(key);
+      addPreference(item);
+      }
+
+void PreferencesListWidget::visit(std::string key, StringPreference*)
+      {
+      StringPreferenceItem* item = new StringPreferenceItem(key);
+      addPreference(item);
+      }
+
+void PreferencesListWidget::visit(std::string key, ColorPreference*)
+      {
+      ColorPreferenceItem* item = new ColorPreferenceItem(key);
+      addPreference(item);
+      }
+
+std::vector<QString> PreferencesListWidget::save()
+      {
+      std::vector<QString> changedPreferences;
+      for (int i = 0; i < topLevelItemCount(); ++i) {
+            PreferenceItem* item = static_cast<PreferenceItem*>(topLevelItem(i));
+            if (item->isModified()) {
+                  item->save();
+                  changedPreferences.push_back(QString::fromStdString(item->name()));
+                  }
+            }
+
+      return changedPreferences;
+      }
+
+//---------------------------------------------------------
+//   PreferenceItem
+//---------------------------------------------------------
+
+PreferenceItem::PreferenceItem()
+{
+}
+
+PreferenceItem::PreferenceItem(std::string name)
+      : _name(name)
+      {
+      setText(0, QString::fromStdString(name));
+      setSizeHint(0, QSize(0, 25));
+      }
+
+void PreferenceItem::save(QVariant value)
+      {
+      preferences.setPreference(name(), value);
+      }
+
+//---------------------------------------------------------
+//   ColorPreferenceItem
+//---------------------------------------------------------
+
+ColorPreferenceItem::ColorPreferenceItem(std::string name)
+      : PreferenceItem(name),
+        _initialValue(preferences.getColor(name)),
+        _editor(new Awl::ColorLabel)
+      {
+      _editor->setColor(_initialValue);
+      _editor->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+      }
+
+void ColorPreferenceItem::save()
+      {
+      QColor newValue = _editor->color();
+      _initialValue = newValue;
+      PreferenceItem::save(newValue);
+      }
+
+void ColorPreferenceItem::update()
+      {
+      QColor newValue = preferences.getColor(name());
+      _editor->setColor(newValue);
+      }
+
+void ColorPreferenceItem::setDefaultValue()
+      {
+      _editor->setColor(preferences.defaultValue(name()).value<QColor>());
+      }
+
+bool ColorPreferenceItem::isModified() const
+      {
+      return _initialValue != _editor->color();
+      }
+
+
+//---------------------------------------------------------
+//   IntPreferenceItem
+//---------------------------------------------------------
+
+IntPreferenceItem::IntPreferenceItem(std::string name)
+      : PreferenceItem(name),
+        _initialValue(preferences.getInt(name))
+{
+      _editor = new QSpinBox;
+      _editor->setMaximum(INT_MAX);
+      _editor->setMinimum(INT_MIN);
+      _editor->setValue(_initialValue);
+}
+
+void IntPreferenceItem::save()
+      {
+      int newValue = _editor->value();
+      _initialValue = newValue;
+      PreferenceItem::save(newValue);
+      }
+
+void IntPreferenceItem::update()
+      {
+      int newValue = preferences.getInt(name());
+      _editor->setValue(newValue);
+      }
+
+void IntPreferenceItem::setDefaultValue()
+      {
+      _editor->setValue(preferences.defaultValue(name()).toInt());
+      }
+
+
+bool IntPreferenceItem::isModified() const
+      {
+      return _initialValue != _editor->value();
+      }
+
+//---------------------------------------------------------
+//   DoublePreferenceItem
+//---------------------------------------------------------
+
+DoublePreferenceItem::DoublePreferenceItem(std::string name)
+      : PreferenceItem(name),
+        _initialValue(preferences.getDouble(name)),
+        _editor(new QDoubleSpinBox)
+      {
+      _editor->setMaximum(DBL_MAX);
+      _editor->setMinimum(DBL_MIN);
+      _editor->setValue(_initialValue);
+      }
+
+void DoublePreferenceItem::save()
+      {
+      double newValue = _editor->value();
+      _initialValue = newValue;
+      PreferenceItem::save(newValue);
+      }
+
+void DoublePreferenceItem::update()
+      {
+      double newValue = preferences.getDouble(name());
+      _editor->setValue(newValue);
+      }
+
+void DoublePreferenceItem::setDefaultValue()
+      {
+      _editor->setValue(preferences.defaultValue(name()).toDouble());
+      }
+
+bool DoublePreferenceItem::isModified() const
+      {
+      return _initialValue != _editor->value();
+      }
+
+
+//---------------------------------------------------------
+//   BoolPreferenceItem
+//---------------------------------------------------------
+
+BoolPreferenceItem::BoolPreferenceItem(std::string name)
+      : PreferenceItem(name),
+        _initialValue(preferences.getBool(name)),
+        _editor(new QCheckBox)
+      {
+      _editor->setChecked(_initialValue);
+      }
+
+void BoolPreferenceItem::save()
+      {
+      bool newValue = _editor->isChecked();
+      _initialValue = newValue;
+      PreferenceItem::save(newValue);
+      }
+
+void BoolPreferenceItem::update()
+      {
+      bool newValue = preferences.getBool(name());
+      _editor->setChecked(newValue);
+      }
+
+void BoolPreferenceItem::setDefaultValue()
+      {
+      _editor->setChecked(preferences.defaultValue(name()).toBool());
+      }
+
+bool BoolPreferenceItem::isModified() const
+      {
+      return _initialValue != _editor->isChecked();
+      }
+
+//---------------------------------------------------------
+//   StringPreferenceItem
+//---------------------------------------------------------
+
+StringPreferenceItem::StringPreferenceItem(std::string name)
+      : PreferenceItem(name),
+        _initialValue(preferences.getString(name)),
+        _editor(new QLineEdit)
+      {
+      _editor->setText(_initialValue);
+      }
+
+void StringPreferenceItem::save()
+      {
+      QString newValue = _editor->text();
+      _initialValue = newValue;
+      PreferenceItem::save(newValue);
+      }
+
+void StringPreferenceItem::update()
+      {
+      QString newValue = preferences.getString(name());
+      _editor->setText(newValue);
+      }
+
+void StringPreferenceItem::setDefaultValue()
+      {
+      _editor->setText(preferences.defaultValue(name()).toString());
+      }
+
+bool StringPreferenceItem::isModified() const
+      {
+      return _initialValue != _editor->text();
+      }
+
+
+
+} // namespace Ms

--- a/mscore/preferenceslistwidget.h
+++ b/mscore/preferenceslistwidget.h
@@ -1,0 +1,170 @@
+//=============================================================================
+//  MuseScore
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2002-2017 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __PREFERENCESLISTWIDGET_H__
+#define __PREFERENCESLISTWIDGET_H__
+
+#include "awl/colorlabel.h"
+#include "preferences.h"
+
+#define PREF_VALUE_COLUMN 1
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   PreferenceItem
+//---------------------------------------------------------
+class PreferenceItem : public QTreeWidgetItem, public QObject {
+
+      std::string _name;
+
+    protected:
+      void save(QVariant value);
+
+    public:
+      PreferenceItem();
+      PreferenceItem(std::string name);
+
+      virtual void save() = 0;
+      virtual void update() = 0;
+      virtual void setDefaultValue() = 0;
+      virtual QWidget* editor() const = 0;
+      virtual bool isModified() const = 0;
+
+      std::string name() const {return _name;}
+
+      };
+
+//---------------------------------------------------------
+//   BoolPreferenceItem
+//---------------------------------------------------------
+class BoolPreferenceItem : public PreferenceItem {
+   private:
+      bool _initialValue;
+      QCheckBox* _editor;
+
+   public:
+      BoolPreferenceItem(std::string name);
+
+      void save();
+      void update();
+      void setDefaultValue();
+      QWidget* editor() const {return _editor;}
+      bool isModified() const;
+
+      };
+
+
+//---------------------------------------------------------
+//   IntPreferenceItem
+//---------------------------------------------------------
+class IntPreferenceItem : public PreferenceItem {
+      int _initialValue;
+      QSpinBox* _editor;
+
+   public:
+      IntPreferenceItem(std::string name);
+
+      void save();
+      void update();
+      void setDefaultValue();
+      QWidget* editor() const {return _editor;}
+      bool isModified() const;
+      };
+
+//---------------------------------------------------------
+//   DoublePreferenceItem
+//---------------------------------------------------------
+class DoublePreferenceItem : public PreferenceItem {
+      double _initialValue;
+      QDoubleSpinBox* _editor;
+
+   public:
+      DoublePreferenceItem(std::string name);
+
+      void save();
+      void update();
+      void setDefaultValue();
+      QWidget* editor() const {return _editor;}
+      bool isModified() const;
+      };
+
+//---------------------------------------------------------
+//   StringPreferenceItem
+//---------------------------------------------------------
+class StringPreferenceItem : public PreferenceItem {
+      QString _initialValue;
+      QLineEdit* _editor;
+
+   public:
+      StringPreferenceItem(std::string name);
+
+      void save();
+      void update();
+      void setDefaultValue();
+      QWidget* editor() const {return _editor;}
+      bool isModified() const;
+      };
+
+//---------------------------------------------------------
+//   ColorPreferenceItem
+//---------------------------------------------------------
+class ColorPreferenceItem : public PreferenceItem {
+      QColor _initialValue;
+      Awl::ColorLabel* _editor;
+
+   public:
+      ColorPreferenceItem(std::string name);
+
+      void save();
+      void update();
+      void setDefaultValue();
+      QWidget* editor() const {return _editor;}
+      bool isModified() const;
+      };
+
+
+//---------------------------------------------------------
+//   PreferencesListWidget
+//---------------------------------------------------------
+
+class PreferencesListWidget : public QTreeWidget, public PreferenceVisitor {
+
+      std::unordered_map<std::string, PreferenceItem*> preferenceItems;
+
+      void addPreference(PreferenceItem* item);
+
+   public:
+      explicit PreferencesListWidget(QWidget* parent = 0);
+      void loadPreferences();
+      void updatePreferences();
+
+      std::vector<QString> save();
+
+      void visit(std::string key, IntPreference*);
+      void visit(std::string key, DoublePreference*);
+      void visit(std::string key, BoolPreference*);
+      void visit(std::string key, StringPreference*);
+      void visit(std::string key, ColorPreference*);
+
+};
+
+} // namespace Ms
+
+#endif // __PREFERENCESLISTWIDGET_H__

--- a/mscore/preferenceslistwidget.h
+++ b/mscore/preferenceslistwidget.h
@@ -32,14 +32,14 @@ namespace Ms {
 //---------------------------------------------------------
 class PreferenceItem : public QTreeWidgetItem, public QObject {
 
-      std::string _name;
+      QString _name;
 
     protected:
       void save(QVariant value);
 
     public:
       PreferenceItem();
-      PreferenceItem(std::string name);
+      PreferenceItem(QString name);
 
       virtual void save() = 0;
       virtual void update() = 0;
@@ -47,7 +47,7 @@ class PreferenceItem : public QTreeWidgetItem, public QObject {
       virtual QWidget* editor() const = 0;
       virtual bool isModified() const = 0;
 
-      std::string name() const {return _name;}
+      QString name() const {return _name;}
 
       };
 
@@ -60,7 +60,7 @@ class BoolPreferenceItem : public PreferenceItem {
       QCheckBox* _editor;
 
    public:
-      BoolPreferenceItem(std::string name);
+      BoolPreferenceItem(QString name);
 
       void save();
       void update();
@@ -79,7 +79,7 @@ class IntPreferenceItem : public PreferenceItem {
       QSpinBox* _editor;
 
    public:
-      IntPreferenceItem(std::string name);
+      IntPreferenceItem(QString name);
 
       void save();
       void update();
@@ -96,7 +96,7 @@ class DoublePreferenceItem : public PreferenceItem {
       QDoubleSpinBox* _editor;
 
    public:
-      DoublePreferenceItem(std::string name);
+      DoublePreferenceItem(QString name);
 
       void save();
       void update();
@@ -113,7 +113,7 @@ class StringPreferenceItem : public PreferenceItem {
       QLineEdit* _editor;
 
    public:
-      StringPreferenceItem(std::string name);
+      StringPreferenceItem(QString name);
 
       void save();
       void update();
@@ -130,7 +130,7 @@ class ColorPreferenceItem : public PreferenceItem {
       Awl::ColorLabel* _editor;
 
    public:
-      ColorPreferenceItem(std::string name);
+      ColorPreferenceItem(QString name);
 
       void save();
       void update();
@@ -146,7 +146,7 @@ class ColorPreferenceItem : public PreferenceItem {
 
 class PreferencesListWidget : public QTreeWidget, public PreferenceVisitor {
 
-      std::unordered_map<std::string, PreferenceItem*> preferenceItems;
+      QHash<QString, PreferenceItem*> preferenceItems;
 
       void addPreference(PreferenceItem* item);
 
@@ -157,11 +157,11 @@ class PreferencesListWidget : public QTreeWidget, public PreferenceVisitor {
 
       std::vector<QString> save();
 
-      void visit(std::string key, IntPreference*);
-      void visit(std::string key, DoublePreference*);
-      void visit(std::string key, BoolPreference*);
-      void visit(std::string key, StringPreference*);
-      void visit(std::string key, ColorPreference*);
+      void visit(QString key, IntPreference*);
+      void visit(QString key, DoublePreference*);
+      void visit(QString key, BoolPreference*);
+      void visit(QString key, StringPreference*);
+      void visit(QString key, ColorPreference*);
 
 };
 

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -24,6 +24,7 @@
 #include "ui_prefsdialog.h"
 #include "preferences.h"
 #include "abstractdialog.h"
+#include "preferenceslistwidget.h"
 
 namespace Ms {
 
@@ -39,6 +40,7 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       QMap<QString, Shortcut*> localShortcuts;
       bool shortcutsChanged;
       QButtonGroup* recordButtons;
+      PreferencesListWidget* advancedWidget;
 
       virtual void hideEvent(QHideEvent*);
       void apply();
@@ -76,6 +78,8 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       void selectImagesDirectory();
       void printShortcutsClicked();
       void filterShortcutsTextChanged(const QString &);
+      void filterAdvancedPreferences(const QString&);
+      void resetAdvancedPreferenceToDefault();
 
       void changeSoundfontPaths();
       void updateTranslationClicked();

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -4148,6 +4148,69 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabAdvanced">
+      <property name="accessibleName">
+       <string>Advanced Tab</string>
+      </property>
+      <attribute name="title">
+       <string>Advanced</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QVBoxLayout" name="advancedTabLayout">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="QPushButton" name="resetPreference">
+             <property name="toolTip">
+              <string>Select a preference to reset to default value</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleDescription">
+              <string>Select a preference to reset to default value</string>
+             </property>
+             <property name="text">
+              <string>Reset to default</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="advancedSearch">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="placeholderText">
+              <string>Search</string>
+             </property>
+             <property name="clearButtonEnabled">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3877,6 +3877,16 @@ void Shortcut::retranslate()
             }
       }
 
+void Shortcut::refreshIcons()
+      {
+      foreach (Shortcut* s, _shortcuts) {
+            QAction* a = s->action();
+            if (a && s->icon() != Icons::Invalid_ICON) {
+                  a->setIcon(*icons[int(s->icon())]);
+                  }
+            }
+      }
+
 //---------------------------------------------------------
 //   save
 //---------------------------------------------------------

--- a/mscore/shortcut.h
+++ b/mscore/shortcut.h
@@ -164,6 +164,7 @@ class Shortcut {
 
       static void init();
       static void retranslate();
+      static void refreshIcons();
       static void load();
       static void loadFromNewFile(QString fileLocation);
       static void save();


### PR DESCRIPTION
Adds logic and GUI to handle preferences without adding a separate widget to
prefsdialog. Changes within the application because of a preferences change still
needs to be handled separately in other parts of the code.

When adding a preferences there is the option whether to have the preference in
the advanced list or not. If not a separate widget must be added to prefsdialog.

Note: Enums are currently not supported (as there are no enums in the advanced
list as of now, but can be easily added.