### PR TITLE
Fix #275659: Redundant undo entries

### DIFF
--- a/mscore/pagesettings.h
+++ b/mscore/pagesettings.h
@@ -31,12 +31,13 @@ class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
 
       Navigator* preview;
       bool mmUnit;
+      bool _changeFlag;
       Score* cs;
       std::unique_ptr<Score> clonedScoreForNavigator;
 
       virtual void hideEvent(QHideEvent*);
       void updateValues();
-      void updatePreview(int);
+      void updatePreview();
       void blockSignals(bool);
       void applyToScore(Score*);
       void setMarginsMax(double);


### PR DESCRIPTION
_changeFlag tracks changes and ensure that applyToScore is only executed when something has changed.
startCmd and endCmd moved to applyToAllParts only generate one undo entry, instead of one per excerpt.
Meningles case statement and paramerter removed from updateValues()