### PR TITLE
fix #272595: Inspector not updating properly leads to crash

### DIFF
--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -363,6 +363,7 @@ class Inspector : public QDockWidget {
       bool _inspectorEdit;    // set to true when an edit originates from
                               // within the inspector itself
       Element* oe;
+      bool oSameTypes;
 
    public slots:
       void update();


### PR DESCRIPTION
See [272595: Inspector not updating properly leads to crash](https://musescore.org/en/node/272595).

The inspector remembers the element at the beginning of the previous selection list, and if it is the same as the element at the beginning of the current selection list, it will use the old InspectorBase object. It needs to also remember whether or not the previous selection contains all objects of the same type, and use a new InspectorBase object if the current selection differs from the previous selection in this regard. 