### PR TITLE
#275264: Add ability to select rests of same duration

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3000,6 +3000,13 @@ void Score::collectMatch(void* data, Element* e)
                   ee = ee->parent();
                   } while (ee);
             }
+
+      if (e->isRest()) {
+            const Rest* r = toRest(e);
+            if (p->durationTicks != r->actualTicks())
+                  return;
+            }
+
       p->el.append(e);
       }
 

--- a/libmscore/select.h
+++ b/libmscore/select.h
@@ -42,6 +42,7 @@ struct ElementPattern {
       int voice;
       const System* system;
       bool subtypeValid;
+      int durationTicks;
       };
 
 //---------------------------------------------------------

--- a/mscore/selectdialog.cpp
+++ b/mscore/selectdialog.cpp
@@ -31,6 +31,7 @@
 #include "libmscore/slur.h"
 #include "libmscore/articulation.h"
 #include "musescore.h"
+#include "libmscore/rest.h"
 
 namespace Ms {
 
@@ -67,6 +68,7 @@ SelectDialog::SelectDialog(const Element* _e, QWidget* parent)
       sameSubtype->setEnabled(e->subtype() != -1);
       subtype->setEnabled(e->subtype() != -1);
       inSelection->setEnabled(e->score()->selection().isRange());
+      sameDuration->setEnabled(e->isRest());
 
       MuseScore::restoreGeometry(this);
       }
@@ -93,6 +95,11 @@ void SelectDialog::setPattern(ElementPattern* p)
       else {
             p->staffStart = -1;
             p->staffEnd = -1;
+            }
+
+      if (sameDuration->isChecked() && e->isRest()) {
+            const Rest* r = toRest(e);
+            p->durationTicks = r->actualTicks();
             }
 
       p->voice   = sameVoice->isChecked() ? e->voice() : -1;

--- a/mscore/selectdialog.ui
+++ b/mscore/selectdialog.ui
@@ -55,6 +55,13 @@
           </property>
          </widget>
         </item>
+        <item row="4" column="0">
+         <widget class="QCheckBox" name="sameDuration">
+          <property name="text">
+           <string>Same duration</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="0">
          <widget class="QCheckBox" name="sameSubtype">
           <property name="text">


### PR DESCRIPTION
This addresses a feature request at: https://musescore.org/en/node/275264

This PR adds the ability to select rests based on a duration in the Select>More... dialog box. An option has been added which will need translation, I'm not too sure how that works in terms of the workflow.

Selection of rests of same duration:
![rests1](https://user-images.githubusercontent.com/8274049/44255345-ac0b0000-a1fd-11e8-9160-d2f18df18ef4.png)

Selection of element that isn't a rest (disabled duration checkbox):
![rests2](https://user-images.githubusercontent.com/8274049/44255347-aca39680-a1fd-11e8-9712-fc4770c79a34.png)

Quaver rests selected by duration:
![rests3](https://user-images.githubusercontent.com/8274049/44255348-aca39680-a1fd-11e8-8428-ea3d0484354d.png)

 