### PR TITLE
fix #273917: Crash when adjusting a system bracket loaded from a template

### DIFF
--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -1060,6 +1060,7 @@ void Staff::init(const Staff* s)
       for (BracketItem* i : s->_brackets){
             BracketItem* ni = new BracketItem(*i);
             ni->setScore(score());
+            ni->setStaff(this);
             _brackets.push_back(ni);
             }
       _barLineSpan       = s->_barLineSpan;


### PR DESCRIPTION
See [Crash when adjusting a system bracket loaded from a template](https://musescore.org/en/node/273917).