### PR TITLE
fix #276526: play panel position not restored on toggle

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2511,9 +2511,14 @@ void MuseScore::showPlayPanel(bool visible)
             playPanel->setGain(synti->gain());
             playPanel->setScore(cs);
             addDockWidget(Qt::RightDockWidgetArea, playPanel);
+
+            // The play panel must be set visible before being set floating for positioning
+            // and window geometry reasons.
+            playPanel->setVisible(visible);
+            playPanel->setFloating(false);
             }
-      playPanel->setVisible(visible);
-      playPanel->setFloating(false);
+      else
+            playPanel->setVisible(visible);
       playId->setChecked(visible);
       }
 

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -33,7 +33,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 PlayPanel::PlayPanel(QWidget* parent)
-    : QDockWidget("PlayPanel", parent)
+    : QDockWidget("Play Panel", parent)
       {
       cachedTickPosition = -1;
       cachedTimePosition = -1;


### PR DESCRIPTION
References: https://musescore.org/en/node/276526

I think this fix is needed because the behaviour for other Widgets like the Play Panel is to stay in the same position after being toggled (e.g. palette, inspector). 