### PR TITLE
fix #273601: Updated UI for pianoroll editor.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1324,7 +1324,7 @@ static void setTpc(Note* oNote, int tpc, int& newTpc1, int& newTpc2)
 ///   Increment/decrement pitch of note by one or by an octave.
 //---------------------------------------------------------
 
-void Score::upDown(bool up, UpDownMode mode)
+void Score::upDown(bool up, UpDownMode mode, bool updateSelection)
       {
       QList<Note*> el = selection().uniqueNotes();
 
@@ -1347,7 +1347,7 @@ void Score::upDown(bool up, UpDownMode mode)
                         {
                         const Drumset* ds = part->instrument()->drumset();
                         if (ds) {
-                              newPitch = up ? ds->prevPitch(pitch) : ds->nextPitch(pitch);
+                              newPitch = up ? ds->nextPitch(pitch) : ds->prevPitch(pitch);
                               newTpc1 = pitch2tpc(newPitch, Key::C, Prefer::NEAREST);
                               newTpc2 = newTpc1;
                               }
@@ -1493,9 +1493,29 @@ void Score::upDown(bool up, UpDownMode mode)
             setPlayNote(true);
             }
 
-      _selection.clear();
-      for (Note* note : el)
-            _selection.add(note);
+      if (updateSelection) {
+            _selection.clear();
+            for (Note* note : el)
+                  _selection.add(note);
+            }
+      }
+
+//---------------------------------------------------------
+//   upDownDelta
+///   Add the delta to the pitch of note.
+//---------------------------------------------------------
+
+void Score::upDownDelta(int pitchDelta, bool updateSelection)
+      {
+      while (pitchDelta > 0) {
+            upDown(true, UpDownMode::CHROMATIC, updateSelection);
+            pitchDelta--;
+            }
+
+      while (pitchDelta < 0) {
+            upDown(false, UpDownMode::CHROMATIC, updateSelection);
+            pitchDelta++;
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -651,7 +651,8 @@ class Score : public QObject, public ScoreElement {
       ChordRest* addClone(ChordRest* cr, int tick, const TDuration& d);
       Rest* setRest(int tick,  int track, Fraction, bool useDots, Tuplet* tuplet, bool useFullMeasureRest = true);
 
-      void upDown(bool up, UpDownMode);
+      void upDown(bool up, UpDownMode, bool updateSelection = true);
+      void upDownDelta(int pitchDelta, bool updateSelection);
       ChordRest* searchNote(int tick, int track) const;
 
       // undo/redo ops

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -278,7 +278,9 @@ add_executable ( ${ExecutableName}
       measureproperties.h mediadialog.h metaedit.h miconengine.h mididriver.h mixer.h musedata.h
       musescore.h musicxml.h musicxmlfonthandler.h musicxmlsupport.h navigator.h newwizard.h noteGroups.h
       omrpanel.h ove.h pa.h pagesettings.h palette.h palettebox.h paletteBoxButton.h partedit.h
-      pathlistdialog.h piano.h pianoroll.h pianotools.h pianoview.h playpanel.h pluginCreator.h
+      pathlistdialog.h piano.h pianolevels.h pianolevelschooser.h  pianolevelsfilter.h
+      pianokeyboard.h pianoroll.h pianoruler.h pianotools.h pianoview.h
+      playpanel.h pluginCreator.h
       pluginManager.h pm.h preferences.h preferenceslistwidget.h prefsdialog.h qmledit.h
       qmlplugin.h recordbutton.h resourceManager.h revision.h ruler.h scoreaccessibility.h
       scoreBrowser.h scoreInfo.h scorePreview.h scoretab.h scoreview.h searchComboBox.h
@@ -309,7 +311,8 @@ add_executable ( ${ExecutableName}
       excerptsdialog.cpp metaedit.cpp magbox.cpp
       capella.cpp capxml.cpp exportaudio.cpp palettebox.cpp
       synthcontrol.cpp drumroll.cpp pianoroll.cpp piano.cpp
-      pianoview.cpp drumview.cpp scoretab.cpp keyedit.cpp harmonyedit.cpp
+      pianokeyboard.cpp pianolevels.cpp pianolevelschooser.cpp pianolevelsfilter.cpp
+      pianoruler.cpp pianoview.cpp drumview.cpp scoretab.cpp keyedit.cpp harmonyedit.cpp
       updatechecker.cpp
       importove.cpp
       ove.cpp

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -715,7 +715,7 @@ void ScoreView::contextMenuEvent(QContextMenuEvent* ev)
             int staffIdx;
             Measure* m = _score->pos2measure(editData.startMove, &staffIdx, 0, 0, 0);
             if (m && m->staffLines(staffIdx)->canvasBoundingRect().contains(editData.startMove))
-                  measurePopup(gp, m);
+                  measurePopup(ev, m);
             else {
                   QMenu* popup = new QMenu();
                   popup->addAction(getAction("edit-style"));

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4248,13 +4248,14 @@ void MuseScore::handleMessage(const QString& message)
 //   editInPianoroll
 //---------------------------------------------------------
 
-void MuseScore::editInPianoroll(Staff* staff)
+void MuseScore::editInPianoroll(Staff* staff, Position* p)
       {
       if (pianorollEditor == 0)
             pianorollEditor = new PianorollEditor;
       pianorollEditor->setScore(staff->score());
       pianorollEditor->setStaff(staff);
       pianorollEditor->show();
+      pianorollEditor->focusOnPosition(p);
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -584,7 +584,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QString lastSaveDirectory;
       QString lastSaveCaptureName;
       SynthControl* getSynthControl() const       { return synthControl; }
-      void editInPianoroll(Staff* staff);
+      void editInPianoroll(Staff* staff, Position* p = 0);
       void editInDrumroll(Staff* staff);
       PianorollEditor* getPianorollEditor() const { return pianorollEditor; }
       DrumrollEditor* getDrumrollEditor() const   { return drumrollEditor; }

--- a/mscore/pianokeyboard.cpp
+++ b/mscore/pianokeyboard.cpp
@@ -1,0 +1,339 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "pianokeyboard.h"
+
+#include "libmscore/staff.h"
+#include "libmscore/part.h"
+#include "libmscore/drumset.h"
+
+namespace Ms {
+
+const QColor colKeySelect = QColor(224, 170, 20);
+
+const QString PianoKeyboard::pitchNames[] =
+            {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+
+
+//---------------------------------------------------------
+//   PianoKeyboard
+//---------------------------------------------------------
+
+PianoKeyboard::PianoKeyboard(QWidget* parent)
+   : QWidget(parent)
+      {
+      setMouseTracking(true);
+      setAttribute(Qt::WA_NoSystemBackground);
+      setAttribute(Qt::WA_StaticContents);
+      setMouseTracking(true);
+      yRange   = noteHeight * 128;
+      curPitch = -1;
+      _ypos    = 0;
+      curKeyPressed = -1;
+      noteHeight = DEFAULT_KEY_HEIGHT;
+      _orientation = PianoOrientation::VERTICAL;
+      _staff = 0;
+      }
+
+
+
+//---------------------------------------------------------
+//   paint
+//---------------------------------------------------------
+
+void PianoKeyboard::paintEvent(QPaintEvent* /*event*/)
+      {
+      QPainter p(this);
+      p.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
+      
+      const int fontSize = 8;
+      QFont f("FreeSans", fontSize);
+      p.setFont(f);
+
+      //Check for drumset, if any
+      Part* part = _staff->part();
+      Drumset* ds = part->instrument()->drumset();
+      Interval transp = part->instrument()->transpose();
+
+      p.setPen(QPen(Qt::black, 2));
+      
+      int keyboardLen = 128 * noteHeight;
+      const int blackKeyLen = BLACK_KEY_WIDTH;
+
+      const qreal whiteKeyOffset[] = {0, 1.5, 3.5, 5, 6.5, 8.5, 10.5, 12};
+      const int whiteKeyDegree[] = {0, 2, 4, 5, 7, 9, 11};
+      const qreal blackKeyOffset[] = {1.5, 3.5, 6.5, 8.5, 10.5};
+      const int blackKeyDegree[] = {1, 3, 6, 8, 10};
+
+      //White keys
+      p.setPen(QPen(Qt::black));
+      for (int midiPitch = 0; midiPitch < 128; ++midiPitch) {
+            int midiOctave = midiPitch / 12;
+            int midiDegree = midiPitch % 12;
+
+            int instrPitch = midiPitch - transp.chromatic;
+
+            int octave = instrPitch / 12;
+            int degree = (instrPitch + 60) % 12;
+
+            int key = -1;
+            for (int i = 0; i < 7; ++i)
+                  if (whiteKeyDegree[i] == degree) {
+                        key = i;
+                        break;
+                        }
+
+            if (key == -1)
+                  continue;
+
+            QString noteName = pitchNames[degree] % QString::number(octave - 1);
+            if (ds)
+                  noteName = ds->name(instrPitch);
+
+            p.setBrush(curPitch == midiPitch ? colKeySelect : Qt::white);
+
+            qreal off1 = whiteKeyOffset[key] * noteHeight + (octave * 12 + transp.chromatic) * noteHeight;
+            qreal off2 = whiteKeyOffset[key + 1] * noteHeight + (octave * 12 + transp.chromatic) * noteHeight;
+            if (_orientation == PianoOrientation::HORIZONTAL) {
+                  QRectF rect(-_ypos + off2, 0, off2 - off1, height());
+                  p.drawRect(rect);
+
+                  if (degree == 0 && noteHeight > fontSize + 2) {
+                        QRectF rectText(rect.x() + 1, rect.y(), rect.height() - 2, rect.width() - 2);
+                        QTransform xform = p.transform();
+                        p.rotate(90);
+                        p.drawText(rectText,
+                                ds ?  Qt::AlignLeft | Qt::AlignBottom
+                                    : Qt::AlignRight | Qt::AlignBottom,
+                                noteName);
+                        p.setTransform(xform);
+                        }
+                  }
+            else {
+                  QRectF rect(0, -_ypos + keyboardLen - off2, width(), off2 - off1);
+
+                  p.drawRect(rect);
+
+                  if (noteHeight > fontSize + 2) {
+                        if (ds) {
+                              QRectF rectText(rect.x() + 1, -_ypos + keyboardLen - (instrPitch + 1) * noteHeight, rect.width() - 1, noteHeight);
+
+                              p.drawText(rectText, Qt::AlignBottom | Qt::AlignLeft, noteName);
+                              }
+                        else if (degree == 0) {
+                              QRectF rectText(rect.x(), rect.y(), rect.width() - 4, rect.height() - 1);
+                              p.drawText(rectText, Qt::AlignRight | Qt::AlignBottom, noteName);
+                              }
+                        }
+                  }
+            }
+
+      //Black keys
+      for (int midiPitch = 0; midiPitch < 128; ++midiPitch) {
+            int instrPitch = midiPitch - transp.chromatic;
+
+            int octave = instrPitch / 12;
+            int degree = instrPitch % 12;
+
+            int key = -1;
+            for (int i = 0; i < 5; ++i)
+                  if (blackKeyDegree[i] == degree) {
+                        key = i;
+                        break;
+                        }
+
+            if (key == -1)
+                  continue;
+
+            QString noteName = pitchNames[blackKeyDegree[key]]  % QString::number(octave) + " ";
+            if (ds)
+                  noteName = ds->name(instrPitch);
+
+            qreal center = blackKeyOffset[key] * noteHeight;
+            qreal offset = center - noteHeight / 2.0 + (octave * 12 + transp.chromatic) * noteHeight;
+
+            p.setPen(QPen(Qt::black));
+            p.setBrush(curPitch == midiPitch ? colKeySelect : Qt::black);
+
+            if (_orientation == PianoOrientation::HORIZONTAL) {
+                  QRectF rect(offset, 0, noteHeight, blackKeyLen);
+
+                  p.drawRect(rect);
+
+                  if (ds) {
+                        if (noteHeight > fontSize + 2) {
+                              rect.setWidth(blackKeyLen);
+                              rect.setHeight(noteHeight);
+
+                              p.setPen(QPen(Qt::white));
+                              p.drawText(rect, Qt::AlignLeft | Qt::AlignBottom, noteName);
+                              }
+                        }
+                  }
+            else {
+                  QRectF rect(0, -_ypos + keyboardLen - offset - noteHeight, blackKeyLen, noteHeight);
+
+                  p.drawRect(rect);
+
+                  if (noteHeight > fontSize + 2) {
+                        if (ds) {
+                              p.setPen(QPen(Qt::white));
+                              p.drawText(rect, Qt::AlignLeft | Qt::AlignBottom, noteName);
+                              }
+                        }
+                  }
+            }
+
+      }
+
+//---------------------------------------------------------
+//   setYpos
+//---------------------------------------------------------
+
+void PianoKeyboard::setYpos(int val)
+      {
+      if (_ypos != val) {
+            _ypos = val;
+            update();
+            }
+      }
+
+//---------------------------------------------------------
+//   setNoteHeight
+//---------------------------------------------------------
+
+void PianoKeyboard::setNoteHeight(int nh)
+      {
+      if (noteHeight != nh) {
+            noteHeight = nh;
+            update();
+            }
+      }
+
+//---------------------------------------------------------
+//   setPitch
+//---------------------------------------------------------
+
+void PianoKeyboard::setPitch(int val)
+      {
+      if (curPitch != val) {
+            curPitch = val;
+            update();
+            }
+      }
+
+//---------------------------------------------------------
+//   mousePressEvent
+//---------------------------------------------------------
+
+void PianoKeyboard::mousePressEvent(QMouseEvent* event)
+      {
+      int offset = _orientation == PianoOrientation::HORIZONTAL
+            ? event->pos().x()
+            : 128 * noteHeight - (event->y() + _ypos);
+
+      curKeyPressed = offset / noteHeight;
+      if (curKeyPressed < 0 || curKeyPressed > 127)
+            curKeyPressed = -1;
+      
+      emit keyPressed(curKeyPressed);
+      }
+
+//---------------------------------------------------------
+//   mouseReleaseEvent
+//---------------------------------------------------------
+
+void PianoKeyboard::mouseReleaseEvent(QMouseEvent*)
+      {
+      emit keyReleased(curKeyPressed);
+      curKeyPressed = -1;
+      }
+
+//---------------------------------------------------------
+//   mouseMoveEvent
+//---------------------------------------------------------
+
+void PianoKeyboard::mouseMoveEvent(QMouseEvent* event)
+      {
+      int offset = _orientation == PianoOrientation::HORIZONTAL
+            ? event->pos().x()
+            : 128 * noteHeight - (event->y() + _ypos);
+
+      int pitch = offset / noteHeight;
+
+      if (pitch != curPitch) {
+            curPitch = pitch;
+
+            //Set tooltip
+            int degree = curPitch % 12;
+            int octave = curPitch / 12;
+            QString text = pitchNames[degree] + QString::number(octave - 1);
+            Part* part = _staff->part();
+            Drumset* ds = part->instrument()->drumset();
+            if (ds)
+                  text += " - " + ds->name(curPitch);
+
+            setToolTip(text);
+
+            //Send event
+            emit pitchChanged(curPitch);
+            if ((curKeyPressed != -1) && (curKeyPressed != pitch)) {
+                  emit keyReleased(curKeyPressed);
+                  curKeyPressed = pitch;
+                  emit keyPressed(curKeyPressed);
+                  }
+            update();
+            }
+      }
+
+//---------------------------------------------------------
+//   leaveEvent
+//---------------------------------------------------------
+
+void PianoKeyboard::leaveEvent(QEvent*)
+      {
+      if (curPitch != -1) {
+            curPitch = -1;
+            emit pitchChanged(-1);
+            update();
+            }
+      }
+
+
+//---------------------------------------------------------
+//   setStaff
+//---------------------------------------------------------
+
+void PianoKeyboard::setStaff(Staff* staff)
+      {
+      _staff = staff;
+      update();
+      }
+
+//---------------------------------------------------------
+//   setOrientation
+//---------------------------------------------------------
+
+void PianoKeyboard::setOrientation(PianoOrientation o)
+      {
+      _orientation = o;
+      update();
+      }
+}

--- a/mscore/pianokeyboard.h
+++ b/mscore/pianokeyboard.h
@@ -1,0 +1,81 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __PIANO_KEYBOARD_H__
+#define __PIANO_KEYBOARD_H__
+
+#include "piano.h"
+
+namespace Ms {
+
+class Staff;
+
+static const int PIANO_KEYBOARD_WIDTH = 100;
+static const int BLACK_KEY_WIDTH = PIANO_KEYBOARD_WIDTH * 9 / 14;
+const int MAX_KEY_HEIGHT = 20;
+const int MIN_KEY_HEIGHT = 8;
+const int DEFAULT_KEY_HEIGHT = 14;
+const int BEAT_WIDTH_IN_PIXELS = 50;
+const double X_ZOOM_RATIO = 1.1;
+const double X_ZOOM_INITIAL = 0.1;
+
+      
+//Alternative implementation with evenly spaced notes
+class PianoKeyboard : public QWidget {
+      Q_OBJECT
+
+      static const QString pitchNames[];
+
+      PianoOrientation _orientation;
+      int _ypos;
+
+      int noteHeight;
+      int yRange;
+      int curPitch;
+      int curKeyPressed;
+      Staff* _staff;
+
+      virtual void paintEvent(QPaintEvent*);
+      virtual void mousePressEvent(QMouseEvent*);
+      virtual void mouseReleaseEvent(QMouseEvent*);
+      virtual void mouseMoveEvent(QMouseEvent* event);
+      virtual void leaveEvent(QEvent*);
+
+   signals:
+      void pitchChanged(int);
+      void keyPressed(int pitch);
+      void keyReleased(int pitch);
+
+   public slots:
+      void setYpos(int val);
+      void setNoteHeight(int);
+      void setPitch(int);
+
+   public:
+      PianoKeyboard(QWidget* parent = 0);
+      Staff* staff() { return _staff; }
+      void setStaff(Staff* staff);
+      void setOrientation(PianoOrientation);
+      };
+
+
+} // namespace Ms
+#endif
+

--- a/mscore/pianolevels.cpp
+++ b/mscore/pianolevels.cpp
@@ -1,0 +1,613 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "pianolevels.h"
+
+#include "pianoruler.h"
+#include "pianokeyboard.h"
+#include "pianoview.h"
+#include "pianolevelsfilter.h"
+#include "preferences.h"
+#include "libmscore/segment.h"
+#include "libmscore/score.h"
+#include "libmscore/staff.h"
+#include "libmscore/chord.h"
+#include "libmscore/rest.h"
+#include "libmscore/note.h"
+#include "libmscore/slur.h"
+#include "libmscore/tie.h"
+#include "libmscore/tuplet.h"
+#include "libmscore/noteevent.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   PianoLevels
+//---------------------------------------------------------
+
+PianoLevels::PianoLevels(QWidget *parent)
+    : QWidget(parent)
+       {
+       setMouseTracking(true);
+       _xpos   = 0;
+       _xZoom = X_ZOOM_INITIAL;
+       _tuplet = 1;
+       _subdiv = 0;
+       _levelsIndex = 0;
+       minBeatGap = 20;
+       vMargin = 10;
+       levelLen = 20;
+       mouseDown = false;
+       dragging = false;
+       }
+
+//---------------------------------------------------------
+//   ~PianoLevels
+//---------------------------------------------------------
+
+PianoLevels::~PianoLevels()
+      {
+      clearNoteData();
+      }
+
+//---------------------------------------------------------
+//   setScore
+//---------------------------------------------------------
+
+void PianoLevels::setScore(Score* s, Pos* lc)
+      {
+      _score = s;
+      _locator = lc;
+      if (_score)
+            _cursor.setContext(_score->tempomap(), _score->sigmap());
+      setEnabled(_score != 0);
+      }
+
+//---------------------------------------------------------
+//   setXpos
+//---------------------------------------------------------
+
+void PianoLevels::setXpos(int val)
+      {
+      _xpos = val;
+      update();
+      }
+
+
+//---------------------------------------------------------
+//   pixelXToTick
+//---------------------------------------------------------
+
+int PianoLevels::pixelXToTick(int pixX) {
+      return (int)((pixX + _xpos) / _xZoom) - MAP_OFFSET;
+      }
+
+
+//---------------------------------------------------------
+//   tickToPixelX
+//---------------------------------------------------------
+
+int PianoLevels::tickToPixelX(int tick) {
+      return (int)(tick + MAP_OFFSET) * _xZoom - _xpos;
+      }
+
+
+//---------------------------------------------------------
+//   paintEvent
+//---------------------------------------------------------
+
+void PianoLevels::paintEvent(QPaintEvent* e)
+      {
+      QPainter p(this);
+
+      QColor colPianoBg;
+      QColor noteDeselected;
+      QColor noteSelected;
+
+      QColor colGridLine;
+      QColor colText;
+
+      switch (preferences.globalStyle()) {
+            case MuseScoreStyleType::DARK_FUSION:
+                  colPianoBg = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_BASE_COLOR));
+                  noteDeselected = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_NOTE_UNSEL_COLOR));
+                  noteSelected = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_NOTE_SEL_COLOR));
+
+                  colGridLine = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_GRIDLINE_COLOR));
+                  colText = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_TEXT_COLOR));
+                  break;
+            default:
+                  colPianoBg = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_BG_BASE_COLOR));
+                  noteDeselected = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_NOTE_UNSEL_COLOR));
+                  noteSelected = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_NOTE_SEL_COLOR));
+
+                  colGridLine = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_BG_GRIDLINE_COLOR));
+                  colText = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_BG_TEXT_COLOR));
+                  break;
+            }
+
+
+      const QPen penLineMajor = QPen(colGridLine, 2.0, Qt::SolidLine);
+      const QPen penLineMinor = QPen(colGridLine, 1.0, Qt::SolidLine);
+      const QPen penLineSub = QPen(colGridLine, 1.0, Qt::DotLine);
+
+      const QRect& r = e->rect();
+
+      p.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
+
+      p.setBrush(colPianoBg);
+      p.drawRect(0, 0, width(), height());
+
+      if (!_score)
+            return;
+
+      Pos pos1(_score->tempomap(), _score->sigmap(), qMax(pixelXToTick(r.x()), 0), TType::TICKS);
+      Pos pos2(_score->tempomap(), _score->sigmap(), qMax(pixelXToTick(r.x() + r.width()), 0), TType::TICKS);
+
+      //draw vert lines
+      int bar1, bar2, beat, tick;
+
+      pos1.mbt(&bar1, &beat, &tick);
+      pos2.mbt(&bar2, &beat, &tick);
+
+      //Estimate bar width since changing time signatures can make this inconsistent.
+      // Assuming 480 ticks per beat, 4 beats per bar
+      qreal pixPerBar = MScore::division * 4 * _xZoom;
+      qreal pixPerBeat = MScore::division * _xZoom;
+
+      int barSkip = ceil(minBeatGap / pixPerBar);
+      barSkip = (int)pow(2, ceil(log(barSkip)/log(2)));
+
+      int beatSkip = ceil(minBeatGap / pixPerBeat);
+      beatSkip = (int)pow(2, ceil(log(beatSkip)/log(2)));
+
+      //Round down to first bar to be a multiple of barSkip
+      bar1 = (bar1 / barSkip) * barSkip;
+
+//      int subExp = qMin((int)floor(log2(pixPerBeat / minBeatGap)), _subBeats);
+//      int numSubBeats = pow(2, subExp);
+
+      for (int bar = bar1; bar <= bar2; bar += barSkip) {
+            Pos stick(_score->tempomap(), _score->sigmap(), bar, 0, 0);
+
+            SigEvent sig = stick.timesig();
+            int z = sig.timesig().numerator();
+            for (int beat = 0; beat < z; beat += beatSkip) {
+                  Pos beatPos(_score->tempomap(), _score->sigmap(), bar, beat, 0);
+                  double xp = tickToPixelX(beatPos.time(TType::TICKS));
+                  if (xp < 0)
+                        continue;
+
+                  if (beat == 0) {
+                        p.setPen(penLineMajor);
+                        }
+                  else {
+                        p.setPen(penLineMinor);
+                        }
+
+                  p.drawLine(xp, 0, xp, height());
+
+                  int subbeats = _tuplet * (1 << _subdiv);
+
+                  for (int sub = 1; sub < subbeats; ++sub) {
+                        Pos subBeatPos(_score->tempomap(), _score->sigmap(), bar, beat, sub * MScore::division / subbeats);
+                        xp = tickToPixelX(subBeatPos.time(TType::TICKS));
+
+                        p.setPen(penLineSub);
+                        p.drawLine(xp, 0, xp, height());
+                        }
+                  }
+            }
+
+
+      //draw horiz lines
+      PianoLevelsFilter* filter = PianoLevelsFilter::FILTER_LIST[_levelsIndex];
+
+      QFont f("FreeSans", 7);
+      p.setFont(f);
+
+      int div = filter->divisionGap();
+      int minGuide = (int)floor(filter->minRange() / (qreal)div);
+      int maxGuide = (int)ceil(filter->maxRange() / (qreal)div);
+
+      for (int i = minGuide; i <= maxGuide; ++i) {
+            p.setPen(i == 0 || i == minGuide || i == maxGuide ? penLineMajor : penLineMinor);
+
+            int y = valToPixelY(i * div);
+            p.drawLine(0, y, width(), y);
+
+            //labels
+            QRectF textRect(2, y - 12, width() - 2, 12);
+            p.setPen(QPen(colText));
+            p.drawText(textRect,
+                  Qt::AlignLeft | Qt::AlignBottom, QString::number(i * div));
+            }
+
+
+      //Note lines
+      p.setBrush(Qt::NoBrush);
+      int pix0 = valToPixelY(0);
+
+      for (int i = 0; i < noteList.size(); ++i) {
+            Note* note = noteList[i];
+            if (filter->isPerEvent()) {
+                  for (NoteEvent& e : note->playEvents()) {
+                        int x = tickToPixelX(noteStartTick(note, &e));
+
+                        int val = filter->value(_staff, note, &e);
+                        p.setPen(QPen(note->selected() ? noteSelected : noteDeselected, 2));
+                        int pixY = valToPixelY(val);
+                        p.drawLine(x, pix0, x, pixY);
+
+                        //hbar
+                        p.setPen(QPen(note->selected() ? noteSelected : noteDeselected, 2));
+                        p.drawLine(x, pixY, x + levelLen, pixY);
+                        p.drawEllipse(x - 1, pixY - 1, 3, 3);
+                        }
+
+                  }
+            else {
+                  int x = tickToPixelX(noteStartTick(note, 0));
+
+                  int val = filter->value(_staff, note, 0);
+
+                  p.setPen(QPen(note->selected() ? noteSelected : noteDeselected, 2));
+                  int pixY = valToPixelY(val);
+                  p.drawLine(x, pix0, x, pixY);
+
+                  //hbar
+                  p.setPen(QPen(note->selected() ? noteSelected : noteDeselected, 2));
+                  p.drawLine(x, pixY, x + levelLen, pixY);
+                  p.drawEllipse(x - 1, pixY - 1, 3, 3);
+                  }
+            }
+      }
+
+
+//---------------------------------------------------------
+//   noteStartTick
+//---------------------------------------------------------
+
+int PianoLevels::noteStartTick(Note* note, NoteEvent* evt) {
+      Chord* chord = note->chord();
+      int ticks = chord->duration().ticks();
+
+      return note->chord()->tick()
+            + (evt ? evt->ontime() * ticks / 1000 : 0);
+      }
+
+
+//---------------------------------------------------------
+//   valToPixelY
+//---------------------------------------------------------
+
+int PianoLevels::valToPixelY(int value) {
+      PianoLevelsFilter* filter = PianoLevelsFilter::FILTER_LIST[_levelsIndex];
+
+      int range = filter->maxRange() - filter->minRange();
+      qreal frac = (value - filter->minRange()) / (qreal)range;
+
+      return (int)(height() - vMargin * 2) * (1 - frac) + vMargin;
+      }
+
+
+//---------------------------------------------------------
+//   pixelYToVal
+//---------------------------------------------------------
+
+int PianoLevels::pixelYToVal(int pix) {
+      qreal frac = 1 - (pix - vMargin) / (qreal)(height() - vMargin * 2);
+
+      PianoLevelsFilter* filter = PianoLevelsFilter::FILTER_LIST[_levelsIndex];
+      int range = filter->maxRange() - filter->minRange();
+      return (int)(frac * range + filter->minRange());
+      }
+
+
+//---------------------------------------------------------
+//   mousePressEvent
+//       For all points between tick0 and tick1, linearly interploate between value0 and value1 and
+//       use it to set the value of the level.
+//---------------------------------------------------------
+
+void PianoLevels::adjustLevel(int tick0, int value0, int tick1, int value1, bool selectedOnly)
+      {
+      if (tick1 < tick0) {
+            int tmp = tick0;
+            tick0 = tick1;
+            tick1 = tmp;
+
+            tmp = value0;
+            value0 = value1;
+            value1 = tmp;
+            }
+
+      PianoLevelsFilter* filter = PianoLevelsFilter::FILTER_LIST[_levelsIndex];
+      bool hitNote = false;
+
+      for (int i = 0; i < noteList.size(); ++i) {
+            Note* note = noteList[i];
+            if (selectedOnly && !note->selected())
+                  continue;
+
+            if (filter->isPerEvent()) {
+                  for (NoteEvent& e : note->playEvents()) {
+                        int tick = noteStartTick(note, &e);
+                        if (tick0 <= tick && tick <= tick1) {
+                              int value = tick0 == tick1 ? value0
+                                    : (value1 - value0) * (tick - tick0) / (tick1 - tick0) + value0;
+
+                              filter->setValue(_staff, note, &e, value);
+                              hitNote = true;
+                              }
+                        }
+                  }
+            else {
+                  int tick = noteStartTick(note, 0);
+                  if (tick0 <= tick && tick <= tick1) {
+                        int value = (value1 - value0) * (tick - tick0) / (tick1 - tick0) + value0;
+                        filter->setValue(_staff, note, 0, value);
+                        hitNote = true;
+                        }
+                  }
+            }
+
+      if (hitNote) {
+            update();
+            emit noteLevelsChanged();
+            }
+
+      }
+
+//---------------------------------------------------------
+//   mousePressEvent
+//---------------------------------------------------------
+
+void PianoLevels::mousePressEvent(QMouseEvent* e)
+      {
+      if (e->button() == Qt::LeftButton) {
+            mouseDown = true;
+            mouseDownPos = e->pos();
+            lastMousePos = mouseDownPos;
+            }
+      }
+
+
+//---------------------------------------------------------
+//   mouseReleaseEvent
+//---------------------------------------------------------
+
+void PianoLevels::mouseReleaseEvent(QMouseEvent* e)
+      {
+      if (e->button() == Qt::LeftButton) {
+
+            if (!dragging) {
+                  //Handle click
+                  lastMousePos = e->pos();
+
+                  int tick0 = pixelXToTick(lastMousePos.x() - 4);
+                  int tick1 = pixelXToTick(lastMousePos.x() + 4);
+                  int val = pixelYToVal(lastMousePos.y());
+                  adjustLevel(tick0, val, tick1, val);
+            }
+
+            mouseDown = false;
+            dragging = false;
+            }
+      }
+
+//---------------------------------------------------------
+//   mouseMoveEvent
+//---------------------------------------------------------
+
+void PianoLevels::mouseMoveEvent(QMouseEvent* e)
+      {
+      int modifiers = QGuiApplication::keyboardModifiers();
+      bool bnShift = modifiers & Qt::ShiftModifier;
+
+      if (mouseDown) {
+            if (!dragging) {
+                  int dx = e->x() - mouseDownPos.x();
+                  int dy = e->y() - mouseDownPos.y();
+                  if (dx * dx + dy * dy > 4) {
+                        //Start dragging
+                        dragging = true;
+                        }
+                  }
+
+            if (dragging) {
+                  int tick0 = pixelXToTick(lastMousePos.x());
+                  int tick1 = pixelXToTick(e->x());
+
+                  int val0;
+                  int val1;
+
+                  if (bnShift) {
+                        //If shift is held, set to value at mousedown
+                        val0 = pixelYToVal(mouseDownPos.y());
+                        val1 = pixelYToVal(mouseDownPos.y());
+                        }
+                  else {
+                        val0 = pixelYToVal(lastMousePos.y());
+                        val1 = pixelYToVal(e->y());
+                        }
+
+                  lastMousePos = e->pos();
+                  adjustLevel(tick0, val0, tick1, val1);
+                  }
+
+            }
+      }
+
+//---------------------------------------------------------
+//   moveLocator
+//---------------------------------------------------------
+
+void PianoLevels::moveLocator(QMouseEvent* e)
+      {
+      Pos pos(_score->tempomap(), _score->sigmap(), qMax(pixelXToTick(e->pos().x()), 0), TType::TICKS);
+      if (e->buttons() & Qt::LeftButton)
+            emit locatorMoved(0, pos);
+      else if (e->buttons() & Qt::MidButton)
+            emit locatorMoved(1, pos);
+      else if (e->buttons() & Qt::RightButton)
+            emit locatorMoved(2, pos);
+      }
+
+//---------------------------------------------------------
+//   leaveEvent
+//---------------------------------------------------------
+
+void PianoLevels::leaveEvent(QEvent*)
+      {
+      _cursor.setInvalid();
+      emit posChanged(_cursor);
+      update();
+      }
+
+//---------------------------------------------------------
+//   setPos
+//---------------------------------------------------------
+
+void PianoLevels::setPos(const Pos& pos)
+      {
+      if (_cursor != pos) {
+            _cursor = pos;
+            update();
+            }
+      }
+
+//---------------------------------------------------------
+//   setXZoom
+//---------------------------------------------------------
+
+void PianoLevels::setXZoom(qreal xZoom)
+      {
+      _xZoom = xZoom;
+      update();
+      }
+
+//---------------------------------------------------------
+//   setStaff
+//---------------------------------------------------------
+
+void PianoLevels::setStaff(Staff* s, Pos* l)
+      {
+      _locator = l;
+
+      if (_staff == s)
+            return;
+
+      _staff    = s;
+      updateNotes();
+      }
+
+
+//---------------------------------------------------------
+//   addChord
+//---------------------------------------------------------
+
+void PianoLevels::addChord(Chord* chord, int voice)
+      {
+      for (Chord* c : chord->graceNotes())
+            addChord(c, voice);
+      for (Note* note : chord->notes()) {
+            if (note->tieBack())
+                  continue;
+            noteList.append(note);
+            }
+      }
+
+//---------------------------------------------------------
+//   updateNotes
+//---------------------------------------------------------
+
+void PianoLevels::updateNotes()
+      {
+      clearNoteData();
+
+      if (!_staff) {
+            return;
+            }
+
+      int staffIdx   = _staff->idx();
+
+      SegmentType st = SegmentType::ChordRest;
+      for (Segment* s = _staff->score()->firstSegment(st); s; s = s->next1(st)) {
+            for (int voice = 0; voice < VOICES; ++voice) {
+                  int track = voice + staffIdx * VOICES;
+                  Element* e = s->element(track);
+                  if (e && e->isChord())
+                        addChord(toChord(e), voice);
+                  }
+            }
+
+      update();
+      }
+
+//---------------------------------------------------------
+//   clearNoteData
+//---------------------------------------------------------
+
+void PianoLevels::clearNoteData()
+      {
+      noteList.clear();
+      }
+
+//---------------------------------------------------------
+//   setTuplet
+//---------------------------------------------------------
+
+void PianoLevels::setTuplet(int value)
+      {
+      if (_tuplet != value) {
+            _tuplet = value;
+            update();
+            emit tupletChanged(_tuplet);
+            }
+      }
+
+//---------------------------------------------------------
+//   setSubdiv
+//---------------------------------------------------------
+
+void PianoLevels::setSubdiv(int value)
+      {
+      if (_subdiv != value) {
+            _subdiv = value;
+            update();
+            emit subdivChanged(_subdiv);
+            }
+      }
+
+//---------------------------------------------------------
+//   setLevelsIndex
+//---------------------------------------------------------
+
+void PianoLevels::setLevelsIndex(int index)
+      {
+      if (_levelsIndex != index) {
+            _levelsIndex = index;
+            update();
+            emit levelsIndexChanged(_levelsIndex);
+            }
+      }
+
+}

