### PR TITLE
Measure numbering by interval should take 1st measure number into account

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -578,7 +578,7 @@ void Measure::layout2()
                         smn = system()->firstMeasure() == this;
                   else {
                         smn = (_no == 0 && score()->styleB(StyleIdx::showMeasureNumberOne)) ||
-                              ( ((_no+1) % score()->style(StyleIdx::measureNumberInterval).toInt()) == 0 );
+                              ( ((_no + 1) % score()->style(StyleIdx::measureNumberInterval).toInt()) == (score()->styleB(StyleIdx::showMeasureNumberOne) ? 1 : 0) );
                         }
                   }
             }


### PR DESCRIPTION
See discussion in https://musescore.org/en/node/272390, this PR is for 2.3