### PR TITLE
fix #267644 Integrate Sparkle to Musescore development version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,11 @@ clone_depth: 3                      # clone entire repository history if not def
 
 image: Visual Studio 2017
 
+branches:
+  only:
+  - master
+  - 3.0alpha
+
 # build cache to preserve files/folders between builds
 cache:
   - dependencies.7z

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,9 @@ include (CreatePrecompiledHeader)
 
 set(CMAKE_AUTOMOC     TRUE)
 set(MSCORE_UNSTABLE   TRUE)          # Mark as unstable
+set(MSCORE_RELEASE_CHANNEL "devel")
+#set(MSCORE_RELEASE_CHANNEL "testing")
+#set(MSCORE_RELEASE_CHANNEL "stable")
 set(USE_SSE           TRUE)
 set(SCRIPT_INTERFACE  TRUE)
 
@@ -123,6 +126,7 @@ option(BUILD_PCH "Build using precompiled headers." ON)
 option(BUILD_FOR_WINSTORE "Build for the Windows Store." OFF)
 option(COVERAGE "Build with instrumentation to record code coverage." OFF)
 option(BUILD_64 "Build 64 bit version of editor" ON)
+option(BUILD_AUTOUPDATE "Build with autoupdate support" OFF)
 
 if (APPLE)
       set (CMAKE_CXX_COMPILER   clang++)
@@ -140,6 +144,7 @@ if (APPLE)
 
       set(CMAKE_OSX_DEPLOYMENT_TARGET 10.7)      # Min version required
       set(HAS_AUDIOFILE TRUE)            # Requires libsndfile
+      set(MAC_APPCAST_URL "")
 
       find_library(AudioToolboxFW        NAMES AudioToolbox)
       find_library(AudioUnitFW           NAMES AudioUnit)
@@ -149,6 +154,14 @@ if (APPLE)
       find_library(CoreServicesFW        NAMES CoreServices)
       find_library(AppKit                NAMES AppKit)
       set(OsxFrameworks ${AudioToolboxFW} ${AudioUnitFW} ${CoreAudioFW} ${CoreMidiFW} ${SystemConfigurationFW} ${CoreServicesFW} ${AppKit})
+      if (BUILD_AUTOUPDATE)
+        find_package(Sparkle) #needed for SPARKLE_FOUND variable
+        if(SPARKLE_FOUND)
+          set(MAC_SPARKLE_ENABLED 1)
+          set(OsxFrameworks ${OsxFrameworks} ${SPARKLE_LIBRARY})
+          set(MAC_APPCAST_URL "https://sparkle.musescore.org/${MSCORE_RELEASE_CHANNEL}/3/macos/appcast.xml")
+        endif(SPARKLE_FOUND)
+      endif(BUILD_AUTOUPDATE)
 endif (APPLE)
 
 #
@@ -373,30 +386,30 @@ else (BUILD_64 STREQUAL "ON")
       SET (ARCH_TYPE "_x86")
       SET (DEPENDENCIES_DIR "${PROJECT_SOURCE_DIR}/dependencies/libx86")
 endif (BUILD_64 STREQUAL "ON")
- 
-if (APPLE OR MINGW) 
-      if (BUILD_LAME) 
-            include (FindLame) 
-            set (USE_LAME 1) 
-      endif (BUILD_LAME) 
+
+if (APPLE OR MINGW)
+      if (BUILD_LAME)
+            include (FindLame)
+            set (USE_LAME 1)
+      endif (BUILD_LAME)
 else (APPLE OR MINGW)
-      if (BUILD_LAME) 
+      if (BUILD_LAME)
             if (MSVC)
                include(FindLameMSVC)
