### PR TITLE
fix #276111: Inserting system break causes distorted tie

### DIFF
--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -491,7 +491,10 @@ void Tie::slurPos(SlurPos* sp)
             }
       Chord* ec = endNote()->chord();
       sp->p2    = ec->pos() + ec->segment()->pos() + ec->measure()->pos();
-      sp->system2 = ec->measure()->system();
+      if ((sc->measure() == sp->system1->lastMeasure()) && (ec->measure() != sc->measure()))
+            sp->system2 = nullptr;
+      else
+            sp->system2 = ec->measure()->system();
 
       hw = endNote()->tabHeadWidth(stt);
       if ((ec->notes().size() > 1) || (ec->stem() && !ec->up() && !_up))


### PR DESCRIPTION
See https://musescore.org/en/node/276111.