### PR TITLE
Allow setting Average Bitrate for MP3 export

### DIFF
--- a/mscore/exportmp3.cpp
+++ b/mscore/exportmp3.cpp
@@ -44,7 +44,7 @@ MP3Exporter::MP3Exporter()
       mBitrate = 128;
       mQuality = QUALITY_2;
       mChannel = CHANNEL_JOINT;
-      mMode = MODE_CBR;
+      mMode    = MODE_CBR;
       mRoutine = ROUTINE_FAST;
       }
 

--- a/mscore/loginmanager.cpp
+++ b/mscore/loginmanager.cpp
@@ -17,6 +17,7 @@
 #include "preferences.h"
 #include "kQOAuth/kqoauthrequest.h"
 #include "kQOAuth/kqoauthrequest_xauth.h"
+#include "exportmp3.h"
 
 namespace Ms {
 
@@ -402,13 +403,16 @@ void LoginManager::onGetMediaUrlRequestReady(QByteArray ba)
             QString mp3Path = QDir::tempPath() + QString("/temp_%1.mp3").arg(qrand() % 100000);
             _mp3File = new QFile(mp3Path);
             Score* score = mscore->currentScore()->masterScore();
-            int br = preferences.getInt(PREF_EXPORT_MP3_BITRATE);
+            int br   = preferences.getInt(PREF_EXPORT_MP3_BITRATE);
+            int mode = preferences.getInt(PREF_EXPORT_MP3_MODE);
             preferences.setPreference(PREF_EXPORT_MP3_BITRATE, 128);
+            preferences.setPreference(PREF_EXPORT_MP3_MODE, MODE_ABR);
             if (mscore->saveMp3(score, mp3Path)) { // no else, error handling is done in saveMp3
                   _uploadTryCount = 0;
                   uploadMedia();
                   }
             preferences.setPreference(PREF_EXPORT_MP3_BITRATE, br);
+            preferences.setPreference(PREF_EXPORT_MP3_MODE, mode);
             }
       }
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6042,6 +6042,7 @@ bool MuseScore::saveMp3(Score* score, const QString& name)
       int oldSampleRate = MScore::sampleRate;
       int sampleRate = preferences.getInt(PREF_EXPORT_AUDIO_SAMPLERATE);
       exporter.setBitrate(preferences.getInt(PREF_EXPORT_MP3_BITRATE));