-            else (MSVC) 
-               include (FindLame) 
-            endif (MSVC) 
-            if (LAME_FOUND) 
-                  set(USE_LAME 1) 
-                  MESSAGE("LAME found.") 
-            else (LAME_FOUND) 
-                  set(USE_LAME 0) 
-                  MESSAGE("LAME not found.") 
-            endif (LAME_FOUND) 
-      else (BUILD_LAME) 
-            MESSAGE(STATUS "LAME MP3 support disabled") 
-      endif (BUILD_LAME) 
-endif (APPLE OR MINGW) 
+            else (MSVC)
+               include (FindLame)
+            endif (MSVC)
+            if (LAME_FOUND)
+                  set(USE_LAME 1)
+                  MESSAGE("LAME found.")
+            else (LAME_FOUND)
+                  set(USE_LAME 0)
+                  MESSAGE("LAME not found.")
+            endif (LAME_FOUND)
+      else (BUILD_LAME)
+            MESSAGE(STATUS "LAME MP3 support disabled")
+      endif (BUILD_LAME)
+endif (APPLE OR MINGW)
 
 ##
 ## Find JACK >= JACK_MIN_VERSION
@@ -450,7 +463,7 @@ if (BUILD_PORTAUDIO)
         set ( USE_PORTAUDIO 1 )
         if (MSVC)
            include(FindPortAudio)
-           add_library(portaudiodll SHARED IMPORTED)	
+           add_library(portaudiodll SHARED IMPORTED)
            set_target_properties(portaudiodll PROPERTIES IMPORTED_IMPLIB ${PORTAUDIO_LIBRARY})
         endif(MSVC)
     else (MINGW OR MSVC)
@@ -762,7 +775,7 @@ if (MSVC)
    include_directories(${PORTAUDIO_INCLUDE_DIR})
    include_directories(${OGG_INCLUDE_DIR})
 endif (MSVC)
-   
+
 if (USE_SYSTEM_FREETYPE)
       include_directories(${FREETYPE_INCLUDE_DIRS})
 else (USE_SYSTEM_FREETYPE)
@@ -824,7 +837,7 @@ add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/plugins
 
 
 ##
-##  For MSVC: set the startup project to be mscore 
+##  For MSVC: set the startup project to be mscore
 ##     (requires CMake 3.6.3+ to work, but should be benign on other versions
 ##      as it is just setting the value for a property).
 ##

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -85,7 +85,7 @@ ci: revision
 	mkdir build.release;     \
     cd build.release;            \
     cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=RELEASE \
-          -DCMAKE_BUILD_NUMBER="${BUILD_NUMBER}"  \
+          -DCMAKE_BUILD_NUMBER="${BUILD_NUMBER}" -DBUILD_AUTOUPDATE=ON  \
           .. -G Xcode;                                                  \
     xcodebuild -project ${XCODEPROJ} -target lrelease;                  \
     $(FORMATTER_START) xcodebuild -project ${XCODEPROJ} -configuration Release -target install $(FORMATTER_END);

--- a/build/FindSparkle.cmake
+++ b/build/FindSparkle.cmake
@@ -1,0 +1,7 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(SPARKLE_INCLUDE_DIR Sparkle.h)
+find_library(SPARKLE_LIBRARY NAMES Sparkle)
+
+find_package_handle_standard_args(Sparkle DEFAULT_MSG SPARKLE_INCLUDE_DIR SPARKLE_LIBRARY)
+mark_as_advanced(SPARKLE_INCLUDE_DIR SPARKLE_LIBRARY)

--- a/build/MacOSXBundleInfo.plist.in
+++ b/build/MacOSXBundleInfo.plist.in
@@ -364,5 +364,43 @@
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>ATSApplicationFontsPath</key>
 	<string>fonts/</string>
