### PR TITLE
fix #276160: Crash when entering notes or rests if no duration is selected

### DIFF
--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -69,8 +69,12 @@ void MuseScore::updateInputState(Score* score)
       {
       InputState& is = score->inputState();
       if (is.noteEntryMode()) {
-            if (is.usingNoteEntryMethod(NoteEntryMethod::REPITCH))
-                  is.setDuration(is.cr()->durationType());
+            if (is.usingNoteEntryMethod(NoteEntryMethod::REPITCH)) {
+                  TDuration d = is.cr()->durationType();
+                  if (!d.isValid() || d.isZero() || d.isMeasure())
+                        d = TDuration::DurationType::V_QUARTER;
+                  is.setDuration(d);
+                  }
             Staff* staff = score->staff(is.track() / VOICES);
             switch (staff->staffType(is.tick())->group()) {
                   case StaffGroup::STANDARD:


### PR DESCRIPTION
See https://musescore.org/en/node/276160.