### PR TITLE
fix #276539: correct switching from drag-edit mode to edit mode

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -881,7 +881,7 @@ void ScoreView::changeState(ViewState s)
                         startEdit();
                   break;
             case ViewState::EDIT:
-                  if (state != ViewState::DRAG_EDIT)
+                  if ( !((mscoreState() & STATE_ALLTEXTUAL_EDIT) && state == ViewState::DRAG_EDIT) )
                         startEdit();
                   break;
             case ViewState::LASSO:


### PR DESCRIPTION
This patch fixes [this issue](https://musescore.org/en/node/276539) or, at least, the crash described in it. The proposed solution is to correct switching from `DRAG_EDIT` score view mode to `EDIT` mode. Previously `startEdit()` call was disabled for such a switch, and it was done for text editing mode to behave correctly when user selects some chunk of text by dragging a mouse. [Here](https://github.com/musescore/MuseScore/commit/90d3a6ff2f95a09623aa5fd8300394e74c2151a5) is the commit that introduced this `startEdit` disabling.

However such a transition between the states occurs also for slurs and ties in some cases when changing an anchor: see [this](https://github.com/dmitrio95/MuseScore/blob/d7eecfb35d2442a4bd54a56bdf1c5b3466ec731d/libmscore/slur.cpp#L183) for example. In that case calling `startEdit()` is necessary as it correctly initializes data used during the latter processing. The proposed patch makes `startEdit()` call disabled for `DRAG_EDIT`→`EDIT` transitions only in text edit mode which was probably intended initially when writing this call disabling condition.