### PR TITLE
Advanced preferences

### DIFF
--- a/awl/colorlabel.cpp
+++ b/awl/colorlabel.cpp
@@ -31,6 +31,8 @@ ColorLabel::ColorLabel(QWidget* parent)
       {
       _color  = Qt::blue;
       _pixmap = 0;
+      _text = "";
+      setCursor(Qt::PointingHandCursor);
       }
 
 ColorLabel::~ColorLabel()
@@ -45,7 +47,17 @@ ColorLabel::~ColorLabel()
 void ColorLabel::setColor(const QColor& c)
       {
       _color = c;
+      emit colorChanged(_color);
       update();
+      }
+
+//---------------------------------------------------------
+//   color
+//---------------------------------------------------------
+
+const QColor ColorLabel::color() const
+      {
+      return _color;
       }
 
 //---------------------------------------------------------
@@ -56,6 +68,7 @@ void ColorLabel::setPixmap(QPixmap* pm)
       {
       delete _pixmap;
       _pixmap = pm;
+      emit pixmapChanged(_pixmap);
       update();
       }
 
@@ -69,6 +82,35 @@ QSize ColorLabel::sizeHint() const
       }
 
 //---------------------------------------------------------
+//   pixmap
+//---------------------------------------------------------
+
+QPixmap* ColorLabel::pixmap() const
+      {
+      return _pixmap;
+      }
+
+//---------------------------------------------------------
+//   text
+//---------------------------------------------------------
+
+const QString& ColorLabel::text() const
+      {
+      return _text;
+      }
+
+//---------------------------------------------------------
+//   setText
+//---------------------------------------------------------
+
+void ColorLabel::setText(const QString& text)
+      {
+      _text = text;
+      emit textChanged(text);
+      update();
+      }
+
+//---------------------------------------------------------
 //   paintEvent
 //---------------------------------------------------------
 
@@ -77,11 +119,18 @@ void ColorLabel::paintEvent(QPaintEvent* ev)
       {
       QPainter p(this);
       int fw = frameWidth();
-      QRect r(frameRect().adjusted(fw, fw, -2*fw, -2*fw));
+      QRect r = QRect(frameRect().adjusted(fw, fw, -2 * fw, -2 * fw));
       if (_pixmap)
             p.drawTiledPixmap(r, *_pixmap);
-      else
+      else {
             p.fillRect(r, _color);
+            if (!_text.isEmpty()) {
+                  // Get a visible text: white if the text is dark and black if it's light.
+                  // Get the average of R, G and B. If it's greater than or equal to 128, it means the text is light.
+                  p.setPen(QColor((((_color.red() + _color.green() + _color.blue()) / 3) >= 128) ? Qt::black : Qt::white));
+                  p.drawText(frameRect(), _text, QTextOption(Qt::AlignCenter));
+                  }
+            }
       }
       QFrame::paintEvent(ev);
       }

--- a/awl/colorlabel.cpp
+++ b/awl/colorlabel.cpp
@@ -52,6 +52,25 @@ void ColorLabel::setColor(const QColor& c)
       }
 
 //---------------------------------------------------------
+//   get
+//---------------------------------------------------------
+
+void ColorLabel::getColor()
+      {
+      QColor c = QColorDialog::getColor(_color, this,
+         tr("Select Color"),
+         QColorDialog::ShowAlphaChannel
+         );
+      if (c.isValid()) {
+            if (_color != c) {
+                  _color = c;
+                  emit colorChanged(_color);
+                  update();
+                  }
+            }
+      }
+
+//---------------------------------------------------------
 //   color
 //---------------------------------------------------------
 
@@ -126,7 +145,8 @@ void ColorLabel::paintEvent(QPaintEvent* ev)
             p.fillRect(r, _color);
             if (!_text.isEmpty()) {
                   // Get a visible text: white if the text is dark and black if it's light.
-                  // Get the average of R, G and B. If it's greater than or equal to 128, it means the text is light.
+                  // Get the average of R, G and B. If it's greater than or equal to 128,
+                  // then consider that the text is light.
                   p.setPen(QColor((((_color.red() + _color.green() + _color.blue()) / 3) >= 128) ? Qt::black : Qt::white));
                   p.drawText(frameRect(), _text, QTextOption(Qt::AlignCenter));
                   }
@@ -139,21 +159,21 @@ void ColorLabel::paintEvent(QPaintEvent* ev)
 //   mousePressEvent
 //---------------------------------------------------------
 
-void ColorLabel::mousePressEvent(QMouseEvent*)
+void ColorLabel::mousePressEvent(QMouseEvent* event)
       {
+      event->accept();
       if (_pixmap)
             return;
-      QColor c = QColorDialog::getColor(_color, this,
-         tr("Select Color"),
-         QColorDialog::ShowAlphaChannel
-         );
-      if (c.isValid()) {
-            if (_color != c) {
-                  _color = c;
-                  emit colorChanged(_color);
-                  update();
-                  }
-            }
+      getColor();
+      }
+
+void ColorLabel::keyPressEvent(QKeyEvent* event)
+      {
+      event->accept();
+      if (_pixmap)
+            return;
+      if ((event->key() == Qt::Key_Space) || (event->key() == Qt::Key_Enter))
+            getColor();
       }
 
 } // namespace Awl

--- a/awl/colorlabel.h
+++ b/awl/colorlabel.h
@@ -39,6 +39,7 @@ class ColorLabel : public QFrame {
 
       virtual void paintEvent(QPaintEvent*) override;
       virtual void mousePressEvent(QMouseEvent*) override;
+      virtual void keyPressEvent(QKeyEvent*) override;
 
    signals:
       void colorChanged(const QColor&);
@@ -49,16 +50,17 @@ class ColorLabel : public QFrame {
       ColorLabel(QWidget* parent = nullptr);
       ~ColorLabel();
 
-      void setColor(const QColor&);
-      const QColor color() const;
-
       virtual QSize sizeHint() const override;
-
+      const QColor color() const;
       QPixmap* pixmap() const;
-      void setPixmap(QPixmap*);
-
       const QString& text() const;
+
+   public slots:
       void setText(const QString& text);
+      void setPixmap(QPixmap*);
+      void setColor(const QColor&);
+      void getColor();
+
 };
 
 }  // namespace Awl

