### PR TITLE
Fix #109661: Regression - Page settings does not work for parts

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2460,7 +2460,7 @@ void MuseScore::showPageSettings()
       {
       if (pageSettings == 0)
             pageSettings = new PageSettings();
-      pageSettings->setScore(cs->masterScore());
+      pageSettings->setScore(cs);
       pageSettings->show();
       pageSettings->raise();
       }

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -97,12 +97,16 @@ void PageSettings::hideEvent(QHideEvent* ev)
 //   setScore
 //---------------------------------------------------------
 
-void PageSettings::setScore(MasterScore* s)
+void PageSettings::setScore(Score* s)
       {
-      cs  = s;
-      MasterScore* sl = s->clone();
-      preview->setScore(sl);
-      buttonApplyToAllParts->setEnabled(!s->isMaster());
+      cs  = static_cast<MasterScore*>(s);
+      if (cs)
+            preview->setScore(cs->clone());
+      else
+            cs = s;
+            preview->setScore(cs);
+		
+      buttonApplyToAllParts->setEnabled(!cs->isMaster());
       updateValues();
       updatePreview(0);
       }

--- a/mscore/pagesettings.h
+++ b/mscore/pagesettings.h
@@ -71,7 +71,7 @@ class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
    public:
       PageSettings(QWidget* parent = 0);
       ~PageSettings();
-      void setScore(MasterScore*);
+      void setScore(Score*);
       };
 
 


### PR DESCRIPTION
Type in call from musescore.cpp has changed from MasterScore to Score.
Type of parameter for Pagesettings/setScore changed and member variables changed accordingly.
Clone method moved to class Score instead of MasterScore to be available for object of class Score*.
