### PR TITLE
change permissions for QtWebEngineProcess in AppImage

### DIFF
--- a/build/Linux+BSD/portable/RecipeDebian
+++ b/build/Linux+BSD/portable/RecipeDebian
@@ -153,6 +153,7 @@ package() {
   appimage="$(echo "$appdir" | sed 's|\.AppDir$|.AppImage|')"
 
   cd AppImageKit-5/AppImageAssistant.AppDir
+  chmod u+x /$appdir/bin/QtWebEngineProcess 
 
   ./package  "$appdir" "$appimage"
 

--- a/build/Linux+BSD/portable/x86_32/Recipe
+++ b/build/Linux+BSD/portable/x86_32/Recipe
@@ -103,6 +103,7 @@ appimage="$(echo "$appdir" | sed 's|\.AppDir$|.AppImage|')"
 ##########################################################################
 
 cd ../AppImageKit/AppImageAssistant.AppDir
+chmod u+x /$appdir/bin/QtWebEngineProcess 
 
 ./package  "$appdir" "$appimage"
 

--- a/build/Linux+BSD/portable/x86_64/Recipe
+++ b/build/Linux+BSD/portable/x86_64/Recipe
@@ -114,6 +114,7 @@ appimage="$(echo "$appdir" | sed 's|\.AppDir$|.AppImage|')"
 ##########################################################################
 
 cd ../AppImageKit/AppImageAssistant.AppDir
+chmod u+x /$appdir/bin/QtWebEngineProcess 
 
 ./package "$appdir" "$appimage"
 


### PR DESCRIPTION
We need to change permissions because by default QtWebEngineProcess cannot be launched