### PR TITLE
partial fix for #276102: show the correct icon for bottom align 

### DIFF
--- a/mscore/inspector/alignSelect.cpp
+++ b/mscore/inspector/alignSelect.cpp
@@ -42,7 +42,7 @@ AlignSelect::AlignSelect(QWidget* parent)
       alignVCenter->setIcon(*icons[int(Icons::textVCenter_ICON)]);
       alignTop->setIcon(*icons[int(Icons::textTop_ICON)]);
       alignBaseline->setIcon(*icons[int(Icons::textBaseline_ICON)]);
-      alignBottom->setIcon(*icons[int(Icons::textBaseline_ICON)]);
+      alignBottom->setIcon(*icons[int(Icons::textBottom_ICON)]);
 
       connect(g1, SIGNAL(buttonToggled(int,bool)), SLOT(_alignChanged()));
       connect(g2, SIGNAL(buttonToggled(int,bool)), SLOT(_alignChanged()));


### PR DESCRIPTION
With this change at least the correct icon is shown, but that and the other are very similar and hard to tell apart, so better, easier to distinguish icons might be called for.