### PR TITLE
fix #275273: Crash after appending frames and their deletion

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1407,7 +1407,6 @@ void Score::removeElement(Element* element)
                         QPointF pos = page->pos();
                         auto i = std::find(pages().begin(), pages().end(), page);
                         pages().erase(i);
-                        i++;
                         while (i != pages().end()) {
                               page = *i;
                               page->setNo(page->no() - 1);


### PR DESCRIPTION
See https://musescore.org/en/node/275273.

It is a mistake to advance the iterator after erasing the page.