### PR TITLE
fix #277326: Segfault when selecting first measure with a barline that isn't an EndBarLine

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1750,7 +1750,8 @@ void Timeline::drawSelection()
                   if (barline &&
                       (barline->barLineType() == BarLineType::END_REPEAT || barline->barLineType() == BarLineType::DOUBLE || barline->barLineType() == BarLineType::END) &&
                       measure != _score->lastMeasure()) {
-                        measure = measure->prevMeasure();
+                        if (measure->prevMeasure())
+                              measure = measure->prevMeasure();
                         }
                   }
 
@@ -2213,7 +2214,6 @@ void Timeline::updateGrid()
             mouseOver(mapToScene(mapFromGlobal(QCursor::pos())));
             row_names->updateLabels(getLabels(), grid_height);
             }
-
       viewport()->update();
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/277326

This was caused by an error deep within the Timeline code, because whoever wrote it assumed that a barline would signify the end of a measure, and forgot that barlines could be in the middle of a measure.