### PR TITLE
Fix #273963: Use `"/"`  rather than `QDir::separator()` for pathnames

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1745,7 +1745,7 @@ bool MuseScore::exportParts()
       QString skipMessage = tr("Skip");
       foreach (Excerpt* e, thisScore->excerpts())  {
             Score* pScore = e->partScore();
-            QString partfn = fi.absolutePath() + QDir::separator() + fi.completeBaseName() + "-" + createDefaultFileName(pScore->title()) + "." + ext;
+            QString partfn = fi.absolutePath() + "/" + fi.completeBaseName() + "-" + createDefaultFileName(pScore->title()) + "." + ext;
             QFileInfo fip(partfn);
             if (fip.exists() && !overwrite) {
                   if(noToAll)
@@ -1779,7 +1779,7 @@ bool MuseScore::exportParts()
             foreach(Excerpt* e, thisScore->excerpts())  {
                   scores.append(e->partScore());
                   }
-            QString partfn(fi.absolutePath() + QDir::separator() + fi.completeBaseName() + "-" + createDefaultFileName(tr("Score_and_Parts")) + ".pdf");
+            QString partfn(fi.absolutePath() + "/" + fi.completeBaseName() + "-" + createDefaultFileName(tr("Score_and_Parts")) + ".pdf");
             QFileInfo fip(partfn);
             if(fip.exists() && !overwrite) {
                   if (!noToAll) {

--- a/mscore/resourceManager.cpp
+++ b/mscore/resourceManager.cpp
@@ -169,7 +169,7 @@ void ResourceManager::download()
             QList<MQZipReader::FileInfo> allFiles = zipFile.fileInfoList();
             bool result = true;
             foreach (MQZipReader::FileInfo fi, allFiles) {
-                  const QString absPath = destinationDir + QDir::separator() + fi.filePath;
+                  const QString absPath = destinationDir + "/" + fi.filePath;
                   if (fi.isFile) {
                         QFile f(absPath);
                         if (!f.open(QIODevice::WriteOnly)) {

--- a/mscore3.txt
+++ b/mscore3.txt
@@ -158,6 +158,10 @@ Palette handling
               (see undo.h undo.cpp for example usage)
               TODO: check if they can be removed in system mode
 
+      * path separator
+            Don't use QDir::separtor(), but "/", see https://doc.qt.io/qt-5/qdir.html#separator
+            and http://agateau.com/2015/qdir-separator-considered-harmful/
+
 
 ====================================================================
       some rules


### PR DESCRIPTION
See also #3785