### PR TITLE
Make welcome tours appear after Start Center actually closes

### DIFF
--- a/mscore/startcenter.cpp
+++ b/mscore/startcenter.cpp
@@ -15,6 +15,7 @@
 #include "libmscore/mscore.h"
 #include "startcenter.h"
 #include "scoreBrowser.h"
+#include "tourhandler.h"
 
 namespace Ms {
 
@@ -31,7 +32,7 @@ void MuseScore::showStartcenter(bool val)
             startcenter->readSettings();
             connect(startcenter, SIGNAL(closed(bool)), a, SLOT(setChecked(bool)));
             connect(startcenter, SIGNAL(rejected()), a, SLOT(toggle()));
-            connect(startcenter, SIGNAL(closed(bool)), reinterpret_cast<QObject*>(tourHandler()), SLOT(showWelcomeTour(bool)));
+            connect(startcenter, SIGNAL(closed(bool)), tourHandler(), SLOT(showWelcomeTour()), Qt::QueuedConnection);
             }
       startcenter->setVisible(val);
       }

--- a/mscore/tourhandler.cpp
+++ b/mscore/tourhandler.cpp
@@ -93,7 +93,7 @@ void OverlayWidget::paintEvent(QPaintEvent *)
 //   showWelcomeTour
 //---------------------------------------------------------
 
-void TourHandler::showWelcomeTour(bool)
+void TourHandler::showWelcomeTour()
       {
       startTour("welcome");
       }

--- a/mscore/tourhandler.h
+++ b/mscore/tourhandler.h
@@ -82,7 +82,7 @@ class TourHandler : public QObject
       static QList<QWidget*> getWidgetsByNames(Tour* tour, QList<QString> names);
 
 public slots:
-      void showWelcomeTour(bool);
+      void showWelcomeTour();
 
 public:
       TourHandler(QObject* parent) : QObject(parent) {}


### PR DESCRIPTION
This pull request makes Welcome Tours appear after actual disappearing of Start Center window. This is done simply by setting a queued connection instead of the default one between the `closed()` signal of `StartCenter` and `showWelcomeTour` slot. Unused parameters and redundant type cast are also removed within the proposed commit.