### PR TITLE
fix #269253: Opening bass clef disappears when mid-measure treble clef is applied

### DIFF
--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -428,6 +428,8 @@ void Clef::read(XmlReader& e)
                   _clefTypes._transposingClef = Clef::clefType(e.readElementText());
             else if (tag == "showCourtesyClef")
                   _showCourtesy = e.readInt();
+            else if (tag == "header")
+                  _small = !e.readInt();
             else if (!Element::readProperties(e))
                   e.unknown();
             }
@@ -444,6 +446,8 @@ void Clef::read(XmlReader& e)
 void Clef::write(Xml& xml) const
       {
       xml.stag(name());
+      if (tick() == measure()->tick() && _small)
+            xml.tag("header", QVariant(false));
       if(_clefTypes._concertClef != ClefType::INVALID)
             xml.tag("concertClefType", ClefInfo::tag(_clefTypes._concertClef));
       if(_clefTypes._transposingClef != ClefType::INVALID)

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1625,6 +1625,7 @@ void Score::addSystemHeader(Measure* m, bool isFirstSystem)
       if (undoRedo())   // no change possible in this state
             return;
 
+      Segment* headerClefSeg = 0;
       int tick = m->tick();
       int i    = 0;
       foreach (Staff* staff, _staves) {
@@ -1657,8 +1658,12 @@ void Score::addSystemHeader(Measure* m, bool isFirstSystem)
                               keysig = static_cast<KeySig*>(el);
                               break;
                         case Element::Type::CLEF:
-                              clef = static_cast<Clef*>(el);
-                              clef->setSmall(false);
+                              if (!clef) {
+                                    clef = static_cast<Clef*>(el);
+                                    if (clef->small())
+                                          // this is not the clef we are looking for
+                                          clef = 0;
+                                    }
                               break;
                         default:
                               break;
@@ -1691,6 +1696,18 @@ void Score::addSystemHeader(Measure* m, bool isFirstSystem)
                || staff->clef(m->tick()) != staff->clef(m->tick()-1);
 
             if (needClef) {
+                  // find the clef type at the previous tick
+                  ClefTypeList clefType = staff->clefType(m->tick() - 1);
+                  // look for a clef change at the end of the previous measure
+                  Measure* prevMeasure = m->prevMeasure();
+                  if (prevMeasure) {
+                        Segment* clefSeg = prevMeasure->findSegment(Segment::Type::Clef, m->tick());
+                        if (clefSeg) {
+                              Clef* prevClef = static_cast<Clef*>(clefSeg->element(strack));
+                              if (prevClef)
+                                    clefType = prevClef->clefTypeList();
+                              }
+                        }
                   if (!clef) {
                         //
                         // create missing clef
@@ -1700,31 +1717,36 @@ void Score::addSystemHeader(Measure* m, bool isFirstSystem)
                         clef->setSmall(false);
                         clef->setGenerated(true);
 
-                        Segment* ns = m->findSegment(Segment::Type::Clef, tick);
-                        Segment* s;
-                        if (ns && !ns->element(clef->track())) {
-                              s = ns;
-                              ns = 0;
+                        if (!headerClefSeg) {
+                              // if there is a header clef segment, it will be the first segment of the measure
+                              Segment* s = m->first();
+                              if (s && s->segmentType() == Segment::Type::Clef) {
+                                    // check for a clef in each staff
+                                    // stop when a clef is found
+                                    // if it is small, then a new segment will have to be created
+                                    Clef* c = 0;
+                                    for (int t = 0; !c && t < score()->ntracks(); t += VOICES)
+                                          c = static_cast<Clef*>(s->element(t));
+                                    if (c && !c->small())
+                                          // this is the header clef segment
+                                          headerClefSeg = s;
+                                    }
+                              if (!headerClefSeg) {
+                                    // create a new segment for the header clef
+                                    headerClefSeg = new Segment(m, Segment::Type::Clef, tick);
+                                    // insert the new segment at the front of the segments list
+                                    headerClefSeg->setNext(m->first());
+                                    undoAddElement(headerClefSeg);
+                                    }
                               }
-                        else {
-                              s  = new Segment(m, Segment::Type::Clef, tick);
-                              undoAddElement(s);
-                              }
-                        clef->setParent(s);
-
-                        // if there is already a clef at the same tick position,
-                        // then this is the real clef change and we have to
-                        // show the previous clef type at tick-1
-
-                        ClefTypeList clefType = staff->clefType(ns ? tick - 1 : tick);
-                        clef->layout();
+                        clef->setParent(headerClefSeg);
                         clef->setClefType(clefType);  // set before add !
                         undo(new AddElement(clef));
                         }
-                  else if (clef->generated()) {
-                        ClefTypeList cl = staff->clefType(tick);
-                        if (cl != clef->clefTypeList())
-                              undo(new ChangeClefType(clef, cl._concertClef, cl._transposingClef));
+                  else {
+                        headerClefSeg = clef->segment();
+                        if (clef->generated() && clef->clefTypeList() != clefType)
+                              undo(new ChangeClefType(clef, clefType._concertClef, clefType._transposingClef));
                         }
                   }
             else {

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2095,50 +2095,41 @@ void Measure::read(XmlReader& e, int staffIdx)
                   // if (score()->mscVersion() > 114)
                   //      staff->setClef(e.tick(), clef->clefTypeList());
 
-                  // there may be more than one clef segment for same tick position
-                  if (!segment) {
-                        // this is the first segment of measure
-                        segment = getSegment(Segment::Type::Clef, e.tick());
+                  if (segment)
+                        // not the first segment, so this is not a header clef
+                        clef->setSmall(true);
+                  segment = 0;
+                  Segment* ns = 0;  // the place to insert a new segment
+                  Segment* s = 0;   // the segment to try to reuse, if possible
+                  if (clef->small()) {
+                        // mid-measure clefs are inserted right before the ChordRest
+                        ns = findSegment(Segment::Type::ChordRest, e.tick());
+                        // there might already be a segment for mid-measure clefs
+                        s = ns ? ns->prev() : 0;
                         }
                   else {
-                        bool firstSegment = false;
-                        // the first clef may be missing and is added later in layout
-                        for (Segment* s = _segments.first(); s && s->tick() == e.tick(); s = s->next()) {
-                              if (s->segmentType() == Segment::Type::Clef
-                                    // hack: there may be other segment types which should
-                                    // generate a clef at current position
-                                 || s->segmentType() == Segment::Type::StartRepeatBarLine
-                                 ) {
-                                    firstSegment = true;
-                                    break;
-                                    }
-                              }
-                        if (firstSegment) {
-                              Segment* ns = 0;
-                              if (segment->next()) {
-                                    ns = segment->next();
-                                    while (ns && ns->tick() < e.tick())
-                                          ns = ns->next();
-                                    }
-                              segment = 0;
-                              for (Segment* s = ns; s && s->tick() == e.tick(); s = s->next()) {
-                                    if (s->segmentType() == Segment::Type::Clef) {
-                                          segment = s;
-                                          break;
-                                          }
-                                    }
-                              if (!segment) {
-                                    segment = new Segment(this, Segment::Type::Clef, e.tick());
-                                    _segments.insert(segment, ns);
-                                    }
-                              }
-                        else {
-                              // this is the first clef: move to left
-                              segment = getSegment(Segment::Type::Clef, e.tick());
-                              }
+                        // header clefs are inserted at the front of the segments list
+                        ns = first();
+                        // there might already be a segment for header clefs
+                        s = ns;
                         }
-                  if (e.tick() != tick())
-                        clef->setSmall(true);         // layout does this ?
+                  if (s && s->segmentType() == Segment::Type::Clef) {
+                        // check for a clef in each staff
+                        // stop when a clef is found
+                        // if it is the same size as the new clef, then use this segment
+                        // otherwise, create a new segment for the clef
+                        Clef* c = 0;
+                        for (int t = 0; !c && t < score()->ntracks(); t += VOICES)
+                              c = static_cast<Clef*>(s->element(t));
+                        if (c && c->small() == clef->small())
+                              // use this segment for the clef
+                              segment = s;
+                        }
+                  if (!segment) {
+                        // create a new segment for the clef
+                        segment = new Segment(this, Segment::Type::Clef, e.tick());
+                        _segments.insert(segment, ns);
+                        }
                   segment->add(clef);
                   }
             else if (tag == "TimeSig") {


### PR DESCRIPTION
See [269253: Opening bass clef disappears when mid-measure treble clef is applied](https://musescore.org/en/node/269253).

Header clefs are often omitted from the MSCX because they can often be generated. But, for example, if a header clef in the first measure has been changed from the default clef for that staff, then it will appear in the MSCX. The problem is that there is not enough information in the MSCX to distinguish between a header clef and a mid-measure clef on the first tick of the measure, especially if the clef is the first element that Measure::read() encounters. But it should be safe to assume that the clef is not a header clef if it is not the first element encountered. Such clefs will be loaded correctly now.

For the sake of compatibility, a clef that is the first element that Measure::read() encounters will continue to be treated as a header clef, unless it has been saved with additional information to tell Measure::read() that it is not a header clef. Because of this, certain existing scores may contain clefs that are still loaded incorrectly. These clefs must only be corrected once, and saved. Afterwards, all clefs in the score will be correct when the score is loaded.

I did not originally intend to replace quite so many lines of code. Measure::read() and Score::addSystemHeader() each seem to try to do the right thing regarding mid-measure clefs on the first tick of the measure, but neither function gets it quite right in certain cases, and the code has become quite hard to follow. I believe that I have made the code much simpler and more readable, whereas a more conservative approach would have been more confusing and prone to error.

The master branch introduces a separate HeaderClef segment type, and inserts Clef segments later in the measure. As a result, Measure::read() and Measure::addSystemHeader() are greatly simplified in the master branch where clefs are concerned. But in the master branch it is currently not possible to create a mid-measure clef on the first tick of the measure. This is presumably an unintended result of recent changes to the inner workings of the clef insertion process.
