### PR TITLE
fix #137766, fix #272598, fix #277404: correct font size setting when rendering a score in pdf printing mode

### DIFF
--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -5657,9 +5657,9 @@ void ScoreFont::draw(SymId id, QPainter* painter, const QSizeF& mag, const QPoin
                   font->setFamily(_family);
                   font->setStyleStrategy(QFont::NoFontMerging);
                   font->setHintingPreference(QFont::PreferVerticalHinting);
-                  qreal size = 20.0 * MScore::pixelRatio;
-                  font->setPointSize(size);
                   }
+            qreal size = 20.0 * MScore::pixelRatio;
+            font->setPointSize(size);
             QSizeF imag = QSizeF(1.0 / mag.width(), 1.0 / mag.height());
             painter->scale(mag.width(), mag.height());
             painter->setFont(*font);


### PR DESCRIPTION
The proposed patch makes font size be set correctly for each pdf export/printing operation. Previously font size was set once and for the entire MuseScore session at font initialization. However font size depends on `pixelRatio` which may differ for different operations in pdf printing mode. Thus font size may become incorrect in certain conditions which could lead to the following issues:
https://musescore.org/en/node/137766
https://musescore.org/en/node/272598
https://musescore.org/en/node/277404

I believe this patch should fix these issues although it would be better if issues authors test this patch too in case there are some other pdf/printing-related issues.