### PR TITLE
fix #253926: Key signature not displaying correctly on clef change at the start of a score

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -105,8 +105,18 @@ void KeySig::layout()
 
       // determine current clef for this staff
       ClefType clef = ClefType::G;
-      if (staff())
-            clef = staff()->clef(segment()->tick());
+      if (staff()) {
+            // Look for a clef before the key signature at the same tick
+            Clef* c = nullptr;
+            for (Segment* seg = segment()->prev1(); !c && seg && seg->tick() == segment()->tick(); seg = seg->prev1())
+                  if (seg->segmentType() == Segment::Type::Clef)
+                        c = static_cast<Clef*>(seg->element(track()));
+            if (c)
+                  clef = c->clefType();
+            else
+                  // no clef found, so get the clef type from the clefs list, using the previous tick
+                  clef = staff()->clef(segment()->tick() - 1);
+            }
 
       int accidentals = 0, naturals = 0;
       int t1 = int(_sig.key());


### PR DESCRIPTION
See [Key signature not displaying correctly on clef change at the start of a score](https://musescore.org/en/node/253926).

This is currently not an issue in the master branch, because the master branch does not currently allow "mid-measure" clef changes on the first tick of the measure. If this was an unintended consequence of the restructuring of code involving clef changes, I can submit a patch to bring back this ability.