### PR TITLE
fix #276149: Resizing bracket causes crash

### DIFF
--- a/libmscore/bracket.cpp
+++ b/libmscore/bracket.cpp
@@ -276,6 +276,7 @@ void Bracket::draw(QPainter* painter) const
 void Bracket::startEdit(EditData& ed)
       {
       Element::startEdit(ed);
+      ay1 = pagePos().y();
       ed.grips   = 1;
       ed.curGrip = Grip::START;
       }
@@ -315,7 +316,6 @@ void Bracket::editDrag(EditData& ed)
 
 void Bracket::endEditDrag(EditData&)
       {
-      qreal ay1 = pagePos().y();
       qreal ay2 = ay1 + h2 * 2;
 
       int staffIdx1 = staffIdx();

--- a/libmscore/bracket.h
+++ b/libmscore/bracket.h
@@ -28,6 +28,7 @@ enum class BracketType : signed char;
 
 class Bracket final : public Element {
       BracketItem* _bi;
+      qreal ay1;
       qreal h2;
 
       int _firstStaff;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3744,10 +3744,6 @@ void Score::doLayoutRange(int stick, int etick)
 //      qDebug("start <%s> tick %d, system %p", m->name(), m->tick(), m->system());
       lc.score        = m->score();
 
-      if (lineMode()) {
-            layoutLinear(layoutAll, lc);
-            return;
-            }
       std::vector<std::pair<int, BracketItem*>> selectedBrackets;
 
       if (!layoutAll && m->system()) {
@@ -3812,6 +3808,11 @@ void Score::doLayoutRange(int stick, int etick)
             pages().clear();
 
             lc.nextMeasure = _measures.first();
+            }
+
+      if (lineMode()) {
+            layoutLinear(layoutAll, lc);
+            return;
             }
 
       lc.prevMeasure = 0;


### PR DESCRIPTION
See https://musescore.org/en/node/276149.

The problem is that layoutLinear() is called before the brackets are removed from the selection list. Moving this chunk of code further down in the function solves the problem.

Notice that the brackets are not re-selected after layoutLinear() is called. I tried to do this using the data stored in selectedBrackets, but it did not seem to work. It works better in Page View, but even then it may be a little buggy.