### PR TITLE
fix #277497: adding text causes crash in debug mode

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -523,16 +523,17 @@ Element* ChordRest::drop(EditData& data)
                   // fall through
 
             case ElementType::REHEARSAL_MARK:
+                  {
                   e->setParent(segment());
                   e->setTrack((track() / VOICES) * VOICES);
-                  {
-                  RehearsalMark* m = toRehearsalMark(e);
-                  if (fromPalette)
-                        m->setXmlText(score()->createRehearsalMarkText(m));
-                  }
+                  if (e->isRehearsalMark()) {
+                        RehearsalMark* m = toRehearsalMark(e);
+                        if (fromPalette)
+                              m->setXmlText(score()->createRehearsalMarkText(m));
+                        }
                   score()->undoAddElement(e);
                   return e;
-
+                  }
             case ElementType::FIGURED_BASS:
                   {
                   bool bNew;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/277497