### PR TITLE
fix #277038: concert pitch doesn't reset key sig to C at start of system when toggled

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -120,7 +120,7 @@ void CmdState::setUpdateMode(UpdateMode m)
 //---------------------------------------------------------
 //   startCmd
 ///   Start a GUI command by clearing the redraw area
-///   and starting a user-visble undo.
+///   and starting a user-visible undo.
 //---------------------------------------------------------
 
 void Score::startCmd()

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3551,9 +3551,16 @@ void Measure::addSystemHeader(bool isFirstSystem)
                               Key key = score()->staff(i)->key(tick());
                               if ((e && !e->generated()) || (key != keyIdx.key())) {
                                     disable = false;
-                                    break;
+                                    }
+                              else if (e && e->generated() && key == keyIdx.key() && keyIdx.key() == Key::C){
+                                    // If a key sig segment is disabled, it may be re-enabled if there is
+                                    // a transposing instrument using a different key sig.
+                                    // To prevent this from making the wrong key sig display, remove any key
+                                    // sigs on staves where the key in this measure is C.
+                                    score()->undo(new RemoveElement(e));
                                     }
                               }
+
                         if (disable)
                               kSegment->setEnabled(false);
                         else {

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -509,9 +509,7 @@ void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickE
                               segmentInterval.flip();
                         }
                   KeySig* ks = toKeySig(s->element(staffIdx * VOICES));
-                  if (!ks)
-                        continue;
-                  if (ks->generated())
+                  if (!ks || (ks->generated() && ks->segment()->rtick() > 0))
                         continue;
                   if (s->tick() == 0)
                         createKey = false;


### PR DESCRIPTION
Fixes: https://musescore.org/en/node/277038 and another undocumented (?) issue with key signatures at the start of systems not being updated in pages with transposing instruments in different keys, when the key signature for one of the instruments was changed to C.