### PR TITLE
fix #210116: Delete all and Undo duplicates the clef

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3358,7 +3358,7 @@ qreal Measure::createEndBarLines(bool isLastMeasureInSystem)
                         bl->setSpanFrom(staff->barLineFrom());
                         bl->setSpanTo(staff->barLineTo());
                         bl->setBarLineType(t);
-                        score()->addElement(bl);
+                        score()->undoAddElement(bl);
                         }
                   else {
                         // do not change bar line type if bar line is user modified
@@ -3478,7 +3478,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
                   if (!kSegment) {
                         kSegment = new Segment(this, SegmentType::KeySig, 0);
                         kSegment->setHeader(true);
-                        add(kSegment);
+                        score()->undoAddElement(kSegment);
                         keysig = 0;
                         }
                   else
@@ -3491,7 +3491,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
                         keysig->setTrack(track);
                         keysig->setGenerated(true);
                         keysig->setParent(kSegment);
-                        kSegment->add(keysig);
+                        score()->undoAddElement(keysig);
                         }
                   keysig->setKeySigEvent(keyIdx);
                   keysig->layout();
@@ -3527,7 +3527,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
                   if (!cSegment) {
                         cSegment = new Segment(this, SegmentType::HeaderClef, 0);
                         cSegment->setHeader(true);
-                        add(cSegment);
+                        score()->undoAddElement(cSegment);
                         clef = 0;
                         }
                   else
@@ -3541,7 +3541,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
                               clef->setTrack(track);
                               clef->setGenerated(true);
                               clef->setParent(cSegment);
-                              cSegment->add(clef);
+                              score()->undoAddElement(clef);
                               }
                         if (clef->generated())
                               clef->setClefType(cl);
@@ -3569,7 +3569,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
       if ((n > 1 && score()->styleB(Sid::startBarlineMultiple)) || (n == 1 && score()->styleB(Sid::startBarlineSingle))) {
             if (!s) {
                   s = new Segment(this, SegmentType::BeginBarLine, 0);
-                  add(s);
+                  score()->undoAddElement(s);
                   }
             for (int track = 0; track < score()->ntracks(); track += VOICES) {
                   BarLine* bl = toBarLine(s->element(track));
@@ -3581,7 +3581,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
                         bl->setBarLineType(BarLineType::NORMAL);
                         bl->setSpanStaff(true);
                         bl->layout();
-                        s->add(bl);
+                        score()->undoAddElement(bl);
                         s->createShapes();
                         }
                   }
@@ -3618,7 +3618,7 @@ void Measure::addSystemTrailer(Measure* nm)
                         if (!s) {
                               s  = new Segment(this, SegmentType::TimeSigAnnounce, _rtick);
                               s->setTrailer(true);
-                              add(s);
+                              score()->undoAddElement(s);
                               }
                         s->setEnabled(true);
                         int nstaves = score()->nstaves();
@@ -3662,7 +3662,7 @@ void Measure::addSystemTrailer(Measure* nm)
                   if (!s) {
                         s = new Segment(this, SegmentType::KeySigAnnounce, _rtick);
                         s->setTrailer(true);
-                        add(s);
+                        score()->undoAddElement(s);
                         }
                   KeySig* ks = toKeySig(s->element(track));
                   KeySigEvent key2 = staff->keySigEvent(endTick());
@@ -3672,7 +3672,7 @@ void Measure::addSystemTrailer(Measure* nm)
                         ks->setTrack(track);
                         ks->setGenerated(true);
                         ks->setParent(s);
-                        s->add(ks);
+                        score()->undoAddElement(ks);
                         }
                   //else if (!(ks->keySigEvent() == key2)) {
                   //      score()->undo(new ChangeKeySig(ks, key2, ks->showCourtesy()));


### PR DESCRIPTION
See [210116: Delete all and Undo duplicates the clef](https://musescore.org/en/node/210116).