### PR TITLE
fix #275946: Clicking off of an element does not update Inspector

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -252,6 +252,7 @@ void ScoreView::mouseReleaseEvent(QMouseEvent*)
                   if (editData.startMove == editData.pos && clickOffElement) {
                         _score->deselectAll();
                         _score->update();
+                        mscore->updateInspector();
                         }
             case ViewState::EDIT:
             case ViewState::NOTE_ENTRY:


### PR DESCRIPTION
See https://musescore.org/en/node/275946.