### PR TITLE
Revert the unison restriking patch

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -166,7 +166,7 @@ static void playNote(EventMap* events, const Note* note, int channel, int pitch,
       NPlayEvent ev(ME_NOTEON, channel, pitch, velo);
       ev.setOriginatingStaff(staffIdx);
       ev.setTuning(note->tuning());
-      ev.setNote(note);
+      ev.notes.push_back(note);
       if (offTime < onTime)
             offTime = onTime;
       events->insert(std::pair<int, NPlayEvent>(onTime, ev));

--- a/mscore/exportmidi.cpp
+++ b/mscore/exportmidi.cpp
@@ -289,16 +289,7 @@ bool ExportMidi::write(const QString& name, bool midiExpandRepeats)
                         for (auto i = events.begin(); i != events.end(); ++i) {
                               const NPlayEvent& event = i->second;
 
-                              if (event.discard() == staffIdx + 1 && event.velo() > 0)
-                                    // turn note off so we can restrike it in another track
-                                    track.insert(pauseMap.addPauseTicks(i->first), MidiEvent(ME_NOTEON, channel,
-                                                                     event.pitch(), 0));
-
                               if (event.getOriginatingStaff() != staffIdx)
-                                    continue;
-
-                              if (event.discard() && event.velo() == 0)
-                                    // ignore noteoff but restrike noteon
                                     continue;
 
                               char eventPort    = cs->midiPort(event.channel());

--- a/mtest/libmscore/midi/tst_midi.cpp
+++ b/mtest/libmscore/midi/tst_midi.cpp
@@ -378,7 +378,6 @@ void TestMidi::events()
       QTextStream out(&filehandler);
       multimap<int, NPlayEvent> ::iterator iter;
       for (auto iter = events.begin(); iter!= events.end(); ++iter){
-            if (iter->second.discard()) continue;
             out << qSetFieldWidth(5) << "Tick  =  ";
             out << qSetFieldWidth(5) << iter->first;
             out << qSetFieldWidth(5) << "   Type  = ";

--- a/synthesizer/event.cpp
+++ b/synthesizer/event.cpp
@@ -390,28 +390,37 @@ void EventMap::fixupMIDI()
 
       auto it = begin();
       while (it != end()) {
+            bool discard = false;
+
             /* ME_NOTEOFF is never emitted, no need to check for it */
             if (it->second.type() == ME_NOTEON) {
                   unsigned short np = info[it->second.channel()].nowPlaying[it->second.pitch()];
                   if (it->second.velo() == 0) {
                         /* already off (should not happen) or still playing? */
                         if (np == 0 || --np > 0)
-                              it->second.setDiscard(1);
+                              discard = true;
                         else {
                               /* hoist NOTEOFF to same track as NOTEON */
                               it->second.setOriginatingStaff(info[it->second.channel()].event[it->second.pitch()]->getOriginatingStaff());
+                              /* copy linked Notes */
+                              it->second.notes = info[it->second.channel()].event[it->second.pitch()]->notes;
                               }
                         }
-                  else {
-                        if (++np > 1)
-                              /* restrike, possibly on different track */
-                              it->second.setDiscard(info[it->second.channel()].event[it->second.pitch()]->getOriginatingStaff() + 1);
-                        info[it->second.channel()].event[it->second.pitch()] = &(it->second);
+                  else if (++np > 1) {
+                        /* already playing */
+                        discard = true;
+                        /* carry over the corresponding score notes */
+                        info[it->second.channel()].event[it->second.pitch()]->notes.insert(info[it->second.channel()].event[it->second.pitch()]->notes.end(), it->second.notes.begin(), it->second.notes.end());
                         }
+                  else
+                        info[it->second.channel()].event[it->second.pitch()] = &(it->second);
                   info[it->second.channel()].nowPlaying[it->second.pitch()] = np;
                   }
 
-            ++it;
+            if (discard)
+                  it = erase(it);
+            else
+                  ++it;
             }
 
             free((void *)info);

--- a/synthesizer/event.h
+++ b/synthesizer/event.h
@@ -234,9 +234,7 @@ class PlayEvent : public MidiCoreEvent {
 //---------------------------------------------------------
 
 class NPlayEvent : public PlayEvent {
-      const Note* _note = 0;
       int _origin = -1;
-      int _discard = 0;
 
    public:
       NPlayEvent() : PlayEvent() {}
@@ -245,13 +243,10 @@ class NPlayEvent : public PlayEvent {
       NPlayEvent(const MidiCoreEvent& e) : PlayEvent(e) {}
       NPlayEvent(BeatType beatType);
 
-      const Note* note() const       { return _note; }
-      void setNote(const Note* v)    { _note = v; }
+      std::vector<const Note*> notes;
 
       int getOriginatingStaff() const { return _origin; }
       void setOriginatingStaff(int i) { _origin = i; }
-      void setDiscard(int d) { _discard = d; }
-      int discard() const { return _discard; }
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR is intended to help debugging the [popped-up again “Same note in different voices and lengths plays only the length of the shortest note” issue](https://musescore.org/en/node/12971#comment-843432) in `2.3.1`.

This patch will _also_ need to be applied *anyway* when restriking will be reverted, once we have a more user-friendly UI for stave/voice → channel assignment, so it’s not completely useless… it’s effectively reverting the second commit (96d95c798) from [the `3.0` PR](https://github.com/musescore/MuseScore/pull/3548), except against `2.3.1`.