### PR TITLE
fix #274117: Crash on timewise delete of tuplet

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -682,6 +682,7 @@ class Score : public QObject, public ScoreElement {
 
       void repitchNote(const Position& pos, bool replace);
       void regroupNotesAndRests(int startTick, int endTick, int track);
+      bool checkTimeDelete(Segment*, Segment*);
       void timeDelete(Measure*, Segment*, const Fraction&);
 
       void startCmd();                          // start undoable command


### PR DESCRIPTION
Also, fix #137821: Timewise Delete doesn't behave the same on last chordrest of a measure

See https://musescore.org/en/node/274117
and https://musescore.org/en/node/137821.