### PR TITLE
fix #274870: fix resetting shortcuts

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6811,8 +6811,10 @@ int main(int argc, char* av[])
                   preferences.setToDefaultValue(PREF_APP_PATHS_MYEXTENSIONS);
                   updateExternalValuesFromPreferences();
                   }
-            QString keyboardLayout = preferences.getString(PREF_APP_KEYBOARDLAYOUT);
-            StartupWizard::autoSelectShortcuts(keyboardLayout);
+            if (!Shortcut::customSource()) {
+                  QString keyboardLayout = preferences.getString(PREF_APP_KEYBOARDLAYOUT);
+                  StartupWizard::autoSelectShortcuts(keyboardLayout);
+                  }
             }
 
       QApplication::instance()->installEventFilter(mscore);

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -1053,7 +1053,7 @@ void PreferenceDialog::apply()
                   Shortcut* os = Shortcut::getShortcut(s->key());
                   if (os) {
                         if (!os->compareKeys(*s))
-                              os->setKeys(s->keys());
+                              os->setKeys(*s);
                         }
                   }
             Shortcut::dirty = true;

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -20,6 +20,7 @@
 namespace Ms {
 
 bool Shortcut::dirty = false;
+QString Shortcut::source;
 QHash<QByteArray, Shortcut*> Shortcut::_shortcuts;
 extern QString dataPath;
 
@@ -3975,7 +3976,7 @@ void Shortcut::load()
       {
       QFile f(dataPath + "/shortcuts.xml");
       if (!f.exists())
-            f.setFileName(":/data/shortcuts.xml");
+            f.setFileName(defaultFileName);
       if (!f.open(QIODevice::ReadOnly)) {
             qDebug("Cannot open shortcuts <%s>", qPrintable(f.fileName()));
             return;
@@ -4021,6 +4022,7 @@ void Shortcut::load()
             else
                   e.unknown();
             }
+      source = f.fileName();
       dirty = false;
       }
 
@@ -4087,6 +4089,7 @@ void Shortcut::loadFromNewFile(QString fileLocation)
                   s->setStandardKey(sc.standardKey);
                   }
             }
+      source = fileLocation;
       dirty = true;
       }
 
@@ -4124,7 +4127,7 @@ QActionGroup* Shortcut::getActionGroupForWidget(MsWidget w, Qt::ShortcutContext 
 
 void Shortcut::resetToDefault()
       {
-      QList<Shortcut1> sl = loadShortcuts(":/data/shortcuts.xml");
+      QList<Shortcut1> sl = loadShortcuts(defaultFileName);
       for (const Shortcut1& sc : sl) {
             Shortcut* s = getShortcut(sc.key);
             if (s) {
@@ -4132,6 +4135,7 @@ void Shortcut::resetToDefault()
                   s->setStandardKey(sc.standardKey);
                   }
             }
+      source = defaultFileName;
       dirty = true;
       }
 
@@ -4143,7 +4147,7 @@ void Shortcut::reset()
       {
       _standardKey = QKeySequence::UnknownKey;
       _keys.clear();
-      QList<Shortcut1> sl = loadShortcuts(":/data/shortcuts.xml");
+      QList<Shortcut1> sl = loadShortcuts(defaultFileName);
       for (const Shortcut1& sc : sl) {
             if (sc.key == _key) {
                   setKeys(sc.keys);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3669,6 +3669,17 @@ void Shortcut::setStandardKey(QKeySequence::StandardKey k)
       }
 
 //---------------------------------------------------------
+//   setKeys
+//    Copies keys from the other Shortcut object
+//---------------------------------------------------------
+
+void Shortcut::setKeys(const Shortcut& sc)
+      {
+      setKeys(sc._keys);
+      setStandardKey(sc._standardKey);
+      }
+
+//---------------------------------------------------------
 //   descr
 //---------------------------------------------------------
 
@@ -3846,7 +3857,7 @@ bool Shortcut::compareKeys(const Shortcut& sc) const
             if (sc._keys[i] != _keys[i])
                   return false;
             }
-      return true;
+      return _standardKey == sc._standardKey;
       }
 
 //---------------------------------------------------------

--- a/mscore/shortcut.h
+++ b/mscore/shortcut.h
@@ -115,11 +115,15 @@ class Shortcut {
       QKeySequence::StandardKey _standardKey { QKeySequence::UnknownKey };
       mutable QAction* _action               { 0 };             //! cached action
 
+      static QString source;
+
       static Shortcut _sc[];
       static QHash<QByteArray, Shortcut*> _shortcuts;
       void translateAction(QAction* action) const;
 
    public:
+
+      static constexpr const char* defaultFileName = ":/data/shortcuts.xml";
 
       Shortcut() {}
       Shortcut(
@@ -171,6 +175,7 @@ class Shortcut {
       static void saveToNewFile(QString fileLocation);
       static void resetToDefault();
       static bool dirty;
+      static bool customSource() { return source != defaultFileName; }
       static Shortcut* getShortcut(const char* key);
       static const QHash<QByteArray, Shortcut*>& shortcuts() { return _shortcuts; }
       static QActionGroup* getActionGroupForWidget(MsWidget w);

--- a/mscore/shortcut.h
+++ b/mscore/shortcut.h
@@ -158,6 +158,7 @@ class Shortcut {
       QKeySequence::StandardKey standardKey() const { return _standardKey; }
       void setStandardKey(QKeySequence::StandardKey k);
       void setKeys(const QList<QKeySequence>& ks);
+      void setKeys(const Shortcut&);
 
       bool compareKeys(const Shortcut&) const;
       QString keysToString() const;


### PR DESCRIPTION
This pull request is primarily to fix [this issue](https://musescore.org/en/node/274870). The problem was in reinitializing shortcuts at each program start when setting a shortcut scheme based on user's keyboard layout. The first commit of this PR makes it happen only if "shortcuts.xml" file is not found and thus default shortcuts should be used. The second commit makes preferences dialog be more reliable in resetting keyboard shortcuts to default values in some cases — I didn't find any corresponding bug report but I can file one in case it is needed.

These commits can be squashed before merge, I left them separate to make reviewing them simpler.