### PR TITLE
fix #276144: Scroll in continious view limited to less than all instruments

### DIFF
--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -454,6 +454,7 @@ void LayoutContext::layoutLinear()
       page->setPos(0, 0);
       system->setPos(page->lm(), page->tm() + score->styleP(Sid::staffUpperBorder));
       page->setWidth(system->width() + system->pos().x());
+      page->setHeight(system->height() + system->pos().y());
       page->rebuildBspTree();
       }
 


### PR DESCRIPTION
Extend rectangle of page box to cover all score's area in continious view mode.