--- a/awl/colorlabel.h
+++ b/awl/colorlabel.h
@@ -29,26 +29,37 @@ namespace Awl {
 
 class ColorLabel : public QFrame {
       Q_OBJECT
-      Q_PROPERTY(QColor color READ color WRITE setColor)
+      Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
+      Q_PROPERTY(QString text READ text WRITE setText NOTIFY textChanged)
+      Q_PROPERTY(QPixmap* pixmap READ pixmap WRITE setPixmap NOTIFY pixmapChanged)
 
       QColor _color;
+      QString _text;
       QPixmap* _pixmap;
 
-      virtual void paintEvent(QPaintEvent*);
-      virtual void mousePressEvent(QMouseEvent*);
+      virtual void paintEvent(QPaintEvent*) override;
+      virtual void mousePressEvent(QMouseEvent*) override;
 
    signals:
-      void colorChanged(QColor);
+      void colorChanged(const QColor&);
+      void pixmapChanged(const QPixmap*);
+      void textChanged(const QString&);
 
    public:
-      ColorLabel(QWidget* parent = 0);
+      ColorLabel(QWidget* parent = nullptr);
       ~ColorLabel();
-      void setColor(const QColor& c);
-      virtual QSize sizeHint() const;
+
+      void setColor(const QColor&);
+      const QColor color() const;
+
+      virtual QSize sizeHint() const override;
+
+      QPixmap* pixmap() const;
       void setPixmap(QPixmap*);
-      QColor color() const     { return _color; }
-      QPixmap* pixmap() const  { return _pixmap;  }
-      };
+
+      const QString& text() const;
+      void setText(const QString& text);
+};
 
 }  // namespace Awl
 #endif

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -35,7 +35,7 @@ endif (SCRIPT_INTERFACE)
 
 QT5_WRAP_UI (ui_headers
       insertmeasuresdialog.ui editinstrument.ui editstyle.ui instrdialog.ui instrwidget.ui
-      measuresdialog.ui pagesettings.ui mixer.ui playpanel.ui prefsdialog.ui measureproperties.ui
+      measuresdialog.ui pagesettings.ui mixer.ui playpanel.ui measureproperties.ui
       textpalette.ui  timedialog.ui symboldialog.ui  shortcutcapturedialog.ui  editdrumset.ui
       editstaff.ui timesigproperties.ui
       instrwizard.ui timesigwizard.ui newwizard.ui aboutbox.ui aboutmusicxmlbox.ui
@@ -49,6 +49,8 @@ QT5_WRAP_UI (ui_headers
       startcenter.ui scorePreview.ui scoreBrowser.ui
       logindialog.ui uploadscoredialog.ui breaksdialog.ui
       toolbarEditor.ui
+      # preferences things.
+      advancedpreferenceswidget.ui  prefsdialog.ui
 
       importmidi/importmidi_panel.ui
 
@@ -240,7 +242,7 @@ add_executable ( ${ExecutableName}
       ${resource_file}
       ${INCS}
 
-      recordbutton.h greendotbutton prefsdialog.h prefsdialog.cpp
+      recordbutton.h greendotbutton
       stringutils.h stringutils.cpp
       scoreview.cpp editharmony.cpp editfiguredbass.cpp events.cpp
       editinstrument.cpp editstyle.cpp
@@ -251,7 +253,7 @@ add_executable ( ${ExecutableName}
       debugger/debugger.cpp menus.cpp
       musescore.cpp navigator.cpp pagesettings.cpp palette.cpp
       timeline.cpp
-      mixer.cpp playpanel.cpp selectionwindow.cpp preferences.cpp measureproperties.cpp
+      mixer.cpp playpanel.cpp selectionwindow.cpp measureproperties.cpp
       seq.cpp textpalette.cpp
       timedialog.cpp symboldialog.cpp shortcutcapturedialog.cpp
       simplebutton.cpp musedata.cpp
@@ -330,6 +332,7 @@ add_executable ( ${ExecutableName}
       pathlistdialog.cpp
       exampleview.cpp
       miconengine.cpp
+      #importmidi
       importmidi/importmidi.cpp
       importmidi/importmidi_panel.cpp importmidi/importmidi_operations.cpp
       importmidi/importmidi_model.cpp importmidi/importmidi_delegate.cpp
@@ -345,6 +348,7 @@ add_executable ( ${ExecutableName}
       importmidi/importmidi_voice.cpp importmidi/importmidi_view.cpp importmidi/importmidi_key.cpp
       importmidi/importmidi_tempo.cpp importmidi/importmidi_instrument.cpp
       importmidi/importmidi_chordname.cpp
+
       resourceManager.cpp downloadUtils.cpp
       textcursor.cpp continuouspanel.cpp accessibletoolbutton.cpp scoreaccessibility.cpp
       startcenter.cpp scoreBrowser.cpp scorePreview.cpp scoreInfo.cpp
@@ -353,7 +357,11 @@ add_executable ( ${ExecutableName}
       toolbarEditor.cpp toolbarEditor.h
       abstractdialog.cpp abstractdialog.h
       toolbuttonmenu.cpp
-      preferenceslistwidget.cpp preferenceslistwidget.h
+      # preferences
+      prefsdialog.cpp preferences.cpp
+      preferenceslistwidget.cpp advancedpreferenceswidget.cpp
+      preferencestreewidget_delegate.cpp
+
       extension.cpp extension.h
 
       ${COCOABRIDGE}

--- a/mscore/advancedpreferenceswidget.cpp
+++ b/mscore/advancedpreferenceswidget.cpp
@@ -1,0 +1,69 @@
+//=============================================================================
+//  MuseScore
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2002-2011 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#include "advancedpreferenceswidget.h"
+#include "musescore.h"
+
+namespace Ms {
+
+AdvancedPreferencesWidget::AdvancedPreferencesWidget(QWidget* parent) :
+      QWidget(parent),
+      ui(new Ui::AdvancedPreferencesWidget)
+      {
+      setObjectName("AdvancedPreferencesWidget");
+      ui->setupUi(this);
+
+      connect(ui->resetToDefaultButton, &QPushButton::clicked, ui->treePreferencesWidget, &PreferencesListWidget::resetSelectedPreferencesToDefault);
+      connect(ui->treePreferencesWidget, &QTreeWidget::itemSelectionChanged, this, &AdvancedPreferencesWidget::enableResetPreferenceToDefault);
+      connect(ui->searchLineEdit,  &QLineEdit::textChanged, ui->treePreferencesWidget, &PreferencesListWidget::filter);
+      }
+
+AdvancedPreferencesWidget::~AdvancedPreferencesWidget()
+      {
+      delete ui;
+      }
+
+void AdvancedPreferencesWidget::updatePreferences() const
+      {
+      ui->treePreferencesWidget->updatePreferences();
+      }
+
+void AdvancedPreferencesWidget::enableResetPreferenceToDefault()
+      {
+      if (!ui->treePreferencesWidget->selectedItems().count()) {
+            setEnabled(false);
+            return;
+            }
+
+      // if at least one of the selected items is a PreferenceItem, enable resetToDefaultButton.
+      for (QTreeWidgetItem* item: ui->treePreferencesWidget->selectedItems()) {
+            // it would be faster, but less safe to use (item->childCount()
+            // to determine if the item is a PreferenceItem.
+            PreferenceItem* pref = dynamic_cast<PreferenceItem*>(item);
+            if (pref) {
+                  ui->resetToDefaultButton->setEnabled(true);
+                  return;
+                  }
+            }
+      // if it gets here, it means none of the selected items were PreferenceItems, so disable the button.
+      ui->resetToDefaultButton->setEnabled(false);
+      }
+
+} // namespace Ms
+

--- a/mscore/advancedpreferenceswidget.h
+++ b/mscore/advancedpreferenceswidget.h
@@ -1,0 +1,47 @@
+//=============================================================================
+//  MuseScore
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2002-2011 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef ADVANCEDPREFERENCESWIDGET_H
+#define ADVANCEDPREFERENCESWIDGET_H
+
+#include "ui_advancedpreferenceswidget.h"
+
+namespace Ms {
+
+class AdvancedPreferencesWidget : public QWidget
+{
+      Q_OBJECT
+
+   public:
+      explicit AdvancedPreferencesWidget(QWidget* parent = nullptr);
+      ~AdvancedPreferencesWidget();
+
+      inline void save() { ui->treePreferencesWidget->save(); }
+      inline void updatePreferences() const;
+
+   private:
+      Ui::AdvancedPreferencesWidget* ui;
+
+   private slots:
+      void enableResetPreferenceToDefault();
+};
+
+} // namespace Ms
+
+#endif // ADVANCEDPREFERENCESWIDGET_H

--- a/mscore/advancedpreferenceswidget.ui
+++ b/mscore/advancedpreferenceswidget.ui
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AdvancedPreferencesWidget</class>
+ <widget class="QWidget" name="AdvancedPreferencesWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>480</width>
+    <height>640</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="optionsButton">
+     <item>
+      <widget class="QPushButton" name="resetToDefaultButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="toolTip">
+        <string>Reset selected preference(s) to default</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>This button resets the selected preference(s) to default</string>
+       </property>
+       <property name="text">
+        <string>Reset selection to default</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="searchLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Search for specific preferences</string>
+       </property>
+       <property name="accessibleName">
+        <string>Search filter</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>Search for specific preferences</string>
+       </property>
+       <property name="placeholderText">
+        <string>Search</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="0">
+    <widget class="Ms::PreferencesListWidget" name="treePreferencesWidget">
+     <property name="accessibleName">
+      <string>Advanced preferences</string>
+     </property>
+     <property name="accessibleDescription">
+      <string>Access to more advanced preferences</string>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="uniformRowHeights">
+      <bool>true</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="allColumnsShowFocus">
+      <bool>true</bool>
+     </property>
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <attribute name="headerCascadingSectionResizes">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="headerMinimumSectionSize">
+      <number>100</number>
+     </attribute>
+     <column>
+      <property name="text">
+       <string notr="true">Preference</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string notr="true">Value</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Ms::PreferencesListWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>preferenceslistwidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/mscore/advancedpreferenceswidget.ui
+++ b/mscore/advancedpreferenceswidget.ui
@@ -22,14 +22,14 @@
      <property name="horizontalScrollBarPolicy">
       <enum>Qt::ScrollBarAlwaysOff</enum>
      </property>
+     <property name="tabKeyNavigation">
+      <bool>true</bool>
+     </property>
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectItems</enum>
      </property>
      <property name="uniformRowHeights">
       <bool>true</bool>

--- a/mscore/advancedpreferenceswidget.ui
+++ b/mscore/advancedpreferenceswidget.ui
@@ -11,67 +11,6 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <layout class="QHBoxLayout" name="optionsButton">
-     <item>
-      <widget class="QPushButton" name="resetToDefaultButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="cursor">
-        <cursorShape>PointingHandCursor</cursorShape>
-       </property>
-       <property name="toolTip">
-        <string>Reset selected preference(s) to default</string>
-       </property>
-       <property name="accessibleDescription">
-        <string>This button resets the selected preference(s) to default</string>
-       </property>
-       <property name="text">
-        <string>Reset selection to default</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="searchLineEdit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>Search for specific preferences</string>
-       </property>
-       <property name="accessibleName">
-        <string>Search filter</string>
-       </property>
-       <property name="accessibleDescription">
-        <string>Search for specific preferences</string>
-       </property>
-       <property name="placeholderText">
-        <string>Search</string>
-       </property>
-       <property name="clearButtonEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
    <item row="0" column="0">
     <widget class="Ms::PreferencesListWidget" name="treePreferencesWidget">
      <property name="accessibleName">
@@ -87,7 +26,10 @@
       <bool>true</bool>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectItems</enum>
      </property>
      <property name="uniformRowHeights">
       <bool>true</bool>
@@ -118,6 +60,76 @@
       </property>
      </column>
     </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="optionsButton">
+     <item>
+      <widget class="QPushButton" name="resetToDefaultButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="cursor">
+        <cursorShape>PointingHandCursor</cursorShape>
+       </property>
+       <property name="toolTip">
+        <string>Reset selected preference(s) to default</string>
+       </property>
+       <property name="whatsThis">
+        <string>This button resets the selected preference(s) to default</string>
+       </property>
+       <property name="accessibleName">
+        <string>Reset to default button</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>This button resets the selected preference(s) to default</string>
+       </property>
+       <property name="text">
+        <string>Reset selection to default</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="searchLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Search for specific preferences</string>
+       </property>
+       <property name="whatsThis">
+        <string>Search for specific preferences</string>
+       </property>
+       <property name="accessibleName">
+        <string>Search filter</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>Search for specific preferences</string>
+       </property>
+       <property name="placeholderText">
+        <string>Search</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -499,7 +499,7 @@ void InspectorBase::mapSignals(const std::vector<InspectorItem>& il, const std::
             else if (qobject_cast<QLineEdit*>(w))
                   connect(qobject_cast<QLineEdit*>(w), QOverload<const QString&>::of(&QLineEdit::textChanged), [=] { valueChanged(i); });
             else if (qobject_cast<Awl::ColorLabel*>(w))
-                  connect(qobject_cast<Awl::ColorLabel*>(w), QOverload<QColor>::of(&Awl::ColorLabel::colorChanged), [=] { valueChanged(i); });
+                  connect(qobject_cast<Awl::ColorLabel*>(w), QOverload<const QColor&>::of(&Awl::ColorLabel::colorChanged), [=] { valueChanged(i); });
             else if (qobject_cast<Ms::AlignSelect*>(w))
                   connect(qobject_cast<Ms::AlignSelect*>(w), QOverload<Align>::of(&Ms::AlignSelect::alignChanged), [=] { valueChanged(i); });
             else if (qobject_cast<Ms::OffsetSelect*>(w))

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -441,7 +441,7 @@ void MuseScore::closeEvent(QCloseEvent* ev)
 void updateExternalValuesFromPreferences() {
       // set values in libmscore
       MScore::bgColor = preferences.getColor(PREF_UI_CANVAS_BG_COLOR);
-      MScore::dropColor = preferences.getColor(PREF_UI_SCORE_NOTE_DROPCOLOR);
+      MScore::dropColor = preferences.getColor(PREF_UI_SCORE_NOTEDROPCOLOR);
       MScore::defaultColor = preferences.getColor(PREF_UI_SCORE_DEFAULTCOLOR);
       MScore::defaultPlayDuration = preferences.getInt(PREF_SCORE_NOTE_DEFAULTPLAYDURATION);
       MScore::panPlayback = preferences.getBool(PREF_APP_PLAYBACK_PANPLAYBACK);
@@ -451,10 +451,10 @@ void updateExternalValuesFromPreferences() {
       MScore::frameMarginColor = preferences.getColor(PREF_UI_SCORE_FRAMEMARGINCOLOR);
       MScore::setVerticalOrientation(preferences.getBool(PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION));
 
-      MScore::selectColor[0] = preferences.getColor(PREF_UI_SCORE_VOICE1_COLOR);
-      MScore::selectColor[1] = preferences.getColor(PREF_UI_SCORE_VOICE2_COLOR);
-      MScore::selectColor[2] = preferences.getColor(PREF_UI_SCORE_VOICE3_COLOR);
-      MScore::selectColor[3] = preferences.getColor(PREF_UI_SCORE_VOICE4_COLOR);
+      MScore::selectColor[0] = preferences.getColor(PREF_UI_SCORE_VOICES_VOICE1COLOR);
+      MScore::selectColor[1] = preferences.getColor(PREF_UI_SCORE_VOICES_VOICE2COLOR);
+      MScore::selectColor[2] = preferences.getColor(PREF_UI_SCORE_VOICES_VOICE3COLOR);
+      MScore::selectColor[3] = preferences.getColor(PREF_UI_SCORE_VOICES_VOICE4COLOR);
 
       MScore::setHRaster(preferences.getInt(PREF_UI_APP_RASTER_HORIZONTAL));
       MScore::setVRaster(preferences.getInt(PREF_UI_APP_RASTER_VERTICAL));

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -381,12 +381,12 @@ void PianoKeyItem::paint(QPainter* p, const QStyleOptionGraphicsItem* /*o*/, QWi
       p->setRenderHint(QPainter::Antialiasing, true);
       p->setPen(QPen(Qt::black, .8));
       if (_pressed) {
-            QColor c(preferences.getColor(PREF_UI_PIANO_HIGHLIGHTCOLOR));
+            QColor c(preferences.getColor(PREF_UI_PIANOHIGHLIGHTCOLOR));
             c.setAlpha(180);
             p->setBrush(c);
             }
       else if (_selected) {
-            QColor c(preferences.getColor(PREF_UI_PIANO_HIGHLIGHTCOLOR));
+            QColor c(preferences.getColor(PREF_UI_PIANOHIGHLIGHTCOLOR));
             c.setAlpha(100);
             p->setBrush(c);
             }

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -75,23 +75,23 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_APP_AUTOSAVE_AUTOSAVETIME,                       new IntPreference(2 /* minutes */, false)},
             {PREF_APP_AUTOSAVE_USEAUTOSAVE,                        new BoolPreference(true, false)},
             {PREF_APP_KEYBOARDLAYOUT,                              new StringPreference("US - International")},
-            {PREF_APP_PATHS_INSTRUMENTLIST1,                       new StringPreference(":/data/instruments.xml", false)},
-            {PREF_APP_PATHS_INSTRUMENTLIST2,                       new StringPreference("", false)},
-            {PREF_APP_PATHS_MYIMAGES,                              new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("images_directory", "Images"))).absoluteFilePath(), false)},
-            {PREF_APP_PATHS_MYPLUGINS,                             new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("plugins_directory", "Plugins"))).absoluteFilePath(), false)},
-            {PREF_APP_PATHS_MYSCORES,                              new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("scores_directory", "Scores"))).absoluteFilePath(), false)},
-            {PREF_APP_PATHS_MYSOUNDFONTS,                          new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("soundfonts_directory", "SoundFonts"))).absoluteFilePath(), false)},
-            {PREF_APP_PATHS_MYSHORTCUTS,                           new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("shortcuts_directory", "Shortcuts"))).absoluteFilePath(), false)},
-            {PREF_APP_PATHS_MYSTYLES,                              new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("styles_directory", "Styles"))).absoluteFilePath(), false)},
-            {PREF_APP_PATHS_MYTEMPLATES,                           new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("templates_directory", "Templates"))).absoluteFilePath(), false)},
-            {PREF_APP_PATHS_MYEXTENSIONS,                           new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("extensions_directory", "Extensions"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_INSTRUMENTLIST1,                       new FilePreference(":/data/instruments.xml", QCoreApplication::translate("instrument_list", "Instrument List") + " (*.xml)", false)},
+            {PREF_APP_PATHS_INSTRUMENTLIST2,                       new FilePreference("", QCoreApplication::translate("instrument_list", "Instrument List") + " (*.xml)", false)},
+            {PREF_APP_PATHS_MYIMAGES,                              new DirPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("images_directory", "Images"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYPLUGINS,                             new DirPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("plugins_directory", "Plugins"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYSCORES,                              new DirPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("scores_directory", "Scores"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYSOUNDFONTS,                          new DirPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("soundfonts_directory", "SoundFonts"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYSHORTCUTS,                           new DirPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("shortcuts_directory", "Shortcuts"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYSTYLES,                              new DirPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("styles_directory", "Styles"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYTEMPLATES,                           new DirPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("templates_directory", "Templates"))).absoluteFilePath(), false)},
+            {PREF_APP_PATHS_MYEXTENSIONS,                          new DirPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("extensions_directory", "Extensions"))).absoluteFilePath(), false)},
             {PREF_APP_PLAYBACK_FOLLOWSONG,                         new BoolPreference(true)},
             {PREF_APP_PLAYBACK_PANPLAYBACK,                        new BoolPreference(true)},
             {PREF_APP_PLAYBACK_PLAYREPEATS,                        new BoolPreference(true)},
             {PREF_APP_USESINGLEPALETTE,                            new BoolPreference(false)},
             {PREF_APP_STARTUP_FIRSTSTART,                          new BoolPreference(true)},
             {PREF_APP_STARTUP_SESSIONSTART,                        new EnumPreference(QVariant::fromValue(SessionStart::SCORE), false)},
-            {PREF_APP_STARTUP_STARTSCORE,                          new StringPreference(":/data/My_First_Score.mscz", false)},
+            {PREF_APP_STARTUP_STARTSCORE,                          new FilePreference(":/data/My_First_Score.mscz", QCoreApplication::translate("MuseScore_files", "MuseScore Files") + " (*.mscz *.mscx);;" + QCoreApplication::translate("MuseScore_files", "All") + " (*)", false)},
             {PREF_APP_WORKSPACE,                                   new StringPreference("Basic", false)},
             {PREF_EXPORT_AUDIO_SAMPLERATE,                         new IntPreference(44100, false)},
             {PREF_EXPORT_MP3_BITRATE,                              new IntPreference(128, false)},
@@ -104,7 +104,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_IMPORT_MUSICXML_IMPORTBREAKS,                    new BoolPreference(true, false)},
             {PREF_IMPORT_MUSICXML_IMPORTLAYOUT,                    new BoolPreference(true, false)},
             {PREF_IMPORT_OVERTURE_CHARSET,                         new StringPreference("GBK", false)},
-            {PREF_IMPORT_STYLE_STYLEFILE,                          new StringPreference("", false)},
+            {PREF_IMPORT_STYLE_STYLEFILE,                          new FilePreference("", QCoreApplication::translate("MuseScore_styles", "MuseScore Styles") + " (*.mss)", false)},
             {PREF_IO_ALSA_DEVICE,                                  new StringPreference("default", false)},
             {PREF_IO_ALSA_FRAGMENTS,                               new IntPreference(3, false)},
             {PREF_IO_ALSA_PERIODSIZE,                              new IntPreference(1024, false)},
@@ -138,14 +138,14 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_SCORE_NOTE_PLAYONCLICK,                          new BoolPreference(true, false)},
             {PREF_SCORE_NOTE_DEFAULTPLAYDURATION,                  new IntPreference(300 /* ms */, false)},
             {PREF_SCORE_NOTE_WARNPITCHRANGE,                       new BoolPreference(true, false)},
-            {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new StringPreference("", false)},
-            {PREF_SCORE_STYLE_PARTSTYLEFILE,                       new StringPreference("", false)},
+            {PREF_SCORE_STYLE_DEFAULTSTYLEFILE,                    new FilePreference("", QCoreApplication::translate("MuseScore_styles", "MuseScore Styles") + " (*.mss)", false)},
+            {PREF_SCORE_STYLE_PARTSTYLEFILE,                       new FilePreference("", QCoreApplication::translate("MuseScore_styles", "MuseScore Styles") + " (*.mss)", false)},
             {PREF_UI_CANVAS_BG_USECOLOR,                           new BoolPreference(true, false)},
             {PREF_UI_CANVAS_FG_USECOLOR,                           new BoolPreference(true, false)},
             {PREF_UI_CANVAS_BG_COLOR,                              new ColorPreference(QColor("#dddddd"), false)},
             {PREF_UI_CANVAS_FG_COLOR,                              new ColorPreference(QColor("#f9f9f9"), false)},
