### PR TITLE
fix #274540: save user choice of instrument genre

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -397,7 +397,7 @@ void populateGenreCombo(QComboBox* combo)
       combo->addItem(qApp->translate("InstrumentsDialog", "All instruments"), "all");
       int i = 1;
       int defaultIndex = 0;
-      foreach (InstrumentGenre *ig, instrumentGenres) {
+      for (InstrumentGenre *ig : instrumentGenres) {
             combo->addItem(ig->name, ig->id);
             if (ig->id == "common")
                   defaultIndex = i;
@@ -414,7 +414,7 @@ void populateInstrumentList(QTreeWidget* instrumentList)
       {
       instrumentList->clear();
       // TODO: memory leak?
-      foreach(InstrumentGroup* g, instrumentGroups) {
+      for (InstrumentGroup* g : instrumentGroups) {
             InstrumentTemplateListItem* group = new InstrumentTemplateListItem(g->name, instrumentList);
             group->setFlags(Qt::ItemIsEnabled);
             for (InstrumentTemplate* t : g->instrumentTemplates) {
@@ -456,7 +456,7 @@ void InstrumentsWidget::genPartList(Score* cs)
       {
       partiturList->clear();
 
-      foreach (Part* p, cs->parts()) {
+      for (Part* p : cs->parts()) {
             PartListItem* pli = new PartListItem(p, partiturList);
             pli->setVisible(p->show());
             for (Staff* s : *p->staves()) {
@@ -562,7 +562,7 @@ void InstrumentsWidget::on_instrumentList_itemDoubleClicked(QTreeWidgetItem*, in
 
 void InstrumentsWidget::on_addButton_clicked()
       {
-      foreach(QTreeWidgetItem* i, instrumentList->selectedItems()) {
+      for (QTreeWidgetItem* i : instrumentList->selectedItems()) {
             InstrumentTemplateListItem* item = static_cast<InstrumentTemplateListItem*>(i);
             const InstrumentTemplate* it     = item->instrumentTemplate();
             if (it == 0)
@@ -909,6 +909,11 @@ void InstrumentsWidget::on_search_textChanged(const QString &searchPhrase)
 
 void InstrumentsWidget::on_instrumentGenreFilter_currentIndexChanged(int index)
       {
+      QSettings settings;
+      settings.beginGroup("selectInstrument");  // hard coded, since this is also used in instrwidget
+      settings.setValue("selectedGenre", instrumentGenreFilter->currentText());
+      settings.endGroup();
+
       QString id = instrumentGenreFilter->itemData(index).toString();
       // Redisplay tree, only showing items from the selected genre
       filterInstrumentsByGenre(instrumentList, id);
@@ -1033,6 +1038,7 @@ void InstrumentsWidget::createInstruments(Score* cs)
 
 void InstrumentsWidget::init()
       {
+      qDebug("=== INIT ===");
       partiturList->clear();
       instrumentList->clearSelection();
       addButton->setEnabled(false);
@@ -1041,6 +1047,16 @@ void InstrumentsWidget::init()
       downButton->setEnabled(false);
       linkedButton->setEnabled(false);
       belowButton->setEnabled(false);
+
+      // get last saved, user-selected instrument genre and set filter to it
+      QSettings settings;
+      settings.beginGroup("selectedInstrument");
+      if ( ! settings.value("selectedGenre").isNull() ){
+            QString selectedGenre = settings.value("selectedGenre").value<QString>();
+            instrumentGenreFilter->setCurrentText(selectedGenre);
+            }
+      settings.endGroup();
+
       emit completeChanged(false);
       }
 

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -145,7 +145,6 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
    public:
       InstrumentsWidget(QWidget* parent = 0);
       void genPartList(Score*);
-      void writeSettings();
       void init();
       void createInstruments(Score*);
       QTreeWidget* getPartiturList();

--- a/mscore/selinstrument.cpp
+++ b/mscore/selinstrument.cpp
@@ -43,6 +43,17 @@ SelectInstrument::SelectInstrument(const Instrument* instrument, QWidget* parent
       buildTemplateList();
       buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
       connect(instrumentList, SIGNAL(clicked(const QModelIndex &)), SLOT(expandOrCollapse(const QModelIndex &)));
+
+      qDebug("INIT SELECTINSTRUMENT");
+      // get last saved, user-selected instrument genre and set filter to it
+      QSettings settings;
+      settings.beginGroup("selectInstrument");
+      if (!settings.value("selectedGenre").isNull() ){
+            QString selectedGenre = settings.value("selectedGenre").value<QString>();
+            instrumentGenreFilter->setCurrentText(selectedGenre);
+            }
+      settings.endGroup();
+
       MuseScore::restoreGeometry(this);
       }
 
@@ -125,7 +136,13 @@ void SelectInstrument::on_search_textChanged(const QString &searchPhrase)
 
 void SelectInstrument::on_instrumentGenreFilter_currentIndexChanged(int index)
       {
+      QSettings settings;
+      settings.beginGroup("selectInstrument");  // hard coded, since this is also used in instrwidget
+      settings.setValue("selectedGenre", instrumentGenreFilter->currentText());
+      settings.endGroup();
+
       QString id = instrumentGenreFilter->itemData(index).toString();
+
       // Redisplay tree, only showing items from the selected genre
       filterInstrumentsByGenre(instrumentList, id);
       }
@@ -170,6 +187,4 @@ void SelectInstrument::hideEvent(QHideEvent* event)
       MuseScore::saveGeometry(this);
       QWidget::hideEvent(event);
       }
-
 }
-


### PR DESCRIPTION
This addresses a feature request at: https://musescore.org/en/node/274540

The request was to keep the user's selection of instrument genre so that they don't have to change it every time they add/change an instrument. This PR adds this functionality by saving the user's last choice of instrument in QSettings, which actually means that the last selected genre will be saved even after the application has closed.