### PR TITLE
fix #266205: do not deselect elements in Score::selectAdd

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2832,15 +2832,12 @@ void Score::selectAdd(Element* e)
                   _selection.updateSelectedElements();
                   }
             }
-      else { // None or List
+      else if (!_selection.elements().contains(e)) {
             addRefresh(e->abbox());
-            if (_selection.elements().contains(e))
-                  _selection.remove(e);
-            else {
-                  selState = SelState::LIST;
-                  _selection.add(e);
-                  }
+            selState = SelState::LIST;
+            _selection.add(e);
             }
+
       _selection.setState(selState);
       }
 


### PR DESCRIPTION
This patch fixes [the issue](https://musescore.org/en/node/266205) with "select similar elements" feature not working in some circumstances (at least when applied to ties). The proposed solution is to remove deselection of elements from `Score::selectAdd` since it is not an expected behavior of this function and all of those chunks of code that use this function do not rely on such a behavior. Deselecting selected elements on Ctrl+click is already handled [in ScoreView](https://github.com/musescore/MuseScore/blob/cc84a61fc989383ecc85f877f90126da4dde67d0/mscore/events.cpp#L307) so this functionality is not broken by this patch.

The fact that `Score::scanElements` can scan some elements more than one time can also be considered an issue but I believe that it is much more important for it to touch all elements rather than  aim for doing it one time only. So this issue can be postponed I guess.

There is also a suspicious usage of `Score::select` in [ChangeElement::flip](https://github.com/musescore/MuseScore/blob/cc84a61fc989383ecc85f877f90126da4dde67d0/libmscore/undo.cpp#L999) but there is probably some typo there. The question is what kind of typo is there exactly.