### PR TITLE
fix warning with "Control reaches end of non-void function"

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1553,8 +1553,10 @@ void Seq::updateSynthesizerState(int tick1, int tick2)
 
 double Seq::curTempo() const
       {
-      if (inCountIn)
+      if (playPos != events.end())
             return cs ? cs->tempomap()->tempo(playPos->first) : 0.0;
+      
+      return 0.0;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
fix warning with "Control reaches end of non-void function" in seq.cpp. This additional if statement is needed because MS crushes under MSVC when playing position reach the end of score.