### PR TITLE
fix #122226: Crashes related to having no measures in the score

### DIFF
--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -84,6 +84,8 @@ void Score::layoutLinear(bool layoutAll, LayoutContext& lc)
             systems().clear();
             qDeleteAll(pages());
             pages().clear();
+            if (!firstMeasure())
+                  return;
 
             page = new Page(this);
             pages().push_back(page);
@@ -97,6 +99,8 @@ void Score::layoutLinear(bool layoutAll, LayoutContext& lc)
                   system->insertStaff(i);
             }
       else {
+            if (pages().isEmpty())
+                  return;
             page = pages().front();
             system = systems().front();
             }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1132,8 +1132,8 @@ bool Score::getPosition(Position* pos, const QPointF& p, int voice) const
 
 bool Score::checkHasMeasures() const
       {
-      Page* page = pages().front();
-      const QList<System*>* sl = &page->systems();
+      Page* page = pages().isEmpty() ? 0 : pages().front();
+      const QList<System*>* sl = page ? &page->systems() : 0;
       if (sl == 0 || sl->empty() || sl->front()->measures().empty()) {
             qDebug("first create measure, then repeat operation");
             return false;

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -567,7 +567,7 @@ bool Score::saveCompressedFile(QIODevice* f, QFileInfo& info, bool onlySelection
             }
 
       // create thumbnail
-      if (doCreateThumbnail) {
+      if (doCreateThumbnail && !pages().isEmpty()) {
             QImage pm = createThumbnail();
 
             QByteArray ba;

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -2206,7 +2206,7 @@ void Timeline::wheelEvent(QWheelEvent* event)
 
 void Timeline::updateGrid()
       {
-      if (_score) {
+      if (_score && _score->firstMeasure()) {
             drawGrid(nstaves(), _score->nmeasures());
             updateView();
             drawSelection();


### PR DESCRIPTION
See https://musescore.org/en/node/122226.