### PR TITLE
fix incorrect index in mixer combobox when loading MDL instruments

### DIFF
--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -525,7 +525,7 @@ void InstrumentTemplate::read(XmlReader& e)
             channel.append(a);
             }
       if (useDrumset) {
-            if (channel[0].bank == 0)
+            if (channel[0].bank == 0 && channel[0].name == "Fluid")
                   channel[0].bank = 128;
             channel[0].updateInitList();
             }

--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -380,7 +380,7 @@ void Instrument::read(XmlReader& e)
             _channel.append(a);
             }
       if (_useDrumset) {
-            if (_channel[0]->bank == 0)
+            if (_channel[0]->bank == 0 && _channel[0]->name == "Fluid")
                   _channel[0]->bank = 128;
             _channel[0]->updateInitList();
             }

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -205,7 +205,7 @@ void Mixer::patchListChanged()
       {
       if (!cs)
             return;
-      QString s;
+
       int idx = 0;
       QList<MidiMapping>* mm = cs->midiMapping();
       const QList<MidiPatch*> pl = synti->getPatchInfo();

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1708,7 +1708,7 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
             synthControl->setScore(cs);
       if (selectionWindow)
             selectionWindow->setScore(cs);
-      if (mixer)
+      if (mixer && mixer->isVisible())
             mixer->updateAll(cs);
 #ifdef OMR
       if (omrPanel) {
@@ -4693,7 +4693,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
       {
       if (cmd == "instruments") {
             editInstrList();
-            if (mixer)
+            if (mixer && mixer->isVisible())
                   mixer->updateAll(cs);
             }
       else if (cmd == "rewind") {
@@ -5079,7 +5079,7 @@ void MuseScore::noteTooShortForTupletDialog()
 
 void MuseScore::instrumentChanged()
       {
-      if (mixer)
+      if (mixer && mixer->isVisible())
             mixer->updateAll(cs);
       }
 


### PR DESCRIPTION
Also optimized mixer->updateAll() calls which did rely on pointer validity but not visibility, so it was called every time even if the mixer was opened once and then hidden.