### PR TITLE
fix #273601: Updated UI for pianoroll editor.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -145,16 +145,20 @@ void Score::startCmd()
 //   undoRedo
 //---------------------------------------------------------
 
-void Score::undoRedo(bool undo, EditData* ed)
+void Score::undoRedo(bool undo, EditData* ed, bool updateSelect)
       {
-      deselectAll();
+      if (updateSelect)
+            deselectAll();
+      
       cmdState().reset();
       if (undo)
             undoStack()->undo(ed);
       else
             undoStack()->redo(ed);
       update();
-      updateSelection();
+      
+      if (updateSelect)
+            updateSelection();
       }
 
 //---------------------------------------------------------
@@ -1318,7 +1322,7 @@ static void setTpc(Note* oNote, int tpc, int& newTpc1, int& newTpc2)
 ///   Increment/decrement pitch of note by one or by an octave.
 //---------------------------------------------------------
 
-void Score::upDown(bool up, UpDownMode mode)
+void Score::upDown(bool up, UpDownMode mode, bool updateSelection)
       {
       QList<Note*> el = selection().uniqueNotes();
 
@@ -1487,9 +1491,42 @@ void Score::upDown(bool up, UpDownMode mode)
             setPlayNote(true);
             }
 
-      _selection.clear();
-      for (Note* note : el)
-            _selection.add(note);
+      if (updateSelection)
+            {
+            _selection.clear();
+            for (Note* note : el)
+                  _selection.add(note);
+            }
+      }
+
+//---------------------------------------------------------
+//   upDownDelta
+///   Add the delta to the pitch of note.
+//---------------------------------------------------------
+
+void Score::upDownDelta(int pitchDelta, bool updateSelection)
+      {
+      while (pitchDelta >= 12)
+            {
+            upDown(true, UpDownMode::OCTAVE, updateSelection);
+            pitchDelta -= 12;
+            }
+      while (pitchDelta > 0)
+            {
+            upDown(true, UpDownMode::CHROMATIC, updateSelection);
+            pitchDelta--;
+            }
+
+      while (pitchDelta <= -12)
+            {
+            upDown(false, UpDownMode::OCTAVE, updateSelection);
+            pitchDelta += 12;
+            }
+      while (pitchDelta < 0)
+            {
+            upDown(false, UpDownMode::CHROMATIC, updateSelection);
+            pitchDelta++;
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -647,7 +647,8 @@ class Score : public QObject, public ScoreElement {
       ChordRest* addClone(ChordRest* cr, int tick, const TDuration& d);
       Rest* setRest(int tick,  int track, Fraction, bool useDots, Tuplet* tuplet, bool useFullMeasureRest = true);
 
-      void upDown(bool up, UpDownMode);
+      void upDown(bool up, UpDownMode, bool updateSelection = true);
+      void upDownDelta(int pitchDelta, bool updateSelection = true);
       ChordRest* searchNote(int tick, int track) const;
 
       // undo/redo ops
@@ -688,7 +689,7 @@ class Score : public QObject, public ScoreElement {
       void startCmd();                          // start undoable command
       void endCmd(bool rollback = false);       // end undoable command
       void update();
-      void undoRedo(bool undo, EditData*);
+      void undoRedo(bool undo, EditData*, bool updateSelect = true);
 
       void cmdRemoveTimeSig(TimeSig*);
       void cmdAddTimeSig(Measure*, int staffIdx, TimeSig*, bool local);

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -259,8 +259,8 @@ add_executable ( ${ExecutableName}
       timesigproperties.cpp newwizard.cpp transposedialog.cpp
       excerptsdialog.cpp metaedit.cpp magbox.cpp
       capella.cpp capxml.cpp exportaudio.cpp palettebox.cpp
-      synthcontrol.cpp drumroll.cpp pianoroll.cpp piano.cpp
-      pianoview.cpp drumview.cpp scoretab.cpp keyedit.cpp harmonyedit.cpp
+      synthcontrol.cpp drumroll.cpp pianoroll.cpp piano.cpp pianokeyboard.cpp
+      pianoruler.cpp pianoview.cpp drumview.cpp scoretab.cpp keyedit.cpp harmonyedit.cpp
       updatechecker.cpp
       importove.cpp
       ove.cpp

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -673,7 +673,7 @@ void ScoreView::contextMenuEvent(QContextMenuEvent* ev)
             int staffIdx;
             Measure* m = _score->pos2measure(editData.startMove, &staffIdx, 0, 0, 0);
             if (m && m->staffLines(staffIdx)->canvasBoundingRect().contains(editData.startMove))
-                  measurePopup(gp, m);
+                  measurePopup(ev, m);
             else {
                   QMenu* popup = new QMenu();
                   popup->addAction(getAction("edit-style"));

--- a/mscore/inspector/inspector_arpeggio.ui
+++ b/mscore/inspector/inspector_arpeggio.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>76</width>
-    <height>60</height>
+    <height>69</height>
    </rect>
   </property>
   <property name="accessibleName">
-   <string>Glissando Inspector</string>
+   <string>Arpeggio Inspector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/mscore/inspector/inspector_bend.ui
+++ b/mscore/inspector/inspector_bend.ui
@@ -14,7 +14,7 @@
    <string/>
   </property>
   <property name="accessibleName">
-   <string>Glissando Inspector</string>
+   <string>Bend Inspector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/mscore/inspector/inspector_break.ui
+++ b/mscore/inspector/inspector_break.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="accessibleName">
-   <string>Element Inspector</string>
+   <string>Layout Break Inspector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/mscore/inspector/inspector_fermata.ui
+++ b/mscore/inspector/inspector_fermata.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="accessibleName">
-   <string>Articulation Inspector</string>
+   <string>Fermata Inspector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/mscore/inspector/inspector_fret.ui
+++ b/mscore/inspector/inspector_fret.ui
@@ -178,12 +178,18 @@
         <property name="text">
          <string>Frets:</string>
         </property>
+        <property name="buddy">
+         <cstring>frets</cstring>
+        </property>
        </widget>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
          <string>Barre:</string>
+        </property>
+        <property name="buddy">
+         <cstring>barre</cstring>
         </property>
        </widget>
       </item>
@@ -208,6 +214,9 @@
         <property name="text">
          <string>Strings:</string>
         </property>
+        <property name="buddy">
+         <cstring>strings</cstring>
+        </property>
        </widget>
       </item>
       <item row="2" column="2">
@@ -216,7 +225,7 @@
          <string>Reset to default</string>
         </property>
         <property name="accessibleName">
-         <string>Reset 'Placement' value</string>
+         <string>Reset 'Strings' value</string>
         </property>
         <property name="text">
          <string notr="true"/>
@@ -250,7 +259,7 @@
          <string>Reset to default</string>
         </property>
         <property name="accessibleName">
-         <string>Reset 'Placement' value</string>
+         <string>Reset 'Frets' value</string>
         </property>
         <property name="text">
          <string notr="true"/>
@@ -267,7 +276,7 @@
          <string>Reset to default</string>
         </property>
         <property name="accessibleName">
-         <string>Reset 'Placement' value</string>
+         <string>Reset 'Barre' value</string>
         </property>
         <property name="text">
          <string notr="true"/>
@@ -283,6 +292,9 @@
         <property name="text">
          <string>Offset:</string>
         </property>
+        <property name="buddy">
+         <cstring>offset</cstring>
+        </property>
        </widget>
       </item>
       <item row="6" column="1">
@@ -294,7 +306,7 @@
          <string>Reset to default</string>
         </property>
         <property name="accessibleName">
-         <string>Reset 'Placement' value</string>
+         <string>Reset 'Offset' value</string>
         </property>
         <property name="text">
          <string notr="true"/>
@@ -314,6 +326,16 @@
   <tabstop>title</tabstop>
   <tabstop>mag</tabstop>
   <tabstop>resetMag</tabstop>
+  <tabstop>placement</tabstop>
+  <tabstop>resetPlacement</tabstop>
+  <tabstop>strings</tabstop>
+  <tabstop>resetStrings</tabstop>
+  <tabstop>frets</tabstop>
+  <tabstop>resetFrets</tabstop>
+  <tabstop>barre</tabstop>
+  <tabstop>resetBarre</tabstop>
+  <tabstop>offset</tabstop>
+  <tabstop>resetOffset</tabstop>
   <tabstop>properties</tabstop>
  </tabstops>
  <resources>

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -498,6 +498,18 @@
   <tabstop>resetType</tabstop>
   <tabstop>showText</tabstop>
   <tabstop>resetShowText</tabstop>
+  <tabstop>text</tabstop>
+  <tabstop>resetText</tabstop>
+  <tabstop>fontFace</tabstop>
+  <tabstop>resetFontFace</tabstop>
+  <tabstop>fontSize</tabstop>
+  <tabstop>resetFontSize</tabstop>
+  <tabstop>fontBold</tabstop>
+  <tabstop>resetFontBold</tabstop>
+  <tabstop>fontItalic</tabstop>
+  <tabstop>resetFontItalic</tabstop>
+  <tabstop>fontUnderline</tabstop>
+  <tabstop>resetFontUnderline</tabstop>
   <tabstop>glissandoStyle</tabstop>
   <tabstop>resetGlissandoStyle</tabstop>
   <tabstop>playGlissando</tabstop>

--- a/mscore/inspector/inspector_harmony.ui
+++ b/mscore/inspector/inspector_harmony.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="accessibleName">
-   <string>Image Inspector</string>
+   <string>Chord Symbol Inspector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
@@ -44,7 +44,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Chord Name</string>
+      <string>Chord Symbol</string>
      </property>
     </widget>
    </item>
@@ -95,8 +95,6 @@
  <tabstops>
   <tabstop>title</tabstop>
  </tabstops>
- <resources>
-  <include location="../musescore.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_lasso.ui
+++ b/mscore/inspector/inspector_lasso.ui
@@ -49,6 +49,19 @@
     </widget>
    </item>
    <item>
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::HLine</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <property name="lineWidth">
+      <number>2</number>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QWidget" name="widget" native="true">
      <layout class="QGridLayout" name="gridLayout">
       <property name="leftMargin">
@@ -74,19 +87,6 @@
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Size:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QFrame" name="frame">
-        <property name="frameShape">
-         <enum>QFrame::HLine</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <property name="lineWidth">
-         <number>2</number>
         </property>
        </widget>
       </item>

--- a/mscore/inspector/inspector_lyric.ui
+++ b/mscore/inspector/inspector_lyric.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="accessibleName">
-   <string>Articulation Inspector</string>
+   <string>Lyrics Inspector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/mscore/inspector/inspector_slur.ui
+++ b/mscore/inspector/inspector_slur.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>168</width>
+    <width>177</width>
     <height>91</height>
    </rect>
   </property>
   <property name="accessibleName">
-   <string>Slur Inspector</string>
+   <string>Slur/Tie Inspector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/mscore/inspector/inspector_stem.ui
+++ b/mscore/inspector/inspector_stem.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="accessibleName">
-   <string>Clef Inspector</string>
+   <string>Stem Inspector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
@@ -107,6 +107,9 @@
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Line width:</string>
+        </property>
+        <property name="buddy">
+         <cstring>lineWidth</cstring>
         </property>
        </widget>
       </item>

--- a/mscore/inspector/inspector_tempotext.ui
+++ b/mscore/inspector/inspector_tempotext.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="accessibleName">
-   <string>Tempo Marking Inspector</string>
+   <string>Tempo Text Inspector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
@@ -44,7 +44,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Tempo Marking</string>
+      <string>Tempo Text</string>
      </property>
     </widget>
    </item>

--- a/mscore/inspector/inspector_text.ui
+++ b/mscore/inspector/inspector_text.ui
@@ -658,10 +658,20 @@
   <tabstop>underline</tabstop>
   <tabstop>resetUnderline</tabstop>
   <tabstop>resetAlign</tabstop>
+  <tabstop>hasFrame</tabstop>
+  <tabstop>resetHasFrame</tabstop>
   <tabstop>circle</tabstop>
   <tabstop>resetCircle</tabstop>
   <tabstop>square</tabstop>
   <tabstop>resetSquare</tabstop>
+  <tabstop>resetFrameColor</tabstop>
+  <tabstop>resetBgColor</tabstop>
+  <tabstop>frameWidth</tabstop>
+  <tabstop>resetFrameWidth</tabstop>
+  <tabstop>paddingWidth</tabstop>
+  <tabstop>resetPaddingWidth</tabstop>
+  <tabstop>frameRound</tabstop>
+  <tabstop>resetFrameRound</tabstop>
   <tabstop>resetToStyle</tabstop>
  </tabstops>
  <resources>

--- a/mscore/inspector/inspector_textline.ui
+++ b/mscore/inspector/inspector_textline.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>290</width>
+    <width>298</width>
     <height>605</height>
    </rect>
   </property>
@@ -1331,6 +1331,65 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>title</tabstop>
+  <tabstop>beginHookType</tabstop>
+  <tabstop>resetBeginHookType</tabstop>
+  <tabstop>beginHookHeight</tabstop>
+  <tabstop>resetBeginHookHeight</tabstop>
+  <tabstop>endHookType</tabstop>
+  <tabstop>resetEndHookType</tabstop>
+  <tabstop>endHookHeight</tabstop>
+  <tabstop>resetEndHookHeight</tabstop>
+  <tabstop>hasBeginText</tabstop>
+  <tabstop>beginText</tabstop>
+  <tabstop>resetBeginText</tabstop>
+  <tabstop>beginFontFace</tabstop>
+  <tabstop>resetBeginFontFace</tabstop>
+  <tabstop>beginFontSize</tabstop>
+  <tabstop>resetBeginFontSize</tabstop>
+  <tabstop>beginFontBold</tabstop>
+  <tabstop>resetBeginFontBold</tabstop>
+  <tabstop>beginFontItalic</tabstop>
+  <tabstop>resetBeginFontItalic</tabstop>
+  <tabstop>beginFontUnderline</tabstop>
+  <tabstop>resetBeginFontUnderline</tabstop>
+  <tabstop>beginTextPlacement</tabstop>
+  <tabstop>resetBeginTextPlacement</tabstop>
+  <tabstop>resetBeginTextOffset</tabstop>
+  <tabstop>hasContinueText</tabstop>
+  <tabstop>continueText</tabstop>
+  <tabstop>resetContinueText</tabstop>
+  <tabstop>continueFontFace</tabstop>
+  <tabstop>resetContinueFontFace</tabstop>
+  <tabstop>continueFontSize</tabstop>
+  <tabstop>resetContinueFontSize</tabstop>
+  <tabstop>continueFontBold</tabstop>
+  <tabstop>resetContinueFontBold</tabstop>
+  <tabstop>continueFontItalic</tabstop>
+  <tabstop>resetContinueFontItalic</tabstop>
+  <tabstop>continueFontUnderline</tabstop>
+  <tabstop>resetContinueFontUnderline</tabstop>
+  <tabstop>continueTextPlacement</tabstop>
+  <tabstop>resetContinueTextPlacement</tabstop>
+  <tabstop>resetContinueTextOffset</tabstop>
+  <tabstop>hasEndText</tabstop>
+  <tabstop>endText</tabstop>
+  <tabstop>resetEndText</tabstop>
+  <tabstop>endFontFace</tabstop>
+  <tabstop>resetEndFontFace</tabstop>
+  <tabstop>endFontSize</tabstop>
+  <tabstop>resetEndFontSize</tabstop>
+  <tabstop>endFontBold</tabstop>
+  <tabstop>resetEndFontBold</tabstop>
+  <tabstop>endFontItalic</tabstop>
+  <tabstop>resetEndFontItalic</tabstop>
+  <tabstop>endFontUnderline</tabstop>
+  <tabstop>resetEndFontUnderline</tabstop>
+  <tabstop>endTextPlacement</tabstop>
+  <tabstop>resetEndTextPlacement</tabstop>
+  <tabstop>resetEndTextOffset</tabstop>
+ </tabstops>
  <resources>
   <include location="../musescore.qrc"/>
  </resources>

--- a/mscore/inspector/inspector_tuplet.ui
+++ b/mscore/inspector/inspector_tuplet.ui
@@ -529,12 +529,25 @@
  </widget>
  <tabstops>
   <tabstop>title</tabstop>
+  <tabstop>tupletFontFace</tabstop>
+  <tabstop>resetTupletFontFace</tabstop>
+  <tabstop>tupletFontSize</tabstop>
+  <tabstop>resetTupletFontSize</tabstop>
+  <tabstop>tupletBold</tabstop>
+  <tabstop>resetTupletBold</tabstop>
+  <tabstop>tupletItalic</tabstop>
+  <tabstop>resetTupletItalic</tabstop>
+  <tabstop>tupletUnderline</tabstop>
+  <tabstop>resetTupletUnderline</tabstop>
+  <tabstop>title_2</tabstop>
   <tabstop>direction</tabstop>
   <tabstop>resetDirection</tabstop>
   <tabstop>numberType</tabstop>
   <tabstop>resetNumberType</tabstop>
   <tabstop>bracketType</tabstop>
   <tabstop>resetBracketType</tabstop>
+  <tabstop>lineWidth</tabstop>
+  <tabstop>resetLineWidth</tabstop>
  </tabstops>
  <resources>
   <include location="../musescore.qrc"/>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4233,13 +4233,14 @@ void MuseScore::handleMessage(const QString& message)
 //   editInPianoroll
 //---------------------------------------------------------
 
-void MuseScore::editInPianoroll(Staff* staff)
+void MuseScore::editInPianoroll(Staff* staff, Position *p)
       {
       if (pianorollEditor == 0)
             pianorollEditor = new PianorollEditor;
       pianorollEditor->setScore(staff->score());
       pianorollEditor->setStaff(staff);
       pianorollEditor->show();
+      pianorollEditor->focusOnPosition(p);
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -583,7 +583,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QString lastSaveDirectory;
       QString lastSaveCaptureName;
       SynthControl* getSynthControl() const       { return synthControl; }
-      void editInPianoroll(Staff* staff);
+      void editInPianoroll(Staff* staff, Position* p = 0);
       void editInDrumroll(Staff* staff);
       PianorollEditor* getPianorollEditor() const { return pianorollEditor; }
       DrumrollEditor* getDrumrollEditor() const   { return drumrollEditor; }

--- a/mscore/pianokeyboard.cpp
+++ b/mscore/pianokeyboard.cpp
@@ -1,0 +1,301 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "pianokeyboard.h"
+
+#include "libmscore/staff.h"
+#include "libmscore/part.h"
+#include "libmscore/drumset.h"
+
+namespace Ms {
+
+const QColor colKeySelect = QColor(224, 170, 20);
+
+PianoKeyboard::PianoKeyboard(QWidget* parent)
+   : QWidget(parent)
+      {
+      setMouseTracking(true);
+      setAttribute(Qt::WA_NoSystemBackground);
+      setAttribute(Qt::WA_StaticContents);
+      setMouseTracking(true);
+      yRange   = noteHeight * 128;
+      curPitch = -1;
+      _ypos    = 0;
+      curKeyPressed = -1;
+      noteHeight = DEFAULT_KEY_HEIGHT;
+      _orientation = PianoOrientation::VERTICAL;
+      _staff = 0;
+      }
+
+
+
+//---------------------------------------------------------
+//   paint
+//---------------------------------------------------------
+
+void PianoKeyboard::paintEvent(QPaintEvent* /*event*/)
+      {
+      QPainter p(this);
+      p.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
+      
+      const int fontSize = 8;
+      QFont f("FreeSans", fontSize);
+      p.setFont(f);
+
+      //Check for drumset, if any
+      Part* part = _staff->part();
+      Drumset* ds = part->instrument()->drumset();
+      
+      p.setPen(QPen(Qt::black, 2));
+      
+      int keyboardLen = 128 * noteHeight;
+      const int blackKeyLen = PIANO_KEYBOARD_HEIGHT * 9 / 14;
+
+      const qreal whiteKeyOffset[] = {0, 1.5, 3.5, 5, 6.5, 8.5, 10.5, 12};
+      const int whiteKeyDegree[] = {0, 2, 4, 5, 7, 9, 11};
+      const qreal blackKeyOffset[] = {1.5, 3.5, 6.5, 8.5, 10.5};
+      const int blackKeyDegree[] = {1, 3, 6, 8, 10};
+      const QString pitchNames[] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+      
+      int pitch = -1;
+      for (int octave = 0; octave < 11; ++octave) {
+            //White keys
+            p.setPen(QPen(Qt::black));
+            
+            for (int key = 0; key < 7; ++key) {
+                  int degree = whiteKeyDegree[key];
+                  
+                  pitch = degree + octave * 12;
+                  if (pitch >= 128)
+                        break;
+
+                  QString noteName = pitchNames[degree] % QString::number(octave - 1);
+                  if (ds)
+                        noteName = ds->name(pitch);
+                  
+                  p.setBrush(curPitch == pitch ? colKeySelect : Qt::white);
+
+                  qreal off1 = whiteKeyOffset[key] * noteHeight + octave * 12 * noteHeight;
+                  qreal off2 = whiteKeyOffset[key + 1] * noteHeight + octave * 12 * noteHeight;
+                  if (_orientation == PianoOrientation::HORIZONTAL) {
+                        QRectF rect(-_ypos + off2, 0, off2 - off1, PIANO_KEYBOARD_HEIGHT);
+                        p.drawRect(rect);
+                        
+                        if (degree == 0 && noteHeight > fontSize + 2) {
+                              QRectF rectText(rect.x() + 1, rect.y(), rect.height() - 2, rect.width() - 2);
+                              QTransform xform = p.transform();
+                              p.rotate(90);
+                              p.drawText(rectText, 
+                                      ds ?  Qt::AlignLeft | Qt::AlignBottom
+                                          : Qt::AlignRight | Qt::AlignBottom,
+                                      noteName);
+                              p.setTransform(xform);
+                              }
+                        }
+                  else {
+                        QRectF rect(0, -_ypos + keyboardLen - off2, PIANO_KEYBOARD_HEIGHT, off2 - off1);
+                        
+                        p.drawRect(rect);
+                        
+                        if (noteHeight > fontSize + 2) {
+                              if (ds) {
+                                    QRectF rectText(rect.x() + 1, -_ypos + keyboardLen - (pitch + 1) * noteHeight, rect.width() - 1, noteHeight);
+                                    
+                                    p.drawText(rectText, Qt::AlignBottom | Qt::AlignLeft, noteName);
+                                    }
+                              else if (degree == 0) {
+                                    QRectF rectText(rect.x(), rect.y(), rect.width() - 4, rect.height() - 1);
+                                    p.drawText(rectText, Qt::AlignRight | Qt::AlignBottom, noteName);
+                                    }
+                              }
+                        }
+                  }
+            
+            //Black keys
+            for (int key = 0; key < 5; ++key) {
+                  pitch = blackKeyDegree[key] + octave * 12;
+                  if (pitch >= 128)
+                        break;
+
+                  QString noteName = pitchNames[blackKeyDegree[key]]  % QString::number(octave) + " ";
+                  if (ds)
+                        noteName = ds->name(pitch);
+                  
+                  qreal center = blackKeyOffset[key] * noteHeight;
+                  qreal offset = center - noteHeight / 2.0 + octave * 12 * noteHeight;
+                  
+                  p.setPen(QPen(Qt::black));
+                  p.setBrush(curPitch == pitch ? colKeySelect : Qt::black);
+                  
+                  if (_orientation == PianoOrientation::HORIZONTAL) {
+                        QRectF rect(offset, 0, noteHeight, blackKeyLen);
+                        
+                        p.drawRect(rect);
+                        
+                        if (ds) {
+                              if (noteHeight > fontSize + 2)
+                                    {
+                                    rect.setWidth(blackKeyLen);
+                                    rect.setHeight(noteHeight);
+                                    
+                                    p.setPen(QPen(Qt::white));
+                                    p.drawText(rect, Qt::AlignLeft | Qt::AlignBottom, noteName);
+                                    }
+                              }
+                        }
+                  else {
+                        QRectF rect(0, -_ypos + keyboardLen - offset - noteHeight, blackKeyLen, noteHeight);
+                        
+                        p.drawRect(rect);
+                        
+                        if (noteHeight > fontSize + 2) {
+                              if (ds) {
+                                    p.setPen(QPen(Qt::white));
+                                    p.drawText(rect, Qt::AlignLeft | Qt::AlignBottom, noteName);
+                                    }
+                              }
+                        }
+                  }
+            }
+      
+      
+      }
+
+//---------------------------------------------------------
+//   setYpos
+//---------------------------------------------------------
+
+void PianoKeyboard::setYpos(int val)
+      {
+      if (_ypos != val) {
+            _ypos = val;
+            update();
+            }
+      }
+
+//---------------------------------------------------------
+//   setNoteHeight
+//---------------------------------------------------------
+
+void PianoKeyboard::setNoteHeight(int nh)
+      {
+      if (noteHeight != nh) {
+            noteHeight = nh;
+            update();
+            }
+      }
+
+//---------------------------------------------------------
+//   setPitch
+//---------------------------------------------------------
+
+void PianoKeyboard::setPitch(int val)
+      {
+      if (curPitch != val) {
+            curPitch = val;
+            update();
+            }
+      }
+
+//---------------------------------------------------------
+//   mousePressEvent
+//---------------------------------------------------------
+
+void PianoKeyboard::mousePressEvent(QMouseEvent* event)
+      {
+      int offset = _orientation == PianoOrientation::HORIZONTAL
+            ? event->pos().x()
+            : 128 * noteHeight - (event->y() + _ypos);
+      
+      curKeyPressed = offset / noteHeight;
+      if (curKeyPressed < 0 || curKeyPressed > 127)
+            curKeyPressed = -1;
+      
+      //curKeyPressed = y2pitch(event->pos().y());
+      emit keyPressed(curKeyPressed);
+      }
+
+//---------------------------------------------------------
+//   mouseReleaseEvent
+//---------------------------------------------------------
+
+void PianoKeyboard::mouseReleaseEvent(QMouseEvent*)
+      {
+      emit keyReleased(curKeyPressed);
+      curKeyPressed = -1;
+      }
+
+//---------------------------------------------------------
+//   mouseMoveEvent
+//---------------------------------------------------------
+
+void PianoKeyboard::mouseMoveEvent(QMouseEvent* event)
+      {
+      int offset = _orientation == PianoOrientation::HORIZONTAL
+            ? event->pos().x()
+            : 128 * noteHeight - (event->y() + _ypos);
+      int pitch = offset / noteHeight;
+
+      if (pitch != curPitch) {
+            curPitch = pitch;
+            emit pitchChanged(curPitch);
+            if ((curKeyPressed != -1) && (curKeyPressed != pitch)) {
+                  emit keyReleased(curKeyPressed);
+                  curKeyPressed = pitch;
+                  emit keyPressed(curKeyPressed);
+                  }
+            update();
+            }
+      }
+
+//---------------------------------------------------------
+//   leaveEvent
+//---------------------------------------------------------
+
+void PianoKeyboard::leaveEvent(QEvent*)
+      {
+      if (curPitch != -1) {
+            curPitch = -1;
+            emit pitchChanged(-1);
+            update();
+            }
+      }
+
+
+//---------------------------------------------------------
+//   setStaff
+//---------------------------------------------------------
+
+void PianoKeyboard::setStaff(Staff* staff)
+      {
+      _staff = staff;
+      update();
+      }
+
+//---------------------------------------------------------
+//   setOrientation
+//---------------------------------------------------------
+
+void PianoKeyboard::setOrientation(PianoOrientation o)
+      {
+      _orientation = o;
+      update();
+      }
+}

--- a/mscore/pianokeyboard.h
+++ b/mscore/pianokeyboard.h
@@ -1,0 +1,77 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __PIANO_KEYBOARD_H__
+#define __PIANO_KEYBOARD_H__
+
+#include "piano.h"
+
+namespace Ms {
+
+class Staff;
+
+static const int PIANO_KEYBOARD_HEIGHT = 40;
+const int MAX_KEY_HEIGHT = 20;
+const int MIN_KEY_HEIGHT = 8;
+const int DEFAULT_KEY_HEIGHT = 14;
+const int BEAT_WIDTH_IN_PIXELS = 50;
+const double X_ZOOM_RATIO = 1.1;
+
+      
+//Alternative implementation with evenly spaced notes
+class PianoKeyboard : public QWidget {
+      Q_OBJECT
+
+      PianoOrientation _orientation;
+      int _ypos;
+
+      int noteHeight;
+      int yRange;
+      int curPitch;
+      int curKeyPressed;
+      Staff* _staff;
+
+      virtual void paintEvent(QPaintEvent*);
+      virtual void mousePressEvent(QMouseEvent*);
+      virtual void mouseReleaseEvent(QMouseEvent*);
+      virtual void mouseMoveEvent(QMouseEvent* event);
+      virtual void leaveEvent(QEvent*);
+
+   signals:
+      void pitchChanged(int);
+      void keyPressed(int pitch);
+      void keyReleased(int pitch);
+
+   public slots:
+      void setYpos(int val);
+      void setNoteHeight(int);
+      void setPitch(int);
+
+   public:
+      PianoKeyboard(QWidget* parent = 0);
+      Staff* staff() { return _staff; }
+      void setStaff(Staff* staff);
+      void setOrientation(PianoOrientation);
+      };
+
+
+} // namespace Ms
+#endif
+

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -12,8 +12,8 @@
 
 #include "pianoroll.h"
 #include "config.h"
-#include "piano.h"
-#include "ruler.h"
+#include "pianokeyboard.h"
+#include "pianoruler.h"
 #include "pianoview.h"
 #include "musescore.h"
 #include "seq.h"
@@ -133,21 +133,18 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       tickLen->setRange(-2000, 2000);
 
       //-------------
-      qreal xmag = .1;
-      ruler = new Ruler;
-      ruler->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-      ruler->setFixedHeight(rulerHeight);
-
-      ruler->setMag(xmag, 1.0);
-
-      Piano* piano = new Piano;
-      piano->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
-      piano->setFixedWidth(pianoWidth);
+      pianoKbd = new PianoKeyboard;
+      pianoKbd->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+      pianoKbd->setFixedWidth(PIANO_KEYBOARD_HEIGHT);
 
       gv  = new PianoView;
-      gv->scale(xmag, 1.0);
       gv->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
       gv->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+      ruler = new PianoRuler;
+      ruler->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+      ruler->setFixedHeight(pianoRulerHeight);
+      ruler->setXZoom(gv->xZoom());
 
       hsb = new QScrollBar(Qt::Horizontal);
       connect(gv->horizontalScrollBar(), SIGNAL(rangeChanged(int,int)),
@@ -156,7 +153,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       // layout
       QHBoxLayout* hbox = new QHBoxLayout;
       hbox->setSpacing(0);
-      hbox->addWidget(piano);
+      hbox->addWidget(pianoKbd);
       hbox->addWidget(gv);
 
       split = new QSplitter(Qt::Vertical);
@@ -169,7 +166,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       QGridLayout* layout = new QGridLayout;
       layout->setContentsMargins(0, 0, 0, 0);
       layout->setSpacing(0);
-      layout->setColumnMinimumWidth(0, pianoWidth + 5);
+      layout->setColumnMinimumWidth(0, PIANO_KEYBOARD_HEIGHT + 5);
       layout->addWidget(tb,    0, 0, 1, 2);
       layout->addWidget(ruler, 1, 1);
       layout->addWidget(split, 2, 0, 1, 2);
@@ -178,32 +175,33 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       mainWidget->setLayout(layout);
       setCentralWidget(mainWidget);
 
-      connect(gv->verticalScrollBar(), SIGNAL(valueChanged(int)), piano, SLOT(setYpos(int)));
+      connect(gv->verticalScrollBar(),   SIGNAL(valueChanged(int)), pianoKbd, SLOT(setYpos(int)));
+      connect(gv->horizontalScrollBar(), SIGNAL(valueChanged(int)), hsb,      SLOT(setValue(int)));
 
-      connect(gv,          SIGNAL(magChanged(double,double)),  ruler, SLOT(setMag(double,double)));
-      connect(gv,          SIGNAL(magChanged(double,double)),  piano, SLOT(setMag(double,double)));
-      connect(gv,          SIGNAL(pitchChanged(int)),          pl,    SLOT(setPitch(int)));
-      connect(gv,          SIGNAL(pitchChanged(int)),          piano, SLOT(setPitch(int)));
-      connect(piano,       SIGNAL(pitchChanged(int)),          pl,    SLOT(setPitch(int)));
-      connect(gv,          SIGNAL(posChanged(const Pos&)),     pos,   SLOT(setValue(const Pos&)));
-      connect(gv,          SIGNAL(posChanged(const Pos&)),     ruler, SLOT(setPos(const Pos&)));
-      connect(ruler,       SIGNAL(posChanged(const Pos&)),     pos,   SLOT(setValue(const Pos&)));
+      connect(gv,          SIGNAL(xZoomChanged(qreal)),            ruler,    SLOT(setXZoom(qreal)));
+      connect(gv,          SIGNAL(noteHeightChanged(int)),         pianoKbd, SLOT(setNoteHeight(int)));
+      connect(gv,          SIGNAL(pitchChanged(int)),              pl,       SLOT(setPitch(int)));
+      connect(gv,          SIGNAL(pitchChanged(int)),              pianoKbd, SLOT(setPitch(int)));
+      connect(pianoKbd,    SIGNAL(pitchChanged(int)),              pl,       SLOT(setPitch(int)));
+      connect(gv,          SIGNAL(trackingPosChanged(const Pos&)), pos,      SLOT(setValue(const Pos&)));
+      connect(gv,          SIGNAL(trackingPosChanged(const Pos&)), ruler,    SLOT(setPos(const Pos&)));
+      connect(ruler,       SIGNAL(posChanged(const Pos&)),         pos,      SLOT(setValue(const Pos&)));
 
-      connect(hsb,         SIGNAL(valueChanged(int)),  SLOT(setXpos(int)));
-      connect(gv,          SIGNAL(xposChanged(int)),   SLOT(setXpos(int)));
-      connect(gv->horizontalScrollBar(), SIGNAL(valueChanged(int)), SLOT(setXpos(int)));
+      connect(hsb,         SIGNAL(valueChanged(int)),                 SLOT(setXpos(int)));
+      connect(gv->horizontalScrollBar(), SIGNAL(valueChanged(int)),   SLOT(setXpos(int)));
 
       connect(ruler,       SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
-      connect(veloType,    SIGNAL(activated(int)),     SLOT(veloTypeChanged(int)));
-      connect(velocity,    SIGNAL(valueChanged(int)),  SLOT(velocityChanged(int)));
-      connect(onTime,      SIGNAL(valueChanged(int)),  SLOT(onTimeChanged(int)));
-      connect(tickLen,     SIGNAL(valueChanged(int)),  SLOT(tickLenChanged(int)));
-      connect(gv->scene(), SIGNAL(selectionChanged()), SLOT(selectionChanged()));
-      connect(piano,       SIGNAL(keyPressed(int)),    SLOT(keyPressed(int)));
-      connect(piano,       SIGNAL(keyReleased(int)),   SLOT(keyReleased(int)));
+      connect(veloType,    SIGNAL(activated(int)),                SLOT(veloTypeChanged(int)));
+      connect(velocity,    SIGNAL(valueChanged(int)),             SLOT(velocityChanged(int)));
+      connect(onTime,      SIGNAL(valueChanged(int)),             SLOT(onTimeChanged(int)));
+      connect(tickLen,     SIGNAL(valueChanged(int)),             SLOT(tickLenChanged(int)));
+      connect(gv,          SIGNAL(selectionChanged()),            SLOT(selectionChanged()));
+      connect(pianoKbd,    SIGNAL(keyPressed(int)),               SLOT(keyPressed(int)));
+      connect(pianoKbd,    SIGNAL(keyReleased(int)),              SLOT(keyReleased(int)));
 
       readSettings();
 
+      actions.append(getAction("play"));
       actions.append(getAction("delete"));
       actions.append(getAction("pitch-up"));
       actions.append(getAction("pitch-down"));
@@ -229,11 +227,27 @@ PianorollEditor::~PianorollEditor()
       }
 
 //---------------------------------------------------------
+//   focucOnElement
+//---------------------------------------------------------
+
+void PianorollEditor::focusOnPosition(Position* p)
+      {
+      if (!p || !p->segment)
+            return;
+
+      //Move view so that view is centered on this element
+      gv->ensureVisible(p->segment->tick());
+      }
+
+//---------------------------------------------------------
 //   setStaff
 //---------------------------------------------------------
 
 void PianorollEditor::setStaff(Staff* st)
       {
+      if (staff == st)
+            return;
+
       if ((st && st->score() != _score) || (!st && _score)) {
             if (_score) {
                   _score->removeViewer(this);
@@ -262,6 +276,8 @@ void PianorollEditor::setStaff(Staff* st)
             }
       ruler->setScore(_score, locator);
       gv->setStaff(staff, locator);
+      pianoKbd->setStaff(staff);
+
       updateSelection();
       setEnabled(st != nullptr);
       }
@@ -312,25 +328,30 @@ void PianorollEditor::rangeChanged(int min, int max)
 
 void PianorollEditor::updateSelection()
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = gv->getSelectedItems();
+      bool enabled = false;
+
       if (items.size() == 1) {
-            PianoItem* item = static_cast<PianoItem*>(items[0]);
-            if (item->type() == PianoItemType) {
-                  Note* note = item->note();
-                  NoteEvent* event = item->event();
-                  pitch->setEnabled(true);
-                  pitch->setValue(note->pitch());
+            PianoItem* item = items[0];
+            Note* note = item->note();
+
+            pitch->setValue(note->pitch());
+
+            NoteEvent* event = item->getTweakNoteEvent();
+            if (event) {
                   onTime->setValue(event->ontime());
                   tickLen->setValue(event->len());
-                  updateVelocity(note);
                   }
+            
+            updateVelocity(note);
+            enabled = true;
             }
-      bool b = items.size() != 0;
-      velocity->setEnabled(b);
-      pitch->setEnabled(b);
-      veloType->setEnabled(b);
-      onTime->setEnabled(b);
-      tickLen->setEnabled(b);
+
+      velocity->setEnabled(enabled);
+      pitch->setEnabled(enabled);
+      veloType->setEnabled(enabled);
+      onTime->setEnabled(enabled);
+      tickLen->setEnabled(enabled);
       }
 
 //---------------------------------------------------------
@@ -340,33 +361,25 @@ void PianorollEditor::updateSelection()
 
 void PianorollEditor::selectionChanged()
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = gv->getSelectedItems();
       if (items.size() == 1) {
-            QGraphicsItem* item = items[0];
-            if (item->type() == PianoItemType) {
-                  Note* note = static_cast<PianoItem*>(item)->note();
-                  _score->select(note, SelectType::SINGLE, 0);
-                  }
+            Note* note = items[0]->note();
+            _score->select(note, SelectType::SINGLE, 0);
             }
       else if (items.size() == 0)
             _score->select(0, SelectType::SINGLE, 0);
       else {
             _score->deselectAll();
-            for (QGraphicsItem* item : items) {
-                  if (item->type() == PianoItemType) {
-                        Note* note = static_cast<PianoItem*>(item)->note();
-                        if (!note->selected())
-                              _score->select(note, SelectType::ADD, 0);
-                        }
+            for (PianoItem* item : items) {
+                  Note* note = item->note();
+                  if (!note->selected())
+                        _score->select(note, SelectType::ADD, 0);
                   }
             }
       for (MuseScoreView* view : score()->getViewer())
             view->updateAll();
 
       gv->scene()->blockSignals(true);
-      for (QGraphicsItem* item : gv->scene()->items())
-            if (item->type() == PianoItemType)
-                item->setSelected(static_cast<PianoItem*>(item)->note()->selected());
       gv->scene()->blockSignals(false);
 
       gv->scene()->update();
@@ -381,13 +394,7 @@ void PianorollEditor::changeSelection(SelState)
       {
       gv->scene()->blockSignals(true);
       gv->scene()->clearSelection();
-      QList<QGraphicsItem*> il = gv->scene()->items();
-      for (QGraphicsItem* item : il) {
-            if (item->type() == PianoItemType) {
-                  Note* note = static_cast<PianoItem*>(item)->note();
-                  item->setSelected(note->selected());
-                  }
-            }
+      QList<PianoItem*> il = gv->getItems();
       gv->scene()->blockSignals(false);
       }
 
@@ -397,18 +404,29 @@ void PianorollEditor::changeSelection(SelState)
 
 void PianorollEditor::veloTypeChanged(int val)
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = gv->getSelectedItems();
       if (items.size() != 1)
             return;
-      QGraphicsItem* item = items[0];
-      if (item->type() != PianoItemType)
-            return;
-      Note* note = static_cast<PianoItem*>(item)->note();
+      PianoItem* item = items[0];
+      Note* note = item->note();
       if (Note::ValueType(val) == note->veloType())
             return;
 
+      int newVelocity = note->veloOffset();
+      int dynamicsVel = staff->velocities().velo(note->tick());
+
+      //Change velocity to equivilent in new metric
+      switch (Note::ValueType(val)) {
+            case Note::ValueType::USER_VAL:
+                  newVelocity = note->customizeVelocity(dynamicsVel);
+                  break;
+            case Note::ValueType::OFFSET_VAL:
+                  newVelocity = newVelocity - dynamicsVel;
+                  break;
+            }
+
       _score->undoStack()->beginMacro();
-      _score->undo(new ChangeVelocity(note, Note::ValueType(val), note->veloOffset()));
+      _score->undo(new ChangeVelocity(note, Note::ValueType(val), newVelocity));
       _score->undoStack()->endMacro(_score->undoStack()->current()->childCount() == 0);
       updateVelocity(note);
       }
@@ -420,24 +438,23 @@ void PianorollEditor::veloTypeChanged(int val)
 void PianorollEditor::updateVelocity(Note* note)
       {
       Note::ValueType vt = note->veloType();
-      if (vt != Note::ValueType(veloType->currentIndex())) {
-            veloType->setCurrentIndex(int(vt));
-            switch(vt) {
-                  case Note::ValueType::USER_VAL:
-                        velocity->setReadOnly(false);
-                        velocity->setSuffix("");
-                        velocity->setRange(0, 127);
-                        break;
-                  case Note::ValueType::OFFSET_VAL:
-                        velocity->setReadOnly(false);
-                        velocity->setSuffix("%");
-                        velocity->setRange(-200, 200);
-                        break;
-                  }
-            }
+      veloType->setCurrentIndex(int(vt));
       switch(vt) {
             case Note::ValueType::USER_VAL:
-                  // TODO velocity->setValue(note->velocity());
+                  velocity->setReadOnly(false);
+                  velocity->setSuffix("");
+                  velocity->setRange(0, 127);
+                  break;
+            case Note::ValueType::OFFSET_VAL:
+                  velocity->setReadOnly(false);
+                  velocity->setSuffix("%");
+                  velocity->setRange(-200, 200);
+                  break;
+            }
+
+      switch(vt) {
+            case Note::ValueType::USER_VAL:
+                  velocity->setValue(note->veloOffset());
                   break;
             case Note::ValueType::OFFSET_VAL:
                   velocity->setValue(note->veloOffset());
@@ -451,16 +468,14 @@ void PianorollEditor::updateVelocity(Note* note)
 
 void PianorollEditor::velocityChanged(int val)
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = gv->getSelectedItems();
       if (items.size() != 1)
             return;
-      QGraphicsItem* item = items[0];
-      if (item->type() != PianoItemType)
-            return;
-      Note* note = static_cast<PianoItem*>(item)->note();
+      PianoItem* item = items[0];
+      Note* note = item->note();
       Note::ValueType vt = note->veloType();
 
-      if (vt == Note::ValueType::OFFSET_VAL)
+      if (val == note->veloOffset())
             return;
 
       _score->undoStack()->beginMacro();
@@ -520,6 +535,7 @@ void PianorollEditor::cmd(QAction* /*a*/)
       {
       //score()->startCmd();
       gv->setStaff(staff, locator);
+      pianoKbd->setStaff(staff);
       //score()->endCmd();
       }
 
@@ -639,9 +655,9 @@ Element* PianorollEditor::elementNear(QPointF)
 
 void PianorollEditor::updateAll()
       {
-//      startTimer(0);    // delayed update
-//      gv->updateNotes();
-//      gv->update();
+      startTimer(0);    // delayed update
+      gv->updateNotes();
+      gv->update();
       }
 
 void PianorollEditor::playlistChanged()
@@ -662,7 +678,6 @@ void PianorollEditor::showWaveView(bool val)
                   waveView->setAudio(_score->audio());
                   waveView->setScore(_score, locator);
                   split->addWidget(waveView);
-                  waveView->setMag(ruler->xmag(), 1.0);
                   waveView->setXpos(ruler->xpos());
                   }
             waveView->setVisible(true);
@@ -695,16 +710,13 @@ void PianorollEditor::posChanged(POS pos, unsigned tick)
 
 void PianorollEditor::onTimeChanged(int val)
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = gv->getSelectedItems();
       if (items.size() != 1)
             return;
-      QGraphicsItem* item = items[0];
-      if (item->type() != PianoItemType)
-            return;
-      PianoItem* pi = static_cast<PianoItem*>(item);
-      Note* note       = pi->note();
-      NoteEvent* event = pi->event();
-      if (event->ontime() == val)
+      PianoItem* item = items[0];
+      Note* note       = item->note();
+      NoteEvent* event = item->getTweakNoteEvent();
+      if (!event || event->ontime() == val)
             return;
 
       NoteEvent ne = *event;
@@ -712,6 +724,8 @@ void PianorollEditor::onTimeChanged(int val)
       _score->startCmd();
       _score->undo(new ChangeNoteEvent(note, event, ne));
       _score->endCmd();
+
+      gv->updateNotes();
       }
 
 //---------------------------------------------------------
@@ -720,16 +734,13 @@ void PianorollEditor::onTimeChanged(int val)
 
 void PianorollEditor::tickLenChanged(int val)
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = gv->getSelectedItems();
       if (items.size() != 1)
             return;
-      QGraphicsItem* item = items[0];
-      if (item->type() != PianoItemType)
-            return;
-      PianoItem* pi = static_cast<PianoItem*>(item);
-      Note* note       = pi->note();
-      NoteEvent* event = pi->event();
-      if (event->len() == val)
+      PianoItem* item = items[0];
+      Note* note       = item->note();
+      NoteEvent* event = item->getTweakNoteEvent();
+      if (!event || event->len() == val)
             return;
 
       NoteEvent ne = *event;
@@ -737,6 +748,8 @@ void PianorollEditor::tickLenChanged(int val)
       _score->startCmd();
       _score->undo(new ChangeNoteEvent(note, event, ne));
       _score->endCmd();
+
+      gv->updateNotes();
       }
 
 }

--- a/mscore/pianoroll.h
+++ b/mscore/pianoroll.h
@@ -28,8 +28,9 @@ namespace Ms {
 class Score;
 class Staff;
 class PianoView;
+class PianoKeyboard;
 class Note;
-class Ruler;
+class PianoRuler;
 class Seq;
 class WaveView;
 
@@ -41,6 +42,7 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       Q_OBJECT
 
       PianoView* gv;
+      PianoKeyboard* pianoKbd;
       QScrollBar* hsb;        // horizontal scroll bar for pianoView
       Score* _score;
       Staff* staff;
@@ -51,7 +53,7 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       Pos locator[3];
       QComboBox* veloType;
       Awl::PosLabel* pos;
-      Ruler* ruler;
+      PianoRuler* ruler;
       QAction* showWave;
       WaveView* waveView;
       QSplitter* split;
@@ -85,6 +87,7 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       virtual ~PianorollEditor();
 
       void setStaff(Staff* staff);
+      void focusOnPosition(Position* p);
       void heartBeat(Seq*);
 
       virtual void dataChanged(const QRectF&);

--- a/mscore/pianoruler.cpp
+++ b/mscore/pianoruler.cpp
@@ -1,0 +1,356 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "pianoruler.h"
+#include "libmscore/score.h"
+
+namespace Ms {
+
+#if 0 // yet(?) unused
+static const int MAP_OFFSET = 480;
+#endif
+
+QPixmap* PianoRuler::markIcon[3];
+
+static const char* rmark_xpm[]={
+      "18 18 2 1",
+      "# c #0000ff",
+      ". c None",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "........##########",
+      "........#########.",
+      "........########..",
+      "........#######...",
+      "........######....",
+      "........#####.....",
+      "........####......",
+      "........###.......",
+      "........##........",
+      "........##........",
+      "........##........"};
+static const char* lmark_xpm[]={
+      "18 18 2 1",
+      "# c #0000ff",
+      ". c None",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "##########........",
+      ".#########........",
+      "..########........",
+      "...#######........",
+      "....######........",
+      ".....#####........",
+      "......####........",
+      ".......###........",
+      "........##........",
+      "........##........",
+      "........##........"};
+static const char* cmark_xpm[]={
+      "18 18 2 1",
+      "# c #ff0000",
+      ". c None",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "##################",
+      ".################.",
+      "..##############..",
+      "...############...",
+      "....##########....",
+      ".....########.....",
+      "......######......",
+      ".......####.......",
+      "........##........",
+      "........##........",
+      "........##........"};
+
+
+//---------------------------------------------------------
+//   Ruler
+//---------------------------------------------------------
+
+PianoRuler::PianoRuler(QWidget* parent)
+   : QWidget(parent)
+      {
+      if (markIcon[0] == 0) {
+            markIcon[0] = new QPixmap(cmark_xpm);
+            markIcon[1] = new QPixmap(lmark_xpm);
+            markIcon[2] = new QPixmap(rmark_xpm);
+            }
+      setMouseTracking(true);
+      _xpos   = 0;
+      _xZoom = .1;
+      _timeType = TType::TICKS;
+      _font2.setPixelSize(14);
+      _font2.setBold(true);
+      _font1.setPixelSize(10);
+      }
+
+//---------------------------------------------------------
+//   setScore
+//---------------------------------------------------------
+
+void PianoRuler::setScore(Score* s, Pos* lc)
+      {
+      _score = s;
+      _locator = lc;
+      if (_score)
+            _cursor.setContext(_score->tempomap(), _score->sigmap());
+      setEnabled(_score != 0);
+      }
+
+//---------------------------------------------------------
+//   setXpos
+//---------------------------------------------------------
+
+void PianoRuler::setXpos(int val)
+      {
+      _xpos = val;
+      update();
+      }
+
+//---------------------------------------------------------
+//   pix2pos
+//---------------------------------------------------------
+
+Pos PianoRuler::pix2pos(int x) const
+      {
+      int val = (x + _xpos - 5) / _xZoom - MAP_OFFSET;
+      
+      if (val < 0)
+            val = 0;
+      return Pos(_score->tempomap(), _score->sigmap(), val, _timeType);
+      
+      }
+
+//---------------------------------------------------------
+//   pos2pix
+//---------------------------------------------------------
+
+int PianoRuler::pos2pix(const Pos& p) const
+      {
+      return (p.time(TType::TICKS) + MAP_OFFSET) * _xZoom - _xpos + 5;
+      }
+
+//---------------------------------------------------------
+//   paintEvent
+//---------------------------------------------------------
+
+void PianoRuler::paintEvent(QPaintEvent* e)
+      {
+      QPainter p(this);
+      const QRect& r = e->rect();
+
+      int x  = r.x();
+      int w  = r.width();
+      int y  = pianoRulerHeight - 16;
+      int h  = 16; // 14;
+      int y1 = r.y();
+      int rh = r.height();
+      if (y1 < pianoRulerHeight) {
+            rh -= pianoRulerHeight - y1;
+            y1 = pianoRulerHeight;
+            }
+      int y2 = y1 + rh;
+
+      if (x < (-_xpos))
+            x = -_xpos;
+
+      if (!_score)
+            return;
+
+      Pos pos1 = pix2pos(x);
+      Pos pos2 = pix2pos(x+w);
+
+      //---------------------------------------------------
+      //    draw raster
+      //---------------------------------------------------
+
+      int bar1, bar2, beat, tick;
+
+      pos1.mbt(&bar1, &beat, &tick);
+      pos2.mbt(&bar2, &beat, &tick);
+
+      const int minBarGapSize = 48;
+      const int minBeatGapSize = 30;
+      
+      //Estimate bar width since changing time signatures can make this inconsistent.
+      // Assuming 480 ticks per beat, 4 beats per bar
+      qreal pixPerBar = MScore::division * 4 * _xZoom;
+      qreal pixPerBeat = MScore::division * _xZoom;
+      
+      int barSkip = ceil(minBarGapSize / pixPerBar);
+      barSkip = (int)pow(2, ceil(log(barSkip)/log(2)));
+
+      int beatSkip = ceil(minBeatGapSize / pixPerBeat);
+      beatSkip = (int)pow(2, ceil(log(beatSkip)/log(2)));
+      
+      //Round down to first bar to be a multiple of barSkip
+      bar1 = (bar1 / barSkip) * barSkip;
+      
+      for (int bar = bar1; bar <= bar2; bar += barSkip) {
+            Pos stick(_score->tempomap(), _score->sigmap(), bar, 0, 0);
+            
+            SigEvent sig = stick.timesig();
+            int z = sig.timesig().numerator();
+            for (int beat = 0; beat < z; beat += beatSkip) {
+                  Pos xx(_score->tempomap(), _score->sigmap(), bar, beat, 0);
+                  int xp = pos2pix(xx);
+                  if (xp < 0)
+                        continue;
+                  QString s;
+                  QRect r(xp+2, y + 1, 1000, h);
+                  int y3;
+                  int num;
+                  if (beat == 0) {
+                        num = bar + 1;
+                        y3  = y + 2;
+                        p.setFont(_font2);
+                        }
+                  else {
+                        num = beat + 1;
+                        y3  = y + 8;
+                        p.setFont(_font1);
+                        r.moveTop(r.top() + 1);
+                        }
+                  s.setNum(num);
+                  p.setPen(Qt::black);
+                  p.drawLine(xp, y3, xp, y+h);
+                  p.drawText(r, Qt::AlignLeft | Qt::AlignVCenter, s);
+                  p.setPen(beat == 0 ? Qt::lightGray : Qt::gray);
+                  if (xp > 0)
+                        p.drawLine(xp, y1, xp, y2);
+                  }
+            
+            }
+      //
+      //  draw mouse cursor marker
+      //
+      p.setPen(Qt::black);
+      if (_cursor.valid()) {
+            int xp = pos2pix(_cursor);
+            if (xp >= x && xp < x+w)
+                  p.drawLine(xp, 0, xp, pianoRulerHeight);
+            }
+      static const QColor lcColors[3] = { Qt::red, Qt::blue, Qt::blue };
+      for (int i = 0; i < 3; ++i) {
+            if (!_locator[i].valid())
+                  continue;
+            p.setPen(lcColors[i]);
+            int xp      = pos2pix(_locator[i]);
+            QPixmap* pm = markIcon[i];
+            int pw = pm->width() / 2;
+            int x1 = x - pw;
+            int x2 = x + w + pw;
+            if (xp >= x1 && xp < x2)
+                  p.drawPixmap(xp - pw, y-2, *pm);
+            }
+      }
+
+//---------------------------------------------------------
+//   mousePressEvent
+//---------------------------------------------------------
+
+void PianoRuler::mousePressEvent(QMouseEvent* e)
+      {
+      moveLocator(e);
+      }
+
+//---------------------------------------------------------
+//   mouseMoveEvent
+//---------------------------------------------------------
+
+void PianoRuler::mouseMoveEvent(QMouseEvent* e)
+      {
+      moveLocator(e);
+      }
+
+//---------------------------------------------------------
+//   moveLocator
+//---------------------------------------------------------
+
+void PianoRuler::moveLocator(QMouseEvent* e)
+      {
+      Pos pos(pix2pos(e->pos().x()));
+      if (e->buttons() & Qt::LeftButton)
+            emit locatorMoved(0, pos);
+      else if (e->buttons() & Qt::MidButton)
+            emit locatorMoved(1, pos);
+      else if (e->buttons() & Qt::RightButton)
+            emit locatorMoved(2, pos);
+      }
+
+//---------------------------------------------------------
+//   leaveEvent
+//---------------------------------------------------------
+
+void PianoRuler::leaveEvent(QEvent*)
+      {
+      _cursor.setInvalid();
+      emit posChanged(_cursor);
+      update();
+      }
+
+//---------------------------------------------------------
+//   setPos
+//---------------------------------------------------------
+
+void PianoRuler::setPos(const Pos& pos)
+      {
+      if (_cursor != pos) {
+            int x1 = pos2pix(_cursor);
+            int x2 = pos2pix(pos);
+            if (x1 > x2) {
+                  int tmp = x2;
+                  x2 = x1;
+                  x1 = tmp;
+                  }
+            update(QRect(x1-1, 0, x2-x1+2, height()));
+            _cursor = pos;
+            }
+      }
+
+//---------------------------------------------------------
+//   setXZoom
+//---------------------------------------------------------
+
+void PianoRuler::setXZoom(qreal xZoom)
+      {
+      _xZoom = xZoom;
+      update();
+      }
+
+}
+

--- a/mscore/pianoruler.h
+++ b/mscore/pianoruler.h
@@ -1,0 +1,80 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __PIANO_RULER_H__
+#define __PIANO_RULER_H__
+
+#include "libmscore/pos.h"
+
+namespace Ms {
+
+class Score;
+
+static const int pianoRulerHeight = 28;
+static const int MAP_OFFSET = 480;
+
+//---------------------------------------------------------
+//   Ruler
+//---------------------------------------------------------
+
+class PianoRuler : public QWidget {
+      Q_OBJECT
+
+      Score* _score;
+      Pos _cursor;
+      Pos* _locator;
+
+      qreal _xZoom;
+      int _xpos;
+      TType _timeType;
+      QFont _font1, _font2;
+
+      static QPixmap* markIcon[3];
+
+      virtual void paintEvent(QPaintEvent*);
+      virtual void mousePressEvent(QMouseEvent*);
+      virtual void mouseMoveEvent(QMouseEvent* event);
+      virtual void leaveEvent(QEvent*);
+
+      Pos pix2pos(int x) const;
+      int pos2pix(const Pos& p) const;
+      void moveLocator(QMouseEvent*);
+
+   signals:
+      void posChanged(const Pos&);
+      void locatorMoved(int idx, const Pos&);
+
+   public slots:
+      void setXpos(int);
+      void setXZoom(qreal);
+      void setPos(const Pos&);
+
+   public:
+      PianoRuler(QWidget* parent = 0);
+      void setScore(Score*, Pos* locator);
+      int xpos() const { return _xpos; }
+      qreal xZoom() const { return _xZoom; }
+      };
+
+
+} // namespace Ms
+#endif
+
+

--- a/mscore/pianoview.h
+++ b/mscore/pianoview.h
@@ -17,29 +17,51 @@
 
 namespace Ms {
 
+class Score;
 class Staff;
 class Chord;
+class ChordRest;
 class Note;
 class NoteEvent;
+class PianoView;
 
-const int PianoItemType = QGraphicsItem::UserType + 1;
+enum class NoteSelectType {
+      REPLACE = 0,
+      XOR,
+      ADD,
+      SUBTRACT,
+      FIRST
+      };
 
+enum class DragStyle {
+    NONE = 0,
+    SELECTION_RECT,
+    MOVE_NOTES
+};
+      
 //---------------------------------------------------------
 //   PianoItem
 //---------------------------------------------------------
 
-class PianoItem : public QGraphicsRectItem {
-      Note*      _note;
-      NoteEvent* _event;
-      virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = 0);
-
+class PianoItem {
+      Note* _note;
+      PianoView* _pianoView;
+      
+      void paintNoteBlock(QPainter* painter, NoteEvent* evt);
+      QRect boundingRectTicks(NoteEvent* evt);
+      QRect boundingRectPixels(NoteEvent* evt);
+      bool intersectsBlock(int startTick, int endTick, int highPitch, int lowPitch, NoteEvent* evt);
+      
    public:
-      PianoItem(Note*, NoteEvent*);
-      virtual ~PianoItem() {}
-      virtual int type() const { return PianoItemType; }
-      Note* note()       { return _note; }
-      NoteEvent* event() { return _event; }
-      QRectF updateValues();
+      PianoItem(Note*, PianoView*);
+      ~PianoItem() {}
+      Note* note() { return _note; }
+      void paint(QPainter* painter);
+      bool intersects(int startTick, int endTick, int highPitch, int lowPitch);
+      
+      QRect boundingRect();
+      
+      NoteEvent* getTweakNoteEvent();
       };
 
 //---------------------------------------------------------
@@ -49,33 +71,50 @@ class PianoItem : public QGraphicsRectItem {
 class PianoView : public QGraphicsView {
       Q_OBJECT
 
-      Staff* staff;
+      Staff* _staff;
       Chord* chord;
-      Pos pos;
+      
+      Pos trackingPos;  //Track mouse position
       Pos* _locator;
-      QGraphicsLineItem* locatorLines[3];
       int ticks;
       TType _timeType;
-      int magStep;
+      int _noteHeight;
+      qreal _xZoom;
+      
+      bool _playEventsView;
+      bool mouseDown;
+      bool dragStarted;
+      QPointF mouseDownPos;
+      QPointF lastMousePos;
+      DragStyle dragStyle;
+      int lastDragPitch;
+      bool inProgressUndoEvent;
+      
+      QList<PianoItem*> noteList;
 
       virtual void drawBackground(QPainter* painter, const QRectF& rect);
 
-      int y2pitch(int y) const;
-      Pos pix2pos(int x) const;
-      int pos2pix(const Pos& p) const;
-      void createLocators();
-      void addChord(Chord* chord);
+      void addChord(Chord* chord, int voice);
+      void updateBoundingSize();
+      void clearNoteData();
+      void selectNotes(int startTick, int endTick, int lowPitch, int highPitch, NoteSelectType selType);
+
+      QAction* getAction(const char* id);
+//      void splitCR(Score* score, ChordRest* chordHead, Fraction frac);
 
    protected:
       virtual void wheelEvent(QWheelEvent* event);
+      virtual void mousePressEvent(QMouseEvent* event);
+      virtual void mouseReleaseEvent(QMouseEvent* event);
       virtual void mouseMoveEvent(QMouseEvent* event);
       virtual void leaveEvent(QEvent*);
 
    signals:
-      void magChanged(double, double);
-      void xposChanged(int);
+      void xZoomChanged(qreal);
+      void noteHeightChanged(int);
       void pitchChanged(int);
-      void posChanged(const Pos&);
+      void trackingPosChanged(const Pos&);
+      void selectionChanged();
 
    public slots:
       void moveLocator(int);
@@ -83,9 +122,25 @@ class PianoView : public QGraphicsView {
 
    public:
       PianoView();
+      ~PianoView();
+      Staff* staff() { return _staff; }
       void setStaff(Staff*, Pos* locator);
       void ensureVisible(int tick);
+      int noteHeight() { return _noteHeight; }
+      qreal xZoom() { return _xZoom; }
       QList<QGraphicsItem*> items() { return scene()->selectedItems(); }
+
+      int pixelXToTick(int pixX);
+      int tickToPixelX(int tick);
+      int pixelYToPitch(int pixY) { return (int)floor(128 - pixY / (qreal)_noteHeight); }
+      
+      PianoItem* pickNote(int tick, int pitch);
+
+      QList<PianoItem*> getSelectedItems();
+      QList<PianoItem*> getItems();
+      
+      bool playEventsView() { return _playEventsView; }
+
       };
 
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -355,12 +355,14 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
 //   measurePopup
 //---------------------------------------------------------
 
-void ScoreView::measurePopup(const QPoint& gpos, Measure* obj)
+void ScoreView::measurePopup(QContextMenuEvent* ev, Measure* obj)
       {
       int staffIdx;
       int pitch;
       Segment* seg;
 
+      QPoint gpos = ev->globalPos();
+      
       if (!_score->pos2measure(editData.startMove, &staffIdx, &pitch, &seg, 0))
             return;
       if (staffIdx == -1) {
@@ -447,7 +449,10 @@ void ScoreView::measurePopup(const QPoint& gpos, Measure* obj)
             }
       else if (cmd == "pianoroll") {
             _score->endCmd();
-            mscore->editInPianoroll(staff);
+            QPointF p = toLogical(ev->pos());
+            Position pp;
+            bool foundPos = _score->getPosition(&pp, p, 0);
+            mscore->editInPianoroll(staff, foundPos ? &pp : 0);
             }
       else if (cmd == "staff-properties") {
             int tick = obj ? obj->tick() : -1;
@@ -4183,6 +4188,8 @@ static bool elementLower(const Element* e1, const Element* e2)
             }
       return e1->z() < e2->z();
       }
+
+
 
 //---------------------------------------------------------
 //   elementNear

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -153,7 +153,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void paint(const QRect&, QPainter&);
 
       void objectPopup(const QPoint&, Element*);
-      void measurePopup(const QPoint&, Measure*);
+      void measurePopup(QContextMenuEvent* ev, Measure*);
 
       void saveChord(XmlWriter&);
 


### PR DESCRIPTION
Updating main piano roll display to have 12 rows per octave.

Updating piano keyboard to track main piano roll window.

Moving PianoKeyboard to its own file.

Better tracking of playhead during playback.

Drawing beat lines within measure.

Scrollbars now adjusted for stasis when zooming in the pianoview.

Piano ruler now showing tick marks respecting zoom level.

Fixing scroll issue during playback.

Taking direct control of selection.

PianoItem is no longer a Qt object.

Preping  for note group drag.

Can now drag pitch changes.

Adjusting viewport pos when staff set.

Removing CMakeLists.txt

Adding CMakeLists.txt back in.

Cleaning things up for resubmission.

Now displaying drumset names in PianoKeyboard when relevant.

when relevant.
'd0c9e4f4a'.
Creatung new Pianoroll editor UI.

Removing local files from .gitignore

Fixing indent.

'175d5aadb'.
New pianoroll editor UI.

Removing local changes.

'd1d386102'.

Cleanup.
'1daf4db7a'.

fix #273601: Updated UI for pianoroll editor.

Updating tracking signal in Pianoroll Editor.  Cleanup.

Cleanup.
'1daf4db7a'.
fix #273601: Updated UI for pianoroll editor.

Changing bracket formatting.

'504fe96af'.

fix #273601: Updated UI for pianoroll editor.

More neatness fixes.

'504fe96af'.
fix #273601: Updated UI for pianoroll editor.

Now caching pitch when note block calculated.

'04de06e2e'.

fix #273601: Updated UI for pianoroll editor.

Caching note pitch

PianoItem now tracks notes, not note events.

Locator lines no longer Qt objects.  Removing redundant note move on
mouse up.

redundant note move on mouse up.
'd1d386102'.

fix #273601: Updated UI for pianoroll editor.

Adding support back in for displaying note events.

Now adjusting final event for playback.

events.
'e33bf2fe5'.

fix #273601: Updated UI for pianoroll editor.

Now showing note voice name.  Using Tpc to use note name tha reflects
accidentals.

note name tha reflects accidentals.
'e131f3876'.
fix #273601: Updated UI for pianoroll editor.

Better checking for Position when opening Pianoroll window.
Adding note for ctrl-click on rest.

Swithing velocity type will now also adjust to equivilent velocity
value.  Better checking for single note selection.

Pianoroll window.  Adding note for ctrl-click on rest.
equivilent velocity value.  Better checking for single note selection.
'99f3cd48f'.

fix #273601: Updated UI for pianoroll editor.