### PR TITLE
fix #276392: shift+click to select in foto mode doesn't work

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -260,7 +260,9 @@ void ScoreView::mouseReleaseEvent(QMouseEvent*)
             case ViewState::PLAY:
             case ViewState::ENTRY_PLAY:
             case ViewState::FOTO:
+                  break;
             case ViewState::FOTO_LASSO:
+                  changeState(ViewState::FOTO);
                   break;
             }
       }
@@ -379,10 +381,13 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                               break;
                               }
                         }
+
                   if (gripClicked)
                         changeState(ViewState::FOTO_DRAG_EDIT);
                   else if (_foto->canvasBoundingRect().contains(editData.startMove))
                         changeState(ViewState::FOTO_DRAG_OBJECT);
+                  else if (ev->modifiers() & Qt::ShiftModifier)
+                        changeState(ViewState::FOTO_LASSO);
                   else
                         changeState(ViewState::FOTO_DRAG);
                   }
@@ -511,6 +516,10 @@ void ScoreView::mouseMoveEvent(QMouseEvent* me)
             case ViewState::PLAY:
                   if (drag && !editData.element)
                         dragScoreView(me);
+                  break;
+
+            case ViewState::FOTO_LASSO:
+                  doDragFoto(me);
                   break;
 
             default:
@@ -825,6 +834,9 @@ void ScoreView::changeState(ViewState s)
             case ViewState::LASSO:
                   endLasso();
                   break;
+            case ViewState::FOTO_LASSO:
+                  endFotoDrag();
+                  break;
             case ViewState::PLAY:
                   seq->stop();
                   break;
@@ -878,7 +890,9 @@ void ScoreView::changeState(ViewState s)
                   seq->start();
                   break;
             case ViewState::ENTRY_PLAY:
+                  break;
             case ViewState::FOTO_LASSO:
+                  startFotoDrag();
                   break;
             }
 

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -135,9 +135,13 @@ void ScoreView::startFotoDrag()
 
 void ScoreView::doDragFoto(QMouseEvent* ev)
       {
+      _foto->setUserOff(QPointF(0.0, 0.0));
       QPointF p = toLogical(ev->pos());
+      QPointF sm = editData.startMove;
+
       QRectF r;
-      r.setCoords(editData.startMove.x(), editData.startMove.y(), p.x(), p.y());
+      r.setCoords(sm.x(), sm.y(), p.x(), p.y());
+
       _foto->setbbox(r.normalized());
 
       QRectF rr(_foto->bbox());


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/276392
Ready to merge.