### PR TITLE
fix #260921: Continuous View: Inability to reach measures with Ctrl + F

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4104,7 +4104,7 @@ bool ScoreView::searchRehearsalMark(const QString& s)
 
 void ScoreView::gotoMeasure(Measure* measure)
       {
-      adjustCanvasPosition(measure, true);
+      adjustCanvasPosition(measure, state != ViewState::NORMAL);
       int tracks = _score->nstaves() * VOICES;
       for (Segment* segment = measure->first(); segment; segment = segment->next()) {
             if (segment->segmentType() != SegmentType::ChordRest)


### PR DESCRIPTION
Change parameter of function to false. Because value true do not allow to reach certain measures. 