### PR TITLE
changes needed for MuseScore to build with Qt 5.12 (Alpha)

### DIFF
--- a/mscore/editstringdata.cpp
+++ b/mscore/editstringdata.cpp
@@ -52,7 +52,7 @@ EditStringData::EditStringData(QWidget *parent, QList<instrString> * strings, in
                   strg = (*_strings)[numOfStrings - i - 1];
                   _stringsLoc.append(strg);
                   QTableWidgetItem *newCheck = new QTableWidgetItem();
-                  newCheck->setFlags(Qt::ItemFlag(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled));
+                  newCheck->setFlags(Qt::ItemFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled));
                   newCheck->setCheckState(strg.open ? Qt::Checked : Qt::Unchecked);
                   stringList->setItem(i, 0, newCheck);
                   QTableWidgetItem *newPitch = new QTableWidgetItem(midiCodeToStr(strg.pitch));
@@ -168,7 +168,7 @@ void EditStringData::newStringClicked()
             _stringsLoc.insert(i, strg);
             stringList->insertRow(i);
             QTableWidgetItem *newCheck = new QTableWidgetItem();
-            newCheck->setFlags(Qt::ItemFlag(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled));
+            newCheck->setFlags(Qt::ItemFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled));
             newCheck->setCheckState(strg.open ? Qt::Checked : Qt::Unchecked);
             stringList->setItem(i, 0, newCheck);
             QTableWidgetItem *newPitch = new QTableWidgetItem(midiCodeToStr(strg.pitch));

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -4276,7 +4276,6 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
    </item>
   </layout>
  </widget>
- <pixmapfunction>getPixmap</pixmapfunction>
  <customwidgets>
   <customwidget>
    <class>Awl::ColorLabel</class>


### PR DESCRIPTION
One needed for MSVC only (and only since Alpha, not with the previous preview), the other needed for MSVC and MinGW (see also #3961).
Neither seems to cause issues with Qt 5.9 (like AppVeyor and Travis CI prove, as both use Qt 5.9)