### PR TITLE
fix #275275: Move cancel button on new document to right for consistency

### DIFF
--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -453,7 +453,7 @@ NewWizard::NewWizard(QWidget* parent)
       setWindowTitle(tr("New Score Wizard"));
 
       setOption(QWizard::NoCancelButton, false);
-      setOption(QWizard::CancelButtonOnLeft, true);
+      setOption(QWizard::CancelButtonOnLeft, false);
       setOption(QWizard::HaveFinishButtonOnEarlyPages, true);
       setOption(QWizard::HaveNextButtonOnLastPage, true);
 


### PR DESCRIPTION
Addresses: https://musescore.org/en/node/275275