### PR TITLE
fix #276076: Creating new score doesn't switch active score

### DIFF
--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -289,7 +289,7 @@ void ScoreTab::updateExcerpts()
             }
       else {
             tab2->setVisible(false);
-            setCurrentIndex(0);
+            setCurrent(0);
             }
       blockSignals(true);
       setExcerpt(0);


### PR DESCRIPTION
See https://musescore.org/en/node/276076.

When I made #3915, I had not understood the distinction between `ScoreTab::setCurrent()` and `ScoreTab::setCurrentIndex()`. Now I believe I do, and `setCurrent()` is what is wanted here.

As I understand it now, `setCurrent()` sets the current tab bar, and `setCurrentIndex()` sets the current tab.