### PR TITLE
fix #276049: 'Measure numbers every system' should place numbers after split measures

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -516,7 +516,7 @@ void Measure::layout2()
                && !irregular()
                && (no() || score()->styleB(Sid::showMeasureNumberOne))) {
                   if (score()->styleB(Sid::measureNumberSystem))
-                        smn = system()->firstMeasure() == this;
+                        smn = (system()->firstMeasure() == this) || (prevMeasure() && prevMeasure()->irregular() && system()->firstMeasure() == prevMeasure());
                   else {
                         smn = (no() == 0 && score()->styleB(Sid::showMeasureNumberOne)) ||
                               ( ((no() + 1) % score()->styleI(Sid::measureNumberInterval)) == (score()->styleB(Sid::showMeasureNumberOne) ? 1 : 0) ) ||


### PR DESCRIPTION
See https://musescore.org/en/node/276049#comment-852071.