### PR TITLE
fix #274026: Unable to save synth settings in two scores in the same session

### DIFF
--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -206,6 +206,16 @@ void SynthControl::setMeter(float l, float r, float left_peak, float right_peak)
       }
 
 //---------------------------------------------------------
+//   setScore
+//---------------------------------------------------------
+void SynthControl::setScore(Score* s) {
+      _score = s;
+
+      loadButton->setEnabled(true);
+      saveButton->setEnabled(true);
+      }
+
+//---------------------------------------------------------
 //   stop
 //---------------------------------------------------------
 

--- a/mscore/synthcontrol.h
+++ b/mscore/synthcontrol.h
@@ -73,7 +73,7 @@ class SynthControl : public QWidget, Ui::SynthControl {
       SynthControl(QWidget* parent);
       void setMeter(float, float, float, float);
       void stop();
-      void setScore(Score* s) { _score = s; }
+      void setScore(Score* s);
       void writeSettings();
       };
 }


### PR DESCRIPTION
Simple fix. Buttons 'save/load to Score' always become enable when user click on another score. In the current implementation, there is no verification of already loaded synth. 