### PR TITLE
fix #275288 crash during opening score

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2113,8 +2113,13 @@ void Measure::read(XmlReader& e, int staffIdx)
                   t->setTrack(e.track());
                   t->read(e);
                   if (t->empty()) {
-                        qDebug("==reading empty text: deleted");
-                        delete t;
+                        if (t->links()) {
+                              if (t->links()->size() == 1) {
+                                    qDebug("==reading empty text: deleted lid = %d", t->links()->lid());
+                                    e.linkIds().remove(t->links()->lid());
+                                    delete t;
+                                    }
+                              }
                         }
                   else {
                         segment = getSegment(SegmentType::ChordRest, e.tick());

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2041,8 +2041,13 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   t->setTrack(e.track());
                   readText206(e, t, t);
                   if (t->empty()) {
-                        qDebug("reading empty text: deleted");
-                        delete t;
+                        if (t->links()) {
+                              if (t->links()->size() == 1) {
+                                    qDebug("reading empty text: deleted lid = %d", t->links()->lid());
+                                    e.linkIds().remove(t->links()->lid());
+                                    delete t;
+                                    }
+                              }
                         }
                   else {
                         if (!t->autoplace()) {

--- a/mtest/libmscore/compat206/lidemptytext-ref.mscx
+++ b/mtest/libmscore/compat206/lidemptytext-ref.mscx
@@ -1,0 +1,345 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.00">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <clefLeftMargin>0.64</clefLeftMargin>
+      <clefKeyRightMargin>1.75</clefKeyRightMargin>
+      <barNoteDistance>1.2</barNoteDistance>
+      <pedalPosBelow>0</pedalPosBelow>
+      <trillPosAbove>0</trillPosAbove>
+      <dynamicsFontItalic>0</dynamicsFontItalic>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>1</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          </StaffType>
+        <bracket type="-1" span="1" col="0"/>
+        <barLineSpan>1</barLineSpan>
+        </Staff>
+      <trackName>Lead</trackName>
+      <Instrument>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="73"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <defaultClef>F8vb</defaultClef>
+        </Staff>
+      <show>0</show>
+      <trackName>Bass</trackName>
+      <Instrument>
+        <trackName>Contrabass</trackName>
+        <minPitchP>28</minPitchP>
+        <maxPitchP>67</maxPitchP>
+        <minPitchA>28</minPitchA>
+        <maxPitchA>62</maxPitchA>
+        <instrumentId>strings.contrabass</instrumentId>
+        <clef>F8vb</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="43"/>
+          </Channel>
+        <Channel name="pizzicato">
+          <program value="32"/>
+          </Channel>
+        <Channel name="tremolo">
+          <program value="44"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>8</height>
+        <bottomGap>6</bottomGap>
+        </VBox>
+      <Measure number="1">
+        <stretch>0.9</stretch>
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          </TimeSig>
+        <Beam id="1">
+          <l1>23</l1>
+          <l2>17</l2>
+          </Beam>
+        <Tuplet id="1">
+          <normalNotes>2</normalNotes>
+          <actualNotes>3</actualNotes>
+          <baseNote>eighth</baseNote>
+          <Number>
+            <text>3</text>
+            </Number>
+          </Tuplet>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <Accidental>
+              <subtype>accidentalSharp</subtype>
+              </Accidental>
+            <pitch>68</pitch>
+            <tpc>22</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <Accidental>
+              <subtype>accidentalSharp</subtype>
+              </Accidental>
+            <pitch>73</pitch>
+            <tpc>21</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <pitch>76</pitch>
+            <tpc>18</tpc>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>quarter</durationType>
+          </Rest>
+        <Rest>
+          <durationType>quarter</durationType>
+          </Rest>
+        <Rest>
+          <durationType>quarter</durationType>
+          </Rest>
+        <BarLine>
+          <span>0</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure number="1">
+        <TimeSig>
+          <lid>2</lid>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          </TimeSig>
+        <Harmony>
+          <root>21</root>
+          <name>-</name>
+          <lid>5</lid>
+          </Harmony>
+        <Chord>
+          <lid>3</lid>
+          <durationType>whole</durationType>
+          <Note>
+            <lid>4</lid>
+            <Accidental>
+              <subtype>accidentalSharp</subtype>
+              </Accidental>
+            <pitch>37</pitch>
+            <tpc>21</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      </Staff>
+    <Score>
+      <LayerTag id="0" tag="default"></LayerTag>
+      <currentLayer>0</currentLayer>
+      <Division>480</Division>
+      <Style>
+        <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+        <clefLeftMargin>0.64</clefLeftMargin>
+        <clefKeyRightMargin>1.75</clefKeyRightMargin>
+        <barNoteDistance>1.2</barNoteDistance>
+        <pedalPosBelow>0</pedalPosBelow>
+        <trillPosAbove>0</trillPosAbove>
+        <dynamicsFontItalic>0</dynamicsFontItalic>
+        <Spatium>1.76389</Spatium>
+        </Style>
+      <showInvisible>1</showInvisible>
+      <showUnprintable>1</showUnprintable>
+      <showFrames>1</showFrames>
+      <showMargins>0</showMargins>
+      <metaTag name="partName">Bass</metaTag>
+      <Part>
+        <Staff id="1">
+          <linkedTo>2</linkedTo>
+          <StaffType group="pitched">
+            <name>stdNormal</name>
+            </StaffType>
+          <defaultClef>F8vb</defaultClef>
+          </Staff>
+        <trackName>Contrabass</trackName>
+        <Instrument>
+          <trackName>Contrabass</trackName>
+          <minPitchP>28</minPitchP>
+          <maxPitchP>67</maxPitchP>
+          <minPitchA>28</minPitchA>
+          <maxPitchA>62</maxPitchA>
+          <instrumentId>strings.contrabass</instrumentId>
+          <clef>F8vb</clef>
+          <Articulation>
+            <velocity>100</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Articulation name="staccatissimo">
+            <velocity>100</velocity>
+            <gateTime>33</gateTime>
+            </Articulation>
+          <Articulation name="staccato">
+            <velocity>100</velocity>
+            <gateTime>50</gateTime>
+            </Articulation>
+          <Articulation name="portato">
+            <velocity>100</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="tenuto">
+            <velocity>100</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Articulation name="marcato">
+            <velocity>120</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="sforzato">
+            <velocity>120</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Channel>
+            <program value="43"/>
+            </Channel>
+          <Channel name="pizzicato">
+            <program value="32"/>
+            </Channel>
+          <Channel name="tremolo">
+            <program value="44"/>
+            </Channel>
+          </Instrument>
+        </Part>
+      <Staff id="1">
+        <VBox>
+          <height>8</height>
+          <bottomGap>6</bottomGap>
+          <Text>
+            <offset x="0.362523" y="-2.94812"/>
+            <style>Instrument Name (Part)</style>
+            <text>Bass</text>
+            </Text>
+          </VBox>
+        <Measure number="1">
+          <TimeSig>
+            <lid>2</lid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Harmony>
+            <root>21</root>
+            <name>-</name>
+            <lid>5</lid>
+            </Harmony>
+          <Chord>
+            <lid>3</lid>
+            <durationType>whole</durationType>
+            <Note>
+              <lid>4</lid>
+              <Accidental>
+                <subtype>accidentalSharp</subtype>
+                </Accidental>
+              <pitch>37</pitch>
+              <tpc>21</tpc>
+              </Note>
+            </Chord>
+          </Measure>
+        </Staff>
+      <name>Bass</name>
+      </Score>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/compat206/lidemptytext.mscx
+++ b/mtest/libmscore/compat206/lidemptytext.mscx
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="2.06">
+  <programVersion>2.0.1</programVersion>
+  <programRevision>4592407</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <clefLeftMargin>0.64</clefLeftMargin>
+      <clefKeyRightMargin>1.75</clefKeyRightMargin>
+      <barNoteDistance>1.2</barNoteDistance>
+      <pedalPosBelow>0</pedalPosBelow>
+      <trillPosAbove>0</trillPosAbove>
+      <dynamicsFontItalic>0</dynamicsFontItalic>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>1</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <PageList>
+      <Page>
+        <System>
+          </System>
+        <System>
+          </System>
+        </Page>
+      </PageList>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          </StaffType>
+        <bracket type="-1" span="1"/>
+        <barLineSpan>2</barLineSpan>
+        </Staff>
+      <trackName>Lead</trackName>
+      <Instrument>
+        <trackName>Flute</trackName>
+        <minPitchP>59</minPitchP>
+        <maxPitchP>98</maxPitchP>
+        <minPitchA>60</minPitchA>
+        <maxPitchA>93</maxPitchA>
+        <instrumentId>wind.flutes.flute</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="73"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Part>
+      <Staff id="2">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        <defaultClef>F8vb</defaultClef>
+        <bracket type="-1" span="0"/>
+        <barLineSpan>0</barLineSpan>
+        </Staff>
+      <show>0</show>
+      <trackName>Bass</trackName>
+      <Instrument>
+        <trackName>Contrabass</trackName>
+        <minPitchP>28</minPitchP>
+        <maxPitchP>67</maxPitchP>
+        <minPitchA>28</minPitchA>
+        <maxPitchA>62</maxPitchA>
+        <instrumentId>strings.contrabass</instrumentId>
+        <clef>F8vb</clef>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="43"/>
+          </Channel>
+        <Channel name="pizzicato">
+          <program value="32"/>
+          </Channel>
+        <Channel name="tremolo">
+          <program value="44"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>8</height>
+        <bottomGap>6</bottomGap>
+        <lid>1</lid>
+        </VBox>
+      <Measure number="1">
+        <stretch>0.9</stretch>
+        <Clef>
+          <concertClefType>G</concertClefType>
+          <transposingClefType>G</transposingClefType>
+          </Clef>
+        <StaffText>
+          <lid>2</lid>
+          <pos x="-0.529167" y="-4"/>
+          <style>System</style>
+          <text/>
+          </StaffText>		  
+        <TimeSig>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+		<Beam id="1">
+          <l1>23</l1>
+          <l2>17</l2>
+          </Beam>
+        <StaffText>
+          <text></text>
+          </StaffText>
+        <Tuplet id="1">
+          <normalNotes>2</normalNotes>
+          <actualNotes>3</actualNotes>
+          <baseNote>eighth</baseNote>
+          <Number>
+            <style>Tuplet</style>
+            <text>3</text>
+            </Number>
+          </Tuplet>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
+            <pitch>68</pitch>
+            <tpc>22</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
+            <pitch>73</pitch>
+            <tpc>21</tpc>
+            </Note>
+          </Chord>
+        <Chord>
+          <Tuplet>1</Tuplet>
+          <durationType>eighth</durationType>
+          <Beam>1</Beam>
+          <Note>
+            <pitch>76</pitch>
+            <tpc>18</tpc>
+            </Note>
+          </Chord>
+        <Rest>
+          <durationType>quarter</durationType>
+          </Rest>
+        <Rest>
+          <durationType>quarter</durationType>
+          </Rest>
+        <Rest>
+          <durationType>quarter</durationType>
+          </Rest>
+        <BarLine>
+          <subtype>normal</subtype>
+          <span from="0" to="8">1</span>
+          </BarLine>
+        </Measure>
+      </Staff>
+    <Staff id="2">
+      <Measure number="1">
+        <TimeSig>
+          <lid>6</lid>
+          <sigN>4</sigN>
+          <sigD>4</sigD>
+          <showCourtesySig>1</showCourtesySig>
+          </TimeSig>
+        <Harmony>
+          <root>21</root>
+          <name>-</name>
+          <lid>9</lid>
+          </Harmony>
+        <Chord>
+          <lid>7</lid>
+          <durationType>whole</durationType>
+          <Note>
+            <lid>8</lid>
+            <Accidental>
+              <subtype>sharp</subtype>
+              </Accidental>
+            <pitch>37</pitch>
+            <tpc>21</tpc>
+            </Note>
+          </Chord>
+        </Measure>
+      </Staff>
+    <Score>
+      <LayerTag id="0" tag="default"></LayerTag>
+      <currentLayer>0</currentLayer>
+      <Division>480</Division>
+      <Style>
+        <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+        <clefLeftMargin>0.64</clefLeftMargin>
+        <clefKeyRightMargin>1.75</clefKeyRightMargin>
+        <barNoteDistance>1.2</barNoteDistance>
+        <pedalPosBelow>0</pedalPosBelow>
+        <trillPosAbove>0</trillPosAbove>
+        <dynamicsFontItalic>0</dynamicsFontItalic>
+        <Spatium>1.76389</Spatium>
+        </Style>
+      <showInvisible>1</showInvisible>
+      <showUnprintable>1</showUnprintable>
+      <showFrames>1</showFrames>
+      <showMargins>0</showMargins>
+      <metaTag name="partName">Bass</metaTag>
+      <PageList>
+        <Page>
+          <System>
+            </System>
+          <System>
+            </System>
+          </Page>
+        </PageList>
+      <Part>
+        <Staff id="1">
+          <linkedTo>2</linkedTo>
+          <StaffType group="pitched">
+            <name>stdNormal</name>
+            </StaffType>
+          <defaultClef>F8vb</defaultClef>
+          <bracket type="-1" span="0"/>
+          </Staff>
+        <trackName>Contrabass</trackName>
+        <Instrument>
+          <trackName>Contrabass</trackName>
+          <minPitchP>28</minPitchP>
+          <maxPitchP>67</maxPitchP>
+          <minPitchA>28</minPitchA>
+          <maxPitchA>62</maxPitchA>
+          <instrumentId>strings.contrabass</instrumentId>
+          <clef>F8vb</clef>
+          <Articulation>
+            <velocity>100</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Articulation name="staccatissimo">
+            <velocity>100</velocity>
+            <gateTime>33</gateTime>
+            </Articulation>
+          <Articulation name="staccato">
+            <velocity>100</velocity>
+            <gateTime>50</gateTime>
+            </Articulation>
+          <Articulation name="portato">
+            <velocity>100</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="tenuto">
+            <velocity>100</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Articulation name="marcato">
+            <velocity>120</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="sforzato">
+            <velocity>120</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Channel>
+            <program value="43"/>
+            </Channel>
+          <Channel name="pizzicato">
+            <program value="32"/>
+            </Channel>
+          <Channel name="tremolo">
+            <program value="44"/>
+            </Channel>
+          </Instrument>
+        </Part>
+      <Staff id="1">
+        <VBox>
+          <height>8</height>
+          <bottomGap>6</bottomGap>
+          <lid>10</lid>
+          <Text>
+            <pos x="0.362523" y="-2.94812"/>
+            <style>Instrument Name (Part)</style>
+            <text>Bass</text>
+            </Text>
+          </VBox>
+        <Measure number="1">
+          <StaffText>
+            <lid>2</lid>
+            <pos x="-0.529167" y="-4"/>
+            <style>System</style>
+            <text/>
+            </StaffText>
+          <TimeSig>
+            <lid>6</lid>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            <showCourtesySig>1</showCourtesySig>
+            </TimeSig>
+          <Harmony>
+            <root>21</root>
+            <name>-</name>
+            <lid>9</lid>
+            </Harmony>
+          <Chord>
+            <lid>7</lid>
+            <durationType>whole</durationType>
+            <Note>
+              <lid>8</lid>
+              <Accidental>
+                <subtype>sharp</subtype>
+                </Accidental>
+              <pitch>37</pitch>
+              <tpc>21</tpc>
+              </Note>
+            </Chord>
+          </Measure>
+        </Staff>
+      <name>Bass</name>
+      </Score>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/compat206/tst_compat206.cpp
+++ b/mtest/libmscore/compat206/tst_compat206.cpp
@@ -42,6 +42,7 @@ class TestCompat206 : public QObject, public MTest
       void tuplets()          { compat("tuplets");          }
       void hairpin()          { compat("hairpin");          }
       void brlines()          { compat("barlines");         }
+      void lidEmptyText()     { compat("lidemptytext");     }
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fix deleting tag "Text" when it is empty.
During the reading XML MuseScore populate map which consist of 'lid'. This map is container of LinkedElements which is defined by the tag "lid". When tag "Text" doesn't have any text it is deleted. Error was that removing corresponding element from map container is missing. So I add such kind of removing.