### PR TITLE
Save locale-dependent preferences on program start

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -565,6 +565,17 @@ void Preferences::read()
 //      s.endGroup();
 
       readPluginList();
+
+      // store preferences with locale-dependent default values
+      // so that the values from first start will be used later
+      s.setValue("myScoresPath", myScoresPath);
+      s.setValue("myStylesPath", myStylesPath);
+      s.setValue("myImagesPath", myImagesPath);
+      s.setValue("myTemplatesPath", myTemplatesPath);
+      s.setValue("myPluginsPath", myPluginsPath);
+      s.setValue("mySoundfontsPath", mySoundfontsPath);
+      s.setValue("myExtensionsPath", myExtensionsPath);
+      s.remove("sfPath");
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Otherwise, they will depend on the locale of each individual invocation, instead of reusing the paths used at the first start, letting users not find their scores.

Noticed by Natureshadow <dominik.george@teckids.org>
Author: mirabilos <tg@debian.org>

Submitted against 2.3.2 because the entire `Preferences::read` method is gone in master, and I can’t easily figure out how to adjust it, and not test it at all at the moment, whereas the code against 2.3.2 is tested (and uploaded to Debian).