### PR TITLE
fix #274902 #274925: Incorrect chord symbol position

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -369,6 +369,7 @@ void Harmony::read(XmlReader& e)
 
       // render chord from description (or _textName)
       render();
+      setXmlText(harmonyName());
       }
 
 //---------------------------------------------------------
@@ -707,6 +708,8 @@ void Harmony::startEdit(EditData& ed)
       {
       if (!textList.empty())
             setXmlText(harmonyName());
+
+      layoutInvalid = false;
       TextBase::startEdit(ed);
       }
 
@@ -737,7 +740,8 @@ bool Harmony::edit(EditData& ed)
 void Harmony::endEdit(EditData& ed)
       {
       TextBase::endEdit(ed);
-      layout();
+      if (isLayoutInvalid())
+            layout();
       if (links()) {
             for (ScoreElement* e : *links()) {
                   if (e == this)

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -230,7 +230,6 @@ class TextBase : public Element {
       QString _text;
       QList<TextBlock> _layout;
       bool textInvalid              { true  };
-      bool layoutInvalid            { true  };
       Tid _tid;         // text style id
 
       QString preEdit;              // move to EditData?
@@ -245,6 +244,8 @@ class TextBase : public Element {
       int getPropertyFlagsIdx(Pid id) const;
 
    protected:
+      bool layoutInvalid            { true  };
+      
       QColor textColor() const;
       QRectF frame;           // calculated in layout()
       void layoutFrame();


### PR DESCRIPTION
Prevent excess layout of Harmony when switch to editing element. 