### PR TITLE
fix #275588: Instrument names aligned to the left 2.X->3.0

### DIFF
--- a/libmscore/iname.cpp
+++ b/libmscore/iname.cpp
@@ -44,6 +44,7 @@ InstrumentName::InstrumentName(Score* s)
    : TextBase(s, ElementFlag::NOTHING | ElementFlag::NOT_SELECTABLE)
       {
       setInstrumentNameType(InstrumentNameType::SHORT);
+      setAlign(Align::RIGHT);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Set default alignment of insrument name to the right in InstumentName constructor.