### PR TITLE
fix #276051: lyrics changes position while press 'up' button

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2895,6 +2895,29 @@ void Score::layoutLyrics(System* system)
                   lls->rUserYoffset() = lls->lyrics()->rUserYoffset();
                   }
             }
+
+      // need to restore ry position of lyrics relates to the first measure of next System
+      // because collectSystem could be not called but ry position is reseted in Score::getNextMeasure
+      Measure* lastMeasure = system->lastMeasure();
+      if (!lastMeasure)
+            return;
+      Measure* firstMeasureNextSystem = lastMeasure->nextMeasure();
+      if (!firstMeasureNextSystem)
+            return;
+      for (int staffIdx : visibleStaves) {
+            for (Segment& s : firstMeasureNextSystem->segments()) {
+                  if (s.isChordRestType()) {
+                        for (int voice = 0; voice < VOICES; ++voice) {
+                              ChordRest* cr = s.cr(staffIdx * VOICES + voice);
+                              if (cr) {
+                                    for (Lyrics* l : cr->lyrics()) 
+                                          l->setOldryPos();
+                                    }
+                              }
+                        }
+                  }
+            }
+            
       }
 
 //---------------------------------------------------------

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -46,6 +46,7 @@ Lyrics::Lyrics(Score* s)
       _ticks      = 0;
       _syllabic   = Syllabic::SINGLE;
       _separator  = 0;
+      _oldrypos   = qreal(0);
       }
 
 Lyrics::Lyrics(const Lyrics& l)
@@ -282,6 +283,7 @@ void Lyrics::layout()
             styleChanged();
 
       QPointF o(offset() * (offsetType() == OffsetType::SPATIUM ? spatium() : DPI));
+      _oldrypos = rypos(); // store current position to restore it in Score::lyricLayout
       setPos(o);
       qreal x = pos().x();
       TextBase::layout1();

--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -45,6 +45,8 @@ class Lyrics final : public TextBase {
       Syllabic _syllabic;
       LyricsLine* _separator;
 
+      qreal _oldrypos;
+
       bool isMelisma() const;
       virtual void undoChangeProperty(Pid id, const QVariant&, PropertyFlags ps) override;
 
@@ -87,6 +89,7 @@ class Lyrics final : public TextBase {
       void setTicks(int tick)                         { _ticks = tick;    }
       int endTick() const;
       void removeFromScore();
+      void setOldryPos()                             { rypos() = _oldrypos; }
 
       using ScoreElement::undoChangeProperty;
       using TextBase::paste;


### PR DESCRIPTION
 lirics has two layout function - layout() and layout2(). The second define vertical position of lirics. First one is called from getNextMeasure the second is called from collectSystem. Error was that to correct placement of lyrics we need to call both this functions. But getNextMeasure is calledfrom the collectSystem and it layouts elements not only for current system, but also for the first measure of next System. In this way  lyrics::layout2() is not called. Because collectSystem is not called for the next System.

I remove lyrics::layout() from getNextMeasure and places it to collectSystem function but before implementing skyline algorithm. It is needed otherwise the another bug appears. Lyrics jumps away.