### PR TITLE
fix #75991: Split a measure in direct relation (time duration) with some tuplets owned to another staff causes crash

### DIFF
--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -146,7 +146,7 @@ void TrackList::append(Element* e)
                   Element* element = 0;
                   if (e->isTuplet()) {
                         Tuplet* src = toTuplet(e);
-                        if (src->generated() && back()->isTuplet()) {
+                        if (src->generated() && !empty() && back()->isTuplet()) {
                               Tuplet* b = toTuplet(back());
                               combineTuplet(b, src);
                               }


### PR DESCRIPTION
See https://musescore.org/en/node/75991.

Need to verify that the list is not empty before accessing back().