### PR TITLE
Courtesy fixes

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -140,7 +140,7 @@ void KeySig::layout()
       // OR key sig is CMaj/Amin (in which case they are always shown)
 
       Measure* m           = measure();
-      Measure* prevMeasure = m ? m->prevMeasure() : nullptr;
+      Measure* prevMeasure = m ? m->prevMeasureMM() : nullptr;
 
       // display of naturals defaults according to style
       bool naturalsOn = score()->styleI(StyleIdx::keySigNaturals) != int(KeySigNatural::NONE) || t1 == 0;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2167,6 +2167,7 @@ qreal Score::cautionaryWidth(Measure* m, bool& hasCourtesy)
             for (int staffIdx = 0; staffIdx < _staves.size(); ++staffIdx) {
                   int track = staffIdx * VOICES;
 
+                  // the real key signature in the next measure, if present
                   KeySig* nks = static_cast<KeySig*>(ns->element(track));
 
                   if (nks && nks->showCourtesy() && !nks->generated()) {
@@ -2185,14 +2186,23 @@ qreal Score::cautionaryWidth(Measure* m, bool& hasCourtesy)
                                      }
                                }
 
+                        // the courtesy key signature in this measure, if present
                         Segment* s  = m->findSegment(Segment::Type::KeySigAnnounce, tick);
 
                         if (s && s->element(track)) {
+                              // use width of existing courtesy key signature
                               wwMax = qMax(wwMax, s->element(track)->width() + leftMargin);
                               hasCourtesy = true;
                               }
                         else {
+                              // no courtesy key sig present
+                              // use width of real key signature in next measure
+                              // but make sure naturals are generated for us if appropriate
+                              // just as if this were a courtesy key signature
+                              bool saveCourtesy = nks->showCourtesy();
+                              nks->setShowCourtesy(false);
                               nks->layout();
+                              nks->setShowCourtesy(saveCourtesy);
                               wwMax = qMax(wwMax, nks->width() + leftMargin);
                               //hasCourtesy = false;
                               }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3130,7 +3130,7 @@ qreal Measure::minWidth1() const
                   }
             _minWidth1 = score()->computeMinWidth(s, false);
             if (MScore::debugMode)
-                  qDebug("Measure::minWidth1: %d %f", no(), _minWidth1 / DPMM);
+                  qDebug("Measure::minWidth1: %d %f", no(), _minWidth1);
             }
       return _minWidth1;
       }


### PR DESCRIPTION
Review welcome as always, especially shortly before a release.  But I feel good about these - they fix the problems at hand, don't seem to introduce new problems in my testing and do seem pretty safe.

Fix for https://musescore.org/en/node/267602: problem was introduced with my original fix for the original issue in #3356 .  In trying to gauge if a measure will fit on the system, we are using the width of the real key signature as a stand-in for the width of the courtesy signature that hasn't been generated yet.  Unfortunately, the real key signature may or may not have naturals depending on whether a courtesy exists, but a courtesy always has them (assuming the conditions otherwise make them appropriate.  So my fix here is to temporarily fool the layout of the real key signature into generating the accidentals.  This is a "throwaway" layout anyhow - it's used only for the purpose of this calculation, as it gets laid again for real later.

Fix for https://musescore.org/en/node/272691: again, problem was introduced with that earlier fix.  Here the problem is simply that in checking the "previous measure" for the purpose of ascertaining whether a courtesy signature is appropriate, I wasn't considering mmrests.

In the process of testing my fixes for these, I found a related issue that has existed much longer - see https://musescore.org/en/node/273596.  This one confuses me more, and any fix seems a bit riskier.  I've got some analysis in the issue report.  I probably won't be pursuing it further; someone else is welcome to.

Note that my original PR #3356 was 2.2 only - not master - because master was totally broken with respect to naturals so I couldn't test.  Presumably that would still be valid to merge for master, possibly with some hand tweaking needed, and this should be applied on top.  I wouldn't expect master to reproduce the same layout shift issue with the same score because it is dependent on specific measures widths and those will have changed, but the bug is almost certain there.