### PR TITLE
fix #275942: Crash while open score in debug mode of MS

### DIFF
--- a/libmscore/xmlreader.cpp
+++ b/libmscore/xmlreader.cpp
@@ -600,8 +600,9 @@ void XmlReader::removeConnector(const ConnectorInfoReader& cref)
       while (c->prev())
             c = c->prev();
       while (c) {
+            ConnectorInfoReader* next = c->next();
             removeConnectorInfo(*c);
-            c = c->next();
+            c = next;
             }
       }
 


### PR DESCRIPTION
Error consist of removing ConnectorInfoReader which lead to utilize already deleted pointer