### PR TITLE
Add ability to add notes to selection in transposition

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -578,7 +578,8 @@ class Score : public QObject, public ScoreElement {
       bool transpose(Note* n, Interval, bool useSharpsFlats);
       void transposeKeys(int staffStart, int staffEnd, int tickStart, int tickEnd, const Interval&, bool useInstrument = false, bool flip = false);
       bool transpose(TransposeMode mode, TransposeDirection, Key transposeKey, int transposeInterval,
-      bool trKeys, bool transposeChordNames, bool useDoubleSharpsFlats);
+      bool trKeys, bool transposeChordNames, bool useDoubleSharpsFlats, bool addToNotes);
+      bool duplicateNote(Element* e);
 
       static bool& isScoreLoaded();
       bool appendScore(Score*, bool addPageBreak = false, bool addSectionBreak = true);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5054,7 +5054,7 @@ void MuseScore::transpose()
             return;
 
       cs->transpose(td.mode(), td.direction(), td.transposeKey(), td.transposeInterval(),
-         td.getTransposeKeys(), td.getTransposeChordNames(), td.useDoubleSharpsFlats());
+         td.getTransposeKeys(), td.getTransposeChordNames(), td.useDoubleSharpsFlats(), td.addToNotes());
 
       if (noSelection)
             cs->deselectAll();

--- a/mscore/transposedialog.h
+++ b/mscore/transposedialog.h
@@ -59,6 +59,7 @@ class TransposeDialog : public QDialog, Ui::TransposeDialogBase {
       TransposeMode mode() const;
       void setKey(Key k)                  { keyList->setCurrentIndex(int(k) + 7); }
       bool useDoubleSharpsFlats() const   { return accidentalOptions->currentIndex() == 1; }
+      bool addToNotes() const             { return addToNotesCheckbox->isChecked() == 1; }
       };
 }
 

--- a/mscore/transposedialog.ui
+++ b/mscore/transposedialog.ui
@@ -465,6 +465,16 @@
            </item>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="addToNotesCheckbox">
+           <property name="text">
+            <string>Add notes instead of moving</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>

--- a/mtest/libmscore/chordsymbol/tst_chordsymbol.cpp
+++ b/mtest/libmscore/chordsymbol/tst_chordsymbol.cpp
@@ -180,7 +180,7 @@ void TestChordSymbol::testTranspose()
       MasterScore* score = test_pre("transpose");
       score->startCmd();
       score->cmdSelectAll();
-      score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
+      score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true, false);
       score->endCmd();
       test_post(score, "transpose");
       }
@@ -190,7 +190,7 @@ void TestChordSymbol::testTransposePart()
       MasterScore* score = test_pre("transpose-part");
       score->startCmd();
       score->cmdSelectAll();
-      score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true);
+      score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4, false, true, true, false);
       score->endCmd();
       test_post(score, "transpose-part");
       }

--- a/mtest/libmscore/transpose/tst_transpose.cpp
+++ b/mtest/libmscore/transpose/tst_transpose.cpp
@@ -63,7 +63,7 @@ void TestTranspose::undoTranspose()
       // transpose major second up
       score->startCmd();
       score->transpose(TransposeMode::BY_INTERVAL, TransposeDirection::UP, Key::C, 4,
-                       true, true, true);
+                       true, true, true, false);
       score->endCmd();
       QVERIFY(saveCompareScore(score, writeFile1, reference1));
 
@@ -95,7 +95,7 @@ void TestTranspose::undoDiatonicTranspose()
       // transpose diatonic fourth down
       score->startCmd();
       score->transpose(TransposeMode::DIATONICALLY, TransposeDirection::DOWN, Key::C, 3,
-                       true, false, false);
+                       true, false, false, false);
       score->endCmd();
       QVERIFY(saveCompareScore(score, writeFile1, reference1));
 


### PR DESCRIPTION
This is an ability I've wanted for quite a while. It allows you to transpose notes, but instead of just moving them, it adds them to the preexisting notes. So, if you had a melody line that you wanted to put into octaves (something I often want to do), you just transpose it up an octave, and make sure to select the new 'Add notes instead of moving' checkbox (better name suggestions are welcome :)). It works for chords, key signatures, and altered notes as well, in the unlikely case that someone would want to use those options.

Here are some screenshots:
![addtrans1](https://user-images.githubusercontent.com/8274049/44303281-b4198b80-a334-11e8-9dde-5ff061763476.png)
![addtrans2](https://user-images.githubusercontent.com/8274049/44303282-b4b22200-a334-11e8-82d1-fab334a74097.png)
![addtrans3](https://user-images.githubusercontent.com/8274049/44303283-b4b22200-a334-11e8-8c12-f4023733b51d.png)

This wasn't a musescore.org feature request, I just really wanted it :)