+	<key>SUFeedURL</key>
+	<string>${MAC_APPCAST_URL}</string>
+	<key>SUAllowsAutomaticUpdates</key>
+	<false/>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>ar</string>
+		<string>cs</string>
+		<string>da</string>
+		<string>de</string>
+		<string>el</string>
+		<string>en</string>
+		<string>es</string>
+		<string>fi</string>
+		<string>fr</string>
+		<string>fr_CA</string>
+		<string>hu</string>
+		<string>is</string>
+		<string>it</string>
+		<string>ja</string>
+		<string>ko</string>
+		<string>nb</string>
+		<string>nl</string>
+		<string>pl</string>
+		<string>pt</string>
+		<string>pt_BR</string>
+		<string>pt_PT</string>
+		<string>ro</string>
+		<string>ru</string>
+		<string>sk</string>
+		<string>sl</string>
+		<string>sv</string>
+		<string>th</string>
+		<string>tr</string>
+		<string>uk</string>
+		<string>zh_CN</string>
+		<string>zh_TW</string>
+	</array>
 </dict>
 </plist>

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -41,6 +41,8 @@
 #define VERSION                 "${MUSESCORE_VERSION_FULL}"
 #define BUILD_NUMBER            "${CMAKE_BUILD_NUMBER}"
 
+
+#cmakedefine MAC_SPARKLE_ENABLED
 #cmakedefine AEOLUS
 #cmakedefine ZERBERUS
 #cmakedefine OMR

--- a/build/travis/job_macos/before_install.sh
+++ b/build/travis/job_macos/before_install.sh
@@ -28,4 +28,13 @@ expect << EOF
   send "${OSUOSL_NIGHTLY_PASSPHRASE}\r"
   expect eof
 EOF
