### PR TITLE
fix #277280: To Coda and Fine shown wrong in palette and score

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -437,7 +437,11 @@ Palette* MuseScore::newRepeatsPalette()
             if(markerTypeTable[i].type == Marker::Type::CODETTA) //not in smufl
                   continue;
 
-            Marker* mk = new Marker(gscore);
+            Marker* mk;
+            if (markerTypeTable[i].type == Marker::Type::FINE || markerTypeTable[i].type == Marker::Type::TOCODA)
+                  mk = new Marker(gscore, Tid::REPEAT_RIGHT);
+            else
+                  mk = new Marker(gscore);
             mk->setMarkerType(markerTypeTable[i].type);
             sp->append(mk, qApp->translate("markerType", markerTypeTable[i].name.toUtf8().constData()));
             }


### PR DESCRIPTION
...when added to score from palette. Existing Fine and To Coda look fine though.
So here we need to special-case those two to have a text Style of `Tid::REPEAT_RIGHT`, same as the jumps, rather than the markers' default of `Tid::REPEAT_LEFT`, which is used for Segno, Coda, and their variations.