### PR TITLE
fix #273823: wrong bank for zerberus channel

### DIFF
--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -526,7 +526,7 @@ void InstrumentTemplate::read(XmlReader& e)
             channel.append(a);
             }
       if (useDrumset) {
-            if (channel[0].bank == 0 && channel[0].name != "Zerberus")
+            if (channel[0].bank == 0 && channel[0].synti.toLower() != "zerberus")
                   channel[0].bank = 128;
             channel[0].updateInitList();
             }

--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -382,7 +382,7 @@ void Instrument::read(XmlReader& e)
             _channel.append(a);
             }
       if (_useDrumset) {
-            if (_channel[0]->bank == 0 && _channel[0]->name != "Zerberus")
+            if (_channel[0]->bank == 0 && _channel[0]->synti.toLower() != "zerberus")
                   _channel[0]->bank = 128;
             _channel[0]->updateInitList();
             }
@@ -552,7 +552,7 @@ void Channel::read(XmlReader& e)
             else
                   e.unknown();
             }
-      if (128 == bank && "Zerberus" == synti)
+      if (128 == bank && "zerberus" == synti.toLower())
             bank = 0;
 
       updateInitList();


### PR DESCRIPTION
See issue https://musescore.org/en/node/273823 for description of problem.

It is worth observing a few other things:

- The problem was introduced by the last-minute fix here: https://github.com/musescore/MuseScore/commit/63fa5670db23c1372474753027cff1b93367beea, and no argument from me, the original problem fixed by that commit was worse than the one it introduced.  better to fix them both thouh, and my change should do that.

- Supposedly this problem isn't reproducible on Mac using 2.3 release build.  I have to think maybe the wrong build was uploaded, one from before that fix, because I can't see how it could work with that code in place.  But then, it should show the other problem with marching snare sounding like trumpet.  I remain mystified about that.  However, that said:

- There is simply no way that *name* is ever going to be "Fluid" *or* "Zerberus".  Channel *names* are things like "normal", "arco", mute" etc.  This should have been *synti* in the first place.  So checking "name" was going to fail one way or another because it is simply not relevant in figuring out the bank.

- If the intent is to make it so Fluid gets bank 128 and Zerberus gets 0, fine, you can actually get that either by comparing synti == Fluid or synti != Zerberus.  But is that really the goal?  I was understanding this is really about General MIDI, and just because we're using Fluid doesn't mean the loaded soundfonts are General MIDI compatible.  Well, whatever, the fix should at least be an improvement.