### PR TITLE
added missing #include <QButtonGroup> required by qt >= 5.11

### DIFF
--- a/all.h
+++ b/all.h
@@ -131,6 +131,7 @@
 #include <QProgressBar>
 #include <QProgressDialog>
 #include <QRadioButton>
+#include <QButtonGroup>
 #include <QSplashScreen>
 #include <QFontComboBox>
 #include <QApplication>


### PR DESCRIPTION
With the recent qt-5.11 update we started getting build errors such as

`
/builddir/build/BUILD/mscore-2.2.1/mscore/preferences.cpp: In constructor 'Ms::PreferenceDialog::PreferenceDialog(QWidget*)':
/builddir/build/BUILD/mscore-2.2.1/mscore/preferences.cpp:668:54: error: invalid use of incomplete type 'class QButtonGroup'
`

This commit makes the build succeed.