### PR TITLE
fix #273919: Crash when adding text to a ChordRest

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -556,7 +556,7 @@ Element* ChordRest::drop(EditData& data)
                   if (st >= SubStyleId::DEFAULT && fromPalette)
                         t->textStyle().restyle(MScore::baseStyle()->textStyle(st), score()->textStyle(st));
 #endif
-                  if (fromPalette)
+                  if (e->isRehearsalMark() && fromPalette)
                         t->setXmlText(score()->createRehearsalMarkText(toRehearsalMark(e)));
                   }
 


### PR DESCRIPTION
See [Crash when adding text to a ChordRest](https://musescore.org/en/node/273919).