--- a/mscore/pianolevels.h
+++ b/mscore/pianolevels.h
@@ -1,0 +1,117 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __PIANOLEVELS_H__
+#define __PIANOLEVELS_H__
+
+#include <QWidget>
+
+#include "libmscore/pos.h"
+
+namespace Ms {
+
+class Score;
+class Staff;
+class Chord;
+class Note;
+class NoteEvent;
+class PianoItem;
+
+
+
+//---------------------------------------------------------
+//   PianoLevels
+//---------------------------------------------------------
+
+class PianoLevels : public QWidget
+{
+      Q_OBJECT
+
+      Score* _score;
+      int _xpos;
+      qreal _xZoom;
+      Pos _cursor;
+      Pos* _locator;
+      Staff* _staff;
+      int _tuplet;
+      int _subdiv;
+      int _levelsIndex;
+      int vMargin;
+      int levelLen;
+
+      bool mouseDown;
+      QPointF mouseDownPos;
+      QPointF lastMousePos;
+      int dragging;
+
+      int minBeatGap;
+
+      QList<Note*> noteList;
+
+      virtual void paintEvent(QPaintEvent*);
+      virtual void mousePressEvent(QMouseEvent*);
+      virtual void mouseReleaseEvent(QMouseEvent* event);
+      virtual void mouseMoveEvent(QMouseEvent* event);
+      virtual void leaveEvent(QEvent*);
+
+      int pixelXToTick(int pixX);
+      int tickToPixelX(int tick);
+      int valToPixelY(int value);
+      int pixelYToVal(int value);
+      int noteStartTick(Note* note, NoteEvent* evt);
+      void moveLocator(QMouseEvent*);
+      void addChord(Chord* chord, int voice);
+      void clearNoteData();
+
+      void adjustLevel(int tick0, int value0, int tick1, int value1, bool selectedOnly = true);
+
+signals:
+      void posChanged(const Pos&);
+      void tupletChanged(int);
+      void subdivChanged(int);
+      void levelsIndexChanged(int);
+      void locatorMoved(int idx, const Pos&);
+      void noteLevelsChanged();
+
+public slots:
+      void setXpos(int);
+      void setTuplet(int);
+      void setSubdiv(int);
+      void setXZoom(qreal);
+      void setPos(const Pos&);
+      void setLevelsIndex(int index);
+
+public:
+      PianoLevels(QWidget *parent = 0);
+      ~PianoLevels();
+
+      void setScore(Score*, Pos* locator);
+      Staff* staff() { return _staff; }
+      void setStaff(Staff*, Pos* locator);
+      void updateNotes();
+      int tuplet() const { return _tuplet; }
+      int subdiv() const { return _subdiv; }
+
+      int xpos() const { return _xpos; }
+      qreal xZoom() const { return _xZoom; }
+};
+
+}
+#endif // __PIANOLEVELS_H__

--- a/mscore/pianolevelschooser.cpp
+++ b/mscore/pianolevelschooser.cpp
@@ -1,0 +1,44 @@
+#include "pianolevelschooser.h"
+#include "pianolevelsfilter.h"
+
+namespace Ms {
+
+
+//---------------------------------------------------------
+//   PianoLevelsChooser
+//---------------------------------------------------------
+
+PianoLevelsChooser::PianoLevelsChooser(QWidget *parent)
+      : QWidget(parent)
+{
+      _levelsIndex = 0;
+
+      QGridLayout* layout = new QGridLayout;
+
+      levelsCombo = new QComboBox;
+      for (int i = 0; PianoLevelsFilter::FILTER_LIST[i]; ++i) {
+            QString name = PianoLevelsFilter::FILTER_LIST[i]->name();
+            levelsCombo->addItem(name, i);
+            }
+
+      layout->addWidget(levelsCombo, 0, 0, 1, 1);
+
+      setLayout(layout);
+
+      connect(levelsCombo, SIGNAL(activated(int)), SLOT(setLevelsIndex(int)));
+}
+
+
+//---------------------------------------------------------
+//   PianoLevelsChooser
+//---------------------------------------------------------
+
+void PianoLevelsChooser::setLevelsIndex(int index)
+{
+      if (_levelsIndex != index) {
+            _levelsIndex = index;
+            emit levelsIndexChanged(index);
+            }
+}
+
+}