+      exporter.setMode(preferences.getInt(PREF_EXPORT_MP3_MODE));
 
       int inSamples = exporter.initializeStream(channels, sampleRate);
       if (inSamples < 0) {

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -21,6 +21,7 @@
 #include "libmscore/style.h"
 #include "libmscore/mscore.h"
 #include "preferences.h"
+#include "exportmp3.h"
 
 namespace Ms {
 
@@ -96,6 +97,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_EXPORT_AUDIO_NORMALIZE,                          new BoolPreference(44100, true)},
             {PREF_EXPORT_AUDIO_SAMPLERATE,                         new IntPreference(44100, false)},
             {PREF_EXPORT_MP3_BITRATE,                              new IntPreference(128, false)},
+            {PREF_EXPORT_MP3_MODE,                                 new IntPreference(MODE_CBR, false)},
             {PREF_EXPORT_MUSICXML_EXPORTBREAKS,                    new EnumPreference(QVariant::fromValue(MusicxmlExportBreaks::ALL), false)},
             {PREF_EXPORT_MUSICXML_EXPORTLAYOUT,                    new BoolPreference(true, false)},
             {PREF_EXPORT_PDF_DPI,                                  new IntPreference(300, false)},

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -103,6 +103,7 @@ enum class MusicxmlExportBreaks : char {
 #define PREF_EXPORT_AUDIO_NORMALIZE                         "export/audio/normalize"
 #define PREF_EXPORT_AUDIO_SAMPLERATE                        "export/audio/sampleRate"
 #define PREF_EXPORT_MP3_BITRATE                             "export/mp3/bitRate"
+#define PREF_EXPORT_MP3_MODE                                "export/mp3/mode"
 #define PREF_EXPORT_MUSICXML_EXPORTLAYOUT                   "export/musicXML/exportLayout"
 #define PREF_EXPORT_MUSICXML_EXPORTBREAKS                   "export/musicXML/exportBreaks"
 #define PREF_EXPORT_PDF_DPI                                 "export/pdf/dpi"

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -25,6 +25,7 @@
 #include "scoreview.h"
 #include "pa.h"
 #include "shortcut.h"
+#include "exportmp3.h"
 
 #ifdef USE_PORTMIDI
 #include "pm.h"
@@ -542,6 +543,7 @@ void PreferenceDialog::updateValues(bool useDefaultValues)
 
       index = exportMp3BitRate->findData(preferences.getInt(PREF_EXPORT_MP3_BITRATE));
       exportMp3BitRate->setCurrentIndex(index);
+      exportMp3Mode->setChecked(preferences.getInt(PREF_EXPORT_MP3_MODE) == MODE_ABR);
 
       exportPdfDpi->setValue(preferences.getInt(PREF_EXPORT_PDF_DPI));
       pageVertical->setChecked(MScore::verticalOrientation());
@@ -906,6 +908,7 @@ void PreferenceDialog::apply()
       preferences.setPreference(PREF_APP_STARTUP_STARTSCORE, sessionScore->text());
       preferences.setPreference(PREF_EXPORT_AUDIO_SAMPLERATE, exportAudioSampleRate->currentData().toInt());
       preferences.setPreference(PREF_EXPORT_MP3_BITRATE, exportMp3BitRate->currentData().toInt());
+      preferences.setPreference(PREF_EXPORT_MP3_MODE, exportMp3Mode->isChecked() ? MODE_ABR : MODE_CBR);
       preferences.setPreference(PREF_EXPORT_MUSICXML_EXPORTLAYOUT, exportLayout->isChecked());
       preferences.setPreference(PREF_EXPORT_PDF_DPI, exportPdfDpi->value());
       preferences.setPreference(PREF_EXPORT_PNG_RESOLUTION, pngResolution->value());

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -3798,6 +3798,12 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
          <layout class="QGridLayout" name="gridLayout_15">
           <item row="2" column="2">
            <widget class="QComboBox" name="exportMp3BitRate">
+            <property name="accessibleName">
+             <string>MP3 bitrate</string>
+            </property>
+            <property name="accessibleDescription">
+             <string>Choose MP3 bitrate</string>
+            </property>
             <property name="currentText">
              <string>128</string>
             </property>
@@ -3925,23 +3931,10 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
             </property>
            </widget>
           </item>
-          <item row="2" column="4">
-           <spacer name="horizontalSpacer_19">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
           <item row="2" column="0">
            <widget class="QLabel" name="exportMp3BitRateLabel">
             <property name="text">
-             <string>MP3 Bitrate:</string>
+             <string>MP3 bitrate:</string>
             </property>
            </widget>
           </item>
@@ -3951,6 +3944,32 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
              <string>Normalize</string>
             </property>
            </widget>
+          </item>
+          <item row="2" column="5">
+           <widget class="QCheckBox" name="exportMp3Mode">
+            <property name="accessibleName">
+             <string>MP3 average bitrate</string>
+            </property>
+            <property name="accessibleDescription">
+             <string/>
+            </property>
+            <property name="text">
+             <string>MP3 average bitrate</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="6">
+           <spacer name="horizontalSpacer_19">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
See https://musescore.org/en/node/273880

Should we allow for VBR too, or instead of ABR? If so, would we need to allow quality setting (0-9, high -low), or just take the default (2, recommended)
 Should MuseScore continue to use 128kBit/s CBR on "Save online", or take benefit from ABR/VBR?
 Would a commandline option be needed for setting this?