### PR TITLE
fix #273080 - Visible mixer with no score leads to instant crash on s…

### DIFF
--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -390,6 +390,9 @@ void Mixer::midiPrefsChanged(bool showMidiControls)
 
 void MuseScore::showMixer(bool val)
       {
+      if (!cs)
+            return;
+
       QAction* a = getAction("toggle-mixer");
       if (mixer == 0) {
             mixer = new Mixer(this);


### PR DESCRIPTION
…tartup