### PR TITLE
fix #272995: avoid handling single clicks twice in ScoreBrowser

### DIFF
--- a/mscore/scoreBrowser.cpp
+++ b/mscore/scoreBrowser.cpp
@@ -98,7 +98,11 @@ ScoreListWidget* ScoreBrowser::createScoreList()
       if (!_showPreview)
             sl->setSelectionMode(QAbstractItemView::NoSelection);
 
-      connect(sl, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(scoreClicked(QListWidgetItem*)), Qt::QueuedConnection);
+      if (!style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick)) {
+            // Set our handler for item clicks only if Qt
+            // doesn't treat a click as an item activation.
+            connect(sl, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(scoreClicked(QListWidgetItem*)), Qt::QueuedConnection);
+            }
       connect(sl, SIGNAL(itemActivated(QListWidgetItem*)), SLOT(setScoreActivated(QListWidgetItem*)));
       scoreLists.append(sl);
       return sl;
@@ -327,12 +331,6 @@ void ScoreBrowser::scoreClicked(QListWidgetItem* current)
       {
       if (!current)
             return;
-
-      if (style()->styleHint(QStyle::SH_ItemView_ActivateItemOnSingleClick)) {
-            // Qt will consider this click an item activation.
-            // Just let it happen.
-            return;
-            }
 
       ScoreItem* item = static_cast<ScoreItem*>(current);
       if (!_showPreview)


### PR DESCRIPTION
This pull request is probably a better version of #3545. Unfortunately after applying that patch `ScoreBrowser` in the start center still keeps crashing on selecting some scores though it now happens much more rarely. This patch stops MuseScore from setting that "bad" connection between `itemClicked` signal and `scoreClicked` slot at all if single clicks are treated by Qt in its current configuration as an item activation. This should prevent the crash completely — and it seems to do so according to my tests.