### PR TITLE
#undefine qt's foreach to re#define it to c++11's for.

### DIFF
--- a/all.h
+++ b/all.h
@@ -213,6 +213,14 @@
 #define Q_ASSERT(a)
 #endif
 
+// Define qt's foreach to c++ 11's for.
+// More infos at qglobal.h at #define Q_FOREACH(variable, container)...
+#ifdef Q_FOREACH
+#  undef Q_FOREACH
+#  define Q_FOREACH(variable, container) for(variable : container)
+#endif // Q_FOREACH
+
+
 #if (defined (_MSCVER) || defined (_MSC_VER))
    // Undefined problematic #def'd macros in Microsoft headers
    #undef STRING_NONE


### PR DESCRIPTION
The readme says not to use Qt`s foreach. This is not removing all foreachs, simply re#defining them to cpp11's for.
qglobal.h does this:
```cpp
#define Q_FOREACH(variable, container)
//...

#endif // QT_NO_FOREACH
//...
#ifndef QT_NO_KEYWORDS
# ifndef QT_NO_FOREACH
#  ifndef foreach
#    define foreach Q_FOREACH
#  endif
#endif
```
So this pull request simply redefined foreach to for(variable : container)