### PR TITLE
fix #276670: Crash on mouse press on tablature in Re-Pitch input mode

### DIFF
--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -290,7 +290,9 @@ void Score::putNote(const QPointF& pos, bool replace, bool insert)
             return;
             }
       Score* score = p.segment->score();
-      if (score->inputState().usingNoteEntryMethod(NoteEntryMethod::REPITCH))
+      // it is not safe to call Score::repitchNote() if p is on a TAB staff
+      bool isTablature = staff(p.staffIdx)->isTabStaff(p.segment->tick());
+      if (score->inputState().usingNoteEntryMethod(NoteEntryMethod::REPITCH) && !isTablature)
             score->repitchNote(p, replace);
       else {
             if (insert)


### PR DESCRIPTION
See https://musescore.org/en/node/276670.

`Score::repitchNote()` was not written to work on TAB staves, and if the active staff is a TAB staff, then  `score->inputState().usingNoteEntryMethod(NoteEntryMethod::REPITCH)` is never `true`, even when "Re-Pitch" mode is selected. But if the active staff is a standard staff, the user may still attempt to place a note on a TAB staff while in "Re-Pitch" mode. With the current code, this results in `Score::repitchNote()` being called with a `Position* p` that is on a TAB staff. This must not be allowed to happen.