### PR TITLE
fix #274841: rewind should reposition score

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5265,9 +5265,17 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                   mixer->updateAll(cs->masterScore());
             }
       else if (cmd == "rewind") {
-            seq->rewindStart();
-            if (playPanel)
-                  playPanel->heartBeat(0, 0, 0);
+            if (cs) {
+                  int tick = loop() ? cs->loopInTick() : 0;
+                  seq->seek(tick);
+                  if (cv) {
+                        Measure* m = cs->tick2measureMM(tick);
+                        if (m)
+                              cv->gotoMeasure(m);
+                        }
+                  if (playPanel)
+                        playPanel->heartBeat(0, 0, 0);
+                  }
             }
       else if (cmd == "play-next-measure")
             seq->nextMeasure();


### PR DESCRIPTION
Straightforward - just adding a gotoMeasure() call to the "rewind" command handler.

BTW, I might have preferred to use cmdGotoElement & score()->firstElement (which is what the "first-element" command does), but cmdGotoElement is private to ScoreView.  Is there a good reason for that?