### PR TITLE
fix #275552 fix#137501: Inability to show multi-measure rests in Continuous View

### DIFF
--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -43,7 +43,22 @@ add_library (
       ${_all_h_file}
       ${INCS}
       ${LIB_SCRIPT_FILES}
-      types.h
+
+      types.h accidental.h ambitus.h arpeggio.h articulation.h audio.h bagpembell.h barline.h beam.h bend.h
+      box.h bracket.h bracketItem.h breath.h bsp.h bsymbol.h chord.h chordline.h chordlist.h chordrest.h clef.h
+      cleflist.h connector.h cursor.h drumset.h dsp.h duration.h durationtype.h dynamic.h element.h elementlayout.h
+      elementmap.h excerpt.h fermata.h fifo.h figuredbass.h fingering.h fraction.h fret.h glissando.h groups.h hairpin.h
+      harmony.h hook.h icon.h image.h imageStore.h iname.h input.h instrchange.h instrtemplate.h instrument.h interval.h
+      jump.h key.h keyfinder.h keylist.h keysig.h lasso.h layout.h layoutbreak.h ledgerline.h letring.h line.h location.h
+      lyrics.h marker.h mcursor.h measure.h measurebase.h mscore.h mscoreview.h musescoreCore.h navigate.h note.h notedot.h
+      noteevent.h noteline.h ossia.h ottava.h page.h palmmute.h part.h pedal.h pitch.h pitchspelling.h pitchvalue.h plugins.h
+      pos.h property.h range.h read206.h rehearsalmark.h repeat.h repeatlist.h rest.h revisions.h score.h scoreElement.h segment.h
+      segmentlist.h select.h sequencer.h shadownote.h shape.h sig.h slur.h slurtie.h spacer.h spanner.h spannermap.h spatium.h 
+      staff.h stafflines.h staffstate.h stafftext.h stafftextbase.h stafftype.h stafftypechange.h stafftypelist.h stem.h
+      stemslash.h stringdata.h style.h sym.h symbol.h synthesizerstate.h system.h systemdivider.h systemtext.h tempo.h 
+      tempotext.h text.h textbase.h textedit.h textframe.h textline.h textlinebase.h tie.h tiemap.h timesig.h
+      tremolo.h tremolobar.h trill.h tuplet.h tupletmap.h types.h undo.h utils.h velo.h vibrato.h volta.h xml.h
+
       segmentlist.cpp fingering.cpp accidental.cpp arpeggio.cpp
       fermata.cpp articulation.cpp barline.cpp beam.cpp bend.cpp box.cpp
       bracket.cpp breath.cpp bsp.cpp chord.cpp chordline.cpp

--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -147,7 +147,7 @@ void Clef::layout()
                   }
 
             Measure* meas = clefSeg->measure();
-            if (meas && meas->system()) {
+            if (meas && meas->system() && !score()->lineMode()) {
                   auto ml = meas->system()->measures();
                   bool found = (std::find(ml.begin(), ml.end(), meas) != ml.end());
                   bool courtesy = (tick == meas->endTick() && (meas == meas->system()->lastMeasure() || !found));

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -375,12 +375,12 @@ QPointF Element::pagePos() const
 QPointF Element::canvasPos() const
       {
       QPointF p(pos());
-      if (parent() == 0)
+      if (parent() == nullptr)
             return p;
 
       if (_flags & ElementFlag::ON_STAFF) {
-            System* system = 0;
-            Measure* measure = 0;
+            System* system = nullptr;
+            Measure* measure = nullptr;
             if (parent()->isSegment())
                   measure = toSegment(parent())->measure();
             else if (parent()->isMeasure())     // used in measure number

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -508,6 +508,9 @@ class Score : public QObject, public ScoreElement {
       void cmdAddFret(int fret);
       void cmdToggleVisible();
 
+      void resetSystems(bool layoutAll, LayoutContext& lc);
+      void collectLinearSystem(LayoutContext& lc);
+
    protected:
       int _fileDivision; ///< division of current loading *.msc file
       LayoutMode _layoutMode { LayoutMode::PAGE };


### PR DESCRIPTION
1) The reason of crash is utilizing already deleted pointer. Each element are lying in the tree.   The parent of VBox element is System element. When we change mode to continuous view MS deleted all System elements and create new one. Then populate new tree with new System which is root. But VBox is not shown in continuous view and MS do not set new parent for VBox. Sow VBox have pointer to deleted Sytem element. I fixed it by setting parent of Vbox nullptr.

2) Add header files to libmscore/CMakeLists. It doesn't effect on building solution. But it is necessary to include header files to Visual Studio IDE