### PR TITLE
fix #274934: Incorrect articulations palette displaying

### DIFF
--- a/libmscore/fermata.cpp
+++ b/libmscore/fermata.cpp
@@ -189,6 +189,8 @@ void Fermata::layout()
       Segment* s = segment();
       if (!s) {          // for use in palette
             setPos(QPointF());
+            QRectF b(symBbox(_symId));
+            setbbox(b.translated(-0.5 * b.width(), 0.0));
             return;
             }
 


### PR DESCRIPTION
See https://musescore.org/en/node/274934.

This will cause the fermatas in the articulations palette to be centered in the cells.