--- a/mscore/pianolevelschooser.h
+++ b/mscore/pianolevelschooser.h
@@ -1,0 +1,52 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __PIANOLEVELSCHOOSER_H__
+#define __PIANOLEVELSCHOOSER_H__
+
+#include <QObject>
+#include <QWidget>
+
+namespace Ms {
+
+
+//---------------------------------------------------------
+//   PianoLevelsChooser
+//---------------------------------------------------------
+
+class PianoLevelsChooser : public QWidget
+{
+    Q_OBJECT
+
+      QComboBox* levelsCombo;
+      int _levelsIndex;
+signals:
+      void levelsIndexChanged(int);
+
+public slots:
+      void setLevelsIndex(int index);
+
+public:
+    explicit PianoLevelsChooser(QWidget *parent = 0);
+};
+
+}
+
+#endif // __PIANOLEVELSCHOOSER_H__

--- a/mscore/pianolevelsfilter.cpp
+++ b/mscore/pianolevelsfilter.cpp
@@ -1,0 +1,162 @@
+#include "pianolevelsfilter.h"
+
+#include "libmscore/note.h"
+#include "libmscore/staff.h"
+#include "libmscore/score.h"
+#include "libmscore/undo.h"
+
+
+namespace Ms {
+
+PianoLevelsFilter* PianoLevelsFilter::FILTER_LIST[] = {
+      new PianoLevelFilterLen,
+      new PianoLevelFilterVeloOffset,
+      new PianoLevelFilterVeloUser,
+      new PianoLevelFilterOnTime,
+      0  //end of list indicator
+};
+
+//---------------------------------------------------------
+//   value
+//---------------------------------------------------------
+
+int PianoLevelFilterOnTime::value(Staff* /*staff*/, Note* /*note*/, NoteEvent* evt)
+      {
+      return evt->ontime();
+      }
+
+//---------------------------------------------------------
+//   setValue
+//---------------------------------------------------------
+
+void PianoLevelFilterOnTime::setValue(Staff* staff, Note* note, NoteEvent* evt, int value)
+      {
+      Score* score = staff->score();
+
+      NoteEvent ne = *evt;
+      ne.setOntime(value);
+
+      score->startCmd();
+      score->undo(new ChangeNoteEvent(note, evt, ne));
+      score->endCmd();
+      }
+
+//---------------------------------------------------------
+//   value
+//---------------------------------------------------------
+
+int PianoLevelFilterLen::value(Staff* /*staff*/, Note* /*note*/, NoteEvent* evt)
+      {
+      return evt->len();
+      }
+
+//---------------------------------------------------------
+//   setValue
+//---------------------------------------------------------
+
+void PianoLevelFilterLen::setValue(Staff* staff, Note* note, NoteEvent* evt, int value)
+      {
+      Score* score = staff->score();
+
+      NoteEvent ne = *evt;
+      ne.setLen(value);
+
+      score->startCmd();
+      score->undo(new ChangeNoteEvent(note, evt, ne));
+      score->endCmd();
+      }
+
+//---------------------------------------------------------
+//   value
+//---------------------------------------------------------
+
+int PianoLevelFilterVeloOffset::value(Staff* staff, Note* note, NoteEvent* /*evt*/)
+      {
+      //Change velocity to equivilent in new metric
+      switch (Note::ValueType(note->veloType())) {
+            case Note::ValueType::USER_VAL: {
+                  int dynamicsVel = staff->velocities().velo(note->tick());
+                  return (int)((note->veloOffset() / (qreal)dynamicsVel - 1) * 100);
+                  }
+            default:
+            case Note::ValueType::OFFSET_VAL:
+                  return note->veloOffset();
+            }
+      }
+
+//---------------------------------------------------------
+//   setValue
+//---------------------------------------------------------
+
+void PianoLevelFilterVeloOffset::setValue(Staff* staff, Note* note, NoteEvent* /*evt*/, int value)
+      {
+      Score* score = staff->score();
+
+      score->startCmd();
+
+      switch (Note::ValueType(note->veloType())) {
+            case Note::ValueType::USER_VAL: {
+                  int dynamicsVel = staff->velocities().velo(note->tick());
+                  int newVelocity = (int)(dynamicsVel * (1 + value / 100.0));
+
+                  score->undo(new ChangeVelocity(note, Note::ValueType::USER_VAL, newVelocity));
+
+                  break;
+                  }
+            default:
+            case Note::ValueType::OFFSET_VAL: {
+                  score->undo(new ChangeVelocity(note, Note::ValueType::OFFSET_VAL, value));
+                  break;
+                  }
+            }
+
+      score->endCmd();
+      }
+
+
+//---------------------------------------------------------
+//   value
+//---------------------------------------------------------
+
+int PianoLevelFilterVeloUser::value(Staff* staff, Note* note, NoteEvent* /*evt*/)
+      {
+      //Change velocity to equivilent in new metric
+      switch (Note::ValueType(note->veloType())) {
+            case Note::ValueType::USER_VAL:
+                  return note->veloOffset();
+            default:
+            case Note::ValueType::OFFSET_VAL: {
+                  int dynamicsVel = staff->velocities().velo(note->tick());
+                  return (int)(dynamicsVel * (1 + note->veloOffset() / 100.0));
+                  }
+            }
+      }
+
+//---------------------------------------------------------
+//   setValue
+//---------------------------------------------------------
+
+void PianoLevelFilterVeloUser::setValue(Staff* staff, Note* note, NoteEvent* /*evt*/, int value)
+      {
+      Score* score = staff->score();
+
+      score->startCmd();
+
+      switch (Note::ValueType(note->veloType())) {
+            case Note::ValueType::USER_VAL:
+                  score->undo(new ChangeVelocity(note, Note::ValueType::USER_VAL, value));
+                  break;
+            default:
+            case Note::ValueType::OFFSET_VAL: {
+                  int dynamicsVel = staff->velocities().velo(note->tick());
+                  int newVelocity = (int)((value / (qreal)dynamicsVel - 1) * 100);
+
+                  score->undo(new ChangeVelocity(note, Note::ValueType::OFFSET_VAL, newVelocity));
+                  break;
+                  }
+            }
+
+      score->endCmd();
+      }
+
+}

--- a/mscore/pianolevelsfilter.h
+++ b/mscore/pianolevelsfilter.h
@@ -1,0 +1,125 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __PIANOLEVELSFILTER_H__
+#define __PIANOLEVELSFILTER_H__
+
+#include <QString>
+
+namespace Ms {
+
+class Note;
+class NoteEvent;
+class Staff;
+
+
+//---------------------------------------------------------
+//   PianoLevelsFilter
+//       Manage note/event data for different views when drawing in the PianoLevels window
+//---------------------------------------------------------
+
+class PianoLevelsFilter
+{
+public:
+      static PianoLevelsFilter* FILTER_LIST[];
+
+      virtual QString name() = 0;
+      virtual int maxRange() = 0;
+      virtual int minRange() = 0;
+      virtual int divisionGap() = 0;  //Vertical guide line seperation gap
+      virtual bool isPerEvent() = 0;
+      virtual int value(Staff* staff, Note* note, NoteEvent* evt) = 0;
+      virtual void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) = 0;
+};
+
+
+//---------------------------------------------------------
+//   PianoLevelFilterOnTime
+//---------------------------------------------------------
+
+class PianoLevelFilterOnTime : public PianoLevelsFilter
+{
+public:
+      QString name() override { return "On Time"; }
+      int maxRange() override { return 1000; }
+      int minRange() override { return 0; }
+      int divisionGap() override { return 250; }
+      bool isPerEvent() override { return true; }
+      int value(Staff* staff, Note* note, NoteEvent* evt) override;
+      void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
+};
+
+
+//---------------------------------------------------------
+//   PianoLevelFilterLen
+//---------------------------------------------------------
+
+
+class PianoLevelFilterLen : public PianoLevelsFilter
+{
+public:
+      QString name() override { return "Length"; }
+      int maxRange() override { return 1000; }
+      int minRange() override { return 0; }
+      int divisionGap() override { return 250; }
+      bool isPerEvent() override { return true; }
+      int value(Staff* staff, Note* note, NoteEvent* evt) override;
+      void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
+};
+
+
+//---------------------------------------------------------
+//   PianoLevelFilterVeloOffset
+//---------------------------------------------------------
+
+
+class PianoLevelFilterVeloOffset : public PianoLevelsFilter
+{
+public:
+      QString name() override { return "Velocity Offset"; }
+      int maxRange() override { return 200; }
+      int minRange() override { return -200; }
+      int divisionGap() override { return 100; }
+      bool isPerEvent() override { return false; }
+      int value(Staff* staff, Note* note, NoteEvent* evt) override;
+      void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
+};
+
+
+//---------------------------------------------------------
+//   PianoLevelFilterVeloUser
+//---------------------------------------------------------
+
+
+class PianoLevelFilterVeloUser : public PianoLevelsFilter
+{
+public:
+      QString name() override { return "Velocity Absolute"; }
+      int maxRange() override { return 128; }
+      int minRange() override { return 0; }
+      int divisionGap() override { return 32; }
+      bool isPerEvent() override { return false; }
+      int value(Staff* staff, Note* note, NoteEvent* evt) override;
+      void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
+};
+
+}
+
+#endif // __PIANOLEVELSFILTER_H__

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -12,8 +12,10 @@
 
 #include "pianoroll.h"
 #include "config.h"
-#include "piano.h"
-#include "ruler.h"
+#include "pianokeyboard.h"
+#include "pianoruler.h"
+#include "pianolevels.h"
+#include "pianolevelschooser.h"
 #include "pianoview.h"
 #include "musescore.h"
 #include "seq.h"
@@ -83,8 +85,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       connect(showWave, SIGNAL(toggled(bool)), SLOT(showWaveView(bool)));
       tb->addAction(showWave);
 
-      //-------------
-      tb = addToolBar(tr("Toolbar 2"));
+      tb->addSeparator();
       for (int i = 0; i < VOICES; ++i) {
             QToolButton* b = new QToolButton(this);
             b->setToolButtonStyle(Qt::ToolButtonTextOnly);
@@ -97,6 +98,14 @@ PianorollEditor::PianorollEditor(QWidget* parent)
             }
 
       tb->addSeparator();
+
+      partLabel = new QLabel("Part:");
+      tb->addWidget(partLabel);
+
+
+      //-------------
+      tb = addToolBar(tr("Toolbar 2"));
+
       tb->addWidget(new QLabel(tr("Cursor:")));
       pos = new Awl::PosLabel;
       pos->setFrameStyle(QFrame::NoFrame | QFrame::Plain);
@@ -107,6 +116,30 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       tb->addWidget(pl);
 
       tb->addSeparator();
+
+      tb->addWidget(new QLabel(tr("Subdiv:")));
+      subdiv = new QSpinBox;
+      subdiv->setToolTip(tr("Subdivide the beat this many times"));
+      subdiv->setMinimum(0);
+      subdiv->setValue(0);
+      tb->addWidget(subdiv);
+
+      tb->addWidget(new QLabel(tr("Tuplet:")));
+      tuplet = new QSpinBox;
+      tuplet->setToolTip(tr("Edit notes aligned to tuplets of this many beats"));
+      tuplet->setMinimum(1);
+      tuplet->setValue(1);
+      tb->addWidget(tuplet);
+
+      tb->addWidget(new QLabel(tr("Bar Pattern:")));
+      barPattern = new QComboBox;
+      barPattern->setToolTip(tr("White key lines show the tones of this chord."));
+      for (int i = 0; !PianoView::barPatterns[i].name.isEmpty(); ++i) {
+            barPattern->addItem(PianoView::barPatterns[i].name, i);
+            }
+      tb->addWidget(barPattern);
+
+      tb->addSeparator();
       tb->addWidget(new QLabel(tr("Velocity:")));
       veloType = new QComboBox;
       veloType->addItem(tr("Offset"), int(Note::ValueType::OFFSET_VAL));
@@ -114,8 +147,7 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       tb->addWidget(veloType);
 
       velocity = new QSpinBox;
-      velocity->setRange(-1, 127);
-      velocity->setSpecialValueText("--");
+      velocity->setRange(-1000, 1000);
       velocity->setReadOnly(true);
       tb->addWidget(velocity);
 
@@ -133,82 +165,133 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       tickLen->setRange(-2000, 2000);
 
       //-------------
-      qreal xmag = .1;
-      ruler = new Ruler;
+      //Empty area for spacing
+      QWidget* topLeftSpacer = new QWidget;
+      topLeftSpacer->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+      topLeftSpacer->setFixedWidth(PIANO_KEYBOARD_WIDTH);
+      topLeftSpacer->setFixedHeight(pianoRulerHeight);
+
+      ruler = new PianoRuler;
       ruler->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-      ruler->setFixedHeight(rulerHeight);
+      ruler->setFixedHeight(pianoRulerHeight);
 
-      ruler->setMag(xmag, 1.0);
+      pianoKbd = new PianoKeyboard;
+      pianoKbd->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+      pianoKbd->setFixedWidth(PIANO_KEYBOARD_WIDTH);
 
-      Piano* piano = new Piano;
-      piano->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
-      piano->setFixedWidth(pianoWidth);
-
-      gv  = new PianoView;
-      gv->scale(xmag, 1.0);
-      gv->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-      gv->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+      pianoView = new PianoView;
+      pianoView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+      pianoView->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
       hsb = new QScrollBar(Qt::Horizontal);
