### PR TITLE
fix #275808: Crash in parts after undo-redo

### DIFF
--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -289,6 +289,7 @@ void ScoreTab::updateExcerpts()
             }
       else {
             tab2->setVisible(false);
+            setCurrentIndex(0);
             }
       blockSignals(true);
       setExcerpt(0);


### PR DESCRIPTION
See https://musescore.org/en/node/275808.

When `ScoreTab::updateExcerpts()` is called after `AddExcerpt::undo()`, the excerpt tab is hidden and the master score tab becomes visible. But as far as the ScoreTab is concerned, the current tab is still the (now invisible and invalid) excerpts tab. The problem is solved by setting the current tab to the master score tab when the excerpt tab is hidden.