### PR TITLE
fix #78591: undo of instrument change

### DIFF
--- a/libmscore/instrchange.cpp
+++ b/libmscore/instrchange.cpp
@@ -54,8 +54,9 @@ InstrumentChange::~InstrumentChange()
 
 void InstrumentChange::setInstrument(const Instrument& i)
       {
-      delete _instrument;
-      _instrument = new Instrument(i);
+      *_instrument = i;
+      //delete _instrument;
+      //_instrument = new Instrument(i);
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1326,6 +1326,8 @@ void Score::addElement(Element* element)
 
             case ElementType::INSTRUMENT_CHANGE: {
                   InstrumentChange* ic = toInstrumentChange(element);
+                  ic->part()->setInstrument(ic->instrument(), ic->segment()->tick());
+#if 0
                   int tickStart = ic->segment()->tick();
                   auto i = ic->part()->instruments()->upper_bound(tickStart);
                   int tickEnd;
@@ -1336,6 +1338,7 @@ void Score::addElement(Element* element)
                   Interval oldV = ic->part()->instrument(tickStart)->transpose();
                   ic->part()->setInstrument(ic->instrument(), tickStart);
                   transpositionChanged(ic->part(), oldV, tickStart, tickEnd);
+#endif
                   masterScore()->rebuildMidiMapping();
                   cmdState()._instrumentsChanged = true;
                   }
@@ -1480,6 +1483,8 @@ void Score::removeElement(Element* element)
                   break;
             case ElementType::INSTRUMENT_CHANGE: {
                   InstrumentChange* ic = toInstrumentChange(element);
+                  ic->part()->removeInstrument(ic->segment()->tick());
+#if 0
                   int tickStart = ic->segment()->tick();
                   auto i = ic->part()->instruments()->upper_bound(tickStart);
                   int tickEnd;
@@ -1490,6 +1495,7 @@ void Score::removeElement(Element* element)
                   Interval oldV = ic->part()->instrument(tickStart)->transpose();
                   ic->part()->removeInstrument(tickStart);
                   transpositionChanged(ic->part(), oldV, tickStart, tickEnd);
+#endif
                   masterScore()->rebuildMidiMapping();
                   cmdState()._instrumentsChanged = true;
                   }

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -673,8 +673,18 @@ void Score::transpositionChanged(Part* part, Interval oldV, int tickStart, int t
       Interval diffV(oldV.chromatic + v.chromatic);
 
       // transpose keys first
-      if (!styleB(Sid::concertPitch))
-            transposeKeys(part->startTrack() / VOICES, part->endTrack() / VOICES, tickStart, tickEnd, diffV);
+      QList<Score*> scores;
+      for (Staff* ls : part->staff(0)->staffList()) {
+            // TODO: special handling for linked staves within a score
+            // could be useful for capo
+            Score* score = ls->score();
+            if (scores.contains(score))
+                  continue;
+            scores.append(score);
+            Part* lp = ls->part();
+            if (!score->styleB(Sid::concertPitch))
+                  score->transposeKeys(lp->startTrack() / VOICES, lp->endTrack() / VOICES, tickStart, tickEnd, diffV);
+            }
 
       // now transpose notes and chord symbols
       for (Segment* s = firstSegment(SegmentType::ChordRest); s; s = s->next1(SegmentType::ChordRest)) {

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1798,23 +1798,21 @@ void ChangeNoteEvents::flip(EditData*)
 
 void ChangeInstrument::flip(EditData*)
       {
-      Instrument* oi = is->instrument();  //new Instrument(*is->instrument());
-      is->setInstrument(instrument);      //*instrument
-
-      // transpose
+      Part* part = is->staff()->part();
       int tickStart = is->segment()->tick();
-      auto i = is->staff()->part()->instruments()->find(tickStart);
-      ++i;
-      int tickEnd;
-      if (i == is->staff()->part()->instruments()->end())
-            tickEnd = -1;
-      else
-            tickEnd = i->first;
-      is->score()->transpositionChanged(is->staff()->part(), oi->transpose(), tickStart, tickEnd);
+      Instrument* oi = is->instrument();  //new Instrument(*is->instrument());
 
+      // set instrument in both part and instrument change element
+      is->setInstrument(instrument);      //*instrument
+      part->setInstrument(instrument, tickStart);
+
+      // update score
       is->masterScore()->rebuildMidiMapping();
+      is->masterScore()->updateChannel();
       is->score()->setInstrumentsChanged(true);
       is->score()->setLayoutAll();
+
+      // remember original instrument
       instrument = oi;
       }
 

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -491,10 +491,28 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
             if (si.exec()) {
                   const InstrumentTemplate* it = si.instrTemplate();
                   if (it) {
+                        int tickStart = ic->segment()->tick();
+                        Part* part = ic->staff()->part();
+                        Interval oldV = part->instrument(tickStart)->transpose();
+                        //Instrument* oi = ic->instrument();  //part->instrument(tickStart);
                         //Instrument* instrument = new Instrument(Instrument::fromTemplate(it));
-                        ic->setInstrument(Instrument::fromTemplate(it));
-                        score()->undo(new ChangeInstrument(ic, ic->instrument()));
-                        score()->masterScore()->updateChannel();
+                        // change instrument in all linked scores
+                        for (ScoreElement* se : ic->linkList()) {
+                              InstrumentChange* lic = static_cast<InstrumentChange*>(se);
+                              Instrument* instrument = new Instrument(Instrument::fromTemplate(it));
+                              lic->score()->undo(new ChangeInstrument(lic, instrument));
+                              }
+                        // transpose for current score only
+                        // this automatically propagates to linked scores
+                        if (part->instrument(tickStart)->transpose() != oldV) {
+                              auto i = part->instruments()->upper_bound(tickStart);    // find(), ++i
+                              int tickEnd;
+                              if (i == part->instruments()->end())
+                                    tickEnd = -1;
+                              else
+                                    tickEnd = i->first;
+                              ic->score()->transpositionChanged(part, oldV, tickStart, tickEnd);
+                              }
                         }
                   else
                         qDebug("no template selected?");


### PR DESCRIPTION
When I first implemented transposition on instrument change, it was for master (merged years ago - see #2228), and didn't necessarily work completely because master was in pretty rough state.  A couple of years later I ported this to 2.1 and made improvements (see #3029).  Among those improvements was a fix for https://musescore.org/en/node/78591.  So I have now taken those improvements and ported them back to master again.

I have verified the things I fixed here do in fact work, but there are other things that do not.  In particular, if you add an instrument change to a score with parts, things don't go well.  If you add it by double-clicking in the palette, it doesn't show up in the part at all.  I see the code to add it being hit twice, but somehow it's trying to use the same score twice it seems.  If you add via drag & drop, it works, but layout is bad in the part, and if you then change instrument in the score, you get no sound in the part.