### PR TITLE
fix #275751: Continuous view mode is not saved in master

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2790,6 +2790,18 @@ void Score::selectSingle(Element* e, int staffIdx)
       }
 
 //---------------------------------------------------------
+//   switchToPageMode
+//---------------------------------------------------------
+
+void Score::switchToPageMode()
+      {
+            if (_layoutMode != LayoutMode::PAGE) {
+                  setLayoutMode(LayoutMode::PAGE);
+                  doLayout();
+            }
+      }
+
+//---------------------------------------------------------
 //   selectAdd
 //---------------------------------------------------------
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1032,6 +1032,7 @@ class Score : public QObject, public ScoreElement {
       bool floatMode() const                { return layoutMode() == LayoutMode::FLOAT; }
       bool pageMode() const                 { return layoutMode() == LayoutMode::PAGE; }
       bool lineMode() const                 { return layoutMode() == LayoutMode::LINE; }
+      bool systemMode() const               { return layoutMode() == LayoutMode::SYSTEM; }
 
       Tuplet* searchTuplet(XmlReader& e, int id);
       void cmdSelectAll();
@@ -1130,6 +1131,8 @@ class Score : public QObject, public ScoreElement {
 
       bool checkKeys();
       bool checkClefs();
+
+      void switchToPageMode();
 
       virtual QVariant getProperty(Pid) const override;
       virtual bool setProperty(Pid, const QVariant&) override;

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -115,8 +115,10 @@ void Score::writeMovement(XmlWriter& xml, bool selectionOnly)
                   }
             }
 
-      if (_layoutMode == LayoutMode::LINE)
+      if (lineMode())
             xml.tag("layoutMode", "line");
+      if (systemMode())
+            xml.tag("layoutMode", "system");
 
 #ifdef OMR
       if (masterScore()->omr() && xml.writeOmr())

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -1819,10 +1819,6 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy, const QString& path, const QStr
             fn += suffix;
 
       LayoutMode layoutMode = cs->layoutMode();
-      if (layoutMode != LayoutMode::PAGE) {
-            cs->setLayoutMode(LayoutMode::PAGE);
-            cs->doLayout();
-            }
       if (ext == "mscx" || ext == "mscz") {
             // save as mscore *.msc[xz] file
             QFileInfo fi(fn);
@@ -1895,14 +1891,17 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy, const QString& path, const QStr
             }
       else if (ext == "pdf") {
             // save as pdf file *.pdf
+            cs->switchToPageMode();
             rv = savePdf(cs, fn);
             }
       else if (ext == "png") {
             // save as png file *.png
+            cs->switchToPageMode();
             rv = savePng(cs, fn);
             }
       else if (ext == "svg") {
             // save as svg file *.svg
+            cs->switchToPageMode();
             rv = saveSvg(cs, fn);
             }
 #ifdef HAS_AUDIOFILE
@@ -1914,10 +1913,12 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy, const QString& path, const QStr
             rv = saveMp3(cs, fn);
 #endif
       else if (ext == "spos") {
+            cs->switchToPageMode();
             // save positions of segments
             rv = savePositions(cs, fn, true);
             }
       else if (ext == "mpos") {
+            cs->switchToPageMode();
             // save positions of measures
             rv = savePositions(cs, fn, false);
             }
@@ -1931,6 +1932,7 @@ bool MuseScore::saveAs(Score* cs, bool saveCopy, const QString& path, const QStr
             }
       if (!rv && !MScore::noGui)
             QMessageBox::critical(this, tr("MuseScore:"), tr("Cannot write into %1").arg(fn));
+      
       if (layoutMode != cs->layoutMode()) {
             cs->setLayoutMode(layoutMode);
             cs->doLayout();


### PR DESCRIPTION
In MuseScore::saveAs there was a code which change layout mode to PageView. I deleted it to allow saving layout mode to mscz