### PR TITLE
fix #277145: Delete entire score in Continuous View causes crash

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3704,7 +3704,7 @@ void Score::doLayoutRange(int stick, int etick)
       {
       if (stick == -1 && etick == -1)
             abort();
-      if (!last()) {
+      if (!last() || (lineMode() && !firstMeasure())) {
             qDeleteAll(_systems);
             _systems.clear();
             qDeleteAll(pages());


### PR DESCRIPTION
The purpose of this _if_ is to determine if there is anything to be displayed, and if not, then exit the function early after clearing the systems and pages. `Score::last()` returns a MeasureBase, which could be a Box or a Measure. If we are in Continuous View, we should check if there are any actual Measures, even if `last()` is not NULL, since Boxes are not displayed in Continuous View.