### PR TITLE
Fix #109661 Regression: Page settings does not work for parts

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2458,7 +2458,7 @@ void MuseScore::showPageSettings()
       {
       if (pageSettings == 0)
             pageSettings = new PageSettings();
-      pageSettings->setScore(cs->masterScore());
+      pageSettings->setScore(cs);
       pageSettings->show();
       pageSettings->raise();
       }

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -97,10 +97,10 @@ void PageSettings::hideEvent(QHideEvent* ev)
 //   setScore
 //---------------------------------------------------------
 
-void PageSettings::setScore(MasterScore* s)
+void PageSettings::setScore(Score* s)
       {
-      cs  = s;
-      MasterScore* sl = s->clone();
+      cs = static_cast<MasterScore*>(s);
+      MasterScore* sl = static_cast<MasterScore*>(s)->clone();
       preview->setScore(sl);
       buttonApplyToAllParts->setEnabled(!s->isMaster());
       updateValues();

--- a/mscore/pagesettings.h
+++ b/mscore/pagesettings.h
@@ -71,7 +71,7 @@ class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
    public:
       PageSettings(QWidget* parent = 0);
       ~PageSettings();
-      void setScore(MasterScore*);
+      void setScore(Score*);
       };
 
 


### PR DESCRIPTION
Caused by changed call from musescore.cpp/setScore, as parameter cs no longer of type MasterScore.
resulted in all changes beeing applied to master instead of parts.
Changed call and parameter type of SetScore to Score*. Added static cast as required.