### PR TITLE
fix #268966: Insert measures dialog goes behind main window

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -323,6 +323,7 @@ InsertMeasuresDialog::InsertMeasuresDialog(QWidget* parent)
       setObjectName("InsertMeasuresDialog");
       setupUi(this);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
+      setModal(true);
       insmeasures->selectAll();
       }
 
@@ -2539,6 +2540,7 @@ MeasuresDialog::MeasuresDialog(QWidget* parent)
       {
       setupUi(this);
       setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
+      setModal(true);
       measures->selectAll();
       }
 


### PR DESCRIPTION
See https://musescore.org/en/node/268966.