### PR TITLE
fix #274659: crash on adjsut measure duration in part

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1621,7 +1621,7 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
                               }
                         }
                   }
-            Fraction stretch = score()->staff(staffIdx)->timeStretch(tick());
+            Fraction stretch = s->staff(staffIdx)->timeStretch(tick());
             // if just a single rest
             if (rests == 1 && chords == 0) {
                   // if measure value didn't change, stick to whole measure rest


### PR DESCRIPTION
staffIdx is relative to root score.

BTW, there is another place a bit further down where we add a rest and it seems also odd how we mix and match "score()" and "s", but it works, and changing it doesn't, that code wasn't mine, so I left it alone :-)