### PR TITLE
fix #273159: Crash when pasting note with receiving tie on a new score

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1417,7 +1417,7 @@ bool Note::readProperties(XmlReader& e)
                   if (id != -1 &&
                               // DISABLE if pasting into a staff with linked staves
                               // because the glissando is not properly cloned into the linked staves
-                              (!e.pasteMode() || !staff()->links() || staff()->links()->empty())) {
+                              staff() && (!e.pasteMode() || !staff()->links() || staff()->links()->empty())) {
                         Spanner* placeholder = new TextLine(score());
                         placeholder->setAnchor(Spanner::Anchor::NOTE);
                         placeholder->setEndElement(this);
@@ -1453,7 +1453,7 @@ bool Note::readProperties(XmlReader& e)
             sp->read(e);
             // DISABLE pasting of glissandi into staves with other lionked staves
             // because the glissando is not properly cloned into the linked staves
-            if (e.pasteMode() && staff()->links() && !staff()->links()->empty()) {
+            if (e.pasteMode() && staff() && staff()->links() && !staff()->links()->empty()) {
                   e.removeSpanner(sp);    // read() added the element to the XMLReader: remove it
                   delete sp;
                   }


### PR DESCRIPTION
This is a fix to [this issue](https://musescore.org/en/node/273159) which happens when trying to paste (or even load from a file) tied notes if a note has sufficiently large track number specified. In the example shown in the issue description something like this is pasted to the score:
```
<!-- Staff, Chord, etc. -->
<Note>
  <track>4</track>
  <endSpanner id="2"/>
  <!-- other properties -->
  </Note>
<!-- end of Chord, Staff, etc. -->
```
so the Note was considered to be at the 2nd staff which may eventually not exist in the destination score. Thus `staff()` calls for the note return a null pointer, and the absence of check for it leads to its dereferencing and a crash of the program. This patch adds the necessary nullpointer checks which prevents program crashes in such cases.