### PR TITLE
fix #274121: Crash on slur drag-and-drop from panel

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1677,8 +1677,8 @@ Element* Note::drop(EditData& data)
                   return 0;
 
             case ElementType::SLUR:
-                  delete e;
                   data.view->cmdAddSlur(chord(), nullptr);
+                  delete e;
                   return 0;
 
             case ElementType::HAIRPIN:


### PR DESCRIPTION
This pull request aims to fix [this issue](https://musescore.org/en/node/274121). The issue description itself contains some notes on reasons of the described crash. As the current way of management of deletion of dropped elements is also the same for other types of elements (for example, [hairpins](https://github.com/dmitrio95/MuseScore/blob/e634e724678304d17d0004e9b682da1a355b21b9/libmscore/note.cpp#L1684)) and is not going to change in the nearest future the fastest way to fix the issue is to delete the dropped slur after `cmdAddSlur` similarly to what has already been done for hairpins.