### PR TITLE
fix #276441: Multiple articulations on a single note possible

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2650,17 +2650,8 @@ bool Chord::setProperty(Pid propertyId, const QVariant& v)
 
 Articulation* Chord::hasArticulation(const Articulation* aa)
       {
-      return hasArticulation(aa->symId());
-      }
-
-//---------------------------------------------------------
-//   hasArticulation
-//---------------------------------------------------------
-
-Articulation* Chord::hasArticulation(SymId id)
-      {
       for (Articulation* a : _articulations) {
-            if (id == a->symId())
+            if (a->articulationName() == aa->articulationName())
                   return a;
             }
       return 0;

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -202,7 +202,6 @@ class Chord final : public ChordRest {
       QVector<Articulation*>& articulations()             { return _articulations; }
       const QVector<Articulation*>& articulations() const { return _articulations; }
       Articulation* hasArticulation(const Articulation*);
-      Articulation* hasArticulation(SymId id);
       bool hasSingleArticulation() const                  { return _articulations.size() == 1; }
 
       virtual void crossMeasureSetup(bool on);


### PR DESCRIPTION
See https://musescore.org/en/node/276441.

There are different SymIds for whether the Articulation is above the Chord or below the Chord. `Articulation::articulationName()` removes this distinction.