### PR TITLE
fix #276691: Jump symbols (segno, coda) wrongly positioned

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -501,7 +501,6 @@ void readTextStyle206(MStyle* style, XmlReader& e)
             { "Staff",                   Tid::STAFF },
             { "Chord Symbol",            Tid::HARMONY_A },
             { "Rehearsal Mark",          Tid::REHEARSAL_MARK },
-            { "Repeat Text",             Tid::REPEAT_LEFT },
             { "Repeat Text Left",        Tid::REPEAT_LEFT },
             { "Repeat Text Right",       Tid::REPEAT_RIGHT },
             { "Frame",                   Tid::FRAME },


### PR DESCRIPTION
See https://musescore.org/en/node/276691.