-      connect(gv->horizontalScrollBar(), SIGNAL(rangeChanged(int,int)),
+      connect(pianoView->horizontalScrollBar(), SIGNAL(rangeChanged(int,int)),
          SLOT(rangeChanged(int,int)));
 
+      QWidget* noteAreaWidget = new QWidget;
+
+      QGridLayout* noteAreaLayout = new QGridLayout;
+      noteAreaLayout->setContentsMargins(0, 0, 0, 0);
+      noteAreaLayout->setSpacing(0);
+      noteAreaLayout->addWidget(topLeftSpacer, 0, 0, 1, 1);
+      noteAreaLayout->addWidget(ruler, 0, 1, 1, 1);
+      noteAreaLayout->addWidget(pianoKbd, 1, 0, 1, 1);
+      noteAreaLayout->addWidget(pianoView, 1, 1, 1, 1);
+      noteAreaLayout->addWidget(hsb, 2, 1, 1, 1);
+      noteAreaWidget->setLayout(noteAreaLayout);
+
+      //Levels area
+      pianoLevelsChooser = new PianoLevelsChooser;
+      pianoLevelsChooser->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+      pianoLevelsChooser->setFixedWidth(PIANO_KEYBOARD_WIDTH);
+
+      pianoLevels = new PianoLevels;
+      pianoLevels->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+      QWidget* levelsAreaWidget = new QWidget;
+      QHBoxLayout* levelsAreaLayout = new QHBoxLayout;
+      levelsAreaLayout->setContentsMargins(0, 0, 0, 0);
+      levelsAreaLayout->setSpacing(0);
+      levelsAreaLayout->addWidget(pianoLevelsChooser);
+      levelsAreaLayout->addWidget(pianoLevels);
+      levelsAreaWidget->setLayout(levelsAreaLayout);
+
       // layout
-      QHBoxLayout* hbox = new QHBoxLayout;
-      hbox->setSpacing(0);
-      hbox->addWidget(piano);
-      hbox->addWidget(gv);
+      QSplitter* editAreaSplitter = new QSplitter(Qt::Vertical);
+      editAreaSplitter->addWidget(noteAreaWidget);
+      editAreaSplitter->addWidget(levelsAreaWidget);
+      editAreaSplitter->setFrameShape(QFrame::NoFrame);
+
+      editAreaSplitter->setSizes(QList<int>() << (height() * 3 / 4) << (height() * 1 / 4));
+
+
 
       split = new QSplitter(Qt::Vertical);
       split->setFrameShape(QFrame::NoFrame);
 
-      QWidget* split1 = new QWidget;      // piano - pianoview
-      split1->setLayout(hbox);
-      split->addWidget(split1);
-
       QGridLayout* layout = new QGridLayout;
       layout->setContentsMargins(0, 0, 0, 0);
       layout->setSpacing(0);
-      layout->setColumnMinimumWidth(0, pianoWidth + 5);
-      layout->addWidget(tb,    0, 0, 1, 2);
-      layout->addWidget(ruler, 1, 1);
-      layout->addWidget(split, 2, 0, 1, 2);
-      layout->addWidget(hsb,   3, 1);
+      layout->setColumnMinimumWidth(0, PIANO_KEYBOARD_WIDTH);
+      layout->addWidget(tb,    0, 0, 1, 1);
+      layout->addWidget(editAreaSplitter, 1, 0, 1, 1);
 
       mainWidget->setLayout(layout);
       setCentralWidget(mainWidget);
 
-      connect(gv->verticalScrollBar(), SIGNAL(valueChanged(int)), piano, SLOT(setYpos(int)));
+      connect(pianoView->verticalScrollBar(),   SIGNAL(valueChanged(int)), pianoKbd, SLOT(setYpos(int)));
+      connect(pianoView->horizontalScrollBar(), SIGNAL(valueChanged(int)), hsb,      SLOT(setValue(int)));
 
-      connect(gv,          SIGNAL(magChanged(double,double)),  ruler, SLOT(setMag(double,double)));
-      connect(gv,          SIGNAL(magChanged(double,double)),  piano, SLOT(setMag(double,double)));
-      connect(gv,          SIGNAL(pitchChanged(int)),          pl,    SLOT(setPitch(int)));
-      connect(gv,          SIGNAL(pitchChanged(int)),          piano, SLOT(setPitch(int)));
-      connect(piano,       SIGNAL(pitchChanged(int)),          pl,    SLOT(setPitch(int)));
-      connect(gv,          SIGNAL(posChanged(const Pos&)),     pos,   SLOT(setValue(const Pos&)));
-      connect(gv,          SIGNAL(posChanged(const Pos&)),     ruler, SLOT(setPos(const Pos&)));
-      connect(ruler,       SIGNAL(posChanged(const Pos&)),     pos,   SLOT(setValue(const Pos&)));
+      connect(pianoView,          SIGNAL(xZoomChanged(qreal)),            ruler,       SLOT(setXZoom(qreal)));
+      connect(pianoView,          SIGNAL(xZoomChanged(qreal)),            pianoLevels, SLOT(setXZoom(qreal)));
+      connect(pianoView,          SIGNAL(noteHeightChanged(int)),         pianoKbd,    SLOT(setNoteHeight(int)));
+      connect(pianoView,          SIGNAL(pitchChanged(int)),              pl,          SLOT(setPitch(int)));
+      connect(pianoView,          SIGNAL(pitchChanged(int)),              pianoKbd,    SLOT(setPitch(int)));
+      connect(pianoKbd,           SIGNAL(pitchChanged(int)),              pl,          SLOT(setPitch(int)));
+      connect(pianoView,          SIGNAL(trackingPosChanged(const Pos&)), pos,         SLOT(setValue(const Pos&)));
+      connect(pianoView,          SIGNAL(trackingPosChanged(const Pos&)), ruler,       SLOT(setPos(const Pos&)));
+      connect(pianoView,          SIGNAL(trackingPosChanged(const Pos&)), pianoLevels, SLOT(setPos(const Pos&)));
+      connect(ruler,              SIGNAL(posChanged(const Pos&)),         pos,         SLOT(setValue(const Pos&)));
+      connect(pianoLevels,        SIGNAL(posChanged(const Pos&)),         pos,         SLOT(setValue(const Pos&)));
+      connect(tuplet,             SIGNAL(valueChanged(int)),              pianoView,   SLOT(setTuplet(int)));
+      connect(tuplet,             SIGNAL(valueChanged(int)),              pianoLevels, SLOT(setTuplet(int)));
+      connect(barPattern,         SIGNAL(activated(int)),                 pianoView,   SLOT(setBarPattern(int)));
+      connect(subdiv,             SIGNAL(valueChanged(int)),              pianoView,   SLOT(setSubdiv(int)));
+      connect(subdiv,             SIGNAL(valueChanged(int)),              pianoLevels, SLOT(setSubdiv(int)));
+      connect(pianoLevelsChooser, SIGNAL(levelsIndexChanged(int)),        pianoLevels, SLOT(setLevelsIndex(int)));
 
-      connect(hsb,         SIGNAL(valueChanged(int)),  SLOT(setXpos(int)));
-      connect(gv,          SIGNAL(xposChanged(int)),   SLOT(setXpos(int)));
-      connect(gv->horizontalScrollBar(), SIGNAL(valueChanged(int)), SLOT(setXpos(int)));
+      connect(hsb,         SIGNAL(valueChanged(int)),                 SLOT(setXpos(int)));
+      connect(pianoView->horizontalScrollBar(), SIGNAL(valueChanged(int)),   SLOT(setXpos(int)));
 
       connect(ruler,       SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
-      connect(veloType,    SIGNAL(activated(int)),     SLOT(veloTypeChanged(int)));
-      connect(velocity,    SIGNAL(valueChanged(int)),  SLOT(velocityChanged(int)));
-      connect(onTime,      SIGNAL(valueChanged(int)),  SLOT(onTimeChanged(int)));
-      connect(tickLen,     SIGNAL(valueChanged(int)),  SLOT(tickLenChanged(int)));
-      connect(gv->scene(), SIGNAL(selectionChanged()), SLOT(selectionChanged()));
-      connect(piano,       SIGNAL(keyPressed(int)),    SLOT(keyPressed(int)));
-      connect(piano,       SIGNAL(keyReleased(int)),   SLOT(keyReleased(int)));
+      connect(pianoLevels, SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
+      connect(veloType,    SIGNAL(activated(int)),                SLOT(veloTypeChanged(int)));
+      connect(velocity,    SIGNAL(valueChanged(int)),             SLOT(velocityChanged(int)));
+      connect(onTime,      SIGNAL(valueChanged(int)),             SLOT(onTimeChanged(int)));
+      connect(tickLen,     SIGNAL(valueChanged(int)),             SLOT(tickLenChanged(int)));
+      connect(pianoView,   SIGNAL(selectionChanged()),            SLOT(selectionChanged()));
+      connect(pianoKbd,    SIGNAL(keyPressed(int)),               SLOT(keyPressed(int)));
+      connect(pianoKbd,    SIGNAL(keyReleased(int)),              SLOT(keyReleased(int)));
+      connect(pianoLevels, SIGNAL(noteLevelsChanged()),           SLOT(selectionChanged()));
 
       readSettings();
 
+      actions.append(getAction("tie"));
+      actions.append(getAction("play"));
       actions.append(getAction("delete"));
       actions.append(getAction("pitch-up"));
       actions.append(getAction("pitch-down"));
       actions.append(getAction("pitch-up-octave"));
       actions.append(getAction("pitch-down-octave"));
+
+//      QMenu* popup = new QMenu(this);
+//      popup->setSeparatorsCollapsible(false);
+//      QAction* a = popup->addSeparator();
+//      popup->addAction(getAction("cut"));
+//      popup->addAction(getAction("copy"));
+//      popup->addAction(getAction("paste"));
+//      popup->addAction(getAction("swap"));
+//      popup->addAction(getAction("delete"));
+
       addActions(actions);
       for (auto* action : actions)
             connect(action, &QAction::triggered, this, [this, action](bool){ cmd(action); });
@@ -229,11 +312,29 @@ PianorollEditor::~PianorollEditor()
       }
 
 //---------------------------------------------------------
+//   focucOnElement
+//---------------------------------------------------------
+
+void PianorollEditor::focusOnPosition(Position* p)
+      {
+      if (!p || !p->segment)
+            return;
+
+      //Move view so that view is centered on this element
+      pianoView->ensureVisible(p->segment->tick());
+      }
+
+//---------------------------------------------------------
 //   setStaff
 //---------------------------------------------------------
 
 void PianorollEditor::setStaff(Staff* st)
       {
+      if (staff == st)
+            return;
+
+      partLabel->setText("Part: " + st->partName());
+
       if ((st && st->score() != _score) || (!st && _score)) {
             if (_score) {
                   _score->removeViewer(this);
@@ -261,7 +362,11 @@ void PianorollEditor::setStaff(Staff* st)
             showWave->setEnabled(_score->audio() != 0);
             }
       ruler->setScore(_score, locator);
-      gv->setStaff(staff, locator);
+      pianoView->setStaff(staff, locator);
+      pianoLevels->setScore(_score, locator);
+      pianoLevels->setStaff(staff, locator);
+      pianoKbd->setStaff(staff);
+
       updateSelection();
       setEnabled(st != nullptr);
       }
@@ -291,8 +396,9 @@ void PianorollEditor::readSettings()
 
 void PianorollEditor::setXpos(int x)
       {
-      gv->horizontalScrollBar()->setValue(x);
+      pianoView->horizontalScrollBar()->setValue(x);
       ruler->setXpos(x);
+      pianoLevels->setXpos(x);
       if (waveView && showWave->isChecked())
             waveView->setXpos(x);
       }
@@ -312,25 +418,30 @@ void PianorollEditor::rangeChanged(int min, int max)
 
 void PianorollEditor::updateSelection()
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = pianoView->getSelectedItems();
+      bool enabled = false;
+
       if (items.size() == 1) {
-            PianoItem* item = static_cast<PianoItem*>(items[0]);
-            if (item->type() == PianoItemType) {
-                  Note* note = item->note();
-                  NoteEvent* event = item->event();
-                  pitch->setEnabled(true);
-                  pitch->setValue(note->pitch());
+            PianoItem* item = items[0];
+            Note* note = item->note();
+
+            pitch->setValue(note->pitch());
+
+            NoteEvent* event = item->getTweakNoteEvent();
+            if (event) {
                   onTime->setValue(event->ontime());
                   tickLen->setValue(event->len());
-                  updateVelocity(note);
                   }
+
+            updateVelocity(note);
+            enabled = true;
             }
-      bool b = items.size() != 0;
-      velocity->setEnabled(b);
-      pitch->setEnabled(b);
-      veloType->setEnabled(b);
-      onTime->setEnabled(b);
-      tickLen->setEnabled(b);
+
+      velocity->setEnabled(enabled);
+      pitch->setEnabled(enabled);
+      veloType->setEnabled(enabled);
+      onTime->setEnabled(enabled);
+      tickLen->setEnabled(enabled);
       }
 
 //---------------------------------------------------------
@@ -340,36 +451,26 @@ void PianorollEditor::updateSelection()
 
 void PianorollEditor::selectionChanged()
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = pianoView->getSelectedItems();
       if (items.size() == 1) {
-            QGraphicsItem* item = items[0];
-            if (item->type() == PianoItemType) {
-                  Note* note = static_cast<PianoItem*>(item)->note();
-                  _score->select(note, SelectType::SINGLE, 0);
-                  }
+            Note* note = items[0]->note();
+            _score->select(note, SelectType::SINGLE, 0);
             }
       else if (items.size() == 0)
             _score->select(0, SelectType::SINGLE, 0);
       else {
             _score->deselectAll();
-            for (QGraphicsItem* item : items) {
-                  if (item->type() == PianoItemType) {
-                        Note* note = static_cast<PianoItem*>(item)->note();
-                        if (!note->selected())
-                              _score->select(note, SelectType::ADD, 0);
-                        }
+            for (PianoItem* item : items) {
+                  Note* note = item->note();
+                  if (!note->selected())
+                        _score->select(note, SelectType::ADD, 0);
                   }
             }
       for (MuseScoreView* view : score()->getViewer())
             view->updateAll();
 
-      gv->scene()->blockSignals(true);
-      for (QGraphicsItem* item : gv->scene()->items())
-            if (item->type() == PianoItemType)
-                item->setSelected(static_cast<PianoItem*>(item)->note()->selected());
-      gv->scene()->blockSignals(false);
-
-      gv->scene()->update();
+      pianoView->scene()->update();
+      pianoLevels->update();
       updateSelection();
       }
 
@@ -379,17 +480,8 @@ void PianorollEditor::selectionChanged()
 
 void PianorollEditor::changeSelection(SelState)
       {
-      gv->scene()->blockSignals(true);
-      gv->scene()->clearSelection();
-      QList<QGraphicsItem*> il = gv->scene()->items();
-      for (QGraphicsItem* item : il) {
-            if (item->type() == PianoItemType) {
-                  Note* note = static_cast<PianoItem*>(item)->note();
-                  item->setSelected(note->selected());
-                  }
-            }
-      gv->scene()->blockSignals(false);
       }
+
 
 //---------------------------------------------------------
 //   veloTypeChanged
@@ -397,18 +489,29 @@ void PianorollEditor::changeSelection(SelState)
 
 void PianorollEditor::veloTypeChanged(int val)
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = pianoView->getSelectedItems();
       if (items.size() != 1)
             return;
-      QGraphicsItem* item = items[0];
-      if (item->type() != PianoItemType)
-            return;
-      Note* note = static_cast<PianoItem*>(item)->note();
+      PianoItem* item = items[0];
+      Note* note = item->note();
       if (Note::ValueType(val) == note->veloType())
             return;
 
+      int newVelocity = note->veloOffset();
+      int dynamicsVel = staff->velocities().velo(note->tick());
+
+      //Change velocity to equivilent in new metric
+      switch (Note::ValueType(val)) {
+            case Note::ValueType::USER_VAL:
+                  newVelocity = (int)(dynamicsVel * (1 + newVelocity / 100.0));
+                  break;
+            case Note::ValueType::OFFSET_VAL:
+                  newVelocity = (int)((newVelocity / (qreal)dynamicsVel - 1) * 100);
+                  break;
+            }
+
       _score->undoStack()->beginMacro();
-      _score->undo(new ChangeVelocity(note, Note::ValueType(val), note->veloOffset()));
+      _score->undo(new ChangeVelocity(note, Note::ValueType(val), newVelocity));
       _score->undoStack()->endMacro(_score->undoStack()->current()->childCount() == 0);
       updateVelocity(note);
       }
@@ -420,29 +523,28 @@ void PianorollEditor::veloTypeChanged(int val)
 void PianorollEditor::updateVelocity(Note* note)
       {
       Note::ValueType vt = note->veloType();
-      if (vt != Note::ValueType(veloType->currentIndex())) {
-            veloType->setCurrentIndex(int(vt));
-            switch(vt) {
-                  case Note::ValueType::USER_VAL:
-                        velocity->setReadOnly(false);
-                        velocity->setSuffix("");
-                        velocity->setRange(0, 127);
-                        break;
-                  case Note::ValueType::OFFSET_VAL:
-                        velocity->setReadOnly(false);
-                        velocity->setSuffix("%");
-                        velocity->setRange(-200, 200);
-                        break;
-                  }
-            }
+      veloType->setCurrentIndex(int(vt));
       switch(vt) {
             case Note::ValueType::USER_VAL:
-                  // TODO velocity->setValue(note->velocity());
+                  velocity->setReadOnly(false);
+                  velocity->setSuffix("");
+                  break;
+            case Note::ValueType::OFFSET_VAL:
+                  velocity->setReadOnly(false);
+                  velocity->setSuffix("%");
+                  break;
+            }
+
+      switch(vt) {
+            case Note::ValueType::USER_VAL:
+                  velocity->setValue(note->veloOffset());
                   break;
             case Note::ValueType::OFFSET_VAL:
                   velocity->setValue(note->veloOffset());
                   break;
             }
+
+      pianoLevels->update();
       }
 
 //---------------------------------------------------------
@@ -451,30 +553,30 @@ void PianorollEditor::updateVelocity(Note* note)
 
 void PianorollEditor::velocityChanged(int val)
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = pianoView->getSelectedItems();
       if (items.size() != 1)
             return;
-      QGraphicsItem* item = items[0];
-      if (item->type() != PianoItemType)
-            return;
-      Note* note = static_cast<PianoItem*>(item)->note();
+      PianoItem* item = items[0];
+      Note* note = item->note();
       Note::ValueType vt = note->veloType();
 
-      if (vt == Note::ValueType::OFFSET_VAL)
+      if (val == note->veloOffset())
             return;
 
       _score->undoStack()->beginMacro();
       _score->undo(new ChangeVelocity(note, vt, val));
       _score->undoStack()->endMacro(_score->undoStack()->current()->childCount() == 0);
+
+      pianoLevels->update();
       }
 
 //---------------------------------------------------------
 //   keyPressed
 //---------------------------------------------------------
 
-void PianorollEditor::keyPressed(int p)
+void PianorollEditor::keyPressed(int pitch)
       {
-      seq->startNote(staff->part()->instrument()->channel(0)->channel, p, 80, 0, 0.0);
+      seq->startNote(staff->part()->instrument()->channel(0)->channel, pitch, 80, 0, 0.0);
       }
 
 //---------------------------------------------------------
@@ -498,7 +600,7 @@ void PianorollEditor::heartBeat(Seq* s)
       if (locator[0].tick() != tick) {
             posChanged(POS::CURRENT, tick);
             if (preferences.getBool(PREF_APP_PLAYBACK_FOLLOWSONG))
-                  gv->ensureVisible(tick);
+                  pianoView->ensureVisible(tick);
             }
       }
 
@@ -506,10 +608,10 @@ void PianorollEditor::heartBeat(Seq* s)
 //   moveLocator
 //---------------------------------------------------------
 
-void PianorollEditor::moveLocator(int i, const Pos& p)
+void PianorollEditor::moveLocator(int i, const Pos& pos)
       {
       if (locator[i].valid())
-            score()->setPos(POS(i), p.tick());
+            score()->setPos(POS(i), pos.tick());
       }
 
 //---------------------------------------------------------
@@ -519,7 +621,9 @@ void PianorollEditor::moveLocator(int i, const Pos& p)
 void PianorollEditor::cmd(QAction* /*a*/)
       {
       //score()->startCmd();
-      gv->setStaff(staff, locator);
+      pianoView->setStaff(staff, locator);
+      pianoLevels->setStaff(staff, locator);
+      pianoKbd->setStaff(staff);
       //score()->endCmd();
       }
 
@@ -639,9 +743,9 @@ Element* PianorollEditor::elementNear(QPointF)
 
 void PianorollEditor::updateAll()
       {
-//      startTimer(0);    // delayed update
-//      gv->updateNotes();
-//      gv->update();
+      startTimer(0);    // delayed update
+      pianoView->updateNotes();
+      pianoLevels->updateNotes();
       }
 
 void PianorollEditor::playlistChanged()
@@ -657,12 +761,11 @@ void PianorollEditor::showWaveView(bool val)
       if (val) {
             if (waveView == 0) {
                   waveView = new WaveView;
-                  connect(gv, SIGNAL(magChanged(double,double)), waveView, SLOT(setMag(double,double)));
-                  connect(gv, SIGNAL(posChanged(const Pos&)), waveView,   SLOT(setValue(const Pos&)));
+                  connect(pianoView, SIGNAL(magChanged(double,double)), waveView, SLOT(setMag(double,double)));
+                  connect(pianoView, SIGNAL(posChanged(const Pos&)), waveView,   SLOT(setValue(const Pos&)));
                   waveView->setAudio(_score->audio());
                   waveView->setScore(_score, locator);
                   split->addWidget(waveView);
-                  waveView->setMag(ruler->xmag(), 1.0);
                   waveView->setXpos(ruler->xpos());
                   }
             waveView->setVisible(true);
@@ -678,15 +781,16 @@ void PianorollEditor::showWaveView(bool val)
 //    position in score has changed
 //---------------------------------------------------------
 
-void PianorollEditor::posChanged(POS p, unsigned tick)
+void PianorollEditor::posChanged(POS pos, unsigned tick)
       {
-      if (locator[int(p)].tick() == unsigned(tick))
+      if (locator[int(pos)].tick() == unsigned(tick))
             return;
-      setLocator(p, tick);
-      gv->moveLocator(int(p));
+      setLocator(pos, tick);
+      pianoView->moveLocator(int(pos));
       if (waveView)
-            waveView->moveLocator(int(p));
+            waveView->moveLocator(int(pos));
       ruler->update();
+      pianoLevels->update();
       }
 
 //---------------------------------------------------------
@@ -695,16 +799,13 @@ void PianorollEditor::posChanged(POS p, unsigned tick)
 
 void PianorollEditor::onTimeChanged(int val)
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = pianoView->getSelectedItems();
       if (items.size() != 1)
             return;
-      QGraphicsItem* item = items[0];
-      if (item->type() != PianoItemType)
-            return;
-      PianoItem* pi = static_cast<PianoItem*>(item);
-      Note* note       = pi->note();
-      NoteEvent* event = pi->event();
-      if (event->ontime() == val)
+      PianoItem* item = items[0];
+      Note* note       = item->note();
+      NoteEvent* event = item->getTweakNoteEvent();
+      if (!event || event->ontime() == val)
             return;
 
       NoteEvent ne = *event;
@@ -712,6 +813,9 @@ void PianorollEditor::onTimeChanged(int val)
       _score->startCmd();
       _score->undo(new ChangeNoteEvent(note, event, ne));
       _score->endCmd();
+
+      pianoView->updateNotes();
+      pianoLevels->updateNotes();
       }
 
 //---------------------------------------------------------
@@ -720,16 +824,13 @@ void PianorollEditor::onTimeChanged(int val)
 
 void PianorollEditor::tickLenChanged(int val)
       {
-      QList<QGraphicsItem*> items = gv->scene()->selectedItems();
+      QList<PianoItem*> items = pianoView->getSelectedItems();
       if (items.size() != 1)
             return;
-      QGraphicsItem* item = items[0];
-      if (item->type() != PianoItemType)
-            return;
-      PianoItem* pi = static_cast<PianoItem*>(item);
-      Note* note       = pi->note();
-      NoteEvent* event = pi->event();
-      if (event->len() == val)
+      PianoItem* item = items[0];
+      Note* note       = item->note();
+      NoteEvent* event = item->getTweakNoteEvent();
+      if (!event || event->len() == val)
             return;
 
       NoteEvent ne = *event;
@@ -737,6 +838,9 @@ void PianorollEditor::tickLenChanged(int val)
       _score->startCmd();
       _score->undo(new ChangeNoteEvent(note, event, ne));
       _score->endCmd();
+
+      pianoView->updateNotes();
+      pianoLevels->updateNotes();
       }
 
 }

