### PR TITLE
fix #275706: Place all articulations at stem side if direction and anchor is set to automatic

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -84,13 +84,12 @@ int Articulation::subtype() const
 
 void Articulation::setUp(bool val)
       {
-      if (val != _up) {
-            QString s = Sym::id2name(_symId);
-            if (s.endsWith(_up ? "Above" : "Below")) {
-                  QString s2 = s.left(s.size() - 5) + (val ? "Above" : "Below");
-                  _symId = Sym::name2id(s2);
-                  }
-            _up = val;
+      _up = val;
+      bool dup = _direction == Direction::AUTO ? val : _direction == Direction::UP;
+      QString s = Sym::id2name(_symId);
+      if (s.endsWith(!dup ? "Above" : "Below")) {
+            QString s2 = s.left(s.size() - 5) + (dup ? "Above" : "Below");
+            _symId = Sym::name2id(s2);
             }
       }
 
@@ -601,6 +600,3 @@ void Articulation::doAutoplace()
       }
 
 }
-
-
-

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3245,28 +3245,21 @@ void Chord::layoutArticulations()
       //
 
       for (Articulation* a : _articulations) {
-            if (a->direction() != Direction::AUTO)
-                  a->setUp(a->direction() == Direction::UP);
-            else {
-                  if (a->anchor() == ArticulationAnchor::CHORD)
-                        a->setUp(!up());
-                  else
-                        a->setUp(a->anchor() == ArticulationAnchor::TOP_STAFF || a->anchor() == ArticulationAnchor::TOP_CHORD);
+            if (a->anchor() == ArticulationAnchor::CHORD) {
+			if (measure()->hasVoices(a->staffIdx()))
+				a->setUp(up()); // if there are voices place articulation at stem 
+			else if (a->symId() >= SymId::articMarcatoAbove && a->symId() <= SymId::articMarcatoTenutoBelow)
+				a->setUp(true); // Gould, p. 117: strong accents above staff
+			else
+                        a->setUp(!up()); // place articulation at note head
                   }
+            else
+                  a->setUp(a->anchor() == ArticulationAnchor::TOP_STAFF || a->anchor() == ArticulationAnchor::TOP_CHORD);
+
             if (!a->layoutCloseToNote())
                   continue;
-
-            ArticulationAnchor aa = a->anchor();
-            if (aa != ArticulationAnchor::CHORD && aa != ArticulationAnchor::TOP_CHORD && aa != ArticulationAnchor::BOTTOM_CHORD)
-                  continue;
-            bool bottom;                // true: articulation is below chord;  false: articulation is above chord
-            // if there area voices, articulation is on stem side
-            // otherwise, look at specific anchor type (and at chord up/down if necessary)
-            if ((aa == ArticulationAnchor::CHORD) && measure()->hasVoices(a->staffIdx()))
-                  bottom = !up();
-            else
-                  bottom = (aa == ArticulationAnchor::BOTTOM_CHORD) || (aa == ArticulationAnchor::CHORD && up());
-            a->setUp(!bottom);
+                  
+            bool bottom = !a->up();  // true: articulation is below chord;  false: articulation is above chord
             a->layout();
 
             bool headSide = bottom == up();

--- a/mtest/libmscore/compat206/articulations-double-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-double-ref.mscx
@@ -231,7 +231,7 @@
             <linkedMain/>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articMarcatoStaccatoBelow</subtype>
+              <subtype>articMarcatoStaccatoAbove</subtype>
               <linkedMain/>
               </Articulation>
             <Note>
@@ -282,7 +282,7 @@
             <linkedMain/>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articMarcatoTenutoBelow</subtype>
+              <subtype>articMarcatoTenutoAbove</subtype>
               <linkedMain/>
               </Articulation>
             <Note>
@@ -536,7 +536,7 @@
             <linkedMain/>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articMarcatoTenutoBelow</subtype>
+              <subtype>articMarcatoTenutoAbove</subtype>
               <linkedMain/>
               <color r="255" g="0" b="0" a="255"/>
               </Articulation>
@@ -2000,7 +2000,7 @@
                 </linked>
               <durationType>quarter</durationType>
               <Articulation>
-                <subtype>articMarcatoStaccatoBelow</subtype>
+                <subtype>articMarcatoStaccatoAbove</subtype>
                 <linked>
                   </linked>
                 </Articulation>
@@ -2058,7 +2058,7 @@
                 </linked>
               <durationType>quarter</durationType>
               <Articulation>
-                <subtype>articMarcatoTenutoBelow</subtype>
+                <subtype>articMarcatoTenutoAbove</subtype>
                 <linked>
                   </linked>
                 </Articulation>
@@ -2360,7 +2360,7 @@
                 </linked>
               <durationType>quarter</durationType>
               <Articulation>
-                <subtype>articMarcatoTenutoBelow</subtype>
+                <subtype>articMarcatoTenutoAbove</subtype>
                 <linked>
                   </linked>
                 <color r="255" g="0" b="0" a="255"/>

--- a/mtest/libmscore/compat206/articulations-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-ref.mscx
@@ -563,7 +563,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articMarcatoBelow</subtype>
+              <subtype>articMarcatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>60</pitch>

--- a/mtest/libmscore/implode_explode/undoExplode01-ref.mscx
+++ b/mtest/libmscore/implode_explode/undoExplode01-ref.mscx
@@ -640,7 +640,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articMarcatoBelow</subtype>
+              <subtype>articMarcatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>69</pitch>
@@ -820,7 +820,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articMarcatoBelow</subtype>
+              <subtype>articMarcatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>65</pitch>

--- a/mtest/libmscore/parts/voices-ref.mscx
+++ b/mtest/libmscore/parts/voices-ref.mscx
@@ -306,7 +306,7 @@
             <linkedMain/>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articAccentAbove</subtype>
+              <subtype>articAccentBelow</subtype>
               <linkedMain/>
               </Articulation>
             <Note>
@@ -722,7 +722,7 @@
             <linkedMain/>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articAccentAbove</subtype>
+              <subtype>articAccentBelow</subtype>
               <linkedMain/>
               </Articulation>
             <Note>
@@ -1236,7 +1236,7 @@
                 </linked>
               <durationType>quarter</durationType>
               <Articulation>
-                <subtype>articAccentBelow</subtype>
+                <subtype>articAccentAbove</subtype>
                 <linked>
                   <location>
                     <voices>1</voices>


### PR DESCRIPTION
I removed the restriction to staccato and tenuto so that now any articulation is placed at the stem side of the note if multiple voices exists