### PR TITLE
fix #233436: Do not search grace notes in different staves when making a tie

### DIFF
--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -853,6 +853,11 @@ Note* searchTieNote(Note* note)
                   if (e == 0 || !e->isChord())
                         continue;
                   Chord* c = toChord(e);
+                  const int staffIdx = c->staffIdx() + c->staffMove();
+                  if (staffIdx != chord->staffIdx() + chord->staffMove()) {
+                        // this check is needed as we are iterating over all staves to capture cross-staff chords
+                        continue;
+                        }
                   // if there are grace notes before, try to tie to first one
                   QVector<Chord*> gnb = c->graceNotesBefore();
                   if (!gnb.empty()) {
@@ -861,9 +866,6 @@ Note* searchTieNote(Note* note)
                         if (gn2)
                               return gn2;
                         }
-                  int staffIdx = c->staffIdx() + c->staffMove();
-                  if (staffIdx != chord->staffIdx() + chord->staffMove())  // cannot happen?
-                        continue;
                   for (Note* n : c->notes()) {
                         if (n->pitch() == note->pitch()) {
                               if (note2 == 0 || c->track() == chord->track())


### PR DESCRIPTION
The proposed patch is intended to fix [this issue](https://musescore.org/en/node/233436). The problematic place was `searchTieNote` routine. It searched for a note to tie with in all tracks in order to capture cross-staff chords and checked every chord on belonging to the current staff considering the cross-staff notation. However this check was done after a search for a tie note among the chord's grace notes had been already completed which effectively removed this check for searching among grace notes. It rarely can lead to problems — it is not very common case to have the same pitch for the nearest notes in different staves while the latter note is a grace note — but it makes a real problem for linked staves for which all the content is duplicated where it can even lead to crashes like in the case described in the issue.

Since cross-staff ties with grace notes is probably not what we want and this behavior leads to crashes in MuseScore I suggest to remove it and make tie notes search consistent for grace notes and usual notes. This is what have been done in the proposed patch.