### PR TITLE
fix #276382: Crash when adding a glissando on a tablature to a dotted note

### DIFF
--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -322,7 +322,7 @@ void Glissando::layout()
 
       // initial note dots / ledger line / notehead
       offs1 *= -1.0;          // discount changes already applied
-      int dots = cr1->dots();
+      int dots = anchor1->dots().size();
       LedgerLine * ledLin = cr1->ledgerLines();
       // if dots, start at right of last dot
       // if no dots, from right of ledger line, if any; from right of notehead, if no ledger line


### PR DESCRIPTION
See https://musescore.org/en/node/276832.

`cr1->dots()` is nonzero because the chord does have dots, but `anchor1`, being in the TAB staff, does not have any dots. This did not cause a problem in 2.3.2, because for any Note* n, `n->dots().size` is always equal to 4, even though most of the time all of the dots are NULL. But in 3.0, `n->dots().size()` is actually equal to the number of dots that belong to Note* n. Therefore, in 3.0, it is not safe to access the `_dots` vector of `anchor1` with an index of `cr1->dots() - 1`, because in a TAB staff, `anchor1->dots().size()` will be equal to 0.