### PR TITLE
fix #275369: Key signatures are lost 2.X->3.0

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -4016,7 +4016,8 @@ void Measure::addSystemHeader(bool isFirstSystem)
                         bool disable = true;
                         for (int staffIdx = 0; staffIdx < score()->nstaves(); ++staffIdx) {
                               Element* e = kSegment->element(staffIdx * VOICES);
-                              if (e && (!e->generated() || toKeySig(e)->key() != Key::C)) {
+                              Key key = score()->staff(staffIdx)->key(tick());
+                              if ((e && !e->generated()) || (key != keyIdx.key())) {
                                     disable = false;
                                     break;
                                     }


### PR DESCRIPTION
See https://musescore.org/en/node/275369.

Don't disable the KeySig segment if different staves have different keys.