### PR TITLE
[Patch port to 2.3] fix #222031: remove ties and spanners when removing induvidual notes within a chord

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -424,10 +424,7 @@ void Chord::add(Element* e)
                         }
                   if (!found)
                         _notes.append(note);
-                  if (note->tieFor()) {
-                        if (note->tieFor()->endNote())
-                              note->tieFor()->endNote()->setTieBack(note->tieFor());
-                        }
+                  note->connectTiedNotes();
                   if (voice() && measure() && note->visible())
                         measure()->mstaff(staffIdx())->hasVoices = true;
                   }
@@ -504,10 +501,7 @@ void Chord::remove(Element* e)
                   {
                   Note* note = static_cast<Note*>(e);
                   if (_notes.removeOne(note)) {
-                        if (note->tieFor()) {
-                              if (note->tieFor()->endNote())
-                                    note->tieFor()->endNote()->setTieBack(0);
-                              }
+                        note->disconnectTiedNotes();
                         for (Spanner* s : note->spannerBack()) {
                               note->removeSpannerBack(s);
                               }

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2874,6 +2874,36 @@ QList<Note*> Note::tiedNotes() const
       }
 
 //---------------------------------------------------------
+//   disconnectTiedNotes
+//---------------------------------------------------------
+
+void Note::disconnectTiedNotes()
+      {
+      if (tieBack() && tieBack()->startNote()) {
+            tieBack()->startNote()->remove(tieBack());
+            }
+      if (tieFor() && tieFor()->endNote()) {
+            tieFor()->endNote()->setTieBack(0);
+            }
+      }
+
+//---------------------------------------------------------
+//   connectTiedNotes
+//---------------------------------------------------------
+
+void Note::connectTiedNotes()
+      {
+      if (tieBack()) {
+            tieBack()->setEndNote(this);
+            if (tieBack()->startNote())
+                  tieBack()->startNote()->add(tieBack());
+            }
+      if (tieFor() && tieFor()->endNote()) {
+            tieFor()->endNote()->setTieBack(tieFor());
+            }
+      }
+
+//---------------------------------------------------------
 //   accidentalType
 //---------------------------------------------------------
 

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -359,6 +359,8 @@ class Note : public Element {
       Note* firstTiedNote() const;
       Note* lastTiedNote() const;
       QList<Note*> tiedNotes() const;
+      void disconnectTiedNotes();
+      void connectTiedNotes();
 
       Chord* chord() const            { return (Chord*)parent(); }
       void setChord(Chord* a)         { setParent((Element*)a);  }


### PR DESCRIPTION
This is just a backport of the bugfix proposed in #3564 to 2.3 branch. Merging conflicts are resolved, minor changes are made to make the code compile (namely, replaced [here](https://github.com/musescore/MuseScore/commit/1b736ba3e7d3b4123cb0a1cf724c3874c1bcb63b#diff-d1625459d1ed3699c71c0ca942f53b09R1674) `isNote()` and `toNote()` by explicit comparison of element type and `static_cast` conversion).