--- a/mscore/pianoroll.h
+++ b/mscore/pianoroll.h
@@ -28,8 +28,11 @@ namespace Ms {
 class Score;
 class Staff;
 class PianoView;
+class PianoKeyboard;
+class PianoLevels;
+class PianoLevelsChooser;
 class Note;
-class Ruler;
+class PianoRuler;
 class Seq;
 class WaveView;
 
@@ -40,18 +43,25 @@ class WaveView;
 class PianorollEditor : public QMainWindow, public MuseScoreView {
       Q_OBJECT
 
-      PianoView* gv;
+      PianoView* pianoView;
+      PianoKeyboard* pianoKbd;
+      PianoLevels* pianoLevels;
+      PianoLevelsChooser* pianoLevelsChooser;
       QScrollBar* hsb;        // horizontal scroll bar for pianoView
       Score* _score;
       Staff* staff;
+      QLabel* partLabel;
       Awl::PitchEdit* pitch;
       QSpinBox* velocity;
       QSpinBox* onTime;
       QSpinBox* tickLen;
       Pos locator[3];
+      QComboBox* barPattern;
       QComboBox* veloType;
+      QSpinBox* subdiv;
+      QSpinBox* tuplet;
       Awl::PosLabel* pos;
-      Ruler* ruler;
+      PianoRuler* ruler;
       QAction* showWave;
       WaveView* waveView;
       QSplitter* split;
@@ -85,6 +95,7 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       virtual ~PianorollEditor();
 
       void setStaff(Staff* staff);
+      void focusOnPosition(Position* p);
       void heartBeat(Seq*);
 
       virtual void dataChanged(const QRectF&);

--- a/mscore/pianoruler.cpp
+++ b/mscore/pianoruler.cpp
@@ -1,0 +1,357 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "pianoruler.h"
+#include "pianokeyboard.h"
+#include "libmscore/score.h"
+
+namespace Ms {
+
+#if 0 // yet(?) unused
+static const int MAP_OFFSET = 480;
+#endif
+
+QPixmap* PianoRuler::markIcon[3];
+
+static const char* rmark_xpm[]={
+      "18 18 2 1",
+      "# c #0000ff",
+      ". c None",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "........##########",
+      "........#########.",
+      "........########..",
+      "........#######...",
+      "........######....",
+      "........#####.....",
+      "........####......",
+      "........###.......",
+      "........##........",
+      "........##........",
+      "........##........"};
+static const char* lmark_xpm[]={
+      "18 18 2 1",
+      "# c #0000ff",
+      ". c None",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "##########........",
+      ".#########........",
+      "..########........",
+      "...#######........",
+      "....######........",
+      ".....#####........",
+      "......####........",
+      ".......###........",
+      "........##........",
+      "........##........",
+      "........##........"};
+static const char* cmark_xpm[]={
+      "18 18 2 1",
+      "# c #ff0000",
+      ". c None",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "..................",
+      "##################",
+      ".################.",
+      "..##############..",
+      "...############...",
+      "....##########....",
+      ".....########.....",
+      "......######......",
+      ".......####.......",
+      "........##........",
+      "........##........",
+      "........##........"};
+
+
+//---------------------------------------------------------
+//   Ruler
+//---------------------------------------------------------
+
+PianoRuler::PianoRuler(QWidget* parent)
+   : QWidget(parent)
+      {
+      if (markIcon[0] == 0) {
+            markIcon[0] = new QPixmap(cmark_xpm);
+            markIcon[1] = new QPixmap(lmark_xpm);
+            markIcon[2] = new QPixmap(rmark_xpm);
+            }
+      setMouseTracking(true);
+      _xpos   = 0;
+      _xZoom = X_ZOOM_INITIAL;
+      _timeType = TType::TICKS;
+      _font2.setPixelSize(14);
+      _font2.setBold(true);
+      _font1.setPixelSize(10);
+      }
+
+//---------------------------------------------------------
+//   setScore
+//---------------------------------------------------------
+
+void PianoRuler::setScore(Score* s, Pos* lc)
+      {
+      _score = s;
+      _locator = lc;
+      if (_score)
+            _cursor.setContext(_score->tempomap(), _score->sigmap());
+      setEnabled(_score != 0);
+      }
+
+//---------------------------------------------------------
+//   setXpos
+//---------------------------------------------------------
+
+void PianoRuler::setXpos(int val)
+      {
+      _xpos = val;
+      update();
+      }
+
+//---------------------------------------------------------
+//   pix2pos
+//---------------------------------------------------------
+
+Pos PianoRuler::pix2pos(int x) const
+      {
+      int val = (x + _xpos) / _xZoom - MAP_OFFSET;
+      
+      if (val < 0)
+            val = 0;
+      return Pos(_score->tempomap(), _score->sigmap(), val, _timeType);
+      
+      }
+
+//---------------------------------------------------------
+//   pos2pix
+//---------------------------------------------------------
+
+int PianoRuler::pos2pix(const Pos& p) const
+      {
+      return (p.time(TType::TICKS) + MAP_OFFSET) * _xZoom - _xpos;
+      }
+
+//---------------------------------------------------------
+//   paintEvent
+//---------------------------------------------------------
+
+void PianoRuler::paintEvent(QPaintEvent* e)
+      {
+      QPainter p(this);
+      const QRect& r = e->rect();
+
+      int x  = r.x();
+      int w  = r.width();
+      int y  = pianoRulerHeight - 16;
+      int h  = 16; // 14;
+      int y1 = r.y();
+      int rh = r.height();
+      if (y1 < pianoRulerHeight) {
+            rh -= pianoRulerHeight - y1;
+            y1 = pianoRulerHeight;
+            }
+      int y2 = y1 + rh;
+
+      if (x < (-_xpos))
+            x = -_xpos;
+
+      if (!_score)
+            return;
+
+      Pos pos1 = pix2pos(x);
+      Pos pos2 = pix2pos(x+w);
+
+      //---------------------------------------------------
+      //    draw lines
+      //---------------------------------------------------
+
+      int bar1, bar2, beat, tick;
+
+      pos1.mbt(&bar1, &beat, &tick);
+      pos2.mbt(&bar2, &beat, &tick);
+
+      const int minBarGapSize = 48;
+      const int minBeatGapSize = 30;
+      
+      //Estimate bar width since changing time signatures can make this inconsistent.
+      // Assuming 480 ticks per beat, 4 beats per bar
+      qreal pixPerBar = MScore::division * 4 * _xZoom;
+      qreal pixPerBeat = MScore::division * _xZoom;
+      
+      int barSkip = ceil(minBarGapSize / pixPerBar);
+      barSkip = (int)pow(2, ceil(log(barSkip)/log(2)));
+
+      int beatSkip = ceil(minBeatGapSize / pixPerBeat);
+      beatSkip = (int)pow(2, ceil(log(beatSkip)/log(2)));
+      
+      //Round down to first bar to be a multiple of barSkip
+      bar1 = (bar1 / barSkip) * barSkip;
+      
+      for (int bar = bar1; bar <= bar2; bar += barSkip) {
+            Pos stick(_score->tempomap(), _score->sigmap(), bar, 0, 0);
+            
+            SigEvent sig = stick.timesig();
+            int z = sig.timesig().numerator();
+            for (int beat = 0; beat < z; beat += beatSkip) {
+                  Pos xx(_score->tempomap(), _score->sigmap(), bar, beat, 0);
+                  int xp = pos2pix(xx);
+                  if (xp < 0)
+                        continue;
+                  QString s;
+                  QRect r(xp+2, y + 1, 1000, h);
+                  int y3;
+                  int num;
+                  if (beat == 0) {
+                        num = bar + 1;
+                        y3  = y + 2;
+                        p.setFont(_font2);
+                        }
+                  else {
+                        num = beat + 1;
+                        y3  = y + 8;
+                        p.setFont(_font1);
+                        r.moveTop(r.top() + 1);
+                        }
+                  s.setNum(num);
+                  p.setPen(Qt::black);
+                  p.drawLine(xp, y3, xp, y+h);
+                  p.drawText(r, Qt::AlignLeft | Qt::AlignVCenter, s);
+                  p.setPen(beat == 0 ? Qt::lightGray : Qt::gray);
+                  if (xp > 0)
+                        p.drawLine(xp, y1, xp, y2);
+                  }
+            
+            }
+      //
+      //  draw mouse cursor marker
+      //
+      p.setPen(Qt::black);
+      if (_cursor.valid()) {
+            int xp = pos2pix(_cursor);
+            if (xp >= x && xp < x+w)
+                  p.drawLine(xp, 0, xp, pianoRulerHeight);
+            }
+      static const QColor lcColors[3] = { Qt::red, Qt::blue, Qt::blue };
+      for (int i = 0; i < 3; ++i) {
+            if (!_locator[i].valid())
+                  continue;
+            p.setPen(lcColors[i]);
+            int xp      = pos2pix(_locator[i]);
+            QPixmap* pm = markIcon[i];
+            int pw = pm->width() / 2;
+            int x1 = x - pw;
+            int x2 = x + w + pw;
+            if (xp >= x1 && xp < x2)
+                  p.drawPixmap(xp - pw, y-2, *pm);
+            }
+      }
+
+//---------------------------------------------------------
+//   mousePressEvent
+//---------------------------------------------------------
+
+void PianoRuler::mousePressEvent(QMouseEvent* e)
+      {
+      moveLocator(e);
+      }
+
+//---------------------------------------------------------
+//   mouseMoveEvent
+//---------------------------------------------------------
+
+void PianoRuler::mouseMoveEvent(QMouseEvent* e)
+      {
+      moveLocator(e);
+      }
+
+//---------------------------------------------------------
+//   moveLocator
+//---------------------------------------------------------
+
+void PianoRuler::moveLocator(QMouseEvent* e)
+      {
+      Pos pos(pix2pos(e->pos().x()));
+      if (e->buttons() & Qt::LeftButton)
+            emit locatorMoved(0, pos);
+      else if (e->buttons() & Qt::MidButton)
+            emit locatorMoved(1, pos);
+      else if (e->buttons() & Qt::RightButton)
+            emit locatorMoved(2, pos);
+      }
+
+//---------------------------------------------------------
+//   leaveEvent
+//---------------------------------------------------------
+
+void PianoRuler::leaveEvent(QEvent*)
+      {
+      _cursor.setInvalid();
+      emit posChanged(_cursor);
+      update();
+      }
+
+//---------------------------------------------------------
+//   setPos
+//---------------------------------------------------------
+
+void PianoRuler::setPos(const Pos& pos)
+      {
+      if (_cursor != pos) {
+            int x1 = pos2pix(_cursor);
+            int x2 = pos2pix(pos);
+            if (x1 > x2) {
+                  int tmp = x2;
+                  x2 = x1;
+                  x1 = tmp;
+                  }
+            update(QRect(x1-1, 0, x2-x1+2, height()));
+            _cursor = pos;
+            }
+      }
+
+//---------------------------------------------------------
+//   setXZoom
+//---------------------------------------------------------
+
+void PianoRuler::setXZoom(qreal xZoom)
+      {
+      _xZoom = xZoom;
+      update();
+      }
+
+}
+

--- a/mscore/pianoruler.h
+++ b/mscore/pianoruler.h
@@ -1,0 +1,80 @@
+//=============================================================================
+//  MusE Score
+//  Linux Music Score Editor
+//  $Id:$
+//
+//  Copyright (C) 2009 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __PIANO_RULER_H__
+#define __PIANO_RULER_H__
+
+#include "libmscore/pos.h"
+
+namespace Ms {
+
+class Score;
+
+static const int pianoRulerHeight = 28;
+static const int MAP_OFFSET = 480;
+
+//---------------------------------------------------------
+//   PianoRuler
+//---------------------------------------------------------
+
+class PianoRuler : public QWidget {
+      Q_OBJECT
+
+      Score* _score;
+      Pos _cursor;
+      Pos* _locator;
+
+      qreal _xZoom;
+      int _xpos;
+      TType _timeType;
+      QFont _font1, _font2;
+
+      static QPixmap* markIcon[3];
+
+      virtual void paintEvent(QPaintEvent*);
+      virtual void mousePressEvent(QMouseEvent*);
+      virtual void mouseMoveEvent(QMouseEvent* event);
+      virtual void leaveEvent(QEvent*);
+
+      Pos pix2pos(int x) const;
+      int pos2pix(const Pos& p) const;
+      void moveLocator(QMouseEvent*);
+
+   signals:
+      void posChanged(const Pos&);
+      void locatorMoved(int idx, const Pos&);
+
+   public slots:
+      void setXpos(int);
+      void setXZoom(qreal);
+      void setPos(const Pos&);
+
+   public:
+      PianoRuler(QWidget* parent = 0);
+      void setScore(Score*, Pos* locator);
+      int xpos() const { return _xpos; }
+      qreal xZoom() const { return _xZoom; }
+      };
+
+
+} // namespace Ms
+#endif
+
+

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -246,6 +246,10 @@ PianoKeyItem::PianoKeyItem(HPiano* _piano, int p)
       _selected = false;
       _highlighted = false;
       type = -1;
+
+      QString pitchNames[] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+      QString text = pitchNames[_pitch % 12] + QString::number((_pitch / 12) - 1);
+      setToolTip(text);
       }
 
 //---------------------------------------------------------
@@ -395,11 +399,12 @@ void PianoKeyItem::paint(QPainter* p, const QStyleOptionGraphicsItem* /*o*/, QWi
       else
             p->setBrush(type >= 7 ? Qt::black : Qt::white);
       p->drawPath(path());
-      if (_pitch == 60) {
-            QFont f("FreeSerif", 8);
+      if (_pitch % 12 == 0) {
+            QFont f("FreeSerif", 6);
             p->setFont(f);
+            QString text = "C" + QString::number((_pitch / 12) - 1);
             p->drawText(QRectF(KEY_WIDTH / 2, KEY_HEIGHT - 8, 0, 0),
-               Qt::AlignCenter | Qt::TextDontClip, "c'");
+               Qt::AlignCenter | Qt::TextDontClip, text);
             }
       }
 

--- a/mscore/pianoview.cpp
+++ b/mscore/pianoview.cpp
@@ -12,238 +12,255 @@
 
 
 #include "pianoview.h"
+#include "pianoruler.h"
+#include "pianokeyboard.h"
+#include "shortcut.h"
+#include "musescore.h"
+#include "scoreview.h"
+#include "preferences.h"
+#include "libmscore/part.h"
 #include "libmscore/staff.h"
-#include "piano.h"
 #include "libmscore/measure.h"
 #include "libmscore/chord.h"
+#include "libmscore/rest.h"
 #include "libmscore/score.h"
 #include "libmscore/note.h"
 #include "libmscore/slur.h"
+#include "libmscore/tie.h"
+#include "libmscore/tuplet.h"
 #include "libmscore/segment.h"
 #include "libmscore/noteevent.h"
 
 namespace Ms {
 
-static const int MAP_OFFSET = 480;
+extern MuseScore* mscore;
 
-//---------------------------------------------------------
-//   pitch2y
-//---------------------------------------------------------
+static const qreal MIN_DRAG_DIST_SQ = 9;
 
-static int pitch2y(int pitch)
-      {
-      static int tt[] = {
-            12, 19, 25, 32, 38, 51, 58, 64, 71, 77, 84, 90
-            };
-      int y = (75 * keyHeight) - (tt[pitch % 12] + (7 * keyHeight) * (pitch / 12));
-      if (y < 0)
-            y = 0;
-      return y;
-      }
+const BarPattern PianoView::barPatterns[] = {
+      {"C maj/A min",   {1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1}},
+      {"Db maj/Bb min", {1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0}},
+      {"D maj/B min",   {0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1}},
+      {"Eb maj/C min",  {1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0}},
+      {"E maj/Db min",  {0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1}},
+      {"F maj/D min",   {1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0}},
+      {"Gb maj/Eb min", {0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1}},
+      {"G maj/E min",   {1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1}},
+      {"Ab maj/F min",  {1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0}},
+      {"A maj/Gb min",  {0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1}},
+      {"Bb maj/G min",  {1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0}},
+      {"B maj/Ab min",  {0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1}},
+      {"C Diminished",  {1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0}},
+      {"Db Diminished", {0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0}},
+      {"D Diminished",  {0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1}},
+      {"C Half/Whole",  {1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0}},
+      {"Db Half/Whole", {0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1}},
+      {"D Half/Whole",  {1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1}},
+      {"C Whole tone",  {1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}},
+      {"Db Whole tone", {0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1}},
+      {"C Augmented",   {1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0}},
+      {"Db Augmented",  {0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0}},
+      {"D Augmented",   {0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0}},
+      {"Eb Augmented",  {0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1}},
+      {"",              {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}
+};
 
 //---------------------------------------------------------
 //   PianoItem
 //---------------------------------------------------------
 
-PianoItem::PianoItem(Note* n, NoteEvent* e)
-   : QGraphicsRectItem(0), _note(n), _event(e)
+PianoItem::PianoItem(Note* n, PianoView* pianoView)
+   : _note(n), _pianoView(pianoView)
       {
-      setFlags(flags() | QGraphicsItem::ItemIsSelectable);
-      setBrush(QBrush());
-      updateValues();
+      }
+
+
+//---------------------------------------------------------
+//   boundingRectTicks
+//---------------------------------------------------------
+
+QRect PianoItem::boundingRectTicks(NoteEvent* evt)
+      {
+      Chord* chord = _note->chord();
+      int ticks = chord->duration().ticks();
+      int tieLen = _note->playTicks() - ticks;
+      int pitch = _note->pitch() + (evt ? evt->pitch() : 0);
+      int len = (evt ? ticks * evt->len() / 1000 : ticks) + tieLen;
+
+      int x1 = _note->chord()->tick()
+            + (evt ? evt->ontime() * ticks / 1000 : 0);
+      qreal y1 = pitch;
+
+      QRect rect;
+      rect.setRect(x1, y1, len, 1);
+      return rect; 
       }
 
 //---------------------------------------------------------
-//   updateValues
+//   boundingRectPixels
 //---------------------------------------------------------
 
-QRectF PianoItem::updateValues()
+QRect PianoItem::boundingRectPixels(NoteEvent* evt)
       {
-      QRectF r(rect().translated(pos()));
+      QRect rect = boundingRectTicks(evt);
+      
+      qreal tix2pix = _pianoView->xZoom();
+      int noteHeight = _pianoView->noteHeight();
+      
+      rect.setRect(_pianoView->tickToPixelX(rect.x()), 
+              (127 - rect.y()) * noteHeight,
+              rect.width() * tix2pix,
+              rect.height() * noteHeight
+              );
+      
+      return rect;
+      }
+
+//---------------------------------------------------------
+//   boundingRect
+//---------------------------------------------------------
+
+QRect PianoItem::boundingRect() {
       Chord* chord = _note->chord();
-      int ticks    = chord->duration().ticks();
-      int tieLen   = _note->playTicks() - ticks;
-      int pitch    = _note->pitch() + _event->pitch();
-      int len      = ticks * _event->len() / 1000 + tieLen;
+      int ticks = chord->duration().ticks();
+      int tieLen = _note->playTicks() - ticks;
+      int len = ticks + tieLen;
+      int pitch = _note->pitch();
 
-      setRect(0, 0, len, keyHeight/2);
-      setSelected(_note->selected());
+      qreal tix2pix = _pianoView->xZoom();
+      int noteHeight = _pianoView->noteHeight();
+      
+      qreal x1 = _pianoView->tickToPixelX(_note->chord()->tick());
+      qreal y1 = (127 - pitch) * noteHeight;
 
-      setPos(_note->chord()->tick() + _event->ontime() * ticks / 1000 + MAP_OFFSET,
-         pitch2y(pitch) + keyHeight / 4);
+      QRect rect;      
+      rect.setRect(x1, y1, len * tix2pix, noteHeight);
+      return rect; 
+      }
 
-      return r | rect().translated(pos());
+
+
+//---------------------------------------------------------
+//   intersects
+//---------------------------------------------------------
+
+bool PianoItem::intersectsBlock(int startTick, int endTick, int highPitch, int lowPitch, NoteEvent* evt)
+      {
+      QRect r = boundingRectTicks(evt);
+      int pitch = r.y();
+
+      return r.right() >= startTick && r.left() <= endTick 
+            && pitch >= lowPitch && pitch <= highPitch;
+      }
+
+//---------------------------------------------------------
+//   intersects
+//---------------------------------------------------------
+
+bool PianoItem::intersects(int startTick, int endTick, int highPitch, int lowPitch)
+      {
+      if (_pianoView->playEventsView()) {
+            for (NoteEvent& e : _note->playEvents())
+                  if (intersectsBlock(startTick, endTick, highPitch, lowPitch, &e))
+                        return true;
+            return false;
+            }
+      else 
+            return intersectsBlock(startTick, endTick, highPitch, lowPitch, 0);
+      
+      }
+
+
+//---------------------------------------------------------
+//   getTweakNoteEvent
+//---------------------------------------------------------
+
+NoteEvent* PianoItem::getTweakNoteEvent()
+      {
+      //Get topmost play event for note
+      if (_note->playEvents().size() > 0)
+            return &(_note->playEvents()[_note->playEvents().size() - 1]);
+            
+      return 0;
+      }
+
+
+//---------------------------------------------------------
+//   paintNoteBlock
+//---------------------------------------------------------
+
+void PianoItem::paintNoteBlock(QPainter* painter, NoteEvent* evt)
+      {
+      int roundRadius = 3;
+
+      QColor noteDeselected;
+      QColor noteSelected;
+
+      switch (preferences.globalStyle()) {
+            case MuseScoreStyleType::DARK_FUSION:
+                  noteDeselected = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_NOTE_UNSEL_COLOR));
+                  noteSelected = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_NOTE_SEL_COLOR));
+                  break;
+            default:
+                  noteDeselected = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_NOTE_UNSEL_COLOR));
+                  noteSelected = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_NOTE_SEL_COLOR));
+                  break;
+            }
+
+      QColor noteColor = _note->selected() ? noteSelected : noteDeselected;
+      painter->setBrush(noteColor);
+      
+      painter->setPen(QPen(noteColor.darker(250)));
+      QRectF bounds = boundingRectPixels(evt);
+      painter->drawRoundedRect(bounds, roundRadius, roundRadius);
+
+      //Pitch name
+      if (bounds.width() >= 20 && bounds.height() >= 12) {
+            QRectF textRect(bounds.x() + 2, bounds.y(), bounds.width() - 6, bounds.height() + 1);
+            QRectF textHiliteRect(bounds.x() + 3, bounds.y() + 1, bounds.width() - 6, bounds.height());
+            
+            QFont f("FreeSans", 8);
+            painter->setFont(f);
+
+            //Note name
+            QString name = tpc2name(_note->tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, false);
+            painter->setPen(QPen(noteColor.lighter(130)));
+            painter->drawText(textHiliteRect,
+                  Qt::AlignLeft | Qt::AlignTop, name);
+
+            painter->setPen(QPen(noteColor.darker(180)));
+            painter->drawText(textRect,
+                  Qt::AlignLeft | Qt::AlignTop, name);
+
+            //Voice number
+            if (bounds.width() >= 26) {
+                  painter->setPen(QPen(noteColor.lighter(130)));
+                  painter->drawText(textHiliteRect,
+                        Qt::AlignRight | Qt::AlignTop, QString::number(_note->voice() + 1));
+
+                  painter->setPen(QPen(noteColor.darker(180)));
+                  painter->drawText(textRect,
+                        Qt::AlignRight | Qt::AlignTop, QString::number(_note->voice() + 1));
+                  }
+            }
       }
 
 //---------------------------------------------------------
 //   paint
 //---------------------------------------------------------
 
