### PR TITLE
fix #89016: Disappearing dots (using NoteDot)

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1184,12 +1184,15 @@ void Note::write(XmlWriter& xml) const
       if (_accidental)
             _accidental->write(xml);
       _el.write(xml);
-      for (NoteDot* dot : _dots) {
+      bool write_dots = false;
+      for (NoteDot* dot : _dots)
             if (!dot->userOff().isNull() || !dot->visible() || dot->color() != Qt::black || dot->visible() != visible()) {
-                  dot->write(xml);
+                  write_dots = true;
                   break;
                   }
-            }
+      if (write_dots)
+            for (NoteDot* dot : _dots)
+                  dot->write(xml);
       if (_tieFor)
             _tieFor->write(xml);
       if (_tieBack) {

--- a/libmscore/notedot.cpp
+++ b/libmscore/notedot.cpp
@@ -16,6 +16,7 @@
 #include "sym.h"
 #include "xml.h"
 #include "chord.h"
+#include "rest.h"
 
 namespace Ms {
 
@@ -37,7 +38,7 @@ void NoteDot::draw(QPainter* p) const
       {
       if (note() && note()->dotsHidden())     // don't draw dot if note is hidden
             return;
-      int tick = note()->chord()->tick();
+      int tick = note() ? note()->chord()->tick() : rest()->tick();
       if (!staff()->isTabStaff(tick) || staff()->staffType(tick)->stemThrough()) {
             p->setPen(curColor());
             drawSymbol(SymId::augmentationDot, p);

--- a/libmscore/notedot.h
+++ b/libmscore/notedot.h
@@ -18,6 +18,7 @@
 namespace Ms {
 
 class Note;
+class Rest;
 
 //---------------------------------------------------------
 //   @@ NoteDot
@@ -35,7 +36,8 @@ class NoteDot final : public Element {
       virtual void read(XmlReader&) override;
       virtual void layout() override;
 
-      Note* note() const { return (Note*)parent(); }
+      Note* note() const { return parent()->isNote() ? toNote(parent()) : 0; }
+      Rest* rest() const { return parent()->isRest() ? toRest(parent()) : 0; }
       };
 
 

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -66,6 +66,8 @@ Rest::Rest(const Rest& r, bool link)
       _sym     = r._sym;
       dotline  = r.dotline;
       _mmWidth = r._mmWidth;
+      for (NoteDot* dot : r._dots)
+            add(new NoteDot(*dot));
       }
 
 //---------------------------------------------------------
@@ -114,19 +116,8 @@ void Rest::draw(QPainter* painter) const
             x      -= symBbox(s).width() * .5;
             drawSymbols(s, painter, QPointF(x, y));
             }
-      else {
+      else
             drawSymbol(_sym, painter);
-            int dots = durationType().dots();
-            if (dots) {
-                  qreal y = dotline * _spatium * .5;
-                  qreal dnd = score()->styleP(Sid::dotNoteDistance) * mag();
-                  qreal ddd = score()->styleP(Sid::dotDotDistance) * mag();
-                  for (int i = 1; i <= dots; ++i) {
-                        qreal x = symWidth(_sym) + dnd + ddd * (i - 1);
-                        drawSymbol(SymId::augmentationDot, painter, QPointF(x, y));
-                        }
-                  }
-            }
       }
 
 //---------------------------------------------------------
@@ -402,7 +393,55 @@ void Rest::layout()
       _sym = getSymbol(durationType().type(), lineOffset / 2 + userLine, lines, &yo);
       rypos() = (qreal(yo) + qreal(lineOffset) * .5) * lineDist * _spatium;
       setbbox(symBbox(_sym));
+      layoutDots();
       }
+
+//---------------------------------------------------------
+//   layout
+//---------------------------------------------------------
+
+void Rest::layoutDots()
+      {
+      checkDots();
+      qreal x = symWidth(_sym) + score()->styleP(Sid::dotNoteDistance) * mag();
+      qreal dx = score()->styleP(Sid::dotDotDistance) * mag();
+      qreal y = dotline * spatium() * .5;
+      for (NoteDot* dot : _dots) {
+            dot->layout();
+            dot->setPos(x, y);
+            x += dx;
+            }
+      }
+
+//---------------------------------------------------------
+//   checkDots
+//---------------------------------------------------------
+
+void Rest::checkDots()
+      {
+      int n = dots() - _dots.size();
+      for (int i = 0; i < n; ++i) {
+            NoteDot* dot = new NoteDot(score());
+            dot->setParent(this);
+            dot->setVisible(visible());
+            score()->undoAddElement(dot);
+            }
+      if (n < 0) {
+            for (int i = 0; i < -n; ++i)
+                  score()->undoRemoveElement(_dots.back());
+            }
+      }
+
+//---------------------------------------------------------
+//   dot
+//---------------------------------------------------------
+
+NoteDot* Rest::dot(int n)
+      {
+      checkDots();
+      return _dots[n];
+      }
+
 
 //---------------------------------------------------------
 //   getDotline
@@ -613,8 +652,21 @@ void Rest::scanElements(void* data, void (*func)(void*, Element*), bool all)
       ChordRest::scanElements(data, func, all);
       for (Element* e : el())
             e->scanElements(data, func, all);
+      for (NoteDot* dot : _dots)
+            dot->scanElements(data, func, all);
       if (!isGap())
             func(data, this);
+      }
+
+//---------------------------------------------------------
+//   setTrack
+//---------------------------------------------------------
+
+void Rest::setTrack(int val)
+      {
+      ChordRest::setTrack(val);
+      for (NoteDot* dot : _dots)
+            dot->setTrack(val);
       }
 
 //---------------------------------------------------------
