### PR TITLE
fix #272403: Corruption on pasting a range with a truncated note that requires a tie

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -34,6 +34,7 @@
 #include "tremolo.h"
 #include "slur.h"
 #include "articulation.h"
+#include "sig.h"
 
 namespace Ms {
 
@@ -530,7 +531,7 @@ void Score::pasteChordRest(ChordRest* cr, int tick, const Interval& srcTranspose
       // we have already disallowed a tuplet from crossing the barline, so there is no problem here
       // but due to rounding, it might appear from actualTicks() that the last note is too long by a couple of ticks
 
-      if (!isGrace && !cr->tuplet() && (tick + cr->actualTicks() > measureEnd || convertMeasureRest)) {
+      if (!isGrace && !cr->tuplet() && (tick + cr->actualTicks() > measureEnd || (cr->durationTypeTicks() != cr->actualTicks()) || convertMeasureRest)) {
             if (cr->isChord()) {
                   // split Chord
                   Chord* c = toChord(cr);
@@ -543,7 +544,7 @@ void Score::pasteChordRest(ChordRest* cr, int tick, const Interval& srcTranspose
                               c2->removeMarkings(true);
                         int mlen = measure->tick() + measure->ticks() - tick;
                         int len = mlen > rest ? rest : mlen;
-                        std::vector<TDuration> dl = toDurationList(Fraction::fromTicks(len), true);
+                        std::vector<TDuration> dl = toRhythmicDurationList(Fraction::fromTicks(len), false, tick - measure->tick(), sigmap()->timesig(tick).nominal(), measure, MAX_DOTS);
                         TDuration d = dl[0];
                         c2->setDurationType(d);
                         c2->setDuration(d.fraction());
@@ -583,7 +584,7 @@ void Score::pasteChordRest(ChordRest* cr, int tick, const Interval& srcTranspose
                         measure       = tick2measure(tick);
                         Fraction mlen = Fraction::fromTicks(measure->tick() + measure->ticks() - tick);
                         Fraction len  = rest > mlen ? mlen : rest;
-                        std::vector<TDuration> dl = toDurationList(len, false);
+                        std::vector<TDuration> dl = toRhythmicDurationList(len, true, tick - measure->tick(), sigmap()->timesig(tick).nominal(), measure, MAX_DOTS);
                         TDuration d = dl[0];
                         r2->setDuration(d.fraction());
                         r2->setDurationType(d);

--- a/mtest/libmscore/copypaste/copypaste17-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste17-ref.mscx
@@ -165,10 +165,10 @@
             <durationType>eighth</durationType>
             </Rest>
           <Rest>
-            <durationType>quarter</durationType>
+            <durationType>eighth</durationType>
             </Rest>
           <Rest>
-            <durationType>eighth</durationType>
+            <durationType>quarter</durationType>
             </Rest>
           </voice>
         </Measure>

--- a/mtest/libmscore/copypaste/copypaste20-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste20-ref.mscx
@@ -150,10 +150,8 @@
             <durationType>16th</durationType>
             </Rest>
           <Rest>
+            <dots>1</dots>
             <durationType>eighth</durationType>
-            </Rest>
-          <Rest>
-            <durationType>16th</durationType>
             </Rest>
           </voice>
         <voice>


### PR DESCRIPTION
See [272403: Corruption on pasting a range with a truncated note that requires a tie](https://musescore.org/en/node/272403).

`Score::pasteStaff()` will shorten a ChordRest if necessary to make it fit into the gap created for it. This may result in a duration which is not achievable without ties (or multiple rests). The ChordRest is then assigned a duration type which may or may not match its actual duration. `Score::pasteChordRest()` can then check for this mismatch, and it is already able to do what needs to be done.

The example given in the bug report uses a compound meter. `toRhythmicDurationList()` does a better job of choosing appropriate `TDuration`s for the individual ChordRests than `toDurationList()` in the case of a compound meter, and it handles simple meters just as well. The second argument to `toRhythmicDurationList()` has nothing to do with the second argument to `toDurationList()`. They just both happen to be of type `bool`.