### PR TITLE
fix #276869: Adding barline with ctrl+doubleclick does not create a split.

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1787,6 +1787,18 @@ void EditData::init()
       }
 
 //---------------------------------------------------------
+//   control
+//---------------------------------------------------------
+
+bool EditData::control(bool textEditing) const
+      {
+      if (textEditing)
+            return modifiers & CONTROL_MODIFIER;
+      else
+            return modifiers & Qt::ControlModifier;
+      }
+
+//---------------------------------------------------------
 //   clearData
 //---------------------------------------------------------
 

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -131,7 +131,7 @@ class EditData {
 
       ElementEditData* getData(const Element*) const;
       void addData(ElementEditData*);
-      bool control() const  { return modifiers & CONTROL_MODIFIER; }
+      bool control(bool textEditing = false) const;
       bool shift() const    { return modifiers & Qt::ShiftModifier; }
       bool isStartEndGrip() { return curGrip == Grip::START || curGrip == Grip::END; }
       };

--- a/mscore/editlyrics.cpp
+++ b/mscore/editlyrics.cpp
@@ -30,9 +30,10 @@ bool ScoreView::editKeyLyrics()
       {
       Q_ASSERT(editData.element->isLyrics());
 
+      const bool textEditing = true;
       switch (editData.key) {
             case Qt::Key_Space:
-                  if (!editData.control()) {
+                  if (!editData.control(textEditing)) {
                         if (editData.s == "_")
                               lyricsUnderscore();
                         else // TODO: shift+tab events are filtered by qt
@@ -44,7 +45,7 @@ bool ScoreView::editKeyLyrics()
 
             case Qt::Key_Left:
             case Qt::Key_Right:
-                  if (!editData.control() && editData.element->edit(editData))
+                  if (!editData.control(textEditing) && editData.element->edit(editData))
                         mscore->textTools()->updateTools(editData);
                   else {
                         bool kl = editData.key == Qt::Key_Left;
@@ -62,7 +63,7 @@ bool ScoreView::editKeyLyrics()
                   break;
 
             case Qt::Key_Minus:
-                  if (editData.control()) {
+                  if (editData.control(textEditing)) {
                         // change into normal minus
                         editData.modifiers &= ~CONTROL_MODIFIER;
                         return false;
@@ -72,7 +73,7 @@ bool ScoreView::editKeyLyrics()
                   break;
 
             case Qt::Key_Underscore:
-                  if (editData.control()) {
+                  if (editData.control(textEditing)) {
                         // change into normal underscore
                         editData.modifiers = 0; // &= ~CONTROL_MODIFIER;
                         return false;

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -400,13 +400,13 @@ void Palette::mouseMoveEvent(QMouseEvent* ev)
 //   applyDrop
 //---------------------------------------------------------
 
-static void applyDrop(Score* score, ScoreView* viewer, Element* target, Element* e, QPointF pt = QPointF())
+static void applyDrop(Score* score, ScoreView* viewer, Element* target, Element* e, Qt::KeyboardModifiers modifiers, QPointF pt = QPointF())
       {
       EditData dropData = viewer->getEditData();
 //      EditData dropData;
       dropData.pos        = pt.isNull() ? target->pagePos() : pt;
       dropData.dragOffset = QPointF();
-      dropData.modifiers  = 0;
+      dropData.modifiers  = modifiers;
       dropData.element    = e;
 
       if (target->acceptDrop(dropData)) {
@@ -434,7 +434,7 @@ static void applyDrop(Score* score, ScoreView* viewer, Element* target, Element*
 //   applyPaletteElement
 //---------------------------------------------------------
 
-void Palette::applyPaletteElement(PaletteCell* cell)
+void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modifiers)
       {
       Score* score = mscore->currentScore();
       if (score == 0)
@@ -480,7 +480,7 @@ void Palette::applyPaletteElement(PaletteCell* cell)
                               e = toChord(e)->upNote();
                         // use voice of element being added to (otherwise we can might corrupt the measure)
                         element->setTrack(e->voice());
-                        applyDrop(score, viewer, e, element);
+                        applyDrop(score, viewer, e, element, modifiers);
                         // continue in same track
                         score->inputState().setTrack(e->track());
                         }
@@ -514,7 +514,7 @@ void Palette::applyPaletteElement(PaletteCell* cell)
                   }
             else {
                   for (Element* e : sel.elements())
-                        applyDrop(score, viewer, e, element);
+                        applyDrop(score, viewer, e, element, modifiers);
                   }
             }
       else if (sel.isRange()) {
@@ -538,7 +538,7 @@ void Palette::applyPaletteElement(PaletteCell* cell)
                         QRectF r = m->staffabbox(sel.staffStart());
                         QPointF pt(r.x() + r.width() * .5, r.y() + r.height() * .5);
                         pt += m->system()->page()->pos();
-                        applyDrop(score, viewer, m, element, pt);
+                        applyDrop(score, viewer, m, element, modifiers, pt);
                         if (m == last)
                               break;
                         }
@@ -618,26 +618,26 @@ void Palette::applyPaletteElement(PaletteCell* cell)
                                     }
                               if (oelement) {
                                     if (e2) {
-                                          applyDrop(score, viewer, e2, oelement);
+                                          applyDrop(score, viewer, e2, oelement, modifiers);
                                           }
                                     else {
                                           QRectF r = m2->staffabbox(i);
                                           QPointF pt(r.x() + r.width() * .5, r.y() + r.height() * .5);
                                           pt += m2->system()->page()->pos();
-                                          applyDrop(score, viewer, m2, oelement, pt);
+                                          applyDrop(score, viewer, m2, oelement, modifiers, pt);
                                           }
                                     delete oelement;
                                     }
                               }
                         // apply new clef/keysig/timesig
                         if (e1) {
-                              applyDrop(score, viewer, e1, element);
+                              applyDrop(score, viewer, e1, element, modifiers);
                               }
                         else {
                               QRectF r = m1->staffabbox(i);
                               QPointF pt(r.x() + r.width() * .5, r.y() + r.height() * .5);
                               pt += m1->system()->page()->pos();
-                              applyDrop(score, viewer, m1, element, pt);
+                              applyDrop(score, viewer, m1, element, modifiers, pt);
                               }
                         }
                   }
@@ -667,12 +667,12 @@ void Palette::applyPaletteElement(PaletteCell* cell)
                               if (e->isChord()) {
                                     Chord* chord = toChord(e);
                                     for (Note* n : chord->notes())
-                                          applyDrop(score, viewer, n, element);
+                                          applyDrop(score, viewer, n, element, modifiers);
                                     }
                               else {
                                     // do not apply articulation to barline in a range selection
                                     if (!e->isBarLine() || !element->isArticulation())
-                                          applyDrop(score, viewer, e, element);
+                                          applyDrop(score, viewer, e, element, modifiers);
                                     }
                               }
                         }
@@ -745,7 +745,7 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
       if (sel.isNone())
             return;
 
-      applyPaletteElement(cellAt(i));
+      applyPaletteElement(cellAt(i), ev->modifiers());
       }
 
 //---------------------------------------------------------

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -137,7 +137,7 @@ class Palette : public QWidget {
       virtual void leaveEvent(QEvent*) override;
       virtual bool event(QEvent*) override;
       virtual void resizeEvent(QResizeEvent*) override;
-      void applyPaletteElement(PaletteCell* cell);
+      void applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modifiers = 0);
 
       virtual void dragEnterEvent(QDragEnterEvent*) override;
       virtual void dragMoveEvent(QDragMoveEvent*) override;


### PR DESCRIPTION
See https://musescore.org/en/node/276869.

Originally, the keyboard modifiers that were available to Palette::mouseDoubleClickEvent() were not passed down through to the element's drop() method, which meant that it could not tell that Ctrl was pressed. This makes sure that the keyboard modifiers are passed down through to the drop() method intact. This means that local time signatures may now be added with Ctrl + double click also.

This corrects another error as well. In general, the Command key is the Mac counterpart to the 
Ctrl key on other systems. The exception is when editing text. In that case, the Option key is used instead. This leads to a little bit of confusion over how to tell if the right modifier is pressed in the right scenario, which led to incorrect results. I have attempted to clear up this confusion with a comment in the code.