-            {PREF_UI_CANVAS_BG_WALLPAPER,                          new StringPreference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/background1.png")).absoluteFilePath(), false)},
-            {PREF_UI_CANVAS_FG_WALLPAPER,                          new StringPreference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/paper5.png")).absoluteFilePath(), false)},
+            {PREF_UI_CANVAS_BG_WALLPAPER,                          new FilePreference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/background1.png")).absoluteFilePath(), QCoreApplication::translate("images_files", "Images") + " (*.jpg *.jpeg *.png);;" + QCoreApplication::translate("images_files", "All") + " (*)", false)},
+            {PREF_UI_CANVAS_FG_WALLPAPER,                          new FilePreference(QFileInfo(QString("%1%2").arg(mscoreGlobalShare).arg("wallpaper/paper5.png")).absoluteFilePath(), QCoreApplication::translate("images_files", "Images") + " (*.jpg *.jpeg *.png);;" + QCoreApplication::translate("images_files", "All") + " (*)", false)},
             {PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING,               new BoolPreference(true, false)},
             {PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY,               new IntPreference(6, false)},
             {PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA,                new BoolPreference(false, false)},
@@ -162,15 +162,15 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_APP_RASTER_VERTICAL,                          new IntPreference(2)},
             {PREF_UI_APP_SHOWSTATUSBAR,                            new BoolPreference(true)},
             {PREF_UI_APP_USENATIVEDIALOGS,                         new BoolPreference(nativeDialogs)},
-            {PREF_UI_PIANO_HIGHLIGHTCOLOR,                         new ColorPreference(QColor("#1259d0"))},
-            {PREF_UI_SCORE_NOTE_DROPCOLOR,                         new ColorPreference(QColor("#1778db"))},
+            {PREF_UI_PIANOHIGHLIGHTCOLOR,                          new ColorPreference(QColor("#1259d0"))},
+            {PREF_UI_SCORE_NOTEDROPCOLOR,                          new ColorPreference(QColor("#1778db"))},
             {PREF_UI_SCORE_DEFAULTCOLOR,                           new ColorPreference(QColor("#000000"))},
             {PREF_UI_SCORE_FRAMEMARGINCOLOR,                       new ColorPreference(QColor("#5999db"))},
             {PREF_UI_SCORE_LAYOUTBREAKCOLOR,                       new ColorPreference(QColor("#5999db"))},
-            {PREF_UI_SCORE_VOICE1_COLOR,                           new ColorPreference(QColor("#1259d0"))},    // blue
-            {PREF_UI_SCORE_VOICE2_COLOR,                           new ColorPreference(QColor("#009234"))},    // green
-            {PREF_UI_SCORE_VOICE3_COLOR,                           new ColorPreference(QColor("#c04400"))},    // orange
-            {PREF_UI_SCORE_VOICE4_COLOR,                           new ColorPreference(QColor("#70167a"))},    // purple
+            {PREF_UI_SCORE_VOICES_VOICE1COLOR,                     new ColorPreference(QColor("#1259d0"))},    // blue
+            {PREF_UI_SCORE_VOICES_VOICE2COLOR,                     new ColorPreference(QColor("#009234"))},    // green
+            {PREF_UI_SCORE_VOICES_VOICE3COLOR,                     new ColorPreference(QColor("#c04400"))},    // orange
+            {PREF_UI_SCORE_VOICES_VOICE4COLOR,                     new ColorPreference(QColor("#70167a"))},    // purple
             {PREF_UI_THEME_ICONWIDTH,                              new IntPreference(28, false)},
             {PREF_UI_THEME_ICONHEIGHT,                             new IntPreference(24, false)}
       });
@@ -416,55 +416,77 @@ IntPreference::IntPreference(int defaultValue, bool showInAdvancedList)
       : Preference(defaultValue, QMetaType::Int, showInAdvancedList)
       {}
 
-void IntPreference::accept(QString key, PreferenceVisitor& v)
+void IntPreference::accept(QString key, QTreeWidgetItem* parent, PreferenceVisitor& v)
       {
-      v.visit(key, this);
+      v.visit(key, parent, this);
       }
 
 DoublePreference::DoublePreference(double defaultValue, bool showInAdvancedList)
       : Preference(defaultValue, QMetaType::Double, showInAdvancedList)
       {}
 
-void DoublePreference::accept(QString key, PreferenceVisitor& v)
+void DoublePreference::accept(QString key, QTreeWidgetItem* parent, PreferenceVisitor& v)
       {
-      v.visit(key, this);
+      v.visit(key, parent, this);
       }
 
 BoolPreference::BoolPreference(bool defaultValue, bool showInAdvancedList)
       : Preference(defaultValue, QMetaType::Bool, showInAdvancedList)
       {}
 
-void BoolPreference::accept(QString key, PreferenceVisitor& v)
+void BoolPreference::accept(QString key, QTreeWidgetItem* parent, PreferenceVisitor& v)
       {
-      v.visit(key, this);
+      v.visit(key, parent, this);
       }
 
 StringPreference::StringPreference(QString defaultValue, bool showInAdvancedList)
       : Preference(defaultValue, QMetaType::QString, showInAdvancedList)
       {}
 
-void StringPreference::accept(QString key, PreferenceVisitor& v)
+void StringPreference::accept(QString key, QTreeWidgetItem* parent, PreferenceVisitor& v)
       {
-      v.visit(key, this);
+      v.visit(key, parent, this);
+      }
+
+QString FilePreference::filter() const
+      {
+      return _filter;
+      }
+
+FilePreference::FilePreference(QString defaultValue, QString filter, bool showInAdvancedList)
+      : Preference(defaultValue, QMetaType::QString, showInAdvancedList),
+        _filter(filter)
+      {}
+
+void FilePreference::accept(QString key, QTreeWidgetItem* parent, PreferenceVisitor& v)
+      {
+      v.visit(key, parent, this);
+      }
+
+DirPreference::DirPreference(QString defaultValue, bool showInAdvancedList)
+      : Preference(defaultValue, QMetaType::QString, showInAdvancedList)
+      {}
+
+void DirPreference::accept(QString key, QTreeWidgetItem* parent, PreferenceVisitor& v)
+      {
+      v.visit(key, parent, this);
       }
 
 ColorPreference::ColorPreference(QColor defaultValue, bool showInAdvancedList)
       : Preference(defaultValue, QMetaType::QColor, showInAdvancedList)
       {}
 
-void ColorPreference::accept(QString key, PreferenceVisitor& v)
+void ColorPreference::accept(QString key, QTreeWidgetItem* parent, PreferenceVisitor& v)
       {
-      v.visit(key, this);
+      v.visit(key, parent, this);
       }
 
 EnumPreference::EnumPreference(QVariant defaultValue, bool showInAdvancedList)
       : Preference(defaultValue, QMetaType::User, showInAdvancedList)
       {}
 
-void EnumPreference::accept(QString, PreferenceVisitor&)
+void EnumPreference::accept(QString, QTreeWidgetItem*, PreferenceVisitor&)
       {
       }
-
-
 
 } // namespace Ms

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -92,6 +92,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_APP_STARTUP_FIRSTSTART,                          new BoolPreference(true)},
             {PREF_APP_STARTUP_SESSIONSTART,                        new EnumPreference(QVariant::fromValue(SessionStart::SCORE), false)},
             {PREF_APP_STARTUP_STARTSCORE,                          new FilePreference(":/data/My_First_Score.mscz", QCoreApplication::translate("MuseScore_files", "MuseScore Files") + " (*.mscz *.mscx);;" + QCoreApplication::translate("MuseScore_files", "All") + " (*)", false)},
+            {PREF_APP_SHOWADVANCEDPREFERENCESWARNING,              new BoolPreference(true)},
             {PREF_APP_WORKSPACE,                                   new StringPreference("Basic", false)},
             {PREF_EXPORT_AUDIO_SAMPLERATE,                         new IntPreference(44100, false)},
             {PREF_EXPORT_MP3_BITRATE,                              new IntPreference(128, false)},
@@ -323,7 +324,7 @@ int Preferences::getInt(const QString key) const
             return defaultValue(key).toInt();
             }
       return pref;
