### PR TITLE
Fix #274710: incorrect text autoplacement

### DIFF
--- a/libmscore/shape.cpp
+++ b/libmscore/shape.cpp
@@ -96,7 +96,7 @@ qreal Shape::minHorizontalDistance(const Shape& a) const
 
 //-------------------------------------------------------------------
 //   minVerticalDistance
-//    a is located below of this shape.
+//    a is located below this shape.
 //    Calculates the minimum distance between two shapes.
 //-------------------------------------------------------------------
 

--- a/libmscore/shape.h
+++ b/libmscore/shape.h
@@ -39,7 +39,7 @@ struct ShapeElement : public QRectF {
 //   Shape
 //---------------------------------------------------------
 
-class Shape : std::vector<ShapeElement> {
+class Shape : public std::vector<ShapeElement> {
    public:
       Shape() {}
 #ifndef NDEBUG


### PR DESCRIPTION
Fixes: https://musescore.org/en/node/274710

This required a large rework of autoplacement for text bases. It also fixes a (probably) unreported issue with right-aligned text colliding with text in previous measures, and an issue with text colliding with text in measures after the next measure, if it was very long.

See screenshot of fixed autoplacement:

![text1](https://user-images.githubusercontent.com/8274049/44620890-49b49e00-a894-11e8-915e-8546f724db3e.png)
 