### PR TITLE
fix #274280: Undoing timewise delete does not restore slur position

### DIFF
--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -586,10 +586,14 @@ void Segment::remove(Element* el)
                   auto spanners = smap.findOverlapping(tick(), tick());
                   for (auto interval : spanners) {
                         Spanner* s = interval.value;
+                        Element* start = s->startElement();
+                        Element* end = s->endElement();
                         if (s->startElement() == el)
-                              s->setStartElement(nullptr);
+                              start = nullptr;
                         if (s->endElement() == el)
-                              s->setEndElement(nullptr);
+                              end = nullptr;
+                        if (start != s->startElement() || end != s->endElement())
+                              score()->undo(new ChangeStartEndSpanner(s, start, end));
                         }
                   }
                   break;

--- a/libmscore/splitMeasure.cpp
+++ b/libmscore/splitMeasure.cpp
@@ -17,6 +17,7 @@
 #include "range.h"
 #include "tuplet.h"
 #include "spanner.h"
+#include "undo.h"
 
 namespace Ms {
 
@@ -54,12 +55,19 @@ void Score::splitMeasure(Segment* segment)
       int stick = measure->tick();
       int etick = measure->endTick();
 
+      std::list<std::tuple<Spanner*, int, int>> sl;
       for (auto i : spanner()) {
             Spanner* s = i.second;
+            Element* start = s->startElement();
+            Element* end = s->endElement();
             if (s->tick() >= stick && s->tick() < etick)
-                  s->setStartElement(0);
+                  start = nullptr;
             if (s->tick2() >= stick && s->tick2() < etick)
-                  s->setEndElement(0);
+                  end = nullptr;
+            if (start != s->startElement() || end != s->endElement())
+                  undo(new ChangeStartEndSpanner(s, start, end));
+            if (s->tick() < stick && s->tick2() > stick)
+                  sl.push_back(make_tuple(s, s->tick(), s->ticks()));
             }
 
       MeasureBase* nm = measure->next();
@@ -82,6 +90,16 @@ void Score::splitMeasure(Segment* segment)
       m1->adjustToLen(Fraction::fromTicks(ticks1), false);
       m2->adjustToLen(Fraction::fromTicks(ticks2), false);
       range.write(this, m1->tick());
+
+      for (auto i : sl) {
+            Spanner* s = std::get<0>(i);
+            int tick   = std::get<1>(i);
+            int ticks  = std::get<2>(i);
+            if (s->tick() != tick)
+                  s->undoChangeProperty(Pid::SPANNER_TICK, tick);
+            if (s->ticks() != ticks)
+                  s->undoChangeProperty(Pid::SPANNER_TICKS, ticks);
+            }
       }
 }
 


### PR DESCRIPTION
See https://musescore.org/en/node/274280.

This fixes the issue by setting the spanner's startElement and endElement in an undoable manner when the startElement or endElement is removed.

I took this opportunity to make a few corrections involving 
- tick rounding errors
- incorrect use of tick() versus rtick()
- an unhandled case for area of deletion compared to spanner position and length

It was necessary to change the order of cases B and C in Score::undoInsertTime() when I changed < and > to <= and >=. This makes it a little harder to see what I actually changed when viewing the diff.