### PR TITLE
fix #275805: Change actual duration after joining measures leads to crash

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3360,7 +3360,7 @@ qreal Measure::createEndBarLines(bool isLastMeasureInSystem)
       else {
             BarLineType t = nm ? BarLineType::NORMAL : BarLineType::END;
             if (!seg)
-                  seg = undoGetSegmentR(SegmentType::EndBarLine, ticks());
+                  seg = getSegmentR(SegmentType::EndBarLine, ticks());
             seg->setEnabled(true);
             //
             //  Set flag "hasCourtesyKeySig" if this measure needs a courtesy key sig.


### PR DESCRIPTION
fixed as proposed by @mattmcclinch in https://musescore.org/en/node/275805#comment-851139, adjusted to a meanwhile changed line number