### PR TITLE
fix #276076, fix #275808: fix issues related to active tab tracking that led to crashes

### DIFF
--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -169,6 +169,9 @@ void ScoreTab::tabMoved(int from, int to)
 
 //---------------------------------------------------------
 //   setCurrent
+//    Sets current view to the content of n-th tab.
+//    You will rarely need to call this function directly,
+//    consider using setCurrentIndex instead.
 //---------------------------------------------------------
 
 void ScoreTab::setCurrent(int n)
@@ -289,7 +292,7 @@ void ScoreTab::updateExcerpts()
             }
       else {
             tab2->setVisible(false);
-            setCurrent(0);
+            setExcerpt(0);
             }
       blockSignals(true);
       setExcerpt(0);
@@ -300,6 +303,10 @@ void ScoreTab::updateExcerpts()
 
 //---------------------------------------------------------
 //   setExcerpt
+//    Sets the currently selected excerpt tab to the n-th
+//    excerpt tab (where 0 is a tab for a master score).
+//    For selecting the current score see
+//    ScoreTab::setCurrentIndex
 //---------------------------------------------------------
 
 void ScoreTab::setExcerpt(int n)
@@ -370,6 +377,10 @@ int ScoreTab::currentIndex() const
 
 //---------------------------------------------------------
 //   setCurrentIndex
+//    Sets the currently selected score tab to the tab
+//    number idx.
+//    For selecting the current excerpt see
+//    ScoreTab::setExcerpt.
 //---------------------------------------------------------
 
 void ScoreTab::setCurrentIndex(int idx)

--- a/mscore/scoretab.h
+++ b/mscore/scoretab.h
@@ -58,10 +58,12 @@ class ScoreTab : public QWidget {
       void tabCloseRequested(int);
       void actionTriggered(QAction*);
 
+   private slots:
+      void setCurrent(int);
+
    public slots:
       void updateExcerpts();
       void setExcerpt(int);
-      void setCurrent(int);
       void tabMoved(int, int);
 
    public:

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2285,7 +2285,7 @@ void ScoreView::showOmr(bool flag)
       if (t->view() != this)
             t = mscore->getTab2();
       if (t->view() == this)
-            t->setCurrent(t->currentIndex());
+            t->setCurrentIndex(t->currentIndex());
       else
             qDebug("view not found");
       }


### PR DESCRIPTION
This pull request complements recently accepted pull requests #3915 and #3946. Those pull requests fixed an original issue [275808](https://musescore.org/en/node/275808) but had an unwanted side effect that led to an incorrect setting of the current active score when creating a new file. This didn't lead to a crash directly but this made MuseScore crash in case user tries to close an inactive tab.

This pull request replaces previously used `setCurrent()` and `setCurrentIndex()` calls used to prevent crashes in situations described in [275808](https://musescore.org/en/node/275808) to `setExcerpt()` call which was probably required by the context of the relevant chunk of code. This still fixes issue  [275808](https://musescore.org/en/node/275808) but avoids side effects which made it possible for a user to accidentally crash MuseScore editor.