### PR TITLE
fix #105936 and move tempo selection to timesig page of New Wizard

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -725,10 +725,52 @@ MasterScore* MuseScore::getNewFile()
             delete nvb;
             }
 
-      if (newWizard->createTempo()) {
-            double tempo = newWizard->tempo();
+      double tempo = 120;
+      if (newWizard->tempo(&tempo)) {
+
+            Fraction timesig = newWizard->timesig();
+
+            QString text("<sym>metNoteQuarterUp</sym> = %1");
+            switch (timesig.denominator()) {
+                  case 1:
+                        text = "<sym>metNoteWhole</sym> = %1";
+                        break;
+                  case 2:
+                        text = "<sym>metNoteHalfUp</sym> = %1";
+                        break;
+                  case 4:
+                        text = "<sym>metNoteQuarterUp</sym> = %1";
+                        break;
+                  case 8:
+                        if(timesig.numerator() % 3 == 0)
+                              text = "<sym>metNoteQuarterUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                        else
+                              text = "<sym>metNote8thUp</sym> = %1";
+                        break;
+                  case 16:
+                        if(timesig.numerator() % 3 == 0)
+                              text = "<sym>metNote8thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                        else
+                              text = "<sym>metNote16thUp</sym> = %1";
+                        break;
+                  case 32:
+                        if(timesig.numerator() % 3 == 0)
+                              text = "<sym>metNote16thUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                        else
+                              text = "<sym>metNote32ndUp</sym> = %1";
+                        break;
+                  case 64:
+                        if(timesig.numerator() % 3 == 0)
+                              text = "<sym>metNote32ndUp</sym><sym>space</sym><sym>metAugmentationDot</sym> = %1";
+                        else
+                              text = "<sym>metNote64thUp</sym> = %1";
+                        break;
+                  default:
+                        break;
+                  }
+
             TempoText* tt = new TempoText(score);
-            tt->setXmlText(QString("<sym>metNoteQuarterUp</sym> = %1").arg(tempo));
+            tt->setXmlText(text.arg(tempo));
             tempo /= 60;      // bpm -> bps
 
             tt->setTempo(tempo);

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -90,6 +90,16 @@ bool TimesigWizard::pickup(int* z, int* n) const
       }
 
 //---------------------------------------------------------
+//   tempo
+//---------------------------------------------------------
+
+bool TimesigWizard::tempo(double* t) const
+    {
+    *t = spinboxTempo->value();
+    return tempoGroup->isChecked();
+    }
+
+//---------------------------------------------------------
 //   type
 //---------------------------------------------------------
 
@@ -249,7 +259,7 @@ NewWizardPage3::NewWizardPage3(QWidget* parent)
       {
       setFinalPage(true);
       setTitle(tr("Create New Score"));
-      setSubTitle(tr("Choose time signature:"));
+      setSubTitle(tr("Choose time signature and tempo:"));
       setAccessibleName(title());
       setAccessibleDescription(subTitle());
 
@@ -366,7 +376,7 @@ NewWizardPage5::NewWizardPage5(QWidget* parent)
       {
       setFinalPage(true);
       setTitle(tr("Create New Score"));
-      setSubTitle(tr("Choose key signature and tempo:"));
+      setSubTitle(tr("Choose key signature:"));
       setAccessibleName(title());
       setAccessibleDescription(subTitle());
 
@@ -384,26 +394,8 @@ NewWizardPage5::NewWizardPage5(QWidget* parent)
       l1->addWidget(sa);
       b1->setLayout(l1);
 
-      tempoGroup = new QGroupBox;
-      tempoGroup->setCheckable(true);
-      tempoGroup->setChecked(false);
-      tempoGroup->setTitle(tr("Tempo"));
-      QLabel* bpm = new QLabel;
-      bpm->setText(tr("BPM:"));
-      _tempo = new QDoubleSpinBox;
-      _tempo->setAccessibleName(tr("Beats per minute"));
-      _tempo->setRange(20.0, 400.0);
-      _tempo->setValue(120.0);
-      _tempo->setDecimals(1);
-      QHBoxLayout* l2 = new QHBoxLayout;
-      l2->addWidget(bpm);
-      l2->addWidget(_tempo);
-      l2->addStretch(100);
-      tempoGroup->setLayout(l2);
-
       QVBoxLayout* l3 = new QVBoxLayout;
       l3->addWidget(b1);
-      l3->addWidget(tempoGroup);
       l3->addStretch(100);
       setLayout(l3);
       setFocusPolicy(Qt::StrongFocus);

--- a/mscore/newwizard.h
+++ b/mscore/newwizard.h
@@ -55,6 +55,7 @@ class TimesigWizard : public QWidget, private Ui::TimesigWizard {
       int measures() const;
       Fraction timesig() const;
       bool pickup(int* z, int* n) const;
+      bool tempo(double* t) const;
       TimeSigType type() const;
       };
 
@@ -123,6 +124,7 @@ class NewWizardPage3 : public QWizardPage {
       Fraction timesig() const                 { return w->timesig();    }
       bool pickupMeasure(int* z, int* n) const { return w->pickup(z, n); }
       TimeSigType timesigType() const          { return w->type();       }
+      bool tempo(double* t) const              { return w->tempo(t);     }
       };
 
 //---------------------------------------------------------
@@ -155,15 +157,11 @@ class NewWizardPage5 : public QWizardPage {
       Q_OBJECT
 
       Palette* sp;
-      QDoubleSpinBox* _tempo;
-      QGroupBox* tempoGroup;
 
    public:
       NewWizardPage5(QWidget* parent = 0);
       virtual bool isComplete() const override { return true; }
       KeySigEvent keysig() const;
-      double tempo() const            { return _tempo->value(); }
-      bool createTempo() const        { return tempoGroup->isChecked(); }
       void init();
       };
 
@@ -203,9 +201,8 @@ class NewWizard : public QWizard {
       QString copyright() const          { return p1->copyright();   }
       KeySigEvent keysig() const         { return p5->keysig();      }
       bool pickupMeasure(int* z, int* n) const { return p3->pickupMeasure(z, n); }
-      TimeSigType timesigType() const     { return p3->timesigType();       }
-      double tempo() const                { return p5->tempo();       }
-      bool createTempo() const            { return p5->createTempo(); }
+      TimeSigType timesigType() const     { return p3->timesigType(); }
+      bool tempo(double* t) const         { return p3->tempo(t);     }
       bool emptyScore() const;
       };
 

--- a/mscore/timesigwizard.ui
+++ b/mscore/timesigwizard.ui
@@ -361,6 +361,63 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <widget class="QGroupBox" name="tempoGroup">
+     <property name="accessibleName">
+      <string>Tempo</string>
+     </property>
+     <property name="title">
+      <string>Tempo</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QHBoxLayout">
+      <item>
+       <widget class="QLabel" name="labelBpm">
+        <property name="text">
+         <string>BPM:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDoubleSpinBox" name="spinboxTempo">
+        <property name="accessibleName">
+         <string>Beats per minute</string>
+        </property>
+        <property name="minimum">
+         <number>20</number>
+        </property>
+        <property name="maximum">
+         <number>400</number>
+        </property>
+        <property name="decimals">
+         <number>1</number>
+        </property>
+        <property name="value">
+         <number>120</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
@@ -373,6 +430,8 @@
   <tabstop>pickupTimesigZ</tabstop>
   <tabstop>pickupTimesigN</tabstop>
   <tabstop>measureCount</tabstop>
+  <tabstop>tempoGroup</tabstop>
+  <tabstop>spinboxTempo</tabstop>
  </tabstops>
  <resources>
   <include location="musescore.qrc"/>


### PR DESCRIPTION
Fixes https://musescore.org/en/node/105936
And, as suggested in the issue, moves the tempo field in the New Wizard to the more logical page dealing with time signatures, as opposed to the page dealing with key signatures as it had been before.