### PR TITLE
Fix #275574: crash when dragging element onto score in (text) edit mode

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -322,6 +322,11 @@ void Palette::mousePressEvent(QMouseEvent* ev)
       dragStartPosition = ev->pos();
       dragIdx           = idx(dragStartPosition);
 
+      // Take out of edit mode to prevent crashes when adding
+      // elements from palette
+      ScoreView* cv = mscore->currentScoreView();
+      cv->changeState(ViewState::NORMAL);
+
       if (dragIdx == -1)
             return;
       if (_selectable) {


### PR DESCRIPTION
Fixes: https://musescore.org/en/node/275574