### PR TITLE
Fix #274839: Add capo setting to staff text

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2346,7 +2346,11 @@ int Note::ppitch() const
                         return div.pitch;
                   }
             }
-      return _pitch + staff()->pitchOffset(ch->segment()->tick());;
+      int capoFretId = staff()->capo(ch->segment()->tick());
+      if (capoFretId != 0)
+            capoFretId -= 1;
+      
+      return _pitch + staff()->pitchOffset(ch->segment()->tick()) + capoFretId;
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -876,6 +876,8 @@ class Score : public QObject, public ScoreElement {
       void updateSwing();
       void createPlayEvents();
 
+      void updateCapo();
+
       void cmdConcertPitchChanged(bool, bool /*useSharpsFlats*/);
 
       virtual inline TempoMap* tempomap() const;

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -837,6 +837,21 @@ SwingParameters Staff::swing(int tick) const
       }
 
 //---------------------------------------------------------
+//   capo
+//---------------------------------------------------------
+
+int Staff::capo(int tick) const
+      {
+      if (_capoList.empty())
+            return 0;
+      QMap<int, int>::const_iterator i = _capoList.upperBound(tick);
+      if (i == _capoList.begin())
+            return 0;
+      --i;
+      return i.value();
+      }
+
+//---------------------------------------------------------
 //   channel
 //---------------------------------------------------------
 

--- a/libmscore/staff.h
+++ b/libmscore/staff.h
@@ -91,6 +91,7 @@ class Staff final : public ScoreElement {
 //      LinkedStaves* _linkedStaves { 0 };
       QMap<int,int> _channelList[VOICES];
       QMap<int,SwingParameters> _swingList;
+      QMap<int,int> _capoList;
       bool _playbackVoice[VOICES] { true, true, true, true };
 
       VeloList _velocities;         ///< cached value
@@ -181,10 +182,18 @@ class Staff final : public ScoreElement {
       void setBarLineFrom(int val)   { _barLineFrom = val;  }
       void setBarLineTo(int val)     { _barLineTo = val;    }
       qreal height() const;
+
       int channel(int tick, int voice) const;
-      QMap<int,int>* channelList(int voice) { return  &_channelList[voice]; }
+      void clearChannelList(int voice)                               { _channelList[voice].clear(); }
+      void insertIntoChannelList(int voice, int tick, int channelId) { _channelList[voice].insert(tick, channelId); }
+
       SwingParameters swing(int tick)  const;
-      QMap<int,SwingParameters>* swingList() { return &_swingList; }
+      void clearSwingList()                                  { _swingList.clear(); }
+      void insertIntoSwingList(int tick, SwingParameters sp) { _swingList.insert(tick, sp); }
+
+      int capo(int tick) const;
+      void clearCapoList()                             { _capoList.clear(); }
+      void insertIntoCapoList(int tick, int fretId)    { _capoList.insert(tick, fretId); }
 
       //==== staff type
       const StaffType* staffType(int tick) const;

--- a/libmscore/stafftextbase.cpp
+++ b/libmscore/stafftextbase.cpp
@@ -63,6 +63,8 @@ void StaffTextBase::write(XmlWriter& xml) const
             int swingRatio = swingParameters()->swingRatio;
             xml.tagE(QString("swing unit=\"%1\" ratio= \"%2\"").arg(swingUnit).arg(swingRatio));
             }
+      if (capo() != 0)
+            xml.tagE(QString("capo fretId=\"%1\"").arg(capo()));
       TextBase::writeProperties(xml);
 
       xml.etag();
@@ -144,6 +146,11 @@ bool StaffTextBase::readProperties(XmlReader& e)
             int ratio = e.intAttribute("ratio", 60);
             setSwing(true);
             setSwingParameters(unit, ratio);
+            e.readNext();
+            }
+      else if (tag == "capo") {
+            int fretId = e.intAttribute("fretId", 0);
+            setCapo(fretId);
             e.readNext();
             }
       else if (!TextBase::readProperties(e))

--- a/libmscore/stafftextbase.h
+++ b/libmscore/stafftextbase.h
@@ -39,6 +39,7 @@ class StaffTextBase : public TextBase  {
       bool _setAeolusStops { false };
       int aeolusStops[4]   { 0, 0, 0, 0 };
       bool _swing          { false };
+      int _capo            { 0 };
 
    public:
       StaffTextBase(Score*, Tid tid, ElementFlags = ElementFlag::NOTHING);
@@ -61,8 +62,10 @@ class StaffTextBase : public TextBase  {
       bool getAeolusStop(int group, int idx) const;
       void setSetAeolusStops(bool val)                    { _setAeolusStops = val; }
       void setSwing(bool checked)                         { _swing = checked; }
+      void setCapo(int fretId)                            { _capo = fretId; }
       bool setAeolusStops() const                         { return _setAeolusStops; }
       bool swing() const                                  { return _swing; }
+      int capo() const                                    { return _capo; }
       };
 
 }     // namespace Ms

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -309,8 +309,10 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                   else
                         e->score()->select(e, st, -1);
                   }
