### PR TITLE
fix #277566: Add "Count-In" to the toolbar editor "Playback Controls"

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -289,7 +289,8 @@ const std::list<const char*> MuseScore::_allPlaybackControlEntries {
             "loop",
             "repeat",
             "pan",
-            "metronome"
+            "metronome",
+            "countin"
             };
 
 extern bool savePositions(Score*, const QString& name, bool segments );


### PR DESCRIPTION
needs #3689 or rather its rebased version #4078 to really work, but could get merged independantly