### PR TITLE
fix #275369: Key signatures are lost 2.X->3.0

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3517,7 +3517,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
                         bool disable = true;
                         for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
                               Element* e = kSegment->element(staffIdx * VOICES);
-                              if (e && !e->generated()) {
+                              if (e && (!e->generated() || toKeySig(e)->key() != Key::C)) {
                                     disable = false;
                                     break;
                                     }


### PR DESCRIPTION
See https://musescore.org/en/node/275369.