### PR TITLE
Fix signal-slot connections for feedback menu entries

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1728,12 +1728,12 @@ MuseScore::MuseScore()
       Workspace::addActionAndString(askForHelpAction, "ask-help");
 
       reportBugAction = new QAction("", 0);
-      connect(reportBugAction, SIGNAL(triggered()), this, SLOT(reportBug("menu")));
+      connect(reportBugAction, &QAction::triggered, this, [this]{ reportBug("menu"); });
       menuHelp->addAction(reportBugAction);
       Workspace::addActionAndString(reportBugAction, "report-bug");
 
       leaveFeedbackAction = new QAction("", 0);
-      connect(leaveFeedbackAction, SIGNAL(triggered()), this, SLOT(leaveFeedback("menu")));
+      connect(leaveFeedbackAction, &QAction::triggered, this, [this]{ leaveFeedback("menu"); });
       menuHelp->addAction(leaveFeedbackAction);
       Workspace::addActionAndString(leaveFeedbackAction, "leave-feedback");
 


### PR DESCRIPTION
This pull request is to fix signal-slot connections for feedback menu entries which became broken after my PR #4034. I wanted to add arguments to a slot call but apparently I needed to use the new signal-slot connection syntax and lambda functions for that.