### PR TITLE
fix #276217 Support MIDI-IN while playback engaged

### DIFF
--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -154,9 +154,9 @@ QSize HPiano::sizeHint() const
 //   pressKeys
 //---------------------------------------------------------
 
-void HPiano::setPressedPitches(QSet<int> pitches)
+void HPiano::setPressedPlaybackPitches(QSet<int> pitches)
       {
-      _pressedPitches = pitches;
+      _pressedPlaybackPitches = pitches;
       updateAllKeys();
       }
 
@@ -218,7 +218,8 @@ void HPiano::clearSelection()
 void HPiano::updateAllKeys()
       {
       for (PianoKeyItem* key : keys) {
-            key->setPressed(_pressedPitches.contains(key->pitch()));
+            key->setPressed(_pressedPitches.contains(key->pitch())
+                            || _pressedPlaybackPitches.contains(key->pitch()));
             key->update();
             }
       }
@@ -443,13 +444,13 @@ void PianoTools::retranslate()
 //   heartBeat
 //---------------------------------------------------------
 
-void PianoTools::heartBeat(QList<const Ms::Note *> notes)
+void PianoTools::setPlaybackNotes(QList<const Ms::Note *> notes)
       {
       QSet<int> pitches;
       for (const Note* note : notes) {
           pitches.insert(note->ppitch());
           }
-      _piano->setPressedPitches(pitches);
+      _piano->setPressedPlaybackPitches(pitches);
       }
 
 //---------------------------------------------------------

--- a/mscore/pianotools.h
+++ b/mscore/pianotools.h
@@ -60,6 +60,9 @@ class HPiano : public QGraphicsView {
       Q_OBJECT
       int _firstKey;
       int _lastKey;
+      //Pitches pressed due to playback
+      QSet<int> _pressedPlaybackPitches;
+      //Pitches pressed due to user interaction
       QSet<int> _pressedPitches;
       QList<PianoKeyItem*> keys;
       qreal scaleVal;
@@ -75,7 +78,7 @@ class HPiano : public QGraphicsView {
    public:
       HPiano(QWidget* parent = 0);
       friend class PianoKeyItem;
-      void setPressedPitches(QSet<int> pitches);
+      void setPressedPlaybackPitches(QSet<int> pitches);
       void pressPitch(int pitch);
       void releasePitch(int pitch);
       void clearSelection();
@@ -108,7 +111,7 @@ class PianoTools : public QDockWidget {
       PianoTools(QWidget* parent = 0);
       void pressPitch(int pitch)    { _piano->pressPitch(pitch);   }
       void releasePitch(int pitch)  { _piano->releasePitch(pitch); }
-      void heartBeat(QList<const Note*> notes);
+      void setPlaybackNotes(QList<const Note*> notes);
       void clearSelection();
       void changeSelection(Selection selection);
       };

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -87,6 +87,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_APP_PLAYBACK_FOLLOWSONG,                         new BoolPreference(true)},
             {PREF_APP_PLAYBACK_PANPLAYBACK,                        new BoolPreference(true)},
             {PREF_APP_PLAYBACK_PLAYREPEATS,                        new BoolPreference(true)},
+            {PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY,              new BoolPreference(true)},
             {PREF_APP_USESINGLEPALETTE,                            new BoolPreference(false)},
             {PREF_APP_STARTUP_FIRSTSTART,                          new BoolPreference(true)},
             {PREF_APP_STARTUP_SESSIONSTART,                        new EnumPreference(QVariant::fromValue(SessionStart::SCORE), false)},

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -94,6 +94,7 @@ enum class MusicxmlExportBreaks : char {
 #define PREF_APP_PLAYBACK_FOLLOWSONG                        "application/playback/followSong"
 #define PREF_APP_PLAYBACK_PANPLAYBACK                       "application/playback/panPlayback"
 #define PREF_APP_PLAYBACK_PLAYREPEATS                       "application/playback/playRepeats"
+#define PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY             "application/playback/setLoopToSelectionOnPlay"
 #define PREF_APP_USESINGLEPALETTE                           "application/useSinglePalette"
 #define PREF_APP_STARTUP_FIRSTSTART                         "application/startup/firstStart"
 #define PREF_APP_STARTUP_SESSIONSTART                       "application/startup/sessionStart"

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3550,7 +3550,7 @@ void ScoreView::cmdTuplet(int n)
 
 void ScoreView::midiNoteReceived(int pitch, bool chord, int velocity)
       {
-      qDebug("midiNoteReceived %d chord %d", pitch, chord);
+      qDebug("midiNoteReceived: pitch %d, chord %d, velocity %d", pitch, chord, velocity);
 
       MidiInputEvent ev;
       ev.pitch = pitch;

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -318,8 +318,10 @@ void Seq::start()
                   }
             }
       if ((mscore->loop())) {
-            if (cs->selection().isRange())
-                  setLoopSelection();
+            if (preferences.getBool(PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY)) {
+                  if (cs->selection().isRange())
+                        setLoopSelection();
+                  }
             if (!preferences.getBool(PREF_IO_JACK_USEJACKTRANSPORT) || (preferences.getBool(PREF_IO_JACK_USEJACKTRANSPORT) && state == Transport::STOP))
                   seek(cs->repeatList()->tick2utick(cs->loopInTick()));
             }
@@ -417,7 +419,7 @@ void Seq::unmarkNotes()
       markedNotes.clear();
       PianoTools* piano = mscore->pianoTools();
       if (piano && piano->isVisible())
-            piano->heartBeat(markedNotes);
+            piano->setPlaybackNotes(markedNotes);
       }
 
 //---------------------------------------------------------
@@ -1133,7 +1135,7 @@ void Seq::seekRT(int utick)
 
 void Seq::startNote(int channel, int pitch, int velo, double nt)
       {
-      if (state != Transport::STOP)
+      if (state != Transport::STOP && state != Transport::PLAY)
             return;
       NPlayEvent ev(ME_NOTEON, channel, pitch, velo);
       ev.setTuning(nt);
@@ -1518,7 +1520,7 @@ void Seq::heartBeatTimeout()
 
       PianoTools* piano = mscore->pianoTools();
       if (piano && piano->isVisible())
-            piano->heartBeat(markedNotes);
+            piano->setPlaybackNotes(markedNotes);
 
       cv->update(cv->toPhysical(r));
       }


### PR DESCRIPTION
Can now play in any part while playback is engaged.  PianoTools reflects both the note the user is pressing and the playback notes at the same time.  Loop range is no longer automatically set when Play is pressed.