### PR TITLE
fix slur entry mode to behave like it did in 2.x

### DIFF
--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -159,7 +159,7 @@ void SlurTieSegment::editDrag(EditData& ed)
                                     if (km != (Qt::ShiftModifier | Qt::ControlModifier)) {
                                           Chord* c = note->chord();
                                           ed.view->setDropTarget(note);
-                                          if (c != spanner->endChord())
+                                          if (c != spanner->endCR())
                                                 changeAnchor(ed, c);
                                           }
                                     }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3094,7 +3094,7 @@ void ScoreView::addSlur()
                               continue;
                         if (e->isNote())
                               e = toNote(e)->chord();
-                        if (!e->isChordRest())
+                        if (!e->isChord())
                               continue;
                         ChordRest* cr = toChordRest(e);
                         if (!cr1 || cr1->tick() > cr->tick())
@@ -3112,7 +3112,7 @@ void ScoreView::addSlur()
             for (Element* e : el) {
                   if (e->isNote())
                         e = toNote(e)->chord();
-                  if (!e->isChordRest())
+                  if (!e->isChord())
                         continue;
                   ChordRest* cr = toChordRest(e);
                   if (!cr1 || cr->isBefore(cr1))


### PR DESCRIPTION
see https://musescore.org/en/node/276559

Not sure whether the current behavoir is actually wanted though, e.g. to allow for 'open ended' slurs?