@@ -756,6 +808,9 @@ void Rest::add(Element* e)
       e->setTrack(track());
 
       switch(e->type()) {
+            case ElementType::NOTEDOT:
+                  _dots.push_back(toNoteDot(e));
+                  break;
             case ElementType::SYMBOL:
             case ElementType::IMAGE:
                   el().push_back(e);
@@ -773,6 +828,9 @@ void Rest::add(Element* e)
 void Rest::remove(Element* e)
       {
       switch(e->type()) {
+            case ElementType::NOTEDOT:
+                  _dots.pop_back();
+                  break;
             case ElementType::SYMBOL:
             case ElementType::IMAGE:
                   if (!el().remove(e))
@@ -795,6 +853,15 @@ void Rest::write(XmlWriter& xml) const
       xml.stag(name());
       ChordRest::writeProperties(xml);
       el().write(xml);
+      bool write_dots = false;
+      for (NoteDot* dot : _dots)
+            if (!dot->userOff().isNull() || !dot->visible() || dot->color() != Qt::black || dot->visible() != visible()) {
+                  write_dots = true;
+                  break;
+                  }
+      if (write_dots)
+            for (NoteDot* dot: _dots)
+                  dot->write(xml);
       xml.etag();
       }
 
@@ -821,6 +888,11 @@ void Rest::read(XmlReader& e)
                         image->read(e);
                         add(image);
                         }
+                  }
+            else if (tag == "NoteDot") {
+                  NoteDot* dot = new NoteDot(score());
+                  dot->read(e);
+                  add(dot);
                   }
             else if (ChordRest::readProperties(e))
                   ;
@@ -868,7 +940,11 @@ bool Rest::setProperty(Pid propertyId, const QVariant& v)
                   _gap = v.toBool();
                   score()->setLayout(tick());
                   break;
-
+            case Pid::VISIBLE:
+                  setVisible(v.toBool());
+                  for (NoteDot* dot : _dots)
+                        dot->setVisible(visible());
+                  break;
             case Pid::USER_OFF:
                   score()->addRefresh(canvasBoundingRect());
                   setUserOff(v.toPointF());
@@ -925,6 +1001,8 @@ Shape Rest::shape() const
                   }
             else
                   shape.add(bbox());
+            for (NoteDot* dot : _dots)
+                  shape.add(symBbox(SymId::augmentationDot).translated(dot->pos()));
             }
       return shape;
       }

--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -14,6 +14,7 @@
 #define __REST_H__
 
 #include "chordrest.h"
