### PR TITLE
fix #276868: Adding barline in mid-measure fails

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -445,6 +445,7 @@ Element* ChordRest::drop(EditData& data)
                               l->setScore(score);
                               l->setParent(seg);
                               score->undoAddElement(l);
+                              l->layout();
                               }
                         }
                   delete e;


### PR DESCRIPTION
See https://musescore.org/en/node/276868.

The problem, of course, is that `BarLine::layout()` never gets called for the new BarLine, even during a full re-layout of the score, since it is not an EndBarLine. Thus the width of the BarLine's bbox remains at its default value of 0. For BarLines that are EndBarLines, `BarLine::layout()` is called from `Measure::createEndBarLines()` during `Score::collectSystem()`. If the barline is dragged from the palette, `BarLine::layout()` is called from `ScoreView::dragEnterEvent()` when the BarLine is dragged into the ScoreView.