### PR TITLE
fix #273746: articulations do not not inherit score style settings wh…

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -289,6 +289,8 @@ static void applyDrop(Score* score, ScoreView* viewer, Element* target, Element*
       if (target->acceptDrop(dropData)) {
             Element* ne = e->clone();
             ne->setScore(score);
+            ne->reset();
+            ne->layout();
 
             dropData.element    = ne;
             ne = target->drop(dropData);


### PR DESCRIPTION
…en added by double-click

NOTE: I am not comfortable with this PR.  The code itself is simple and OK in itself - maybe the layout() isn't really needed, but there is one in the drag&drop code, so what the heck.

My concern is that while it fixes the issue at hand, it *also* changes how customization works in a palette.  Basically, certain things you have customized in a custom palette entry would be reset to score style.  That's either what you want or it isn't, so this might improve things for some cases, break things for others.  I think we really should spend more time looking at the differences between double-click vs drag&drop.  I believe @divya-urs had already done some work in this area in her palette shortcut code for master.

If we want to address the issue for 2.3 without risking breaking anything, I'd recommend we simply hack the MDL workspace to use explicit TOP_STAFF attributes on the articulations.  That would have the same effect but only for articulations and only in the MDL workspace.