### PR TITLE
fix #272887: Unable to add mid-measure clef on the first tick of a measure

### DIFF
--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -252,7 +252,7 @@ Element* Clef::drop(EditData& data)
             Clef* clef = toClef(e);
             ClefType stype  = clef->clefType();
             if (clefType() != stype) {
-                  score()->undoChangeClef(staff(), segment(), stype);
+                  score()->undoChangeClef(staff(), this, stype);
                   c = this;
                   }
             }

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2401,7 +2401,7 @@ void Score::cmdInsertClef(ClefType type)
       {
       if (!noteEntryMode())
             return;
-      undoChangeClef(staff(inputTrack()/VOICES), inputState().segment(), type);
+      undoChangeClef(staff(inputTrack()/VOICES), inputState().cr(), type);
       }
 
 //---------------------------------------------------------
@@ -2411,7 +2411,7 @@ void Score::cmdInsertClef(ClefType type)
 
 void Score::cmdInsertClef(Clef* clef, ChordRest* cr)
       {
-      undoChangeClef(cr->staff(), cr->segment(), clef->clefType());
+      undoChangeClef(cr->staff(), cr, clef->clefType());
       delete clef;
       }
 

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -106,8 +106,18 @@ void KeySig::layout()
 
       // determine current clef for this staff
       ClefType clef = ClefType::G;
-      if (staff())
-            clef = staff()->clef(tick());
+      if (staff()) {
+            // Look for a clef before the key signature at the same tick
+            Clef* c = nullptr;
+            for (Segment* seg = segment()->prev1(); !c && seg && seg->tick() == tick(); seg = seg->prev1())
+                  if (seg->isClefType() || seg->isHeaderClefType())
+                        c = toClef(seg->element(track()));
+            if (c)
+                  clef = c->clefType();
+            else
+                  // no clef found, so get the clef type from the clefs list, using the previous tick
+                  clef = staff()->clef(tick() - 1);
+            }
 
       int accidentals = 0, naturals = 0;
       int t1 = int(_sig.key());

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1361,7 +1361,7 @@ Element* Measure::drop(EditData& data)
                   return 0;
 
             case ElementType::CLEF:
-                  score()->undoChangeClef(staff, first(), toClef(e)->clefType());
+                  score()->undoChangeClef(staff, this, toClef(e)->clefType());
                   delete e;
                   break;
 
