### PR TITLE
fix #272023: Downstem mirrored notes lose accidental

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -908,6 +908,11 @@ void Score::layoutChords3(std::vector<Note*>& notes, Staff* staff, Segment* segm
             note->setDotY(dotPosition);  // also removes invalid dots
             }
 
+      // if there are no non-mirrored notes in a downstem chord,
+      // then use the stem X position as X origin for accidental layout
+      if (nNotes && leftNotes.size() == nNotes)
+            lx = notes.front()->chord()->stemPosX();
+
       if (segment) {
             // align all dots for segment/staff
             // it would be possible to dots for up & down chords separately


### PR DESCRIPTION
See [272023: Downstem mirrored notes lose accidental](https://musescore.org/en/node/272023).