### PR TITLE
fix #271723: implement filters in Zerberus

### DIFF
--- a/zerberus/CMakeLists.txt
+++ b/zerberus/CMakeLists.txt
@@ -17,6 +17,7 @@ QT5_WRAP_UI (zerberusUi zerberus_gui.ui)
 add_library (zerberus STATIC
       ${zerberusUi}
       channel.cpp
+      filter.cpp
       instrument.cpp
       sfz.cpp
       voice.cpp

--- a/zerberus/filter.cpp
+++ b/zerberus/filter.cpp
@@ -1,0 +1,287 @@
+//=============================================================================
+//  Zerberus
+//  Filters implementation
+//
+//  Copyright (C) 2018 Werner Schweer
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "filter.h"
+#include "zerberus.h"
+#include "zone.h"
+
+#include <math.h>
+#include <functional>
+
+static constexpr int INTERP_MAX = 256;
+static float interpCoeff[INTERP_MAX][4];
+
+//---------------------------------------------------------
+//   FilterBQ
+//---------------------------------------------------------
+
+ZFilter::ZFilter()
+      {
+      constexpr double ff = 1.0 / 32768.0;
+      for (int i = 0; i < INTERP_MAX; i++) {
+            double x = (double) i / (double) INTERP_MAX;
+            interpCoeff[i][0] = (x * (-0.5 + x * (1 - 0.5 * x)))  * ff;
+            interpCoeff[i][1] = (1.0 + x * x * (1.5 * x - 2.5))   * ff;
+            interpCoeff[i][2] = (x * (0.5 + x * (2.0 - 1.5 * x))) * ff;
+            interpCoeff[i][3] = (0.5 * x * x * (x - 1.0))         * ff;
+            }
+      }
+
+//---------------------------------------------------------
+//   initialize
+//---------------------------------------------------------
+
+void ZFilter::initialize(const Zerberus* zerberus, const Zone* z, int velocity)
+      {
+      this->zerberus = zerberus;
+      this->sampleZone = z;
+
+      resonanceF = zerberus->ct2hz(13500.0);
+      if (z->isCutoffDefined) {
+            //calculate current cutoff value
+            float cutoffHz = z->cutoff;
+            //Formula for converting the interval frequency ratio f2 / f1 to cents (c or ¢).
+            //¢ or c = 1200 × log2 (f2 / f1)
+            cutoffHz *= pow(2.0, velocity / 127.0f * z->fil_veltrack / 1200.0);
+            resonanceF = cutoffHz;
+            }
+
+      last_resonanceF   = -1.0;
+      float GEN_FILTERQ = 100.0;  // 0 - 960
+      float q_db  = GEN_FILTERQ / 10.0f - 3.01f;
+      q_lin       = pow(10.0f, q_db / 20.0f);
+      gain = 1.0 / sqrt(q_lin);
+      }
+
+//---------------------------------------------------------
+//   update
+//---------------------------------------------------------
+
+void ZFilter::update()
+      {
+      float adaptedFrequency = resonanceF;
+      const float sr = zerberus->sampleRate();
+      if (adaptedFrequency > 0.45f * sr)
+            adaptedFrequency = 0.45f * sr;
+      else if (adaptedFrequency < 5.f)
+            adaptedFrequency = 5.f;
+
+      const bool freqWasUpdated = fabs(adaptedFrequency - last_resonanceF) > 0.01f;
+      if (!freqWasUpdated)
+            return;
+
+      last_resonanceF = adaptedFrequency;
+
+      // The filter coefficients have to be recalculated (filter
+      // parameters have changed). Recalculation for various reasons is
+      // forced by setting last_fres to -1.  The flag filter_startup
+      // indicates, that the DSP loop runs for the first time, in this
+      // case, the filter is set directly, instead of smoothly fading
+      // between old and new settings.
+      //
+      // Those equations from Robert Bristow-Johnson's `Cookbook
+      // formulae for audio EQ biquad filter coefficients', obtained
+      // from Harmony-central.com / Computer / Programming. They are
+      // the result of the bilinear transform on an analogue filter
+      // prototype. To quote, `BLT frequency warping has been taken
+      // into account for both significant frequency relocation and for
+      // bandwidth readjustment'.
+
+      const float omega       = (float) 2.0f * M_PI * (adaptedFrequency / sr);
+      const float sin_coeff   = sin(omega);
+      const float cos_coeff   = cos(omega);
+      const float alpha_coeff = sin_coeff / (2.0f * q_lin);
+      const float a0_inv      = 1.0f / (1.0f + alpha_coeff);
+      const float linCosCoeff = 2.f - cos_coeff;
+
+      float a1_temp = 0.f;
+      float a2_temp = 0.f;
+      float b1_temp = 0.f;
+      float b0_temp = 0.f;
+      float b2_temp = 0.f;
+      switch (sampleZone->fil_type) {
+            case FilterType::lpf_2p: {
+                  a1_temp = 2.0f * cos_coeff * a0_inv;
+                  a2_temp = (alpha_coeff - 1.f) * a0_inv;
+                  b1_temp = (1.0f - cos_coeff) * a0_inv * gain;
+                  b0_temp = b2_temp = b1_temp * 0.5f;
+                  break;
+                  }
+            case FilterType::hpf_2p: {
+                  a1_temp = 2.0f * cos_coeff * a0_inv;
+                  a2_temp = (alpha_coeff - 1.f) * a0_inv;
+                  b1_temp = -(1.0f + cos_coeff) * a0_inv * gain;
+                  b0_temp = b2_temp = -b1_temp * 0.5f;
+                  break;
+                  }
+            case FilterType::bpf_2p: {
+                  a1_temp = 2.0f * cos_coeff * a0_inv;
+                  a2_temp = (alpha_coeff - 1.f) * a0_inv;
+                  b0_temp = alpha_coeff * a0_inv;
+                  b1_temp = 0.f;
+                  b2_temp = -b0_temp;
+                  break;
+                  }
+            case FilterType::brf_2p: {
+                  a1_temp = 2.0f * cos_coeff * a0_inv;
+                  a2_temp = (alpha_coeff - 1.f) * a0_inv;
+                  b1_temp = a0_inv * (-2.f * cos_coeff);
+                  b0_temp = b2_temp = a0_inv;
+                  break;
+                  }
+            case FilterType::lpf_1p: {
+                  a1_temp = -(linCosCoeff - sqrt(linCosCoeff * linCosCoeff - 1));
+                  b0_temp = 1 + a1_temp;
+                  break;
+                  }
+            case FilterType::hpf_1p: {
+                  a1_temp = -(linCosCoeff - sqrt(linCosCoeff * linCosCoeff - 1));
+                  b0_temp = -a1_temp;
+                  b1_temp = a1_temp;
+                  break;
+                  }
+            default:
+                  qWarning() << "fil_type is not implemented: " << (int)sampleZone->fil_type;
+            }
+
+      if (firstRun) {
+            /* The filter is calculated, because the voice was started up.
+             * In this case set the filter coefficients without delay.
+             */
+            a1 = a1_temp;
+            a2 = a2_temp;
+            b0 = b0_temp;
+            b2 = b2_temp;
+            b1 = b1_temp;
+            filter_coeff_incr_count = 0;
+            firstRun = false;
+            }
+      else {
+            /* The filter frequency is changed.  Calculate an increment
+            * factor, so that the new setting is reached after some time.
+            */
+
+            static const int FILTER_TRANSITION_SAMPLES = 64;
+
+            a1_incr = (a1_temp - a1) / FILTER_TRANSITION_SAMPLES;
+            a2_incr = (a2_temp - a2) / FILTER_TRANSITION_SAMPLES;
+            b0_incr = (b0_temp - b0) / FILTER_TRANSITION_SAMPLES;
+            b1_incr = (b1_temp - b1) / FILTER_TRANSITION_SAMPLES;
+            b2_incr = (b2_temp - b2) / FILTER_TRANSITION_SAMPLES;
+            /* Have to add the increments filter_coeff_incr_count times. */
+            filter_coeff_incr_count = FILTER_TRANSITION_SAMPLES;
+            }
+      }
+
+//---------------------------------------------------------
+//   apply
+//---------------------------------------------------------
+
+float ZFilter::apply(float inputValue, bool leftChannel)
+      {
+      float value = 0.f;
+      const auto applyBqEquation = [this, &inputValue](float& histX1, float& histX2, float& histY1, float& histY2) {
+            //apply filter
+            /*
+                  float y = d.b0 * x + d.b1 * d.x1 + d.b2 * d.x2 +
+                            d.a1 * d.y1 + d.a2 * d.y2;
+                  d.x2 = d.x1;
+                  d.x1 = x;
+                  d.y2 = d.y1;
+                  d.y1 = y;
+                  return y;
+             */
+            float value = b0 * inputValue + b1 * histX1 + b2 * histX2 + a1 * histY1 + a2 * histY2;
+            histX2 = histX1;
+            histX1 = inputValue;
+            histY2 = histY1;
+            histY1 = value;
+            return value;
+            };
+      const auto applyHPF1PEquation = [this, &inputValue](float& histX1, float& histY1) {
+            float value = b0 * inputValue + b1 * histX1 - a1 * histY1;
+            histX1 = inputValue;
+            histY1 = value;
+            return value;
+            };
+      const auto applyLPF1PEquation = [this, &inputValue](float& histY1) {
+            float value = b0 * inputValue - a1 * histY1;
+            histY1 = value;
+            return value;
+            };
+      if (leftChannel) {
+            switch (sampleZone->fil_type) {
+                  case FilterType::hpf_2p:
+                  case FilterType::lpf_2p:
+                  case FilterType::bpf_2p:
+                  case FilterType::brf_2p: {
+                        value = applyBqEquation(monoL.histX1, monoL.histX2, monoL.histY1, monoL.histY2);
+                        break;
+                        }
+                  case FilterType::hpf_1p: {
+                        value = applyHPF1PEquation(monoL.histX1, monoL.histY1);
+                        break;
+                        }
+                  case FilterType::lpf_1p: {
+                        value = applyLPF1PEquation(monoL.histY1);
+                        break;
+                        }
+                  default:
+                        qWarning() << "this equation is not implemented" << (int)sampleZone->fil_type;
+                  }
+            }
+      else { //right channel in stereo samples
+            switch (sampleZone->fil_type) {
+                  case FilterType::hpf_2p:
+                  case FilterType::lpf_2p:
+                  case FilterType::bpf_2p:
+                  case FilterType::brf_2p: {
+                        value = applyBqEquation(monoR.histX1, monoR.histX2, monoR.histY1, monoR.histY2);
+                        break;
+                        }
+                  case FilterType::hpf_1p: {
+                        value = applyHPF1PEquation(monoR.histX1, monoR.histY1);
+                        break;
+                        }
+                  case FilterType::lpf_1p: {
+                        value = applyLPF1PEquation(monoR.histY1);
+                        break;
+                        }
+                  default:
+                        qWarning() << "this equation is not implemented" << (int)sampleZone->fil_type;
+                  }
+            }
+
+      if (filter_coeff_incr_count) {
+            --filter_coeff_incr_count;
+            a1 += a1_incr;
+            a2 += a2_incr;
+            b0 += b0_incr;
+            b1 += b1_incr;
+            b2 += b2_incr;
+            }
+
+      return value;
+      }
+
+//---------------------------------------------------------
+//   interpolate
+//---------------------------------------------------------
+
+float ZFilter::interpolate(unsigned phase, short prevVal, short currVal, short nextVal, short nextNextVal) const
+      {
+      const auto& interpValTable = interpCoeff[phase];
+      return (interpValTable[0] * prevVal
+          + interpValTable[1] * currVal
+          + interpValTable[2] * nextVal
+          + interpValTable[3] * nextNextVal);
+      }

--- a/zerberus/filter.h
+++ b/zerberus/filter.h
@@ -1,0 +1,76 @@
+//=============================================================================
+//  Zerberus
+//  Zample player
+//
+//  Copyright (C) 2013 Werner Schweer
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __MFILTER_H__
+#define __MFILTER_H__
+
+struct Zone;
+class Zerberus;
+
+//---------------------------------------------------------
+//   Envelope
+//---------------------------------------------------------
+
+//Biquad filter implementation
+class ZFilter {
+public:
+      ZFilter();
+
+      void initialize(const Zerberus* zerberus, const Zone* z, int velocity);
+
+      void update();
+      float apply(float inputValue, bool leftChannel);
+      float interpolate(unsigned phase, short prevVal, short currVal, short nextVal, short nextNextVal) const; //pure function
+
+private:
+      const Zerberus* zerberus;
+      const Zone* sampleZone;
+
+      float resonanceF = 0.f;        // the resonance frequency in Hz
+      float last_resonanceF = 0.f;   // current resonance frequency of the filter
+
+      // Serves as a flag: A deviation between fres and last_fres
+      // indicates, that the filter has to be recalculated.
+      float q_lin = 0.f;             // the q-factor on a linear scale
+      float gain = 0.f;       // Gain correction factor, depends on q
+
+      // Flag: If set, the filter will be set directly.
+      //       Else it changes smoothly
+      bool firstRun = true;
+
+      struct FilterData {
+            float histX1 = 0.f;
+            float histX2 = 0.f;
+            float histY1 = 0.f;
+            float histY2 = 0.f;
+            };
+      FilterData monoL;
+      FilterData monoR;
+
+      // normalized filter coefficients (bX = bX/a0 and aX = aX/a0)
+      // see Robert Bristow-Johnson's 'Cookbook formulae for audio EQ biquad filter coefficients'
+      float b0 = 0.f;              // b0 / a0
+      float b1 = 0.f;              // b1 / a0
+      float b2 = 0.f;              // b2 / a0
+      float a1 = 0.f;              // a0 / a0
+      float a2 = 0.f;              // a1 / a0
+
+      float b0_incr = 0.f;
+      float b1_incr = 0.f;
+      float b2_incr = 0.f;
+      float a1_incr = 0.f;
+      float a2_incr = 0.f;
+      int filter_coeff_incr_count = 0;
+      };
+
+#endif //__MFILTER_H__
+

--- a/zerberus/voice.cpp
+++ b/zerberus/voice.cpp
@@ -20,7 +20,6 @@
 #include "sample.h"
 #include "synthesizer/msynthesizer.h"
 
-float Voice::interpCoeff[INTERP_MAX][4];
 float Envelope::egPow[EG_SIZE];
 float Envelope::egLin[EG_SIZE];
 
@@ -74,14 +73,6 @@ void Voice::init()
       // list (I found it in the music-dsp archives
       // http://www.smartelectronix.com/musicdsp/).
 
-      double ff = 1.0 / 32768.0;
-      for (int i = 0; i < INTERP_MAX; i++) {
-            double x = (double) i / (double) INTERP_MAX;
-            interpCoeff[i][0] = (x * (-0.5 + x * (1 - 0.5 * x)))  * ff;
-            interpCoeff[i][1] = (1.0 + x * x * (1.5 * x - 2.5))   * ff;
-            interpCoeff[i][2] = (x * (0.5 + x * (2.0 - 1.5 * x))) * ff;
-            interpCoeff[i][3] = (0.5 * x * x * (x - 1.0))         * ff;
-            }
       static const float MIN_GAIN = -80.0;
       static const float dbStep = MIN_GAIN / float(EG_SIZE);
 
@@ -145,31 +136,7 @@ void Voice::start(Channel* c, int key, int v, const Zone* zone, double durSinceN
             targetcents = z->keyBase * 100;
       phaseIncr.set(_zerberus->ct2hz(targetcents) * sr/_zerberus->ct2hz(z->keyBase * 100.0));
 
-      fres = _zerberus->ct2hz(13500.0);
-      if (z->isCutoffDefined) {
-            //calculate current cutoff value
-            float cutoffHz = z->cutoff;
-            //Formula for converting the interval frequency ratio f2 / f1 to cents (c or ¢).
-            //¢ or c = 1200 × log2 (f2 / f1)
-            cutoffHz *= pow(2.0, _velocity / 127.0f * z->fil_veltrack / 1200.0);
-            fres = cutoffHz;
-            }
-
-      last_fres   = -1.0;
-      qreal GEN_FILTERQ = 100.0;  // 0 - 960
-      qreal q_db  = GEN_FILTERQ / 10.0f - 3.01f;
-      q_lin       = pow(10.0f, q_db / 20.0f);
-      filter_gain = 1.0 / sqrt(q_lin);
-
-      hist1r = 0;
-      hist2r = 0;
-      hist1l = 0;
-      hist2l = 0;
-
-      filter_startup = true;
-
-      modenv_val = 0.0;
-      modlfo_val = 0.0;
+      filter.initialize(_zerberus, z, _velocity);
 
       currentEnvelope = V1Envelopes::DELAY;
 
@@ -216,95 +183,6 @@ void Voice::start(Channel* c, int key, int v, const Zone* zone, double durSinceN
       }
 
 //---------------------------------------------------------
-//   updateFilter
-//---------------------------------------------------------
-
-void Voice::updateFilter(float _fres)
-      {
-      // The filter coefficients have to be recalculated (filter
-      // parameters have changed). Recalculation for various reasons is
-      // forced by setting last_fres to -1.  The flag filter_startup
-      // indicates, that the DSP loop runs for the first time, in this
-      // case, the filter is set directly, instead of smoothly fading
-      // between old and new settings.
-      //
-      // Those equations from Robert Bristow-Johnson's `Cookbook
-      // formulae for audio EQ biquad filter coefficients', obtained
-      // from Harmony-central.com / Computer / Programming. They are
-      // the result of the bilinear transform on an analogue filter
-      // prototype. To quote, `BLT frequency warping has been taken
-      // into account for both significant frequency relocation and for
-      // bandwidth readjustment'.
-
-      float sr          = _zerberus->sampleRate();
-      float omega       = (float) 2.0f * M_PI * (_fres / sr);
-      float sin_coeff   = sin(omega);
-      float cos_coeff   = cos(omega);
-      float alpha_coeff = sin_coeff / (2.0f * q_lin);
-      float a0_inv      = 1.0f / (1.0f + alpha_coeff);
-
-      /* Calculate the filter coefficients. All coefficients are
-       * normalized by a0. Think of `a1' as `a1/a0'.
-       *
-       * Here a couple of multiplications are saved by reusing common expressions.
-       * The original equations should be:
-       *  b0=(1.-cos_coeff)*a0_inv*0.5*voice->filter_gain;
-       *  b1=(1.-cos_coeff)*a0_inv*voice->filter_gain;
-       *  b2=(1.-cos_coeff)*a0_inv*0.5*voice->filter_gain; */
-
-      float a1_temp = 0.f;
-      float a2_temp = 0.f;
-      float b1_temp = 0.f;
-      float b02_temp = 0.f;
-      switch (z->fil_type) {
-            case FilterType::lpf_2p: {
-                  a1_temp = -2.0f * cos_coeff * a0_inv;
-                  a2_temp = (1.0f - alpha_coeff) * a0_inv;
-                  b1_temp = (1.0f - cos_coeff) * a0_inv * filter_gain;
-                  // both b0 -and- b2
-                  b02_temp = b1_temp * 0.5f;
-                  break;
-                  }
-            case FilterType::hpf_2p: {
-                  a1_temp = -2.0f * cos_coeff * a0_inv;
-                  a2_temp = (1.0f - alpha_coeff) * a0_inv;
-                  b1_temp = -(1.0f + cos_coeff) * a0_inv * filter_gain;
-                  // both b0 -and- b2
-                  b02_temp = -b1_temp * 0.5f;
-                  break;
-                  }
-            default:
-                  qWarning() << "fil_type is not implemented: " << (int)z->fil_type;
-            }
-
-      if (filter_startup) {
-            /* The filter is calculated, because the voice was started up.
-             * In this case set the filter coefficients without delay.
-             */
-            a1  = a1_temp;
-            a2  = a2_temp;
-            b02 = b02_temp;
-            b1  = b1_temp;
-            filter_coeff_incr_count = 0;
-            filter_startup = false;
-            }
-      else {
-            /* The filter frequency is changed.  Calculate an increment
-            * factor, so that the new setting is reached after some time.
-            */
-
-            static const int FILTER_TRANSITION_SAMPLES = 64;
-
-            a1_incr  = (a1_temp - a1) / FILTER_TRANSITION_SAMPLES;
-            a2_incr  = (a2_temp - a2) / FILTER_TRANSITION_SAMPLES;
-            b02_incr = (b02_temp - b02) / FILTER_TRANSITION_SAMPLES;
-            b1_incr  = (b1_temp - b1) / FILTER_TRANSITION_SAMPLES;
-            /* Have to add the increments filter_coeff_incr_count times. */
-            filter_coeff_incr_count = FILTER_TRANSITION_SAMPLES;
-            }
-      }
-
-//---------------------------------------------------------
 //   updateEnvelopes
 //---------------------------------------------------------
 
@@ -338,21 +216,12 @@ void Voice::updateEnvelopes() {
 
 void Voice::process(int frames, float* p)
       {
-      float adaptedFrequency = fres;
-      int sr = _zerberus->sampleRate();
-      if (adaptedFrequency > 0.45f * sr)
-            adaptedFrequency = 0.45f * sr;
-      else if (adaptedFrequency < 5.f)
-            adaptedFrequency = 5.f;
-
-      bool freqWasUpdated = fabs(adaptedFrequency - last_fres) > 0.01f;
-      if (freqWasUpdated) {
-            updateFilter(adaptedFrequency);
-            last_fres = adaptedFrequency;
-            }
+      filter.update();
 
       const float opcodePanLeftGain = 1.f - fmax(0.0f, z->pan / 100.0); //[0, 1]
       const float opcodePanRightGain = 1.f + fmin(0.0f, z->pan / 100.0); //[0, 1]
+      const float leftChannelVol = gain * z->ccGain * _channel->panLeftGain() * opcodePanLeftGain;
+      const float rightChannelVol = gain * z->ccGain * _channel->panRightGain() * opcodePanRightGain;
       if (audioChan == 1) {
             while (frames--) {
 
@@ -364,34 +233,18 @@ void Voice::process(int frames, float* p)
                         off();
                         break;
                         }
-                  const float* coeffs = interpCoeff[phase.fract()];
-                  float f;
-                  f =  (coeffs[0] * getData(idx-1)
-                      + coeffs[1] * getData(idx+0)
-                      + coeffs[2] * getData(idx+1)
-                      + coeffs[3] * getData(idx+2)) * gain
-                      - a1 * hist1l
-                      - a2 * hist2l;
-                  float v = b02 * (f + hist2l) + b1 * hist1l;
-                  hist2l  = hist1l;
-                  hist1l  = f;
 
-                  if (filter_coeff_incr_count) {
-                        --filter_coeff_incr_count;
-                        a1  += a1_incr;
-                        a2  += a2_incr;
-                        b02 += b02_incr;
-                        b1  += b1_incr;
-                        }
+                  float interpVal = filter.interpolate(phase.fract(),
+                                                       getData(idx-1), getData(idx), getData(idx+1), getData(idx+2));
+                  float v = filter.apply(interpVal, true);
 
                   updateEnvelopes();
                   if (_state == VoiceState::OFF)
                         break;
 
-                  v *= envelopes[currentEnvelope].val * z->ccGain;
+                  *p++  += v * envelopes[currentEnvelope].val * leftChannelVol;
+                  *p++  += v * envelopes[currentEnvelope].val * rightChannelVol;
 
-                  *p++  += v * _channel->panLeftGain() * opcodePanLeftGain;
-                  *p++  += v * _channel->panRightGain() * opcodePanRightGain;
                   if (V1Envelopes::DELAY != currentEnvelope)
                         phase += phaseIncr;
 
@@ -413,48 +266,20 @@ void Voice::process(int frames, float* p)
                         break;
                         }
 
-                  const float* coeffs = interpCoeff[phase.fract()];
-                  float f1, f2;
+                  float interpValL = filter.interpolate(phase.fract(),
+                                                       getData(idx-2), getData(idx), getData(idx+2), getData(idx+4));
+                  float interpValR = filter.interpolate(phase.fract(),
+                                                       getData(idx-1), getData(idx+1), getData(idx+3), getData(idx+5));
+                  float valueL = filter.apply(interpValL, true);
+                  float valueR = filter.apply(interpValR, false);
 
-                  f1 = (coeffs[0] * getData(idx-2)
-                      + coeffs[1] * getData(idx)
-                      + coeffs[2] * getData(idx+2)
-                      + coeffs[3] * getData(idx+4))
-                      * gain * _channel->panLeftGain() * z->ccGain;
-
-                  f2 = (coeffs[0] * getData(idx-1)
-                      + coeffs[1] * getData(idx+1)
-                      + coeffs[2] * getData(idx+3)
-                      + coeffs[3] * getData(idx+5))
-                      * gain * _channel->panRightGain() * z->ccGain;
-
+                  //apply volume
                   updateEnvelopes();
                   if (_state == VoiceState::OFF)
                         break;
 
-                  f1 *= envelopes[currentEnvelope].val;
-                  f2 *= envelopes[currentEnvelope].val;
-
-                  f1      += -a1 * hist1l - a2 * hist2l;
-                  float vl = b02 * (f1 + hist2l) + b1 * hist1l;
-                  hist2l   = hist1l;
-                  hist1l   = f1;
-
-                  f2      +=  -a1 * hist1r - a2 * hist2r;
-                  float vr = b02 * (f2 + hist2r) + b1 * hist1r;
-                  hist2r   = hist1r;
-                  hist1r   = f2;
-
-                  if (filter_coeff_incr_count) {
-                        --filter_coeff_incr_count;
-                        a1  += a1_incr;
-                        a2  += a2_incr;
-                        b02 += b02_incr;
-                        b1  += b1_incr;
-                        }
-
-                  *p++  += vl * opcodePanLeftGain;
-                  *p++  += vr * opcodePanRightGain;
+                  *p++  += valueL * envelopes[currentEnvelope].val * leftChannelVol;
+                  *p++  += valueR * envelopes[currentEnvelope].val * rightChannelVol;
 
                   if (V1Envelopes::DELAY != currentEnvelope)
                         phase += phaseIncr;

--- a/zerberus/voice.h
+++ b/zerberus/voice.h
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 #include <math.h>
+#include "filter.h"
 
 class Channel;
 struct Zone;
@@ -25,7 +26,6 @@ enum class LoopMode : char;
 enum class OffMode : char;
 enum class Trigger : char;
 
-static const int INTERP_MAX = 256;
 static const int EG_SIZE    = 256;
 
 //---------------------------------------------------------
@@ -134,41 +134,10 @@ class Voice {
 
       Phase phase, phaseIncr;
 
-      float fres;              // the resonance frequency, in cents (not absolute cents)
-      float last_fres;         // Current resonance frequency of the IIR filter
-
-      // Serves as a flag: A deviation between fres and last_fres
-      // indicates, that the filter has to be recalculated.
-      float q_lin;             // the q-factor on a linear scale
-      float filter_gain;       // Gain correction factor, depends on q
-
-      float hist1r, hist2r;    // Sample history for the IIR filter
-      float hist1l, hist2l;
-
-      bool filter_startup;     // Flag: If set, the filter will be set directly.
-                               // Else it changes smoothly.
-
-      // filter coefficients
-      // b0 and b2 are identical >= b02
-      float b02;             // b0 / a0
-      float b1;              // b1 / a0
-      float a1;              // a0 / a0
-      float a2;              // a1 / a0
-
-      float b02_incr;
-      float b1_incr;
-      float a1_incr;
-      float a2_incr;
-      int filter_coeff_incr_count;
-
-      float modenv_val;
-      float modlfo_val;
+      ZFilter filter;
 
       int currentEnvelope;
       Envelope envelopes[V1Envelopes::COUNT];
-      static float interpCoeff[INTERP_MAX][4];
-
-      void updateFilter(float fres);
 
       Trigger trigger;
 

--- a/zerberus/zerberus.h
+++ b/zerberus/zerberus.h
@@ -108,7 +108,7 @@ class Zerberus : public Ms::Synthesizer {
       virtual void setMasterTuning(double val) { _masterTuning = val;  }
       virtual double masterTuning() const      { return _masterTuning; }
 
-      double ct2hz(double c) { return pow(2.0, (c-6900.0) / 1200.0) * _masterTuning; }
+      double ct2hz(double c) const { return pow(2.0, (c-6900.0) / 1200.0) * masterTuning(); }
 
       virtual const char* name() const;
       virtual const QList<Ms::MidiPatch*>& getPatchInfo() const;

--- a/zerberus/zone.h
+++ b/zerberus/zone.h
@@ -44,7 +44,9 @@ enum class FilterType {
       lpf_2p, //default, double-pole low-pass filter
       lpf_1p, //single-pole low-pass filter
       hpf_2p, //double-pole high-pass filter
-      hpf_1p  //single-pole high-pass filter
+      hpf_1p, //single-pole high-pass filter
+      bpf_2p, //double-pole band-pass filter
+      brf_2p //double-pole band-reject filter
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Implement bpf_2p, brf_2p, lpf_1p and hpf_1p filters.
Make refactoring: extract filter logic to separate class, make voice class simpler and easier. Optimize and fix code in applying filters.