@@ -3567,7 +3567,17 @@ void Measure::addSystemHeader(bool isFirstSystem)
                   }
 
             if (isFirstSystem || score()->styleB(Sid::genClef)) {
-                  ClefTypeList cl = staff->clefType(tick());
+                  // find the clef type at the previous tick
+                  ClefTypeList cl = staff->clefType(tick() - 1);
+                  // look for a clef change at the end of the previous measure
+                  if (prevMeasure()) {
+                        Segment* s = prevMeasure()->findSegment(SegmentType::Clef, tick());
+                        if (s) {
+                              Clef* c = toClef(s->element(track));
+                              if (c)
+                                    cl = c->clefTypeList();
+                              }
+                        }
                   Clef* clef;
                   if (!cSegment) {
                         cSegment = new Segment(this, SegmentType::HeaderClef, 0);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2004,7 +2004,7 @@ bool Score::appendScore(Score* score, bool addPageBreak, bool addSectionBreak)
                         if (clef && clef->generated() && clef->clefType() != this->staff(staffIdx)->clef(tickOfAppend)) {
                               // then convert that generated clef into a real non-generated clef
                               // so that its different type will be copied to joined score
-                              score->undoChangeClef(staff, seg, clef->clefType());
+                              score->undoChangeClef(staff, clef, clef->clefType());
                               }
                         }
                   }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -634,8 +634,8 @@ class Score : public QObject, public ScoreElement {
       void undoChangeTuning(Note*, qreal);
       void undoChangeUserMirror(Note*, MScore::DirectionH);
       void undoChangeKeySig(Staff* ostaff, int tick, KeySigEvent);
-      void undoChangeClef(Staff* ostaff, Segment*, ClefType st);
-      bool undoPropertyChanged(Element* e, Pid t, const QVariant& st, PropertyFlags ps = PropertyFlags::NOSTYLE);
+      void undoChangeClef(Staff* ostaff, Element* e, ClefType ct);
+      bool undoPropertyChanged(Element*, Pid, const QVariant& v, PropertyFlags ps = PropertyFlags::NOSTYLE);
       void undoPropertyChanged(ScoreElement*, Pid, const QVariant& v, PropertyFlags ps = PropertyFlags::NOSTYLE);
       inline virtual UndoStack* undoStack() const;
       void undo(UndoCommand*, EditData* = 0) const;

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -389,8 +389,10 @@ void Staff::setClef(Clef* clef)
       if (clef->generated())
             return;
       int tick = clef->segment()->tick();
-      for (Segment* s = clef->segment()->next(); s && s->tick() == tick; s = s->next()) {
-            if (s->segmentType() == SegmentType::Clef && s->element(clef->track())) {
+      for (Segment* s = clef->segment()->next1(); s && s->tick() == tick; s = s->next1()) {
+            if ((s->segmentType() == SegmentType::Clef || s->segmentType() == SegmentType::HeaderClef)
+                && s->element(clef->track())
+                && !s->element(clef->track())->generated()) {
                   // adding this clef has no effect on the clefs list
                   return;
                   }
@@ -409,15 +411,17 @@ void Staff::removeClef(Clef* clef)
       if (clef->generated())
             return;
       int tick = clef->segment()->tick();
-      for (Segment* s = clef->segment()->next(); s && s->tick() == tick; s = s->next()) {
-            if (s->segmentType() == SegmentType::Clef && s->element(clef->track())) {
+      for (Segment* s = clef->segment()->next1(); s && s->tick() == tick; s = s->next1()) {
+            if ((s->segmentType() == SegmentType::Clef || s->segmentType() == SegmentType::HeaderClef)
+                && s->element(clef->track())
+                && !s->element(clef->track())->generated()) {
                   // removal of this clef has no effect on the clefs list
                   return;
                   }
             }
       clefs.erase(clef->segment()->tick());
-      for (Segment* s = clef->segment()->prev(); s && s->tick() == tick; s = s->prev()) {
-            if (s->segmentType() == SegmentType::Clef
+      for (Segment* s = clef->segment()->prev1(); s && s->tick() == tick; s = s->prev1()) {
+            if ((s->segmentType() == SegmentType::Clef || s->segmentType() == SegmentType::HeaderClef)
                && s->element(clef->track())
                && !s->element(clef->track())->generated()) {
                   // a previous clef at the same tick position gets valid

--- a/mtest/libmscore/clef_courtesy/tst_clef_courtesy.cpp
+++ b/mtest/libmscore/clef_courtesy/tst_clef_courtesy.cpp
@@ -88,7 +88,7 @@ void TestClefCourtesy::clef_courtesy01()
       // check the required courtesy clef is there and it is shown
       Clef*    clefCourt = 0;
       Measure* m = m1->prevMeasure();
-      Segment* seg = m->findSegment(SegmentType::HeaderClef, m1->tick());
+      Segment* seg = m->findSegment(SegmentType::Clef, m1->tick());
       QVERIFY2(seg, "No SegClef in measure 3.");
       clefCourt = static_cast<Clef*>(seg->element(0));
       QVERIFY2(clefCourt, "No courtesy clef element in measure 3.");
@@ -97,7 +97,7 @@ void TestClefCourtesy::clef_courtesy01()
       // check the not required courtesy clef element is there but it is not shown
       clefCourt = nullptr;
       m   = m2->prevMeasure();
-      seg = m->findSegment(SegmentType::HeaderClef, m2->tick());
+      seg = m->findSegment(SegmentType::Clef, m2->tick());
       QVERIFY2(seg, "No SegClef in measure 6.");
       clefCourt = toClef(seg->element(0));
       QVERIFY2(clefCourt, "No courtesy clef element in measure 6.");
@@ -144,7 +144,7 @@ void TestClefCourtesy::clef_courtesy02()
       // check both clef elements are there, but none is shown
       Clef*    clefCourt = nullptr;
       Measure* m = m1->prevMeasure();
-      Segment* seg = m->findSegment(SegmentType::HeaderClef, m1->tick());
+      Segment* seg = m->findSegment(SegmentType::Clef, m1->tick());
       QVERIFY2(seg != nullptr, "No SegClef in measure 3.");
       clefCourt = toClef(seg->element(0));
       QVERIFY2(clefCourt != nullptr, "No courtesy clef element in measure 3.");
@@ -152,7 +152,7 @@ void TestClefCourtesy::clef_courtesy02()
 
       clefCourt = nullptr;
       m = m2->prevMeasure();
-      seg = m->findSegment(SegmentType::HeaderClef, m2->tick());
+      seg = m->findSegment(SegmentType::Clef, m2->tick());
       QVERIFY2(seg != nullptr, "No SegClef in measure 6.");
       clefCourt = static_cast<Clef*>(seg->element(0));
       QVERIFY2(clefCourt != nullptr, "No courtesy clef element in measure 6.");
@@ -188,7 +188,7 @@ void TestClefCourtesy::clef_courtesy03()
 
       // verify the not required courtesy clef element is on end of m1 but is not shown
       Clef *clefCourt = nullptr;
-      Segment *seg = m1->findSegment(SegmentType::HeaderClef, m2->tick());
+      Segment *seg = m1->findSegment(SegmentType::Clef, m2->tick());
       QVERIFY2(seg != nullptr, "No SegClef in measure 1.");
       clefCourt = static_cast<Clef*>(seg->element(0));
       QVERIFY2(clefCourt != nullptr, "No courtesy clef element in measure 1.");


### PR DESCRIPTION
See [272887: Unable to add mid-measure clef on the first tick of a measure](https://musescore.org/en/node/272887).

This pull request brings back the ability to have a mid-measure clef on the first tick of a measure. It also fixes some errors that can result from multiple clefs at the same tick.