### PR TITLE
fix #275589: Chord symbols fly away in Continuous view

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3192,26 +3192,8 @@ System* Score::collectSystem(LayoutContext& lc)
             }
       system->setWidth(pos.x());
 
-      //
-      // compute measure shape
-      //
+      lc.computeMeasureShape(system);
 
-      for (int si = 0; si < score()->nstaves(); ++si) {
-            for (MeasureBase* mb : system->measures()) {
-                  if (!mb->isMeasure())
-                        continue;
-                  Measure* m = toMeasure(mb);
-                  Shape& ss  = m->staffShape(si);
-                  ss.clear();
-
-                  for (Segment& s : m->segments()) {
-                        if (s.isTimeSigType())       // hack: ignore time signatures
-                              continue;
-                        ss.add(s.staffShape(si).translated(s.pos()));
-                        }
-                  ss.add(m->staffLines(si)->bbox());
-                  }
-            }
       //
       // layout
       //    - beams
@@ -3488,6 +3470,30 @@ System* Score::collectSystem(LayoutContext& lc)
             }
 
       return system;
+      }
+
+//---------------------------------------------------------
+//   computeMeasureShape
+//---------------------------------------------------------
+
+void LayoutContext::computeMeasureShape(System* system)
+      {
+      for (int si = 0; si < score->nstaves(); ++si) {
+            for (MeasureBase* mb : system->measures()) {
+                  if (!mb->isMeasure())
+                        continue;
+                  Measure* m = toMeasure(mb);
+                  Shape& ss  = m->staffShape(si);
+                  ss.clear();
+
+                  for (Segment& s : m->segments()) {
+                        if (s.isTimeSigType())       // hack: ignore time signatures
+                              continue;
+                        ss.add(s.staffShape(si).translated(s.pos()));
+                        }
+                  ss.add(m->staffLines(si)->bbox());
+                  }
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -53,6 +53,8 @@ struct LayoutContext {
       int adjustMeasureNo(MeasureBase*);
       void getEmptyPage();
       void collectPage();
+
+      void computeMeasureShape(System* system);
       };
 
 //---------------------------------------------------------

--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -193,6 +193,8 @@ void LayoutContext::layoutLinear()
       {
       System* system = score->systems().front();
 
+      computeMeasureShape(system);
+      
       //
       // layout
       //    - beams


### PR DESCRIPTION
Auto-placement add new shape of element to _staves but in continuous view old _staves is not reseted. So this container consist of ghost shapes after every update