### PR TITLE
fix #138941: Subsequent time signatures are shown twice when the first one is changed

### DIFF
--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -261,10 +261,10 @@ void TrackList::read(const Segment* fs, const Segment* es)
       int tick = fs->tick();
       int gap  = 0;
 
-      while (fs && !fs->enabled())
-            fs = fs->next1();
       const Segment* s;
-      for (s = fs; s && (s != es); s = s->next1enabled()) {
+      for (s = fs; s && (s != es); s = s->next1()) {
+            if (!s->enabled())
+                  continue;
             Element* e = s->element(_track);
             if (!e || e->generated()) {
                   for (Element* ee : s->annotations()) {


### PR DESCRIPTION
See https://musescore.org/en/node/138941#comment-751716.

If _es_ is not enabled, the loop will not terminate until the end of the score is reached. This can have **very** bad consequences.