### PR TITLE
Fix #275218: Fix more MSVC warnings

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1524,8 +1524,8 @@ void Chord::layout2()
 
       const qreal minDist = _spatium * .17;
 
-      Segment* s = segment()->prev(SegmentType::ChordRest);
-      if (s) {
+      Segment* ps = segment()->prev(SegmentType::ChordRest);
+      if (ps) {
             int strack = staff2track(staffIdx());
             int etrack = strack + VOICES;
 
@@ -1537,7 +1537,7 @@ void Chord::layout2()
                   qreal cx  = h->measureXPos();
 
                   for (int track = strack; track < etrack; ++track) {
-                        Element* el = s->element(track);
+                        Element* el = ps->element(track);
                         if (!el || !el->isChord())
                               continue;
                         Chord* e = toChord(el);
@@ -2510,8 +2510,8 @@ void Chord::layoutArpeggio2()
 
 Note* Chord::findNote(int pitch) const
       {
-      int n = _notes.size();
-      for (int i = 0; i < n; ++i) {
+      int ns = _notes.size();
+      for (int i = 0; i < ns; ++i) {
             Note* n = _notes.at(i);
             if (n->pitch() == pitch)
                   return n;

--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -1147,7 +1147,7 @@ QString ParsedChord::fromXml(const QString& rawKind, const QString& rawKindText,
       {
       QString kind = rawKind;
       QString kindText = rawKindText;
-      bool symbols = (useSymbols == "yes");
+      bool syms = (useSymbols == "yes");
       bool parens = (useParens == "yes");
       bool implied = false;
       bool extend = false;
@@ -1182,7 +1182,7 @@ QString ParsedChord::fromXml(const QString& rawKind, const QString& rawKindText,
             _quality = "augmented";
       else if (kind == "half-diminished") {
             _quality = "half-diminished";
-            if (symbols) {
+            if (syms) {
                   extension = 7;
                   extend = true;
                   }
@@ -1327,15 +1327,15 @@ QString ParsedChord::fromXml(const QString& rawKind, const QString& rawKindText,
             _name = _extension;
       else {
             if (_quality == "major")
-                  _name = symbols ? "^" : "maj";
+                  _name = syms ? "^" : "maj";
             else if (_quality == "minor")
-                  _name = symbols ? "-" : "m";
+                  _name = syms ? "-" : "m";
             else if (_quality == "augmented")
-                  _name = symbols ? "+" : "aug";
+                  _name = syms ? "+" : "aug";
             else if (_quality == "diminished")
-                  _name = symbols ? "o" : "dim";
+                  _name = syms ? "o" : "dim";
             else if (_quality == "half-diminished")
-                  _name = symbols ? "0" : "m7b5";
+                  _name = syms ? "0" : "m7b5";
             else
                   _name = _quality;
             _name += _extension;
@@ -1677,8 +1677,8 @@ void ChordList::write(XmlWriter& xml) const
             writeRenderList(xml, &renderListRoot, "renderRoot");
       if (!renderListBase.empty())
             writeRenderList(xml, &renderListBase, "renderBase");
-      foreach(const ChordDescription& d, *this)
-            d.write(xml);
+      for (const ChordDescription& cd : *this)
+            cd.write(xml);
       }
 
 //---------------------------------------------------------

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1153,8 +1153,8 @@ void Element::undoSetVisible(bool v)
 QRectF Element::scriptBbox() const
       {
       qreal  _sp = spatium();
-      QRectF _bbox = bbox();
-      return QRectF(_bbox.x() / _sp, _bbox.y() / _sp, _bbox.width() / _sp, _bbox.height() / _sp);
+      QRectF bbox_ = bbox();
+      return QRectF(bbox_.x() / _sp, bbox_.y() / _sp, bbox_.width() / _sp, bbox_.height() / _sp);
       }
 
 //---------------------------------------------------------

--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -1527,22 +1527,22 @@ bool FiguredBassFont::read(XmlReader& e)
                   if (digit < 0 || digit > 9)
                         return false;
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "simple")
+                        const QStringRef& t(e.name());
+                        if (t == "simple")
                               displayDigit[int(FiguredBassItem::Style::MODERN)]  [digit][int(FiguredBassItem::Combination::SIMPLE)]      = e.readElementText()[0];
-                        else if (tag == "crossed")
+                        else if (t == "crossed")
                               displayDigit[int(FiguredBassItem::Style::MODERN)]  [digit][int(FiguredBassItem::Combination::CROSSED)]     = e.readElementText()[0];
-                        else if (tag == "backslashed")
+                        else if (t == "backslashed")
                               displayDigit[int(FiguredBassItem::Style::MODERN)]  [digit][int(FiguredBassItem::Combination::BACKSLASHED)] = e.readElementText()[0];
-                        else if (tag == "slashed")
+                        else if (t == "slashed")
                               displayDigit[int(FiguredBassItem::Style::MODERN)]  [digit][int(FiguredBassItem::Combination::SLASHED)]     = e.readElementText()[0];
-                        else if (tag == "simpleHistoric")
+                        else if (t == "simpleHistoric")
                               displayDigit[int(FiguredBassItem::Style::HISTORIC)][digit][int(FiguredBassItem::Combination::SIMPLE)]      = e.readElementText()[0];
-                        else if (tag == "crossedHistoric")
+                        else if (t == "crossedHistoric")
                               displayDigit[int(FiguredBassItem::Style::HISTORIC)][digit][int(FiguredBassItem::Combination::CROSSED)]     = e.readElementText()[0];
-                        else if (tag == "backslashedHistoric")
+                        else if (t == "backslashedHistoric")
                               displayDigit[int(FiguredBassItem::Style::HISTORIC)][digit][int(FiguredBassItem::Combination::BACKSLASHED)] = e.readElementText()[0];
-                        else if (tag == "slashedHistoric")
+                        else if (t == "slashedHistoric")
                               displayDigit[int(FiguredBassItem::Style::HISTORIC)][digit][int(FiguredBassItem::Combination::SLASHED)]     = e.readElementText()[0];
                         else {
                               e.unknown();
@@ -1585,13 +1585,13 @@ bool FiguredBass::readConfigFile(const QString& fileName)
       else
             path = fileName;
 
-      QFile f(path);
-      if (!f.open(QIODevice::ReadOnly)) {
-            MScore::lastError = QObject::tr("Cannot open figured bass description:\n%1\n%2").arg(f.fileName()).arg(f.errorString());
+      QFile fi(path);
+      if (!fi.open(QIODevice::ReadOnly)) {
+            MScore::lastError = QObject::tr("Cannot open figured bass description:\n%1\n%2").arg(fi.fileName()).arg(fi.errorString());
             qDebug("FiguredBass::read failed: <%s>", qPrintable(path));
             return false;
             }
-      XmlReader e(&f);
+      XmlReader e(&fi);
       while (e.readNextStartElement()) {
             if (e.name() == "museScore") {
                   // QString version = e.attribute(QString("version"));

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -447,12 +447,12 @@ void FretDiagram::read(XmlReader& e)
             else if (tag == "string") {
                   int no = e.intAttribute("no");
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "dot")
+                        const QStringRef& t(e.name());
+                        if (t == "dot")
                               setDot(no, e.readInt());
-                        else if (tag == "marker")
+                        else if (t == "marker")
                               setMarker(no, e.readInt());
-                        else if (tag == "fingering")
+                        else if (t == "fingering")
                               setFingering(no, e.readInt());
                         else
                               e.unknown();
@@ -591,14 +591,14 @@ void FretDiagram::scanElements(void* data, void (*func)(void*, Element*), bool a
 void FretDiagram::writeMusicXML(XmlWriter& xml) const
       {
       qDebug("FretDiagram::writeMusicXML() this %p harmony %p", this, _harmony);
-      int _strings = strings();
+      int strings_ = strings();
       xml.stag("frame");
-      xml.tag("frame-strings", _strings);
+      xml.tag("frame-strings", strings_);
       xml.tag("frame-frets", frets());
       QString strDots = "'";
       QString strMarker = "'";
       QString strFingering = "'";
-      for (int i = 0; i < _strings; ++i) {
+      for (int i = 0; i < strings_; ++i) {
             // TODO print frame note
             if (_dots)
                   strDots += QString("%1'").arg(static_cast<int>(_dots[i]));
@@ -608,7 +608,7 @@ void FretDiagram::writeMusicXML(XmlWriter& xml) const
                   strFingering += QString("%1'").arg(static_cast<int>(_fingering[i]));
             if (_marker[i] != 88) {
                   xml.stag("frame-note");
-                  xml.tag("string", _strings - i);
+                  xml.tag("string", strings_ - i);
                   if (_dots)
                         xml.tag("fret", _dots[i]);
                   else

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -93,9 +93,9 @@ void GlissandoSegment::draw(QPainter* painter) const
             }
       else if (glissando()->glissandoType() == GlissandoType::WAVY) {
             QRectF b = symBbox(SymId::wiggleTrill);
-            qreal w  = symAdvance(SymId::wiggleTrill);
-            int n    = (int)(l / w);      // always round down (truncate) to avoid overlap
-            qreal x  = (l - n*w) * 0.5;   // centre line in available space
+            qreal a  = symAdvance(SymId::wiggleTrill);
+            int n    = (int)(l / a);      // always round down (truncate) to avoid overlap
+            qreal x  = (l - n*a) * 0.5;   // centre line in available space
             std::vector<SymId> ids;
             for (int i = 0; i < n; ++i)
                   ids.push_back(SymId::wiggleTrill);
@@ -331,10 +331,10 @@ void Glissando::layout()
 
       // final note arpeggio / accidental / ledger line / accidental / arpeggio (i.e. from outermost to innermost)
       offs2 *= -1.0;          // discount changes already applied
-      if (Arpeggio* a = cr2->arpeggio())
-            offs2.rx() += a->pos().x() + a->userOff().x();
-      else if (Accidental* a = anchor2->accidental())
-            offs2.rx() += a->pos().x() + a->userOff().x();
+      if (Arpeggio* ap = cr2->arpeggio())
+            offs2.rx() += ap->pos().x() + ap->userOff().x();
+      else if (Accidental* ac = anchor2->accidental())
+            offs2.rx() += ac->pos().x() + ac->userOff().x();
       else if ( (ledLin = cr2->ledgerLines()) != nullptr)
             offs2.rx() += ledLin->pos().x();
 

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -293,12 +293,12 @@ void Harmony::read(XmlReader& e)
                   int degreeAlter = 0;
                   QString degreeType = "";
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "degree-value")
+                        const QStringRef& t(e.name());
+                        if (t == "degree-value")
                               degreeValue = e.readInt();
-                        else if (tag == "degree-alter")
+                        else if (t == "degree-alter")
                               degreeAlter = e.readInt();
-                        else if (tag == "degree-type")
+                        else if (t == "degree-type")
                               degreeType = e.readElementText();
                         else
                               e.unknown();

--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -92,8 +92,8 @@ void InstrumentGroup::read(XmlReader& e)
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "instrument" || tag == "Instrument") {
-                  QString id = e.attribute("id");
-                  InstrumentTemplate* t = searchTemplate(id);
+                  QString sid = e.attribute("id");
+                  InstrumentTemplate* t = searchTemplate(sid);
                   if (t == 0) {
                         t = new InstrumentTemplate;
                         t->articulation.append(articulation);     // init with global articulation

--- a/libmscore/key.cpp
+++ b/libmscore/key.cpp
@@ -174,10 +174,10 @@ void AccidentalState::init(Key key)
             for (int i = 0; i < int(key); ++i) {
                   int idx = tpc2step(20 + i);
                   for (int octave = 0; octave < (11 * 7); octave += 7) {
-                        int i = idx + octave;
-                        if (i >= MAX_ACC_STATE)
+                        int j = idx + octave;
+                        if (j >= MAX_ACC_STATE)
                               break;
-                        state[i] = 1 + 2;
+                        state[j] = 1 + 2;
                         }
                   }
             }
@@ -185,10 +185,10 @@ void AccidentalState::init(Key key)
             for (int i = 0; i > int(key); --i) {
                   int idx = tpc2step(12 + i);
                   for (int octave = 0; octave < (11 * 7); octave += 7) {
-                        int i = idx + octave ;
-                        if (i >= MAX_ACC_STATE)
+                        int j = idx + octave ;
+                        if (j >= MAX_ACC_STATE)
                               break;
-                        state[i] = -1 + 2;
+                        state[j] = -1 + 2;
                         }
                   }
             }

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -372,8 +372,8 @@ void KeySig::read(XmlReader& e)
             if (tag == "KeySym") {
                   KeySym ks;
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "sym") {
+                        const QStringRef& t(e.name());
+                        if (t == "sym") {
                               QString val(e.readElementText());
                               bool valid;
                               SymId id = SymId(val.toInt(&valid));
@@ -387,7 +387,7 @@ void KeySig::read(XmlReader& e)
                                     }
                               ks.sym = id;
                               }
-                        else if (tag == "pos")
+                        else if (t == "pos")
                               ks.spos = e.readPoint();
                         else
                               e.unknown();

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1396,8 +1396,8 @@ bool Note::readProperties(XmlReader& e)
       else if (tag == "Events") {
             _playEvents.clear();    // remove default event
             while (e.readNextStartElement()) {
-                  const QStringRef& tag(e.name());
-                  if (tag == "Event") {
+                  const QStringRef& t(e.name());
+                  if (t == "Event") {
                         NoteEvent ne;
                         ne.read(e);
                         _playEvents.append(ne);

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -572,14 +572,14 @@ void Score::localInsertChord(const Position& pos)
                         continue;
                         }
                   Segment* seg1 = 0;
-                  for (Segment* s = fs; s; s = s->next(SegmentType::ChordRest)) {
-                        if (s->element(track)) {
-                              ChordRest* cr = toChordRest(s->element(track));
-                              if (s->tick() > tick)
+                  for (Segment* ns = fs; ns; ns = ns->next(SegmentType::ChordRest)) {
+                        if (ns->element(track)) {
+                              ChordRest* cr = toChordRest(ns->element(track));
+                              if (ns->tick() > tick)
                                     break;
-                              if (s->tick() + cr->duration().ticks() < tick)
+                              if (ns->tick() + cr->duration().ticks() < tick)
                                     continue;
-                              seg1 = s;
+                              seg1 = ns;
                               break;
                               }
                         }

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -316,8 +316,8 @@ QString Page::replaceTextMacros(const QString& s) const
       for (int i = 0, n = s.size(); i < n; ++i) {
             QChar c = s[i];
             if (c == '$' && (i < (n-1))) {
-                  QChar c = s[i+1];
-                  switch(c.toLatin1()) {
+                  QChar nc = s[i+1];
+                  switch(nc.toLatin1()) {
                         case 'p': // not on first page 1
                               if (_no) // FALLTHROUGH
                         case 'N': // on page 1 only if there are multiple pages
@@ -392,7 +392,7 @@ QString Page::replaceTextMacros(const QString& s) const
                               break;
                         default:
                               d += '$';
-                              d += c;
+                              d += nc;
                               break;
                         }
                   ++i;

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1343,12 +1343,12 @@ static void readHarmony114(XmlReader& e, Harmony* h)
                   int degreeAlter = 0;
                   QString degreeType = "";
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "degree-value")
+                        const QStringRef& t(e.name());
+                        if (t == "degree-value")
                               degreeValue = e.readInt();
-                        else if (tag == "degree-alter")
+                        else if (t == "degree-alter")
                               degreeAlter = e.readInt();
-                        else if (tag == "degree-type")
+                        else if (t == "degree-type")
                               degreeType = e.readElementText();
                         else
                               e.unknown();
@@ -1477,8 +1477,8 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   barLine->resetProperty(Pid::BARLINE_SPAN_TO);
 
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "subtype") {
+                        const QStringRef& tg(e.name());
+                        if (tg == "subtype") {
                               BarLineType t = BarLineType::NORMAL;
                               switch (e.readInt()) {
                                     default:
@@ -1795,10 +1795,10 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   Text* _verseNumber = 0;
 
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "no")
+                        const QStringRef& t(e.name());
+                        if (t == "no")
                               l->setNo(e.readInt());
-                        else if (tag == "syllabic") {
+                        else if (t == "syllabic") {
                               QString val(e.readElementText());
                               if (val == "single")
                                     l->setSyllabic(Lyrics::Syllabic::SINGLE);
@@ -1811,14 +1811,14 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                               else
                                     qDebug("bad syllabic property");
                               }
-                        else if (tag == "endTick") {          // obsolete
+                        else if (t == "endTick") {          // obsolete
                               // store <endTick> tag value until a <ticks> tag has been read
                               // which positions this lyrics element in the score
                               iEndTick = e.readInt();
                               }
-                        else if (tag == "ticks")
+                        else if (t == "ticks")
                               l->setTicks(e.readInt());
-                        else if (tag == "Number") {                           // obsolete
+                        else if (t == "Number") {                           // obsolete
                               _verseNumber = new Text(l->score());
                               _verseNumber->read(e);
                               _verseNumber->setParent(l);
@@ -1911,16 +1911,16 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   Jump* j = new Jump(m->score());
                   j->setTrack(e.track());
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "jumpTo")
+                        const QStringRef& t(e.name());
+                        if (t == "jumpTo")
                               j->setJumpTo(e.readElementText());
-                        else if (tag == "playUntil")
+                        else if (t == "playUntil")
                               j->setPlayUntil(e.readElementText());
-                        else if (tag == "continueAt")
+                        else if (t == "continueAt")
                               j->setContinueAt(e.readElementText());
-                        else if (tag == "playRepeats")
+                        else if (t == "playRepeats")
                               j->setPlayRepeats(e.readBool());
-                        else if (tag == "subtype")
+                        else if (t == "subtype")
                               e.readInt();
                         else if (!j->TextBase::readProperties(e))
                               e.unknown();
@@ -1933,8 +1933,8 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
 
                   Marker::Type mt = Marker::Type::SEGNO;
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "subtype") {
+                        const QStringRef& t(e.name());
+                        if (t == "subtype") {
                               QString s(e.readElementText());
                               a->setLabel(s);
                               mt = a->markerType(s);
@@ -2034,8 +2034,8 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             else if (tag == "Segment") {
                   segment->read(e);
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "off1") {
+                        const QStringRef& t(e.name());
+                        if (t == "off1") {
                               qreal o = e.readDouble();
                               qDebug("TODO: off1 %f", o);
                               }
@@ -2458,8 +2458,8 @@ static void readPart(Part* part, XmlReader& e)
                         int n = 0;
                         if (st->lines(0) == 1)
                               n = 4;
-                        for (int  i = 0; i < DRUM_INSTRUMENTS; ++i)
-                              d->drum(i).line -= n;
+                        for (int  j = 0; j < DRUM_INSTRUMENTS; ++j)
+                              d->drum(j).line -= n;
                         }
                   }
             else if (tag == "name") {
@@ -2529,15 +2529,15 @@ static void readPageFormat(PageFormat* pf, XmlReader& e)
                   type = e.attribute("type","both");
                   qreal lm = 0.0, rm = 0.0, tm = 0.0, bm = 0.0;
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
+                        const QStringRef& t(e.name());
                         qreal val = e.readDouble() * 0.5 / PPI;
-                        if (tag == "left-margin")
+                        if (t == "left-margin")
                               lm = val;
-                        else if (tag == "right-margin")
+                        else if (t == "right-margin")
                               rm = val;
-                        else if (tag == "top-margin")
+                        else if (t == "top-margin")
                               tm = val;
-                        else if (tag == "bottom-margin")
+                        else if (t == "bottom-margin")
                               bm = val;
                         else
                               e.unknown();

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -966,8 +966,8 @@ static void readPart(Part* part, XmlReader& e)
                   Staff*   s = part->staff(0);
                   int lld = s ? qRound(s->lineDistance(0)) : 1;
                   if (ds && s && lld > 1) {
-                        for (int i = 0; i < DRUM_INSTRUMENTS; ++i)
-                              ds->drum(i).line /= lld;
+                        for (int j = 0; j < DRUM_INSTRUMENTS; ++j)
+                              ds->drum(j).line /= lld;
                         }
                   }
             else if (tag == "Staff") {
@@ -1279,8 +1279,8 @@ static void readChord(Chord* chord, XmlReader& e)
             else if (tag == "Stem") {
                   Stem* stem = new Stem(chord->score());
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "subtype")        // obsolete
+                        const QStringRef& t(e.name());
+                        if (t == "subtype")        // obsolete
                               e.skipCurrentElement();
                         else if (!stem->readProperties(e))
                               e.unknown();
@@ -1737,12 +1737,12 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   BarLine* bl = new BarLine(score);
                   bl->setTrack(e.track());
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "subtype")
+                        const QStringRef& t(e.name());
+                        if (t == "subtype")
                               bl->setBarLineType(e.readElementText());
-                        else if (tag == "customSubtype")                      // obsolete
+                        else if (t == "customSubtype")                      // obsolete
                               e.readInt();
-                        else if (tag == "span") {
+                        else if (t == "span") {
                               //TODO bl->setSpanFrom(e.intAttribute("from", bl->spanFrom()));  // obsolete
                               // bl->setSpanTo(e.intAttribute("to", bl->spanTo()));            // obsolete
                               int span = e.readInt();
@@ -1750,11 +1750,11 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                                     span--;
                               bl->setSpanStaff(span);
                               }
-                        else if (tag == "spanFromOffset")
+                        else if (t == "spanFromOffset")
                               bl->setSpanFrom(e.readInt());
-                        else if (tag == "spanToOffset")
+                        else if (t == "spanToOffset")
                               bl->setSpanTo(e.readInt());
-                        else if (tag == "Articulation") {
+                        else if (t == "Articulation") {
                               Articulation* a = new Articulation(score);
                               a->read(e);
                               bl->add(a);
@@ -2340,11 +2340,11 @@ static void readStaffContent(Score* score, XmlReader& e)
                         else {
                               // this is a multi measure rest
                               // always preceded by the first measure it replaces
-                              Measure* m = e.lastMeasure();
+                              Measure* lm = e.lastMeasure();
 
-                              if (m) {
-                                    m->setMMRest(measure);
-                                    measure->setTick(m->tick());
+                              if (lm) {
+                                    lm->setMMRest(measure);
+                                    measure->setTick(lm->tick());
                                     }
                               }
                         }
@@ -2507,10 +2507,10 @@ static bool readScore(Score* score, XmlReader& e)
                   score->setPlayMode(PlayMode(e.readInt()));
             else if (tag == "LayerTag") {
                   int id = e.intAttribute("id");
-                  const QString& tag = e.attribute("tag");
+                  const QString& t = e.attribute("tag");
                   QString val(e.readElementText());
                   if (id >= 0 && id < 32) {
-                        score->layerTags()[id] = tag;
+                        score->layerTags()[id] = t;
                         score->layerTagComments()[id] = val;
                         }
                   }
@@ -2738,15 +2738,15 @@ void PageFormat::read(XmlReader& e)
                   type = e.attribute("type","both");
                   qreal lm = 0.0, rm = 0.0, tm = 0.0, bm = 0.0;
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
+                        const QStringRef& t(e.name());
                         qreal val = e.readDouble() * 0.5 / PPI;
-                        if (tag == "left-margin")
+                        if (t == "left-margin")
                               lm = val;
-                        else if (tag == "right-margin")
+                        else if (t == "right-margin")
                               rm = val;
-                        else if (tag == "top-margin")
+                        else if (t == "top-margin")
                               tm = val;
-                        else if (tag == "bottom-margin")
+                        else if (t == "bottom-margin")
                               bm = val;
                         else
                               e.unknown();

--- a/libmscore/read300.cpp
+++ b/libmscore/read300.cpp
@@ -61,10 +61,10 @@ bool Score::read(XmlReader& e)
                   _playMode = PlayMode(e.readInt());
             else if (tag == "LayerTag") {
                   int id = e.intAttribute("id");
-                  const QString& tag = e.attribute("tag");
+                  const QString& t = e.attribute("tag");
                   QString val(e.readElementText());
                   if (id >= 0 && id < 32) {
-                        _layerTags[id] = tag;
+                        _layerTags[id] = t;
                         _layerTagComments[id] = val;
                         }
                   }

--- a/libmscore/splitMeasure.cpp
+++ b/libmscore/splitMeasure.cpp
@@ -93,10 +93,10 @@ void Score::splitMeasure(Segment* segment)
 
       for (auto i : sl) {
             Spanner* s = std::get<0>(i);
-            int tick   = std::get<1>(i);
+            int t      = std::get<1>(i);
             int ticks  = std::get<2>(i);
-            if (s->tick() != tick)
-                  s->undoChangeProperty(Pid::SPANNER_TICK, tick);
+            if (s->tick() != t)
+                  s->undoChangeProperty(Pid::SPANNER_TICK, t);
             if (s->ticks() != ticks)
                   s->undoChangeProperty(Pid::SPANNER_TICKS, ticks);
             }

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -5913,35 +5913,35 @@ void ScoreFont::load()
                   continue;
                   }
             Sym* sym = &_symbols[int(symId)];
-            for (auto i : ooo.keys()) {
-                  if (i == "stemDownNW") {
-                        qreal x = ooo.value(i).toArray().at(0).toDouble();
-                        qreal y = ooo.value(i).toArray().at(1).toDouble();
+            for (auto j : ooo.keys()) {
+                  if (j == "stemDownNW") {
+                        qreal x = ooo.value(j).toArray().at(0).toDouble();
+                        qreal y = ooo.value(j).toArray().at(1).toDouble();
                         sym->setStemDownNW(QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
                         }
-                  else if (i == "stemUpSE") {
-                        qreal x = ooo.value(i).toArray().at(0).toDouble();
-                        qreal y = ooo.value(i).toArray().at(1).toDouble();
+                  else if (j == "stemUpSE") {
+                        qreal x = ooo.value(j).toArray().at(0).toDouble();
+                        qreal y = ooo.value(j).toArray().at(1).toDouble();
                         sym->setStemUpSE(QPointF(4.0 * DPI_F * x, 4.0 * DPI_F * -y));
                         }
-                  else if (i == "cutOutNE") {
-                        qreal x = ooo.value(i).toArray().at(0).toDouble() * scale;
-                        qreal y = ooo.value(i).toArray().at(1).toDouble() * scale;
+                  else if (j == "cutOutNE") {
+                        qreal x = ooo.value(j).toArray().at(0).toDouble() * scale;
+                        qreal y = ooo.value(j).toArray().at(1).toDouble() * scale;
                         sym->setCutOutNE(QPointF(x, -y));
                         }
-                  else if (i == "cutOutNW") {
-                        qreal x = ooo.value(i).toArray().at(0).toDouble() * scale;
-                        qreal y = ooo.value(i).toArray().at(1).toDouble() * scale;
+                  else if (j == "cutOutNW") {
+                        qreal x = ooo.value(j).toArray().at(0).toDouble() * scale;
+                        qreal y = ooo.value(j).toArray().at(1).toDouble() * scale;
                         sym->setCutOutNW(QPointF(x, -y));
                         }
-                  else if (i == "cutOutSE") {
-                        qreal x = ooo.value(i).toArray().at(0).toDouble() * scale;
-                        qreal y = ooo.value(i).toArray().at(1).toDouble() * scale;
+                  else if (j == "cutOutSE") {
+                        qreal x = ooo.value(j).toArray().at(0).toDouble() * scale;
+                        qreal y = ooo.value(j).toArray().at(1).toDouble() * scale;
                         sym->setCutOutSE(QPointF(x, -y));
                         }
-                  else if (i == "cutOutSW") {
-                        qreal x = ooo.value(i).toArray().at(0).toDouble() * scale;
-                        qreal y = ooo.value(i).toArray().at(1).toDouble() * scale;
+                  else if (j == "cutOutSW") {
+                        qreal x = ooo.value(j).toArray().at(0).toDouble() * scale;
+                        qreal y = ooo.value(j).toArray().at(1).toDouble() * scale;
                         sym->setCutOutSW(QPointF(x, -y));
                         }
                   }

--- a/mscore/capxml.cpp
+++ b/mscore/capxml.cpp
@@ -934,10 +934,10 @@ void Capella::readCapxStaveLayout(XmlReader& e, CapStaffLayout* sl, int /*idx*/)
                   sl->abbrev = e.attribute("abbrev");
                   // elements name and abbrev overrule attributes name and abbrev
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "name")
+                        const QStringRef& t(e.name());
+                        if (t == "name")
                               sl->name = e.readElementText();
-                        else if (tag == "abbrev")
+                        else if (t == "abbrev")
                               sl->abbrev = e.readElementText();
                         else
                               e.unknown();

--- a/mscore/drumroll.cpp
+++ b/mscore/drumroll.cpp
@@ -89,8 +89,8 @@ DrumrollEditor::DrumrollEditor(QWidget* parent)
             QPalette p(b->palette());
             p.setColor(QPalette::Base, MScore::selectColor[i]);
             b->setPalette(p);
-            QAction* a = getAction(voiceActions[i]);
-            b->setDefaultAction(a);
+            QAction* aa = getAction(voiceActions[i]);
+            b->setDefaultAction(aa);
             tb->addWidget(b);
             }
 

--- a/mscore/editdrumset.cpp
+++ b/mscore/editdrumset.cpp
@@ -294,22 +294,20 @@ void EditDrumset::setEnabledPitchControls(bool enable)
 //   nameChanged
 //---------------------------------------------------------
 
-void EditDrumset::nameChanged(const QString& name)
+void EditDrumset::nameChanged(const QString& n)
       {
       QTreeWidgetItem* item = pitchList->currentItem();
       if (item) {
-            item->setText(Column::NAME, name);
+            item->setText(Column::NAME, n);
             int pitch = item->data(Column::PITCH, Qt::UserRole).toInt();
-            if (!name.isEmpty()) {
+            if (!n.isEmpty()) {
                   if (!nDrumset.isValid(pitch))
                         noteHead->setCurrentIndex(0);
                   }
-            else {
-                  int pitch = item->data(Column::PITCH, Qt::UserRole).toInt();
+            else
                   nDrumset.drum(pitch).name.clear();
-                  }
             }
-      setEnabledPitchControls(!name.isEmpty());
+      setEnabledPitchControls(!n.isEmpty());
       }
 
 //---------------------------------------------------------
@@ -527,24 +525,24 @@ void EditDrumset::updateExample()
             return;
             }
       int line      = nDrumset.line(pitch);
-      NoteHead::Group noteHead = nDrumset.noteHead(pitch);
-      int voice     = nDrumset.voice(pitch);
+      NoteHead::Group nh = nDrumset.noteHead(pitch);
+      int v         = nDrumset.voice(pitch);
       Direction dir = nDrumset.stemDirection(pitch);
       bool up = (Direction::UP == dir) || (Direction::AUTO == dir && line > 4);
       Chord* chord = new Chord(gscore);
       chord->setDurationType(TDuration::DurationType::V_QUARTER);
       chord->setStemDirection(dir);
-      chord->setTrack(voice);
+      chord->setTrack(v);
       chord->setUp(up);
       Note* note = new Note(gscore);
       note->setParent(chord);
-      note->setTrack(voice);
+      note->setTrack(v);
       note->setPitch(pitch);
       note->setTpcFromPitch();
       note->setLine(line);
       note->setPos(0.0, gscore->spatium() * .5 * line);
       note->setHeadType(NoteHead::Type::HEAD_QUARTER);
-      note->setHeadGroup(noteHead);
+      note->setHeadGroup(nh);
       note->setCachedNoteheadSym(Sym::name2id(quarterCmb->currentData().toString()));
       chord->add(note);
       Stem* stem = new Stem(gscore);
@@ -559,11 +557,11 @@ void EditDrumset::updateExample()
 
 void EditDrumset::load()
       {
-      QString name = mscore->getDrumsetFilename(true);
-      if (name.isEmpty())
+      QString fname = mscore->getDrumsetFilename(true);
+      if (fname.isEmpty())
             return;
 
-      QFile fp(name);
+      QFile fp(fname);
       if (!fp.open(QIODevice::ReadOnly))
             return;
 
@@ -593,11 +591,11 @@ void EditDrumset::load()
 
 void EditDrumset::save()
       {
-      QString name = mscore->getDrumsetFilename(false);
-      if (name.isEmpty())
+      QString fname = mscore->getDrumsetFilename(false);
+      if (fname.isEmpty())
             return;
 
-      QFile f(name);
+      QFile f(fname);
       if (!f.open(QIODevice::WriteOnly)) {
             QString s = tr("Open File\n%1\nfailed: %1").arg(strerror(errno));
             QMessageBox::critical(mscore, tr("Open File"), s.arg(f.fileName()));

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -80,12 +80,12 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
 
       // tab page configuration
       QList<QString> fontNames = StaffType::fontNames(false);
-      foreach (const QString& name, fontNames)   // fill fret font name combo
-            fretFontName->addItem(name);
+      foreach (const QString& fn, fontNames)   // fill fret font name combo
+            fretFontName->addItem(fn);
       fretFontName->setCurrentIndex(0);
       fontNames = StaffType::fontNames(true);
-      foreach(const QString& name, fontNames)   // fill duration font name combo
-            durFontName->addItem(name);
+      foreach(const QString& fn, fontNames)   // fill duration font name combo
+            durFontName->addItem(fn);
       durFontName->setCurrentIndex(0);
 
       for (auto i : noteHeadSchemes)
@@ -190,10 +190,10 @@ void EditStaffType::setValues()
       blockSignals(true);
 
       StaffGroup group = staffType.group();
-      int idx = int(group);
-      stack->setCurrentIndex(idx);
-      groupName->setText(qApp->translate("staff group header name", g_groupNames[idx]));
-//      groupCombo->setCurrentIndex(idx);
+      int i = int(group);
+      stack->setCurrentIndex(i);
+      groupName->setText(qApp->translate("staff group header name", g_groupNames[i]));
+//      groupCombo->setCurrentIndex(i);
 
       name->setText(staffType.name());
       lines->setValue(staffType.lines());
@@ -557,22 +557,22 @@ void EditStaffType::updatePreview()
 
 QString EditStaffType::createUniqueStaffTypeName(StaffGroup group)
       {
-      QString name;
+      QString sn;
       for (int idx = 1; ; ++idx) {
             switch (group) {
                   case StaffGroup::STANDARD:
-                        name = QString("Standard-%1 [*]").arg(idx);
+                        sn = QString("Standard-%1 [*]").arg(idx);
                         break;
                   case StaffGroup::PERCUSSION:
-                        name = QString("Perc-%1 [*]").arg(idx);
+                        sn = QString("Perc-%1 [*]").arg(idx);
                         break;
                   case StaffGroup::TAB:
-                        name = QString("Tab-%1 [*]").arg(idx);
+                        sn = QString("Tab-%1 [*]").arg(idx);
                         break;
                   }
             bool found = false;
             for (const StaffType& st : StaffType::presets()) {
-                  if (st.name() == name) {
+                  if (st.name() == sn) {
                         found = true;
                         break;
                         }
@@ -580,7 +580,7 @@ QString EditStaffType::createUniqueStaffTypeName(StaffGroup group)
             if (!found)
                   break;
             }
-      return name;
+      return sn;
       }
 
 //---------------------------------------------------------

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -287,9 +287,9 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                   Segment* s = toKeySig(e)->segment();
                   bool first = true;
                   for (int staffIdx = 0; staffIdx < _score->nstaves(); ++staffIdx) {
-                        Element* e = s->element(staffIdx * VOICES);
-                        if (e) {
-                              e->score()->select(e, first ? SelectType::SINGLE : SelectType::ADD);
+                        Element* ee = s->element(staffIdx * VOICES);
+                        if (ee) {
+                              ee->score()->select(ee, first ? SelectType::SINGLE : SelectType::ADD);
                               first = false;
                               }
                         }

--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -221,11 +221,11 @@ void ExampleView::paintEvent(QPaintEvent* ev)
 
 void ExampleView::dragEnterEvent(QDragEnterEvent* event)
       {
-      const QMimeData* data = event->mimeData();
-      if (data->hasFormat(mimeSymbolFormat)) {
+      const QMimeData* d = event->mimeData();
+      if (d->hasFormat(mimeSymbolFormat)) {
             event->acceptProposedAction();
 
-            QByteArray a = data->data(mimeSymbolFormat);
+            QByteArray a = d->data(mimeSymbolFormat);
 
 // qDebug("ExampleView::dragEnterEvent Symbol: <%s>", a.data());
 

--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -179,14 +179,14 @@ void ExcerptsDialog::newClicked()
       excerptList->selectionModel()->clearSelection();
       excerptList->setCurrentItem(ei, QItemSelectionModel::SelectCurrent);
       for (int i = 0; i < excerptList->count(); ++i) {
-            ExcerptItem* e = (ExcerptItem*)excerptList->item(i);
-            if (e->excerpt()->title() != e->text()) {
+            ExcerptItem* eii = (ExcerptItem*)excerptList->item(i);
+            if (eii->excerpt()->title() != eii->text()) {
                   // if except score not created yet, change the UI title
                   // if already created, change back(see createName) the excerpt title
-                  if (!e->excerpt()->partScore())
-                        e->setText(e->excerpt()->title());
+                  if (!eii->excerpt()->partScore())
+                        eii->setText(eii->excerpt()->title());
                   else
-                        e->excerpt()->setTitle(e->text());
+                        eii->excerpt()->setTitle(eii->text());
                   }
             }
       }
@@ -281,8 +281,8 @@ void ExcerptsDialog::addButtonClicked()
             for (Staff* s : *pi->part()->staves()) {
                   StaffItem* sli = new StaffItem(pi);
                   sli->setStaff(s);
-                  for (int i = 0; i < VOICES; i++)
-                        sli->setCheckState(i + 1, Qt::Checked);
+                  for (int j = 0; j < VOICES; j++)
+                        sli->setCheckState(j + 1, Qt::Checked);
                   }
             pi->setText(0, pi->part()->partName());
             }
@@ -580,7 +580,7 @@ void ExcerptsDialog::accept()
       // Update the score parts order following excerpList widget
       // The reference is the excerpt list. So we iterate following it and swap parts in the score accordingly
 
-      for (int i = 0; i < excerptList->count(); ++i) {
+      for (int j = 0; j < excerptList->count(); ++j) {
             excerptList->setCurrentRow(i);
             QListWidgetItem* cur = excerptList->currentItem();
             if (cur == 0)
@@ -597,8 +597,8 @@ void ExcerptsDialog::accept()
                         }
                   position++;
                   }
-            if ((found) && (position != i))
-                  score->undo(new SwapExcerpt(score, i, position));
+            if ((found) && (position != j))
+                  score->undo(new SwapExcerpt(score, j, position));
             }
       score->endCmd();
       QDialog::accept();

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -619,8 +619,8 @@ MasterScore* MuseScore::getNewFile()
                                           KeySig* keysig = new KeySig(score);
                                           keysig->setTrack(staffIdx * VOICES);
                                           keysig->setKeySigEvent(nKey);
-                                          Segment* s = measure->getSegment(SegmentType::KeySig, 0);
-                                          s->add(keysig);
+                                          Segment* ss = measure->getSegment(SegmentType::KeySig, 0);
+                                          ss->add(keysig);
                                           }
                                     }
                               }

--- a/mscore/importgtp-gp4.cpp
+++ b/mscore/importgtp-gp4.cpp
@@ -1019,7 +1019,7 @@ bool GuitarPro4::read(QFile* fp)
                                           if (seg->segmentType() == SegmentType::ChordRest) {
                                                 bool br = false;
                                                 Chord* cr = toChord(seg->cr(chord->track()));
-                                                if (cr)
+                                                if (cr) {
                                                       for (auto n : cr->notes()) {
                                                             if (n->string() == last->string()) {
                                                                   Glissando* s = new Glissando(score);
@@ -1039,10 +1039,11 @@ bool GuitarPro4::read(QFile* fp)
                                                                               createSlur(false, chord->staffIdx(), chord);
                                                                               }
                                                                         }
+                                                                  br = true;
+                                                                  break;
                                                                   }
-                                                            br = true;
-                                                            break;
                                                             }
+                                                      }
                                                 if (br)
                                                       break;
                                                 }
@@ -1090,24 +1091,24 @@ bool GuitarPro4::read(QFile* fp)
                                                       }
                                                 }
                                           }
-                                    }
-                              if (br)
-                                    break;
+                                    if (br)
+                                          break;
 #if 1  // TODO-ws: crash
-                              Glissando* s = new Glissando(score);
-                              s->setAnchor(Spanner::Anchor::NOTE);
-                              s->setStartElement(n);
-                              s->setTick(n->chord()->segment()->tick());
-                              s->setTrack(n->track());
-                              s->setParent(n);
-                              s->setGlissandoType(GlissandoType::STRAIGHT);
-                              s->setEndElement(nt);
-                              s->setTick2(nt->chord()->segment()->tick());
-                              s->setTrack2(n->track());
-                              score->addElement(s);
+                                    Glissando* s = new Glissando(score);
+                                    s->setAnchor(Spanner::Anchor::NOTE);
+                                    s->setStartElement(n);
+                                    s->setTick(n->chord()->segment()->tick());
+                                    s->setTrack(n->track());
+                                    s->setParent(n);
+                                    s->setGlissandoType(GlissandoType::STRAIGHT);
+                                    s->setEndElement(nt);
+                                    s->setTick2(nt->chord()->segment()->tick());
+                                    s->setTrack2(n->track());
+                                    score->addElement(s);
 #endif
-                              br = true;
-                              break;
+                                    br = true;
+                                    break;
+                                    }
                               }
                         if (br)
                               break;

--- a/mscore/importgtp-gp4.cpp
+++ b/mscore/importgtp-gp4.cpp
@@ -86,10 +86,10 @@ bool GuitarPro4::readMixChange(Measure* measure)
       if (tremolo >= 0)
             readChar();
       if (tempo >= 0) {
-	      if (last_segment) {
-		      score->setTempo(last_segment->tick(), double(tempo) / 60.0f);
-			last_segment = nullptr;
-			}
+            if (last_segment) {
+                  score->setTempo(last_segment->tick(), double(tempo) / 60.0f);
+                  last_segment = nullptr;
+                  }
             if (tempo != previousTempo) {
                   previousTempo = tempo;
                   setTempo(tempo, measure);
@@ -215,7 +215,7 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
             }
       else if (previousDynamic) {
             previousDynamic = 0;
-		//addDynamic(note, 0);
+            //addDynamic(note, 0);
             }
 
       int fretNumber = -1;
@@ -267,20 +267,20 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
             f->reset();
             }
       bool slur = false;
-	uchar modMask2{ 0 };
+      uchar modMask2{ 0 };
       if (noteBits & BEAT_EFFECTS) {
             uchar modMask1 = readUChar();
             modMask2 = readUChar();
-		if (modMask1 & EFFECT_BEND) {
+            if (modMask1 & EFFECT_BEND) {
                   readBend(note);
-			}
+                  }
             if (modMask1 & EFFECT_HAMMER) {
                   slur = true;
-			}
+                  }
             if (modMask1 & EFFECT_LET_RING) {
                   addLetRing(note);
-			//note->setLetRing(true);
-			}
+                  //note->setLetRing(true);
+                  }
             if (modMask2 & 0x40)
                   addVibrato(note);
             if (modMask1 & EFFECT_GRACE) {
@@ -332,7 +332,7 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
                         }
                   else if(transition == 1) {
                         //TODO: Add a 'slide' guitar effect when implemented
-//TODO-ws				note->setSlideNote(gn);
+                        //TODO-ws				note->setSlideNote(gn);
                         }
                   else if (transition == 2 && fretNumber>=0 && fretNumber<=255 && fretNumber!=gn->fret()) {
 #if 0
@@ -346,25 +346,25 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
                         gn->add(b);
 #endif
                         }
-                   else if (transition == 3) {
-                         // TODO:
-                         //     major: replace with a 'hammer-on' guitar effect when implemented
-                         //     minor: make slurs for parts
+                  else if (transition == 3) {
+                        // TODO:
+                        //     major: replace with a 'hammer-on' guitar effect when implemented
+                        //     minor: make slurs for parts
 
-                         ChordRest* cr1 = toChord(gc);
-                         ChordRest* cr2 = toChord(note->chord());
+                        ChordRest* cr1 = toChord(gc);
+                        ChordRest* cr2 = toChord(note->chord());
 
-                         Slur* slur = new Slur(score);
-                         slur->setAnchor(Spanner::Anchor::CHORD);
-                         slur->setStartElement(cr1);
-                         slur->setEndElement(cr2);
-                         slur->setTick(cr1->tick());
-                         slur->setTick2(cr2->tick());
-                         slur->setTrack(cr1->track());
-                         slur->setTrack2(cr2->track());
-                         // this case specifies only two-note slurs, don't set a parent
-                         score->undoAddElement(slur);
-                         }
+                        Slur* slur = new Slur(score);
+                        slur->setAnchor(Spanner::Anchor::CHORD);
+                        slur->setStartElement(cr1);
+                        slur->setEndElement(cr2);
+                        slur->setTick(cr1->tick());
+                        slur->setTick2(cr2->tick());
+                        slur->setTrack(cr1->track());
+                        slur->setTrack2(cr2->track());
+                        // this case specifies only two-note slurs, don't set a parent
+                        score->undoAddElement(slur);
+                        }
                   }
             if (modMask2 & EFFECT_STACATTO) {   // staccato
                   Chord* chord = note->chord();
@@ -374,8 +374,8 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
                   }
             if (modMask2 & EFFECT_PALM_MUTE) {
                   //note->setPalmMute(true);
-			addPalmMute(note);
-			}
+                  addPalmMute(note);
+                  }
 
             if (modMask2 & EFFECT_TREMOLO) {    // tremolo picking length
                   int tremoloDivision = readUChar();
@@ -399,19 +399,19 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
             if (modMask2 & EFFECT_SLIDE) {
                   int slideKind = readUChar();
                   // if slide >= 4 then we are not dealing with legato slide nor shift slide
-				  if (slideKind >= 3 || slideKind == 254 || slideKind == 255) {
-					  slide = slideKind;
-				  }
-				  else
-					  //slides[note->chord()->track()] = slideKind;
-					  slideList.push_back(note);
-				  if (slideKind == 2)
-					  slur = true;
+                  if (slideKind >= 3 || slideKind == 254 || slideKind == 255) {
+                        slide = slideKind;
+                        }
+                  else
+                        //slides[note->chord()->track()] = slideKind;
+                        slideList.push_back(note);
+                  if (slideKind == 2)
+                        slur = true;
                   }
 
             if (modMask2 & EFFECT_TRILL) {
                   /* unsigned char a = */ readUChar();
-//TODO-ws                  note->setTrillFret(a);      // trill fret
+                  //TODO-ws                  note->setTrillFret(a);      // trill fret
                   /*int period =*/ readUChar();      // trill length
 
                   // add the trill articulation to the note
@@ -440,117 +440,117 @@ bool GuitarPro4::readNote(int string, int staffIdx, Note* note)
       note->setPitch(std::min(pitch, 127));
 
       if (modMask2 & 0x10) {
-	      int type = readUChar();      // harmonic kind
-		if (type == 1) //Natural
-		      ; // TODO-ws note->setHarmonic(false);
-		else if (type == 3) // Tapped
-			addTextToNote("T.H.", Align::CENTER, note);
-		else if (type == 4) //Pinch
-			addTextToNote("P.H.", Align::CENTER, note);
-		else if (type == 5) //semi
-			addTextToNote("S.H.", Align::CENTER, note);
-		else { //Artificial
-		      addTextToNote("A.H.", Align::CENTER, note);
-			int harmonicFret = note->fret();
-			harmonicFret += type - 10;
-			Note* harmonicNote = new Note(score);
-			note->chord()->add(harmonicNote);
-			harmonicNote->setFret(harmonicFret);
-			harmonicNote->setString(note->string());
-//TODO-ws			harmonicNote->setHarmonic(true);
-			harmonicNote->setPitch(note->staff()->part()->instrument()->stringData()->getPitch(note->string(), harmonicFret, nullptr, 0));
-			harmonicNote->setTpcFromPitch();
+            int type = readUChar();      // harmonic kind
+            if (type == 1) //Natural
+                  ; // TODO-ws note->setHarmonic(false);
+            else if (type == 3) // Tapped
+                  addTextToNote("T.H.", Align::CENTER, note);
+            else if (type == 4) //Pinch
+                  addTextToNote("P.H.", Align::CENTER, note);
+            else if (type == 5) //semi
+                  addTextToNote("S.H.", Align::CENTER, note);
+            else { //Artificial
+                  addTextToNote("A.H.", Align::CENTER, note);
+                  int harmonicFret = note->fret();
+                  harmonicFret += type - 10;
+                  Note* harmonicNote = new Note(score);
+                  note->chord()->add(harmonicNote);
+                  harmonicNote->setFret(harmonicFret);
+                  harmonicNote->setString(note->string());
+                  //TODO-ws			harmonicNote->setHarmonic(true);
+                  harmonicNote->setPitch(note->staff()->part()->instrument()->stringData()->getPitch(note->string(), harmonicFret, nullptr, 0));
+                  harmonicNote->setTpcFromPitch();
                   }
             }
 
       if (tieNote) {
-	      int si = note->staffIdx();
-		if (slurs[si]) {
+            int si = note->staffIdx();
+            if (slurs[si]) {
                   score->removeSpanner(slurs[si]);
-			delete slurs[si];
-			slurs[si] = 0;
-		      }
+                  delete slurs[si];
+                  slurs[si] = 0;
+                  }
             bool found = false;
-		Chord* chord = note->chord();
-		Segment* segment = chord->segment()->prev1(SegmentType::ChordRest);
-		int track = note->track();
-		std::vector<ChordRest*> chords;
-		Note* true_note = 0;
-		while (segment) {
+            Chord* chord = note->chord();
+            Segment* segment = chord->segment()->prev1(SegmentType::ChordRest);
+            int track = note->track();
+            std::vector<ChordRest*> chords;
+            Note* true_note = 0;
+            while (segment) {
                   Element* e = segment->element(track);
-			if (e) {
-			      if (e->isChord()) {
-				      Chord* chord2 = toChord(e);
-					foreach (Note* note2, chord2->notes()) {
-					      if (note2->string() == string) {
-						      if (chords.empty()) {
+                  if (e) {
+                        if (e->isChord()) {
+                              Chord* chord2 = toChord(e);
+                              foreach (Note* note2, chord2->notes()) {
+                                    if (note2->string() == string) {
+                                          if (chords.empty()) {
                                                 Tie* tie = new Tie(score);
-								tie->setEndNote(note);
-								note2->add(tie);
-							      }
+                                                tie->setEndNote(note);
+                                                note2->add(tie);
+                                                }
                                           note->setFret(note2->fret());
-							note->setPitch(note2->pitch());
-							true_note = note2;
-							found = true;
+                                          note->setPitch(note2->pitch());
+                                          true_note = note2;
+                                          found = true;
                                           break;
-						      }
-					      }
-				      }
+                                          }
+                                    }
+                              }
                         if (found)
-				      break;
+                              break;
                         else {
-				      if (e)
+                              if (e)
                                     chords.push_back(toChordRest(e));
                               }
-			      }
+                        }
                   segment = segment->prev1(SegmentType::ChordRest);
                   }
             if (true_note && chords.size()) {
                   Note* end_note = note;
-			for (unsigned int i = 0; i < chords.size(); ++i) {
+                  for (unsigned int i = 0; i < chords.size(); ++i) {
                         Chord* chord = nullptr;
-				auto cr = chords.at(i);
-				if (cr->isChord())
+                        auto cr = chords.at(i);
+                        if (cr->isChord())
                               chord = toChord(cr);
                         else {
-				      Rest* rest = toRest(cr);
-					auto dur = rest->duration();
-					auto dut = rest->durationType();
-					auto seg = rest->segment();
-					seg->remove(rest);
-					auto tuplet = rest->tuplet();
-					if (tuplet)
+                              Rest* rest = toRest(cr);
+                              auto dur = rest->duration();
+                              auto dut = rest->durationType();
+                              auto seg = rest->segment();
+                              seg->remove(rest);
+                              auto tuplet = rest->tuplet();
+                              if (tuplet)
                                     tuplet->remove(rest);
                               delete rest;
-					chord = new Chord(score);
-					chord->setTrack(note->track());
-					chord->setDuration(dur);
-					chord->setDurationType(dut);
-					seg->add(chord);
-					if (tuplet)
+                              chord = new Chord(score);
+                              chord->setTrack(note->track());
+                              chord->setDuration(dur);
+                              chord->setDurationType(dut);
+                              seg->add(chord);
+                              if (tuplet)
                                     tuplet->add(chord);
                               }
 
                         Note* note2 = new Note(score);
-				note2->setString(true_note->string());
-				note2->setFret(true_note->fret());
-				note2->setPitch(true_note->pitch());
-				note2->setTpcFromPitch();
-				chord->setNoteType(true_note->noteType());
-				chord->add(note2);
-				Tie* tie = new Tie(score);
-				tie->setEndNote(end_note);
-//TODO-ws			end_note->setHarmonic(true_note->harmonic());
-				end_note = note2;
-				note2->add(tie);
+                        note2->setString(true_note->string());
+                        note2->setFret(true_note->fret());
+                        note2->setPitch(true_note->pitch());
+                        note2->setTpcFromPitch();
+                        chord->setNoteType(true_note->noteType());
+                        chord->add(note2);
+                        Tie* tie = new Tie(score);
+                        tie->setEndNote(end_note);
+                        //TODO-ws			end_note->setHarmonic(true_note->harmonic());
+                        end_note = note2;
+                        note2->add(tie);
                         }
                   Tie* tie = new Tie(score);
-			tie->setEndNote(end_note);
-//TODO-ws		end_note->setHarmonic(true_note->harmonic());
+                  tie->setEndNote(end_note);
+                  //TODO-ws		end_note->setHarmonic(true_note->harmonic());
                   true_note->add(tie);
                   }
             if (!found) {
-		      qDebug("tied note not found, pitch %d fret %d string %d", note->pitch(), note->fret(), note->string());
+                  qDebug("tied note not found, pitch %d fret %d string %d", note->pitch(), note->fret(), note->string());
                   return false;
                   }
             }
@@ -587,9 +587,9 @@ int GuitarPro4::convertGP4SlideNum(int slide)
       {
       switch (slide) {
             case 1:
-		      return SHIFT_SLIDE;
-		case 2:
-			return LEGATO_SLIDE;
+                  return SHIFT_SLIDE;
+            case 2:
+                  return LEGATO_SLIDE;
             case 3:     // slide out downwards
                   return SLIDE_OUT_DOWN;
             case 4:     // slide out upwards
@@ -630,8 +630,8 @@ bool GuitarPro4::read(QFile* fp)
       measures = readInt();
       staves   = readInt();
 
-	curDynam.resize(staves * VOICES);
-	for (auto& i : curDynam)
+      curDynam.resize(staves * VOICES);
+      for (auto& i : curDynam)
             i = -1;
 
       int tnumerator   = 4;
@@ -716,12 +716,12 @@ bool GuitarPro4::read(QFile* fp)
             int capo         = readInt();
             /*int color        =*/ readInt();
 
-			std::vector<int> tuning2(strings);
+            std::vector<int> tuning2(strings);
             //int tuning2[strings];
             for (int k = 0; k < strings; ++k)
                   tuning2[strings-k-1] = tuning[k];
             StringData stringData(frets, strings, &tuning2[0]);
-			createTuningString(strings, &tuning2[0]);
+            createTuningString(strings, &tuning2[0]);
             Part* part = score->staff(i)->part();
             Instrument* instr = part->instrument();
             instr->setStringData(stringData);
@@ -777,18 +777,18 @@ bool GuitarPro4::read(QFile* fp)
             }
 
       slurs = new Slur*[staves];
-	tupleKind.resize(staves);
-	for (auto& i : tupleKind)
-	      i = 0;
+      tupleKind.resize(staves);
+      for (auto& i : tupleKind)
+            i = 0;
       for (int i = 0; i < staves; ++i)
             slurs[i] = 0;
 
       Measure* measure = score->firstMeasure();
       bool mixChange = false;
-	bool lastSlurAdd = false;
+      bool lastSlurAdd = false;
       for (int bar = 0; bar < measures; ++bar, measure = measure->nextMeasure()) {
-		  if (!f->isReadable())
-			  break;
+            if (!f->isReadable())
+                  break;
             const GpBar& gpbar = bars[bar];
             if (!gpbar.marker.isEmpty()) {
                   RehearsalMark* s = new RehearsalMark(score);
@@ -822,21 +822,21 @@ bool GuitarPro4::read(QFile* fp)
                               pause = readUChar();
                         int len = readChar();
                         int tuple = 0;
-				if (beatBits & BEAT_TUPLET) {
+                        if (beatBits & BEAT_TUPLET) {
                               tuple = readInt();
 #if 0 // TODO: ws
-					if (tupleKind[staffIdx])
+                              if (tupleKind[staffIdx])
                                     --tupleKind[staffIdx];
                               else {
                                     tupleKind[staffIdx] = tuple - 1;
-						curTuple = tuple;
-						}
+                                    curTuple = tuple;
+                                    }
 #endif
-				      }
+                              }
                         else if (tupleKind[staffIdx]) {
-//TODO: ws                              tuple = curTuple;
-//					--tupleKind[staffIdx];
-					}
+                              //TODO: ws                              tuple = curTuple;
+                              //					--tupleKind[staffIdx];
+                              }
                         Segment* segment = measure->getSegment(SegmentType::ChordRest, tick);
                         if (beatBits & BEAT_CHORD) {
                               int numStrings = score->staff(staffIdx)->part()->instrument()->stringData()->strings();
@@ -856,24 +856,24 @@ bool GuitarPro4::read(QFile* fp)
                               }
 
                         Lyrics* lyrics = 0;
-				if (beatBits & BEAT_LYRICS) {
+                        if (beatBits & BEAT_LYRICS) {
                               lyrics = new Lyrics(score);
-					auto  str = readDelphiString();
-//TODO-ws					str.erase(std::remove_if(str.begin(), str.end(), [](char c){return c == '_'; }), str.end());
-					lyrics->setPlainText(str);
+                              auto  str = readDelphiString();
+                              //TODO-ws					str.erase(std::remove_if(str.begin(), str.end(), [](char c){return c == '_'; }), str.end());
+                              lyrics->setPlainText(str);
                               }
                         gpLyrics.beatCounter++;
                         if (gpLyrics.beatCounter >= gpLyrics.fromBeat && gpLyrics.lyricTrack == staffIdx + 1) {
                               int index = gpLyrics.beatCounter - gpLyrics.fromBeat;
                               if (index < gpLyrics.lyrics.size()) {
                                     lyrics = new Lyrics(score);
-									lyrics->setPlainText(gpLyrics.lyrics[index]);
+                                    lyrics->setPlainText(gpLyrics.lyrics[index]);
                                     }
                               }
                         int beatEffects = 0;
                         if (beatBits & BEAT_EFFECTS)
                               beatEffects = readBeatEffects(track, segment);
-						last_segment = segment;
+                        last_segment = segment;
                         if (beatBits & BEAT_MIX_CHANGE) {
                               readMixChange(measure);
                               mixChange = true;
@@ -942,35 +942,35 @@ bool GuitarPro4::read(QFile* fp)
                         Staff* staff   = cr->staff();
                         int numStrings = staff->part()->instrument()->stringData()->strings();
                         bool hasSlur   = false;
-				int dynam      = -1;
-if (cr && cr->isChord()) {    // TODO::ws  crashes without if
-                        for (int i = 6; i >= 0; --i) {
-                              if (strings & (1 << i) && ((6-i) < numStrings)) {
-                                    Note* note = new Note(score);
-                                    // apply dotted notes to the note
-                                    if (dotted) {
-                                          // there is at most one dotted note in this guitar pro version
-                                          NoteDot* dot = new NoteDot(score);
-                                          dot->setParent(note);
-                                          dot->setTrack(track);  // needed to know the staff it belongs to (and detect tablature)
-                                          dot->setVisible(true);
-                                          note->add(dot);
-                                          }
-                                    toChord(cr)->add(note);
+                        int dynam      = -1;
+                        if (cr && cr->isChord()) {    // TODO::ws  crashes without if
+                              for (int i = 6; i >= 0; --i) {
+                                    if (strings & (1 << i) && ((6-i) < numStrings)) {
+                                          Note* note = new Note(score);
+                                          // apply dotted notes to the note
+                                          if (dotted) {
+                                                // there is at most one dotted note in this guitar pro version
+                                                NoteDot* dot = new NoteDot(score);
+                                                dot->setParent(note);
+                                                dot->setTrack(track);  // needed to know the staff it belongs to (and detect tablature)
+                                                dot->setVisible(true);
+                                                note->add(dot);
+                                                }
+                                          toChord(cr)->add(note);
 
-                                    hasSlur = readNote(6-i, staffIdx, note);
-						dynam = std::max(dynam, previousDynamic);
-                                    note->setTpcFromPitch();
+                                          hasSlur = readNote(6-i, staffIdx, note);
+                                          dynam = std::max(dynam, previousDynamic);
+                                          note->setTpcFromPitch();
+                                          }
                                     }
-                              }
-} //ws
+                              } //ws
                         if (cr && cr->isChord()) {
                               applyBeatEffects(toChord(cr), beatEffects);
-					if (dynam != curDynam[track]) {
+                              if (dynam != curDynam[track]) {
                                     curDynam[track] = dynam;
-						addDynamic(toChord(cr)->notes().front(), dynam);
-						}
-				      }
+                                    addDynamic(toChord(cr)->notes().front(), dynam);
+                                    }
+                              }
 
                         // if we see that a tied note has been constructed do not create the tie
                         if (slides[track] == -2) {
@@ -978,81 +978,81 @@ if (cr && cr->isChord()) {    // TODO::ws  crashes without if
                               slides[track] = -1;
                               }
                         bool slurSwap = true;
-				if (slide != 2) {
+                        if (slide != 2) {
                               if (hasSlur && (slurs[staffIdx] == 0)) {
-					      Slur* slur = new Slur(score);
-						slur->setParent(0);
-						slur->setTrack(track);
-						slur->setTrack2(track);
-						slur->setTick(cr->tick());
-						slur->setTick2(cr->tick());
-						slurs[staffIdx] = slur;
-						score->addElement(slur);
-						}
-					else if (slurs[staffIdx] && !hasSlur) {
-					      // TODO: check slur
-						Slur* s = slurs[staffIdx];
-						slurs[staffIdx] = 0;
-						s->setTick2(cr->tick());
-						s->setTrack2(cr->track());
-						if (cr->isChord()) {
+                                    Slur* slur = new Slur(score);
+                                    slur->setParent(0);
+                                    slur->setTrack(track);
+                                    slur->setTrack2(track);
+                                    slur->setTick(cr->tick());
+                                    slur->setTick2(cr->tick());
+                                    slurs[staffIdx] = slur;
+                                    score->addElement(slur);
+                                    }
+                              else if (slurs[staffIdx] && !hasSlur) {
+                                    // TODO: check slur
+                                    Slur* s = slurs[staffIdx];
+                                    slurs[staffIdx] = 0;
+                                    s->setTick2(cr->tick());
+                                    s->setTrack2(cr->track());
+                                    if (cr->isChord()) {
                                           lastSlurAdd = true;
                                           slurSwap = false;
                                           }
-//TODO-ws                           cr->has_slur = true;
-						}
-					else if (slurs[staffIdx] && hasSlur) {
-					      }
+                                    //TODO-ws                           cr->has_slur = true;
+                                    }
+                              else if (slurs[staffIdx] && hasSlur) {
+                                    }
                               }
                         if (cr && (cr->isChord()) && slide > 0) {
                               auto chord = toChord(cr);
-					auto effect = convertGP4SlideNum(slide);
-					if (slide > 2)
-					      createSlide(convertGP4SlideNum(slide), cr, staffIdx);
+                              auto effect = convertGP4SlideNum(slide);
+                              if (slide > 2)
+                                    createSlide(convertGP4SlideNum(slide), cr, staffIdx);
                               if (slide < 3 || effect == SLIDE_OUT_UP) {
                                     Note* last = chord->upNote();
-						auto seg = chord->segment();
-						Measure* mes = seg->measure();
-						while ((seg = seg->prev()) || (mes = mes->prevMeasure())) {
+                                    auto seg = chord->segment();
+                                    Measure* mes = seg->measure();
+                                    while ((seg = seg->prev()) || (mes = mes->prevMeasure())) {
                                           if (!seg)
                                                 break;//seg = mes->last();
                                           if (seg->segmentType() == SegmentType::ChordRest) {
                                                 bool br = false;
-								Chord* cr = toChord(seg->cr(chord->track()));
-								if (cr)
-								      for (auto n : cr->notes()) {
-									      if (n->string() == last->string()) {
+                                                Chord* cr = toChord(seg->cr(chord->track()));
+                                                if (cr)
+                                                      for (auto n : cr->notes()) {
+                                                            if (n->string() == last->string()) {
                                                                   Glissando* s = new Glissando(score);
-											s->setAnchor(Spanner::Anchor::NOTE);
-											s->setStartElement(n);
-											s->setTick(seg->tick());
-											s->setTrack(chord->track());
-											s->setParent(n);
-											s->setGlissandoType(GlissandoType::STRAIGHT);
-											s->setEndElement(last);
-											s->setTick2(chord->segment()->tick());
-											s->setTrack2(chord->track());
-											score->addElement(s);
-											if (slide == 2 || effect == SLIDE_OUT_UP) {
-										      	if (!lastSlurAdd) {
-											      	createSlur(true, chord->staffIdx(), cr);
-												      createSlur(false, chord->staffIdx(), chord);
-      											      }
-	      									      }
+                                                                  s->setAnchor(Spanner::Anchor::NOTE);
+                                                                  s->setStartElement(n);
+                                                                  s->setTick(seg->tick());
+                                                                  s->setTrack(chord->track());
+                                                                  s->setParent(n);
+                                                                  s->setGlissandoType(GlissandoType::STRAIGHT);
+                                                                  s->setEndElement(last);
+                                                                  s->setTick2(chord->segment()->tick());
+                                                                  s->setTrack2(chord->track());
+                                                                  score->addElement(s);
+                                                                  if (slide == 2 || effect == SLIDE_OUT_UP) {
+                                                                        if (!lastSlurAdd) {
+                                                                              createSlur(true, chord->staffIdx(), cr);
+                                                                              createSlur(false, chord->staffIdx(), chord);
+                                                                              }
+                                                                        }
                                                                   }
                                                             br = true;
-										break;
-									      }
-									if (br)
                                                             break;
-									}
-								}
-							}
-						}
-				if (slurSwap)
+                                                            }
+                                                if (br)
+                                                      break;
+                                                }
+                                          }
+                                    }
+                              }
+                        if (slurSwap)
                               lastSlurAdd = false;
                         restsForEmptyBeats(segment, measure, cr, l, track, tick);
-				createSlur(hasSlur, staffIdx, cr);
+                        createSlur(hasSlur, staffIdx, cr);
                         tick += cr->actualTicks();
                         measureLen += cr->actualFraction();
                         }
@@ -1066,54 +1066,54 @@ if (cr && cr->isChord()) {    // TODO::ws  crashes without if
             }
 
       for (auto n : slideList) {
-		Segment* segment = n->chord()->segment();
-		Measure* measure = segment->measure();
-		int segment_counter = 0;
-		while ((segment = segment->next1(SegmentType::ChordRest)) || ((measure = measure->nextMeasure()) && (segment = measure->first()))) {
+            Segment* segment = n->chord()->segment();
+            Measure* measure = segment->measure();
+            int segment_counter = 0;
+            while ((segment = segment->next1(SegmentType::ChordRest)) || ((measure = measure->nextMeasure()) && (segment = measure->first()))) {
                   if (!segment->isChordRestType())
                         continue;
                   bool br = false;
-			ChordRest* cr = segment->cr(n->track());
+                  ChordRest* cr = segment->cr(n->track());
                   if (cr && cr->isChord()) {
                         Chord* c = toChord(cr);
                         ++segment_counter;
-				if (segment_counter > 2)
-				      break;
+                        if (segment_counter > 2)
+                              break;
                         for (Note* nt : c->notes()) {
                               if (nt->string() == n->string()) {
                                     for (auto e : nt->el()) {
-						      if (e->isChordLine()) {
+                                          if (e->isChordLine()) {
                                                 auto cl = toChordLine(e);
                                                 if (cl->chordLineType() == ChordLineType::PLOP || cl->chordLineType() == ChordLineType::SCOOP) {
-								      br = true;
-							            break;
-      								}
-	      					      }
-		      				}
+                                                      br = true;
+                                                      break;
+                                                      }
+                                                }
+                                          }
                                     }
-			            if (br)
+                              if (br)
                                     break;
 #if 1  // TODO-ws: crash
                               Glissando* s = new Glissando(score);
-		      		s->setAnchor(Spanner::Anchor::NOTE);
-			      	s->setStartElement(n);
-				      s->setTick(n->chord()->segment()->tick());
-      				s->setTrack(n->track());
-	      			s->setParent(n);
-		      		s->setGlissandoType(GlissandoType::STRAIGHT);
-			      	s->setEndElement(nt);
-				      s->setTick2(nt->chord()->segment()->tick());
-      				s->setTrack2(n->track());
-	      			score->addElement(s);
+                              s->setAnchor(Spanner::Anchor::NOTE);
+                              s->setStartElement(n);
+                              s->setTick(n->chord()->segment()->tick());
+                              s->setTrack(n->track());
+                              s->setParent(n);
+                              s->setGlissandoType(GlissandoType::STRAIGHT);
+                              s->setEndElement(nt);
+                              s->setTick2(nt->chord()->segment()->tick());
+                              s->setTrack2(n->track());
+                              score->addElement(s);
 #endif
-		      		br = true;
-			      	break;
-				      }
-      		      if (br)
+                              br = true;
                               break;
-		            }
-		      }
-	      }
+                              }
+                        if (br)
+                              break;
+                        }
+                  }
+            }
 
       return true;
       }

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -838,10 +838,10 @@ void createMeasures(const ReducedFraction &firstTick, ReducedFraction &lastTick,
 
       for (int i = begBarIndex; i < barCount; ++i) {
             Measure* m = new Measure(score);
-            const int tick = score->sigmap()->bar2tick(i, 0);
+            const int t = score->sigmap()->bar2tick(i, 0);
             m->setTick(tick);
             m->setNo(i);
-            const Fraction timeSig = score->sigmap()->timesig(tick).timesig();
+            const Fraction timeSig = score->sigmap()->timesig(t).timesig();
             m->setTimesig(timeSig);
             m->setLen(timeSig);
             score->measures()->add(m);

--- a/mscore/importmidi/importmidi_meter.cpp
+++ b/mscore/importmidi/importmidi_meter.cpp
@@ -211,8 +211,8 @@ Meter::MaxLevel maxLevelBetween(const ReducedFraction &startTickInBar,
                   maxEndRaster -= divLen;
             if (startTickInDiv < maxEndRaster) {
                               // max level is found
-                  const auto ratio = startTickInDiv / divLen;
-                  const auto maxStartRaster = divLen * (ratio.numerator() / ratio.denominator());
+                  const auto sratio = startTickInDiv / divLen;
+                  const auto maxStartRaster = divLen * (sratio.numerator() / sratio.denominator());
                   const auto count = (maxEndRaster - maxStartRaster) / divLen;
                   level.pos = maxStartRaster + divLen + divInfo.onTime;
                   level.levelCount = count.numerator() / count.denominator();
@@ -385,8 +385,8 @@ collectDurations(const std::map<ReducedFraction, Node> &nodes,
             const auto tupletRatio = findTupletRatio(it1->first, it2->first, tupletsInBar);
             const auto duration = tupletRatio * (it2->first - it1->first);
             auto list = toDurationList(duration.fraction(), useDots, 1, printRestRemains);
-            for (const auto &duration: list)
-                  resultDurations.push_back({tupletRatio, duration});
+            for (const auto &dur : list)
+                  resultDurations.push_back({tupletRatio, dur});
             }
 
       return resultDurations;

--- a/mscore/importmidi/importmidi_view.cpp
+++ b/mscore/importmidi/importmidi_view.cpp
@@ -265,20 +265,20 @@ void TracksView::setItemDelegate(SeparatorDelegate *delegate)
       _frozenCornerTableView->setItemDelegate(delegate);
       }
 
-void TracksView::restoreHHeaderState(const QByteArray &data)
+void TracksView::restoreHHeaderState(const QByteArray &d)
       {
-      horizontalHeader()->restoreState(data);
-      _frozenHTableView->horizontalHeader()->restoreState(data);
-      _frozenVTableView->horizontalHeader()->restoreState(data);
-      _frozenCornerTableView->horizontalHeader()->restoreState(data);
+      horizontalHeader()->restoreState(d);
+      _frozenHTableView->horizontalHeader()->restoreState(d);
+      _frozenVTableView->horizontalHeader()->restoreState(d);
+      _frozenCornerTableView->horizontalHeader()->restoreState(d);
       }
 
-void TracksView::restoreVHeaderState(const QByteArray &data)
+void TracksView::restoreVHeaderState(const QByteArray &d)
       {
-      verticalHeader()->restoreState(data);
-      _frozenHTableView->verticalHeader()->restoreState(data);
-      _frozenVTableView->verticalHeader()->restoreState(data);
-      _frozenCornerTableView->verticalHeader()->restoreState(data);
+      verticalHeader()->restoreState(d);
+      _frozenHTableView->verticalHeader()->restoreState(d);
+      _frozenVTableView->verticalHeader()->restoreState(d);
+      _frozenCornerTableView->verticalHeader()->restoreState(d);
       }
 
 void TracksView::setHHeaderResizeMode(QHeaderView::ResizeMode mode)

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -214,11 +214,11 @@ void MuseScore::editInstrList()
             masterScore->endCmd();
             return;
             }
-      ScoreView* cv = currentScoreView();
-      if (cv && cv->noteEntryMode()) {
-		cv->cmd(getAction("escape"));
+      ScoreView* csv = currentScoreView();
+      if (csv && csv->noteEntryMode()) {
+		csv->cmd(getAction("escape"));
             qApp->processEvents();
-            updateInputState(cv->score());
+            updateInputState(csv->score());
             }
       masterScore->inputState().setTrack(-1);
 
@@ -354,8 +354,8 @@ void MuseScore::editInstrList()
                               if (linkedStaff) {
                                     // do not create a link if linkedStaff will be removed,
                                     for (int k = 0; pli->child(k); ++k) {
-                                          StaffListItem* i = static_cast<StaffListItem*>(pli->child(k));
-                                          if (i->op() == ListItemOp::I_DELETE && i->staff() == linkedStaff) {
+                                          StaffListItem* li = static_cast<StaffListItem*>(pli->child(k));
+                                          if (li->op() == ListItemOp::I_DELETE && li->staff() == linkedStaff) {
                                                 linkedStaff = 0;
                                                 break;
                                                 }
@@ -429,8 +429,8 @@ void MuseScore::editInstrList()
       for (Score* s : masterScore->scoreList()) {
             int n = s->nstaves();
             int curSpan = 0;
-            for (int i = 0; i < n; ++i) {
-                  Staff* staff = s->staff(i);
+            for (int j = 0; j < n; ++j) {
+                  Staff* staff = s->staff(j);
                   int span = staff->barLineSpan();
                   int setSpan = -1;
 
@@ -440,12 +440,12 @@ void MuseScore::editInstrList()
                         if (span == 0) {
                               // no span; this staff must have been within a span
                               // update it to a span of 1
-                              setSpan = 1;
+                              setSpan = j;
                               }
-                        else if (span > (n - i)) {
+                        else if (span > (n - j)) {
                               // span too big; staves must have been removed
                               // reduce span to last staff
-                              setSpan = n - i;
+                              setSpan = n - j;
                               }
                         else if (span > 1 && staff->barLineTo() > 0) {
                               // TODO: check if span is still valid
@@ -485,8 +485,8 @@ void MuseScore::editInstrList()
 
                   // update brackets
                   for (BracketItem* bi : staff->brackets()) {
-                        if ((bi->bracketSpan() > (n - i)))
-                              bi->undoChangeProperty(Pid::BRACKET_SPAN, n - i);
+                        if ((bi->bracketSpan() > (n - j)))
+                              bi->undoChangeProperty(Pid::BRACKET_SPAN, n - j);
                         }
                   }
             }
@@ -508,8 +508,8 @@ void MuseScore::editInstrList()
                         for (auto le : *sll) {
                               Staff* ss = toStaff(le);
                               if (ss->primaryStaff()) {
-                                    for (int i = s->idx() * VOICES; i < (s->idx() + 1) * VOICES; i++) {
-                                          int strack = tr.key(i, -1);
+                                    for (int j = s->idx() * VOICES; j < (s->idx() + 1) * VOICES; j++) {
+                                          int strack = tr.key(j, -1);
                                           if (strack != -1 && ((strack & ~3) == ss->idx()))
                                                 break;
                                           else if (strack != -1)

--- a/mscore/jackaudio.cpp
+++ b/mscore/jackaudio.cpp
@@ -141,9 +141,9 @@ void JackAudio::unregisterPort(jack_port_t* port)
 
 QList<QString> JackAudio::inputPorts()
       {
-      const char** ports = jack_get_ports(client, 0, 0, 0);
+      const char** prts = jack_get_ports(client, 0, 0, 0);
       QList<QString> clientList;
-      for (const char** p = ports; p && *p; ++p) {
+      for (const char** p = prts; p && *p; ++p) {
             jack_port_t* port = jack_port_by_name(client, *p);
             int flags = jack_port_flags(port);
             if (!(flags & JackPortIsInput))
@@ -378,8 +378,7 @@ int JackAudio::processAudio(jack_nframes_t frames, void* p)
                         jack_nframes_t n = jack_midi_get_event_count(portBuffer);
                         for (jack_nframes_t i = 0; i < n; ++i) {
                               jack_midi_event_t event;
-                              int r = jack_midi_event_get(&event, portBuffer, i);
-                              if (r != 0)
+                              if (jack_midi_event_get(&event, portBuffer, i) != 0)
                                     continue;
                               int nn = event.size;
                               int type = event.buffer[0];
@@ -832,9 +831,9 @@ void JackAudio::restoreAudioConnections()
       // Connecting to saved ports
       int nPorts = ports.size();
       for (int i = 0; i < nPorts; ++i) {
-            int n = settings.value(QString("audio-%1-connections").arg(i), 0).toInt();
+            int j = settings.value(QString("audio-%1-connections").arg(i), 0).toInt();
             const char* src = jack_port_name(ports[i]);
-            for (int k = 0; k < n; ++k) {
+            for (int k = 0; k < j; ++k) {
                   QString dst = settings.value(QString("audio-%1-%2").arg(i).arg(k), "").toString();
                   if (!dst.isEmpty()) {
                         if (jack_port_connected_to(ports[i], qPrintable(dst)))

--- a/mscore/mscorePlugins.cpp
+++ b/mscore/mscorePlugins.cpp
@@ -59,8 +59,8 @@ namespace Ms {
 
 void MuseScore::registerPlugin(PluginDescription* plugin)
       {
-      QString pluginPath = plugin->path;
-      QFileInfo np(pluginPath);
+      QString _pluginPath = plugin->path;
+      QFileInfo np(_pluginPath);
       if (np.suffix() != "qml")
             return;
       QString baseName = np.completeBaseName();
@@ -69,25 +69,25 @@ void MuseScore::registerPlugin(PluginDescription* plugin)
             QFileInfo fi(s);
             if (fi.completeBaseName() == baseName) {
                   if (MScore::debugMode)
-                        qDebug("  Plugin <%s> already registered", qPrintable(pluginPath));
+                        qDebug("  Plugin <%s> already registered", qPrintable(_pluginPath));
                   return;
                   }
             }
 
-      QFile f(pluginPath);
+      QFile f(_pluginPath);
       if (!f.open(QIODevice::ReadOnly)) {
             if (MScore::debugMode)
-                  qDebug("Loading Plugin <%s> failed", qPrintable(pluginPath));
+                  qDebug("Loading Plugin <%s> failed", qPrintable(_pluginPath));
             return;
             }
       if (MScore::debugMode)
-            qDebug("Register Plugin <%s>", qPrintable(pluginPath));
+            qDebug("Register Plugin <%s>", qPrintable(_pluginPath));
       f.close();
       QObject* obj = 0;
-      QQmlComponent component(Ms::MScore::qml(), QUrl::fromLocalFile(pluginPath));
+      QQmlComponent component(Ms::MScore::qml(), QUrl::fromLocalFile(_pluginPath));
       obj = component.create();
       if (obj == 0) {
-            qDebug("creating component <%s> failed", qPrintable(pluginPath));
+            qDebug("creating component <%s> failed", qPrintable(_pluginPath));
             foreach(QQmlError e, component.errors()) {
                   qDebug("   line %d: %s", e.line(), qPrintable(e.description()));
                   }
@@ -111,7 +111,7 @@ void MuseScore::registerPlugin(PluginDescription* plugin)
       QmlPlugin* item = qobject_cast<QmlPlugin*>(obj);
       QString menuPath = item->menuPath();
       plugin->menuPath = menuPath;
-      plugins.append(pluginPath);
+      plugins.append(_pluginPath);
       createMenuEntry(plugin);
 
       QAction* a = plugin->shortcut.action();
@@ -125,8 +125,8 @@ void MuseScore::registerPlugin(PluginDescription* plugin)
 
 void MuseScore::unregisterPlugin(PluginDescription* plugin)
       {
-      QString pluginPath = plugin->path;
-      QFileInfo np(pluginPath);
+      QString _pluginPath = plugin->path;
+      QFileInfo np(_pluginPath);
       if (np.suffix() != "qml")
             return;
       QString baseName = np.completeBaseName();
@@ -141,10 +141,10 @@ void MuseScore::unregisterPlugin(PluginDescription* plugin)
             }
       if (!found) {
             if (MScore::debugMode)
-                  qDebug("  Plugin <%s> not registered", qPrintable(pluginPath));
+                  qDebug("  Plugin <%s> not registered", qPrintable(_pluginPath));
             return;
             }
-      plugins.removeAll(pluginPath);
+      plugins.removeAll(_pluginPath);
 
 
       removeMenuEntry(plugin);
@@ -200,11 +200,11 @@ void MuseScore::createMenuEntry(PluginDescription* plugin)
             bool found = false;
             QList<QObject*> ol = curMenu->children();
             foreach(QObject* o, ol) {
-                  QMenu* menu = qobject_cast<QMenu*>(o);
-                  if (!menu)
+                  QMenu* cmenu = qobject_cast<QMenu*>(o);
+                  if (!cmenu)
                         continue;
-                  if (menu->objectName() == m || menu->title() == m) {
-                        curMenu = menu;
+                  if (cmenu->objectName() == m || cmenu->title() == m) {
+                        curMenu = cmenu;
                         found = true;
                         break;
                         }
@@ -292,11 +292,11 @@ void MuseScore::removeMenuEntry(PluginDescription* plugin)
             QString m  = ml[i];
             QList<QObject*> ol = curMenu->children();
             foreach(QObject* o, ol) {
-                  QMenu* menu = qobject_cast<QMenu*>(o);
-                  if (!menu)
+                  QMenu* cmenu = qobject_cast<QMenu*>(o);
+                  if (!cmenu)
                         continue;
-                  if (menu->objectName() == m || menu->title() == m) {
-                        curMenu = menu;
+                  if (cmenu->objectName() == m || cmenu->title() == m) {
+                        curMenu = cmenu;
                         break;
                         }
                   }
@@ -308,12 +308,12 @@ void MuseScore::removeMenuEntry(PluginDescription* plugin)
       cm->removeAction(a);
       for(int i = n-2; i >= 0; --i) {
 
-            QMenu* menu = qobject_cast<QMenu*>(cm->parent());
+            QMenu* cmenu = qobject_cast<QMenu*>(cm->parent());
             if (cm->isEmpty())
                   if(cm->isEmpty()) {
                         delete cm;
                         }
-            cm = menu;
+            cm = cmenu;
             }
       }
 
@@ -321,8 +321,8 @@ void MuseScore::removeMenuEntry(PluginDescription* plugin)
 //   pluginIdxFromPath
 //---------------------------------------------------------
 
-int MuseScore::pluginIdxFromPath(QString pluginPath) {
-      QFileInfo np(pluginPath);
+int MuseScore::pluginIdxFromPath(QString _pluginPath) {
+      QFileInfo np(_pluginPath);
       QString baseName = np.completeBaseName();
       int idx = 0;
       foreach(QString s, plugins) {

--- a/mscore/musedata.cpp
+++ b/mscore/musedata.cpp
@@ -406,8 +406,8 @@ void MuseData::readNote(Part* part, const QString& s)
                   l->setPlainText(w);
                   l->setNo(no++);
                   l->setTrack(gstaff * VOICES);
-                  Segment* segment = measure->tick2segment(tick);
-                  segment->add(l);
+                  Segment* seg = measure->tick2segment(tick);
+                  seg->add(l);
                   }
             }
       }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4472,14 +4472,14 @@ bool MuseScore::restoreSession(bool always)
                               QString name;
                               bool created = false;
                               while (e.readNextStartElement()) {
-                                    const QStringRef& tag(e.name());
-                                    if (tag == "name")
+                                    const QStringRef& t(e.name());
+                                    if (t == "name")
                                           name = e.readElementText();
-                                    else if (tag == "created")
+                                    else if (t == "created")
                                           created = e.readInt();
-                                    else if (tag == "dirty")
+                                    else if (t == "dirty")
                                           /*int dirty =*/ e.readInt();
-                                    else if (tag == "path") {
+                                    else if (t == "path") {
                                           MasterScore* score = readScore(e.readElementText());
                                           if (score) {
                                                 if (!name.isEmpty()) {
@@ -4509,18 +4509,18 @@ bool MuseScore::restoreSession(bool always)
                               int tab       = 0;
                               int idx       = 0;
                               while (e.readNextStartElement()) {
-                                    const QStringRef& tag(e.name());
-                                    if (tag == "tab")
+                                    const QStringRef& t(e.name());
+                                    if (t == "tab")
                                           tab = e.readInt();
-                                    else if (tag == "idx")
+                                    else if (t == "idx")
                                           idx = e.readInt();
-                                    else if (tag == "mag")
+                                    else if (t == "mag")
                                           vmag = e.readDouble();
-                                    else if (tag == "magIdx")
+                                    else if (t == "magIdx")
                                           magIdx = MagIdx(e.readInt());
-                                    else if (tag == "x")
+                                    else if (t == "x")
                                           x = e.readDouble() * DPMM;
-                                    else if (tag == "y")
+                                    else if (t == "y")
                                           y = e.readDouble() * DPMM;
                                     else {
                                           e.unknown();
@@ -5928,8 +5928,8 @@ QFileInfoList MuseScore::recentScores() const
             QFileInfo fi(s);
             bool alreadyLoaded = false;
             QString fp = fi.canonicalFilePath();
-            for (Score* s : mscore->scores()) {
-                  if ((s->masterScore()->fileInfo()->canonicalFilePath() == fp) || (s->importedFilePath() == fp)) {
+            for (Score* sc : mscore->scores()) {
+                  if ((sc->masterScore()->fileInfo()->canonicalFilePath() == fp) || (sc->importedFilePath() == fp)) {
                         alreadyLoaded = true;
                         break;
                         }

--- a/mscore/piano.cpp
+++ b/mscore/piano.cpp
@@ -346,7 +346,7 @@ void Piano::paintEvent(QPaintEvent* event)
       p.drawTiledPixmap(QRectF(x, y, qreal(r.width()), h), *octave, offset);
 
       if (curPitch != -1) {
-            int y = pitch2y(curPitch);
+            int py = pitch2y(curPitch);
             QPixmap* pm;
             switch(curPitch % 12) {
                   case 0:
@@ -366,7 +366,7 @@ void Piano::paintEvent(QPaintEvent* event)
                         pm = mk4;
                         break;
                   }
-            p.drawPixmap(0, y, *pm);
+            p.drawPixmap(0, py, *pm);
             }
       }
 

--- a/mscore/pianoroll.h
+++ b/mscore/pianoroll.h
@@ -104,7 +104,7 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       virtual Element* elementNear(QPointF);
       virtual void drawBackground(QPainter* /*p*/, const QRectF& /*r*/) const {}
 
-      void setLocator(POS pos, int tick) { locator[int(pos)].setTick(tick); }
+      void setLocator(POS posi, int tick) { locator[int(posi)].setTick(tick); }
 
       void writeSettings();
       virtual const QRect geometry() const override { return QMainWindow::geometry(); }

--- a/mscore/pluginCreator.cpp
+++ b/mscore/pluginCreator.cpp
@@ -117,9 +117,9 @@ PluginCreator::PluginCreator(QWidget* parent)
 
 QString PluginCreator::manualPath()
       {
-      QString path = mscoreGlobalShare;
-      path += "/manual/plugins/plugins.html";
-      return path;
+      QString _path = mscoreGlobalShare;
+      _path += "/manual/plugins/plugins.html";
+      return _path;
       }
 
 //---------------------------------------------------------

--- a/mscore/pluginManager.cpp
+++ b/mscore/pluginManager.cpp
@@ -79,16 +79,16 @@ bool PluginManager::readPluginList()
                         if (tag == "Plugin") {
                               PluginDescription d;
                               while (e.readNextStartElement()) {
-                                    const QStringRef& tag(e.name());
-                                    if (tag == "path")
+                                    const QStringRef& t(e.name());
+                                    if (t == "path")
                                           d.path = e.readElementText();
-                                    else if (tag == "load")
+                                    else if (t == "load")
                                           d.load = e.readInt();
-                                    else if (tag == "SC")
+                                    else if (t == "SC")
                                           d.shortcut.read(e);
-                                    else if (tag == "version")
+                                    else if (t == "version")
                                           d.version = e.readElementText();
-                                    else if (tag == "description")
+                                    else if (t == "description")
                                           d.description = e.readElementText();
                                     else
                                           e.unknown();
@@ -191,8 +191,8 @@ void PluginManager::updatePluginList(bool forceRefresh)
             engine->clearComponentCache(); //TODO: Check this doesn't have unwanted side effects.
             }
 
-      foreach(QString pluginPath, pluginPathList) {
-            Ms::updatePluginList(pluginPathList, pluginPath, _pluginList);
+      for (QString _pluginPath : pluginPathList) {
+            Ms::updatePluginList(pluginPathList, _pluginPath, _pluginList);
             }
       //remove non existing files
       auto i = _pluginList.begin();

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -1396,8 +1396,8 @@ void PreferenceDialog::printShortcutsClicked()
       qreal col1Width = 0.0;
       while (isc.hasNext()) {
             isc.next();
-            Shortcut* s = isc.value();
-            col1Width = qMax(col1Width, QFontMetricsF(p.font()).width(s->descr()));
+            Shortcut* sc = isc.value();
+            col1Width = qMax(col1Width, QFontMetricsF(p.font()).width(sc->descr()));
             }
 
       int idx = 0;

--- a/mscore/resourceManager.cpp
+++ b/mscore/resourceManager.cpp
@@ -93,8 +93,8 @@ void ResourceManager::displayExtensions()
       QPushButton* buttonUninstall;
       extensionsTable->verticalHeader()->show();
 
-      QStringList extensions = result.object().keys();
-      for (QString key : extensions) {
+      QStringList exts = result.object().keys();
+      for (QString key : exts) {
             if (!result.object().value(key).isObject())
                   continue;
             QJsonObject value = result.object().value(key).toObject();
@@ -181,19 +181,19 @@ void ResourceManager::displayLanguages()
       languagesTable->verticalHeader()->show();
 
       // move current language to first row
-      QStringList languages = result.object().keys();
+      QStringList langs = result.object().keys();
       QString lang = mscore->getLocaleISOCode();
-      int index = languages.indexOf(lang);
+      int index = langs.indexOf(lang);
       if (index < 0 &&  lang.size() > 2) {
             lang = lang.left(2);
-            index = languages.indexOf(lang);
+            index = langs.indexOf(lang);
             }
       if (index >= 0) {
-            QString l = languages.takeAt(index);
-            languages.prepend(l);
+            QString l = langs.takeAt(index);
+            langs.prepend(l);
             }
 
-      for (QString key : languages) {
+      for (QString key : langs) {
             if (!result.object().value(key).isObject())
                   continue;
             QJsonObject value = result.object().value(key).toObject();
@@ -266,14 +266,14 @@ bool ResourceManager::verifyLanguageFile(QString filename, QString hash)
 void ResourceManager::downloadLanguage()
       {
       QPushButton *button = static_cast<QPushButton*>( sender() );
-      QString data = languageButtonMap[button];
+      QString dta  = languageButtonMap[button];
       QString hash = languageButtonHashMap[button];
       button->setText(tr("Updating"));
       button->setDisabled(true);
-      QString baseAddress = baseAddr() + data;
+      QString baseAddress = baseAddr() + dta;
       DownloadUtils dl(this);
       dl.setTarget(baseAddress);
-      QString localPath = dataPath + "/locale/" + data.split('/')[1];
+      QString localPath = dataPath + "/locale/" + dta.split('/')[1];
       dl.setLocalFile(localPath);
       dl.download();
       if (!dl.saveFile() || !verifyFile(localPath, hash)) {
@@ -305,7 +305,7 @@ void ResourceManager::downloadLanguage()
                   QFile::remove(localPath);
                   button->setText(tr("Updated"));
                   //  retranslate the UI if current language is updated
-                  if (data == languageButtonMap.first())
+                  if (dta == languageButtonMap.first())
                         setMscoreLocale(localeName);
                   }
             else {
@@ -322,14 +322,14 @@ void ResourceManager::downloadLanguage()
 void ResourceManager::downloadExtension()
       {
       QPushButton* button = static_cast<QPushButton*>(sender());
-      QString data = button->property("path").toString();
+      QString path  = button->property("path").toString();
       QString hash = button->property("hash").toString();
       button->setText(tr("Updating"));
       button->setDisabled(true);
-      QString baseAddress = baseAddr() + data;
+      QString baseAddress = baseAddr() + path;
       DownloadUtils dl(this);
       dl.setTarget(baseAddress);
-      QString localPath = QDir::tempPath() + "/" + data.split('/')[1];
+      QString localPath = QDir::tempPath() + "/" + path.split('/')[1];
       QFile::remove(localPath);
       dl.setLocalFile(localPath);
       dl.download(true);

--- a/mscore/savePositions.cpp
+++ b/mscore/savePositions.cpp
@@ -128,10 +128,10 @@ bool savePositions(Score* score, const QString& name, bool segments)
                               saveMeasureEvents(xml, m, tickOffset);
                         else {
                               int tick = m->tick() + tickOffset;
-                              int id = segs[(void*)m];
+                              int i = segs[(void*)m];
                               int time = lrint(m->score()->repeatList()->utick2utime(tick) * 1000);
                               xml.tagE(QString("event elid=\"%1\" position=\"%2\"")
-                                 .arg(id)
+                                 .arg(i)
                                  .arg(time)
                                  );
                               }

--- a/mscore/scoreBrowser.cpp
+++ b/mscore/scoreBrowser.cpp
@@ -197,9 +197,9 @@ void ScoreBrowser::setScores(QFileInfoList& s)
             std::sort(s.begin(), s.end(), [](QFileInfo a, QFileInfo b)->bool { return a.fileName() < b.fileName(); });
 
       QSet<QString> entries; //to avoid duplicates
-      for (const QFileInfo& fi : s) {
-            if (fi.isDir()) {
-                  QString st(fi.fileName());
+      for (const QFileInfo& fil : s) {
+            if (fil.isDir()) {
+                  QString st(fil.fileName());
                   if (!st.isEmpty() && st[0].isNumber() && _stripNumbers)
                         st = st.mid(3);
                   st = st.replace('_', ' ');
@@ -208,11 +208,11 @@ void ScoreBrowser::setScores(QFileInfoList& s)
                   f.setBold(true);
                   label->setFont(f);
                   static_cast<QVBoxLayout*>(l)->addWidget(label);
-                  QDir dir(fi.filePath());
+                  QDir dir(fil.filePath());
                   sl = createScoreList();
                   l->addWidget(sl);
                   unsigned count = 0; //nbr of entries added
-                  for (const QFileInfo& fi : dir.entryInfoList(filter, QDir::Files, QDir::Name)){
+                  for (const QFileInfo& fi : dir.entryInfoList(filter, QDir::Files, QDir::Name)) {
                         if (entries.contains(fi.filePath()))
                             continue;
                         sl->addItem(genScoreItem(fi, sl));

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -123,10 +123,9 @@ void ScoreAccessibility::currentInfoChanged()
                   }
             Element* el = e->isSpannerSegment() ? static_cast<SpannerSegment*>(e)->spanner() : e;
             QString barsAndBeats = "";
-            std::pair<int, float> bar_beat;
             if (el->isSpanner()){
                   Spanner* s = static_cast<Spanner*>(el);
-                  bar_beat = barbeat(s->startSegment());
+                  std::pair<int, float> bar_beat = barbeat(s->startSegment());
                   barsAndBeats += tr("Start Measure: %1; Start Beat: %2").arg(QString::number(bar_beat.first)).arg(QString::number(bar_beat.second));
                   Segment* seg = s->endSegment();
                   if(!seg)

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -954,10 +954,8 @@ void ScoreView::paintPageBorder(QPainter& p, Page* page)
             QRectF f(page->canvasBoundingRect());
             f.adjust(page->lm(), page->tm(), -page->rm(), -page->bm());
             p.drawRect(f);
-            if (!page->isOdd()) {
-                  QRectF f(page->canvasBoundingRect());
+            if (!page->isOdd())
                   p.drawLine(f.right(), 0.0, f.right(), f.bottom());
-                  }
             }
       }
 
@@ -1651,8 +1649,8 @@ void ScoreView::normalSwap()
       const QMimeData* ms = QApplication::clipboard()->mimeData();
       if (mimeType == mimeStaffListFormat) { // determine size of clipboard selection
             int tickLen = 0, staves = 0;
-            QByteArray data(ms->data(mimeStaffListFormat));
-            XmlReader e(data);
+            QByteArray d(ms->data(mimeStaffListFormat));
+            XmlReader e(d);
             e.readNextStartElement();
             if (e.name() == "StaffList") {
                   tickLen         = e.intAttribute("len", 0);
@@ -1678,10 +1676,10 @@ void ScoreView::normalSwap()
                   ms = QApplication::clipboard()->mimeData();
                   }
             }
-      QByteArray data(_score->selection().mimeData());
+      QByteArray d(_score->selection().mimeData());
       if (this->normalPaste()) {
             QMimeData* mimeData = new QMimeData;
-            mimeData->setData(mimeType, data);
+            mimeData->setData(mimeType, d);
             QApplication::clipboard()->setMimeData(mimeData);
             }
       }
@@ -1919,9 +1917,9 @@ void ScoreView::cmd(const char* s)
                   score()->endCmd();
                   }
             else {
-                  Element* el = _score->move(cmd);
-                  if (el)
-                        adjustCanvasPosition(el, false);
+                  Element* ele = _score->move(cmd);
+                  if (ele)
+                        adjustCanvasPosition(ele, false);
                   updateAll();
                   }
             }
@@ -2578,9 +2576,9 @@ QVariant ScoreView::inputMethodQuery(Qt::InputMethodQuery query) const
                         return QWidget::inputMethodQuery(query); // fall back to QWidget's version as default
                   }
             }
-      QVariant data = QWidget::inputMethodQuery(query); // fall back to QWidget's version as default
-//      qDebug() << "   " << data;
-      return data;
+      QVariant d = QWidget::inputMethodQuery(query); // fall back to QWidget's version as default
+//      qDebug() << "   " << d;
+      return d;
       }
 
 //---------------------------------------------------------
@@ -3992,8 +3990,8 @@ void ScoreView::cmdRepeatSelection()
             qDebug("cmdRepeatSelection: <%s>", mimeData->data(mimeType).data());
       QApplication::clipboard()->setMimeData(mimeData);
 
-      QByteArray data(mimeData->data(mimeType));
-      XmlReader xml(data);
+      QByteArray d(mimeData->data(mimeType));
+      XmlReader xml(d);
       xml.setPasteMode(true);
 
       int dStaff = selection.staffStart();

--- a/mscore/svggenerator.cpp
+++ b/mscore/svggenerator.cpp
@@ -1189,10 +1189,10 @@ void SvgPaintEngine::drawPath(const QPainterPath &p)
             stream() << SVG_CURVE << x << SVG_COMMA << y;
             ++i;
             while (i < p.elementCount()) {
-                const QPainterPath::Element &e = p.elementAt(i);
-                if (e.type == QPainterPath::CurveToDataElement) {
-                    stream() << SVG_SPACE << e.x + _dx
-                             << SVG_COMMA << e.y + _dy;
+                const QPainterPath::Element &ee = p.elementAt(i);
+                if (ee.type == QPainterPath::CurveToDataElement) {
+                    stream() << SVG_SPACE << ee.x + _dx
+                             << SVG_COMMA << ee.y + _dy;
                     ++i;
                 }
                 else {

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -212,7 +212,7 @@ class Timeline : public QGraphicsView {
       unsigned int nmetas();
 
       bool collapsed() { return collapsed_meta; }
-      void setCollapsed(bool state) { collapsed_meta = state; }
+      void setCollapsed(bool st) { collapsed_meta = st; }
 
       Staff* numToStaff(int staff);
       void toggleShow(int staff);

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -411,8 +411,8 @@ void Workspace::read(XmlReader& e)
                   QString name = e.attribute("name");
                   std::list<const char*> l;
                   while (e.readNextStartElement()) {
-                        const QStringRef& tag(e.name());
-                        if (tag == "action") {
+                        const QStringRef& t(e.name());
+                        if (t == "action") {
                               QString s = e.readElementText();
                               for (auto k : mscore->allNoteInputMenuEntries()) {
                                     if (k == s) {
@@ -523,12 +523,12 @@ QList<Workspace*>& Workspace::refreshWorkspaces()
 
 Workspace* Workspace::createNewWorkspace(const QString& name)
       {
-      Workspace* p = new Workspace;
-      p->setName(name);
-      p->setPath("");
-      p->setDirty(false);
-      p->setReadOnly(false);
-      p->write();
+      Workspace* w = new Workspace;
+      w->setName(name);
+      w->setPath("");
+      w->setDirty(false);
+      w->setReadOnly(false);
+      w->write();
 
       // all palettes in new workspace are editable
 
@@ -540,8 +540,8 @@ Workspace* Workspace::createNewWorkspace(const QString& name)
                   p->setCellReadOnly(i, false);
             }
 
-      _workspaces.append(p);
-      return p;
+      _workspaces.append(w);
+      return w;
       }
 
 }

--- a/thirdparty/poppler/CMakeLists.txt
+++ b/thirdparty/poppler/CMakeLists.txt
@@ -151,7 +151,7 @@ else (APPLE)
          # -Woverloaded-virtual  -> /Wall enabled all warnings, no need to enable particularly
          # -Wno-missing-field-initializers -> ???
          # -Wno-unused-but-set-variable -> Warning C4189: 'identifier': local variable is initialized but not referenced
-         set (POPPLER_COMPILE_FLAGS "/wd4065 /wd4100 /wd4121 /wd4127 /wd4189 /wd4244 /wd4245 /wd4310 /wd4255 /wd4309 /wd4456 /wd4458 /wd4459 /wd4701 /wd4702 /wd4706 /wd4805 /wd4996")
+         set (POPPLER_COMPILE_FLAGS "/wd4065 /wd4100 /wd4121 /wd4127 /wd4189 /wd4244 /wd4245 /wd4310 /wd4255 /wd4309 /wd4456 /wd4458 /wd4459 /wd4701 /wd4702 /wd4703 /wd4706 /wd4805 /wd4996")
       endif (NOT MSVC)
    endif(MINGW)
 endif(APPLE)

--- a/zerberus/filter.cpp
+++ b/zerberus/filter.cpp
@@ -40,12 +40,12 @@ ZFilter::ZFilter()
 //   initialize
 //---------------------------------------------------------
 
-void ZFilter::initialize(const Zerberus* zerberus, const Zone* z, int velocity)
+void ZFilter::initialize(const Zerberus* _zerberus, const Zone* z, int velocity)
       {
-      this->zerberus = zerberus;
+      this->zerberus = _zerberus;
       this->sampleZone = z;
 
-      resonanceF = zerberus->ct2hz(13500.0);
+      resonanceF = _zerberus->ct2hz(13500.0);
       if (z->isCutoffDefined) {
             //calculate current cutoff value
             float cutoffHz = z->cutoff;


### PR DESCRIPTION
Done so far:

* Fix some warnings C4456 (66 of 244)
* Fix some warnings C4458 (39 of 163)
* Fix the remaining 2 warnings C4702 (show only in "Debug" mode, not in "RelWithDebInfo" mode)
* Disable warning C4703 in thirdparty/poppler, which shows when building in "RelWithDebInfo" mode

To do (by someone else, or by me after vacation):

* Disable the 7 new warnings C4189 in thirdparty/portmidi, shown when building in "RelWithDebInfo" mode
* Fix the 188 remaining C4456 (2 less in "RelWithDebInfo" mode)
* Fix the 124 remaining C4458 (1 less in "RelWithDebInfo" mode)

Ignored so far (as being code in flux, I believe):

 * Warning C4100 (introduced with 411b463)