### PR TITLE
Fix #275356: tremolo bar displays incorrectly

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -437,7 +437,7 @@ static const StyleType styleTypes[] {
       { Sid::textLinePosAbove,          "textLinePosAbove",          Spatium(-3.5) },
       { Sid::textLinePosBelow,          "textLinePosBelow",          Spatium(3.5) },
 
-      { Sid::tremoloBarLineWidth,       "tremoloBarLineWidth",       Spatium(0.1) },
+      { Sid::tremoloBarLineWidth,       "tremoloBarLineWidth",       Spatium(0.12) },
       { Sid::jumpPosAbove,              "jumpPosAbove",              Spatium(-2.0) },
       { Sid::markerPosAbove,            "markerPosAbove",            Spatium(-2.0) },
 

--- a/libmscore/tremolobar.cpp
+++ b/libmscore/tremolobar.cpp
@@ -65,7 +65,7 @@ void TremoloBar::layout()
       for (auto v : _points)
             polygon << QPointF(v.time * timeFactor, v.pitch * pitchFactor);
 
-      qreal w = _lw.val() * _spatium;
+      qreal w = _lw.val();
       setbbox(polygon.boundingRect().adjusted(-w, -w, w, w));
       }
 
@@ -75,7 +75,7 @@ void TremoloBar::layout()
 
 void TremoloBar::draw(QPainter* painter) const
       {
-      QPen pen(curColor(), _lw.val() * spatium(), Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
+      QPen pen(curColor(), _lw.val(), Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
       painter->setPen(pen);
       painter->drawPolyline(polygon);
       }


### PR DESCRIPTION
This bug was caused by the fact that the line width was being multiplied by `spatium()` before the pen was created. This was unneeded, since the line width is already multiplied by `spatium()` in `line.cpp`. So, in effect, the line width was being displayed as the set line width `* spatium() * spatium()`, making it way too big.

![trembar](https://user-images.githubusercontent.com/8274049/44297699-dc21d400-a2cd-11e8-8870-0b38205cea92.png)
![trembar2](https://user-images.githubusercontent.com/8274049/44297700-dc21d400-a2cd-11e8-9632-0091242c0936.png)

Note that the width is slightly larger than appears in the screenshots (I increased it by 0.02sp after taking them, for consistency).