### PR TITLE
fix #276136: lyrics jumps

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3402,7 +3402,7 @@ System* Score::collectSystem(LayoutContext& lc)
             for (SpannerSegment* ss : system->spannerSegments()) {
                   Spanner* sp = ss->spanner();
                   if (sp->tick() < m->endTick() && sp->tick2() > m->tick())
-                        system->staff(sp->staffIdx())->skyline().add(ss->shape().translated(ss->pos()));
+                        system->staff(sp->staffIdx())->skyline().add(ss->shape().translated(ss->ipos()));
                   }
             }
 


### PR DESCRIPTION
There is a value 'lyricsEvenOffset' in mscx which cause the bug. When  it is setted. It leads to jumping lyrics because calculating new skyline always adds offset to older position of lyrics. I fix it by remove adding offset.