### PR TITLE
fix #275382: Tuplet numbers are not italic from reading old score

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1197,8 +1197,7 @@ static void readTuplet(Tuplet* tuplet, XmlReader& e)
                   _number->setComposition(true);
                   tuplet->setNumber(_number);
                   // _number reads property defaults from parent tuplet as "composition" is set:
-                  for (auto p : { Pid::FONT_FACE, Pid::FONT_SIZE, Pid::FONT_BOLD, Pid::FONT_ITALIC, Pid::FONT_UNDERLINE, Pid::ALIGN })
-                        _number->resetProperty(p);
+                  tuplet->resetNumberProperty();
                   readText206(e, _number, tuplet);
                   _number->setVisible(tuplet->visible());     //?? override saved property
                   _number->setTrack(tuplet->track());

--- a/libmscore/tuplet.h
+++ b/libmscore/tuplet.h
@@ -58,8 +58,6 @@ class Tuplet final : public DurationElement {
       QPointF bracketL[4];
       QPointF bracketR[3];
 
-      void resetNumberProperty();
-
    public:
       Tuplet(Score*);
       Tuplet(const Tuplet&);
@@ -73,6 +71,7 @@ class Tuplet final : public DurationElement {
 
       Text* number() const    { return _number; }
       void setNumber(Text* t) { _number = t; }
+      void resetNumberProperty();
 
       virtual bool isEditable() const override;
       virtual void startEdit(EditData&) override;

--- a/mtest/libmscore/compat206/lidemptytext-ref.mscx
+++ b/mtest/libmscore/compat206/lidemptytext-ref.mscx
@@ -150,6 +150,7 @@
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
             <Number>
+              <italic>1</italic>
               <text>3</text>
               </Number>
             </Tuplet>

--- a/mtest/libmscore/compat206/tuplets-ref.mscx
+++ b/mtest/libmscore/compat206/tuplets-ref.mscx
@@ -98,6 +98,7 @@
             <actualNotes>6</actualNotes>
             <baseNote>16th</baseNote>
             <Number>
+              <italic>1</italic>
               <text>6:4</text>
               </Number>
             </Tuplet>
@@ -164,6 +165,7 @@
             <actualNotes>10</actualNotes>
             <baseNote>eighth</baseNote>
             <Number>
+              <italic>1</italic>
               <text>10:8</text>
               </Number>
             </Tuplet>
@@ -248,6 +250,7 @@
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
             <Number>
+              <italic>1</italic>
               <text>3</text>
               </Number>
             </Tuplet>
@@ -289,6 +292,7 @@
             <actualNotes>3</actualNotes>
             <baseNote>16th</baseNote>
             <Number>
+              <italic>1</italic>
               <text>3</text>
               </Number>
             </Tuplet>
@@ -330,6 +334,7 @@
             <actualNotes>9</actualNotes>
             <baseNote>16th</baseNote>
             <Number>
+              <italic>1</italic>
               <text>9</text>
               </Number>
             </Tuplet>
@@ -363,6 +368,7 @@
             <actualNotes>6</actualNotes>
             <baseNote>64th</baseNote>
             <Number>
+              <italic>1</italic>
               <text>6</text>
               </Number>
             </Tuplet>
@@ -465,6 +471,7 @@
             <actualNotes>11</actualNotes>
             <baseNote>eighth</baseNote>
             <Number>
+              <italic>1</italic>
               <text>11</text>
               </Number>
             </Tuplet>
@@ -485,6 +492,7 @@
             <actualNotes>2</actualNotes>
             <baseNote>16th</baseNote>
             <Number>
+              <italic>1</italic>
               <text>2</text>
               </Number>
             </Tuplet>
@@ -500,6 +508,7 @@
             <actualNotes>3</actualNotes>
             <baseNote>32nd</baseNote>
             <Number>
+              <italic>1</italic>
               <text>3</text>
               </Number>
             </Tuplet>
@@ -558,6 +567,7 @@
             <actualNotes>5</actualNotes>
             <baseNote>32nd</baseNote>
             <Number>
+              <italic>1</italic>
               <text>5</text>
               </Number>
             </Tuplet>


### PR DESCRIPTION
Set default font of tuplet's numeric to italic during reading old score.