### PR TITLE
fix command line options `--template-mode`, `-R` and `--revert-settings` 

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -163,8 +163,8 @@ void Score::writeMovement(XmlWriter& xml, bool selectionOnly)
       QMapIterator<QString, QString> i(_metaTags);
       while (i.hasNext()) {
             i.next();
-            // do not output "platform" and "creationDate" in test mode
-            if ((!MScore::testMode  && !MScore::saveTemplateMode) || (i.key() != "platform" && i.key() != "creationDate"))
+            // do not output "platform" and "creationDate" in test and save template mode
+            if ((!MScore::testMode && !MScore::saveTemplateMode) || (i.key() != "platform" && i.key() != "creationDate"))
                   xml.tag(QString("metaTag name=\"%1\"").arg(i.key().toHtmlEscaped()), i.value());
             }
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6516,14 +6516,14 @@ int main(int argc, char* av[])
       parser.addOption(QCommandLineOption({"D", "monitor-resolution"}, "Specify monitor resolution", "DPI"));
       parser.addOption(QCommandLineOption({"S", "style"}, "Load style file", "style"));
       parser.addOption(QCommandLineOption({"p", "plugin"}, "Execute named plugin", "name"));
-      parser.addOption(QCommandLineOption(      "template-mode", "Save template mode, no page size"));
-      parser.addOption(QCommandLineOption({"F", "factory-settings"}, "Use factory settings"));
+      parser.addOption(QCommandLineOption(      "template-mode", "Save template mode, no page size")); // and no platform and creationDate tags
+      parser.addOption(QCommandLineOption({"F", "factory-settings"}, "Use factory settings"));  // this includes -R, --revert-settimngs
       parser.addOption(QCommandLineOption({"R", "revert-settings"}, "Revert to default preferences"));
       parser.addOption(QCommandLineOption({"i", "load-icons"}, "Load icons from INSTALLPATH/icons"));
       parser.addOption(QCommandLineOption({"j", "job"}, "Process a conversion job", "file"));
       parser.addOption(QCommandLineOption({"e", "experimental"}, "Enable experimental features"));
       parser.addOption(QCommandLineOption({"c", "config-folder"}, "Override configuration and settings folder", "dir"));
-      parser.addOption(QCommandLineOption({"t", "test-mode"}, "Set test mode flag for all files"));
+      parser.addOption(QCommandLineOption({"t", "test-mode"}, "Set test mode flag for all files")); // this includes --template-mode
       parser.addOption(QCommandLineOption({"M", "midi-operations"}, "Specify MIDI import operations file", "file"));
       parser.addOption(QCommandLineOption({"w", "no-webview"}, "No web view in start center"));
       parser.addOption(QCommandLineOption({"P", "export-score-parts"}, "Used with '-o <file>.pdf', export score and parts"));
@@ -6732,7 +6732,7 @@ int main(int argc, char* av[])
 
       // initialize current page size from default printer
 #ifndef QT_NO_PRINTER
-      if (!MScore::testMode) {
+      if (!MScore::testMode && !MScore::saveTemplateMode) {
             QPrinter p;
             if (p.isValid()) {
 //                  qDebug("set paper size from default printer");

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6697,7 +6697,8 @@ int main(int argc, char* av[])
             dataPath = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 
       if (deletePreferences) {
-            QDir(dataPath).removeRecursively();
+            if (useFactorySettings)
+                  QDir(dataPath).removeRecursively();
             QSettings settings;
             QFile::remove(settings.fileName() + ".lock"); //forcibly remove lock
             QFile::remove(settings.fileName());


### PR DESCRIPTION
fix `--template-mode` to really not include page format
fix `-R`, `--revert-settings` to only remove the preferences file, MuseScore*.ini, and not also shortcuts, custom workspaces and palettes, translations, etc., this is left for -F --factory-settings, see https://musescore.org/en/node/276560