### PR TITLE
Styled property fixes for Pedal and Ottava

### DIFF
--- a/libmscore/ottava.cpp
+++ b/libmscore/ottava.cpp
@@ -354,8 +354,11 @@ QVariant Ottava::propertyDefault(Pid propertyId) const
                   }
             default:
                   for (const StyledProperty& p : subStyle(subStyleId())) {
-                        if (p.pid == propertyId)
+                        if (p.pid == propertyId) {
+                              if (propertyType(propertyId) == P_TYPE::SP_REAL)
+                                    return score()->styleP(p.sid);
                               return score()->styleV(p.sid);
+                              }
                         }
                   return getProperty(propertyId);
             }

--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -146,7 +146,7 @@ QVariant Pedal::propertyDefault(Pid propertyId) const
       {
       switch (propertyId) {
             case Pid::LINE_WIDTH:
-                  return score()->styleV(Sid::pedalLineWidth);
+                  return score()->styleP(Sid::pedalLineWidth);
 
             case Pid::LINE_STYLE:
                   return score()->styleV(Sid::pedalLineStyle);

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -1232,6 +1232,8 @@ const std::vector<StyledProperty> pedalStyle {
       { Sid::pedalHookHeight,                    Pid::BEGIN_HOOK_HEIGHT       },
       { Sid::pedalHookHeight,                    Pid::END_HOOK_HEIGHT         },
       { Sid::pedalBeginTextOffset,               Pid::BEGIN_TEXT_OFFSET       },
+      { Sid::pedalLineWidth,                     Pid::LINE_WIDTH              },
+      { Sid::pedalLineStyle,                     Pid::LINE_STYLE              },
       { Sid::pedalPlacement,                     Pid::PLACEMENT               },
       { Sid::NOSTYLE,                            Pid::END                     }      // end of list marker
       };

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -646,6 +646,7 @@ void Palette::applyPaletteElement(PaletteCell* cell)
                   for (int i = sel.staffStart(); i < endStaff; ++i) {
                         Spanner* spanner = static_cast<Spanner*>(element->clone());
                         spanner->setScore(score);
+                        spanner->initSubStyle(element->subStyleId());
                         score->cmdAddSpanner(spanner, i, startSegment, endSegment);
                         }
                   }


### PR DESCRIPTION
This PR addresses the following issues:

1. Pedal and Ottava lines are drawn too thin.
2. Some spanners do not follow style defaults when added to a range from the palette.
3. Style changes to Pedal Line Thickness and Pedal Line Style have no effect.