### PR TITLE
Fix #275386: anchor points not rebuilt after setting autoplacement

### DIFF
--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -23,6 +23,7 @@
 #include "offsetSelect.h"
 #include "scaleSelect.h"
 #include "sizeSelect.h"
+#include "scoreview.h"
 
 namespace Ms {
 
@@ -396,6 +397,9 @@ void InspectorBase::valueChanged(int idx, bool reset)
       if (id == Pid::SUB_STYLE)
             setElement();
       recursion = false;
+
+      ScoreView* cv = mscore->currentScoreView();
+      cv->updateGrips();
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -176,7 +176,6 @@ class ScoreView : public QWidget, public MuseScoreView {
       void drawElements(QPainter& p,QList<Element*>& el, Element* editElement);
       bool dragTimeAnchorElement(const QPointF& pos);
       bool dragMeasureAnchorElement(const QPointF& pos);
-      void updateGrips();
       virtual void lyricsTab(bool back, bool end, bool moveOnly) override;
       virtual void lyricsReturn() override;
       virtual void lyricsEndEdit() override;
@@ -399,6 +398,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       virtual const QRect geometry() const override { return QWidget::geometry(); }
 
       bool clickOffElement;
+      void updateGrips();
       };
 
 } // namespace Ms


### PR DESCRIPTION
Addresses: https://musescore.org/en/node/275386