### PR TITLE
allow packagers to disable automated checking for updates

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -646,7 +646,9 @@ MuseScore::MuseScore()
       setWindowTitle(QString(MUSESCORE_NAME_VERSION));
       setIconSize(QSize(preferences.getInt(PREF_UI_THEME_ICONWIDTH) * guiScaling, preferences.getInt(PREF_UI_THEME_ICONHEIGHT) * guiScaling));
 
+#ifndef MSCORE_NO_UPDATE_CHECKER
       ucheck = new UpdateChecker();
+#endif
 
       setAcceptDrops(true);
       setFocusPolicy(Qt::NoFocus);

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -222,7 +222,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QSettings settings;
       ScoreView* cv                        { 0 };
       ScoreState _sstate;
-      UpdateChecker* ucheck;
+      UpdateChecker* ucheck = nullptr;
 
       static const std::list<const char*> _allNoteInputMenuEntries;
       static const std::list<const char*> _basicNoteInputMenuEntries;


### PR DESCRIPTION
Distributions generally don’t like when packages “phone home”,
and users without administrator rights cannot act on a message
“there are updates” anyway, so disable that optionally.