### PR TITLE
fix #276397: add a missing check for staff presence in KeySig::layout

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -107,7 +107,7 @@ void KeySig::layout()
       // determine current clef for this staff
       ClefType clef = ClefType::G;
       if (staff())
-            clef = staff()->clef(segment()->tick());
+            clef = staff()->clef(tick());
 
       int accidentals = 0, naturals = 0;
       int t1 = int(_sig.key());
@@ -141,7 +141,7 @@ void KeySig::layout()
 
       // Don't repeat naturals if shown in courtesy
       if (measure() && measure()->system() && measure() == measure()->system()->firstMeasure()
-          && prevMeasure && prevMeasure->findSegment(SegmentType::KeySigAnnounce, segment()->tick())
+          && prevMeasure && prevMeasure->findSegment(SegmentType::KeySigAnnounce, tick())
           && !segment()->isKeySigAnnounceType())
             naturalsOn = false;
       if (track() == -1)
@@ -150,7 +150,8 @@ void KeySig::layout()
       int coffset = 0;
       Key t2      = Key::C;
       if (naturalsOn) {
-            t2 = staff()->key(segment()->tick() - 1);
+            if (staff())
+                  t2 = staff()->key(tick() - 1);
             if (t2 == Key::C)
                   naturalsOn = false;
             else {


### PR DESCRIPTION
This pull request is to fix [this issue](https://musescore.org/en/node/276397). It simply adds a check for a staff being non-null in `KeySig::layout` in one specific place. Such checks were already present in `KeySig::layout` ([1](https://github.com/dmitrio95/MuseScore/blob/959a74555e62c455d6fa978c825576022a3de0c0/libmscore/keysig.cpp#L104), [2](https://github.com/dmitrio95/MuseScore/blob/959a74555e62c455d6fa978c825576022a3de0c0/libmscore/keysig.cpp#L109)) so it was probably never assumed that a key signature should always have a staff. The proposed patch adds a missing check for staff being non-null thus making the code of `KeySig::layout` slightly more consistent and fixing the referenced issue.