### PR TITLE
Add a simple check on score validity after reading a file

### DIFF
--- a/libmscore/check.cpp
+++ b/libmscore/check.cpp
@@ -20,6 +20,7 @@
 #include "staff.h"
 #include "keysig.h"
 #include "clef.h"
+#include "excerpt.h"
 #include "utils.h"
 
 namespace Ms {
@@ -248,6 +249,34 @@ bool Score::sanityCheck(const QString& name)
             MScore::lastError = error;
             }
       return result;
+      }
+
+//---------------------------------------------------------
+//   isInvalid
+///    Performes a simple check to check whether the score
+///    contains critical errors which will likely cause
+///    crashes or other serious errors on operating on it.
+//---------------------------------------------------------
+
+bool Score::isInvalid() const
+      {
+      if (!first()) // no measures?
+            return true;
+      for (MeasureBase* mb = first(); mb; mb = mb->next()) {
+            if (mb->isMeasure()) {
+                  // Check that it has at least one segment
+                  if (!toMeasure(mb)->first())
+                        return true;
+                  }
+            }
+      if (isMaster()) {
+            const MasterScore* ms = masterScore();
+            for (const Excerpt* ex : ms->excerpts()) {
+                  if (ex->partScore()->isInvalid())
+                        return true;
+                  }
+            }
+      return false;
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1129,6 +1129,7 @@ class Score : public QObject, public ScoreElement {
       //@ ??
 //      Q_INVOKABLE void cropPage(qreal margins);
       bool sanityCheck(const QString& name = QString());
+      bool isInvalid() const;
 
       bool checkKeys();
       bool checkClefs();

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2225,6 +2225,9 @@ Score::FileError readScore(MasterScore* score, QString name, bool ignoreVersionE
             score->setCreated(true); // force save as for imported files
             }
 
+      if (score->isInvalid())
+            return Score::FileError::FILE_BAD_FORMAT;
+
       {
       Score::isScoreLoaded() = true;
       score->rebuildMidiMapping();


### PR DESCRIPTION
This pull request adds a simple check on whether the score read from some file contains critical errors that are likely to cause crash when trying to do its layout or operate on it in some other ways. This should prevent some cases of crashes when reading corrupted files or files created in unsupported MuseScore versions:
- When startup center is trying to create thumbnails (version errors are ignored in that case);
- When trying to read a corrupted MuseScore file;
- When trying to import some not too well supported format.

Of course, this patch does not aim to prevent all crashes on reading files but this should reduce a number of such cases.