### PR TITLE
fix #276974: Drum palette: Entering via mouse fails

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -325,7 +325,8 @@ void Palette::mousePressEvent(QMouseEvent* ev)
       // Take out of edit mode to prevent crashes when adding
       // elements from palette
       ScoreView* cv = mscore->currentScoreView();
-      cv->changeState(ViewState::NORMAL);
+      if (cv->editMode())
+            cv->changeState(ViewState::NORMAL);
 
       if (dragIdx == -1)
             return;


### PR DESCRIPTION
See https://musescore.org/en/node/276974.