### PR TITLE
fix #275730: Crash when switching in Page View if mm rests are shown

### DIFF
--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -83,6 +83,9 @@ static void processLines(System* system, std::vector<Spanner*> lines, bool align
       if (!firstMeasure())
             return;
 
+      for (MeasureBase* mb = first(); mb; mb = mb->next())
+            mb->setSystem(nullptr);
+
       auto page = new Page(this);
       pages().push_back(page);
       page->bbox().setRect(0.0, 0.0, loWidth(), loHeight());

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5768,7 +5768,7 @@ void MuseScore::switchLayoutMode(LayoutMode mode)
       {
       // find a measure to use as reference, if possible
       QRectF view = cv->toLogical(QRect(0.0, 0.0, width(), height()));
-      Measure* m = cs->firstMeasure();
+      Measure* m = cs->firstMeasureMM();
       while (m && !view.intersects(m->canvasBoundingRect()))
             m = m->nextMeasureMM();
 
@@ -5784,7 +5784,7 @@ void MuseScore::switchLayoutMode(LayoutMode mode)
       // also, better positioning is usually achieved if you start from the top
       // and there is really no better place to position canvas if we were all the way off page previously
       cv->pageTop();
-      if (m && m != cs->firstMeasure())
+      if (m && m != cs->firstMeasureMM())
             cv->adjustCanvasPosition(m, false);
       }
 


### PR DESCRIPTION
See https://musescore.org/en/node/275730.