### PR TITLE
fix #277116: do not reset selection after dragging notes

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1573,7 +1573,6 @@ void Note::endDrag(EditData& ed)
                   score()->undoPropertyChanged(nn, pd.id, pd.data);
                   }
             }
-      score()->select(this, SelectType::SINGLE, 0);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This patch intends to fix the crash described in [this issue](https://musescore.org/en/node/277116). The issue contains two sub-issues one of which is this crash itself and the other is the initially described problem with stems. I added a `fix #277116` prefix here as well as in the [other related pull request](https://github.com/musescore/MuseScore/pull/4037) but perhaps a separate issue should be created for the crash.

The problem this patch tries to address is the following.
When ending dragging of some set of elements `endDrag()` method is called [in a loop](https://github.com/dmitrio95/MuseScore/blob/baf969892bdb58893c7867f706195518723789c2/mscore/dragelement.cpp#L86) on every selected element. However `Note::endDrag` contains a line which changes this selection. Hence the list of elements which is iterated over is also changed which leads to some not too predictable bad consequences — in the given case it is a crash. The proposal is to remove this line as there seems to be no purpose in selecting the note which should have already been selected, and there seems to be no purpose in restricting selection to that note only. However I can be wrong in this so feel free to correct me.

Concerning the history of the discussed line, it seems to appear even before the Git repository history starts so it is hard to say why it has initially been here.