### PR TITLE
Right align "Double augmentation dot" in preferences dialog

### DIFF
--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -1812,6 +1812,9 @@
             <property name="text">
              <string>Double augmentation dot</string>
             </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
            </widget>
           </item>
           <item row="4" column="8">


### PR DESCRIPTION
see https://musescore.org/en/node/273672

Should go to master too, and does `git cherry-pick` cleanly.