### PR TITLE
Fix the missed conversion of ticks to fraction

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1720,7 +1720,7 @@ void Measure::adjustToLen(Fraction nf, bool appendRestsIfNecessary)
                                           if (cr->durationType() == TDuration::DurationType::V_MEASURE) {
                                                 int actualTicks = cr->actualTicks();
                                                 n += actualTicks;
-                                                cr->setDurationType(TDuration(actualTicks));
+                                                cr->setDurationType(TDuration(Fraction::fromTicks(actualTicks)));
                                                 }
                                           else
                                                 n += cr->actualTicks();


### PR DESCRIPTION
This patch fixes a forgotten conversion from ticks to fractions when creating `TDuration` object. `TDuration` class [does not have](https://github.com/musescore/MuseScore/blob/896dafb9393f020f98abfea9145f0d0f64f49658/libmscore/durationtype.h#L42) any constructor accepting `int` as its argument so construction of an object in the fixed line of code was done during an implicit conversion of `int` to `Fraction`. However ticks should be converted to `Fraction` via a `Fraction::fromTicks` function. The missed call to this function was added in this patch.