### PR TITLE
fix #166566: Exchange voices with partial measure selected works all the way to end of score

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2457,7 +2457,7 @@ void Score::cmdExchangeVoice(int s, int d)
             return;
 
       if (t2 > m2->tick())
-            m2 = 0;
+            m2 = m2->nextMeasure();
 
       for (;;) {
             undoExchangeVoice(m1, s, d, selection().staffStart(), selection().staffEnd());


### PR DESCRIPTION
See https://musescore.org/en/node/166566.

This function seems to assume that only entire measures are selected. This is understandable, since the operation works only on entire measures. If the selection ends at the end of a measure, t2 will be set to the start tick of the next measure (or the last tick in the score if there is no next measure), and m2 will be set to the measure that starts at t2 (or the last measure in the score if t2 is the last tick in the score). The only way t2 would be greater than m2->tick() would be if m2 were the last measure in the score. If this is the case, then m2->nextMeasure() is equal to 0, so the logic has not changed. What has changed is that if the selection ends somewhere in the middle of a measure, m2 is set to the correct measure at which to stop.