### PR TITLE
fix #274028: Courtesy accidental on tied note ignored later in measure

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1648,6 +1648,8 @@ void Score::changeAccidental(Note* note, AccidentalType accidental)
             if (forceRemove) {
                   if (a)
                         lns->undoRemoveElement(a);
+                  if (ln->tieBack())
+                        continue;
                   }
             else if (forceAdd) {
                   if (a)

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -348,7 +348,7 @@ AccidentalVal Measure::findAccidental(Note* note) const
                         Chord* chord = toChord(e);
                         for (Chord* chord1 : chord->graceNotes()) {
                               for (Note* note1 : chord1->notes()) {
-                                    if (note1->tieBack())
+                                    if (note1->tieBack() && note1->accidental() == 0)
                                           continue;
                                     //
                                     // compute accidental
@@ -362,7 +362,7 @@ AccidentalVal Measure::findAccidental(Note* note) const
                                     }
                               }
                         for (Note* note1 : chord->notes()) {
-                              if (note1->tieBack())
+                              if (note1->tieBack() && note1->accidental() == 0)
                                     continue;
                               //
                               // compute accidental
@@ -409,7 +409,7 @@ AccidentalVal Measure::findAccidental(Segment* s, int staffIdx, int line, bool &
                   Chord* chord = toChord(e);
                   for (Chord* chord1 : chord->graceNotes()) {
                         for (Note* note : chord1->notes()) {
-                              if (note->tieBack())
+                              if (note->tieBack() && note->accidental() == 0)
                                     continue;
                               int tpc  = note->tpc();
                               int l    = absStep(tpc, note->epitch());
@@ -418,7 +418,7 @@ AccidentalVal Measure::findAccidental(Segment* s, int staffIdx, int line, bool &
                         }
 
                   for (Note* note : chord->notes()) {
-                        if (note->tieBack())
+                        if (note->tieBack() && note->accidental() == 0)
                               continue;
                         int tpc    = note->tpc();
                         int l      = absStep(tpc, note->epitch());

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2137,7 +2137,7 @@ void Note::updateAccidental(AccidentalState* as)
                   return;
                   }
             if ((accVal != relLineAccVal) || hidden() || as->tieContext(relLine)) {
-                  as->setAccidentalVal(relLine, accVal, _tieBack != 0);
+                  as->setAccidentalVal(relLine, accVal, _tieBack != 0 && _accidental == 0);
                   acci = Accidental::value2subtype(accVal);
                   // if previous tied note has same tpc, don't show accidental
                   if (_tieBack && _tieBack->startNote()->tpc1() == tpc1())
@@ -2186,7 +2186,7 @@ void Note::updateAccidental(AccidentalState* as)
             // ultimetely, they should probably get their own state
             // for now, at least change state to natural, so subsequent notes playback as might be expected
             // this is an incompatible change, but better to break it for 2.0 than wait until later
-            as->setAccidentalVal(relLine, AccidentalVal::NATURAL, _tieBack != 0);
+            as->setAccidentalVal(relLine, AccidentalVal::NATURAL, _tieBack != 0 && _accidental == 0);
             }
 
       updateRelLine(relLine, true);


### PR DESCRIPTION
See https://musescore.org/en/node/274028.