### PR TITLE
fix #89016: Disappearing dots

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -402,6 +402,12 @@ void Rest::layout()
       _sym = getSymbol(durationType().type(), lineOffset / 2 + userLine, lines, &yo);
       rypos() = (qreal(yo) + qreal(lineOffset) * .5) * lineDist * _spatium;
       setbbox(symBbox(_sym));
+      if (dots()) {
+            qreal w = width() + score()->styleP(Sid::dotNoteDistance)
+               + (dots() - 1) * score()->styleP(Sid::dotDotDistance)
+               + symWidth(SymId::augmentationDot);
+            setWidth(w);
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See [#89016: Disappearing dots](https://musescore.org/en/node/89016).