+
+#set NIGHTLY_BUILD variable if MSCORE_UNSTABLE is TRUE in CMakeLists.txt
+if [ "$(grep '^[[:blank:]]*set( *MSCORE_UNSTABLE \+TRUE *)' CMakeLists.txt)" ]
+then
+export NIGHTLY_BUILD=TRUE
+fi
+
+export MSCORE_RELEASE_CHANNEL=$(grep '^[[:blank:]]*set *( *MSCORE_RELEASE_CHANNEL' CMakeLists.txt | awk -F \" '{print $2}')
+
 fi

--- a/build/travis/job_macos/generateGitLog.sh
+++ b/build/travis/job_macos/generateGitLog.sh
@@ -1,0 +1,27 @@
+set -e
+
+options="--all -10"
+messages_command="git log --pretty=tformat:'%s' ${options[@]}"
+lines_command="git log --pretty=tformat:'<b>%h</b> -  __XX123XX__ </li>' ${options[@]}"
+
+# damn bash arrays
+OLDIFS=$IFS
+IFS=$'\n'
+
+messages=($(bash -c "$messages_command"))
+lines=($(bash -c "$lines_command"))
+
+IFS=$OLDIFS
+
+mlen=${#messages[@]}
+llen=${#lines[@]}
+
+OUTPUT=${OUTPUT}"<ul>"
+for (( i=0; i<${mlen}; i++ )); do
+  message=$(perl -MHTML::Entities -e '$msg=encode_entities($ARGV[1]);$l=$ARGV[0];$l =~ s/__XX123XX__/$msg/;print $l;' "${lines[$i]}" "${messages[$i]}")
+  OUTPUT=${OUTPUT}"<li>$message"
+done
+OUTPUT=${OUTPUT}"</ul>"
+
+echo $OUTPUT
+

--- a/build/travis/job_macos/install.sh
+++ b/build/travis/job_macos/install.sh
@@ -107,7 +107,18 @@ rvm get head
 wget -nv http://utils.musescore.org.s3.amazonaws.com/qt593_mac.zip
 mkdir -p $QT_MACOS
 unzip -qq qt593_mac.zip -d $QT_MACOS
-rm qt5100_mac.zip
+rm qt593_mac.zip
+
+#install sparkle
+export SPARKLE_VERSION=1.20.0
+mkdir Sparkle-${SPARKLE_VERSION}
+cd Sparkle-${SPARKLE_VERSION}
+wget -nv https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.bz2
+tar jxf Sparkle-${SPARKLE_VERSION}.tar.bz2
+cd ..
+mkdir -p ~/Library/Frameworks
+mv Sparkle-${SPARKLE_VERSION}/Sparkle.framework ~/Library/Frameworks/
+rm -rf Sparkle-${SPARKLE_VERSION}
 
 #install signing certificate
 if [ -n "$CERTIFICATE_OSX_PASSWORD" ]
@@ -123,6 +134,8 @@ then
     security set-keychain-settings -t 3600 -l $KEYCHAIN
     security import $CERTIFICATE_P12 -k $KEYCHAIN -P "$CERTIFICATE_OSX_PASSWORD" -T /usr/bin/codesign
 fi
+
+
 
 
 

--- a/build/travis/job_macos/script.sh
+++ b/build/travis/job_macos/script.sh
@@ -15,7 +15,7 @@ BRANCH="$TRAVIS_BRANCH"
 REVISION="$(echo "$TRAVIS_COMMIT" | cut -c 1-7)"
 [ "REVISION" ] || REVISION="$(make -f Makefile.osx revision && cat mscore/revision.h)"
 
-if [ "$(grep '^[[:blank:]]*set( *MSCORE_UNSTABLE \+TRUE *)' CMakeLists.txt)" ]
+if [[ "$NIGHTLY_BUILD" = "TRUE" ]]
 then
 cp -f build/travis/resources/splash-nightly.png  mscore/data/splash.png
 cp -f build/travis/resources/mscore-nightly.icns mscore/data/mscore.icns
@@ -25,12 +25,18 @@ fi
 
 make -f Makefile.osx ci BUILD_NUMBER=${TRAVIS_BUILD_NUMBER}
 
+
+mkdir -p applebuild/mscore.app/Contents/Resources/Frameworks
+
 # install lame
 wget -c --no-check-certificate -nv -O musescore_dependencies_macos.zip  http://utils.musescore.org.s3.amazonaws.com/musescore_dependencies_macos.zip
-mkdir -p applebuild/mscore.app/Contents/Resources/Frameworks
 unzip musescore_dependencies_macos.zip -d applebuild/mscore.app/Contents/Resources/Frameworks
 
-if [ "$(grep '^[[:blank:]]*set( *MSCORE_UNSTABLE \+TRUE *)' CMakeLists.txt)" ]
+#install Sparkle
+mkdir -p applebuild/mscore.app/Contents/Frameworks
+cp -Rf ~/Library/Frameworks/Sparkle.framework applebuild/mscore.app/Contents/Frameworks
+
+if [[ "$NIGHTLY_BUILD" = "TRUE" ]]
 then # Build is marked UNSTABLE inside CMakeLists.txt
 build/package_mac $BRANCH-$REVISION
 PACKAGE_NAME=MuseScoreNightly
@@ -39,7 +45,8 @@ build/package_mac
 PACKAGE_NAME=MuseScore
 fi
 
-DMGFILE=applebuild/$PACKAGE_NAME-$DATE-$BRANCH-$REVISION.dmg
+DMGFILENAME=$PACKAGE_NAME-$DATE-$BRANCH-$REVISION.dmg
+DMGFILE=applebuild/$DMGFILENAME
 
 mv applebuild/$PACKAGE_NAME-$BRANCH-$REVISION.dmg $DMGFILE
 
@@ -66,8 +73,16 @@ VERSION_PATCH=$(grep 'SET(MUSESCORE_VERSION_PATCH' CMakeLists.txt | cut -d \" -f
 BUILD_NUMBER=${TRAVIS_BUILD_NUMBER}
 MUSESCORE_VERSION=${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.${BUILD_NUMBER}
 SHORT_DATE="$(date -u +%Y-%m-%d)"
+#date -R is not supporte !?
+RSS_DATE="$(LANG=C date +'%a, %d %b %Y %H:%M:%S %z')"
+FILESIZE="$(stat -f%z $DMGFILE)"
+APPCAST_URL=$(defaults read `pwd`/applebuild/mscore.app/Contents/Info.plist SUFeedURL)
+GIT_LOG=$(./build/travis/job_macos/generateGitLog.sh)
 
-if [ "$(grep '^[[:blank:]]*set( *MSCORE_UNSTABLE \+TRUE *)' CMakeLists.txt)" ]
+#install artifacts
+curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
+
+if [[ "$NIGHTLY_BUILD" = "TRUE" ]]
 then
 echo "<update>
 <version>${MUSESCORE_VERSION}</version>
@@ -75,9 +90,10 @@ echo "<update>
 <releaseType>nightly</releaseType>
 <date>${SHORT_DATE}</date>
 <description>MuseScore ${MUSESCORE_VERSION} ${REVISION}</description>
-<downloadUrl>https://ftp.osuosl.org/pub/musescore-nightlies/macosx/$DMGFILE</downloadUrl>
+<downloadUrl>https://ftp.osuosl.org/pub/musescore-nightlies/macosx/$DMGFILENAME</downloadUrl>
 <infoUrl>https://ftp.osuosl.org/pub/musescore-nightlies/macosx/</infoUrl>
 </update>" >> update_mac_nightly.xml
+
 export ARTIFACTS_KEY=$UPDATE_S3_KEY
 export ARTIFACTS_SECRET=$UPDATE_S3_SECRET
 export ARTIFACTS_REGION=us-east-1
@@ -86,7 +102,42 @@ export ARTIFACTS_CACHE_CONTROL='public, max-age=315360000'
 export ARTIFACTS_PERMISSIONS=public-read
 export ARTIFACTS_TARGET_PATHS="/"
 export ARTIFACTS_PATHS=update_mac_nightly.xml
-curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
 artifacts upload
 fi
 
+echo "<rss xmlns:sparkle=\"http://www.andymatuschak.org/xml-namespaces/sparkle\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" version=\"2.0\">
+<channel>
+<title>MuseScore development channel</title>
+<link>
+${APPCAST_URL}
+</link>
+<description>Most recent changes with links to updates.</description>
+<language>en</language>
+<item>
+<title>MuseScore ${MUSESCORE_VERSION} ${REVISION}</title>
+<description>
+<![CDATA[
+${GIT_LOG}
+]]>
+</description>
+<pubDate>${RSS_DATE}</pubDate>
+<enclosure url=\"https://ftp.osuosl.org/pub/musescore-nightlies/macosx/${DMGFILENAME}\" sparkle:version=\"${MUSESCORE_VERSION}\" length=\"${FILESIZE}\" type=\"application/octet-stream\"/>
+</item>
+</channel>
+</rss>" >> appcast.xml
+
+export ARTIFACTS_KEY=$UPDATE_S3_KEY
+export ARTIFACTS_SECRET=$UPDATE_S3_SECRET
+export ARTIFACTS_REGION=us-east-1
+export ARTIFACTS_BUCKET=sparkle.musescore.org
+export ARTIFACTS_CACHE_CONTROL='public, max-age=315360000'
+export ARTIFACTS_PERMISSIONS=public-read
+export ARTIFACTS_TARGET_PATHS="/${MSCORE_RELEASE_CHANNEL}/3/macos/"
+export ARTIFACTS_PATHS=appcast.xml
+artifacts upload
+
+pip install awscli
+export AWS_ACCESS_KEY_ID=$UPDATE_S3_KEY
+export AWS_SECRET_ACCESS_KEY=$UPDATE_S3_SECRET
+aws configure set preview.cloudfront true
+aws cloudfront create-invalidation --distribution-id E15OTT2G07XS8C --paths "${ARTIFACTS_TARGET_PATHS}*"

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -231,6 +231,10 @@ if (APPLE)
       set (MACOSX_BUNDLE_BUNDLE_NAME MuseScore)
       set (MACOSX_BUNDLE_SHORT_VERSION_STRING ${MUSESCORE_VERSION})
       set (MACOSX_BUNDLE_BUNDLE_VERSION ${MUSESCORE_VERSION_FULL})
+      if(CMAKE_BUILD_NUMBER)
+        set (MACOSX_BUNDLE_SHORT_VERSION_STRING ${MUSESCORE_VERSION_FULL}.${CMAKE_BUILD_NUMBER})
+        set (MACOSX_BUNDLE_BUNDLE_VERSION ${MUSESCORE_VERSION_FULL}.${CMAKE_BUILD_NUMBER})
+      endif(CMAKE_BUILD_NUMBER)
       set (MACOSX_BUNDLE_COPYRIGHT musescore.org)
 else (APPLE)
       set (ExecutableName mscore)
@@ -243,9 +247,13 @@ endif (OMR)
 if (APPLE)
       file(GLOB_RECURSE INCS "*.h")
       set(COCOABRIDGE "macos/cocoabridge.mm")
+      if (SPARKLE_FOUND)
+            set(MAC_SPARKLE_FILES "macos/SparkleAutoUpdater.mm")
+      endif(SPARKLE_FOUND)
 else (APPLE)
       set(INCS "")
       set(COCOABRIDGE "")
+      set(MAC_SPARKLE_FILES  "")
 endif (APPLE)
 
 if (NOT MSVC)
@@ -415,9 +423,12 @@ add_executable ( ${ExecutableName}
       ${OMR_FILES}
       ${AUDIO}
       ${SCRIPT_FILES}
+      ${MAC_SPARKLE_FILES}
       driver.h
       tremolobarcanvas.h bendcanvas.h fretcanvas.h keycanvas.h harmonycanvas.h
       )
+
+
 
 if (MSVC)
 	target_link_libraries(mscore vorbisfiledll)

--- a/mscore/macos/SparkleAutoUpdater.h
+++ b/mscore/macos/SparkleAutoUpdater.h
@@ -1,0 +1,18 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2018 Werner Schweer
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+class SparkleAutoUpdater
+{
+    public:
+         static void checkUpdates();
+         static void checkForUpdatesNow();
+};

--- a/mscore/macos/SparkleAutoUpdater.mm
+++ b/mscore/macos/SparkleAutoUpdater.mm
@@ -1,0 +1,28 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2018 Werner Schweer
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "SparkleAutoUpdater.h"
+
+#include "Sparkle/Sparkle.h"
+#include <Sparkle/SUUpdater.h>
+
+static SUUpdater*  updater = [[SUUpdater sharedUpdater] retain];
+
+void SparkleAutoUpdater::checkUpdates()
+      {
+      [updater checkForUpdatesInBackground];
+      }
+
+void SparkleAutoUpdater::checkForUpdatesNow()
+      {
+      [updater checkForUpdates:NULL];
+      }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -118,14 +118,17 @@
 #ifdef USE_LAME
 #include "exportmp3.h"
 #endif
-
 #ifdef Q_OS_MAC
 #include "macos/cocoabridge.h"
+#ifdef MAC_SPARKLE_ENABLED
+#include "macos/SparkleAutoUpdater.h"
+#endif
 #endif
 
 #ifdef AEOLUS
 extern Ms::Synthesizer* createAeolus();
 #endif
+
 #ifdef ZERBERUS
 extern Ms::Synthesizer* createZerberus();
 #endif
@@ -3400,10 +3403,14 @@ bool MuseScore::eventFilter(QObject *obj, QEvent *event)
 
 bool MuseScore::hasToCheckForUpdate()
       {
+#ifdef MAC_SPARKLE_ENABLED
+      return false; // On Mac, sparkle take cares of the scheduling for now. On windows too probably.
+#else
       if (ucheck)
             return ucheck->hasToCheck();
       else
             return false;
+#endif
       }
 
 //---------------------------------------------------------
@@ -3421,8 +3428,13 @@ bool MuseScore::hasToCheckForExtensionsUpdate()
 
 void MuseScore::checkForUpdate()
       {
+#ifdef MAC_SPARKLE_ENABLED
+      SparkleAutoUpdater::checkForUpdatesNow();
+#else
       if (ucheck)
             ucheck->check(version(), sender() != 0);
+
+#endif
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Note that BUILD_AUTOUPDATE is ON by default, it should be OFF
when pushed to master and enabled on the CI only. Also note
that the code assumes that Sparkle.framework is in a search path
(/Library/Frameworks for example)