### PR TITLE
fix #274071: add fingering to non-pitched staves

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3813,8 +3813,11 @@ void ScoreView::cmdAddText(TEXT type)
             case TEXT::FINGERING:
                   {
                   Element* e = _score->getSelectedElement();
-                  if (!e || !e->isNote()
-                     || !e->staff()->isPitchedStaff(e->tick()))
+                  if (!e || !e->isNote())
+                        break;
+                  bool isTablature = e->staff()->isTabStaff(e->tick());
+                  bool tabFingering = e->staff()->staffType(e->tick())->showTabFingering();
+                  if (isTablature && !tabFingering)
                         break;
                   s = new Fingering(_score);
                   s->setTrack(e->track());


### PR DESCRIPTION
Very straightforward, the code already supports adding fingerings, we were just disabling this command unnecessarily.