-void PianoItem::paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*)
+void PianoItem::paint(QPainter* painter)
       {
-      painter->setPen(pen());
-      painter->setBrush(isSelected() ? Qt::yellow : Qt::blue);
-      painter->drawRect(boundingRect());
-      }
+      painter->setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
 
-//---------------------------------------------------------
-//   pix2pos
-//---------------------------------------------------------
-
-Pos PianoView::pix2pos(int x) const
-      {
-      x -= MAP_OFFSET;
-      if (x < 0)
-            x = 0;
-      return Pos(staff->score()->tempomap(), staff->score()->sigmap(), x, _timeType);
-      }
-
-//---------------------------------------------------------
-//   pos2pix
-//---------------------------------------------------------
-
-int PianoView::pos2pix(const Pos& p) const
-      {
-      return p.time(_timeType) + MAP_OFFSET;
-      }
-
-//---------------------------------------------------------
-//   drawBackground
-//---------------------------------------------------------
-
-void PianoView::drawBackground(QPainter* p, const QRectF& r)
-      {
-      if (staff == 0)
-            return;
-      Score* _score = staff->score();
-      setFrameShape(QFrame::NoFrame);
-
-      QRectF r1;
-      r1.setCoords(-1000000.0, 0.0, 480.0, 1000000.0);
-      QRectF r2;
-      r2.setCoords(ticks + MAP_OFFSET, 0.0, 1000000.0, 1000000.0);
-      QColor bg(0x71, 0x8d, 0xbe);
-
-      p->fillRect(r, bg);
-      if (r.intersects(r1))
-            p->fillRect(r.intersected(r1), bg.darker(150));
-      if (r.intersects(r2))
-            p->fillRect(r.intersected(r2), bg.darker(150));
-
-      //
-      // draw horizontal grid lines
-      //
-      qreal y1 = r.y();
-      qreal y2 = y1 + r.height();
-      qreal kh = 13.0;
-      qreal x1 = r.x();
-      qreal x2 = x1 + r.width();
-
-      // int key = floor(y1 / 75);
-      int key = floor(y1 / kh);
-      qreal y = key * kh;
-
-      for (; key < 75; ++key, y += kh) {
-            if (y < y1)
-                  continue;
-            if (y > y2)
-                  break;
-            p->setPen(QPen((key % 7) == 5 ? Qt::lightGray : Qt::gray));
-            p->drawLine(QLineF(x1, y, x2, y));
+      if (_pianoView->playEventsView()) {
+            for (NoteEvent& e : _note->playEvents())
+                  paintNoteBlock(painter, &e);
             }
-
-      //
-      // draw vertical grid lines
-      //
-      static const int mag[7] = {
-            1, 1, 2, 5, 10, 20, 50
-            };
-
-      Pos pos1 = pix2pos(x1);
-      Pos pos2 = pix2pos(x2);
-
-      //---------------------------------------------------
-      //    draw raster
-      //---------------------------------------------------
-
-      int bar1, bar2, beat, tick;
-      pos1.mbt(&bar1, &beat, &tick);
-      pos2.mbt(&bar2, &beat, &tick);
-
-      int mi = mag[magStep < 0 ? 0 : magStep];
-
-      bar1 = (bar1 / mi) * mi;           // round down
-      if (bar1 && mi >= 2)
-            bar1 -= 1;
-      bar2 = ((bar2 + mi - 1) / mi) * mi; // round up
-
-      for (int bar = bar1; bar <= bar2;) {
-            Pos stick(_score->tempomap(), _score->sigmap(), bar, 0, 0);
-            if (magStep > 0) {
-                  double x = double(pos2pix(stick));
-                  if (x > 0) {
-                        p->setPen(QPen(Qt::lightGray, 0.0));
-                        p->drawLine(x, y1, x, y2);
-                        }
-                  else {
-                        p->setPen(QPen(Qt::black, 0.0));
-                        p->drawLine(x, y1, x, y1);
-                        }
-                  }
-            else {
-                  int z = stick.timesig().timesig().numerator();
-                  for (int b = 0; b < z; b++) {
-                        if (magStep == 0) {
-                              Pos xx(_score->tempomap(), _score->sigmap(), bar, b, 0);
-                              int xp = pos2pix(xx);
-                              if (xp < 0)
-                                    continue;
-                              if (xp > 0) {
-                                    p->setPen(QPen(b == 0 ? Qt::lightGray : Qt::gray, 0.0));
-                                    p->drawLine(xp, y1, xp, y2);
-                                    }
-                              else {
-                                    p->setPen(QPen(Qt::black, 0.0));
-                                    p->drawLine(xp, y1, xp, y2);
-                                    }
-                              }
-                        else {
-                              int k;
-                              if (magStep == -1)
-                                    k = 2;
-                              else if (magStep == -2)
-                                    k = 4;
-                              else if (magStep == -3)
-                                    k = 8;
-                              else if (magStep == -4)
-                                    k = 16;
-                              else
-                                    k = 32;
-
-                              int n = (MScore::division * 4) / stick.timesig().timesig().denominator();
-                              for (int i = 0; i < k; ++i) {
-                                    Pos xx(_score->tempomap(), _score->sigmap(), bar, b, (n * i)/ k);
-                                    int xp = pos2pix(xx);
-                                    if (xp < 0)
-                                          continue;
-                                    if (xp > 0) {
-                                          p->setPen(QPen(i == 0 && b == 0 ? Qt::lightGray : Qt::gray, 0.0));
-                                          p->drawLine(xp, y1, xp, y2);
-                                          }
-                                    else {
-                                          p->setPen(QPen(Qt::black, 0.0));
-                                          p->drawLine(xp, y1, xp, y2);
-                                          }
-                                    }
-                              }
-                        }
-                  }
-            if (bar == 0 && mi >= 2)
-                  bar += (mi-1);
-            else
-                  bar += mi;
-            }
+      else 
+            paintNoteBlock(painter, 0);
       }
+
 
 //---------------------------------------------------------
 //   PianoView
@@ -259,45 +276,231 @@ PianoView::PianoView()
       setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
       setResizeAnchor(QGraphicsView::AnchorUnderMouse);
       setMouseTracking(true);
-      setRubberBandSelectionMode(Qt::IntersectsItemBoundingRect);
-      setDragMode(QGraphicsView::RubberBandDrag);
       _timeType = TType::TICKS;
-      magStep   = 0;
-      staff     = 0;
-      chord     = 0;
+      _playEventsView = true;
+      _staff = 0;
+      chord = 0;
+      _barPattern = 0;
+      _tuplet = 1;
+      _subdiv = 0;
+      _noteHeight = DEFAULT_KEY_HEIGHT;
+      _xZoom = X_ZOOM_INITIAL;
+      dragStarted = false;
+      mouseDown = false;
+      dragStyle = DragStyle::NONE;
+      inProgressUndoEvent = false;
       }
 
 //---------------------------------------------------------
-//   createLocators
+//   ~PianoView
 //---------------------------------------------------------
 
-void PianoView::createLocators()
+PianoView::~PianoView()
       {
-      static const QColor lcColors[3] = { Qt::red, Qt::blue, Qt::blue };
+      clearNoteData();
+      }
+
+//---------------------------------------------------------
+//   drawBackground
+//---------------------------------------------------------
+
+void PianoView::drawBackground(QPainter* p, const QRectF& r)
+      {
+      if (_staff == 0)
+            return;
+      Score* _score = _staff->score();
+      setFrameShape(QFrame::NoFrame);
+
+      QColor colSelectionBox;
+
+      QColor colWhiteKeyBg;
+      QColor colGutter;
+      QColor colBlackKeyBg;
+
+      QColor colGridLine;
+
+      switch (preferences.globalStyle()) {
+            case MuseScoreStyleType::DARK_FUSION:
+                  colSelectionBox = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_KEY_WHITE_COLOR));
+
+                  colWhiteKeyBg = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_KEY_WHITE_COLOR));
+                  colGutter = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_BASE_COLOR));
+                  colBlackKeyBg = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_KEY_BLACK_COLOR));
+
+                  colGridLine = QColor(preferences.getColor(PREF_UI_PIANOROLL_DARK_BG_GRIDLINE_COLOR));
+                  break;
+            default:
+                  colSelectionBox = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_BG_KEY_WHITE_COLOR));
+
+                  colWhiteKeyBg = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_BG_KEY_WHITE_COLOR));
+                  colGutter = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_BG_BASE_COLOR));
+                  colBlackKeyBg = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_BG_KEY_BLACK_COLOR));
+
+                  colGridLine = QColor(preferences.getColor(PREF_UI_PIANOROLL_LIGHT_BG_GRIDLINE_COLOR));
+                  break;
+            }
+
+      const QColor colSelectionBoxFill = QColor(
+                        colSelectionBox.red(), colSelectionBox.green(), colSelectionBox.blue(),
+                        128);
+
+      const QPen penLineMajor = QPen(colGridLine, 2.0, Qt::SolidLine);
+      const QPen penLineMinor = QPen(colGridLine, 1.0, Qt::SolidLine);
+      const QPen penLineSub = QPen(colGridLine, 1.0, Qt::DotLine);
+
+      QRectF r1;
+      r1.setCoords(-1000000.0, 0.0, tickToPixelX(0), 1000000.0);
+      QRectF r2;
+      r2.setCoords(tickToPixelX(ticks), 0.0, 1000000.0, 1000000.0);
+      
+      p->fillRect(r, colWhiteKeyBg);
+      if (r.intersects(r1))
+            p->fillRect(r.intersected(r1), colGutter);
+      if (r.intersects(r2))
+            p->fillRect(r.intersected(r2), colGutter);
+
+      //
+      // draw horizontal grid lines
+      //
+      qreal y1 = r.y();
+      qreal y2 = y1 + r.height();
+      qreal x1 = qMax(r.x(), (qreal)tickToPixelX(0));
+      qreal x2 = qMin(x1 + r.width(), (qreal)tickToPixelX(ticks));
+
+      int topPitch = ceil((_noteHeight * 128 - y1) / _noteHeight);
+      int bmPitch = floor((_noteHeight * 128 - y2) / _noteHeight);
+      
+      Part* part = _staff->part();
+      Interval transp = part->instrument()->transpose();
+
+      //MIDI notes span [0, 127] and map to pitches starting at C-1
+      for (int pitch = bmPitch; pitch <= topPitch; ++pitch) {
+            int y = (127 - pitch) * _noteHeight;
+
+            int degree = (pitch - transp.chromatic + 60) % 12;
+            const BarPattern& pat = barPatterns[_barPattern];
+//            if (degree == 1 || degree == 3 || degree == 6 || degree == 8 || degree == 10) {
+              if (!pat.isWhiteKey[degree]) {
+                  qreal px0 = qMax(r.x(), (qreal)tickToPixelX(0));
+                  qreal px1 = qMin(r.x() + r.width(), (qreal)tickToPixelX(ticks));
+                  QRectF hbar;
+                  
+                  hbar.setCoords(px0, y, px1, y + _noteHeight);
+                  p->fillRect(hbar, colBlackKeyBg);
+            }
+            
+            //Lines between rows
+            p->setPen(degree == 0 ? penLineMajor : penLineMinor);
+            p->drawLine(QLineF(x1, y + _noteHeight, x2, y + _noteHeight));
+            }
+
+      //
+      // draw vertical grid lines
+      //
+      Pos pos1(_score->tempomap(), _score->sigmap(), qMax(pixelXToTick(x1), 0), TType::TICKS);
+      Pos pos2(_score->tempomap(), _score->sigmap(), qMax(pixelXToTick(x2), 0), TType::TICKS);
+      
+      int bar1, bar2, beat, tick;
+      pos1.mbt(&bar1, &beat, &tick);
+      pos2.mbt(&bar2, &beat, &tick);
+      
+      //Draw bar lines
+      const int minBeatGap = 20;
+
+      for (int bar = bar1; bar <= bar2; ++bar) {
+            Pos barPos(_score->tempomap(), _score->sigmap(), bar, 0, 0);
+
+            //Beat lines
+            int beatsInBar = barPos.timesig().timesig().numerator();
+            int ticksPerBeat = barPos.timesig().timesig().beatTicks();
+            double pixPerBeat = ticksPerBeat * _xZoom;
+            int beatSkip = ceil(minBeatGap / pixPerBeat);
+
+
+//            int subExp = qMin((int)floor(log2(pixPerBeat / minBeatGap)), _subBeats);
+//            int numSubBeats = pow(2, subExp);
+
+            //Round up to next power of 2
+            beatSkip = (int)pow(2, ceil(log(beatSkip)/log(2)));
+            
+            for (int beat = 0; beat < beatsInBar; beat += beatSkip) {
+                  Pos beatPos(_score->tempomap(), _score->sigmap(), bar, beat, 0);
+                  double x = tickToPixelX(beatPos.time(TType::TICKS));
+                  p->setPen(penLineMinor);
+                  p->drawLine(x, y1, x, y2);
+
+                  int subbeats = _tuplet * (1 << _subdiv);
+
+                  for (int sub = 1; sub < subbeats; ++sub) {
+                      Pos subBeatPos(_score->tempomap(), _score->sigmap(), bar, beat, sub * MScore::division / subbeats);
+                      x = tickToPixelX(subBeatPos.time(TType::TICKS));
+
+                      p->setPen(penLineSub);
+                      p->drawLine(x, y1, x, y2);
+                      }
+
+                  }
+            
+            //Bar line
+            double x = tickToPixelX(barPos.time(TType::TICKS));
+            p->setPen(x > 0 ? penLineMajor : QPen(Qt::black, 2.0));
+            p->drawLine(x, y1, x, y2);
+            }
+      
+      //Draw notes
+      for (int i = 0; i < noteList.size(); ++i)
+            noteList[i]->paint(p);
+
+      //Draw locators
       for (int i = 0; i < 3; ++i) {
-            locatorLines[i] = new QGraphicsLineItem(QLineF(0.0, 0.0, 0.0, keyHeight * 75.0 * 5));
-            QPen pen(lcColors[i]);
-            pen.setWidth(2);
-            locatorLines[i]->setPen(pen);
-            locatorLines[i]->setZValue(1000+i);       // set stacking order
-            locatorLines[i]->setFlag(QGraphicsItem::ItemIgnoresTransformations, true);
-            scene()->addItem(locatorLines[i]);
+            if (_locator[i].valid())
+                  {
+                  p->setPen(QPen(i == 0 ? Qt::red : Qt::blue, 2));
+                  qreal x = tickToPixelX(_locator[i].time(TType::TICKS));
+                  p->drawLine(x, y1, x, y2);
+                  }
+            }
+      
+      //Draw drag selection box
+      if (dragStarted && dragStyle == DragStyle::SELECTION_RECT) {
+            int minX = qMin(mouseDownPos.x(), lastMousePos.x());
+            int minY = qMin(mouseDownPos.y(), lastMousePos.y());
+            int maxX = qMax(mouseDownPos.x(), lastMousePos.x());
+            int maxY = qMax(mouseDownPos.y(), lastMousePos.y());
+            QRectF rect(minX, minY, maxX - minX + 1, maxY - minY + 1);
+            
+            p->setPen(QPen(colSelectionBox, 2));
+            p->setBrush(QBrush(colSelectionBoxFill, Qt::SolidPattern));
+            p->drawRect(rect);
             }
       }
+
 
 //---------------------------------------------------------
 //   moveLocator
 //---------------------------------------------------------
 
-void PianoView::moveLocator(int i)
+void PianoView::moveLocator(int /*i*/)
       {
-      if (_locator[i].valid()) {
-            locatorLines[i]->setVisible(true);
-            qreal x = qreal(pos2pix(_locator[i]));
-            locatorLines[i]->setPos(QPointF(x, 0.0));
-            }
-      else
-            locatorLines[i]->setVisible(false);
+      scene()->update();
+      }
+
+
+//---------------------------------------------------------
+//   pixelXToTick
+//---------------------------------------------------------
+
+int PianoView::pixelXToTick(int pixX) {
+      return (int)(pixX / _xZoom) - MAP_OFFSET; 
+      }
+
+
+//---------------------------------------------------------
+//   tickToPixelX
+//---------------------------------------------------------
+
+int PianoView::tickToPixelX(int tick) { 
+      return (int)(tick + MAP_OFFSET) * _xZoom;
       }
 
 //---------------------------------------------------------
@@ -307,119 +510,261 @@ void PianoView::moveLocator(int i)
 void PianoView::wheelEvent(QWheelEvent* event)
       {
       int step = event->delta() / 120;
-      double xmag = transform().m11();
-      double ymag = transform().m22();
 
       if (event->modifiers() == Qt::ControlModifier) {
-            if (step > 0) {
-                  for (int i = 0; i < step; ++i) {
-                        if (xmag > 10.0)
-                              break;
-                        scale(1.1, 1.0);
-                        xmag *= 1.1;
-                        }
-                  }
-            else {
-                  for (int i = 0; i < -step; ++i) {
-                        if (xmag < 0.001)
-                              break;
-                        scale(.9, 1.0);
-                        xmag *= .9;
-                        }
-                  }
-            emit magChanged(xmag, ymag);
+            //Horizontal zoom
+            
+            QRectF viewRect = mapToScene(viewport()->geometry()).boundingRect();
+            
+            int mouseXTick = pixelXToTick(event->x() + (int)viewRect.x());
+            
+            _xZoom *= pow(X_ZOOM_RATIO, step);
+            emit xZoomChanged(_xZoom);
+            
+            updateBoundingSize();
+            updateNotes();
+            
+            int mousePixX = tickToPixelX(mouseXTick);
+            horizontalScrollBar()->setValue(mousePixX - event->x());
 
-            int tpix  = (480 * 4) * xmag;
-            magStep = -5;
-            if (tpix <= 4000)
-                  magStep = -4;
-            if (tpix <= 2000)
-                  magStep = -3;
-            if (tpix <= 1000)
-                  magStep = -2;
-            if (tpix <= 500)
-                  magStep = -1;
-            if (tpix <= 128)
-                  magStep = 0;
-            if (tpix <= 64)
-                  magStep = 1;
-            if (tpix <= 32)
-                  magStep = 2;
-            if (tpix <= 16)
-                  magStep = 3;
-            if (tpix <= 8)
-                  magStep = 4;
-            if (tpix <= 4)
-                  magStep = 5;
-            if (tpix <= 2)
-                  magStep = 6;
-
-            //
-            // if xpos <= 0, then the scene is centered
-            // there is no scroll bar anymore sending
-            // change signals, so we have to do it here:
-            //
-            double xpos = -(mapFromScene(QPointF()).x());
-            if (xpos <= 0)
-                  emit xposChanged(xpos);
+            scene()->update();
             }
       else if (event->modifiers() == Qt::ShiftModifier) {
+            //Horizontal scroll
             QWheelEvent we(event->pos(), event->delta(), event->buttons(), 0, Qt::Horizontal);
             QGraphicsView::wheelEvent(&we);
             }
       else if (event->modifiers() == 0) {
+            //Vertical scroll
             QGraphicsView::wheelEvent(event);
             }
       else if (event->modifiers() == (Qt::ShiftModifier | Qt::ControlModifier)) {
-            if (step > 0) {
-                  for (int i = 0; i < step; ++i) {
-                        if (ymag > 3.0)
-                              break;
-                        scale(1.0, 1.1);
-                        ymag *= 1.1;
-                        }
-                  }
-            else {
-                  for (int i = 0; i < -step; ++i) {
-                        if (ymag < 0.4)
-                              break;
-                        scale(1.0, .9);
-                        ymag *= .9;
-                        }
-                  }
-            emit magChanged(xmag, ymag);
+            //Vertical zoom
+            QRectF viewRect = mapToScene(viewport()->geometry()).boundingRect();
+            qreal mouseYNote = (event->y() + (int)viewRect.y()) / (qreal)_noteHeight;
+            
+            _noteHeight = qMax(qMin(_noteHeight + step, MAX_KEY_HEIGHT), MIN_KEY_HEIGHT);
+            emit noteHeightChanged(_noteHeight);
+            
+            updateBoundingSize();
+            updateNotes();
+            
+            int mousePixY = (int)(mouseYNote * _noteHeight);
+            verticalScrollBar()->setValue(mousePixY - event->y());
+            
+            scene()->update();
+            }
+      }
+
+
+//---------------------------------------------------------
+//   showPopupMenu
+//---------------------------------------------------------
+
+void PianoView::showPopupMenu(const QPoint& pos)
+      {
+      QMenu popup(this);
+//      popup.addAction(getAction("cut"));
+//      popup.addAction(getAction("copy"));
+      popup.addAction(getAction("paste"));
+//      popup.addAction(getAction("swap"));
+      popup.addAction(getAction("delete"));
+
+      popup.exec(pos);
+      }
+
+//---------------------------------------------------------
+//   contextMenuEvent
+//---------------------------------------------------------
+
+void PianoView::contextMenuEvent(QContextMenuEvent *event)
+      {
+      showPopupMenu(event->globalPos());
+      }
+
+
+//---------------------------------------------------------
+//   mousePressEvent
+//---------------------------------------------------------
+
+void PianoView::mousePressEvent(QMouseEvent* event)
+      {
+      bool rightBn = event->button() == Qt::RightButton;
+      if (!rightBn) {
+            mouseDown = true;
+            mouseDownPos = mapToScene(event->pos());
+            lastMousePos = mouseDownPos;
             }
       }
 
 //---------------------------------------------------------
