### PR TITLE
Fix #271854: Let text elements be placed out of the enclosing box of the previous elements in the measure ONLY if the default baseline placement has a conflict.

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1849,13 +1849,15 @@ void Element::autoplaceSegmentElement(qreal minDistance)
                   Measure* nm = m->nextMeasure();
                   s1.add(nm->staffShape(si).translated(QPointF(m->width(), 0.0)));
                   }
-            qreal d = placeAbove() ? s2.minVerticalDistance(s1) : s1.minVerticalDistance(s2);
-            if (d > -minDistance) {
-                  qreal yd = d + minDistance;
-                  if (placeAbove())
-                        yd *= -1.0;
-                  rUserYoffset() = yd;
-                  s2.translateY(yd);
+            if (s1.intersects(s2)) {
+                  qreal d = placeAbove() ? s2.minVerticalDistance(s1) : s1.minVerticalDistance(s2);
+                  if (d > -minDistance) {
+                        qreal yd = d + minDistance;
+                        if (placeAbove())
+                              yd *= -1.0;
+                        rUserYoffset() = yd;
+                        s2.translateY(yd);
+                        }
                   }
             m->staffShape(si).add(s2);
             if (cnm) {

--- a/libmscore/shape.cpp
+++ b/libmscore/shape.cpp
@@ -255,6 +255,15 @@ bool Shape::intersects(const QRectF& rr) const
       return false;
       }
 
+bool Shape::intersects(const Shape& s) const
+      {
+      for (const QRectF& r : s) {
+            if (intersects(r))
+                  return true;
+            }
+      return false;
+      }
+
 //---------------------------------------------------------
 //   paint
 //---------------------------------------------------------

--- a/libmscore/shape.h
+++ b/libmscore/shape.h
@@ -78,6 +78,7 @@ class Shape : std::vector<ShapeElement> {
 
       bool contains(const QPointF&) const;
       bool intersects(const QRectF& rr) const;
+      bool intersects(const Shape& s) const;
       void paint(QPainter&);
 
 #ifndef NDEBUG


### PR DESCRIPTION
This avoids indefinite accumulation of shortly interspaced text elements piling up to unmanageable graphical heights on the score!