### PR TITLE
Move feedback-tools toolbar to the upper toolbar

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1206,12 +1206,11 @@ MuseScore::MuseScore()
       //    Feedback Tool Bar
       //-------------------------------
 
-      feedbackTools = new QToolBar("", this);
+      feedbackTools = addToolBar("");
       feedbackTools->setObjectName("feedback-tools");
-      // Add the toolbar to the bottom and forbid to move it...
+	  // Forbid to move or undock the toolbar...
       feedbackTools->setMovable(false);
       feedbackTools->setFloatable(false);
-      addToolBar(Qt::BottomToolBarArea, feedbackTools);
       // Add a spacer to align the buttons to the right side.
       QWidget* spacer = new QWidget(feedbackTools);
       spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);


### PR DESCRIPTION
follow up to #4034
Being in that extra line at the bottom may (and likely will) result in users disabling it to save the space, which seems counter-productive.