-//   y2pitch
+//   mouseReleaseEvent
 //---------------------------------------------------------
 
-int PianoView::y2pitch(int y) const
+void PianoView::mouseReleaseEvent(QMouseEvent* event)
       {
-      int pitch;
-      const int total = (10 * 7 + 5) * keyHeight;       // 75 Ganztonschritte
-      y = total - y;
-      int oct = (y / (7 * keyHeight)) * 12;
-      static const char kt[] = {
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            1, 1, 1, 1, 1, 1, 1,
-            2, 2, 2, 2, 2, 2,
-            3, 3, 3, 3, 3, 3, 3,
-            4, 4, 4, 4, 4, 4, 4, 4, 4,
-            5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
-            6, 6, 6, 6, 6, 6, 6,
-            7, 7, 7, 7, 7, 7,
-            8, 8, 8, 8, 8, 8, 8,
-            9, 9, 9, 9, 9, 9,
-            10, 10, 10, 10, 10, 10, 10,
-            11, 11, 11, 11, 11, 11, 11, 11, 11, 11
-            };
-      pitch = kt[y % 91] + oct;
-      if (pitch < 0 || pitch > 127)
-            pitch = -1;
-      return pitch;
+      int modifiers = QGuiApplication::keyboardModifiers();
+      bool bnShift = modifiers & Qt::ShiftModifier;
+      bool bnCtrl = modifiers & Qt::ControlModifier;
+      
+      bool rightBn = event->button() == Qt::RightButton;
+      if (rightBn) {
+            //Right clicks have been handled as popup menu
+            return;
+            }
+
+
+      NoteSelectType selType = bnShift ? (bnCtrl ? NoteSelectType::SUBTRACT : NoteSelectType::XOR)
+              : (bnCtrl ? NoteSelectType::ADD : NoteSelectType::REPLACE);
+
+      if (dragStarted) {
+            if (dragStyle == DragStyle::SELECTION_RECT) {
+                  //Update selection
+                  qreal minX = qMin(mouseDownPos.x(), lastMousePos.x());
+                  qreal minY = qMin(mouseDownPos.y(), lastMousePos.y());
+                  qreal maxX = qMax(mouseDownPos.x(), lastMousePos.x());
+                  qreal maxY = qMax(mouseDownPos.y(), lastMousePos.y());
+
+                  int startTick = pixelXToTick((int)minX);
+                  int endTick = pixelXToTick((int)maxX);
+                  int lowPitch = (int)floor(128 - maxY / noteHeight());
+                  int highPitch = (int)ceil(128 - minY / noteHeight());
+
+                  selectNotes(startTick, endTick, lowPitch, highPitch, selType);
+                  }
+            else if (dragStyle == DragStyle::MOVE_NOTES) {
+                  //Keep last note drag event, if any
+                  if (inProgressUndoEvent)
+                        inProgressUndoEvent = false;
+                  }
+
+            dragStarted = false;
+            }
+      else {
+            Score* score = _staff->score();
+
+            int pickTick = pixelXToTick((int)mouseDownPos.x());
+            int pickPitch = pixelYToPitch(mouseDownPos.y());
+
+            PianoItem *pn = pickNote(pickTick, pickPitch);
+            if (pn) {
+                  if (selType == NoteSelectType::REPLACE)
+                        selType = NoteSelectType::FIRST;
+
+                  mscore->play(pn->note());
+                  score->setPlayNote(false);
+
+                  selectNotes(pickTick, pickTick + 1, pickPitch, pickPitch, selType);
+                  }
+            else {
+                  if (!bnShift && !bnCtrl) {
+                        //Select an empty pixel - should clear selection
+                        selectNotes(pickTick, pickTick + 1, pickPitch, pickPitch, selType);
+                        }
+                  else if (!bnShift && bnCtrl) {
+
+                        //Insert a new note at nearest subbeat
+                        int subbeats = _tuplet * (1 << _subdiv);
+                        int subbeatTicks = MScore::division / subbeats;
+                        int roundedTick = (pickTick / subbeatTicks) * subbeatTicks;
+
+                        InputState& is = score->inputState();
+                        int voice = score->inputState().voice();
+                        int track = _staff->idx() * VOICES + voice;
+
+                        NoteVal nv(pickPitch);
+
+
+                        ChordRest* e = score->findCR(roundedTick, track);
+                        if (!e->tuplet() && _tuplet == 1) {
+                              //Ignore tuplets
+                              score->startCmd();
+                              score->expandVoice(e->segment(), track);
+
+                              ChordRest* cr0;
+                              ChordRest* cr1;
+                              Fraction frac = is.duration().fraction();
+                              if (cutChordRest(e, track, roundedTick, cr0, cr1)) {
+                                    score->setNoteRest(cr1->segment(), track, nv, frac);
+                                    }
+                              else {
+                                    if (cr0->isChord() && cr0->duration().ticks() == frac.ticks()) {
+                                          Chord* ch = toChord(cr0);
+                                          score->addNote(ch, nv);
+                                          }
+                                    else {
+                                          score->setNoteRest(cr0->segment(), track, nv, frac);
+                                          }
+                                    }
+
+                              score->endCmd();
+                              }
+
+                        }
+                  else if (bnShift && !bnCtrl) {
+                        //Append a pitch to our curent chord/rest
+                        int voice = score->inputState().voice();
+
+                        //Find best chord to add to
+                        int track = _staff->idx() * VOICES + voice;
+
+                        ChordRest* e = score->findCR(pickTick, track);
+
+                        if (e && e->isChord()) {
+                              Chord* ch = toChord(e);
+
+                              if (pickTick >= e->tick() && pickTick < ch->tick() + ch->duration().ticks()) {
+                                    NoteVal nv(pickPitch);
+                                    score->startCmd();
+                                    score->addNote(ch, nv);
+                                    score->endCmd();
+                                    }
+
+                              }
+                        else if (e && e->isRest()) {
+                              Rest* r = toRest(e);
+                              NoteVal nv(pickPitch);
+                              score->startCmd();
+                              score->setNoteRest(r->segment(), track, nv, r->duration());
+                              score->endCmd();
+                              }
+                        }
+                  else if (bnShift && bnCtrl) {
+                        //Cut the chord/rest at the nearest subbeat
+                        int voice = score->inputState().voice();
+
+                        //Find best chord to add to
+                        int track = _staff->idx() * VOICES + voice;
+
+                        int subbeats = _tuplet * (1 << _subdiv);
+
+                        int subbeatTicks = MScore::division / subbeats;
+                        int roundedTick = (pickTick / subbeatTicks) * subbeatTicks;
+
+                        ChordRest* e = score->findCR(roundedTick, track);
+                        if (!e->tuplet() && _tuplet == 1) {
+                              score->startCmd();
+                              score->expandVoice(e->segment(), track);
+                              int startTick = e->tick();
+
+                              if (roundedTick != startTick) {
+                                    ChordRest* cr0;
+                                    ChordRest* cr1;
+                                    cutChordRest(e, track, roundedTick, cr0, cr1);
+                                    }
+                              score->endCmd();
+                              }
+                        }
+                  }
+            }
+      
+      
+      dragStyle = DragStyle::NONE;
+      mouseDown = false;
+      scene()->update();
       }
+
+
 
 //---------------------------------------------------------
 //   mouseMoveEvent
@@ -427,19 +772,206 @@ int PianoView::y2pitch(int y) const
 
 void PianoView::mouseMoveEvent(QMouseEvent* event)
       {
+      lastMousePos = mapToScene(event->pos());
+
+      if (mouseDown && !dragStarted) {
+            qreal dx = lastMousePos.x() - mouseDownPos.x();
+            qreal dy = lastMousePos.y() - mouseDownPos.y();
+
+            if (dx * dx + dy * dy >= MIN_DRAG_DIST_SQ) {
+                  //Start dragging
+                  dragStarted = true;
+                  
+                  //Check for move note
+                  int tick = pixelXToTick(mouseDownPos.x());
+                  int mouseDownPitch = pixelYToPitch(mouseDownPos.y());
+                  PianoItem* pi = pickNote(tick, mouseDownPitch);
+                  if (pi) {
+                        if (!pi->note()->selected()) {
+                              selectNotes(tick, tick, mouseDownPitch, mouseDownPitch, NoteSelectType::REPLACE);
+                              }
+                        dragStyle = DragStyle::MOVE_NOTES;
+                        lastDragPitch = mouseDownPitch;
+                        }
+                  else {
+                        dragStyle = DragStyle::SELECTION_RECT;
+                        }
+                  }
+            }
+
+      if (dragStarted) {
+            if (dragStyle == DragStyle::MOVE_NOTES) {
+                  int mouseDownPitch = pixelYToPitch(mouseDownPos.y());
+                  int curPitch = pixelYToPitch(lastMousePos.y());
+                  if (curPitch != lastDragPitch) {
+                        int pitchDelta = curPitch - lastDragPitch;
+
+                        Score* score = _staff->score();
+                        if (inProgressUndoEvent) {
+//                              score->undoRedo(true, 0, false);
+                              inProgressUndoEvent = false;
+                              }
+                        
+                        score->startCmd();
+                        score->upDownDelta(pitchDelta, false);
+                        score->endCmd();
+                        
+                        inProgressUndoEvent = true;
+                        lastDragPitch = curPitch;
+                        }
+                  }
+            
+            scene()->update();
+            }
+      
+
+      //Update mouse tracker      
       QPointF p(mapToScene(event->pos()));
-      int pitch = y2pitch(int(p.y()));
+      int pitch = (int)((_noteHeight * 128 - p.y()) / _noteHeight);
       emit pitchChanged(pitch);
-      int tick = int(p.x()) -480;
+
+      int tick = pixelXToTick(p.x());
       if (tick < 0) {
             tick = 0;
-            pos.setTick(tick);
-            pos.setInvalid();
+            trackingPos.setTick(tick);
+            trackingPos.setInvalid();
             }
       else
-            pos.setTick(tick);
-      emit posChanged(pos);
-      QGraphicsView::mouseMoveEvent(event);
+            trackingPos.setTick(tick);
+      emit trackingPosChanged(trackingPos);
+      }
+
+//---------------------------------------------------------
+//   cutChordRest
+//---------------------------------------------------------
+
+bool PianoView::cutChordRest(ChordRest* e, int track, int cutTick, ChordRest*& cr0, ChordRest*& cr1)
+      {
+      int startTick = e->segment()->tick();
+      int ticks = e->duration().ticks();
+      if (cutTick <= startTick || cutTick > startTick + ticks) {
+            cr0 = e;
+            cr1 = 0;
+            return false;
+            }
+
+      //Deselect note being cut
+      if (e->isChord()) {
+            Chord* ch = toChord(e);
+            for (Note* n: ch->notes()) {
+                  n->setSelected(false);
+                  }
+            }
+      else if (e->isRest()) {
+            Rest* r = toRest(e);
+            r->setSelected(false);
+            }
+
+
+      //Subdivide at the cut tick
+      NoteVal nv(-1);
+
+      Score* score = _staff->score();
+      score->setNoteRest(e->segment(), track, nv, Fraction::fromTicks(cutTick - e->tick()));
+      ChordRest *nextCR = score->findCR(cutTick, track);
+
+//      nextCR->segment()->setTick(cutTick);
+      Chord* ch0 = 0;
+
+      if (nextCR->isChord()) {
+            //Copy chord into initial segment
+            Chord* ch1 = toChord(nextCR);
+            int ch1StartTick = ch1->segment()->tick();
+
+            for (Note* n: ch1->notes()) {
+                  NoteVal nx = n->noteVal();
+                  if (!ch0) {
+                        ChordRest* cr = score->findCR(startTick, track);
+                        score->setNoteRest(cr->segment(), track, nx, cr->duration());
+                        ch0 = toChord(score->findCR(startTick, track));
+                        }
+                  else {
+                        score->addNote(ch0, nx);
+                        }
+                  }
+            }
+
+      cr0 = ch0;
+      cr1 = nextCR;
+      return true;
+      }
+
+//---------------------------------------------------------
+//   selectNotes
+//---------------------------------------------------------
+
+PianoItem* PianoView::pickNote(int tick, int pitch)
+      {
+      for (int i = 0; i < noteList.size(); ++i) {
+            PianoItem* pi = noteList[i];
+            
+            if (pi->intersects(tick, tick, pitch, pitch))
+                  return pi;
+            }
+      
+      return 0;
+      }
+
+//---------------------------------------------------------
+//   selectNotes
+//---------------------------------------------------------
+
+void PianoView::selectNotes(int startTick, int endTick, int lowPitch, int highPitch, NoteSelectType selType)
+      {
+      Score* score = _staff->score();
+      //score->masterScore()->cmdState().reset();      // DEBUG: should not be necessary
+      score->startCmd();
+
+      Selection selection(score);
+
+      for (int i = 0; i < noteList.size(); ++i) {
+            PianoItem* pi = noteList[i];
+            bool inBounds = pi->intersects(startTick, endTick, highPitch, lowPitch);
+            
+            bool sel;
+            switch (selType) {
+                  default:
+                  case NoteSelectType::REPLACE:
+                        sel = inBounds;
+                        break;
+                  case NoteSelectType::XOR:
+                        sel = inBounds != pi->note()->selected();
+                        break;
+                  case NoteSelectType::ADD:
+                        sel = inBounds || pi->note()->selected();
+                        break;
+                  case NoteSelectType::SUBTRACT:
+                        sel = !inBounds && pi->note()->selected();
+                        break;
+                  case NoteSelectType::FIRST:
+                        sel = inBounds && selection.elements().empty();
+                        break;
+                  }
+            
+            if (sel)
+                  selection.add(pi->note());
+            }
+
+      score->setSelection(selection);
+      for (MuseScoreView* view : score->getViewer())
+            view->updateAll();
+      
+//      _selection.setActiveSegment(0);
+//      _selection.setActiveTrack(0);
+
+//      _selection.setState(selState);
+
+      scene()->update();
+      score->setUpdateAll();
+      score->update();
+      score->endCmd();
+
+      emit selectionChanged();
       }
 
 //---------------------------------------------------------
@@ -449,8 +981,8 @@ void PianoView::mouseMoveEvent(QMouseEvent* event)
 void PianoView::leaveEvent(QEvent* event)
       {
       emit pitchChanged(-1);
-      pos.setInvalid();
-      emit posChanged(pos);
+      trackingPos.setInvalid();
+      emit trackingPosChanged(trackingPos);
       QGraphicsView::leaveEvent(event);
       }
 
@@ -460,9 +992,26 @@ void PianoView::leaveEvent(QEvent* event)
 
 void PianoView::ensureVisible(int tick)
       {
-      tick += MAP_OFFSET;
-      QPointF pt = mapToScene(0, height() / 2);
-      QGraphicsView::ensureVisible(qreal(tick), pt.y(), 240.0, 1.0);
+      QRectF rect = mapToScene(viewport()->geometry()).boundingRect();
+
+      qreal xpos = tickToPixelX(tick);
+      qreal margin = rect.width() / 2;
+      if (xpos < rect.x() + margin)
+            horizontalScrollBar()->setValue(qMax(xpos - margin, 0.0));
+      else if (xpos >= rect.x() + rect.width() - margin)
+            horizontalScrollBar()->setValue(qMax(xpos - rect.width() + margin, 0.0));
+      }
+
+//---------------------------------------------------------
+//   updateBoundingSize
+//---------------------------------------------------------
+void PianoView::updateBoundingSize()
+      {
+      Measure* lm = _staff->score()->lastMeasure();
+      ticks       = lm->tick() + lm->ticks();
+      scene()->setSceneRect(0.0, 0.0, 
+              double((ticks + MAP_OFFSET * 2) * _xZoom),
+              _noteHeight * 128);
       }
 
 //---------------------------------------------------------
