### PR TITLE
fix #276537: Hidden Staves appear when Hide Empty Staves enabled

### DIFF
--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -254,7 +254,7 @@ static void countElements(void* data, Element* /*e*/)
 void Page::doRebuildBspTree()
       {
       int n = 0;
-      scanElements(&n, countElements, true);
+      scanElements(&n, countElements, false);
 
       QRectF r;
       if (score()->layoutMode() == LayoutMode::LINE) {
@@ -273,7 +273,7 @@ void Page::doRebuildBspTree()
             r = abbox();
 
       bspTree.initialize(r, n);
-      scanElements(&bspTree, &bspInsert, true);
+      scanElements(&bspTree, &bspInsert, false);
       bspTreeValid = true;
       }
 #endif


### PR DESCRIPTION
See https://musescore.org/en/node/276537.

This reverts the change to libmscore/page.cpp from #3966.