### PR TITLE
fix #277090: reset tempo only for the relevant range on layout

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3829,7 +3829,7 @@ void Score::doLayoutRange(int stick, int etick)
       // we need to reset tempo because fermata is setted
       //inside getNextMeasure and it lead to twice timeStretch
       if (isMaster())
-            resetTempo();
+            resetTempoRange(stick, etick);
 
       getNextMeasure(lc);
       lc.curSystem = collectSystem(lc);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3267,12 +3267,26 @@ void Score::removeTempo(int tick)
 
 void Score::resetTempo()
       {
-      tempomap()->clear();
-      tempomap()->setTempo(0, _defaultTempo);
-      sigmap()->clear();
-      Measure* m = firstMeasure();
-      if (m)
-            sigmap()->add(0, SigEvent(m->len(),  m->timesig(), 0));
+      resetTempoRange(0, std::numeric_limits<int>::max());
+      }
+
+//---------------------------------------------------------
+//   resetTempoRange
+//    Reset tempo and timesig maps in the given range.
+//    Start tick included, end tick excluded.
+//---------------------------------------------------------
+
+void Score::resetTempoRange(int tick1, int tick2)
+      {
+      tempomap()->clearRange(tick1, tick2);
+      if (tempomap()->empty())
+            tempomap()->setTempo(0, _defaultTempo);
+      sigmap()->clearRange(tick1, tick2);
+      if (sigmap()->empty()) {
+            Measure* m = firstMeasure();
+            if (m)
+                  sigmap()->add(0, SigEvent(m->len(),  m->timesig(), 0));
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -517,6 +517,7 @@ class Score : public QObject, public ScoreElement {
       void resetSystems(bool layoutAll, LayoutContext& lc);
       void collectLinearSystem(LayoutContext& lc);
       void resetTempo();
+      void resetTempoRange(int tick1, int tick2);
 
    protected:
       int _fileDivision; ///< division of current loading *.msc file

--- a/libmscore/sig.cpp
+++ b/libmscore/sig.cpp
@@ -231,6 +231,22 @@ void TimeSigMap::del(int tick)
       }
 
 //---------------------------------------------------------
+//   clearRange
+//    Clears the given range, start tick included, end tick
+//    excluded.
+//---------------------------------------------------------
+
+void TimeSigMap::clearRange(int tick1, int tick2)
+      {
+      iterator first = lower_bound(tick1);
+      iterator last = lower_bound(tick2);
+      if (first == last)
+            return;
+      erase(first, last);
+      normalize();
+      }
+
+//---------------------------------------------------------
 //   TimeSigMap::normalize
 //---------------------------------------------------------
 

--- a/libmscore/sig.h
+++ b/libmscore/sig.h
@@ -133,6 +133,8 @@ class TimeSigMap : public std::map<int, SigEvent > {
 
       void del(int tick);
 
+      void clearRange(int tick1, int tick2);
+
       void read(XmlReader&, int fileDiv);
       void write(XmlWriter&) const;
       void dump() const;

--- a/libmscore/tempo.cpp
+++ b/libmscore/tempo.cpp
@@ -139,6 +139,22 @@ void TempoMap::clear()
       }
 
 //---------------------------------------------------------
+//   clearRange
+//    Clears the given range, start tick included, end tick
+//    excluded.
+//---------------------------------------------------------
+
+void TempoMap::clearRange(int tick1, int tick2)
+      {
+      iterator first = lower_bound(tick1);
+      iterator last = lower_bound(tick2);
+      if (first == last)
+            return;
+      erase(first, last);
+      ++_tempoSN;
+      }
+
+//---------------------------------------------------------
 //   tempo
 //---------------------------------------------------------
 

--- a/libmscore/tempo.h
+++ b/libmscore/tempo.h
@@ -53,6 +53,7 @@ class TempoMap : public std::map<int, TEvent> {
    public:
       TempoMap();
       void clear();
+      void clearRange(int tick1, int tick2);
 
       void dump() const;
 


### PR DESCRIPTION
This pull request fixes [an issue](https://musescore.org/en/node/277090) with playback tempo change on editing certain parts of a score. This happened because tempo map is cleared on layout and is then rebuilt from scratch, though only for the layout range. This patch makes tempomap be reset only in the layout range too thus preventing loss of tempo information leading to unwanted playback tempo behavior.