### PR TITLE
fix #276194 Allow MIDI devices to be refreshed without having to restart MuseScore

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2773,12 +2773,39 @@ void MeasuresDialog::accept()
       }
 
 //---------------------------------------------------------
+//   rebuildAudioDrivers
+//---------------------------------------------------------
+
+void MuseScore::restartAudioEngine()
+      {
+      if (seq)
+            seq->exit();
+
+      if (seq) {
+            Driver* driver = driverFactory(seq, "");
+            if (driver) {
+                  // Updating synthesizer's sample rate
+                  if (seq->synti()) {
+                        seq->synti()->setSampleRate(driver->sampleRate());
+                        seq->synti()->init();
+                        }
+                  seq->setDriver(driver);
+                  }
+            if (!seq->init())
+                  qDebug("sequencer init failed");
+            }
+      }
+
+//---------------------------------------------------------
 //   midiinToggled
 //---------------------------------------------------------
 
 void MuseScore::midiinToggled(bool val)
       {
       _midiinEnabled = val;
+
+      if (_midiinEnabled)
+            restartAudioEngine();
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -568,6 +568,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void changeWorkspace(Workspace* p, bool first=false);
       void mixerPreferencesChanged(bool showMidiControls);
       void checkForUpdates();
+      void restartAudioEngine();
 
    public:
       MuseScore();

--- a/mscore/pa.cpp
+++ b/mscore/pa.cpp
@@ -72,6 +72,9 @@ Portaudio::Portaudio(Seq* s)
 Portaudio::~Portaudio()
       {
       if (initialized) {
+            if (midiDriver)
+                  delete midiDriver;
+
             PaError err = Pa_CloseStream(stream);
             if (err != paNoError)
                   qDebug("Portaudio close stream failed: %s", Pa_GetErrorText(err));

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -205,6 +205,7 @@ PreferenceDialog::PreferenceDialog(QWidget* parent)
       connect(jackDriver, SIGNAL(toggled(bool)), SLOT(exclusiveAudioDriver(bool)));
       connect(useJackAudio, SIGNAL(toggled(bool)), SLOT(nonExclusiveJackDriver(bool)));
       connect(useJackMidi,  SIGNAL(toggled(bool)), SLOT(nonExclusiveJackDriver(bool)));
+      connect(rescanDrivers, SIGNAL(clicked()), this, SLOT(restartAudioEngine()));
       updateRemote();
 
       advancedWidget = new PreferencesListWidget();
@@ -988,8 +989,6 @@ void PreferenceDialog::apply()
          || (preferences.getInt(PREF_IO_ALSA_FRAGMENTS) != alsaFragments->value())
 #endif
             ) {
-            if (seq)
-                  seq->exit();
 
             preferences.setPreference(PREF_IO_ALSA_USEALSAAUDIO, alsaDriver->isChecked());
             preferences.setPreference(PREF_IO_PORTAUDIO_USEPORTAUDIO, portaudioDriver->isChecked());
@@ -998,19 +997,8 @@ void PreferenceDialog::apply()
             preferences.setPreference(PREF_IO_ALSA_SAMPLERATE, alsaSampleRate->currentData().toInt());
             preferences.setPreference(PREF_IO_ALSA_PERIODSIZE, alsaPeriodSize->currentData().toInt());
             preferences.setPreference(PREF_IO_ALSA_FRAGMENTS, alsaFragments->value());
-            if (seq) {
-                  Driver* driver = driverFactory(seq, "");
-                  if (driver) {
-                        // Updating synthesizer's sample rate
-                        if (seq->synti()) {
-                              seq->synti()->setSampleRate(driver->sampleRate());
-                              seq->synti()->init();
-                              }
-                        seq->setDriver(driver);
-                        }
-                  if (!seq->init())
-                        qDebug("sequencer init failed");
-                  }
+
+            restartAudioEngine();
             }
 
 #ifdef USE_PORTAUDIO
@@ -1365,6 +1353,7 @@ void PreferenceDialog::defineShortcutClicked()
       shortcutsChanged = true;
       }
 
+
 //---------------------------------------------------------
 //   printShortcutsClicked
 //---------------------------------------------------------
@@ -1436,6 +1425,15 @@ void PreferenceDialog::printShortcutsClicked()
       p.end();
 #endif
 }
+
+//---------------------------------------------------------
+//   rebuildAudioDrivers
+//---------------------------------------------------------
+
+void PreferenceDialog::restartAudioEngine()
+      {
+      mscore->restartAudioEngine();
+      }
 
 
 } // namespace Ms

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -80,6 +80,7 @@ class PreferenceDialog : public AbstractDialog, private Ui::PrefsDialogBase {
       void filterShortcutsTextChanged(const QString &);
       void filterAdvancedPreferences(const QString&);
       void resetAdvancedPreferenceToDefault();
+      void restartAudioEngine();
 
       void changeSoundfontPaths();
       void updateTranslationClicked();

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -3179,6 +3179,38 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_14">
+         <property name="toolTip">
+          <string>Causes the audio engine to restart.  This can allow you to connect to MIDI devices that have been started since you started MuseScore.</string>
+         </property>
+         <property name="title">
+          <string>Audio Engine</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_11">
+          <item row="0" column="0">
+           <widget class="QPushButton" name="rescanDrivers">
+            <property name="text">
+             <string>Restart Audio &amp;&amp; MIDI Devices</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <spacer name="horizontalSpacer_20">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="restartWarning">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">


### PR DESCRIPTION
Fixed a bug in PortAudio where it wasn't deleting PortMidi upon deletion, which left the old MIDI ports open and blocked any new Drivers from using them.

Also added a button to Preferences/I/O.  Now if a user turns off/on their MIDI keyboard while Musescore is running, they can open the Preferences/I/O, press Rescan MIDI Input and they should be able to use their keyboard again.