### PR TITLE
Fix #269952: show new templates in new score wizard w/o restart

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -493,8 +493,7 @@ void MuseScore::updateNewWizard()
 
 void MuseScore::newFile()
       {
-      if (newWizard == 0)
-            newWizard = new NewWizard(this);
+      updateNewWizard();
       newWizard->restart();
       if (newWizard->exec() != QDialog::Accepted)
             return;


### PR DESCRIPTION
replaces #3773 with a much simpler approach (thanks @MarcSabatella)