### PR TITLE
fix #276134: fretboard diagram placement opposite to inspector value

### DIFF
--- a/mscore/inspector/inspector_fret.ui
+++ b/mscore/inspector/inspector_fret.ui
@@ -143,12 +143,12 @@
         </property>
         <item>
          <property name="text">
-          <string notr="true">Below</string>
+          <string notr="true">Above</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string notr="true">Above</string>
+          <string notr="true">Below</string>
          </property>
         </item>
        </widget>


### PR DESCRIPTION
Fixes: https://musescore.org/en/node/276134