### PR TITLE
fix #109661, fix #275659: Regression-Pagesettings not work for parts - Avoid undo entries

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2247,6 +2247,32 @@ void Score::removePart(Part* part)
       }
 
 //---------------------------------------------------------
+//   promote
+//---------------------------------------------------------
+
+MasterScore* Score::promote()
+      {
+      QBuffer buffer;
+      buffer.open(QIODevice::WriteOnly);
+      XmlWriter xml(this, &buffer);
+      xml.header();
+
+      xml.stag("museScore version=\"" MSC_VERSION "\"");
+      write(xml, false);
+      xml.etag();
+
+      buffer.close();
+
+      XmlReader r(buffer.buffer());
+      MasterScore* score = new MasterScore(style());
+      score->read1(r, true);
+
+      score->addLayoutFlags(LayoutFlag::FIX_PITCH_VELO);
+      score->doLayout();
+      return score;
+      }
+
+//---------------------------------------------------------
 //   insertStaff
 //---------------------------------------------------------
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -543,7 +543,8 @@ class Score : public QObject, public ScoreElement {
       Score(MasterScore*);
       Score(MasterScore*, const MStyle&);
       virtual ~Score();
-
+      MasterScore* promote();
+	  
       virtual bool isMaster() const  { return false;        }
 
       virtual inline QList<Excerpt*>& excerpts();

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2460,7 +2460,7 @@ void MuseScore::showPageSettings()
       {
       if (pageSettings == 0)
             pageSettings = new PageSettings();
-      pageSettings->setScore(cs->masterScore());
+      pageSettings->setScore(cs);
       pageSettings->show();
       pageSettings->raise();
       }

--- a/mscore/pagesettings.h
+++ b/mscore/pagesettings.h
@@ -31,13 +31,15 @@ class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
 
       Navigator* preview;
       bool mmUnit;
-      MasterScore* cs;
+      bool changeFlag;
+      Score* cs;
 
       virtual void hideEvent(QHideEvent*);
       void updateValues();
-      void updatePreview(int);
+      void updatePreview(bool);
       void blockSignals(bool);
       void applyToScore(Score*);
+      void setButtonsEnabled(bool, bool);
       void setMarginsMax(double);
 
    private slots:
@@ -71,7 +73,7 @@ class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
    public:
       PageSettings(QWidget* parent = 0);
       ~PageSettings();
-      void setScore(MasterScore*);
+      void setScore(Score*);
       };
 
 


### PR DESCRIPTION
#109661 Replaces PR #3986  
Suggested solution is to add a promote() method to Score class that will create a new MasterScore object and initialise it with the score information form the Score object.
This is done by writing the Score object to file and reading it back into a new MasterScore object using the existing read-methods in the MasterScore class. I find that this is the simplest way to solve the issue, and should not cause problems as the Score object can not have information that cannot be held in a MasterScore. 
The alternative is to add a clone() method to the Score class, which will require that all read methods are copied form MasterScore and adapted to work with Score objects instead, 
#275659
Have added a ChangeFlag that is set when the user makes changes. It is used to set the Apply buttons enabled only when there are chages to be applied, therby avoiding that the user can press Apoply multiple times and create redundant entires in the undo-stack. 
Also som cleanup of code.