### PR TITLE
fix #275365: Glissando is lost (playback works) 2.X->3.0

### DIFF
--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -230,11 +230,11 @@ void Glissando::layout()
             s->layout();
             return;
             }
+      SLine::layout();
       if (spannerSegments().empty()) {
             qDebug("no segments");
             return;
             }
-      SLine::layout();
       setPos(0.0, 0.0);
 
       Note*       anchor1     = toNote(startElement());


### PR DESCRIPTION
See https://musescore.org/en/node/275365.

`spannerSegments().empty()` will be _true_ until `SLine::layout()` is called for the first time. If `Glissando::layout()` returns before `SLine::layout()` is called because `spannerSegments().empty()` is _true_, then the Glissando Segments will never get created, and the Glissando will not be drawn.