### PR TITLE
Make Score publicly inherited from ScoreElement

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -341,7 +341,7 @@ class Movements : public std::vector<MasterScore*> {
 //    a Score has always an associated MasterScore
 //---------------------------------------------------------------------------------------
 
-class Score : public QObject, ScoreElement {
+class Score : public QObject, public ScoreElement {
       Q_OBJECT
       Q_PROPERTY(int                            duration          READ duration)
 //      Q_PROPERTY(QQmlListProperty<Ms::Excerpt>  excerpts          READ qmlExcerpts)


### PR DESCRIPTION
Currently `Score` class is privately inherited from `ScoreElement` which prevents casts from `Score*` to `ScoreElement*` and back and makes some differences for `Score` in having a common interface with other `ScoreElement`-derived classes. A private inheritance in this case was introduced in [this change](https://github.com/musescore/MuseScore/commit/90b1991912d33981dc7bc7d2390bd279f3c45783#diff-8f7bac98173627fe227baa9306520c3cL344) which may have been done just by accident. Although the listed issues may be worked around (for example, by using a friend classes mechanism) having a public inheritance seems to be a better solution, and there seem to be no reasons to make it private in this case. The proposed change makes this inheritance public as it was before the mentioned change.

Feel free to correct me if I am wrong in such a proposal.