### PR TITLE
appveyor: use VS 2013 image

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,8 @@ clone_folder: C:\MuseScore
 # set clone depth
 clone_depth: 3                      # clone entire repository history if not defined
 
+os: Visual Studio 2013
+
 # build cache to preserve files/folders between builds
 cache:
   - dependencies.7z


### PR DESCRIPTION
AppVeyor removed Qt 5.4 from VS2015 Image we used before: https://www.appveyor.com/updates/2018/05/16/.