### PR TITLE
fix #2760989: Crash when flipping selected dotted rests

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1418,7 +1418,7 @@ void Score::cmdFlip()
                         tuplet->undoChangeProperty(Pid::DIRECTION, QVariant::fromValue<Direction>(dir));
                         });
                   }
-            else if (e->isNoteDot()) {
+            else if (e->isNoteDot() && e->parent()->isNote()) {
                   Note* note = toNote(e->parent());
                   Direction d = note->dotIsUp() ? Direction::DOWN : Direction::UP;
                   note->undoChangeProperty(Pid::DOT_POSITION, QVariant::fromValue<Direction>(d));


### PR DESCRIPTION
See https://musescore.org/en/node/276098.

It can no longer be assumed that the parent of a NoteDot is a Note, now that Rests can have NoteDots also.