### PR TITLE
fix #277614: remove a link for a deleted element on double articulations conversion

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1896,7 +1896,7 @@ bool readChordProperties206(XmlReader& e, Chord* ch)
 //    symbols which were not available for use prior to 3.0
 //---------------------------------------------------------
 
-static void convertDoubleArticulations(Chord* chord)
+static void convertDoubleArticulations(Chord* chord, XmlReader& e)
       {
       std::vector<Articulation*> pairableArticulations;
       for (Articulation* a : chord->articulations()) {
@@ -1938,8 +1938,11 @@ static void convertDoubleArticulations(Chord* chord)
             Articulation* newArtic = pairableArticulations[0];
             for (Articulation* a : pairableArticulations) {
                   chord->remove(a);
-                  if (a != newArtic)
+                  if (a != newArtic) {
+                        if (LinkedElements* link = a->links())
+                              e.linkIds().remove(link->lid());
                         delete a;
+                        }
                   }
 
             ArticulationAnchor anchor = newArtic->anchor();
@@ -1987,7 +1990,7 @@ static void readChord(Chord* chord, XmlReader& e)
             else
                   e.unknown();
             }
-      convertDoubleArticulations(chord);
+      convertDoubleArticulations(chord, e);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR fixes [this issue](https://musescore.org/en/node/277614). The issue is introduced by #3995 and is caused by not handling links for a deleted old articulation properly so that an invalid pointer to a link was contained in link IDs list. This pull request fixes that and removes an invalidated link from the list.