@@ -471,49 +1020,78 @@ void PianoView::ensureVisible(int tick)
 
 void PianoView::setStaff(Staff* s, Pos* l)
       {
-      staff    = s;
       _locator = l;
-      setEnabled(staff != nullptr);
-      if (!staff) {
+      
+      if (_staff == s)
+            return;
+      
+      _staff    = s;
+      setEnabled(_staff != nullptr);
+      if (!_staff) {
             scene()->blockSignals(true);  // block changeSelection()
             scene()->clear();
+            clearNoteData();
             scene()->blockSignals(false);
             return;
             }
 
-      pos.setContext(staff->score()->tempomap(), staff->score()->sigmap());
-      Measure* lm = staff->score()->lastMeasure();
-      ticks       = lm->tick() + lm->ticks();
-      scene()->setSceneRect(0.0, 0.0, double(ticks + 960), keyHeight * 75);
+      trackingPos.setContext(_staff->score()->tempomap(), _staff->score()->sigmap());
+      updateBoundingSize();
 
       updateNotes();
-
-      //
-      // move to something interesting
-      //
-      QList<QGraphicsItem*> items = scene()->selectedItems();
+      
       QRectF boundingRect;
-      foreach (QGraphicsItem* item, items) {
-            if (item->type() == PianoItemType)
-                  boundingRect |= item->mapToScene(item->boundingRect()).boundingRect();
+      bool brInit = false;
+      QRectF boundingRectSel;
+      bool brsInit = false;
+      
+      foreach (PianoItem* item, noteList) {
+            if (!brInit) {
+                  boundingRect = item->boundingRect();
+                  brInit = true;
+                  }
+            else
+                  boundingRect |= item->boundingRect();
+
+            if (item->note()->selected()) {
+                  if (!brsInit) {
+                        boundingRectSel = item->boundingRect();
+                        brsInit = true;
+                        }
+                  else
+                        boundingRectSel |= item->boundingRect();
+                  }
+                  
             }
-      centerOn(boundingRect.center());
-      horizontalScrollBar()->setValue(0);
+
+      QRectF viewRect = mapToScene(viewport()->geometry()).boundingRect();
+      
+      if (brsInit) {
+            horizontalScrollBar()->setValue(boundingRectSel.x());
+            verticalScrollBar()->setValue(qMax(boundingRectSel.y() + (boundingRectSel.height() - viewRect.height()) / 2, 0.0));
+            }
+      else if (brInit) {
+            horizontalScrollBar()->setValue(boundingRect.x());
+            verticalScrollBar()->setValue(qMax(boundingRect.y() - (boundingRectSel.height() - viewRect.height()) / 2, 0.0));
+            }
+      else {
+            horizontalScrollBar()->setValue(0);
+            verticalScrollBar()->setValue(qMax(viewRect.y() - viewRect.height() / 2, 0.0));
+            }
       }
 
 //---------------------------------------------------------
 //   addChord
 //---------------------------------------------------------
 
-void PianoView::addChord(Chord* crd)
+void PianoView::addChord(Chord* chord, int voice)
       {
-      for (Chord* c : crd->graceNotes())
-            addChord(c);
-      for (Note* note : crd->notes()) {
+      for (Chord* c : chord->graceNotes())
+            addChord(c, voice);
+      for (Note* note : chord->notes()) {
             if (note->tieBack())
                   continue;
-            for (NoteEvent& e : note->playEvents())
-                  scene()->addItem(new PianoItem(note, &e));
+            noteList.append(new PianoItem(note, this));
             }
       }
 
@@ -526,23 +1104,126 @@ void PianoView::updateNotes()
       scene()->blockSignals(true);  // block changeSelection()
       scene()->clearFocus();
       scene()->clear();
-      createLocators();
+      clearNoteData();
 
-      int staffIdx   = staff->idx();
-      int startTrack = staffIdx * VOICES;
-      int endTrack   = startTrack + VOICES;
+      int staffIdx   = _staff->idx();
 
       SegmentType st = SegmentType::ChordRest;
-      for (Segment* s = staff->score()->firstSegment(st); s; s = s->next1(st)) {
-            for (int track = startTrack; track < endTrack; ++track) {
+      for (Segment* s = _staff->score()->firstSegment(st); s; s = s->next1(st)) {
+            for (int voice = 0; voice < VOICES; ++voice) {
+                  int track = voice + staffIdx * VOICES;
                   Element* e = s->element(track);
                   if (e && e->isChord())
-                        addChord(toChord(e));
+                        addChord(toChord(e), voice);
                   }
             }
       for (int i = 0; i < 3; ++i)
             moveLocator(i);
       scene()->blockSignals(false);
+      
+      scene()->update(sceneRect());
       }
-}
 
+//---------------------------------------------------------
+//   updateNotes
+//---------------------------------------------------------
+
+void PianoView::clearNoteData()
+      {
+      for (int i = 0; i < noteList.size(); ++i)
+            delete noteList[i];
+      
+      noteList.clear();
+      }
+
+
+//---------------------------------------------------------
+//   getSelectedItems
+//---------------------------------------------------------
+
+QList<PianoItem*> PianoView::getSelectedItems()
+      {
+      QList<PianoItem*> list;
+      for (int i = 0; i < noteList.size(); ++i) {
+            if (noteList[i]->note()->selected())
+                  list.append(noteList[i]);
+            }
+      return list;
+      }
+
+//---------------------------------------------------------
+//   getItems
+//---------------------------------------------------------
+
+QList<PianoItem*> PianoView::getItems()
+      {
+      QList<PianoItem*> list;
+      for (int i = 0; i < noteList.size(); ++i)
+            list.append(noteList[i]);
+      return list;
+      }
+
+//---------------------------------------------------------
+//   getAction
+//    returns action for shortcut
+//---------------------------------------------------------
+
+QAction* PianoView::getAction(const char* id)
+      {
+      Shortcut* s = Shortcut::getShortcut(id);
+      return s ? s->action() : 0;
+      }
+
+//---------------------------------------------------------
+//   setXZoom
+//---------------------------------------------------------
+
+void PianoView::setXZoom(int value)
+      {
+      if (_xZoom != value) {
+            _xZoom = value;
+            scene()->update();
+            emit xZoomChanged(_xZoom);
+            }
+      }
+
+//---------------------------------------------------------
+//   setBarPattern
+//---------------------------------------------------------
+
+void PianoView::setBarPattern(int value)
+      {
+      if (_barPattern != value) {
+            _barPattern = value;
+            scene()->update();
+            emit barPatternChanged(_barPattern);
+            }
+      }
+
+//---------------------------------------------------------
+//   setSubBeats
+//---------------------------------------------------------
+
+void PianoView::setTuplet(int value)
+      {
+      if (_tuplet != value) {
+            _tuplet = value;
+            scene()->update();
+            emit tupletChanged(_tuplet);
+            }
+      }
+
+//---------------------------------------------------------
+//   setSubdiv
+//---------------------------------------------------------
+
+void PianoView::setSubdiv(int value)
+      {
+      if (_subdiv != value) {
+            _subdiv = value;
+            scene()->update();
+            emit subdivChanged(_subdiv);
+            }
+      }
+
+}

--- a/mscore/pianoview.h
+++ b/mscore/pianoview.h
@@ -17,29 +17,56 @@
 
 namespace Ms {
 
+class Score;
 class Staff;
 class Chord;
+class ChordRest;
 class Note;
 class NoteEvent;
+class PianoView;
 
-const int PianoItemType = QGraphicsItem::UserType + 1;
+enum class NoteSelectType {
+      REPLACE = 0,
+      XOR,
+      ADD,
+      SUBTRACT,
+      FIRST
+      };
+
+enum class DragStyle {
+    NONE = 0,
+    SELECTION_RECT,
+    MOVE_NOTES
+      };
+
+struct BarPattern {
+      QString name;
+      char isWhiteKey[12];  //Set to 1 for white keys, 0 for black
+      };
 
 //---------------------------------------------------------
 //   PianoItem
 //---------------------------------------------------------
 
-class PianoItem : public QGraphicsRectItem {
-      Note*      _note;
-      NoteEvent* _event;
-      virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = 0);
-
+class PianoItem {
+      Note* _note;
+      PianoView* _pianoView;
+      
+      void paintNoteBlock(QPainter* painter, NoteEvent* evt);
+      QRect boundingRectTicks(NoteEvent* evt);
+      QRect boundingRectPixels(NoteEvent* evt);
+      bool intersectsBlock(int startTick, int endTick, int highPitch, int lowPitch, NoteEvent* evt);
+      
    public:
-      PianoItem(Note*, NoteEvent*);
-      virtual ~PianoItem() {}
-      virtual int type() const { return PianoItemType; }
-      Note* note()       { return _note; }
-      NoteEvent* event() { return _event; }
-      QRectF updateValues();
+      PianoItem(Note*, PianoView*);
+      ~PianoItem() {}
+      Note* note() { return _note; }
+      void paint(QPainter* painter);
+      bool intersects(int startTick, int endTick, int highPitch, int lowPitch);
+      
+      QRect boundingRect();
+      
+      NoteEvent* getTweakNoteEvent();
       };
 
 //---------------------------------------------------------
@@ -49,43 +76,94 @@ class PianoItem : public QGraphicsRectItem {
 class PianoView : public QGraphicsView {
       Q_OBJECT
 
-      Staff* staff;
+public:
+      static const BarPattern barPatterns[];
+
+private:
+      Staff* _staff;
       Chord* chord;
-      Pos pos;
+      
+      Pos trackingPos;  //Track mouse position
       Pos* _locator;
-      QGraphicsLineItem* locatorLines[3];
       int ticks;
       TType _timeType;
-      int magStep;
+      int _noteHeight;
+      qreal _xZoom;
+      int _tuplet;  //Tuplet divisions
+      int _subdiv;  //Beat subdivisions
+      int _barPattern;
+
+      bool _playEventsView;
+      bool mouseDown;
+      bool dragStarted;
+      QPointF mouseDownPos;
+      QPointF lastMousePos;
+      DragStyle dragStyle;
+      int lastDragPitch;
+      bool inProgressUndoEvent;
+      
+      QList<PianoItem*> noteList;
 
       virtual void drawBackground(QPainter* painter, const QRectF& rect);
 
-      int y2pitch(int y) const;
-      Pos pix2pos(int x) const;
-      int pos2pix(const Pos& p) const;
-      void createLocators();
-      void addChord(Chord* chord);
+      void addChord(Chord* chord, int voice);
+      void updateBoundingSize();
+      void clearNoteData();
+      void selectNotes(int startTick, int endTick, int lowPitch, int highPitch, NoteSelectType selType);
+      void showPopupMenu(const QPoint& pos);
+      bool cutChordRest(ChordRest* e, int track, int cutTick, ChordRest*& cr0, ChordRest*& cr1);
+
+      QAction* getAction(const char* id);
 
    protected:
       virtual void wheelEvent(QWheelEvent* event);
+      virtual void mousePressEvent(QMouseEvent* event);
+      virtual void mouseReleaseEvent(QMouseEvent* event);
       virtual void mouseMoveEvent(QMouseEvent* event);
       virtual void leaveEvent(QEvent*);
+      virtual void contextMenuEvent(QContextMenuEvent *event);
 
    signals:
-      void magChanged(double, double);
-      void xposChanged(int);
+      void xZoomChanged(qreal);
+      void tupletChanged(int);
+      void subdivChanged(int);
+      void barPatternChanged(int);
+      void noteHeightChanged(int);
       void pitchChanged(int);
-      void posChanged(const Pos&);
+      void trackingPosChanged(const Pos&);
+      void selectionChanged();
 
    public slots:
       void moveLocator(int);
       void updateNotes();
+      void setXZoom(int);
+      void setTuplet(int);
+      void setSubdiv(int);
+      void setBarPattern(int);
 
    public:
       PianoView();
+      ~PianoView();
+      Staff* staff() { return _staff; }
       void setStaff(Staff*, Pos* locator);
       void ensureVisible(int tick);
+      int noteHeight() { return _noteHeight; }
+      qreal xZoom() { return _xZoom; }
+      int tuplet() { return _tuplet; }
+      int subdiv() { return _subdiv; }
+      int barPattern() { return _barPattern; }
       QList<QGraphicsItem*> items() { return scene()->selectedItems(); }
+
+      int pixelXToTick(int pixX);
+      int tickToPixelX(int tick);
+      int pixelYToPitch(int pixY) { return (int)floor(128 - pixY / (qreal)_noteHeight); }
+      
+      PianoItem* pickNote(int tick, int pitch);
+
+      QList<PianoItem*> getSelectedItems();
+      QList<PianoItem*> getItems();
+      
+      bool playEventsView() { return _playEventsView; }
       };
 
 

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -173,7 +173,23 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_SCORE_VOICE3_COLOR,                           new ColorPreference(QColor("#c04400"))},    // orange
             {PREF_UI_SCORE_VOICE4_COLOR,                           new ColorPreference(QColor("#70167a"))},    // purple
             {PREF_UI_THEME_ICONWIDTH,                              new IntPreference(28, false)},
-            {PREF_UI_THEME_ICONHEIGHT,                             new IntPreference(24, false)}
+            {PREF_UI_THEME_ICONHEIGHT,                             new IntPreference(24, false)},
+            {PREF_UI_PIANOROLL_DARK_SELECTION_BOX_COLOR,           new ColorPreference(QColor("#0cebff"))},
+            {PREF_UI_PIANOROLL_DARK_NOTE_UNSEL_COLOR,              new ColorPreference(QColor("#1dcca0"))},
+            {PREF_UI_PIANOROLL_DARK_NOTE_SEL_COLOR,                new ColorPreference(QColor("#ffff00"))},
+            {PREF_UI_PIANOROLL_DARK_BG_BASE_COLOR,                 new ColorPreference(QColor("#3a3a3a"))},
+            {PREF_UI_PIANOROLL_DARK_BG_KEY_WHITE_COLOR,            new ColorPreference(QColor("#3a3a3a"))},
+            {PREF_UI_PIANOROLL_DARK_BG_KEY_BLACK_COLOR,            new ColorPreference(QColor("#262626"))},
+            {PREF_UI_PIANOROLL_DARK_BG_GRIDLINE_COLOR,             new ColorPreference(QColor("#111111"))},
+            {PREF_UI_PIANOROLL_DARK_BG_TEXT_COLOR,                 new ColorPreference(QColor("#999999"))},
+            {PREF_UI_PIANOROLL_DARK_SELECTION_BOX_COLOR,           new ColorPreference(QColor("#0cebff"))},
+            {PREF_UI_PIANOROLL_LIGHT_NOTE_UNSEL_COLOR,             new ColorPreference(QColor("#1dcca0"))},
+            {PREF_UI_PIANOROLL_LIGHT_NOTE_SEL_COLOR,               new ColorPreference(QColor("#ffff00"))},
+            {PREF_UI_PIANOROLL_LIGHT_BG_BASE_COLOR,                new ColorPreference(QColor("#e0e0e7"))},
+            {PREF_UI_PIANOROLL_LIGHT_BG_KEY_WHITE_COLOR,           new ColorPreference(QColor("#ffffff"))},
+            {PREF_UI_PIANOROLL_LIGHT_BG_KEY_BLACK_COLOR,           new ColorPreference(QColor("#e6e6e6"))},
+            {PREF_UI_PIANOROLL_LIGHT_BG_GRIDLINE_COLOR,            new ColorPreference(QColor("#a2a2a6"))},
+            {PREF_UI_PIANOROLL_LIGHT_BG_TEXT_COLOR,                new ColorPreference(QColor("#111111"))},
       });
 
       _initialized = true;

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -182,6 +182,22 @@ enum class MusicxmlExportBreaks : char {
 #define PREF_UI_SCORE_VOICE4_COLOR                          "ui/score/voice4/color"
 #define PREF_UI_THEME_ICONHEIGHT                            "ui/theme/iconHeight"
 #define PREF_UI_THEME_ICONWIDTH                             "ui/theme/iconWidth"
+#define PREF_UI_PIANOROLL_DARK_SELECTION_BOX_COLOR          "ui/pianoroll/dark/selectionBox/color"
+#define PREF_UI_PIANOROLL_DARK_NOTE_UNSEL_COLOR             "ui/pianoroll/dark/note/unselected/color"
+#define PREF_UI_PIANOROLL_DARK_NOTE_SEL_COLOR               "ui/pianoroll/dark/note/selected/color"
+#define PREF_UI_PIANOROLL_DARK_BG_BASE_COLOR                "ui/pianoroll/dark/background/base/color"
+#define PREF_UI_PIANOROLL_DARK_BG_KEY_WHITE_COLOR           "ui/pianoroll/dark/background/keys/white/color"
+#define PREF_UI_PIANOROLL_DARK_BG_KEY_BLACK_COLOR           "ui/pianoroll/dark/background/keys/black/color"
+#define PREF_UI_PIANOROLL_DARK_BG_GRIDLINE_COLOR            "ui/pianoroll/dark/background/gridLine/color"
+#define PREF_UI_PIANOROLL_DARK_BG_TEXT_COLOR                "ui/pianoroll/dark/background/text/color"
+#define PREF_UI_PIANOROLL_LIGHT_SELECTION_BOX_COLOR         "ui/pianoroll/light/selectionBox/color"
+#define PREF_UI_PIANOROLL_LIGHT_NOTE_UNSEL_COLOR            "ui/pianoroll/light/note/unselected/color"
+#define PREF_UI_PIANOROLL_LIGHT_NOTE_SEL_COLOR              "ui/pianoroll/light/note/selected/color"
+#define PREF_UI_PIANOROLL_LIGHT_BG_BASE_COLOR               "ui/pianoroll/light/background/base/color"
+#define PREF_UI_PIANOROLL_LIGHT_BG_KEY_WHITE_COLOR          "ui/pianoroll/light/background/keys/white/color"
+#define PREF_UI_PIANOROLL_LIGHT_BG_KEY_BLACK_COLOR          "ui/pianoroll/light/background/keys/black/color"
+#define PREF_UI_PIANOROLL_LIGHT_BG_GRIDLINE_COLOR           "ui/pianoroll/light/background/gridLine/color"
+#define PREF_UI_PIANOROLL_LIGHT_BG_TEXT_COLOR               "ui/pianoroll/light/background/text/color"
 
 
 class PreferenceVisitor;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -355,12 +355,14 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
 //   measurePopup
 //---------------------------------------------------------
 
-void ScoreView::measurePopup(const QPoint& gpos, Measure* obj)
+void ScoreView::measurePopup(QContextMenuEvent* ev, Measure* obj)
       {
       int staffIdx;
       int pitch;
       Segment* seg;
 
+      QPoint gpos = ev->globalPos();
+      
       if (!_score->pos2measure(editData.startMove, &staffIdx, &pitch, &seg, 0))
             return;
       if (staffIdx == -1) {
@@ -447,7 +449,10 @@ void ScoreView::measurePopup(const QPoint& gpos, Measure* obj)
             }
       else if (cmd == "pianoroll") {
             _score->endCmd();
-            mscore->editInPianoroll(staff);
+            QPointF p = toLogical(ev->pos());
+            Position pp;
+            bool foundPos = _score->getPosition(&pp, p, 0);
+            mscore->editInPianoroll(staff, foundPos ? &pp : 0);
             }
       else if (cmd == "staff-properties") {
             int tick = obj ? obj->tick() : -1;
@@ -4161,6 +4166,8 @@ static bool elementLower(const Element* e1, const Element* e2)
             }
       return e1->z() < e2->z();
       }
+
+
 
 //---------------------------------------------------------
 //   elementNear

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -139,7 +139,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void paint(const QRect&, QPainter&);
 
       void objectPopup(const QPoint&, Element*);
-      void measurePopup(const QPoint&, Measure*);
+      void measurePopup(QContextMenuEvent* ev, Measure*);
 
       void saveChord(XmlWriter&);
 


### PR DESCRIPTION
This is an update to the pianoroll editor to make it easier to see notes and note events, and to provide some simple editing capabilities.

The note display area has been altered:
- When you open the piano roll editor via the popup menu created by right clicking in the staff, the view will scroll to focus on the staff position where the mouse click occurred.
- The layout has been adjusted to show 12 bars per octave - one for each tone.
- The bars are colored to distinguish white keys from back keys.
- Instruments that are not in C will have the keyboard display adjusted so that their C matches the keyboard C
- Drumkits will display the names of their drum samples on the key of the keyboard with the coresponding pitch
- Added tooltip to keyboard notes to display pitch (and also drumkit name when using drimkit)
- Notes can have their pitch changed by clicking and dragging them
- A subdiv option has been added to allow the displayed beat bar lines to be further subdivided.  So setting subdiv to 2 in 4/4 time will draw lines at every 1/16 note.
- A tuplet option has been added to display lines at tuplet boundaries.  So setting this to 3 will draw lines where triplet notes would be.
- Setting both will draw lines every (1 << subdiv) * tuplet, so setting subdiv to 1 and tuplet to 3 will draw lines at every half-tripplet.
- Clicking and dragging will select notes within the drag area.
- Holding shift and clicking will add a pitch to the segment or create a new note if there is currently a rest.  This does not change the existing length of the segment.
- Holding ctrl and clicking will add a note of the current note edit length to the nearest grid square rounded down where the click happened.  This will only happen if the current segment is not a tuplet and the tuplet control is set to 1, since the current code cannot handle tuplets property.
- Holding ctrl and shift and clicking will cut the current segment at the closest grid line, rounded down.  This is ignored if the coresponding segment is a tuplet or tuplet grid lines are being displayed.
- A dark mode and light mode display are both supported.  The user will be able to adjust the particular colors in the preference for this as they wish.
- Playhead in ruler above note window now matches the play position.
- Added keyboard shortcuts to some common commands.  Pressing space will now start and stop playback.
- Added a right click popup menu with a few common commands.

Some changes have been made to the top bar:
- Changes have been made so event data is updated as the user clicks on individual notes.  This did not always happen before.  It also handles detecting when controls should be disabled due to multiple note selection better.
- The user/offset display has been been adjusted to take the current dynamic value into account so that switching from one to the other will produce the equivalent value.  (Sort of like switching between Farenheit and Celcius.  The old system just swapped the unit tag without adjusting the numeric value).
- Added a label to display the name of the current part.
- Added Bar Pattern, which lets users adjust the pattern of the white and black horizontal bars behind the grid area.  This can be used to provide a visual indicator for a notes of a given chord.

A note event editor (aka: levels editor) has been added below the note area.  This is meant to display and adjust note events associated with notes.  It takes the form of a bar graph, with one bar line for each note.
- There is a combo box on the left which allows the user to pick the type of event displayed.
- The user can edit event data by selecting one or more notes in the note area.  They can then click or click and drag in the levels area to set a new value for that note event.  Only levels for selected notes will be adjusted.
- By pressing shift while dragging, all note events will be adjusted to the height of the initial mouse click instead of the current mouse position when the user sweeps it across.