### PR TITLE
line width of bends wrongly get multiplied by spatium()

### DIFF
--- a/libmscore/bend.cpp
+++ b/libmscore/bend.cpp
@@ -175,7 +175,7 @@ void Bend::layout()
 void Bend::draw(QPainter* painter) const
       {
       qreal _spatium = spatium();
-      qreal _lw = _lineWidth.val() * _spatium;
+      qreal _lw = _lineWidth.val();
 
       QPen pen(curColor(), _lw, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
       painter->setPen(pen);


### PR DESCRIPTION
see https://musescore.org/en/node/272425