### PR TITLE
Fix #275218: MSVC warnings

### DIFF
--- a/fluid/sfont.cpp
+++ b/fluid/sfont.cpp
@@ -163,7 +163,6 @@ void Preset::loadSamples()
             if (i->global_zone && i->global_zone->sample)
                   i->global_zone->sample->load();
 
-            int instrZonesSize = i->zones.size();
             for (Zone* iz : i->zones) {
                   if (sfont->synth->globalTerminate()) {
                         if (locked)

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1071,7 +1071,7 @@ static Bm beamMetric1(bool up, char l1, char l2)
 
 static int adjust(qreal _spatium4, int slant, const std::vector<ChordRest*>& cl)
       {
-      int n = cl.size();
+      size_t n = cl.size();
       const ChordRest* c1 = cl[0];
       const ChordRest* c2 = cl[n-1];
 
@@ -1079,7 +1079,7 @@ static int adjust(qreal _spatium4, int slant, const std::vector<ChordRest*>& cl)
       qreal slope = (slant * _spatium4) / (c2->stemPosBeam().x() - p1.x());
       int ml = -1000;
       if (c1->up()) {
-            for (int i = 1; i < n; ++i) {
+            for (size_t i = 1; i < n; ++i) {
                   QPointF p3(cl[i]->stemPosBeam());
                   qreal yUp   = p1.y() + (p3.x() - p1.x()) * slope;
                   int l       = lrint((yUp - p3.y()) / (_spatium4));
@@ -1087,7 +1087,7 @@ static int adjust(qreal _spatium4, int slant, const std::vector<ChordRest*>& cl)
                   }
             }
       else {
-            for (int i = 1; i < n; ++i) {
+            for (size_t i = 1; i < n; ++i) {
                   const ChordRest* c = cl[i];
                   QPointF p3(c->stemPosBeam());
                   qreal yUp   = p1.y() + (p3.x() - p1.x()) * slope;
@@ -1519,7 +1519,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
 
       _beamDist *= mag();
       _beamDist *= c1->staff()->mag(c1->tick());
-      int n = crl.size();
+      size_t n = crl.size();
 
       StaffType* tab = 0;
       if (staff()->isTabStaff(0) )
@@ -1552,7 +1552,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                   // set stem direction for every chord
                   //
                   bool relayoutGrace = false;
-                  for (int i = 0; i < n; ++i) {
+                  for (size_t i = 0; i < n; ++i) {
                         Chord* c = toChord(crl.at(i));
                         if (c->isRest())
                               continue;
@@ -1583,7 +1583,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                   qreal beamY   = 0.0;  // y position of main beam start
                   qreal y1   = -200000;
                   qreal y2   = 200000;
-                  for (int i = 0; i < n; ++i) {
+                  for (size_t i = 0; i < n; ++i) {
                         Chord* c = toChord(crl.at(i));
                         qreal y;
                         if (c->isRest())
@@ -1672,7 +1672,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
 
             // loop through the different groups for this beam level
             // inner loop will advance through chordrests within each group
-            for (int i = 0; i < n;) {
+            for (size_t i = 0; i < n;) {
                   ChordRest* cr1 = crl[i];
                   int l1 = cr1->durationType().hooks() - 1;
 
@@ -1683,7 +1683,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
 
                   // at the beginning of a group
                   // loop through chordrests looking for end
-                  int currentChordRestIndex = i;
+                  size_t currentChordRestIndex = i;
                   ++i;
                   bool b32 = false, b64 = false;
                   for (; i < n; ++i) {
@@ -1704,7 +1704,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                         }
 
                   // found end of group
-                  int chordRestEndGroupIndex = i;
+                  size_t chordRestEndGroupIndex = i;
                   ChordRest* cr2 = crl[chordRestEndGroupIndex - 1];
 
                   // if group covers whole beam, we are still at base level
@@ -1748,7 +1748,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                   // if there are more beam levels,
                   // record current beam offsets for all notes of this group for re-use
                   if (beamLevel < beamLevels - 1) {
-                        for (int i1 = currentChordRestIndex; i1 < chordRestEndGroupIndex; ++i1)
+                        for (size_t i1 = currentChordRestIndex; i1 < chordRestEndGroupIndex; ++i1)
                               crBase[i1] = bl;
                         }
 
@@ -1777,7 +1777,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                         if (cr1->type() == ElementType::REST)
                               continue;
 
-                        int sizeChordRests = crl.size();
+                        size_t sizeChordRests = crl.size();
                         qreal len = beamMinLen;
                         //
                         // find direction (by default, segment points to right)

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -168,8 +168,8 @@ int Chord::upString() const
       int                     noteLine;
       // scan each note: if TAB strings are not in sequential order,
       // visual order of notes might not correspond to pitch order
-      int n = _notes.size();
-      for (int i = 0; i < n; ++i) {
+      size_t n = _notes.size();
+      for (size_t i = 0; i < n; ++i) {
             noteLine = tab->physStringToVisual(_notes.at(i)->string());
             if (noteLine < line)
                   line = noteLine;
@@ -184,10 +184,10 @@ int Chord::downString() const
       if (!staff()->isTabStaff(tick()))                // if staff not a TAB, return bottom line
             return staff()->lines(tick())-1;
       StaffType* tab = staff()->staffType(tick());
-      int       line = 0;         // start at top line
-      int        noteLine;
-      int n = _notes.size();
-      for (int i = 0; i < n; ++i) {
+      int line = 0;         // start at top line
+      int noteLine;
+      size_t n = _notes.size();
+      for (size_t i = 0; i < n; ++i) {
             noteLine = tab->physStringToVisual(_notes.at(i)->string());
             if (noteLine > line)
                   line = noteLine;
@@ -658,8 +658,8 @@ void Chord::addLedgerLines()
       // NOTE: notes are sorted from bottom to top (line no. decreasing)
       // notes are scanned twice from outside (bottom or top) toward the staff
       // each pass stops at the first note without ledger lines
-      int n = _notes.size();
-      for (int j = 0; j < 2; j++) {             // notes are scanned twice...
+      size_t n = _notes.size();
+      for (size_t j = 0; j < 2; j++) {             // notes are scanned twice...
             int from, delta;
             vector<LedgerLineData> vecLines;
             minX  = maxX = 0;
@@ -670,10 +670,10 @@ void Chord::addLedgerLines()
                   delta = +1;
                   }
             else {
-                  from = n-1;                   // ...once from highest down
+                  from = int(n)-1;                   // ...once from highest down
                   delta = -1;
                   }
-            for (int i = from; i < n && i >=0 ; i += delta) {
+            for (int i = from; i < int(n) && i >= 0 ; i += delta) {
                   Note* note = _notes.at(i);
                   int l = note->line();
 
@@ -861,8 +861,8 @@ void Chord::computeUp()
                   // if extrema symmetrical, average directions of intermediate notes
                   if (-ud == dd) {
                         int up = 0;
-                        int n = _notes.size();
-                        for (int i = 0; i < n; ++i) {
+                        size_t n = _notes.size();
+                        for (size_t i = 0; i < n; ++i) {
                               const Note* currentNote = _notes.at(i);
                               int l = tabStaff ? currentNote->string() * 2 : currentNote->line();
                               if (l <= dnMaxLine)
@@ -886,8 +886,8 @@ void Chord::computeUp()
 Note* Chord::selectedNote() const
       {
       Note* note = 0;
-      int n = _notes.size();
-      for (int i = 0; i < n; ++i) {
+      size_t n = _notes.size();
+      for (size_t i = 0; i < n; ++i) {
             Note* currentNote = _notes.at(i);
             if (currentNote->selected()) {
                   if (note)
@@ -1128,8 +1128,8 @@ void Chord::scanElements(void* data, void (*func)(void*, Element*), bool all)
       if ((st && st->showLedgerLines(tick())) || !st)       // also for palette
             for (LedgerLine* ll = _ledgerLines; ll; ll = ll->next())
                   func(data, ll);
-      int n = _notes.size();
-      for (int i = 0; i < n; ++i)
+      size_t n = _notes.size();
+      for (size_t i = 0; i < n; ++i)
             _notes.at(i)->scanElements(data, func, all);
       for (Chord* chord : _graceNotes)
             chord->scanElements(data, func, all);
@@ -1752,8 +1752,8 @@ void Chord::layoutPitched()
             //
             // hack for use in palette
             //
-            int n = _notes.size();
-            for (int i = 0; i < n; i++) {
+            size_t n = _notes.size();
+            for (size_t i = 0; i < n; i++) {
                   Note* note = _notes.at(i);
                   note->layout();
                   qreal x = 0.0;
@@ -2087,9 +2087,9 @@ void Chord::layoutTablature()
       int   ledgerLines = 0;
       qreal llY         = 0.0;
 
-      int   numOfNotes  = _notes.size();
+      size_t numOfNotes = _notes.size();
       qreal minY        = 1000.0;               // just a very large value
-      for (int i = 0; i < numOfNotes; ++i) {
+      for (size_t i = 0; i < numOfNotes; ++i) {
             Note* note = _notes.at(i);
             note->layout();
             // set headWidth to max fret text width
@@ -2390,7 +2390,7 @@ void Chord::layoutTablature()
                   }
             }
 
-      for (int i = 0; i < numOfNotes; ++i)
+      for (size_t i = 0; i < numOfNotes; ++i)
             _notes.at(i)->layout2();
       QRectF bb;
       processSiblings([&bb] (Element* e) { bb |= e->bbox().translated(e->pos()); } );
@@ -2489,8 +2489,8 @@ void Chord::layoutArpeggio2()
 
 Note* Chord::findNote(int pitch) const
       {
-      int ns = _notes.size();
-      for (int i = 0; i < ns; ++i) {
+      size_t ns = _notes.size();
+      for (size_t i = 0; i < ns; ++i) {
             Note* n = _notes.at(i);
             if (n->pitch() == pitch)
                   return n;
@@ -2748,8 +2748,8 @@ void Chord::setSlash(bool flag, bool stemless)
                   head = NoteHead::Group::HEAD_NORMAL;
             }
 
-      int ns = _notes.size();
-      for (int i = 0; i < ns; ++i) {
+      size_t ns = _notes.size();
+      for (size_t i = 0; i < ns; ++i) {
             Note* n = _notes[i];
             n->undoChangeProperty(Pid::HEAD_GROUP, static_cast<int>(head));
             n->undoChangeProperty(Pid::FIXED, true);

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -628,8 +628,8 @@ Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction 
                   dl = toRhythmicDurationList(dd, isRest, segment->rtick(), sigmap()->timesig(tick).nominal(), measure, 1);
             else
                   dl = toDurationList(dd, true);
-            int n = dl.size();
-            for (int i = 0; i < n; ++i) {
+            size_t n = dl.size();
+            for (size_t i = 0; i < n; ++i) {
                   const TDuration& d = dl[i];
                   ChordRest* ncr;
                   Note* note = 0;
@@ -870,7 +870,7 @@ Fraction Score::makeGap(Segment* segment, int track, const Fraction& _sd, Tuplet
                               }
                         }
                   else {
-                        for (int i = dList.size() - 1; i >= 0; --i) {
+                        for (int i = int(dList.size()) - 1; i >= 0; --i) {
                               if (ltuplet) {
                                     // take care not to recreate tuplet we just deleted
                                     Rest* r = setRest(tick, track, dList[i].fraction(), false, 0, false);
@@ -959,7 +959,7 @@ bool Score::makeGapVoice(Segment* seg, int track, Fraction len, int tick)
             Fraction srcF = cr1->duration();
             Fraction dstF = Fraction::fromTicks(tick - cr1->tick());
             std::vector<TDuration> dList = toDurationList(dstF, true);
-            int n = dList.size();
+            size_t n = dList.size();
             undoChangeChordRestLen(cr1, TDuration(dList[0]));
             if (n > 1) {
                   int crtick = cr1->tick() + cr1->actualTicks();
@@ -967,7 +967,7 @@ bool Score::makeGapVoice(Segment* seg, int track, Fraction len, int tick)
                   if (cr1->type() == ElementType::CHORD) {
                         // split Chord
                         Chord* c = toChord(cr1);
-                        for (int i = 1; i < n; ++i) {
+                        for (size_t i = 1; i < n; ++i) {
                               TDuration d = dList[i];
                               Chord* c2 = addChord(crtick, d, c, true, c->tuplet());
                               c = c2;
@@ -978,7 +978,7 @@ bool Score::makeGapVoice(Segment* seg, int track, Fraction len, int tick)
                   else {
                         // split Rest
                         Rest* r       = toRest(cr1);
-                        for (int i = 1; i < n; ++i) {
+                        for (size_t i = 1; i < n; ++i) {
                               TDuration d = dList[i];
                               Rest* r2      = toRest(r->clone());
                               r2->setDuration(d.fraction());
@@ -1220,7 +1220,7 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
                               }
                         }
                   else {
-                        for (int i = dList.size() - 1; i >= 0; --i) {
+                        for (int i = int(dList.size()) - 1; i >= 0; --i) {
                               bool genTie;
                               Chord* cc;
                               if (oc) {
@@ -2014,7 +2014,7 @@ Element* Score::move(const QString& cmd)
                                     return 0;
                               }
                         // segment for sure contains chords/rests,
-                        int size = seg->elist().size();
+                        int size = int(seg->elist().size());
                         // if segment has a chord/rest in original element track, use it
                         if (track > -1 && track < size && seg->element(track)) {
                               trg  = seg->element(track);
@@ -2442,7 +2442,7 @@ void Score::cmdExplode()
                         if (e && e->type() == ElementType::CHORD) {
                               Chord* c = toChord(e);
                               std::vector<Note*> notes = c->notes();
-                              int nnotes = notes.size();
+                              int nnotes = int(notes.size());
                               // keep note "i" from top, which is backwards from nnotes - 1
                               // reuse notes if there are more instruments than notes
                               int stavesPerNote = qMax((lastStaff - srcStaff) / nnotes, 1);

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -231,8 +231,8 @@ Chord* Score::addChord(int tick, TDuration d, Chord* oc, bool genTie, Tuplet* tu
       // (have segments as parent) we can add ties:
       //
       if (genTie) {
-            int n = oc->notes().size();
-            for(int i = 0; i < n; ++i) {
+            size_t n = oc->notes().size();
+            for(size_t i = 0; i < n; ++i) {
                   Note* n1  = oc->notes()[i];
                   Note* n2 = chord->notes()[i];
                   Tie* tie = new Tie(this);
@@ -344,7 +344,7 @@ Rest* Score::setRest(int tick, int track, Fraction l, bool useDots, Tuplet* tupl
                               }
                         }
                   else {
-                        for (int i = dList.size() - 1; i >= 0; --i) {
+                        for (int i = int(dList.size()) - 1; i >= 0; --i) {
                               rest = addRest(tick, track, dList[i], tuplet);
                               if (r == 0)
                                     r = rest;
@@ -996,7 +996,7 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                         int noteTicks = lastTiedChord->tick() + lastTiedChord->duration().ticks() - chord->tick();
                         if (!(curr->tuplet())) {
                               // store start/end note for backward/forward ties ending/starting on the group of notes being rewritten
-                              int numNotes = chord->notes().size();
+                              size_t numNotes = chord->notes().size();
 #if (!defined (_MSCVER) && !defined (_MSC_VER))
                               Note* tieBack[numNotes];
                               Note* tieFor[numNotes];
@@ -1006,7 +1006,7 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                               std::vector<Note *> tieBack(numNotes);
                               std::vector<Note *> tieFor(numNotes);
 #endif
-                              for (int i = 0; i < numNotes; i++) {
+                              for (size_t i = 0; i < numNotes; i++) {
                                     Note* n = chord->notes()[i];
                                     Note* nn = lastTiedChord->notes()[i];
                                     if (n->tieBack())
@@ -1025,7 +1025,7 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                               Segment* segment = seg;
                               ChordRest* cr = toChordRest(segment->element(tr));
                               Chord* nchord = toChord(chord->clone());
-                              for (int i = 0; i < numNotes; i++) { // strip ties from cloned chord
+                              for (size_t i = 0; i < numNotes; i++) { // strip ties from cloned chord
                                     Note* n = nchord->notes()[i];
                                     n->setTieFor(0);
                                     n->setTieBack(0);
@@ -1043,8 +1043,8 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                                     measure = segment->measure();
                                     std::vector<TDuration> dl;
                                     dl = toRhythmicDurationList(dd, false, segment->rtick(), sigmap()->timesig(tick).nominal(), measure, 1);
-                                    int n = dl.size();
-                                    for (int i = 0; i < n; ++i) {
+                                    size_t n = dl.size();
+                                    for (size_t i = 0; i < n; ++i) {
                                           const TDuration& d = dl[i];
                                           Chord* nchord2 = toChord(nchord->clone());
                                           if (!firstpart)
@@ -1054,7 +1054,7 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                                           std::vector<Note*> nl1 = nchord->notes();
                                           std::vector<Note*> nl2 = nchord2->notes();
                                           if (!firstpart)
-                                                for (unsigned j = 0; j < nl1.size(); ++j) {
+                                                for (size_t j = 0; j < nl1.size(); ++j) {
                                                       tie = new Tie(this);
                                                       tie->setStartNote(nl1[j]);
                                                       tie->setEndNote(nl2[j]);
@@ -1098,7 +1098,7 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
                                           }
                                     }
                               // recreate previously stored pending ties
-                              for (int i = 0; i < numNotes; i++) {
+                              for (size_t i = 0; i < numNotes; i++) {
                                     Note* n = startChord->notes()[i];
                                     Note* nn = nchord->notes()[i];
                                     if (tieBack[i]) {
@@ -2335,7 +2335,7 @@ Lyrics* Score::addLyrics()
       else
             return 0;
 
-      int no = cr->lyrics().size();
+      int no = int(cr->lyrics().size());
       Lyrics* lyrics = new Lyrics(this);
       lyrics->setTrack(cr->track());
       lyrics->setParent(cr);
@@ -3147,8 +3147,8 @@ void Score::cloneVoice(int strack, int dtrack, Segment* sf, int lTick, bool link
                               Chord* och = toChord(ocr);
                               Chord* nch = toChord(ncr);
 
-                              int n = och->notes().size();
-                              for (int i = 0; i < n; ++i) {
+                              size_t n = och->notes().size();
+                              for (size_t i = 0; i < n; ++i) {
                                     Note* on = och->notes().at(i);
                                     Note* nn = nch->notes().at(i);
                                     Interval v = staff(dtrack) ? staff(dtrack)->part()->instrument(dtrack)->transpose() : Interval();

--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -587,8 +587,8 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
                                                       Chord* och = toChord(ocr);
                                                       Chord* nch = toChord(ncr);
 
-                                                      int n = och->notes().size();
-                                                      for (int i = 0; i < n; ++i) {
+                                                      size_t n = och->notes().size();
+                                                      for (size_t i = 0; i < n; ++i) {
                                                             Note* on = och->notes().at(i);
                                                             Note* nn = nch->notes().at(i);
                                                             if (on->tieFor()) {
@@ -899,8 +899,8 @@ void Excerpt::cloneStaff(Staff* srcStaff, Staff* dstStaff)
                               if (oe->isChord()) {
                                     Chord* och = toChord(ocr);
                                     Chord* nch = toChord(ncr);
-                                    int n = och->notes().size();
-                                    for (int i = 0; i < n; ++i) {
+                                    size_t n = och->notes().size();
+                                    for (size_t i = 0; i < n; ++i) {
                                           Note* on = och->notes().at(i);
                                           Note* nn = nch->notes().at(i);
                                           if (on->tieFor()) {
@@ -1106,8 +1106,8 @@ void Excerpt::cloneStaff2(Staff* srcStaff, Staff* dstStaff, int stick, int etick
                               if (oe->isChord()) {
                                     Chord* och = toChord(ocr);
                                     Chord* nch = toChord(ncr);
-                                    int n = och->notes().size();
-                                    for (int i = 0; i < n; ++i) {
+                                    size_t n = och->notes().size();
+                                    for (size_t i = 0; i < n; ++i) {
                                           Note* on = och->notes().at(i);
                                           Note* nn = nch->notes().at(i);
                                           if (on->tieFor()) {

--- a/libmscore/figuredbass.h
+++ b/libmscore/figuredbass.h
@@ -288,7 +288,7 @@ class FiguredBass final : public TextBase {
                                                           return 0;   }
       qreal             printedLineLength() const     { return _printedLineLength; }
       bool              onNote() const          { return _onNote; }
-      int               numOfItems() const      { return items.size(); }
+      size_t            numOfItems() const      { return items.size(); }
       void              setOnNote(bool val)     { _onNote = val;  }
       Segment *         segment() const         { return (Segment*)(parent()); }
       int               ticks() const           { return _ticks;  }

--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -96,7 +96,7 @@ Dynamic* lookupDynamic(Element* e)
 static void moveDynamic(Dynamic* d, qreal y)
       {
       if (d && d->autoplace()) {
-            int staffIdx = d->staffIdx();
+//            int staffIdx = d->staffIdx();
 //            Shape& ss    = d->segment()->staffShape(staffIdx);
 //            Shape& ms    = d->measure()->staffShape(staffIdx);
             QPointF spos = d->segment()->pos();

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -275,13 +275,13 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
                         // overlap (possibly unison)
 
                         // build list of overlapping notes
-                        for (int i = 0, n = upStemNotes.size(); i < n; ++i) {
+                        for (size_t i = 0, n = upStemNotes.size(); i < n; ++i) {
                               if (upStemNotes[i]->line() >= topDownNote->line() - 1)
                                     overlapNotes.append(upStemNotes[i]);
                               else
                                     break;
                               }
-                        for (int i = downStemNotes.size() - 1; i >= 0; --i) {
+                        for (int i = int(downStemNotes.size()) - 1; i >= 0; --i) {
                               if (downStemNotes[i]->line() <= bottomUpNote->line() + 1)
                                     overlapNotes.append(downStemNotes[i]);
                               else
@@ -535,12 +535,12 @@ qreal Score::layoutChords2(std::vector<Note*>& notes, bool up)
       if (up) {
             // loop bottom up
             startIdx = 0;
-            endIdx = notes.size();
+            endIdx = int(notes.size());
             incIdx = 1;
             }
       else {
             // loop top down
-            startIdx = notes.size() - 1;
+            startIdx = int(notes.size()) - 1;
             endIdx = -1;
             incIdx = -1;
             }
@@ -778,7 +778,7 @@ void Score::layoutChords3(std::vector<Note*>& notes, Staff* staff, Segment* segm
       qreal upDotPosX    = 0.0;
       qreal downDotPosX  = 0.0;
 
-      int nNotes = notes.size();
+      int nNotes = int(notes.size());
       int nAcc = 0;
       for (int i = nNotes-1; i >= 0; --i) {
             Note* note     = notes[i];
@@ -1178,8 +1178,8 @@ void Score::layoutSpanner()
       for (int track = 0; track < tracks; ++track) {
             for (Segment* segment = firstSegment(SegmentType::All); segment; segment = segment->next1()) {
                   if (track == tracks-1) {
-                        int n = segment->annotations().size();
-                        for (int i = 0; i < n; ++i)
+                        size_t n = segment->annotations().size();
+                        for (size_t i = 0; i < n; ++i)
                               segment->annotations().at(i)->layout();
                         }
                   Element* e = segment->element(track);
@@ -1564,7 +1564,7 @@ void Score::respace(std::vector<ChordRest*>* elements)
       {
       ChordRest* cr1 = elements->front();
       ChordRest* cr2 = elements->back();
-      int n          = elements->size();
+      int n          = int(elements->size());
       qreal x1       = cr1->segment()->pos().x();
       qreal x2       = cr2->segment()->pos().x();
 

--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -73,7 +73,7 @@ static void processLines(System* system, std::vector<Spanner*> lines, bool align
 //    which contains one system
 //---------------------------------------------------------
 
- void Score::resetSystems(bool layoutAll, LayoutContext& lc)
+ void Score::resetSystems(bool /*layoutAll*/, LayoutContext& lc)
       {
 // if (layoutAll) {
       qDeleteAll(systems());

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -259,7 +259,7 @@ void Measure::layoutStaffLines()
 
 void Measure::createStaves(int staffIdx)
       {
-      for (int n = _mstaves.size(); n <= staffIdx; ++n) {
+      for (int n = int(_mstaves.size()); n <= staffIdx; ++n) {
             Staff* staff = score()->staff(n);
             MStaff* s    = new MStaff;
             s->setLines(new StaffLines(score()));
@@ -1849,7 +1849,7 @@ void Measure::read(XmlReader& e, int staffIdx)
       int nextTrack = staffIdx * VOICES;
       e.setTrack(nextTrack);
 
-      for (int n = _mstaves.size(); n <= staffIdx; ++n) {
+      for (int n = int(_mstaves.size()); n <= staffIdx; ++n) {
             Staff* staff = score()->staff(n);
             MStaff* s    = new MStaff;
             s->setLines(new StaffLines(score()));
@@ -2341,7 +2341,7 @@ void Measure::read300(XmlReader& e, int staffIdx)
       e.tuplets().clear();
       e.setTrack(staffIdx * VOICES);
 
-      for (int n = _mstaves.size(); n <= staffIdx; ++n) {
+      for (int n = int(_mstaves.size()); n <= staffIdx; ++n) {
             Staff* staff = score()->staff(n);
             MStaff* s    = new MStaff;
             s->setLines(new StaffLines(score()));
@@ -2390,7 +2390,7 @@ void Measure::read300(XmlReader& e, int staffIdx)
                   //  EndBarLine:         at the end of a measure
                   //  BeginBarLine:       first segment of a measure, systemic barline
 
-                  SegmentType st;
+                  SegmentType st = SegmentType::Invalid;
                   int t = e.tick() - tick();
                   if (t && (t != ticks()))
                         st = SegmentType::BarLine;
@@ -3100,7 +3100,7 @@ bool Measure::empty() const
       if (irregular())
             return false;
       int n = 0;
-      int tracks = _mstaves.size() * VOICES;
+      int tracks = int(_mstaves.size()) * VOICES;
       static const SegmentType st = SegmentType::ChordRest ;
       for (const Segment* s = first(st); s; s = s->next(st)) {
             bool restFound = false;
@@ -3230,8 +3230,8 @@ Measure* Measure::cloneMeasure(Score* sc, TieMap* tieMap)
                         if (oe->isChord()) {
                               Chord* och = toChord(ocr);
                               Chord* nch = toChord(ncr);
-                              int n = och->notes().size();
-                              for (int i = 0; i < n; ++i) {
+                              size_t n = och->notes().size();
+                              for (size_t i = 0; i < n; ++i) {
                                     Note* on = och->notes().at(i);
                                     Note* nn = nch->notes().at(i);
                                     if (on->tieFor()) {

--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -598,7 +598,7 @@ int Part::lyricCount()
       {
       if (!score())
             return 0;
-      int count = 0;
+      size_t count = 0;
       SegmentType st = SegmentType::ChordRest;
       for (Segment* seg = score()->firstMeasure()->first(st); seg; seg = seg->next1(st)) {
             for (int i = startTrack(); i < endTrack() ; ++i) {
@@ -607,7 +607,7 @@ int Part::lyricCount()
                         count += cr->lyrics().size();
                   }
             }
-      return count;
+      return int(count);
       }
 
 //---------------------------------------------------------

--- a/libmscore/pitchspelling.cpp
+++ b/libmscore/pitchspelling.cpp
@@ -649,7 +649,7 @@ void changeAllTpcs(Note* n, int tpc1)
 
 void Score::spellNotelist(std::vector<Note*>& notes)
       {
-      int n = notes.size();
+      int n = int(notes.size());
 
       int start = 0;
       while (start < n) {

--- a/libmscore/read300.cpp
+++ b/libmscore/read300.cpp
@@ -1759,10 +1759,10 @@ bool ChordRest::readProperties300(XmlReader& e)
                         if (spanner->type() == ElementType::SLUR)
                               spanner->setStartElement(this);
                         if (e.pasteMode()) {
-                              for (ScoreElement* e : spanner->linkList()) {
-                                    if (e == spanner)
+                              for (ScoreElement* el : spanner->linkList()) {
+                                    if (el == spanner)
                                           continue;
-                                    Spanner* ls = static_cast<Spanner*>(e);
+                                    Spanner* ls = static_cast<Spanner*>(el);
                                     ls->setTick(spanner->tick());
                                     for (ScoreElement* ee : linkList()) {
                                           ChordRest* cr = toChordRest(ee);
@@ -1785,10 +1785,10 @@ bool ChordRest::readProperties300(XmlReader& e)
                         if (start)
                               spanner->setTrack(start->track());
                         if (e.pasteMode()) {
-                              for (ScoreElement* e : spanner->linkList()) {
-                                    if (e == spanner)
+                              for (ScoreElement* el : spanner->linkList()) {
+                                    if (el == spanner)
                                           continue;
-                                    Spanner* ls = static_cast<Spanner*>(e);
+                                    Spanner* ls = static_cast<Spanner*>(el);
                                     ls->setTick2(spanner->tick2());
                                     for (ScoreElement* ee : linkList()) {
                                           ChordRest* cr = toChordRest(ee);

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -827,7 +827,7 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
       {
       Segment* seg = chord->segment();
       Tremolo* tremolo = chord->tremolo();
-      int notes = chord->notes().size();
+      int notes = int(chord->notes().size());
 
       // check if tremolo was rendered before for drum staff
       const Drumset* ds = getDrumset(chord);
@@ -853,7 +853,7 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
                   seg2 = seg2->next(st);
             Chord* c2 = seg2 ? toChord(seg2->element(track)) : 0;
             if (c2 && c2->type() == ElementType::CHORD) {
-                  int notes2 = c2->notes().size();
+                  int notes2 = int(c2->notes().size());
                   int tnotes = qMax(notes, notes2);
                   int tticks = chord->actualTicks() * 2; // use twice the size
                   int n = tticks / t;
@@ -926,7 +926,7 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
 
 void renderArpeggio(Chord *chord, QList<NoteEventList> & ell)
       {
-      int notes = chord->notes().size();
+      int notes = int(chord->notes().size());
       int l = 64;
       while (l && (l * notes > chord->upNote()->playTicks()))
             l = 2*l / 3;
@@ -1110,9 +1110,9 @@ bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, i
       int ontime    = 0;
 
       int gnb = note->chord()->graceNotesBefore().size();
-      int p = prefix.size();
-      int b = body.size();
-      int s = suffix.size();
+      int p = int(prefix.size());
+      int b = int(body.size());
+      int s = int(suffix.size());
       int gna = note->chord()->graceNotesAfter().size();
 
       int ticksPerNote = 0;
@@ -1175,7 +1175,7 @@ bool renderNoteArticulation(NoteEventList* events, Note* note, bool chromatic, i
       // of a different pitch.
       // The total duration of the tied note is returned, and the index is modified.
       auto tieForward = [millespernote] (int & j, const vector<int> & vec) {
-            int size = vec.size();
+            int size = int(vec.size());
             int duration = millespernote;
             while ( j < size-1 && vec[j] == vec[j+1] ) {
                   duration += millespernote;
@@ -1531,8 +1531,8 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
       if (chord->notes().empty())
             return ell;
 
-      int notes = chord->notes().size();
-      for (int i = 0; i < notes; ++i)
+      size_t notes = chord->notes().size();
+      for (size_t i = 0; i < notes; ++i)
             ell.append(NoteEventList());
 
       if (chord->tremolo()) {
@@ -1548,7 +1548,7 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
       //
       //    apply gateTime
       //
-      for (int i = 0; i < notes; ++i) {
+      for (int i = 0; i < int(notes); ++i) {
             NoteEventList* el = &ell[i];
             if (el->size() == 0 && chord->tremoloChordType() != TremoloChordType::TremoloSecondNote) {
                   el->append(NoteEvent(0, ontime, 1000 - ontime - trailtime));
@@ -1632,8 +1632,8 @@ void Score::createGraceNotesPlayEvents(int tick, Chord* chord, int &ontime, int 
       for (int i = 0; i < nb; ++i) {
             QList<NoteEventList> el;
             Chord* gc = gnb.at(i);
-            int nn = gc->notes().size();
-            for (int ii = 0; ii < nn; ++ii) {
+            size_t nn = gc->notes().size();
+            for (size_t ii = 0; ii < nn; ++ii) {
                   NoteEventList nel;
                   nel.append(NoteEvent(0, on, graceDuration));
                   el.append(nel);
@@ -1642,7 +1642,7 @@ void Score::createGraceNotesPlayEvents(int tick, Chord* chord, int &ontime, int 
             if (gc->playEventType() == PlayEventType::InvalidUser)
                   gc->score()->undo(new ChangeEventList(gc, el));
             else if (gc->playEventType() == PlayEventType::Auto) {
-                  for (int ii = 0; ii < nn; ++ii)
+                  for (int ii = 0; ii < int(nn); ++ii)
                         gc->notes()[ii]->setPlayEvents(el[ii]);
                   }
             on += graceDuration;
@@ -1659,8 +1659,8 @@ void Score::createGraceNotesPlayEvents(int tick, Chord* chord, int &ontime, int 
             for (int i = 0; i < na; ++i) {
                   QList<NoteEventList> el;
                   Chord* gc = gna.at(i);
-                  int nn = gc->notes().size();
-                  for (int ii = 0; ii < nn; ++ii) {
+                  size_t nn = gc->notes().size();
+                  for (size_t ii = 0; ii < nn; ++ii) {
                         NoteEventList nel;
                         nel.append(NoteEvent(0, on, graceDuration)); // NoteEvent(pitch,ontime,len)
                         el.append(nel);
@@ -1669,7 +1669,7 @@ void Score::createGraceNotesPlayEvents(int tick, Chord* chord, int &ontime, int 
                   if (gc->playEventType() == PlayEventType::InvalidUser)
                         gc->score()->undo(new ChangeEventList(gc, el));
                   else if (gc->playEventType() == PlayEventType::Auto) {
-                        for (int ii = 0; ii < nn; ++ii)
+                        for (int ii = 0; ii < int(nn); ++ii)
                               gc->notes()[ii]->setPlayEvents(el[ii]);
                         }
                   on += graceDuration;
@@ -1722,7 +1722,7 @@ void Score::createPlayEvents(Chord* chord)
             chord->score()->undo(new ChangeEventList(chord, el));
             }
       else if (chord->playEventType() == PlayEventType::Auto) {
-            int n = chord->notes().size();
+            int n = int(chord->notes().size());
             for (int i = 0; i < n; ++i)
                   chord->notes()[i]->setPlayEvents(el[i]);
             }

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -417,7 +417,7 @@ void Rest::layoutDots()
 
 void Rest::checkDots()
       {
-      int n = dots() - _dots.size();
+      int n = dots() - int(_dots.size());
       for (int i = 0; i < n; ++i) {
             NoteDot* dot = new NoteDot(score());
             dot->setParent(this);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3758,7 +3758,7 @@ bool Score::hasHarmonies()
 
 int Score::lyricCount()
       {
-      int count = 0;
+      size_t count = 0;
       SegmentType st = SegmentType::ChordRest;
       for (Segment* seg = firstMeasure()->first(st); seg; seg = seg->next1(st)) {
             for (int i = 0; i < ntracks(); ++i) {
@@ -3767,7 +3767,7 @@ int Score::lyricCount()
                         count += cr->lyrics().size();
                   }
             }
-      return count;
+      return int(count);
       }
 
 //---------------------------------------------------------
@@ -3799,7 +3799,7 @@ QString Score::extractLyrics()
       SegmentType st = SegmentType::ChordRest;
       for (int track = 0; track < ntracks(); track += VOICES) {
             bool found = false;
-            unsigned maxLyrics = 1;
+            size_t maxLyrics = 1;
             for (Measure* m = firstMeasure(); m; m = m->nextMeasure()) {
                   m->setPlaybackCount(0);
                   }
@@ -4033,7 +4033,7 @@ void Score::changeVoice(int voice)
                   if (chord->voice() != voice) {
                         Segment* s       = chord->segment();
                         Measure* m       = s->measure();
-                        int notes        = chord->notes().size();
+                        size_t notes     = chord->notes().size();
                         int dstTrack     = chord->staffIdx() * VOICES + voice;
                         ChordRest* dstCR = toChordRest(s->element(dstTrack));
                         Chord* dstChord  = nullptr;

--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -138,12 +138,12 @@ static const ElementName elementNames[] = {
 
 ScoreElement::ScoreElement(const ScoreElement& se)
       {
-      _score      = se._score;
-      _elementStyle   = se._elementStyle;
+      _score        = se._score;
+      _elementStyle = se._elementStyle;
       if (_elementStyle) {
-            int n       = _elementStyle->size();
+            size_t n = _elementStyle->size();
             _propertyFlagsList = new PropertyFlags[n];
-            for (int i = 0; i < n; ++i)
+            for (size_t i = 0; i < n; ++i)
                   _propertyFlagsList[i] = se._propertyFlagsList[i];
             }
       _links = 0;
@@ -205,12 +205,12 @@ QVariant ScoreElement::propertyDefault(Pid pid) const
 void ScoreElement::initElementStyle(const ElementStyle* ss)
       {
       _elementStyle = ss;
-      int n     = _elementStyle->size();
+      size_t n = _elementStyle->size();
       if (isTextBase())                               // HACK
             n += TEXT_STYLE_SIZE;
       delete[] _propertyFlagsList;
       _propertyFlagsList = new PropertyFlags[n];
-      for (int i = 0; i < n; ++i)
+      for (size_t i = 0; i < n; ++i)
             _propertyFlagsList[i] = PropertyFlags::STYLED;
       int i = 0;
       for (const StyledProperty& spp : *_elementStyle) {

--- a/libmscore/shape.cpp
+++ b/libmscore/shape.cpp
@@ -259,7 +259,7 @@ void Shape::paint(QPainter& p) const
 
 void Shape::dump(const char* p) const
       {
-      printf("Shape dump: %p %s size %d\n", this, p, size());
+      qDebug("Shape dump: %p %s size %zu\n", this, p, size());
       for (const ShapeElement& r : *this) {
             r.dump();
             }
@@ -267,7 +267,7 @@ void Shape::dump(const char* p) const
 
 void ShapeElement::dump() const
       {
-      printf("   %s: %f %f %f %f\n", text ? text : "", x(), y(), width(), height());
+      qDebug("   %s: %f %f %f %f\n", text ? text : "", x(), y(), width(), height());
       }
 
 //---------------------------------------------------------

--- a/libmscore/shape.h
+++ b/libmscore/shape.h
@@ -71,9 +71,9 @@ class Shape : public std::vector<ShapeElement> {
       qreal top() const;
       qreal bottom() const;
 
-      int size() const   { return std::vector<ShapeElement>::size(); }
-      bool empty() const { return std::vector<ShapeElement>::empty(); }
-      void clear()       { std::vector<ShapeElement>::clear();       }
+      size_t size() const { return std::vector<ShapeElement>::size();  }
+      bool empty() const  { return std::vector<ShapeElement>::empty(); }
+      void clear()        { std::vector<ShapeElement>::clear();        }
 
       bool contains(const QPointF&) const;
       bool intersects(const QRectF& rr) const;

--- a/libmscore/skyline.cpp
+++ b/libmscore/skyline.cpp
@@ -199,7 +199,7 @@ void SkylineLine::paint(QPainter& p) const
       {
       qreal x1 = 0.0;
       qreal x2;
-      qreal y;
+      qreal y = 0.0;
 
       bool pvalid = false;
       for (const SkylineSegment& s : *this) {

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -1014,11 +1014,11 @@ void Slur::write(XmlWriter& xml) const
 
 static bool chordsHaveTie(Chord* c1, Chord* c2)
       {
-      int n1 = c1->notes().size();
-      for (int i1 = 0; i1 < n1; ++i1) {
+      size_t n1 = c1->notes().size();
+      for (size_t i1 = 0; i1 < n1; ++i1) {
             Note* n1 = c1->notes().at(i1);
-            int n2 = c2->notes().size();
-            for (int i2 = 0; i2 < n2; ++i2) {
+            size_t n2 = c2->notes().size();
+            for (size_t i2 = 0; i2 < n2; ++i2) {
                   Note* n2 = c2->notes().at(i2);
                   if (n1->tieFor() && n1->tieFor() == n2->tieBack())
                         return true;

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -1121,9 +1121,9 @@ TextBase::TextBase(const TextBase& st)
       _offset                      = st._offset;
       _offsetType                  = st._offsetType;
 
-      int n = _elementStyle->size() + TEXT_STYLE_SIZE;
+      size_t n = _elementStyle->size() + TEXT_STYLE_SIZE;
       _propertyFlagsList = new PropertyFlags[n];
-      for (int i = 0; i < n; ++i)
+      for (size_t i = 0; i < n; ++i)
             _propertyFlagsList[i] = st._propertyFlagsList[i];
       _links = 0;
       }
@@ -2143,7 +2143,7 @@ bool TextBase::validateText(QString& s)
                         if (t.startsWith(k)) {
                               d.append(c);
                               d.append(k);
-                              i += strlen(k);
+                              i += int(strlen(k));
                               found = true;
                               break;
                               }
@@ -2159,7 +2159,7 @@ bool TextBase::validateText(QString& s)
                         if (t.startsWith(k)) {
                               d.append(c);
                               d.append(k);
-                              i += strlen(k);
+                              i += int(strlen(k));
                               found = true;
                               break;
                               }
@@ -2478,13 +2478,13 @@ void TextBase::styleChanged()
 void TextBase::initElementStyle(const ElementStyle* ss)
       {
       _elementStyle = ss;
-      int n     = _elementStyle->size() + TEXT_STYLE_SIZE;
+      size_t n      = _elementStyle->size() + TEXT_STYLE_SIZE;
 
 //      printf("<%s> initElementStyle n=%d + %d\n", name(), int(_elementStyle->size()), TEXT_STYLE_SIZE);
 
       delete[] _propertyFlagsList;
       _propertyFlagsList = new PropertyFlags[n];
-      for (int i = 0; i < n; ++i)
+      for (size_t i = 0; i < n; ++i)
             _propertyFlagsList[i] = PropertyFlags::STYLED;
       for (const StyledProperty& p : *_elementStyle) {
             QVariant v = propertyType(p.pid) == P_TYPE::SP_REAL ? score()->styleP(p.sid) : score()->styleV(p.sid);
@@ -2506,12 +2506,10 @@ void TextBase::initElementStyle(const ElementStyle* ss)
 void TextBase::initTid(Tid tid)
       {
       setTid(tid);
-      int i = _elementStyle->size();
       for (const StyledProperty& p : *textStyle(tid)) {
             Pid pid    = p.pid;
             QVariant v = propertyDefault(pid);
             setProperty(pid, v);
-            ++i;
             }
       }
 

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -362,7 +362,7 @@ void TieSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
             // for two-note chords, it looks better to have notes on spaces tied outside the lines
 
             if (sc) {
-                  int notes = sc->notes().size();
+                  size_t notes = sc->notes().size();
                   bool onLine = !(sn->line() & 1);
                   if ((onLine && notes > 1) || (!onLine && notes > 2))
                         reverseAdjust = true;
@@ -537,7 +537,7 @@ void Tie::calculateDirection()
 
       if (_slurDirection == Direction::AUTO) {
             std::vector<Note*> notes = c1->notes();
-            int n = notes.size();
+            size_t n = notes.size();
             if (m1->hasVoices(c1->staffIdx()) || m2->hasVoices(c2->staffIdx())) {
                   // in polyphonic passage, ties go on the stem side
                   _up = c1->up();
@@ -560,12 +560,12 @@ void Tie::calculateDirection()
                   QList<int> ties;
                   int idx = 0;
                   int noteIdx = -1;
-                  for (int i = 0; i < n; ++i) {
+                  for (size_t i = 0; i < n; ++i) {
                         if (notes[i]->tieFor()) {
                               ties.append(notes[i]->line());
                               if (notes[i] == startNote()) {
                                     idx = ties.size() - 1;
-                                    noteIdx = i;
+                                    noteIdx = int(i);
                                     }
                               }
                         }

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -365,10 +365,10 @@ void Tuplet::layout()
                   }
 
             // check for collisions
-            int n = _elements.size();
+            size_t n = _elements.size();
             if (n >= 3) {
                   d = (p2.y() - p1.y())/(p2.x() - p1.x());
-                  for (int i = 1; i < (n-1); ++i) {
+                  for (size_t i = 1; i < (n-1); ++i) {
                         Element* e = _elements[i];
                         if (e->isChord()) {
                               const Chord* chord = toChord(e);
@@ -475,10 +475,10 @@ void Tuplet::layout()
                   }
 
             // check for collisions
-            int n = _elements.size();
+            size_t n = _elements.size();
             if (n >= 3) {
                   qreal d  = (p2.y() - p1.y())/(p2.x() - p1.x());
-                  for (int i = 1; i < (n-1); ++i) {
+                  for (size_t i = 1; i < (n-1); ++i) {
                         Element* e = _elements[i];
                         if (e->isChord()) {
                               const Chord* chord = toChord(e);

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1960,10 +1960,10 @@ ChangeEventList::ChangeEventList(Chord* c, const QList<NoteEventList> l)
 
 void ChangeEventList::flip(EditData*)
       {
-      int n = chord->notes().size();
-      for (int i = 0; i < n; ++i) {
+      size_t n = chord->notes().size();
+      for (size_t i = 0; i < n; ++i) {
             Note* note = chord->notes()[i];
-            note->playEvents().swap(events[i]);
+            note->playEvents().swap(events[int(i)]);
             }
       PlayEventType t = chord->playEventType();
       chord->setPlayEventType(eventListType);

--- a/mscore/exportaudio.cpp
+++ b/mscore/exportaudio.cpp
@@ -232,7 +232,7 @@ bool MuseScore::saveAudio(Score* score, const QString& name)
         }
 
         virtual qint64 writeData(const char *data, qint64 len) override final {
-            int trueFrames = len / sizeof(float) / 2;
+            size_t trueFrames = len / sizeof(float) / 2;
             sf_writef_float(sf, reinterpret_cast<const float*>(data), trueFrames);
             return trueFrames * 2 * sizeof(float);
         }

--- a/mscore/importgtp-gp5.cpp
+++ b/mscore/importgtp-gp5.cpp
@@ -243,7 +243,7 @@ int GuitarPro5::readBeat(int tick, int voice, Measure* measure, int staffIdx, Tu
             while (txt.size() && txt[txt.size() - 1] == '-')
                   txt.resize(txt.size() - 1);
 //		  gpLyrics.lyrics.append(txt);
-            gpLyrics.lyrics.append(QString::fromUtf8(txt.data(), txt.size()));
+            gpLyrics.lyrics.append(QString::fromUtf8(txt.data(), int(txt.size())));
 		gpLyrics.segments.push_back(segment);
             }
 #if 0
@@ -664,7 +664,7 @@ void GuitarPro5::readMeasures(int /*startingTempo*/)
                                           text = str;
                                     if (pos == std::string::npos)
                                           str.resize(0);
-                                    lyr->setPlainText(QString::fromUtf8(text.data(), text.size()));
+                                    lyr->setPlainText(QString::fromUtf8(text.data(), int(text.size())));
                                     cr->add(lyr);
                                     }
                               else {

--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -196,7 +196,7 @@ void findAllTupletsForDrums(
       for (size_t voice = 0; voice < drumVoiceCount; ++voice) {
             for (auto &chord: chords[voice]) {
                         // correct voice because it can be changed during tuplet detection
-                  setChordVoice(chord.second, voice);
+                  setChordVoice(chord.second, int(voice));
                   mtrack.chords.insert({chord.first, chord.second});
                   }
             }

--- a/mscore/importmidi/importmidi_inner.cpp
+++ b/mscore/importmidi/importmidi_inner.cpp
@@ -240,7 +240,7 @@ QString convertToCharset(const std::string &text)
       if (codec)
             return codec->toUnicode(text.c_str());
       else
-            return QString::fromUtf8(text.data(), text.size());
+            return QString::fromUtf8(text.data(), int(text.size()));
       }
 
 QString defaultCharset()

--- a/mscore/importmidi/importmidi_lrhand.cpp
+++ b/mscore/importmidi/importmidi_lrhand.cpp
@@ -95,7 +95,7 @@ void splitChords(
 
       int splitPoint = findLastSplitPoint(splits);
 
-      for (int pos = splits.size() - 1; ; --pos) {
+      for (size_t pos = splits.size() - 1; ; --pos) {
             MidiChord &oldChord = splits[pos].chord->second;
             MidiChord newChord(oldChord);
 

--- a/mscore/importmidi/importmidi_lyrics.cpp
+++ b/mscore/importmidi/importmidi_lyrics.cpp
@@ -135,7 +135,7 @@ BestTrack findBestTrack(
 
 bool isTitlePrefix(const QString &text)
       {
-      return (text.left(TEXT_PREFIX.size()) == QString::fromUtf8(TEXT_PREFIX.data(), TEXT_PREFIX.size())); 
+      return (text.left(int(TEXT_PREFIX.size())) == QString::fromUtf8(TEXT_PREFIX.data(), int(TEXT_PREFIX.size()))); 
       }
 
 void addTitleToScore(Score *score, const QString &string, int textCounter)
@@ -147,7 +147,7 @@ void addTitleToScore(Score *score, const QString &string, int textCounter)
             ssid = Tid::COMPOSER;
 
       Text* text = new Text(score, ssid);
-      text->setPlainText(string.right(string.size() - TEXT_PREFIX.size()));
+      text->setPlainText(string.right(string.size() - int(TEXT_PREFIX.size())));
 
       MeasureBase* measure = score->first();
       if (!measure->isVBox()) {

--- a/mscore/importmidi/importmidi_meter.cpp
+++ b/mscore/importmidi/importmidi_meter.cpp
@@ -400,7 +400,7 @@ bool badLevelCondition(int startLevelDiff, int endLevelDiff, int tol)
 int noteCount(const ReducedFraction &duration,
               bool useDots)
       {
-      return toDurationList(duration.fraction(), useDots, 1, false).size();
+      return int(toDurationList(duration.fraction(), useDots, 1, false).size());
       }
 
 bool isLessNoteCount(const ReducedFraction &t1,

--- a/mscore/importmidi/importmidi_model.cpp
+++ b/mscore/importmidi/importmidi_model.cpp
@@ -799,7 +799,7 @@ int TracksModel::rowCount(const QModelIndex &/*parent*/) const
 
 int TracksModel::columnCount(const QModelIndex &/*parent*/) const
       {
-      return _columns.size();
+      return int(_columns.size());
       }
 
 bool TracksModel::editableSingleTrack(int trackIndex, int column) const

--- a/mscore/importmidi/importmidi_quant.cpp
+++ b/mscore/importmidi/importmidi_quant.cpp
@@ -1115,7 +1115,7 @@ void quantizeOnTimesInRange(
                  "Quantize::quantizeOnTimesInRange",
                  "Sizes of quant data and chords are not equal");
 
-      for (int chordIndex = quantData.size() - 1; ; --chordIndex) {
+      for (size_t chordIndex = quantData.size() - 1; ; --chordIndex) {
             const QuantPos &p = quantData[chordIndex].positions[posIndex];
             const auto onTime = p.time;
             const auto chordIt = chords[chordIndex];

--- a/mscore/importmidi/importmidi_tuplet_filter.cpp
+++ b/mscore/importmidi/importmidi_tuplet_filter.cpp
@@ -198,7 +198,7 @@ std::vector<TupletCommon> findTupletCommons(const std::vector<TupletInfo> &tuple
       for (size_t i = 0; i != tuplets.size() - 1; ++i) {
             for (size_t j = i + 1; j != tuplets.size(); ++j) {
                   if (areInCommons(tuplets[i], tuplets[j]))
-                        tupletCommons[i].commonIndexes.insert(j);
+                        tupletCommons[i].commonIndexes.insert(int(j));
                   }
             }
       return tupletCommons;
@@ -237,7 +237,7 @@ TupletErrorResult findTupletError(
       {
       ReducedFraction sumError{0, 1};
       ReducedFraction sumLengthOfRests{0, 1};
-      int sumChordCount = 0;
+      size_t sumChordCount = 0;
       int sumChordPlaces = 0;
       std::set<std::pair<const ReducedFraction, MidiChord> *> usedChords;
       std::vector<char> usedIndexes(tuplets.size(), 0);
@@ -498,7 +498,7 @@ class ValidTuplets
             int prev = indexes_[index].first;
             int next = indexes_[index].second;
             indexes_[index].first = -1;
-            indexes_[index].second = indexes_.size();
+            indexes_[index].second = int(indexes_.size());
             if (prev >= first_)
                   indexes_[prev].second = next;
             if (next < (int)indexes_.size())
@@ -518,8 +518,8 @@ class ValidTuplets
 
       void restore(const std::vector<std::pair<int, int>> &indexes)
             {
-            first_ = indexes_.size() - indexes.size();
-            for (int i = 0; i != (int)indexes.size(); ++i)
+            first_ = int(indexes_.size() - indexes.size());
+            for (int i = 0; i != int(indexes.size()); ++i)
                   indexes_[i + first_] = indexes[i];
             }
 
@@ -546,10 +546,10 @@ void findNextTuplet(
             bool isCommonGroupBegins = (selectedTuplets.empty() && index == commonsSize);
             if (isCommonGroupBegins) {      // first level
                   for (size_t i = index; i < tuplets.size(); ++i)
-                        selectedTuplets.push_back(i);
+                        selectedTuplets.push_back(int(i));
                   }
             else {
-                  selectedTuplets.push_back(index);
+                  selectedTuplets.push_back(int(index));
                   }
 
             Q_ASSERT_X(validateSelectedTuplets(selectedTuplets.begin(), selectedTuplets.end(), tuplets),
@@ -566,8 +566,8 @@ void findNextTuplet(
             if (isCommonGroupBegins) {
                   bool canAddMoreIndexes = false;
                   for (size_t i = 0; i != commonsSize; ++i) {
-                        if (!isInCommonIndexes(i, selectedTuplets, tupletCommons)
-                                    && canUseIndex(i, tuplets, tupletIntervals,
+                        if (!isInCommonIndexes(int(i), selectedTuplets, tupletCommons)
+                                    && canUseIndex(int(i), tuplets, tupletIntervals,
                                                    voiceIntervals, usedFirstChords)) {
                               canAddMoreIndexes = true;
                               break;
@@ -580,7 +580,7 @@ void findNextTuplet(
                   return;
                   }
 
-            validTuplets.exclude(index);
+            validTuplets.exclude(int(index));
             const auto savedTuplets = validTuplets.save();
                         // check tuplets for compatibility
             if (!validTuplets.empty()) {
@@ -626,7 +626,7 @@ void findNextTuplet(
 
 void moveUncommonTupletsToEnd(std::vector<TupletInfo> &tuplets, std::set<int> &uncommons)
       {
-      int swapWith = tuplets.size() - 1;
+      int swapWith = int(tuplets.size()) - 1;
       for (int i = swapWith; i >= 0; --i) {
             auto it = uncommons.find(i);
             if (it != uncommons.end()) {
@@ -652,7 +652,7 @@ std::vector<int> findBestTuplets(
       TupletErrorResult minCurrentError;
       const auto tupletIntervals = findTupletIntervals(tuplets, basicQuant);
 
-      ValidTuplets validTuplets(tuplets.size());
+      ValidTuplets validTuplets(int(tuplets.size()));
 
       findNextTuplet(selectedTuplets, validTuplets, bestTupletIndexes, minCurrentError,
                      tupletCommons, tuplets, tupletIntervals, commonsSize, basicQuant);

--- a/mscore/importptb.cpp
+++ b/mscore/importptb.cpp
@@ -493,7 +493,7 @@ void PowerTab::readPosition(int staff, int voice, ptSection& sec)
       beat->accent = data2 & 0x04;
       beat->staccato = data2 & 0x02;
 
-      for (int i = sec.beats.size(); i < staff + 1; ++i) {
+      for (int i = int(sec.beats.size()); i < staff + 1; ++i) {
             sec.beats.push_back({});
             }
       if (add) {
@@ -694,7 +694,7 @@ void PowerTab::fillMeasure(tBeatList& elist, Measure* measure, int staff, std::v
                         note->setFret(n.value);
                         note->setString(n.str);
                         const StringData* sd = score->staff(staff)->part()->instrument()->stringData();
-                        int k     = curTrack->infos[staff].strings.size() - n.str - 1;
+                        int k     = int(curTrack->infos[staff].strings.size()) - n.str - 1;
                         int pitch = sd->stringList().at(k).pitch + n.value; //getPitch(n.str, n.value, 0);
                         note->setPitch(pitch);
                         note->setTpcFromPitch();
@@ -775,13 +775,13 @@ void PowerTab::addToScore(ptSection& sec)
                   part->insertStaff(s, -1);
                   auto info = &curTrack->infos[i];
                   std::string ss = info->name;
-                  part->setPartName(QString::fromUtf8(ss.data(), ss.size()));
-                  part->setPlainLongName(QString::fromUtf8(ss.data(), ss.size()));
+                  part->setPartName(QString::fromUtf8(ss.data(), int(ss.size())));
+                  part->setPlainLongName(QString::fromUtf8(ss.data(), int(ss.size())));
 
                   std::vector<int> reverseStr;
                   for (auto it = info->strings.rbegin(); it != info->strings.rend(); ++it)
                         reverseStr.push_back(*it);
-                  StringData stringData(32, info->strings.size(), reverseStr.data());
+                  StringData stringData(32, int(info->strings.size()), reverseStr.data());
                   part->instrument()->setStringData(stringData);
 
                   part->setMidiProgram(info->instrument);
@@ -833,7 +833,7 @@ void PowerTab::addToScore(ptSection& sec)
 
             t = new RehearsalMark(score);
             t->setFrameType(FrameType::NO_FRAME);
-            t->setPlainText(QString::fromUtf8(sec.partName.data(), sec.partName.size()));
+            t->setPlainText(QString::fromUtf8(sec.partName.data(), int(sec.partName.size())));
             t->setOffset(QPointF(10.0, 0.0));
             t->setTrack(0);
             seg->add(t);
@@ -1210,11 +1210,11 @@ Score::FileError PowerTab::read()
 
       readSongInfo(song.info);
       readDataInstruments(song.track1);
-      staffInc = song.track1.infos.size();
+      staffInc = int(song.track1.infos.size());
       lastStaffMap.clear();
       readDataInstruments(song.track1);
 
-      staves = song.track1.infos.size();
+      staves = int(song.track1.infos.size());
 
       std::vector<tBeatList> parts(staves);
       for (int i = staffInc; i < staves; ++i) {
@@ -1259,7 +1259,7 @@ Score::FileError PowerTab::read()
       std::string name = song.info.name;
       if (!name.empty()) {
             Text* s = new Text(score, Tid::TITLE);
-            s->setPlainText(QString::fromUtf8(name.data(), name.size()));
+            s->setPlainText(QString::fromUtf8(name.data(), int(name.size())));
             m->add(s);
             }
 

--- a/mscore/jackaudio.cpp
+++ b/mscore/jackaudio.cpp
@@ -380,7 +380,7 @@ int JackAudio::processAudio(jack_nframes_t frames, void* p)
                               jack_midi_event_t event;
                               if (jack_midi_event_get(&event, portBuffer, i) != 0)
                                     continue;
-                              int nn = event.size;
+                              size_t nn = event.size;
                               int type = event.buffer[0];
                               if (nn && (type == ME_CLOCK || type == ME_SENSE))
                                     continue;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3456,7 +3456,7 @@ void ScoreView::cmdCreateTuplet(ChordRest* cr, Tuplet* tuplet)
       _score->cmdCreateTuplet(cr, tuplet);
 
       const std::vector<DurationElement*>& cl = tuplet->elements();
-      int ne = cl.size();
+      size_t ne = cl.size();
       DurationElement* el = 0;
       if (ne && cl[0]->type() == ElementType::REST)
             el  = cl[0];

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -101,7 +101,7 @@ static size_t ovRead(void* ptr, size_t size, size_t nmemb, void* datasource)
       if (n) {
             const char* src = vd->data.data() + vd->pos;
             memcpy(ptr, src, n);
-            vd->pos += n;
+            vd->pos += int(n);
             }
       return n;
       }

--- a/mscore/waveview.cpp
+++ b/mscore/waveview.cpp
@@ -52,7 +52,7 @@ static size_t ovRead(void* ptr, size_t size, size_t nmemb, void* datasource)
       if (n) {
             const char* src = vd->data.data() + vd->pos;
             memcpy(ptr, src, n);
-            vd->pos += n;
+            vd->pos += int(n);
             }
       return n;
       }

--- a/thirdparty/beatroot/CMakeLists.txt
+++ b/thirdparty/beatroot/CMakeLists.txt
@@ -20,7 +20,7 @@ if (NOT MSVC)
 else (NOT MSVC)
    set_target_properties ( beatroot
       PROPERTIES
-         COMPILE_FLAGS "${PCH_INCLUDE}"
+         COMPILE_FLAGS "${PCH_INCLUDE} /wd4267"
       )
 endif (NOT MSVC)   
 

--- a/thirdparty/freetype/CMakeLists.txt
+++ b/thirdparty/freetype/CMakeLists.txt
@@ -192,3 +192,8 @@ add_library(mscore_freetype
 ###-###  set_target_properties(freetype PROPERTIES
 ###-###    COMPILE_FLAGS /Fd"$(IntDir)$(TargetName).pdb")
 ###-###endif ()
+if (MSVC)
+  set_target_properties( mscore_freetype PROPERTIES
+    COMPILE_FLAGS "/wd4244 /wd4267"
+  )
+endif (MSVC)

--- a/thirdparty/poppler/CMakeLists.txt
+++ b/thirdparty/poppler/CMakeLists.txt
@@ -151,7 +151,7 @@ else (APPLE)
          # -Woverloaded-virtual  -> /Wall enabled all warnings, no need to enable particularly
          # -Wno-missing-field-initializers -> ???
          # -Wno-unused-but-set-variable -> Warning C4189: 'identifier': local variable is initialized but not referenced
-         set (POPPLER_COMPILE_FLAGS "/wd4065 /wd4100 /wd4121 /wd4127 /wd4189 /wd4244 /wd4245 /wd4310 /wd4255 /wd4309 /wd4456 /wd4458 /wd4459 /wd4701 /wd4702 /wd4703 /wd4706 /wd4805 /wd4996")
+         set (POPPLER_COMPILE_FLAGS "/wd4065 /wd4100 /wd4121 /wd4127 /wd4189 /wd4244 /wd4245 /wd4310 /wd4255 /wd4267 /wd4309 /wd4334 /wd4456 /wd4458 /wd4459 /wd4701 /wd4702 /wd4703 /wd4706 /wd4805 /wd4996")
       endif (NOT MSVC)
    endif(MINGW)
 endif(APPLE)

--- a/thirdparty/portmidi/CMakeLists.txt
+++ b/thirdparty/portmidi/CMakeLists.txt
@@ -48,6 +48,12 @@ else (APPLE)
   )
 endif (APPLE)
 
+if (MSVC)
+  set_target_properties( portmidi PROPERTIES
+    COMPILE_FLAGS "/wd4028 /wd4189 /wd4267 /wd4311 /wd4312"
+  )
+endif (MSVC)
+
 include_directories(
       ${PROJECT_SOURCE_DIR}/thirdparty/portmidi/pm_common
       ${PROJECT_SOURCE_DIR}/thirdparty/portmidi/porttime

--- a/thirdparty/rtf2html/CMakeLists.txt
+++ b/thirdparty/rtf2html/CMakeLists.txt
@@ -49,7 +49,7 @@ if (NOT MSVC)
 else (NOT MSVC)
    set_target_properties ( rtf2html
       PROPERTIES
-         COMPILE_FLAGS "${PCH_INCLUDE}"
+         COMPILE_FLAGS "${PCH_INCLUDE} /wd4267"
       )
 endif (NOT MSVC)   
 


### PR DESCRIPTION
Disable MSVC warnings for thirdparty code:

* C4267 for beatroot
* C4244 and C4267 for freetype
* C4267 and C4334 for poppler (in addition to those disabled earlier)
* C4028, C4189, C4267, C4311 and C4312 for portmidi
* C4267 for rtf2html

Fix more MSVC warnings:

* The one C4100
* The two C4457
* The two C4701
* The 475 C4267 

Also fix GCC warnings reg. wrong printf format for a size_t, reg. unused variables and reg. ambigous else branch, seen on Travis CI

Leaves us with (building for 64bit RelWithDebInfo):

* 193 C4456
* 122 C4458
* 1 LNK4098