### PR TITLE
fix #277564: Strange slur is added when pressing S on the score's last note

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3110,7 +3110,7 @@ void ScoreView::addSlur()
                         if (!cr2 || cr2->tick() < cr->tick())
                               cr2 = cr;
                         }
-                  if (cr1)
+                  if (cr1 && (cr1 != cr2))
                         cmdAddSlur(cr1, cr2);
                   }
             }
@@ -3145,7 +3145,7 @@ void ScoreView::cmdAddSlur(ChordRest* cr1, ChordRest* cr2)
       if (cr2 == 0) {
             cr2 = nextChordRest(cr1);
             if (cr2 == 0)
-                  cr2 = cr1;
+                  return;
             startEditMode = true;      // start slur in edit mode if last chord is not given
             }
 


### PR DESCRIPTION
See https://musescore.org/en/node/277564.