+#include "notedot.h"
 
 namespace Ms {
 
@@ -32,6 +33,7 @@ class Rest : public ChordRest {
       int dotline    { -1  };       // depends on rest symbol
       qreal _mmWidth;               // width of multi measure rest
       bool _gap      { false };     // invisible and not selectable for user
+      std::vector<NoteDot*> _dots;
 
       virtual QRectF drag(EditData&) override;
       virtual qreal upPos()   const override;
@@ -43,7 +45,7 @@ class Rest : public ChordRest {
       Rest(Score* s = 0);
       Rest(Score*, const TDuration&);
       Rest(const Rest&, bool link = false);
-      ~Rest() {}
+      ~Rest() { qDeleteAll(_dots); }
 
       virtual ElementType type() const override { return ElementType::REST; }
       Rest &operator=(const Rest&) = delete;
@@ -54,6 +56,7 @@ class Rest : public ChordRest {
       virtual qreal mag() const override;
       virtual void draw(QPainter*) const override;
       virtual void scanElements(void* data, void (*func)(void*, Element*), bool all=true) override;
+      void setTrack(int val);
 
       virtual bool acceptDrop(EditData&) const override;
       virtual Element* drop(EditData&) override;
@@ -74,6 +77,9 @@ class Rest : public ChordRest {
       qreal mmWidth() const        { return _mmWidth; }
       SymId getSymbol(TDuration::DurationType type, int line, int lines,  int* yoffset);
 
+      void checkDots();
+      void layoutDots();
+      NoteDot* dot(int n);
       int getDotline() const   { return dotline; }
       static int getDotline(TDuration::DurationType durationType);
       SymId sym() const        { return _sym;    }

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -498,6 +498,11 @@ void Selection::updateSelectedElements()
                         }
                   else {
                         appendFiltered(e);
+                        if (e->isRest()) {
+                              Rest* r = toRest(e);
+                              for (int i = 0; i < r->dots(); ++i)
+                                    appendFiltered(r->dot(i));
+                              }
                         }
                   }
             }

--- a/mscore/debugger/chordrest.ui
+++ b/mscore/debugger/chordrest.ui
@@ -200,7 +200,7 @@
            <enum>QAbstractSpinBox::NoButtons</enum>
           </property>
           <property name="maximum">
-           <number>3</number>
+           <number>4</number>
           </property>
          </widget>
         </item>

--- a/mscore/debugger/debugger.cpp
+++ b/mscore/debugger/debugger.cpp
@@ -393,7 +393,10 @@ void Debugger::addMeasure(ElementItem* mi, Measure* measure)
                   ElementItem* sei = new ElementItem(segItem, e);
                   if (e->isChord())
                         addChord(sei, toChord(e));
-                  else if (e->isChordRest()) {
+                  else if (e->isRest()) {
+                        Rest* rest = toRest(e);
+                        for (int i = 0; i < rest->dots(); ++i)
+                              new ElementItem(sei, rest->dot(i));
                         ChordRest* cr = toChordRest(e);
                         if (cr->beam() && cr->beam()->elements().front() == cr)
                               new ElementItem(sei, cr->beam());
@@ -1123,6 +1126,7 @@ ShowNoteWidget::ShowNoteWidget()
       connect(nb.dot1,       SIGNAL(clicked()), SLOT(dot1Clicked()));
       connect(nb.dot2,       SIGNAL(clicked()), SLOT(dot2Clicked()));
       connect(nb.dot3,       SIGNAL(clicked()), SLOT(dot3Clicked()));
+      connect(nb.dot4,       SIGNAL(clicked()), SLOT(dot4Clicked()));
       }
 
 //---------------------------------------------------------
@@ -1153,6 +1157,7 @@ void ShowNoteWidget::setElement(Element* e)
       nb.dot1->setEnabled(note->dots().size() > 0);
       nb.dot2->setEnabled(note->dots().size() > 1);
       nb.dot3->setEnabled(note->dots().size() > 2);
+      nb.dot4->setEnabled(note->dots().size() > 3);
 
       nb.fingering->clear();
       for (Element* text : note->el()) {
@@ -1195,6 +1200,15 @@ void ShowNoteWidget::dot2Clicked()
 void ShowNoteWidget::dot3Clicked()
       {
       emit elementChanged(((Note*)element())->dot(2));
+      }
+
+//---------------------------------------------------------
+//   dot4Clicked
+//---------------------------------------------------------
+
+void ShowNoteWidget::dot4Clicked()
+      {
+      emit elementChanged(((Note*)element())->dot(3));
       }
 
 //---------------------------------------------------------
@@ -1246,6 +1260,11 @@ RestView::RestView()
       connect(crb.tupletButton, SIGNAL(clicked()), SLOT(tupletClicked()));
       connect(crb.attributes,   SIGNAL(itemClicked(QListWidgetItem*)), SLOT(gotoElement(QListWidgetItem*)));
       connect(crb.lyrics,       SIGNAL(itemClicked(QListWidgetItem*)), SLOT(gotoElement(QListWidgetItem*)));
+
+      connect(rb.dot1,          SIGNAL(clicked()), SLOT(dot1Clicked()));
+      connect(rb.dot2,          SIGNAL(clicked()), SLOT(dot2Clicked()));
+      connect(rb.dot3,          SIGNAL(clicked()), SLOT(dot3Clicked()));
+      connect(rb.dot4,          SIGNAL(clicked()), SLOT(dot4Clicked()));
       }
 
 //---------------------------------------------------------
@@ -1282,6 +1301,47 @@ void RestView::setElement(Element* e)
       rb.dotline->setValue(rest->getDotline());
       rb.mmWidth->setValue((rest->measure() && rest->measure()->isMMRest()) ? rest->mmWidth() : 0.0);
       rb.gap->setChecked(rest->isGap());
+      int dots = rest->dots();
+      rb.dot1->setEnabled(dots > 0);
+      rb.dot2->setEnabled(dots > 1);
+      rb.dot3->setEnabled(dots > 2);
+      rb.dot4->setEnabled(dots > 3);
+      }
+
+//---------------------------------------------------------
+//   dot1Clicked
+//---------------------------------------------------------
+
+void RestView::dot1Clicked()
+      {
+      emit elementChanged(toRest(element())->dot(0));
+      }
+
+//---------------------------------------------------------
+//   dot2Clicked
+//---------------------------------------------------------
+
+void RestView::dot2Clicked()
+      {
+      emit elementChanged(toRest(element())->dot(1));
+      }
+
+//---------------------------------------------------------
+//   dot3Clicked
+//---------------------------------------------------------
+
+void RestView::dot3Clicked()
+      {
+      emit elementChanged(toRest(element())->dot(2));
+      }
+
+//---------------------------------------------------------
+//   dot4Clicked
+//---------------------------------------------------------
+
+void RestView::dot4Clicked()
+      {
+      emit elementChanged(toRest(element())->dot(3));
       }
 
 //---------------------------------------------------------

--- a/mscore/debugger/debugger.h
+++ b/mscore/debugger/debugger.h
@@ -262,6 +262,7 @@ class ShowNoteWidget : public ShowElementBase {
       void dot1Clicked();
       void dot2Clicked();
       void dot3Clicked();
+      void dot4Clicked();
 
    signals:
       void scoreChanged();
@@ -282,6 +283,10 @@ class RestView : public ShowElementBase {
       Ui::Rest rb;
 
    private slots:
+      void dot1Clicked();
+      void dot2Clicked();
+      void dot3Clicked();
+      void dot4Clicked();
       void tupletClicked();
       void beamClicked();
 

--- a/mscore/debugger/note.ui
+++ b/mscore/debugger/note.ui
@@ -375,6 +375,13 @@
         </property>
        </widget>
       </item>
+      <item row="8" column="7">
+       <widget class="QPushButton" name="dot4">
+        <property name="text">
+         <string notr="true">Dot4</string>
+        </property>
+       </widget>
+      </item>
       <item row="8" column="6">
        <widget class="QPushButton" name="dot3">
         <property name="text">

--- a/mscore/debugger/rest.ui
+++ b/mscore/debugger/rest.ui
@@ -140,6 +140,34 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="6">
+       <widget class="QPushButton" name="dot1">
+        <property name="text">
+         <string notr="true">Dot1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="7">
+       <widget class="QPushButton" name="dot2">
+        <property name="text">
+         <string notr="true">Dot2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="6">
+       <widget class="QPushButton" name="dot3">
+        <property name="text">
+         <string notr="true">Dot3</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="7">
+       <widget class="QPushButton" name="dot4">
+        <property name="text">
+         <string notr="true">Dot4</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -596,6 +596,20 @@ InspectorRest::InspectorRest(QWidget* parent)
       _layout->addWidget(f);
 
       QHBoxLayout* hbox = new QHBoxLayout;
+      dot1 = new QToolButton(this);
+      dot1->setText(tr("Dot 1"));
+      hbox->addWidget(dot1);
+      dot2 = new QToolButton(this);
+      dot2->setText(tr("Dot 2"));
+      hbox->addWidget(dot2);
+      dot3 = new QToolButton(this);
+      dot3->setText(tr("Dot 3"));
+      hbox->addWidget(dot3);
+      dot4 = new QToolButton(this);
+      dot4->setText(tr("Dot 4"));
+      hbox->addWidget(dot4);
+      _layout->addLayout(hbox);
+      hbox = new QHBoxLayout;
       tuplet = new QToolButton(this);
       tuplet->setText(tr("Tuplet"));
       tuplet->setEnabled(false);
@@ -604,6 +618,10 @@ InspectorRest::InspectorRest(QWidget* parent)
 
 //TODO      e.offset->setSingleStep(1.0);        // step in spatium units
 
+      connect(dot1,     SIGNAL(clicked()),     SLOT(dot1Clicked()));
+      connect(dot2,     SIGNAL(clicked()),     SLOT(dot2Clicked()));
+      connect(dot3,     SIGNAL(clicked()),     SLOT(dot3Clicked()));
+      connect(dot4,     SIGNAL(clicked()),     SLOT(dot4Clicked()));
       connect(tuplet,   SIGNAL(clicked()),     SLOT(tupletClicked()));
       }
 
@@ -614,8 +632,66 @@ InspectorRest::InspectorRest(QWidget* parent)
 void InspectorRest::setElement()
       {
       Rest* rest = toRest(inspector->element());
+      int dots = rest->dots();
+      dot1->setEnabled(dots > 0);
+      dot2->setEnabled(dots > 1);
+      dot3->setEnabled(dots > 2);
+      dot4->setEnabled(dots > 3);
       tuplet->setEnabled(rest->tuplet());
       InspectorElementBase::setElement();
+      }
+
+//---------------------------------------------------------
+//   dotClicked
+//---------------------------------------------------------
+
+void InspectorRest::dotClicked(int n)
+      {
+      Rest* rest = toRest(inspector->element());
+      if (rest == 0)
+            return;
+      if (rest->dots() > n) {
+            NoteDot* dot = rest->dot(n);
+            dot->score()->select(dot);
+            dot->score()->update();
+            inspector->update();
+            }
+      }
+
+//---------------------------------------------------------
+//   dot1Clicked
+//---------------------------------------------------------
+
+void InspectorRest::dot1Clicked()
+      {
+      dotClicked(0);
+      }
+
+//---------------------------------------------------------
+//   dot2Clicked
+//---------------------------------------------------------
+
+void InspectorRest::dot2Clicked()
+      {
+      dotClicked(1);
+      }
+
+//---------------------------------------------------------
+//   dot3Clicked
+//---------------------------------------------------------
+
+void InspectorRest::dot3Clicked()
+      {
+      dotClicked(2);
+      }
+
+//---------------------------------------------------------
+//   dot4Clicked
+//---------------------------------------------------------
+
+void InspectorRest::dot4Clicked()
+      {
+      dotClicked(3);
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -175,9 +175,19 @@ class InspectorRest : public InspectorElementBase {
       Ui::InspectorSegment s;
       Ui::InspectorRest    r;
 
+      QToolButton* dot1;
+      QToolButton* dot2;
+      QToolButton* dot3;
+      QToolButton* dot4;
       QToolButton* tuplet;
 
+      void dotClicked(int n);
+
    private slots:
+      void dot1Clicked();
+      void dot2Clicked();
+      void dot3Clicked();
+      void dot4Clicked();
       void tupletClicked();
 
    public:

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4163,7 +4163,7 @@ static bool elementLower(const Element* e1, const Element* e2)
                   if (e1->type() == ElementType::NOTEDOT) {
                         const NoteDot* n1 = static_cast<const NoteDot*>(e1);
                         const NoteDot* n2 = static_cast<const NoteDot*>(e2);
-                        if (n1->note()->hidden())
+                        if (n1->note() && n1->note()->hidden())
                               return n2;
                         else
                               return n1;


### PR DESCRIPTION
Use NoteDot for the dots after rests, instead of the rest drawing its own dots, which were drawn outside of the rest's bbox.

See [89016: Disappearing dots](https://musescore.org/en/node/89016).