### PR TITLE
fix #275376: Ottava line is displayed incorrectly 2.X->3.0

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3255,7 +3255,9 @@ System* Score::collectSystem(LayoutContext& lc)
                               if (isTopBeam(cr)) {
                                     cr->beam()->layout();
                                     Shape shape(cr->beam()->shape().translated(-(cr->segment()->pos()+mb->pos())));
-                                    s->staffShape(cr->staffIdx()).add(shape);
+                                    // If beams are added to the segment shape,
+                                    // then ottava lines will be drawn too long.
+                                    // s->staffShape(cr->staffIdx()).add(shape);
                                     m->staffShape(cr->staffIdx()).add(shape.translated(s->pos()));
                                     }
                               if (e->isChord()) {
@@ -3324,7 +3326,9 @@ System* Score::collectSystem(LayoutContext& lc)
                         while (de->tuplet() && de->tuplet()->elements().front() == de) {
                               Tuplet* t = de->tuplet();
                               t->layout();
-                              s->staffShape(t->staffIdx()).add(t->shape().translated(-s->pos()));
+                              // If tuplets are added to the segment shape,
+                              // then ottava lines will be drawn too long.
+                              // s->staffShape(t->staffIdx()).add(t->shape().translated(-s->pos()));
                               m->staffShape(t->staffIdx()).add(t->shape());
                               de = de->tuplet();
                               }

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -495,6 +495,8 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                     // lay out just past right edge of all notes for this segment on this staff
 
                                     Segment* s = cr->segment();
+                                    // If this is how ottava line length is calculated,
+                                    // then beams and tuplets cannot be added to the segment shape.
                                     qreal width = s->staffShape(staffIdx()).right();
                                     x = width + sp;
 


### PR DESCRIPTION
See https://musescore.org/en/node/275376.

It seems to me that beams and tuplets should not be added to the segment shape, because they span multiple segments.