### PR TITLE
fix #277030: Crash on changing a property of bracket in a part in Inspector

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3755,8 +3755,6 @@ void Score::doLayoutRange(int stick, int etick)
 //      qDebug("start <%s> tick %d, system %p", m->name(), m->tick(), m->system());
       lc.score        = m->score();
 
-      std::vector<std::pair<int, BracketItem*>> selectedBrackets;
-
       if (!layoutAll && m->system()) {
             System* system  = m->system();
             int systemIndex = _systems.indexOf(system);
@@ -3796,8 +3794,6 @@ void Score::doLayoutRange(int stick, int etick)
             for (System* s : _systems) {
                   for (Bracket* b : s->brackets()) {
                         if (b->selected()) {
-                              auto bracket = make_pair(_systems.indexOf(s), b->bracketItem());
-                              selectedBrackets.push_back(bracket);
                               _selection.elements().removeOne(b);
                               _selection.updateState();
                               setSelectionChanged(true);
@@ -3872,20 +3868,6 @@ void Score::doLayoutRange(int stick, int etick)
 
       for (MuseScoreView* v : viewer)
             v->layoutChanged();
-
-      for (auto bracket : selectedBrackets) {
-            int systemIndex = bracket.first;
-            BracketItem* bi = bracket.second;
-            if (systemIndex < _systems.size()) {
-                  System* system = _systems[systemIndex];
-                  for (Bracket* b : system->brackets()) {
-                        if (b->bracketItem() == bi) {
-                              selectAdd(b);
-                              break;
-                              }
-                        }
-                  }
-            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/277030.

This reverts changes that I had made to Score::doLayoutRange(). The intention was to remember which brackets were selected, so that they could be selected again after being recreated. Unfortunately, the code is not working as intended, and it is what leads to the crash.