### PR TITLE
fix #276537: Instrument names incorrectly positioned when part contains both hidden and visible staves

### DIFF
--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -549,7 +549,7 @@ void System::layout2()
                                     s2 = staff(staffIdx);
                                     for (int i = staffIdx + nstaves - 1; i > 0; --i) {
                                           SysStaff* s3 = staff(i);
-                                          if (s->show()) {        // ??
+                                          if (s3->show()) {
                                                 s2 = s3;
                                                 break;
                                                 }


### PR DESCRIPTION
See https://musescore.org/en/node/276537#comment-858199.

`s` was renamed to `s3` in [this commit](https://github.com/musescore/MuseScore/pull/3958/files#diff-90b0d8289f3e846ac6cd9cc9ef6e1d28) so that it would not overshadow a variable already in scope, but it was never changed here. Werner saw this line and probably noticed that `s->show()` is guaranteed to be `true` at this point, so he left a question mark as a comment. Of course, we are interested in the value of `s3->show()` at this point, rather than `s->show()`.