### PR TITLE
fix #109661: pageSettings are not applied to excerpts

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -326,6 +326,34 @@ Score::~Score()
       }
 
 //---------------------------------------------------------
+//   Score::clone
+//         To create excerpt clone to show when changing PageSettings
+//         Use MasterScore::clone() instead
+//---------------------------------------------------------
+      
+Score* Score::clone()
+      {
+      QBuffer buffer;
+      buffer.open(QIODevice::WriteOnly);
+      XmlWriter xml(this, &buffer);
+      xml.header();
+      
+      xml.stag("museScore version=\"" MSC_VERSION "\"");
+      write(xml, false);
+      xml.etag();
+      
+      buffer.close();
+      
+      XmlReader r(buffer.buffer());
+      MasterScore* score = new MasterScore(style());
+      score->read1(r, true);
+      
+      score->addLayoutFlags(LayoutFlag::FIX_PITCH_VELO);
+      score->doLayout();
+      return score;
+      }
+      
+//---------------------------------------------------------
 //   addMeasure
 //---------------------------------------------------------
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -543,6 +543,7 @@ class Score : public QObject, public ScoreElement {
       Score(MasterScore*);
       Score(MasterScore*, const MStyle&);
       virtual ~Score();
+      Score* clone();
 
       virtual bool isMaster() const  { return false;        }
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2490,7 +2490,7 @@ void MuseScore::showPageSettings()
       {
       if (pageSettings == 0)
             pageSettings = new PageSettings();
-      pageSettings->setScore(cs->masterScore());
+      pageSettings->setScore(cs);
       pageSettings->show();
       pageSettings->raise();
       }

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -97,12 +97,12 @@ void PageSettings::hideEvent(QHideEvent* ev)
 //   setScore
 //---------------------------------------------------------
 
-void PageSettings::setScore(MasterScore* s)
+void PageSettings::setScore(Score* s)
       {
-      cs  = s;
-      MasterScore* sl = s->clone();
-      preview->setScore(sl);
-      buttonApplyToAllParts->setEnabled(!s->isMaster());
+      cs = s;
+      clonedScoreForNavigator.reset(s->clone());
+      preview->setScore(clonedScoreForNavigator.get());
+      buttonApplyToAllParts->setEnabled(!cs->isMaster());
       updateValues();
       updatePreview(0);
       }

--- a/mscore/pagesettings.h
+++ b/mscore/pagesettings.h
@@ -31,7 +31,8 @@ class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
 
       Navigator* preview;
       bool mmUnit;
-      MasterScore* cs;
+      Score* cs;
+      std::unique_ptr<Score> clonedScoreForNavigator;
 
       virtual void hideEvent(QHideEvent*);
       void updateValues();
@@ -71,7 +72,7 @@ class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
    public:
       PageSettings(QWidget* parent = 0);
       ~PageSettings();
-      void setScore(MasterScore*);
+      void setScore(Score*);
       };
 
 


### PR DESCRIPTION
See https://musescore.org/en/node/109661.

Fixed potential memory leak by putting cloned Score pointer to a unique_ptr.

This PR includes the best approaches from https://github.com/musescore/MuseScore/pull/3948, https://github.com/musescore/MuseScore/pull/3944, https://github.com/musescore/MuseScore/pull/3986 and https://github.com/musescore/MuseScore/pull/4019.