### PR TITLE
Fix not accurate conversion of ChordRest in Beam::layout2

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1553,9 +1553,10 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                   //
                   bool relayoutGrace = false;
                   for (size_t i = 0; i < n; ++i) {
-                        Chord* c = toChord(crl.at(i));
-                        if (c->isRest())
+                        ChordRest* cr = crl.at(i);
+                        if (!cr->isChord())
                               continue;
+                        Chord* c = toChord(cr);
                         QPointF p = c->upNote()->pagePos();
                         qreal y1  = beamY + (p.x() - px1) * slope;
                         bool nup  = y1 < p.y();


### PR DESCRIPTION
This pull request fixed assertion failure on opening the score discussed in [this issue](https://musescore.org/en/node/110181). The score opens well on release builds and fails for debug builds of MuseScore as the code in `Beam::layout2` contains a not very accurate conversion of `ChordRest` to a `Chord` which is done before actually checking the type. The proposed commit just makes the relevant code chunk a bit more clear thus fixing an assertion failure for debug builds.