### PR TITLE
fix #273606: Augmentation dot button is not disabled

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3224,8 +3224,6 @@ void MuseScore::changeState(ScoreState val)
                         qDebug("disable synth control");
                   a->setEnabled(driver);
                   }
-            else if (s->key() == "pad-dot" || s->key() == "pad-dot-dot" || s->key() == "delete")
-                  a->setEnabled(!(val & (STATE_ALLTEXTUAL_EDIT | STATE_EDIT)));
             else {
                   a->setEnabled(s->state() & val);
                   }


### PR DESCRIPTION
Remove excessive statement in MuseScore::changeState(ScoreState val)