### PR TITLE
FIxed incorrect path to QWebEngine resources for linux which cause to crash programm

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -629,11 +629,11 @@ else (MINGW)
             )
          install(DIRECTORY
             ${QT_INSTALL_PREFIX}/resources
-            DESTINATION bin
+            DESTINATION lib/qt5
             )
          install(DIRECTORY
             ${QT_INSTALL_PREFIX}/translations/qtwebengine_locales
-            DESTINATION bin/qtwebengine_locales
+            DESTINATION lib/qt5/translations
             )
       endif(APPLE)
 


### PR DESCRIPTION
Replace WebEngine resources for Linux Build to /lib/qt5 folder where QWebEngine try to find it