-}
+      }
 
 double Preferences::getDouble(const QString key) const
       {

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -23,11 +23,13 @@
 
 /*
  * HOW TO ADD A NEW PREFERENCE
- * - Add a new define to the list of defines below
+ * - Add a new define to the list of defines below (since the #defines define char[],
+ *   don't go camelCase in there, it facilitates the translations)
  * - Add the preference to the _allPreferences map in the init() function in preferences.cpp
- *   and specify the default value for this preference
- * - That's it. The preference is stored and retrieved automatically and can be read
- *   using getString(), getInt(), etc., and changed using setPreference()
+ * - Specify the default value for this preference.
+ * - Specify if the preference will go in the advanced list.
+ * That's it. The preference is stored and retrieved automatically and can be read
+ * using getString(), getInt(), etc., and changed using setPreference()
  */
 
 #include "globals.h"
@@ -78,109 +80,109 @@ enum class MusicxmlExportBreaks : char {
 // Every preference should have a define to ease the usage of the preference
 // Make sure the string key has a sensible grouping - use / for grouping
 //
-#define PREF_APP_AUTOSAVE_AUTOSAVETIME                      "application/autosave/autosaveTime"
-#define PREF_APP_AUTOSAVE_USEAUTOSAVE                       "application/autosave/useAutosave"
-#define PREF_APP_KEYBOARDLAYOUT                             "application/keyboardLayout"
+#define PREF_APP_AUTOSAVE_AUTOSAVETIME                      "Application/Autosave/Autosave time"
+#define PREF_APP_AUTOSAVE_USEAUTOSAVE                       "Application/Autosave/Use autosave"
+#define PREF_APP_KEYBOARDLAYOUT                             "Application/Keyboard layout"
 // file path of instrument templates
-#define PREF_APP_PATHS_INSTRUMENTLIST1                      "application/paths/instrumentList1"
-#define PREF_APP_PATHS_INSTRUMENTLIST2                      "application/paths/instrumentList2"
-#define PREF_APP_PATHS_MYIMAGES                             "application/paths/myImages"
-#define PREF_APP_PATHS_MYPLUGINS                            "application/paths/myPlugins"
-#define PREF_APP_PATHS_MYSCORES                             "application/paths/myScores"
-#define PREF_APP_PATHS_MYSHORTCUTS                          "application/paths/myShortcuts"
-#define PREF_APP_PATHS_MYSOUNDFONTS                         "application/paths/mySoundfonts"
-#define PREF_APP_PATHS_MYSTYLES                             "application/paths/myStyles"
-#define PREF_APP_PATHS_MYTEMPLATES                          "application/paths/myTemplates"
-#define PREF_APP_PATHS_MYEXTENSIONS                         "application/paths/myExtensions"
-#define PREF_APP_PLAYBACK_FOLLOWSONG                        "application/playback/followSong"
-#define PREF_APP_PLAYBACK_PANPLAYBACK                       "application/playback/panPlayback"
-#define PREF_APP_PLAYBACK_PLAYREPEATS                       "application/playback/playRepeats"
-#define PREF_APP_USESINGLEPALETTE                           "application/useSinglePalette"
-#define PREF_APP_STARTUP_FIRSTSTART                         "application/startup/firstStart"
-#define PREF_APP_STARTUP_SESSIONSTART                       "application/startup/sessionStart"
-#define PREF_APP_STARTUP_STARTSCORE                         "application/startup/startScore"
-#define PREF_APP_WORKSPACE                                  "application/workspace"
-#define PREF_EXPORT_AUDIO_SAMPLERATE                        "export/audio/sampleRate"
-#define PREF_EXPORT_MP3_BITRATE                             "export/mp3/bitRate"
-#define PREF_EXPORT_MUSICXML_EXPORTLAYOUT                   "export/musicXML/exportLayout"
-#define PREF_EXPORT_MUSICXML_EXPORTBREAKS                   "export/musicXML/exportBreaks"
-#define PREF_EXPORT_PDF_DPI                                 "export/pdf/dpi"
-#define PREF_EXPORT_PNG_RESOLUTION                          "export/png/resolution"
-#define PREF_EXPORT_PNG_USETRANSPARENCY                     "export/png/useTransparency"
-#define PREF_IMPORT_GUITARPRO_CHARSET                       "import/guitarpro/charset"
-#define PREF_IMPORT_MUSICXML_IMPORTBREAKS                   "import/musicXML/importBreaks"
-#define PREF_IMPORT_MUSICXML_IMPORTLAYOUT                   "import/musicXML/importLayout"
-#define PREF_IMPORT_OVERTURE_CHARSET                        "import/overture/charset"
-#define PREF_IMPORT_STYLE_STYLEFILE                         "import/style/styleFile"
-#define PREF_IO_ALSA_DEVICE                                 "io/alsa/device"
-#define PREF_IO_ALSA_FRAGMENTS                              "io/alsa/fragments"
-#define PREF_IO_ALSA_PERIODSIZE                             "io/alsa/periodSize"
-#define PREF_IO_ALSA_SAMPLERATE                             "io/alsa/sampleRate"
-#define PREF_IO_ALSA_USEALSAAUDIO                           "io/alsa/useAlsaAudio"
-#define PREF_IO_JACK_REMEMBERLASTCONNECTIONS                "io/jack/rememberLastConnections"
-#define PREF_IO_JACK_TIMEBASEMASTER                         "io/jack/timebaseMaster"
-#define PREF_IO_JACK_USEJACKAUDIO                           "io/jack/useJackAudio"
-#define PREF_IO_JACK_USEJACKMIDI                            "io/jack/useJackMIDI"
-#define PREF_IO_JACK_USEJACKTRANSPORT                       "io/jack/useJackTransport"
-#define PREF_IO_MIDI_ADVANCEONRELEASE                       "io/midi/advanceOnRelease"
-#define PREF_IO_MIDI_ENABLEINPUT                            "io/midi/enableInput"
-#define PREF_IO_MIDI_EXPANDREPEATS                          "io/midi/expandRepeats"
-#define PREF_IO_MIDI_EXPORTRPNS                             "io/midi/exportRPNs"
-#define PREF_IO_MIDI_REALTIMEDELAY                          "io/midi/realtimeDelay"
-#define PREF_IO_MIDI_REMOTE                                 "io/midi/remote"
-#define PREF_IO_MIDI_SHORTESTNOTE                           "io/midi/shortestNote"
-#define PREF_IO_MIDI_SHOWCONTROLSINMIXER                    "io/midi/showControlsInMixer"
-#define PREF_IO_MIDI_USEREMOTECONTROL                       "io/midi/useRemoteControl"
-#define PREF_IO_OSC_PORTNUMBER                              "io/osc/portNumber"
-#define PREF_IO_OSC_USEREMOTECONTROL                        "io/osc/useRemoteControl"
-#define PREF_IO_PORTAUDIO_DEVICE                            "io/portAudio/device"
-#define PREF_IO_PORTAUDIO_USEPORTAUDIO                      "io/portAudio/usePortAudio"
-#define PREF_IO_PORTMIDI_INPUTBUFFERCOUNT                   "io/portMidi/inputBufferCount"
-#define PREF_IO_PORTMIDI_INPUTDEVICE                        "io/portMidi/inputDevice"
-#define PREF_IO_PORTMIDI_OUTPUTBUFFERCOUNT                  "io/portMidi/outputBufferCount"
-#define PREF_IO_PORTMIDI_OUTPUTDEVICE                       "io/portMidi/outputDevice"
-#define PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS          "io/portMidi/outputLatencyMilliseconds"
-#define PREF_IO_PULSEAUDIO_USEPULSEAUDIO                    "io/pulseAudio/usePulseAudio"
-#define PREF_SCORE_CHORD_PLAYONADDNOTE                      "score/chord/playOnAddNote"
-#define PREF_SCORE_MAGNIFICATION                            "score/magnification"
-#define PREF_SCORE_NOTE_PLAYONCLICK                         "score/note/playOnClick"
-#define PREF_SCORE_NOTE_DEFAULTPLAYDURATION                 "score/note/defaultPlayDuration"
-#define PREF_SCORE_NOTE_WARNPITCHRANGE                      "score/note/warnPitchRange"
-#define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "score/style/defaultStyleFile"
-#define PREF_SCORE_STYLE_PARTSTYLEFILE                      "score/style/partStyleFile"
-#define PREF_UI_CANVAS_BG_USECOLOR                          "ui/canvas/background/useColor"
-#define PREF_UI_CANVAS_FG_USECOLOR                          "ui/canvas/foreground/useColor"
-#define PREF_UI_CANVAS_BG_COLOR                             "ui/canvas/background/color"
-#define PREF_UI_CANVAS_FG_COLOR                             "ui/canvas/foreground/color"
-#define PREF_UI_CANVAS_BG_WALLPAPER                         "ui/canvas/background/wallpaper"
-#define PREF_UI_CANVAS_FG_WALLPAPER                         "ui/canvas/foreground/wallpaper"
-#define PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING              "ui/canvas/misc/antialiasedDrawing"
-#define PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY              "ui/canvas/misc/selectionProximity"
-#define PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION           "ui/canvas/scroll/verticalOrientation"
-#define PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA               "ui/canvas/scroll/limitScrollArea"
-#define PREF_UI_APP_STARTUP_CHECKUPDATE                     "ui/application/startup/checkUpdate"
-#define PREF_UI_APP_STARTUP_CHECK_EXTENSIONS_UPDATE         "ui/application/startup/checkExtensionsUpdate"
-#define PREF_UI_APP_STARTUP_SHOWNAVIGATOR                   "ui/application/startup/showNavigator"
-#define PREF_UI_APP_STARTUP_SHOWPLAYPANEL                   "ui/application/startup/showPlayPanel"
-#define PREF_UI_APP_STARTUP_SHOWSPLASHSCREEN                "ui/application/startup/showSplashScreen"
-#define PREF_UI_APP_STARTUP_SHOWSTARTCENTER                 "ui/application/startup/showStartCenter"
-#define PREF_UI_APP_GLOBALSTYLE                             "ui/application/globalStyle"
-#define PREF_UI_APP_LANGUAGE                                "ui/application/language"
-#define PREF_UI_APP_RASTER_HORIZONTAL                       "ui/application/raster/horizontal"
-#define PREF_UI_APP_RASTER_VERTICAL                         "ui/application/raster/vertical"
-#define PREF_UI_APP_SHOWSTATUSBAR                           "ui/application/showStatusBar"
-#define PREF_UI_APP_USENATIVEDIALOGS                        "ui/application/useNativeDialogs"
-#define PREF_UI_PIANO_HIGHLIGHTCOLOR                        "ui/piano/highlightColor"
-#define PREF_UI_SCORE_NOTE_DROPCOLOR                        "ui/score/note/dropColor"
-#define PREF_UI_SCORE_DEFAULTCOLOR                          "ui/score/defaultColor"
-#define PREF_UI_SCORE_FRAMEMARGINCOLOR                      "ui/score/frameMarginColor"
-#define PREF_UI_SCORE_LAYOUTBREAKCOLOR                      "ui/score/layoutBreakColor"
-#define PREF_UI_SCORE_VOICE1_COLOR                          "ui/score/voice1/color"
-#define PREF_UI_SCORE_VOICE2_COLOR                          "ui/score/voice2/color"
-#define PREF_UI_SCORE_VOICE3_COLOR                          "ui/score/voice3/color"
-#define PREF_UI_SCORE_VOICE4_COLOR                          "ui/score/voice4/color"
-#define PREF_UI_THEME_ICONHEIGHT                            "ui/theme/iconHeight"
-#define PREF_UI_THEME_ICONWIDTH                             "ui/theme/iconWidth"
+#define PREF_APP_PATHS_INSTRUMENTLIST1                      "Application/Paths/Instrument list 1"
+#define PREF_APP_PATHS_INSTRUMENTLIST2                      "Application/Paths/Instrument list 2"
+#define PREF_APP_PATHS_MYIMAGES                             "Application/Paths/My images"
+#define PREF_APP_PATHS_MYPLUGINS                            "Application/Paths/My plugins"
+#define PREF_APP_PATHS_MYSCORES                             "Application/Paths/My scores"
+#define PREF_APP_PATHS_MYSHORTCUTS                          "Application/Paths/My shortcuts"
+#define PREF_APP_PATHS_MYSOUNDFONTS                         "Application/Paths/My soundfonts"
+#define PREF_APP_PATHS_MYSTYLES                             "Application/Paths/My styles"
+#define PREF_APP_PATHS_MYTEMPLATES                          "Application/Paths/My templates"
+#define PREF_APP_PATHS_MYEXTENSIONS                         "Application/Paths/My extensions"
+#define PREF_APP_PLAYBACK_FOLLOWSONG                        "Application/Playback/Follow song"
+#define PREF_APP_PLAYBACK_PANPLAYBACK                       "Application/Playback/Pan playback"
+#define PREF_APP_PLAYBACK_PLAYREPEATS                       "Application/Playback/Play repeats"
+#define PREF_APP_USESINGLEPALETTE                           "Application/Use single palette"
+#define PREF_APP_STARTUP_FIRSTSTART                         "Application/Startup/First start"
+#define PREF_APP_STARTUP_SESSIONSTART                       "Application/Startup/Session start"
+#define PREF_APP_STARTUP_STARTSCORE                         "Application/Startup/Start score"
+#define PREF_APP_WORKSPACE                                  "Application/Workspace"
+#define PREF_EXPORT_AUDIO_SAMPLERATE                        "Export/Audio/Sample rate"
+#define PREF_EXPORT_MP3_BITRATE                             "Export/Mp3/Bit rate"
+#define PREF_EXPORT_MUSICXML_EXPORTLAYOUT                   "Export/MusicXML/Export layout"
+#define PREF_EXPORT_MUSICXML_EXPORTBREAKS                   "Export/MusicXML/Export breaks"
+#define PREF_EXPORT_PDF_DPI                                 "Export/Pdf/Dpi"
+#define PREF_EXPORT_PNG_RESOLUTION                          "Export/Png/Resolution"
+#define PREF_EXPORT_PNG_USETRANSPARENCY                     "Export/Png/Use transparency"
+#define PREF_IMPORT_GUITARPRO_CHARSET                       "Import/Guitarpro/Charset"
+#define PREF_IMPORT_MUSICXML_IMPORTBREAKS                   "Import/MusicXML/Import breaks"
+#define PREF_IMPORT_MUSICXML_IMPORTLAYOUT                   "Import/MusicXML/Import layout"
+#define PREF_IMPORT_OVERTURE_CHARSET                        "Import/Overture/Charset"
+#define PREF_IMPORT_STYLE_STYLEFILE                         "Import/Style/Style file"
+#define PREF_IO_ALSA_DEVICE                                 "IO/Alsa/Device"
+#define PREF_IO_ALSA_FRAGMENTS                              "IO/Alsa/Fragments"
+#define PREF_IO_ALSA_PERIODSIZE                             "IO/Alsa/Period size"
+#define PREF_IO_ALSA_SAMPLERATE                             "IO/Alsa/Sample rate"
+#define PREF_IO_ALSA_USEALSAAUDIO                           "IO/Alsa/Use AlsaAudio"
+#define PREF_IO_JACK_REMEMBERLASTCONNECTIONS                "IO/Jack/Remember last connections"
+#define PREF_IO_JACK_TIMEBASEMASTER                         "IO/Jack/Timebase master"
+#define PREF_IO_JACK_USEJACKAUDIO                           "IO/Jack/Use JackAudio"
+#define PREF_IO_JACK_USEJACKMIDI                            "IO/Jack/Use JackMIDI"
+#define PREF_IO_JACK_USEJACKTRANSPORT                       "IO/Jack/Use JackTransport"
+#define PREF_IO_MIDI_ADVANCEONRELEASE                       "IO/Midi/Advance on release"
+#define PREF_IO_MIDI_ENABLEINPUT                            "IO/Midi/Enable input"
+#define PREF_IO_MIDI_EXPANDREPEATS                          "IO/Midi/Expand repeats"
+#define PREF_IO_MIDI_EXPORTRPNS                             "IO/Midi/Export RPN's"
+#define PREF_IO_MIDI_REALTIMEDELAY                          "IO/Midi/Realtime delay"
+#define PREF_IO_MIDI_REMOTE                                 "IO/Midi/Remote"
+#define PREF_IO_MIDI_SHORTESTNOTE                           "IO/Midi/Shortest note"
+#define PREF_IO_MIDI_SHOWCONTROLSINMIXER                    "IO/Midi/Show controls in mixer"
+#define PREF_IO_MIDI_USEREMOTECONTROL                       "IO/Midi/Use remote control"
+#define PREF_IO_OSC_PORTNUMBER                              "IO/Osc/Port number"
+#define PREF_IO_OSC_USEREMOTECONTROL                        "IO/Osc/Use remote control"
+#define PREF_IO_PORTAUDIO_DEVICE                            "IO/PortAudio/Device"
+#define PREF_IO_PORTAUDIO_USEPORTAUDIO                      "IO/PortAudio/Use PortAudio"
+#define PREF_IO_PORTMIDI_INPUTBUFFERCOUNT                   "IO/PortMidi/Input buffer count"
+#define PREF_IO_PORTMIDI_INPUTDEVICE                        "IO/PortMidi/Input device"
+#define PREF_IO_PORTMIDI_OUTPUTBUFFERCOUNT                  "IO/PortMidi/Output buffer count"
+#define PREF_IO_PORTMIDI_OUTPUTDEVICE                       "IO/PortMidi/Output device"
+#define PREF_IO_PORTMIDI_OUTPUTLATENCYMILLISECONDS          "IO/PortMidi/Output latency (milliseconds)"
+#define PREF_IO_PULSEAUDIO_USEPULSEAUDIO                    "IO/PulseAudio/Use PulseAudio"
+#define PREF_SCORE_CHORD_PLAYONADDNOTE                      "Score/Chord/Play on add note"
+#define PREF_SCORE_MAGNIFICATION                            "Score/Magnification"
+#define PREF_SCORE_NOTE_PLAYONCLICK                         "Score/Note/Play on click"
+#define PREF_SCORE_NOTE_DEFAULTPLAYDURATION                 "Score/Note/Default play duration"
+#define PREF_SCORE_NOTE_WARNPITCHRANGE                      "Score/Note/Warn pitch range"
+#define PREF_SCORE_STYLE_DEFAULTSTYLEFILE                   "Score/Style/Default style file"
+#define PREF_SCORE_STYLE_PARTSTYLEFILE                      "Score/Style/Part style file"
+#define PREF_UI_CANVAS_BG_USECOLOR                          "UI/Canvas/Background/Use color"
+#define PREF_UI_CANVAS_FG_USECOLOR                          "UI/Canvas/Foreground/Use color"
+#define PREF_UI_CANVAS_BG_COLOR                             "UI/Canvas/Background/Color"
+#define PREF_UI_CANVAS_FG_COLOR                             "UI/Canvas/Foreground/Color"
+#define PREF_UI_CANVAS_BG_WALLPAPER                         "UI/Canvas/Background/Wallpaper"
+#define PREF_UI_CANVAS_FG_WALLPAPER                         "UI/Canvas/Foreground/Wallpaper"
+#define PREF_UI_CANVAS_MISC_ANTIALIASEDDRAWING              "UI/Canvas/Misc/Antialiased drawing"
+#define PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY              "UI/Canvas/Misc/Selection proximity"
+#define PREF_UI_CANVAS_SCROLL_VERTICALORIENTATION           "UI/Canvas/Scroll/Vertical orientation"
+#define PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA               "UI/Canvas/Scroll/Limit scroll area"
+#define PREF_UI_APP_STARTUP_CHECKUPDATE                     "UI/Application/Startup/Check for update"
+#define PREF_UI_APP_STARTUP_CHECK_EXTENSIONS_UPDATE         "UI/Application/Startup/Check for extensions update"
+#define PREF_UI_APP_STARTUP_SHOWNAVIGATOR                   "UI/Application/Startup/Show navigator"
+#define PREF_UI_APP_STARTUP_SHOWPLAYPANEL                   "UI/Application/Startup/Show play panel"
+#define PREF_UI_APP_STARTUP_SHOWSPLASHSCREEN                "UI/Application/Startup/Show splash screen"
+#define PREF_UI_APP_STARTUP_SHOWSTARTCENTER                 "UI/Application/Startup/Show start center"
+#define PREF_UI_APP_GLOBALSTYLE                             "UI/Application/Global style"
+#define PREF_UI_APP_LANGUAGE                                "UI/Application/Language"
+#define PREF_UI_APP_RASTER_HORIZONTAL                       "UI/Application/Raster/Horizontal"
+#define PREF_UI_APP_RASTER_VERTICAL                         "UI/Application/Raster/Vertical"
+#define PREF_UI_APP_SHOWSTATUSBAR                           "UI/Application/Show status bar"
+#define PREF_UI_APP_USENATIVEDIALOGS                        "UI/Application/Use native dialogs"
+#define PREF_UI_PIANOHIGHLIGHTCOLOR                         "UI/Piano highlight color"
+#define PREF_UI_SCORE_NOTEDROPCOLOR                         "UI/Score/Note drop color"
+#define PREF_UI_SCORE_DEFAULTCOLOR                          "UI/Score/Default color"
+#define PREF_UI_SCORE_FRAMEMARGINCOLOR                      "UI/Score/Frame margin color"
+#define PREF_UI_SCORE_LAYOUTBREAKCOLOR                      "UI/Score/Layout break color"
+#define PREF_UI_SCORE_VOICES_VOICE1COLOR                    "UI/Score/Voices/Voice 1 color"
+#define PREF_UI_SCORE_VOICES_VOICE2COLOR                    "UI/Score/Voices/Voice 2 color"
+#define PREF_UI_SCORE_VOICES_VOICE3COLOR                    "UI/Score/Voices/Voice 3 color"
+#define PREF_UI_SCORE_VOICES_VOICE4COLOR                    "UI/Score/Voices/Voice 4 color"
+#define PREF_UI_THEME_ICONHEIGHT                            "UI/Theme/Icon height"
+#define PREF_UI_THEME_ICONWIDTH                             "UI/Theme/Icon width"
 
 
 class PreferenceVisitor;
@@ -204,44 +206,60 @@ class Preference {
       QVariant defaultValue() const {return _defaultValue;}
       bool showInAdvancedList() const {return _showInAdvancedList;}
       QMetaType::Type type() {return _type;}
-      virtual void accept(QString key, PreferenceVisitor&) = 0;
+      virtual void accept(QString, QTreeWidgetItem*, PreferenceVisitor&) = 0;
       };
 
 class IntPreference : public Preference {
    public:
       IntPreference(int defaultValue, bool showInAdvancedList = true);
-      virtual void accept(QString key, PreferenceVisitor&);
+      virtual void accept(QString, QTreeWidgetItem*, PreferenceVisitor&) override;
       };
 
 class DoublePreference : public Preference {
    public:
       DoublePreference(double defaultValue, bool showInAdvancedList = true);
-      virtual void accept(QString key, PreferenceVisitor&);
+      virtual void accept(QString, QTreeWidgetItem*, PreferenceVisitor&) override;
       };
 
 class BoolPreference : public Preference {
    public:
       BoolPreference(bool defaultValue, bool showInAdvancedList = true);
-      virtual void accept(QString key, PreferenceVisitor&);
+      virtual void accept(QString, QTreeWidgetItem*, PreferenceVisitor&) override;
       };
 
 class StringPreference: public Preference {
    public:
       StringPreference(QString defaultValue, bool showInAdvancedList = true);
-      virtual void accept(QString key, PreferenceVisitor&);
+      virtual void accept(QString, QTreeWidgetItem*, PreferenceVisitor&) override;
       };
+
+class FilePreference : public Preference {
+      QString _filter;
+   public:
+      FilePreference(QString defaultValue, QString filter, bool showInAdvancedList = true);
+      virtual void accept(QString, QTreeWidgetItem*, PreferenceVisitor&) override;
+
+      QString filter() const;
+};
+
+class DirPreference : public Preference {
+   public:
+      DirPreference(QString defaultValue, bool showInAdvancedList = true);
+      virtual void accept(QString, QTreeWidgetItem*, PreferenceVisitor&) override;
+};
 
 class ColorPreference: public Preference {
    public:
       ColorPreference(QColor defaultValue, bool showInAdvancedList = true);
-      virtual void accept(QString key, PreferenceVisitor&);
+      virtual void accept(QString, QTreeWidgetItem*, PreferenceVisitor&) override;
       };
 
 // Support for EnumPreference is currently not fully implemented
+#define PREFS_NO_SUPPORT_FOR_ENUMS
 class EnumPreference: public Preference {
    public:
       EnumPreference(QVariant defaultValue, bool showInAdvancedList = true);
-      virtual void accept(QString, PreferenceVisitor&);
+      virtual void accept(QString, QTreeWidgetItem*, PreferenceVisitor&) override;
       };
 
 //---------------------------------------------------------
@@ -349,11 +367,13 @@ inline QDataStream &operator>>(QDataStream &in, T &val)
 
 class PreferenceVisitor {
    public:
-      virtual void visit(QString key, IntPreference*) = 0;
-      virtual void visit(QString key, DoublePreference*) = 0;
-      virtual void visit(QString key, BoolPreference*) = 0;
-      virtual void visit(QString key, StringPreference*) = 0;
-      virtual void visit(QString key, ColorPreference*) = 0;
+      virtual void visit(const QString& key, QTreeWidgetItem*, IntPreference*) = 0;
+      virtual void visit(const QString& key, QTreeWidgetItem*, DoublePreference*) = 0;
+      virtual void visit(const QString& key, QTreeWidgetItem*, BoolPreference*) = 0;
+      virtual void visit(const QString& key, QTreeWidgetItem*, StringPreference*) = 0;
+      virtual void visit(const QString& key, QTreeWidgetItem*, FilePreference*) = 0;
+      virtual void visit(const QString& key, QTreeWidgetItem*, DirPreference*) = 0;
+      virtual void visit(const QString& key, QTreeWidgetItem*, ColorPreference*) = 0;
       };
 
 
@@ -362,5 +382,6 @@ class PreferenceVisitor {
 Q_DECLARE_METATYPE(Ms::SessionStart);
 Q_DECLARE_METATYPE(Ms::MusicxmlExportBreaks);
 Q_DECLARE_METATYPE(Ms::MuseScoreStyleType);
+
 
 #endif

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -101,6 +101,7 @@ enum class MusicxmlExportBreaks : char {
 #define PREF_APP_STARTUP_FIRSTSTART                         "Application/Startup/First start"
 #define PREF_APP_STARTUP_SESSIONSTART                       "Application/Startup/Session start"
 #define PREF_APP_STARTUP_STARTSCORE                         "Application/Startup/Start score"
+#define PREF_APP_SHOWADVANCEDPREFERENCESWARNING             "Application/Show advanced preferences warning"
 #define PREF_APP_WORKSPACE                                  "Application/Workspace"
 #define PREF_EXPORT_AUDIO_SAMPLERATE                        "Export/Audio/Sample rate"
 #define PREF_EXPORT_MP3_BITRATE                             "Export/Mp3/Bit rate"

--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -294,9 +294,16 @@ void PreferencesListWidget::selectAllVisiblePreferences()
 // For now, the only preference that is synced with this showEvent is PREF_APP_SHOWADVANCEDPREFERENCESWARNING.
 void PreferencesListWidget::showEvent(QShowEvent* event)
       {
-      // all this long line does it set the PREF_APP_SHOWADVANCEDPREFERENCESWARNING's checkbox to what was set just before in prefsDialog::tabAboutToChange
+      // all this long line does is set the PREF_APP_SHOWADVANCEDPREFERENCESWARNING's checkbox to what was set just before in prefsDialog::tabAboutToChange
       static_cast<QCheckBox*>(static_cast<BoolPreferenceItem*>(preferenceItems.value(PREF_APP_SHOWADVANCEDPREFERENCESWARNING))->editor())->setChecked(preferences.getBool(PREF_APP_SHOWADVANCEDPREFERENCESWARNING));
       QTreeWidget::showEvent(event);
+      }
+
+void PreferencesListWidget::hideEvent(QHideEvent* event)
+      {
+      // all this long line does is set the PREF_APP_SHOWADVANCEDPREFERENCESWARNING preference to its value in the treewidget.
+      preferences.setPreference(PREF_APP_SHOWADVANCEDPREFERENCESWARNING, static_cast<QCheckBox*>(static_cast<BoolPreferenceItem*>(preferenceItems.value(PREF_APP_SHOWADVANCEDPREFERENCESWARNING))->editor())->isChecked());
+      QTreeWidget::hideEvent(event);
       }
 
 void PreferencesListWidget::keyPressEvent(QKeyEvent* event)
@@ -307,12 +314,10 @@ void PreferencesListWidget::keyPressEvent(QKeyEvent* event)
             if (pref) {
                   if (!pref->editor()->hasFocus()) {
                         pref->editor()->setFocus();
-                        pref->editor()->grabKeyboard();
                         }
                   else {
                         setCurrentItem(pref);
                         pref->editor()->clearFocus();
-                        pref->editor()->releaseKeyboard();
                         }
                   }
             event->accept();

--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -18,34 +18,167 @@
 //=============================================================================
 
 #include "preferenceslistwidget.h"
+#include "preferencestreewidget_delegate.h"
 
 namespace Ms {
 
+extern QString mscoreGlobalShare;
 
 PreferencesListWidget::PreferencesListWidget(QWidget* parent)
       : QTreeWidget(parent)
       {
-      setRootIsDecorated(false);
-      setHeaderLabels(QStringList() << tr("Preference") << tr("Value"));
-      header()->setStretchLastSection(false);
-      header()->setSectionResizeMode(0, QHeaderView::Stretch);
-      setAccessibleName(tr("Advanced preferences"));
-      setAccessibleDescription(tr("Access to more advanced preferences"));
-      setAlternatingRowColors(true);
-      setSortingEnabled(true);
+      setObjectName("PreferencesListWidget");
+      header()->setSectionResizeMode(0, QHeaderView::Interactive);
       sortByColumn(0, Qt::AscendingOrder);
-      setAllColumnsShowFocus(true);
+      loadPreferences();
+
+      setItemDelegate(new Ms::PreferencesTreeWidget_Delegate(this));
+      expandAll();
+      resizeColumnToContents(0);
+
+      setContextMenuPolicy(Qt::ActionsContextMenu);
+      QAction* selectAllPreferences = new QAction(tr("Select all preferences"), this);
+      selectAllPreferences->setShortcut(QKeySequence::SelectAll);
+      addAction(selectAllPreferences);
+      connect(selectAllPreferences, &QAction::triggered, this, &PreferencesListWidget::selectAllVisiblePreferences);
+      }
+
+PreferencesListWidget::~PreferencesListWidget()
+      {
+      }
+
+// Find the first child of parent with text 'name'
+QTreeWidgetItem* PreferencesListWidget::findChildByText(const QTreeWidgetItem* parent, const QString& text, const int column) const
+      {
+      for (int childNum = 0; childNum < parent->childCount(); ++childNum) {
+            QTreeWidgetItem* child = parent->child(childNum);
+            if (child->text(column) == text)
+                  return child;
+            }
+      return nullptr;
+      }
+
+// Gets the list af all items in that have parent as a parent, direct or not.
+void PreferencesListWidget::recursiveChildList(QList<QTreeWidgetItem*>& list, QTreeWidgetItem* parent) const
+      {
+      list << parent;
+      for(int i = 0; i < parent->childCount(); ++i)
+            recursiveChildList(list, parent->child(i));
+      }
+
+// Gets the list af all items in that have parent as a parent, direct or not.
+// This is an overloded function.
+const QList<QTreeWidgetItem*> PreferencesListWidget::recursiveChildList(QTreeWidgetItem* parent) const
+      {
+      QList<QTreeWidgetItem*> list;
+
+      // if there's no parent, return an emty list.
+      if (!parent) {
+            qDebug() << "QList<PreferenceItem*> PreferencesListWidget::recursivePreferenceList(QTreeWidgetItem* parent)"
+                        " : invalid parent. Returning an empty list";
+            return list;
+            }
+
+      recursiveChildList(list, parent);
+      return list;
+      }
+
+// for if a 'showAll' checkbox is implemented
+#if 0
+void PreferencesListWidget::showAll(const bool all)
+      {
+      for (PreferenceItem* item : preferenceItems->values()) {
+            if (!(preferences.allPreferences().value(item->name())->showInAdvancedList()))
+                  item->setHidden(!all);
+            }
+      hideEmptyItems();
+      }
+
+// This function combines the search filter and the showAll checkBox (which isn't currently implemented)
+void PreferencesListWidget::filterVisiblePreferences(const QString& query, const bool all)
+      {
+      // if there's no double thing (all and a query) just use one of the two.
+      if (query.isEmpty()) {
+            showAll(all);
+            return;
+            }
+      if (!all) {
+            filter(query);
+            return;
+            }
+
+      QString queryLowered = query.toLower();
+      for (PreferenceItem* item : preferenceItems->values()) {
+            // If the URL of the item contains the query, and the item needs to be shown (because
+            // of paremeter "all" or because the preference is always in the advanced list).
+            item->setVisible(((item->name().toLower().contains(queryLowered))
+                              && (all || (preferences.allPreferences().value(item->name())->showInAdvancedList()))));
+            }
+
+      hideEmptyItems();
+      }
+#endif
+
+const QList<PreferenceItem*> PreferencesListWidget::recursivePreferenceItemList(QTreeWidgetItem* parent) const
+      {
+      QList<PreferenceItem*> preferenceItemList;
+      // return an empty list if parent doesn't exist.
+      if (!parent) {
+            qDebug() << "QList<PreferenceItem*> PreferencesListWidget::recursivePreferenceList(QTreeWidgetItem* parent)"
+                        " : invalid parent. Returning an empty list";
+            return preferenceItemList;
+            }
+
+      for (QTreeWidgetItem* child : recursiveChildList(parent)) {
+            PreferenceItem* castedChild = dynamic_cast<PreferenceItem*> (child);
+            if (castedChild)
+                  preferenceItemList << castedChild;
+            }
+
+      return preferenceItemList;
       }
 
 void PreferencesListWidget::loadPreferences()
       {
-      for (QString key : preferences.allPreferences().keys()) {
-            Preference* pref = preferences.allPreferences().value(key);
+      QTreeWidgetItem* currentParent = invisibleRootItem();
+      // iterate over all the preferences.
+      for (QString path : preferences.allPreferences().keys()) {
+            // see preftranslations.h for details.
+            Preference* pref = preferences.allPreferences().value(path);
+#ifdef PREFS_NO_SUPPORT_FOR_ENUMS
+            // For now, enums are of Type QMetaType::User.
+            // See EnumPreference class for more details.
+            if (pref->type() == QMetaType::User)
+                  continue;
 
-            if (pref->showInAdvancedList()) {
-                  // multiple dispatch using Visitor pattern, see overloaded visit() methods
-                  pref->accept(key, *this);
+#endif // PREFS_NO_SUPPORT_FOR_ENUMS
+            if(!pref->showInAdvancedList())
+                  continue;
+
+            // iterate over the directories of the preferences.
+            QStringList dirs = path.split("/");
+            for (int dirNumber = 0; dirNumber < dirs.count(); ++dirNumber) {
+                  QString currentDir = dirs.at(dirNumber);
+                  // check if child already exists.
+                  QTreeWidgetItem* child = findChildByText(currentParent, currentDir, 0);
+                  // if doesn't exist, appendChild. if exist, current parent becomes child.
+                  if (!child) {
+                        // if it's not a "directory" but it's a "file",
+                        // then just change it to the corresponding preferenceItem.
+                        if (dirNumber == dirs.count() - 1) {
+                              // send the english path as first argument, so the preference keeps its name.
+                              pref->accept(path, currentParent, *this);
+                              }
+                        else
+                              currentParent->addChild(new QTreeWidgetItem(currentParent, QStringList() << currentDir));
+                        currentParent = currentParent->child(currentParent->childCount() - 1);
+                        }
+                  else
+                        currentParent = child;
                   }
+            // once the preference is put, get back to the root item
+            // to put the next preference.
+            currentParent = invisibleRootItem();
             }
       }
 
@@ -57,68 +190,124 @@ void PreferencesListWidget::updatePreferences()
 
 void PreferencesListWidget::addPreference(PreferenceItem* item)
       {
-      addTopLevelItem(item);
       setItemWidget(item, PREF_VALUE_COLUMN, item->editor());
       preferenceItems[item->name()] = item;
       }
 
-void PreferencesListWidget::visit(QString key, IntPreference*)
+void PreferencesListWidget::visit(const QString& key, QTreeWidgetItem* parent, IntPreference*)
       {
       IntPreferenceItem* item = new IntPreferenceItem(key);
+      parent->addChild(item);
       addPreference(item);
       }
 
-void PreferencesListWidget::visit(QString key, DoublePreference*)
+void PreferencesListWidget::visit(const QString& key, QTreeWidgetItem* parent, DoublePreference*)
       {
       DoublePreferenceItem* item = new DoublePreferenceItem(key);
+      parent->addChild(item);
       addPreference(item);
       }
 
-void PreferencesListWidget::visit(QString key, BoolPreference*)
+void PreferencesListWidget::visit(const QString& key, QTreeWidgetItem* parent, BoolPreference*)
       {
       BoolPreferenceItem* item = new BoolPreferenceItem(key);
+      parent->addChild(item);
       addPreference(item);
       }
 
-void PreferencesListWidget::visit(QString key, StringPreference*)
+void PreferencesListWidget::visit(const QString& key, QTreeWidgetItem* parent, StringPreference*)
       {
       StringPreferenceItem* item = new StringPreferenceItem(key);
+      parent->addChild(item);
       addPreference(item);
       }
 
-void PreferencesListWidget::visit(QString key, ColorPreference*)
+void PreferencesListWidget::visit(const QString& key, QTreeWidgetItem* parent, FilePreference*)
+      {
+      FilePreferenceItem* item = new FilePreferenceItem(key);
+      parent->addChild(item);
+      addPreference(item);
+      }
+
+void PreferencesListWidget::visit(const QString& key, QTreeWidgetItem* parent, DirPreference*)
+      {
+      DirPreferenceItem* item = new DirPreferenceItem(key);
+      parent->addChild(item);
+      addPreference(item);
+      }
+
+void PreferencesListWidget::visit(const QString& key, QTreeWidgetItem* parent, ColorPreference*)
       {
       ColorPreferenceItem* item = new ColorPreferenceItem(key);
+      parent->addChild(item);
       addPreference(item);
       }
 
-std::vector<QString> PreferencesListWidget::save()
+void PreferencesListWidget::filter(const QString& query)
       {
-      std::vector<QString> changedPreferences;
-      for (int i = 0; i < topLevelItemCount(); ++i) {
-            PreferenceItem* item = static_cast<PreferenceItem*>(topLevelItem(i));
-            if (item->isModified()) {
-                  item->save();
-                  changedPreferences.push_back(item->name());
-                  }
-            }
+      QString s = query.toLower();
+      for (PreferenceItem* item : preferenceItems.values())
+            item->setVisible(item->name().toLower().contains(s));
+      hideEmptyItems();
+      }
 
-      return changedPreferences;
+void PreferencesListWidget::resetSelectedPreferencesToDefault()
+      {
+      preferences.setReturnDefaultValues(true);
+      for (QTreeWidgetItem* item : selectedItems()) {
+            PreferenceItem* pref = dynamic_cast<PreferenceItem*> (item);
+            if (pref)
+                  pref->setDefaultValue();
+            }
+      preferences.setReturnDefaultValues(false);
+      }
+
+// Hide the QTreeWidgetItems which are not parent of any VISIBLE PreferenceItems.
+void PreferencesListWidget::hideEmptyItems() const
+      {
+      // iterate over all items.
+      for(QTreeWidgetItem* parent : recursiveChildList(invisibleRootItem())) {
+            // If the item is already hidden, nothing to do.
+            if (parent->isHidden())
+                  continue;
+
+            // Hide the parent if it doesn't contain visible PreferenceItems
+            // which aren't hidden.
+            bool hide = true;
+            for(PreferenceItem* pref : recursivePreferenceItemList(parent)) {
+                  if (!pref->isHidden()) {
+                        hide = false;
+                        break;
+                        }
+                  }
+            parent->setHidden(hide);
+            }
+      }
+
+void PreferencesListWidget::selectAllVisiblePreferences()
+      {
+      clearSelection();
+      for (PreferenceItem* pref : preferenceItems.values())
+            pref->setSelected(!pref->isHidden());
+      }
+
+void PreferencesListWidget::save() const
+      {
+      for (PreferenceItem* item : preferenceItems.values()) {
+            if (item->isModified())
+                  item->save();
+            }
       }
 
 //---------------------------------------------------------
 //   PreferenceItem
 //---------------------------------------------------------
 
-PreferenceItem::PreferenceItem()
-{
-}
-
-PreferenceItem::PreferenceItem(QString name)
+PreferenceItem::PreferenceItem(const QString& name)
       : _name(name)
       {
-      setText(0, name);
-      setSizeHint(0, QSize(0, 25));
+      setObjectName("PreferenceItem");
+      setText(0, name.split("/").last());
       }
 
 void PreferenceItem::save(QVariant value)
@@ -126,17 +315,46 @@ void PreferenceItem::save(QVariant value)
       preferences.setPreference(name(), value);
       }
 
+void PreferenceItem::setVisible(const bool visible)
+      {
+      if (visible) {
+            // show the item and it's parents
+            setHidden(false);
+            QTreeWidgetItem* item = this->QTreeWidgetItem::parent();
+            while(item) {
+                  item->setExpanded(true);
+                  item->setHidden(false);
+                  item = item->QTreeWidgetItem::parent();
+                  }
+            }
+      else
+            setHidden(true);
+      }
+
 //---------------------------------------------------------
 //   ColorPreferenceItem
 //---------------------------------------------------------
 
-ColorPreferenceItem::ColorPreferenceItem(QString name)
+ColorPreferenceItem::ColorPreferenceItem(const QString& name)
       : PreferenceItem(name),
         _initialValue(preferences.getColor(name)),
-        _editor(new Awl::ColorLabel)
+        _editor(new Awl::ColorLabel(treeWidget()))
       {
       _editor->setColor(_initialValue);
+      _editor->setText(tr("Click to modify"));
       _editor->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+
+      auto setToolTip = [&](const QColor& c)
+            {
+            _editor->setToolTip(tr("RGBA: (%1, %2, %3, %4)")
+                                .arg(c.red())
+                                .arg(c.green())
+                                .arg(c.blue())
+                                .arg(c.alpha()));
+            };
+      setToolTip(_initialValue);
+
+      connect(_editor, &Awl::ColorLabel::colorChanged, this, setToolTip);
       }
 
 void ColorPreferenceItem::save()
@@ -159,7 +377,7 @@ void ColorPreferenceItem::setDefaultValue()
 
 bool ColorPreferenceItem::isModified() const
       {
-      return _initialValue != _editor->color();
+      return (_initialValue != _editor->color());
       }
 
 
@@ -167,15 +385,16 @@ bool ColorPreferenceItem::isModified() const
 //   IntPreferenceItem
 //---------------------------------------------------------
 
-IntPreferenceItem::IntPreferenceItem(QString name)
+IntPreferenceItem::IntPreferenceItem(const QString& name)
       : PreferenceItem(name),
-        _initialValue(preferences.getInt(name))
-{
-      _editor = new QSpinBox;
+        _initialValue(preferences.getInt(name)),
+        _editor(new QSpinBox(treeWidget()))
+      {
+      setObjectName("IntPreferenceItem");
       _editor->setMaximum(INT_MAX);
       _editor->setMinimum(INT_MIN);
       _editor->setValue(_initialValue);
-}
+      }
 
 void IntPreferenceItem::save()
       {
@@ -198,18 +417,20 @@ void IntPreferenceItem::setDefaultValue()
 
 bool IntPreferenceItem::isModified() const
       {
-      return _initialValue != _editor->value();
+      return (_initialValue != _editor->value());
       }
 
 //---------------------------------------------------------
 //   DoublePreferenceItem
 //---------------------------------------------------------
 
-DoublePreferenceItem::DoublePreferenceItem(QString name)
+DoublePreferenceItem::DoublePreferenceItem(const QString& name)
       : PreferenceItem(name),
         _initialValue(preferences.getDouble(name)),
-        _editor(new QDoubleSpinBox)
+        _editor(new QDoubleSpinBox(treeWidget()))
       {
+      setObjectName("DoublePreferenceItem");
+      _editor->setFocusPolicy(Qt::ClickFocus); // disable accepting wheel events
       _editor->setMaximum(DBL_MAX);
       _editor->setMinimum(DBL_MIN);
       _editor->setValue(_initialValue);
@@ -235,7 +456,7 @@ void DoublePreferenceItem::setDefaultValue()
 
 bool DoublePreferenceItem::isModified() const
       {
-      return _initialValue != _editor->value();
+      return (_initialValue != _editor->value());
       }
 
 
@@ -243,12 +464,22 @@ bool DoublePreferenceItem::isModified() const
 //   BoolPreferenceItem
 //---------------------------------------------------------
 
-BoolPreferenceItem::BoolPreferenceItem(QString name)
+BoolPreferenceItem::BoolPreferenceItem(const QString& name)
       : PreferenceItem(name),
         _initialValue(preferences.getBool(name)),
-        _editor(new QCheckBox)
+        _editor(new QCheckBox(treeWidget()))
       {
+      setObjectName("BoolPreferenceItem");
       _editor->setChecked(_initialValue);
+      _editor->setCursor(Qt::PointingHandCursor);
+      _editor->setForegroundRole(QPalette::NoRole); // make the text visible, even if selected
+      auto setTexts = [&](bool checked)
+            {
+            _editor->setText(checked ? tr("true") : tr("false"));
+            _editor->setToolTip(checked ? tr("true") : tr("false"));
+            };
+      setTexts(_initialValue);
+      connect(_editor, &QCheckBox::toggled, this, setTexts);
       }
 
 void BoolPreferenceItem::save()
@@ -271,18 +502,19 @@ void BoolPreferenceItem::setDefaultValue()
 
 bool BoolPreferenceItem::isModified() const
       {
-      return _initialValue != _editor->isChecked();
+      return (_initialValue != _editor->isChecked());
       }
 
 //---------------------------------------------------------
 //   StringPreferenceItem
 //---------------------------------------------------------
 
-StringPreferenceItem::StringPreferenceItem(QString name)
+StringPreferenceItem::StringPreferenceItem(const QString& name)
       : PreferenceItem(name),
         _initialValue(preferences.getString(name)),
-        _editor(new QLineEdit)
+        _editor(new QLineEdit(treeWidget()))
       {
+      setObjectName("StringPreferenceItem");
       _editor->setText(_initialValue);
       }
 
@@ -306,9 +538,125 @@ void StringPreferenceItem::setDefaultValue()
 
 bool StringPreferenceItem::isModified() const
       {
-      return _initialValue != _editor->text();
+      return (_initialValue != _editor->text());
       }
 
+//---------------------------------------------------------
+//   FilePreferenceItem
+//---------------------------------------------------------
 
+FilePreferenceItem::FilePreferenceItem(const QString& name)
+      : PreferenceItem(name),
+        _initialValue(preferences.getString(name)),
+        _editor(new QPushButton(treeWidget()))
+      {
+      setObjectName("FilePreferenceItem");
+      _editor->setText(_initialValue);
+      _editor->setCursor(Qt::PointingHandCursor);
+      _editor->setToolTip(tr("Click to choose a new file..."));
+      if (_initialValue.isEmpty())
+            _editor->setText(tr("No file selected"));
+      connect(_editor, &QPushButton::clicked, this, &FilePreferenceItem::getFile);
+      }
+
+void FilePreferenceItem::save()
+      {
+      QString newValue = _editor->text();
+      _initialValue = newValue;
+      PreferenceItem::save(newValue);
+      }
+
+void FilePreferenceItem::update()
+      {
+      QString newValue = preferences.getString(name());
+      _editor->setText(newValue);
+      }
+
+void FilePreferenceItem::setDefaultValue()
+      {
+      _editor->setText(preferences.defaultValue(name()).toString());
+      }
+
+bool FilePreferenceItem::isModified() const
+      {
+      return (_initialValue != _editor->text());
+      }
+
+void FilePreferenceItem::getFile() const
+      {
+      QString fileName = QFileDialog::getOpenFileName (
+                               treeWidget(),
+                               tr("Choose file"),
+                               QFile(_editor->text()).exists()
+                               ? _editor->text() : mscoreGlobalShare,
+                               static_cast<FilePreference*> (preferences.allPreferences().value(name()))->filter(),
+                               0,
+                               (preferences.getBool(PREF_UI_APP_USENATIVEDIALOGS)
+                                ? QFileDialog::Options() : QFileDialog::Options() | QFileDialog::DontUseNativeDialog)
+                               );
+      if (!fileName.isNull() && (fileName != _editor->text())) {
+            _editor->setText(fileName);
+            if (fileName.isEmpty())
+                  _editor->setText(tr("No file selected"));
+            }
+      }
+
+//---------------------------------------------------------
+//   DirPreferenceItem
+//---------------------------------------------------------
+
+DirPreferenceItem::DirPreferenceItem(const QString& name)
+      : PreferenceItem(name),
+        _initialValue(preferences.getString(name)),
+        _editor(new QPushButton(treeWidget()))
+      {
+      setObjectName("DirPreferenceItem");
+      _editor->setText(_initialValue);
+      _editor->setCursor(Qt::PointingHandCursor);
+      _editor->setToolTip(tr("Click to choose a new directory..."));
+      if (_initialValue.isEmpty())
+            _editor->setText(tr("No directory selected"));
+      connect(_editor, &QPushButton::clicked, this, &DirPreferenceItem::getDirectory);
+      }
+
+void DirPreferenceItem::save()
+      {
+      QString newValue = _editor->text();
+      _initialValue = newValue;
+      PreferenceItem::save(newValue);
+      }
+
+void DirPreferenceItem::update()
+      {
+      QString newValue = preferences.getString(name());
+      _editor->setText(newValue);
+      }
+
+void DirPreferenceItem::setDefaultValue()
+      {
+      _editor->setText(preferences.defaultValue(name()).toString());
+      }
+
+bool DirPreferenceItem::isModified() const
+      {
+      return (_initialValue != _editor->text());
+      }
+
+void DirPreferenceItem::getDirectory() const
+      {
+      QString dir = QFileDialog::getExistingDirectory (
+                       treeWidget(),
+                       tr("Choose directory"),
+                       QDir(_editor->text()).exists()
+                       ? _editor->text() : mscoreGlobalShare,
+                       (preferences.getBool(PREF_UI_APP_USENATIVEDIALOGS)
+                        ? QFileDialog::Options() : QFileDialog::Options() | QFileDialog::DontUseNativeDialog)
+                       );
+      if (!dir.isNull() && (dir != _editor->text())) {
+            _editor->setText(dir);
+            if (dir.isEmpty())
+                  _editor->setText(tr("No directory selected"));
+            }
+      }
 
 } // namespace Ms

--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -188,12 +188,6 @@ void PreferencesListWidget::updatePreferences()
             item->update();
       }
 
-void PreferencesListWidget::updateToTemporaryPreferences()
-      {
-      for (PreferenceItem* item : preferenceItems.values())
-            item->update(QString("temporary") + item->name());
-      }
-
 void PreferencesListWidget::addPreference(PreferenceItem* item)
       {
       setItemWidget(item, PREF_VALUE_COLUMN, item->editor());
@@ -305,6 +299,29 @@ void PreferencesListWidget::showEvent(QShowEvent* event)
       QTreeWidget::showEvent(event);
       }
 
+void PreferencesListWidget::keyPressEvent(QKeyEvent* event)
+      {
+      // Key_F2 alternates between the item and it's editor
+      if (event->key() == Qt::Key_F2) {
+            PreferenceItem* pref= dynamic_cast<PreferenceItem*> (currentItem());
+            if (pref) {
+                  if (!pref->editor()->hasFocus()) {
+                        pref->editor()->setFocus();
+                        pref->editor()->grabKeyboard();
+                        }
+                  else {
+                        setCurrentItem(pref);
+                        pref->editor()->clearFocus();
+                        pref->editor()->releaseKeyboard();
+                        }
+                  }
+            event->accept();
+            return;
+            }
+
+      QTreeView::keyPressEvent(event);
+      }
+
 void PreferencesListWidget::save() const
       {
       for (PreferenceItem* item : preferenceItems.values()) {
@@ -378,7 +395,7 @@ void ColorPreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void ColorPreferenceItem::update(const QString& name)
+void ColorPreferenceItem::update()
       {
       QColor newValue = preferences.getColor(name());
       _editor->setColor(newValue);
@@ -417,7 +434,7 @@ void IntPreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void IntPreferenceItem::update(const QString& name)
+void IntPreferenceItem::update()
       {
       int newValue = preferences.getInt(name());
       _editor->setValue(newValue);
@@ -457,7 +474,7 @@ void DoublePreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void DoublePreferenceItem::update(const QString& name)
+void DoublePreferenceItem::update()
       {
       double newValue = preferences.getDouble(name());
       _editor->setValue(newValue);
@@ -503,9 +520,9 @@ void BoolPreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void BoolPreferenceItem::update(const QString name)
+void BoolPreferenceItem::update()
       {
-      bool newValue = preferences.getBool(name);
+      bool newValue = preferences.getBool(name());
       _editor->setChecked(newValue);
       }
 
@@ -539,7 +556,7 @@ void StringPreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void StringPreferenceItem::update(const QString& name)
+void StringPreferenceItem::update()
       {
       QString newValue = preferences.getString(name());
       _editor->setText(newValue);
@@ -580,7 +597,7 @@ void FilePreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void FilePreferenceItem::update(const QString& name)
+void FilePreferenceItem::update()
       {
       QString newValue = preferences.getString(name());
       _editor->setText(newValue);
@@ -640,7 +657,7 @@ void DirPreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void DirPreferenceItem::update(const QString& name)
+void DirPreferenceItem::update()
       {
       QString newValue = preferences.getString(name());
       _editor->setText(newValue);

--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -36,11 +36,11 @@ PreferencesListWidget::PreferencesListWidget(QWidget* parent)
       expandAll();
       resizeColumnToContents(0);
 
-      setContextMenuPolicy(Qt::ActionsContextMenu);
       QAction* selectAllPreferences = new QAction(tr("Select all preferences"), this);
       selectAllPreferences->setShortcut(QKeySequence::SelectAll);
       addAction(selectAllPreferences);
       connect(selectAllPreferences, &QAction::triggered, this, &PreferencesListWidget::selectAllVisiblePreferences);
+      setContextMenuPolicy(Qt::ActionsContextMenu);
       }
 
 PreferencesListWidget::~PreferencesListWidget()
@@ -188,6 +188,12 @@ void PreferencesListWidget::updatePreferences()
             item->update();
       }
 
+void PreferencesListWidget::updateToTemporaryPreferences()
+      {
+      for (PreferenceItem* item : preferenceItems.values())
+            item->update(QString("temporary") + item->name());
+      }
+
 void PreferencesListWidget::addPreference(PreferenceItem* item)
       {
       setItemWidget(item, PREF_VALUE_COLUMN, item->editor());
@@ -291,6 +297,14 @@ void PreferencesListWidget::selectAllVisiblePreferences()
             pref->setSelected(!pref->isHidden());
       }
 
+// For now, the only preference that is synced with this showEvent is PREF_APP_SHOWADVANCEDPREFERENCESWARNING.
+void PreferencesListWidget::showEvent(QShowEvent* event)
+      {
+      // all this long line does it set the PREF_APP_SHOWADVANCEDPREFERENCESWARNING's checkbox to what was set just before in prefsDialog::tabAboutToChange
+      static_cast<QCheckBox*>(static_cast<BoolPreferenceItem*>(preferenceItems.value(PREF_APP_SHOWADVANCEDPREFERENCESWARNING))->editor())->setChecked(preferences.getBool(PREF_APP_SHOWADVANCEDPREFERENCESWARNING));
+      QTreeWidget::showEvent(event);
+      }
+
 void PreferencesListWidget::save() const
       {
       for (PreferenceItem* item : preferenceItems.values()) {
@@ -364,7 +378,7 @@ void ColorPreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void ColorPreferenceItem::update()
+void ColorPreferenceItem::update(const QString& name)
       {
       QColor newValue = preferences.getColor(name());
       _editor->setColor(newValue);
@@ -403,7 +417,7 @@ void IntPreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void IntPreferenceItem::update()
+void IntPreferenceItem::update(const QString& name)
       {
       int newValue = preferences.getInt(name());
       _editor->setValue(newValue);
@@ -443,7 +457,7 @@ void DoublePreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void DoublePreferenceItem::update()
+void DoublePreferenceItem::update(const QString& name)
       {
       double newValue = preferences.getDouble(name());
       _editor->setValue(newValue);
@@ -489,9 +503,9 @@ void BoolPreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void BoolPreferenceItem::update()
+void BoolPreferenceItem::update(const QString name)
       {
-      bool newValue = preferences.getBool(name());
+      bool newValue = preferences.getBool(name);
       _editor->setChecked(newValue);
       }
 
@@ -525,7 +539,7 @@ void StringPreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void StringPreferenceItem::update()
+void StringPreferenceItem::update(const QString& name)
       {
       QString newValue = preferences.getString(name());
       _editor->setText(newValue);
@@ -566,7 +580,7 @@ void FilePreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void FilePreferenceItem::update()
+void FilePreferenceItem::update(const QString& name)
       {
       QString newValue = preferences.getString(name());
       _editor->setText(newValue);
@@ -626,7 +640,7 @@ void DirPreferenceItem::save()
       PreferenceItem::save(newValue);
       }
 
-void DirPreferenceItem::update()
+void DirPreferenceItem::update(const QString& name)
       {
       QString newValue = preferences.getString(name());
       _editor->setText(newValue);

--- a/mscore/preferenceslistwidget.h
+++ b/mscore/preferenceslistwidget.h
@@ -53,7 +53,7 @@ class PreferenceItem : public QTreeWidgetItem, public QObject {
       // using a variable other than name means it will go take the information coming
       // from another name. THis is useful, for example, to sync a preference with a
       // temporary copy of itself (probably under the name ("temporary" + name())
-      virtual void update(const QString name = this->name()) = 0;
+      virtual void update() = 0;
       virtual void setDefaultValue() = 0;
       virtual bool isModified() const = 0;
       void setVisible(const bool visible);
@@ -73,7 +73,7 @@ class BoolPreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update(const QString name = name()) override;
+      inline virtual void update() override;
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
       };
@@ -90,7 +90,7 @@ class IntPreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update(const QString name = name()) override;
+      inline virtual void update() override;
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
       };
@@ -107,7 +107,7 @@ class DoublePreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update(const QString name = name()) override;
+      inline virtual void update() override;
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
       };
@@ -124,7 +124,7 @@ class StringPreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update(const QString name = name()) override;
+      inline virtual void update() override;
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
       };
@@ -141,7 +141,7 @@ class FilePreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update(const QString name = name()) override;
+      inline virtual void update() override;
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
 
@@ -161,7 +161,7 @@ class DirPreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update(const QString name = name()) override;
+      inline virtual void update() override;
 
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
@@ -182,7 +182,7 @@ class ColorPreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update(const QString name = name()) override;
+      inline virtual void update() override;
 
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
@@ -216,8 +216,6 @@ class PreferencesListWidget : public QTreeWidget, public PreferenceVisitor {
 
       void loadPreferences();
       void updatePreferences();
-      // not used for now, since there is no syncing with the other tabs of the prefs dialog.
-      void updateToTemporaryPreferences();
 
       void save() const;
 

--- a/mscore/preferenceslistwidget.h
+++ b/mscore/preferenceslistwidget.h
@@ -203,12 +203,13 @@ class PreferencesListWidget : public QTreeWidget, public PreferenceVisitor {
       const QList<QTreeWidgetItem*> recursiveChildList(QTreeWidgetItem* parent) const;
       const QList<PreferenceItem*> recursivePreferenceItemList(QTreeWidgetItem* parent) const;
 
+      virtual void showEvent(QShowEvent* event) override;
+      virtual void keyPressEvent(QKeyEvent* event) override;
+      virtual void hideEvent(QHideEvent* event) override;
+
    private slots:
       void hideEmptyItems() const;
       void selectAllVisiblePreferences();
-
-      virtual void showEvent(QShowEvent* event) override;
-      virtual void keyPressEvent(QKeyEvent* event) override;
 
    public:
       explicit PreferencesListWidget(QWidget* parent = nullptr);

--- a/mscore/preferenceslistwidget.h
+++ b/mscore/preferenceslistwidget.h
@@ -25,6 +25,8 @@
 
 #define PREF_VALUE_COLUMN 1
 
+#include <QtWidgets>
+
 namespace Ms {
 
 //---------------------------------------------------------
@@ -48,10 +50,12 @@ class PreferenceItem : public QTreeWidgetItem, public QObject {
 
       virtual QWidget* editor() const = 0;
       virtual void save() = 0;
-      virtual void update() = 0;
+      // using a variable other than name means it will go take the information coming
+      // from another name. THis is useful, for example, to sync a preference with a
+      // temporary copy of itself (probably under the name ("temporary" + name())
+      virtual void update(const QString name = this->name()) = 0;
       virtual void setDefaultValue() = 0;
       virtual bool isModified() const = 0;
-
       void setVisible(const bool visible);
       const QString& name() const { return _name; }
       };
@@ -69,7 +73,7 @@ class BoolPreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update() override;
+      inline virtual void update(const QString name = name()) override;
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
       };
@@ -86,7 +90,7 @@ class IntPreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update() override;
+      inline virtual void update(const QString name = name()) override;
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
       };
@@ -103,7 +107,7 @@ class DoublePreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update() override;
+      inline virtual void update(const QString name = name()) override;
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
       };
@@ -120,7 +124,7 @@ class StringPreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update() override;
+      inline virtual void update(const QString name = name()) override;
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
       };
@@ -137,7 +141,7 @@ class FilePreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update() override;
+      inline virtual void update(const QString name = name()) override;
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
 
@@ -157,7 +161,8 @@ class DirPreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update() override;
+      inline virtual void update(const QString name = name()) override;
+
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
 
@@ -177,7 +182,8 @@ class ColorPreferenceItem : public PreferenceItem {
 
       QWidget* editor() const override { return _editor; }
       inline virtual void save() override;
-      inline virtual void update() override;
+      inline virtual void update(const QString name = name()) override;
+
       inline virtual void setDefaultValue() override;
       inline virtual bool isModified() const override;
       };
@@ -201,12 +207,17 @@ class PreferencesListWidget : public QTreeWidget, public PreferenceVisitor {
       void hideEmptyItems() const;
       void selectAllVisiblePreferences();
 
+      virtual void showEvent(QShowEvent* event) override;
+      virtual void keyPressEvent(QKeyEvent* event) override;
+
    public:
       explicit PreferencesListWidget(QWidget* parent = nullptr);
       ~PreferencesListWidget();
 
       void loadPreferences();
       void updatePreferences();
+      // not used for now, since there is no syncing with the other tabs of the prefs dialog.
+      void updateToTemporaryPreferences();
 
       void save() const;
 

--- a/mscore/preferencestreewidget_delegate.cpp
+++ b/mscore/preferencestreewidget_delegate.cpp
@@ -1,0 +1,35 @@
+/*******************************************************************************
+//  MusEScore
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2002-2011 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+*******************************************************************************/
+
+#include "preferencestreewidget_delegate.h"
+
+namespace Ms {
+
+PreferencesTreeWidget_Delegate::PreferencesTreeWidget_Delegate(QObject* parent)
+      : QItemDelegate(parent)
+      {
+      setObjectName("PreferencesTreeWidget_Delegate");
+      }
+
+QSize PreferencesTreeWidget_Delegate::sizeHint(const QStyleOptionViewItem&, const QModelIndex&) const
+      {
+      return QSize(160, 24);
+      }
+
+} // Ms

--- a/mscore/preferencestreewidget_delegate.h
+++ b/mscore/preferencestreewidget_delegate.h
@@ -1,0 +1,37 @@
+//=============================================================================
+//  MuseScore
+//  Linux Music Score Editor
+//
+//  Copyright (C) 2002-2011 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef PREFERENCESTREEWIDGET_DELEGATE_H
+#define PREFERENCESTREEWIDGET_DELEGATE_H
+
+namespace Ms {
+
+// This class is needed to increase the default row height of the PreferencesListWidget.
+class PreferencesTreeWidget_Delegate : public QItemDelegate
+{
+   public:
+      PreferencesTreeWidget_Delegate(QObject* parent = nullptr);
+
+      QSize sizeHint(const QStyleOptionViewItem&, const QModelIndex&) const;
+
+}; // class PreferencesTreeWidget_Delegate
+
+} // Ms
+
+#endif // PREFERENCESTREEWIDGET_DELEGATE_H

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -803,10 +803,10 @@ void PreferenceDialog::updateFgView(bool useColor)
 
       if (useColor) {
             fgColorLabel->setColor(preferences.getColor(PREF_UI_CANVAS_FG_COLOR));
-            fgColorLabel->setPixmap(0);
+            fgColorLabel->setText(tr("Click to modify"));
             }
       else {
-            fgColorLabel->setPixmap(new QPixmap(fgWallpaper->text()));
+            fgColorLabel->setText(fgWallpaper->text());
             }
       }
 
@@ -823,10 +823,10 @@ void PreferenceDialog::updateBgView(bool useColor)
 
       if (useColor) {
             bgColorLabel->setColor(preferences.getColor(PREF_UI_CANVAS_BG_COLOR));
-            bgColorLabel->setPixmap(0);
+            bgColorLabel->setText(tr("Click to modify"));
             }
       else {
-            bgColorLabel->setPixmap(new QPixmap(bgWallpaper->text()));
+            bgColorLabel->setText(bgWallpaper->text());
             }
       }
 
@@ -842,12 +842,13 @@ void PreferenceDialog::buttonBoxClicked(QAbstractButton* button)
                   break;
             case QDialogButtonBox::Ok:
                   apply();
-                  // intentional ??
-                  // fall through
-            case QDialogButtonBox::Cancel:
-            default:
                   hide();
                   break;
+            case QDialogButtonBox::Cancel:
+                  hide();
+                  break;
+            default:
+                  hide();
             }
       }
 

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -153,8 +153,8 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       connect(myPluginsButton, SIGNAL(clicked()), SLOT(selectPluginsDirectory()));
       connect(myImagesButton, SIGNAL(clicked()), SLOT(selectImagesDirectory()));
       connect(mySoundfontsButton, SIGNAL(clicked()), SLOT(changeSoundfontPaths()));
-       connect(myExtensionsButton, SIGNAL(clicked()), SLOT(selectExtensionsDirectory()));
-      
+      connect(myExtensionsButton, SIGNAL(clicked()), SLOT(selectExtensionsDirectory()));
+
 
       connect(updateTranslation, SIGNAL(clicked()), SLOT(updateTranslationClicked()));
 
@@ -206,16 +206,15 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       connect(useJackMidi,  SIGNAL(toggled(bool)), SLOT(nonExclusiveJackDriver(bool)));
       updateRemote();
 
-      advancedWidget = new PreferencesListWidget();
-      QVBoxLayout* l = static_cast<QVBoxLayout*> (tabAdvanced->layout());
-      l->insertWidget(0, advancedWidget);
-      advancedWidget->loadPreferences();
-      connect(advancedSearch, &QLineEdit::textChanged, this, &PreferenceDialog::filterAdvancedPreferences);
-      connect(resetPreference, &QPushButton::clicked, this, &PreferenceDialog::resetAdvancedPreferenceToDefault);
+      // get back to the page that was last used.
+      QSettings settings;
+      settings.beginGroup(objectName());
+      tabWidget->setCurrentIndex(settings.value("Current page", 0).toInt());
+      settings.endGroup();
 
       MuseScore::restoreGeometry(this);
 #if !defined(Q_OS_MAC) && (!defined(Q_OS_WIN) || defined(FOR_WINSTORE))
-      General->removeTab(General->indexOf(tabUpdate)); // updateTab not needed on Linux and not wanted in Windows Store
+      tabWidget->removeTab(tabWidget->indexOf(tabUpdate)); // updateTab not needed on Linux and not wanted in Windows Store
 #endif
       }
 
@@ -236,6 +235,12 @@ void PreferenceDialog::start()
 PreferenceDialog::~PreferenceDialog()
       {
       qDeleteAll(localShortcuts);
+
+      // save the current page
+      QSettings settings;
+      settings.beginGroup(objectName());
+      settings.setValue("Current page", tabWidget->currentIndex());
+      settings.endGroup();
       }
 
 //---------------------------------------------------------
@@ -254,7 +259,7 @@ void PreferenceDialog::hideEvent(QHideEvent* ev)
 
 void PreferenceDialog::recordButtonClicked(int val)
       {
-      foreach(QAbstractButton* b, recordButtons->buttons()) {
+      for(QAbstractButton* b : recordButtons->buttons()) {
             b->setChecked(recordButtons->id(b) == val);
             }
       mscore->setMidiRecordId(val);
@@ -314,8 +319,6 @@ void PreferenceDialog::updateValues(bool useDefaultValues)
       {
       if (useDefaultValues)
             preferences.setReturnDefaultValues(true);
-
-      advancedWidget->updatePreferences();
 
       rcGroup->setChecked(preferences.getBool(PREF_IO_MIDI_USEREMOTECONTROL));
       advanceOnRelease->setChecked(preferences.getBool(PREF_IO_MIDI_ADVANCEONRELEASE));
@@ -407,7 +410,7 @@ void PreferenceDialog::updateValues(bool useDefaultValues)
       //
       qDeleteAll(localShortcuts);
       localShortcuts.clear();
-      foreach(const Shortcut* s, Shortcut::shortcuts())
+      for(const Shortcut* s: Shortcut::shortcuts())
             localShortcuts[s->key()] = new Shortcut(*s);
       updateSCListView();
 
@@ -497,7 +500,7 @@ void PreferenceDialog::updateValues(bool useDefaultValues)
       int idx = 0;
       importCharsetListOve->clear();
       importCharsetListGP->clear();
-      foreach (QByteArray charset, charsets) {
+      for (QByteArray charset : charsets) {
             importCharsetListOve->addItem(charset);
             importCharsetListGP->addItem(charset);
             if (charset == preferences.getString(PREF_IMPORT_OVERTURE_CHARSET))
@@ -584,7 +587,7 @@ bool ShortcutItem::operator<(const QTreeWidgetItem& item) const
 void PreferenceDialog::updateSCListView()
       {
       shortcutList->clear();
-      foreach (Shortcut* s, localShortcuts) {
+      for (Shortcut* s : localShortcuts) {
             if (!s)
                   continue;
             ShortcutItem* newItem = new ShortcutItem;
@@ -676,39 +679,8 @@ void  PreferenceDialog::filterShortcutsTextChanged(const QString &query )
           if(item->text(0).toLower().contains(query.toLower()))
               item->setHidden(false);
           else
-              item->setHidden(true);  
+              item->setHidden(true);
           }
-      }
-
-//--------------------------------------------------------
-//   filterAdvancedPreferences
-//--------------------------------------------------------
-
-void PreferenceDialog::filterAdvancedPreferences(const QString& query)
-      {
-      QTreeWidgetItem *item;
-      for(int i = 0; i < advancedWidget->topLevelItemCount(); i++) {
-            item = advancedWidget->topLevelItem(i);
-
-            if(item->text(0).toLower().contains(query.toLower()))
-                  item->setHidden(false);
-            else
-                  item->setHidden(true);
-            }
-      }
-
-//--------------------------------------------------------
-//   resetAdvancedPreferenceToDefault
-//--------------------------------------------------------
-
-void PreferenceDialog::resetAdvancedPreferenceToDefault()
-      {
-      preferences.setReturnDefaultValues(true);
-      for (QTreeWidgetItem* item : advancedWidget->selectedItems()) {
-            PreferenceItem* pref = static_cast<PreferenceItem*>(item);
-            pref->setDefaultValue();
-            }
-      preferences.setReturnDefaultValues(false);
       }
 
 //---------------------------------------------------------
@@ -1042,7 +1014,7 @@ void PreferenceDialog::apply()
 
       if (shortcutsChanged) {
             shortcutsChanged = false;
-            foreach(const Shortcut* s, localShortcuts) {
+           for(const Shortcut* s : localShortcuts) {
                   Shortcut* os = Shortcut::getShortcut(s->key());
                   if (os) {
                         if (!os->compareKeys(*s))
@@ -1108,7 +1080,7 @@ void PreferenceDialog::apply()
       emit preferencesChanged();
       preferences.save();
       mscore->startAutoSave();
-      }
+      } // apply();
 
 //---------------------------------------------------------
 //   resetAllValues
@@ -1122,7 +1094,7 @@ void PreferenceDialog::resetAllValues()
       qDeleteAll(localShortcuts);
       localShortcuts.clear();
       Shortcut::resetToDefault();
-      foreach(const Shortcut* s, Shortcut::shortcuts())
+      for(const Shortcut* s : Shortcut::shortcuts())
             localShortcuts[s->key()] = new Shortcut(*s);
       updateSCListView();
       }

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -40,6 +40,7 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       QMap<QString, Shortcut*> localShortcuts;
       bool shortcutsChanged;
       QButtonGroup* recordButtons;
+      int _currentTabIndex;
 
       virtual void hideEvent(QHideEvent*);
       void apply();
@@ -81,6 +82,8 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
 
       void changeSoundfontPaths();
       void updateTranslationClicked();
+
+      void tabAboutToChange(int index);
 
    signals:
       void preferencesChanged();

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -24,7 +24,7 @@
 #include "ui_prefsdialog.h"
 #include "preferences.h"
 #include "abstractdialog.h"
-#include "preferenceslistwidget.h"
+#include "advancedpreferenceswidget.h"
 
 namespace Ms {
 
@@ -40,7 +40,6 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       QMap<QString, Shortcut*> localShortcuts;
       bool shortcutsChanged;
       QButtonGroup* recordButtons;
-      PreferencesListWidget* advancedWidget;
 
       virtual void hideEvent(QHideEvent*);
       void apply();
@@ -78,9 +77,7 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       void selectImagesDirectory();
       void selectExtensionsDirectory();
       void printShortcutsClicked();
-      void filterShortcutsTextChanged(const QString &);
-      void filterAdvancedPreferences(const QString&);
-      void resetAdvancedPreferenceToDefault();
+      void filterShortcutsTextChanged(const QString&);
 
       void changeSoundfontPaths();
       void updateTranslationClicked();

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -4293,10 +4293,17 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>fgWallpaperButton</tabstop>
   <tabstop>fgWallpaper</tabstop>
   <tabstop>fgWallpaperSelect</tabstop>
+  <tabstop>pageHorizontal</tabstop>
+  <tabstop>pageVertical</tabstop>
+  <tabstop>limitScrollArea</tabstop>
+  <tabstop>drawAntialiased</tabstop>
+  <tabstop>proximity</tabstop>
   <tabstop>enableMidiInput</tabstop>
+  <tabstop>warnPitchRange</tabstop>
+  <tabstop>realtimeDelay</tabstop>
+  <tabstop>playNotes</tabstop>
   <tabstop>defaultPlayDuration</tabstop>
   <tabstop>playChordOnAddNote</tabstop>
-  <tabstop>warnPitchRange</tabstop>
   <tabstop>rcGroup</tabstop>
   <tabstop>rewindActive</tabstop>
   <tabstop>recordRewind</tabstop>
@@ -4326,12 +4333,12 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>recordUndo</tabstop>
   <tabstop>rca9</tabstop>
   <tabstop>rcr9</tabstop>
+  <tabstop>rca12</tabstop>
+  <tabstop>rcr12</tabstop>
   <tabstop>rca10</tabstop>
   <tabstop>rcr10</tabstop>
   <tabstop>rca11</tabstop>
   <tabstop>rcr11</tabstop>
-  <tabstop>rca12</tabstop>
-  <tabstop>rcr12</tabstop>
   <tabstop>realtimeAdvanceActive</tabstop>
   <tabstop>recordRealtimeAdvance</tabstop>
   <tabstop>advanceOnRelease</tabstop>
@@ -4345,6 +4352,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>partStyle</tabstop>
   <tabstop>partStyleButton</tabstop>
   <tabstop>scale</tabstop>
+  <tabstop>showMidiControls</tabstop>
   <tabstop>pulseaudioDriver</tabstop>
   <tabstop>portaudioDriver</tabstop>
   <tabstop>portaudioApi</tabstop>
@@ -4374,7 +4382,11 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>shortestNote</tabstop>
   <tabstop>pngResolution</tabstop>
   <tabstop>pngTransparent</tabstop>
+  <tabstop>expandRepeats</tabstop>
+  <tabstop>exportRPNs</tabstop>
+  <tabstop>exportPdfDpi</tabstop>
   <tabstop>exportAudioSampleRate</tabstop>
+  <tabstop>exportMp3BitRate</tabstop>
   <tabstop>exportLayout</tabstop>
   <tabstop>exportAllBreaks</tabstop>
   <tabstop>exportManualBreaks</tabstop>
@@ -4385,12 +4397,12 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>loadShortcutList</tabstop>
   <tabstop>clearShortcut</tabstop>
   <tabstop>defineShortcut</tabstop>
+  <tabstop>filterShortcuts</tabstop>
   <tabstop>printShortcuts</tabstop>
+  <tabstop>checkUpdateStartup</tabstop>
+  <tabstop>checkExtensionsUpdateStartup</tabstop>
   <tabstop>resetToDefault</tabstop>
   <tabstop>buttonBox</tabstop>
-  <tabstop>limitScrollArea</tabstop>
-  <tabstop>drawAntialiased</tabstop>
-  <tabstop>proximity</tabstop>
  </tabstops>
  <resources>
   <include location="musescore.qrc"/>

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -82,7 +82,7 @@
     </layout>
    </item>
    <item row="0" column="0">
-    <widget class="QTabWidget" name="General">
+    <widget class="QTabWidget" name="tabWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
@@ -4213,53 +4213,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
        <item>
         <layout class="QVBoxLayout" name="advancedTabLayout">
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_6">
-           <item>
-            <widget class="QPushButton" name="resetPreference">
-             <property name="toolTip">
-              <string>Select a preference to reset to default value</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleDescription">
-              <string>Select a preference to reset to default value</string>
-             </property>
-             <property name="text">
-              <string>Reset to default</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="advancedSearch">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="placeholderText">
-              <string>Search</string>
-             </property>
-             <property name="clearButtonEnabled">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
+          <widget class="Ms::AdvancedPreferencesWidget" name="advancedWidget" native="true"/>
          </item>
         </layout>
        </item>
@@ -4287,9 +4241,15 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
    <extends>QToolButton</extends>
    <header>recordbutton.h</header>
   </customwidget>
+  <customwidget>
+   <class>Ms::AdvancedPreferencesWidget</class>
+   <extends>QWidget</extends>
+   <header>advancedpreferenceswidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>General</tabstop>
+  <tabstop>tabWidget</tabstop>
   <tabstop>emptySession</tabstop>
   <tabstop>lastSession</tabstop>
   <tabstop>newSession</tabstop>

--- a/mscore/shortcutcapturedialog.cpp
+++ b/mscore/shortcutcapturedialog.cpp
@@ -107,6 +107,7 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
       {
       if (key.count() >= 4)
             return;
+
       int k = e->key();
       if (k == 0 || k == Qt::Key_Shift || k == Qt::Key_Control ||
          k == Qt::Key_Meta || k == Qt::Key_Alt || k == Qt::Key_AltGr
@@ -118,7 +119,7 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
       // remove shift-modifier for keys that don't need it: letters and special keys
       if ((k & Qt::ShiftModifier) && ((e->key() < 0x41) || (e->key() > 0x5a) || (e->key() >= 0x01000000))) {
             qDebug() << k;
-      	k -= Qt::ShiftModifier;
+            k -= Qt::ShiftModifier;
             qDebug() << k;
             }
 


### PR DESCRIPTION
What has been done:
 - Move the complete advanced preferences tab into a widget: advancedpreferenceswidget.cpp.
 - Use the advancedPreferencesList as a real treeWidget, taking advantage of the "directory" based #defines of the preferences.
 - the preferencestreewidget_delegate is only for purposes of resizing the row heights in the treeWidget.
 - add a few properties to Awl::ColorLabel.
 - Change names of a few preferences, to avoid to many directories in the TreeWidget.
 - Remove camelCase of the #define's values of the preferences, for user-friendlyness. Now, even if the advanced preferences are still not translatable, at least it looks like good english.
 - Add a FilePreference, a DirPreference, and their corresponding Items in the Advanced prefs TreeWidget. for now, they are not used, but they will soon be, as of a pull request I should make in  a few days.