### PR TITLE
fix #277116: do not move non-movable elements while dragging them

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1853,6 +1853,8 @@ void Element::drawEditMode(QPainter* p, EditData& ed)
 
 void Element::startDrag(EditData& ed)
       {
+      if (!isMovable())
+            return;
       ElementEditData* eed = new ElementEditData();
       eed->e = this;
       eed->pushProperty(Pid::USER_OFF);
@@ -1866,6 +1868,9 @@ void Element::startDrag(EditData& ed)
 
 QRectF Element::drag(EditData& ed)
       {
+      if (!isMovable())
+            return QRectF();
+
       QRectF r(canvasBoundingRect());
 
       qreal x = ed.delta.x();
@@ -1931,6 +1936,8 @@ QRectF Element::drag(EditData& ed)
 
 void Element::endDrag(EditData& ed)
       {
+      if (!isMovable())
+            return;
       ElementEditData* eed = ed.getData(this);
       for (PropertyData pd : eed->propertyData)
             score()->undoPropertyChanged(this, pd.id, pd.data);


### PR DESCRIPTION
This patch fixes an issue with stems detaching from notes on dragging described [here](https://musescore.org/en/node/277116).

I added a brief description of the problem to the commit message. I'll add it here as it may be useful:
```
If user tries to drag non-movable element it will not be dragged
due to the check in ScoreView::mouseMoveEvent. However a non-movable
element can be selected with other movable elements, and user can
drag such a selection. This patch prevents improper moving
non-movable elements in such cases.
```

As Stems are non-movable elements and their transformations on note moving are handled differently this patch fixes also the described problem for stems.