### PR TITLE
Shortcuts fixes

### DIFF
--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -254,7 +254,7 @@ void PreferenceDialog::hideEvent(QHideEvent* ev)
 
 void PreferenceDialog::recordButtonClicked(int val)
       {
-      foreach(QAbstractButton* b, recordButtons->buttons()) {
+      for (QAbstractButton* b : recordButtons->buttons()) {
             b->setChecked(recordButtons->id(b) == val);
             }
       mscore->setMidiRecordId(val);
@@ -408,7 +408,7 @@ void PreferenceDialog::updateValues(bool useDefaultValues)
       //
       qDeleteAll(localShortcuts);
       localShortcuts.clear();
-      foreach(const Shortcut* s, Shortcut::shortcuts())
+      for(const Shortcut* s : Shortcut::shortcuts())
             localShortcuts[s->key()] = new Shortcut(*s);
       updateSCListView();
 
@@ -498,7 +498,7 @@ void PreferenceDialog::updateValues(bool useDefaultValues)
       int idx = 0;
       importCharsetListOve->clear();
       importCharsetListGP->clear();
-      foreach (QByteArray charset, charsets) {
+      for (QByteArray charset : charsets) {
             importCharsetListOve->addItem(charset);
             importCharsetListGP->addItem(charset);
             if (charset == preferences.getString(PREF_IMPORT_OVERTURE_CHARSET))
@@ -585,7 +585,7 @@ bool ShortcutItem::operator<(const QTreeWidgetItem& item) const
 void PreferenceDialog::updateSCListView()
       {
       shortcutList->clear();
-      foreach (Shortcut* s, localShortcuts) {
+      for (Shortcut* s : localShortcuts) {
             if (!s)
                   continue;
             ShortcutItem* newItem = new ShortcutItem;
@@ -1044,7 +1044,7 @@ void PreferenceDialog::apply()
 
       if (shortcutsChanged) {
             shortcutsChanged = false;
-            foreach(const Shortcut* s, localShortcuts) {
+            for(const Shortcut* s : localShortcuts) {
                   Shortcut* os = Shortcut::getShortcut(s->key());
                   if (os) {
                         if (!os->compareKeys(*s))
@@ -1124,7 +1124,7 @@ void PreferenceDialog::resetAllValues()
       qDeleteAll(localShortcuts);
       localShortcuts.clear();
       Shortcut::resetToDefault();
-      foreach(const Shortcut* s, Shortcut::shortcuts())
+      for (const Shortcut* s : Shortcut::shortcuts())
             localShortcuts[s->key()] = new Shortcut(*s);
       updateSCListView();
       }

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -3988,6 +3988,9 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
          <property name="accessibleDescription">
           <string>Here you can configure shortcuts for actions</string>
          </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
          <property name="alternatingRowColors">
           <bool>true</bool>
          </property>

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3879,7 +3879,7 @@ void Shortcut::retranslate()
 
 void Shortcut::refreshIcons()
       {
-      foreach (Shortcut* s, _shortcuts) {
+      for (Shortcut* s : _shortcuts) {
             QAction* a = s->action();
             if (a && s->icon() != Icons::Invalid_ICON) {
                   a->setIcon(*icons[int(s->icon())]);
@@ -3933,7 +3933,7 @@ void Shortcut::write(XmlWriter& xml) const
       xml.tag("key", _key.data());
       if (_standardKey != QKeySequence::UnknownKey)
             xml.tag("std", QString("%1").arg(_standardKey));
-      foreach(QKeySequence ks, _keys)
+      for (QKeySequence ks : _keys)
             xml.tag("seq", Shortcut::keySeqToString(ks, QKeySequence::PortableText));
       xml.etag();
       }

--- a/mscore/shortcutcapturedialog.cpp
+++ b/mscore/shortcutcapturedialog.cpp
@@ -88,12 +88,10 @@ bool ShortcutCaptureDialog::eventFilter(QObject* /*o*/, QEvent* e)
       {
       if (e->type() == QEvent::KeyPress) {
             QKeyEvent* keyEvent = static_cast<QKeyEvent*>(e);
-            if(keyEvent->key() == Qt::Key_Tab || keyEvent->key() == Qt::Key_Backtab){
-                  QWidget::keyPressEvent(keyEvent);
+            if((keyEvent->key() != Qt::Key_Tab) && (keyEvent->key() != Qt::Key_Backtab)){
+                  keyPress(keyEvent);
                   return true;
                   }
-            keyPress(keyEvent);
-            return true;
             }
       return false;
       }
@@ -118,7 +116,7 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
       // remove shift-modifier for keys that don't need it: letters and special keys
       if ((k & Qt::ShiftModifier) && ((e->key() < 0x41) || (e->key() > 0x5a) || (e->key() >= 0x01000000))) {
             qDebug() << k;
-      	k -= Qt::ShiftModifier;
+            k -= Qt::ShiftModifier;
             qDebug() << k;
             }
 
@@ -175,21 +173,21 @@ void ShortcutCaptureDialog::keyPress(QKeyEvent* e)
             }
       addButton->setEnabled(conflict == false);
       replaceButton->setEnabled(conflict == false);
+
 //      nshrtLabel->setText(key.toString(QKeySequence::NativeText));
       QString keyStr = Shortcut::keySeqToString(key, QKeySequence::NativeText);
       nshrtLabel->setText(keyStr);
-
 //      QString A = key.toString(QKeySequence::NativeText);
       QString A = keyStr;
       QString B = Shortcut::keySeqToString(key, QKeySequence::PortableText);
-qDebug("capture key 0x%x  modifiers 0x%x virt 0x%x scan 0x%x <%s><%s>",
-      k,
-      int(e->modifiers()),
-      int(e->nativeVirtualKey()),
-      int(e->nativeScanCode()),
-      qPrintable(A),
-      qPrintable(B)
-      );
+      qDebug("capture key 0x%x  modifiers 0x%x virt 0x%x scan 0x%x <%s><%s>",
+            k,
+            int(e->modifiers()),
+            int(e->nativeVirtualKey()),
+            int(e->nativeScanCode()),
+            qPrintable(A),
+            qPrintable(B)
+            );
       }
 
 //---------------------------------------------------------
@@ -220,5 +218,5 @@ void ShortcutCaptureDialog::hideEvent(QHideEvent* event)
       QWidget::hideEvent(event);
       }
 
-}
+} // namespace Ms
 

--- a/mscore/shortcutcapturedialog.ui
+++ b/mscore/shortcutcapturedialog.ui
@@ -34,8 +34,15 @@
    </property>
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="descrLabel">
+     <property name="toolTip">
+      <string>To enter a shortcut, choose a key sequence, for example, Ctrl+A, and press it on your keyboard. 
+A key sequence can be implemented into another: Ctrl+B, and then Ctrl+C is a valid shortcut.
+Up to four combinations can be used: Ctrl+A then Ctrl+B then Ctrl+C then Ctrl+D is also a valid shortcut.
+Note: this last shortcut would be noted &quot;Ctrl+A,Ctrl+B,Ctrl+C,Ctrl+D&quot;</string>
+     </property>
      <property name="text">
-      <string>Press up to four keys to enter shortcut sequence</string>
+      <string>Press up to four key combinations to enter shortcut sequence.
+Note: Ctrl+Shift+1 is one key combination</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -58,6 +65,9 @@
    </item>
    <item row="2" column="1">
     <widget class="QLineEdit" name="oshrtLabel">
+     <property name="cursor">
+      <cursorShape>ArrowCursor</cursorShape>
+     </property>
      <property name="accessibleName">
       <string>Old shortcuts</string>
      </property>
@@ -75,6 +85,9 @@
    </item>
    <item row="3" column="1">
     <widget class="QLineEdit" name="nshrtLabel">
+     <property name="cursor">
+      <cursorShape>ArrowCursor</cursorShape>
+     </property>
      <property name="accessibleName">
       <string>New shortcut</string>
      </property>
@@ -112,7 +125,7 @@
         <string>Clear</string>
        </property>
        <property name="accessibleDescription">
-        <string/>
+        <string>Clear new shortcut</string>
        </property>
        <property name="text">
         <string>Clear</string>
@@ -137,6 +150,9 @@
        <property name="accessibleName">
         <string>Add</string>
        </property>
+       <property name="accessibleDescription">
+        <string>Add the new shortcut to the list of existing shortcuts</string>
+       </property>
        <property name="text">
         <string>Add</string>
        </property>
@@ -149,6 +165,9 @@
        </property>
        <property name="accessibleName">
         <string>Replace</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>Replace the old shortcut(s) with new one.</string>
        </property>
        <property name="text">
         <string>Replace</string>


### PR DESCRIPTION
fix the scrollbar in the preferences' shortcut list: it was appearing when you clickied several times on the headers.
Remove a few old qDebug()s, change a few foreach`s and simplify things a little.
Add more informations about setting shortcuts in shortcutcapturedialog.ui.