### PR TITLE
fix #271616: Fermata tempo is not applied when importing 2.X->3.0 score

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2454,6 +2454,7 @@ void Score::getNextMeasure(LayoutContext& lc)
                   }
             }
 
+      measure->computeTicks();
       for (Segment& segment : measure->segments()) {
             if (segment.isBreathType()) {
                   qreal length = 0.0;
@@ -3857,6 +3858,9 @@ void Score::doLayoutRange(int stick, int etick)
 
       lc.prevMeasure = 0;
 
+      // we need to reset tempo because fermata is setted 
+      //inside getNextMeasure and it lead to twice timeStretch
+      fixTicks();
       getNextMeasure(lc);
       lc.curSystem = collectSystem(lc);
 

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3518,29 +3518,7 @@ void Measure::stretchMeasure(qreal targetWidth)
       {
       bbox().setWidth(targetWidth);
 
-      //---------------------------------------------------
-      //    compute minTick and set ticks for all segments
-      //---------------------------------------------------
-
-      int minTick = ticks();
-      if (minTick <= 0) {
-            qDebug("=====minTick %d measure %p", minTick, this);
-            }
-      Q_ASSERT(minTick > 0);
-
-      Segment* ns = first();
-      while (ns && !ns->enabled())
-            ns = ns->next();
-      while (ns) {
-            Segment* s = ns;
-            ns         = s->nextEnabled();
-            int nticks = (ns ? ns->rtick() : ticks()) - s->rtick();
-            if (nticks) {
-                  if (nticks < minTick)
-                        minTick = nticks;
-                  }
-            s->setTicks(nticks);
-            }
+      int minTick = computeTicks();
 
       //---------------------------------------------------
       //    compute stretch
@@ -3673,6 +3651,36 @@ void Measure::stretchMeasure(qreal targetWidth)
                   }
             }
       }
+
+//---------------------------------------------------
+//    computeTicks
+//    set ticks for all segments
+//       return minTick 
+//---------------------------------------------------
+
+int Measure::computeTicks() {
+      int minTick = ticks();
+      if (minTick <= 0) {
+            qDebug("=====minTick %d measure %p", minTick, this);
+            }
+      Q_ASSERT(minTick > 0);
+
+      Segment* ns = first();
+      while (ns && !ns->enabled())
+            ns = ns->next();
+      while (ns) {
+            Segment* s = ns;
+            ns         = s->nextEnabled();
+            int nticks = (ns ? ns->rtick() : ticks()) - s->rtick();
+            if (nticks) {
+                  if (nticks < minTick)
+                        minTick = nticks;
+                  }
+            s->setTicks(nticks);
+            }
+
+      return minTick;
+}
 
 //---------------------------------------------------------
 //   endBarLine

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -159,6 +159,7 @@ class Measure final : public MeasureBase {
       void setUserStretch(qreal v)              { _userStretch = v; }
 
       void stretchMeasure(qreal stretch);
+      int computeTicks();
       void layout2();
 
       Chord* findChord(int tick, int track);

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1665,6 +1665,9 @@ Element* readArticulation(ChordRest* cr, XmlReader& e)
                               el->readProperties300(e);
                         }
                   }
+            else if (tag == "timeStretch")
+                  if (el && el->isFermata())
+                        el->setProperty(Pid::TIME_STRETCH ,e.readDouble()); 
             else {
                   if (!el) {
                         qDebug("not handled <%s>", qPrintable(tag.toString()));


### PR DESCRIPTION
1) Add reading timeStretch for feramta from mscz
2) Add calculating ticks for segments before first using fermata