### PR TITLE
fix #270433: Crash when pasting a note with an articulation if the final note is split between two measures

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2816,6 +2816,9 @@ void Chord::removeMarkings(bool keepTremolo)
       if (arpeggio())
             remove(arpeggio());
       qDeleteAll(graceNotes());
+      graceNotes().clear();
+      qDeleteAll(articulations());
+      articulations().clear();
       for (Note* n : notes()) {
             for (Element* e : n->el())
                   n->remove(e);

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1235,9 +1235,9 @@ int ChordRest::lastVerse(Placement p) const
 void ChordRest::removeMarkings(bool /* keepTremolo */)
       {
       qDeleteAll(el());
-      if (isChord())
-            qDeleteAll(toChord(this)->articulations());
+      el().clear();
       qDeleteAll(lyrics());
+      lyrics().clear();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/270433.

The objects were being freed, but the vectors were not being cleared. Also, it makes more sense to remove the articulations in Chord::removeMarkings(). This eliminates a type check and cast.