### PR TITLE
Refactor layout: extract getNextPage, refactor page collecting loop

### DIFF
--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -51,7 +51,7 @@ struct LayoutContext {
 
       void layout();
       int adjustMeasureNo(MeasureBase*);
-      void getEmptyPage();
+      void getNextPage();
       void collectPage();
       };
 


### PR DESCRIPTION
While reading the layout engine code I tried also to refactor some parts of the code to understand it better. This pull request contains a relatively small part of that refactoring. The proposed patch extracts the code for obtaining and preparing the next page for layout procedure to the separate function, `LayoutContext::getNextPage()` and thus allows to avoid a code duplication (the extracted procedure was used twice in the code with minor edits). A page collecting loop was slightly rewritten which made it possible to avoid even double usage of the mentioned procedure and to make the loop and its condition hopefully more clear. However I added a `FIXME` note as the reason why the condition is written exactly like that is not clear for me. Still I changed nothing to that condition compared to what was in the code before my changes so the layout engine behaves the same way after the proposed changes.

`LayoutContext::getEmptyPage` was also removed from the code as it was not used while
doing a job largely (but not fully) similar to that which is done by `getNextPage()` after my changes.

I hope the proposed changes are not too large to be reviewed. Feel free to ask for changes if something can be done better way.