-            if (e->isNote())
+            if (e->isNote()) {
+                  e->score()->updateCapo();
                   mscore->play(e);
+                  }
             if (e) {
                   _score = e->score();
                   _score->setUpdateAll();

--- a/mscore/exportmidi.cpp
+++ b/mscore/exportmidi.cpp
@@ -221,6 +221,7 @@ bool ExportMidi::write(const QString& name, bool midiExpandRepeats, bool exportR
       for (int i = 0; i < cs->nstaves(); ++i)
             tracks.append(MidiTrack());
 
+      cs->updateCapo();
       cs->updateSwing();
       cs->createPlayEvents();
       cs->updateRepeatList(midiExpandRepeats);

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -311,6 +311,7 @@ Score* MuseScore::openScore(const QString& fn)
 
       MasterScore* score = readScore(fn);
       if (score) {
+            score->updateCapo();
             setCurrentScoreView(appendScore(score));
             writeSessionFile(false);
             }

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -406,6 +406,7 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
                   nt->setScore(score);
                   score->undoChangeElement(e, nt);
                   score->masterScore()->updateChannel();
+                  score->updateCapo();
                   score->updateSwing();
                   score->setPlaylistDirty();
                   }

--- a/mscore/stafftext.ui
+++ b/mscore/stafftext.ui
@@ -4153,6 +4153,114 @@ VI</string>
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabCapoSettings">
+      <attribute name="title">
+       <string>Capo Settings</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="capoVerticalLayout">
+       <item>
+        <widget class="QGroupBox" name="setCapoBox">
+         <property name="title">
+          <string>Capo Settings</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <widget class="QWidget" name="capoHorizontalLayoutWidget">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>20</y>
+            <width>601</width>
+            <height>31</height>
+           </rect>
+          </property>
+          <layout class="QHBoxLayout" name="capoHorizontalLayout">
+           <item>
+            <widget class="QLabel" name="capoLabel">
+             <property name="text">
+              <string>Capo fret:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+             <widget class="QComboBox" name="fretList">
+              <item>
+               <property name="text">
+                <string>No capo</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>1</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>2</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>3</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>4</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>5</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>6</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>7</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>8</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>9</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>10</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>11</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>12</string>
+               </property>
+              </item>
+             </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/mscore/stafftextproperties.cpp
+++ b/mscore/stafftextproperties.cpp
@@ -60,6 +60,7 @@ StaffTextProperties::StaffTextProperties(const StaffTextBase* st, QWidget* paren
             tabWidget->removeTab(tabWidget->indexOf(tabAeolusStops)); // Aeolus settings  for staff text only
             //if (!enableExperimental) tabWidget->removeTab(tabWidget->indexOf(tabMIDIAction));
             tabWidget->removeTab(tabWidget->indexOf(tabChangeChannel)); // Channel switching  for staff text only
+            tabWidget->removeTab(tabWidget->indexOf(tabCapoSettings)); // Capos for staff text only
             }
       else {
             setWindowTitle(tr("Staff Text Properties"));
@@ -162,6 +163,19 @@ StaffTextProperties::StaffTextProperties(const StaffTextBase* st, QWidget* paren
       connect(swingEighth, SIGNAL(toggled(bool)), SLOT(setSwingControls(bool)));
       connect(swingSixteenth, SIGNAL(toggled(bool)), SLOT(setSwingControls(bool)));
 
+
+      //---------------------------------------------------
+      //    setup capo
+      //      Note that capo is stored as an int, where 0 = no change,
+      //      1 = remove capo, and everyother number (n) = pitch increase
+      //      of n-1 semitones.
+      //---------------------------------------------------
+
+      if (_staffText->capo() != 0) {
+            setCapoBox->setChecked(true);
+            fretList->setCurrentIndex(_staffText->capo()-1);
+            }
+      
       //---------------------------------------------------
       //    setup midi actions
       //---------------------------------------------------
@@ -465,6 +479,11 @@ void StaffTextProperties::saveValues()
                   swingBox->setEnabled(true);
                   }
             }
+
+      if (setCapoBox->isChecked())
+            _staffText->setCapo(fretList->currentIndex()+1);
+      else
+            _staffText->setCapo(0);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Refers to: https://musescore.org/en/node/274839.
This adds the functionality to make staff text change the tuning of a staff by some semitones, as if a capo had been attached to the instrument (most likely a guitar). This is useful for guitars, which of course often have to use capos to make playing tunes easier. Before, there was [a tedious workaround](https://musescore.org/en/node/268639) that allowed this functionality. Now, you can add some staff text, set it to change the capo to a fret of your choice, and change the text to match the capo you have applied. It's a lot easier :)

Here are some screenshots (NOTE: capo numbers are now numbers, not Roman numerals):

Capo staff text in use
![capo1](https://user-images.githubusercontent.com/8274049/44313295-e6db8680-a3fd-11e8-97af-f42fb44380df.png)

Selecting a fret
![capo2](https://user-images.githubusercontent.com/8274049/44313296-e7741d00-a3fd-11e8-909d-558f91b1b8cc.png)

'No capo' removes a previous capo, returning to normal tuning
![capo3](https://user-images.githubusercontent.com/8274049/44313297-e7741d00-a3fd-11e8-888d-5b5d2d88a977.png)

The pitch is recognised as being different, so it will indicate when it is out of the range.
![capo4](https://user-images.githubusercontent.com/8274049/44313298-e7741d00-a3fd-11e8-939e-bb75d43e5fd6.png)