### PR TITLE
fix #272441 Toolbar Editor: Toolbar duplication

### DIFF
--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -780,10 +780,14 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       std::list<const char*>* noteInputMenuEntries()                 { return &_noteInputMenuEntries; }
 
       static const std::list<const char*>& allFileOperationEntries() { return _allFileOperationEntries; }
-      std::list<const char*>* fileOperationEntries()              { return &_fileOperationEntries; }
+      std::list<const char*>* fileOperationEntries()                 { return &_fileOperationEntries; }
+      void setFileOperationEntries(std::list<const char*> l)         { _fileOperationEntries = l; }
+      void populateFileOperations();
 
       static const std::list<const char*>& allPlaybackControlEntries() { return _allPlaybackControlEntries; }
-      std::list<const char*>* playbackControlEntries()      { return &_playbackControlEntries; }
+      std::list<const char*>* playbackControlEntries()               { return &_playbackControlEntries; }
+      void setPlaybackControlEntries(std::list<const char*> l)       { _playbackControlEntries = l; }
+      void populatePlaybackControls();
 
       void setNoteInputMenuEntries(std::list<const char*> l)         { _noteInputMenuEntries = l; }
       void populateNoteInputMenu();

--- a/mscore/toolbarEditor.h
+++ b/mscore/toolbarEditor.h
@@ -24,6 +24,9 @@ namespace Ms {
 class ToolbarEditor : public QDialog, public Ui::ToolbarEditor {
       Q_OBJECT
 
+      std::vector<std::list<const char*>*> *new_toolbars;
+      void updateNewToolbar(int toolbar_to_update);
+
       void populateLists(const std::list<const char*>&, std::list<const char*>*);
       bool isSpacer(QListWidgetItem*) const;
 


### PR DESCRIPTION
Originally, the toolbar only worked for the note input toolbar and had a bug for each other one. Now it correctly handles any edit to the toolbars.
The workspace only had the note input toolbar saved into the workspace. That has now been expanded to playback controls toolbar and file operations toolbar.

This is a rebased PR #3689 
As far as I understood @JoshuaBonn1 lost his build environment and won't get it back up any time soon