### PR TITLE
Fix a nullpointer dereferencing in read206.cpp

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1511,7 +1511,7 @@ Element* readArticulation(ChordRest* cr, XmlReader& e)
                   if (!el) {
                         qDebug("not handled <%s>", qPrintable(tag.toString()));
                         }
-                  if (!el->readProperties(e))
+                  if (!el || !el->readProperties(e))
                         e.unknown();
                   }
             }


### PR DESCRIPTION
This patch just adds a null pointer check for an `el` variable before trying to dereference it. Absence of such a check leads to a crash while reading some old scores with articulations which have some properties which are ignored now (like `<offset>`). Example of such a score is [this one](https://musescore.com/nicolas/scores/30321).