### PR TITLE
fix #276385: hairpin edit mode positioning issue

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -362,6 +362,7 @@ void HairpinSegment::startEdit(EditData& ed)
 void HairpinSegment::startEditDrag(EditData& ed)
       {
       TextLineBaseSegment::startEditDrag(ed);
+      setAutoplace(false);
       ElementEditData* eed = ed.getData(this);
 
       eed->pushProperty(Pid::HAIRPIN_HEIGHT);


### PR DESCRIPTION
This fixes a small issue where a hairpin would temporarily displace other elements when resized, when it should in fact have had its autoplace disabled as soon as the resize began.