### PR TITLE
fix #274309: "Regroup Rhythms" crashes the program if measures contain Measure repeat symbols

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -986,7 +986,7 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                         if (restTicks > curr->duration().ticks())
                               seg = setNoteRest(seg, curr->track(), NoteVal(), Fraction::fromTicks(restTicks), Direction::AUTO, true);
                         }
-                  else {
+                  else if (curr->isChord()) {
                         // combine tied chords
                         Chord* chord = toChord(curr);
                         Chord* lastTiedChord = chord;


### PR DESCRIPTION
See https://musescore.org/en/node/274309.

If a ChordRest is not a Rest, then it must be a Chord, right? Well, RepeatMeasure is a subclass of Rest, but ScoreElement::isRest() returns false unless type() == ElementType::REST. So it is necessary to check that isChord() is true before casting a ChordRest to a Chord, even if we know that isRest() is false.

Hopefully this fix can make it into 2.3.2. 