### PR TITLE
Rework updating excerpts and current view to fix the related issues

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2265,9 +2265,15 @@ void MuseScore::askResetOldScorePositions(Score* score)
 
 void MuseScore::setCurrentScoreView(int idx)
       {
+      tab1->blockSignals(ctab != tab1);
       setCurrentView(0, idx);
-      if (tab2)
+      tab1->blockSignals(false);
+
+      if (tab2) {
+            tab2->blockSignals(ctab != tab2);
             setCurrentView(1, idx);
+            tab2->blockSignals(false);
+            }
       }
 
 void MuseScore::setCurrentView(int tabIdx, int idx)
@@ -2289,6 +2295,7 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
       {
       cv = view;
       if (cv) {
+            ctab = (tab2 && tab2->view() == view) ? tab2 : tab1;
             if (timeline())
                   timeline()->setScoreView(cv);
             if (cv->score() && (cs != cv->score())) {
@@ -5418,21 +5425,15 @@ void MuseScore::endCmd()
                   }
             MasterScore* ms = cs->masterScore();
             if (ms->excerptsChanged()) {
-                  if (tab2) {
-//                      ScoreView* v = tab2->view();
-//                      if (v && v->score() == ms) {
-                              tab2->updateExcerpts();
-//                            }
-                        }
                   if (tab1) {
-                        ScoreView* v = tab1->view();
-                        if (v && v->score()->masterScore() == ms) {
-                              tab1->updateExcerpts();
-                              }
-                        else if (v == 0) {
-                              tab1->setExcerpt(0);
-                              tab1->updateExcerpts();
-                              }
+                        tab1->blockSignals(ctab != tab1);
+                        tab1->updateExcerpts();
+                        tab1->blockSignals(false);
+                        }
+                  if (tab2) {
+                        tab2->blockSignals(ctab != tab2);
+                        tab2->updateExcerpts();
+                        tab2->blockSignals(false);
                         }
                   ms->setExcerptsChanged(false);
                   }

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -221,6 +221,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       QSettings settings;
       ScoreView* cv                        { 0 };
+      ScoreTab* ctab                       { 0 };
       QMap<Score*, bool> scoreWasShown; // whether each score in scoreList has ever been shown
       ScoreState _sstate;
       UpdateChecker* ucheck;
@@ -756,6 +757,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       Inspector* inspector()           { return _inspector; }
       PluginCreator* pluginCreator()   { return _pluginCreator; }
       ScoreView* currentScoreView() const { return cv; }
+      ScoreTab* currentScoreTab() const { return ctab; }
       QToolButton* playButton()        { return _playButton;    }
       void showMessage(const QString& s, int timeout);
       void showHelp(QString);

--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -105,7 +105,7 @@ ScoreView* ScoreTab::view(int n) const
 
 QSplitter* ScoreTab::viewSplitter(int n) const
       {
-      TabScoreView* tsv = static_cast<TabScoreView*>(tab->tabData(n).value<void*>());
+      const TabScoreView* tsv = tabScoreView(n);
       if (tsv == 0) {
             // qDebug("ScoreTab::viewSplitter %d is zero", n);
             return 0;
@@ -183,7 +183,7 @@ void ScoreTab::setCurrent(int n)
             emit currentScoreViewChanged(0);
             return;
             }
-      TabScoreView* tsv = static_cast<TabScoreView*>(tab->tabData(n).value<void*>());
+      TabScoreView* tsv = tabScoreView(n);
       QSplitter* vs = viewSplitter(n);
 
       ScoreView* v;
@@ -314,7 +314,7 @@ void ScoreTab::setExcerpt(int n)
       if (n == -1)
             return;
       int idx           = tab->currentIndex();
-      TabScoreView* tsv = static_cast<TabScoreView*>(tab->tabData(idx).value<void*>());
+      TabScoreView* tsv = tabScoreView(idx);
       if (tsv == 0)
             return;
       tsv->part     = n;
@@ -422,7 +422,7 @@ bool ScoreTab::setCurrentScore(Score* s)
 
 void ScoreTab::removeTab(int idx, bool noCurrentChangedSignal)
       {
-      TabScoreView* tsv = static_cast<TabScoreView*>(tab->tabData(idx).value<void*>());
+      TabScoreView* tsv = tabScoreView(idx);
       Score* score = tsv->score;
 
       for (int i = 0; i < stack->count(); ++i) {

--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -263,11 +263,11 @@ void ScoreTab::updateExcerpts()
       int idx = currentIndex();
       if (idx == -1)
             return;
-      ScoreView* v = view(idx);
-      if (!v)
+      TabScoreView* tsv = tabScoreView(idx);
+      MasterScore* score = tsv->score;
+      if (!score->excerptsChanged())
             return;
 
-      MasterScore* score = v->score()->masterScore();
       clearTab2();
       //delete all scoreviews for parts, especially for the deleted ones
       int n = stack->count() - 1;
@@ -292,11 +292,8 @@ void ScoreTab::updateExcerpts()
             }
       else {
             tab2->setVisible(false);
-            setExcerpt(0);
             }
-      blockSignals(true);
       setExcerpt(0);
-      blockSignals(false);
 
       getAction("file-part-export")->setEnabled(excerpts.size() > 0);
       }

--- a/mscore/scoretab.h
+++ b/mscore/scoretab.h
@@ -32,9 +32,9 @@ enum class MagIdx : char;
 //---------------------------------------------------------
 
 struct TabScoreView {
-      Score* score;
+      MasterScore* score;
       int part;
-      TabScoreView(Score* s) {
+      TabScoreView(MasterScore* s) {
             score   = s;
             part    = 0;
             }

--- a/mscore/scoretab.h
+++ b/mscore/scoretab.h
@@ -52,6 +52,8 @@ class ScoreTab : public QWidget {
       QStackedLayout* stack;
       MuseScore* mainWindow;
       void clearTab2();
+      TabScoreView* tabScoreView(int idx) { return static_cast<TabScoreView*>(tab->tabData(idx).value<void*>()); }
+      const TabScoreView* tabScoreView(int idx) const { return const_cast<ScoreTab*>(this)->tabScoreView(idx); }
 
    signals:
       void currentScoreViewChanged(ScoreView*);


### PR DESCRIPTION
This pull request is intended to resolve the problems handled by #3991 and some other problems related to tracking the current score view including [some crashes](https://musescore.org/en/node/276628). These problems were related to updating excerpts if its number has changed (on score loading or as a result of adding/removing parts). In this pull request excerpts updating process was somewhat reworked regarding maintaining current score view being set and tracked correctly.

The main idea of the proposed changes is in two points:
- `ScoreTab` now decides whether it needs to update its score's excerpts so that there is no need to handle this on the main MuseScore window's level (`MuseScore` class). Previously such a handling should have been done in several places and it was done in somewhat inconsistent way.
- `MuseScore` class representing the main window now tracks the currently active `ScoreTab` (that is, the currently active half of the window in case of split view) and is responsible for the decision on setting or not setting a focus on a specific score view (that is, not blocking or blocking signals from `ScoreTab`) when there might be a need to update excerpts for some score in both `ScoreTab`s.

Such changes should make current view setting behavior more consistent and help to avoid various bugs including those listed in the commit's message.