### PR TITLE
fix #276105: repitch input changes rhythm in drums/percussion instruments

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3662,6 +3662,8 @@ void MuseScore::changeState(ScoreState val)
                   break;
             case STATE_NOTE_ENTRY_STAFF_DRUM:
                   {
+                  if (getAction("note-input-repitch")->isChecked())
+                        cs->setNoteEntryMethod(NoteEntryMethod::REPITCH);
                   showModeText(tr("Drum input mode"));
                   InputState& is = cs->inputState();
                   showDrumTools(is.drumset(), cs->staff(is.track() / VOICES));


### PR DESCRIPTION
See https://musescore.org/en/node/276105.