### PR TITLE
fix #276139: Using Inspector after leaving edit mode causes crash.

### DIFF
--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -399,7 +399,8 @@ void InspectorBase::valueChanged(int idx, bool reset)
       recursion = false;
 
       ScoreView* cv = mscore->currentScoreView();
-      cv->updateGrips();
+      if (cv->editMode())
+            cv->updateGrips();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/276139.