### PR TITLE
fix #274439: Crash when deleting title frame

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3921,6 +3921,11 @@ void LayoutContext::layout()
             while (score->npages() > curPage)        // Remove not needed pages. TODO: make undoable:
                   score->pages().takeLast();
             }
+      else {
+            Page* p = curSystem->page();
+            if (p && (p != page))
+                  p->rebuildBspTree();
+            }
       score->systems().append(systemList);     // TODO
       }
 


### PR DESCRIPTION
See https://musescore.org/en/node/274439.

The last thing that `LayoutContext::collectPage()` does is rebuild the BSP tree for the page it just collected. But if the last system that it collects does not fit on the page, then the BSP tree for that system's page may never get rebuilt. This corrects the problem by rebuilding the BSP tree for the last collected system's page if that page is not the same as the page that was just collected.