### PR TITLE
fix #275588: Set alignment of instrument name to the right

### DIFF
--- a/libmscore/iname.cpp
+++ b/libmscore/iname.cpp
@@ -44,7 +44,6 @@ InstrumentName::InstrumentName(Score* s)
    : TextBase(s, ElementFlag::NOTHING | ElementFlag::NOT_SELECTABLE)
       {
       setInstrumentNameType(InstrumentNameType::SHORT);
-      setAlign(Align::RIGHT);
       }
 
 //---------------------------------------------------------

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -632,6 +632,7 @@ void System::setInstrumentNames(bool longName)
                         iname->setTrack(staffIdx * VOICES);
                         iname->setInstrumentNameType(longName ? InstrumentNameType::LONG : InstrumentNameType::SHORT);
                         iname->setLayoutPos(sn.pos());
+                        iname->setProperty(Pid::ALIGN, int(Align::RIGHT));
                         score()->addElement(iname);
                         }
                   iname->setXmlText(sn.name());


### PR DESCRIPTION
Set alignment of instrument name to the right during building InstrumentName object. 