### PR TITLE
fix #61146: 'Follow text' should be the default in TempoText

### DIFF
--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -384,7 +384,7 @@ QVariant TempoText::propertyDefault(Pid id) const
             case Pid::TEMPO:
                   return 2.0;
             case Pid::TEMPO_FOLLOW_TEXT:
-                  return false;
+                  return true;
             default:
                   return TextBase::propertyDefault(id);
             }


### PR DESCRIPTION
Set default value 'Follow Text' to true which mean that Follow Text is default for TempoText