### PR TITLE
fix #275592: Tempotext is not applied during playback 2.X->3.0

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3406,7 +3406,8 @@ System* Score::collectSystem(LayoutContext& lc)
                   for (Element* e : s->annotations()) {
                         if (e->isTempoText()) {
                               TempoText* tt = toTempoText(e);
-                              setTempo(tt->segment(), tt->tempo());
+                              if (score()->isMaster())
+                                    setTempo(tt->segment(), tt->tempo());
                               tt->layout();
                               }
                         else if (e->isFermata()) {

--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -346,7 +346,8 @@ void LayoutContext::layoutLinear()
                   for (Element* e : s->annotations()) {
                         if (e->isTempoText()) {
                               TempoText* tt = toTempoText(e);
-                              score->setTempo(tt->segment(), tt->tempo());
+                              if (score->isMaster())
+                                    score->setTempo(tt->segment(), tt->tempo());
                               tt->layout();
                               }
                         else if (e->isFermata())


### PR DESCRIPTION
Add if statement before applying new tempo. Because tempo should be setted by the MasterScore.