### PR TITLE
Fix #269952: allow new templates to be shown in new score wizard w/o restart

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -495,6 +495,8 @@ void MuseScore::newFile()
       {
       if (newWizard == 0)
             newWizard = new NewWizard(this);
+      else
+            newWizard->updateTemplate();
       newWizard->restart();
       if (newWizard->exec() != QDialog::Accepted)
             return;

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -373,6 +373,23 @@ QString NewWizardPage4::templatePath() const
 //   NewWizardPage5
 //---------------------------------------------------------
 
+void NewWizardPage4::setTemplateLayout()
+      {
+      QDir dir(mscoreGlobalShare + "/templates");
+      QFileInfoList fil = dir.entryInfoList(QDir::NoDotAndDotDot | QDir::Readable | QDir::Dirs | QDir::Files, QDir::Name);
+      if (fil.isEmpty())
+            fil.append(QFileInfo(QFile(":data/Empty_Score.mscz")));
+
+      QDir myTemplatesDir(preferences.myTemplatesPath);
+      fil.append(myTemplatesDir.entryInfoList(QDir::NoDotAndDotDot | QDir::Readable | QDir::Dirs | QDir::Files, QDir::Name));
+
+      templateFileBrowser->setScores(fil);
+      }
+
+//---------------------------------------------------------
+//   NewWizardPage5
+//---------------------------------------------------------
+
 NewWizardPage5::NewWizardPage5(QWidget* parent)
    : QWizardPage(parent)
       {

--- a/mscore/newwizard.h
+++ b/mscore/newwizard.h
@@ -147,6 +147,7 @@ class NewWizardPage4 : public QWizardPage {
       QString templatePath() const;
       virtual void initializePage();
       void buildTemplatesList();
+      void setTemplateLayout();
       };
 
 //---------------------------------------------------------
@@ -192,6 +193,7 @@ class NewWizard : public QWizard {
       enum class Page : signed char      { Invalid = -1, Type, Instruments, Template, Keysig, Timesig};
 
       QString templatePath() const       { return p4->templatePath(); }
+      void updateTemplate()              { p4->setTemplateLayout();  }
       int measures() const               { return p3->measures();    }
       Fraction timesig() const           { return p3->timesig();     }
       void createInstruments(Score* s)   { p2->createInstruments(s); }


### PR DESCRIPTION
2.3 counterpart for #3522, shamelessly stealing @finleylau 's code and adjusting it for 2.3 (and recycling an old branch of mine).
Travis failure due to being in Release mode now...

It works fine, I see no reason not to merge #3522 into master.
Merging this here into 2.3 might still be an option, although I understand that such a last minute change is frowned upon.