### PR TITLE
fix #277616: ask for resetting positions when importing old scores

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1901,6 +1901,32 @@ void Score::cmdResetNoteAndRestGroupings()
       }
 
 //---------------------------------------------------------
+//   resetElementShapePosition
+//    For use with Score::scanElements.
+//    Reset positions and autoplacement for the given
+//    element.
+//---------------------------------------------------------
+
+static void resetElementPosition(void*, Element* e)
+      {
+      e->undoResetProperty(Pid::AUTOPLACE);
+      e->undoResetProperty(Pid::OFFSET);
+      if (e->isSpanner())
+            e->undoResetProperty(Pid::OFFSET2);
+      }
+
+//---------------------------------------------------------
+//   cmdResetAllPositions
+//---------------------------------------------------------
+
+void Score::cmdResetAllPositions()
+      {
+      startCmd();
+      scanElements(nullptr, resetElementPosition);
+      endCmd();
+      }
+
+//---------------------------------------------------------
 //   processMidiInput
 //---------------------------------------------------------
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -585,6 +585,7 @@ class Score : public QObject, public ScoreElement {
       void cmdAddOttava(OttavaType);
       void cmdAddStretch(qreal);
       void cmdResetNoteAndRestGroupings();
+      void cmdResetAllPositions();
       void cmdDoubleDuration()      { cmdIncDecDuration(-1, 0); }
       void cmdHalfDuration()        { cmdIncDecDuration( 1, 0); }
       void cmdIncDurationDotted()   { cmdIncDecDuration(-1, 1); }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -370,6 +370,7 @@ MasterScore* MuseScore::readScore(const QString& name)
       allowShowMidiPanel(name);
       if (score)
             addRecentScore(score);
+
       return score;
       }
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -371,8 +371,10 @@ void MuseScore::closeEvent(QCloseEvent* ev)
 
       // remove all new created/not save score so they are
       // note saved as session data
-      for (MasterScore* score : removeList)
+      for (MasterScore* score : removeList) {
             scoreList.removeAll(score);
+            scoreWasShown.remove(score);
+            }
 
       writeSessionFile(true);
       for (MasterScore* score : scoreList) {
@@ -2111,6 +2113,7 @@ int MuseScore::appendScore(MasterScore* score)
                   }
             }
       scoreList.insert(index, score);
+      scoreWasShown[score] = false;
       tab1->insertTab(score);
       if (tab2)
             tab2->insertTab(score);
@@ -2228,6 +2231,27 @@ void MuseScore::reloadInstrumentTemplates()
             auto instFiles = extDir.entryInfoList(QDir::Files | QDir::NoSymLinks | QDir::Readable);
             for (auto instFile : instFiles)
                   loadInstrumentTemplates(instFile.absoluteFilePath());
+            }
+      }
+
+//---------------------------------------------------------
+//   askResetOldScorePositions
+//---------------------------------------------------------
+
+void MuseScore::askResetOldScorePositions(Score* score)
+      {
+      if (score->mscVersion() < 300 && score->mscVersion() > 114) {
+            QMessageBox msgBox;
+            QString question = tr("Reset all elements positions?");
+            msgBox.setWindowTitle(question);
+            msgBox.setText(tr("This score was created in older versions of MuseScore. For a better experience of using MuseScore 3.0 it is recommended to reset elements positions to their default values.") + "\n\n" + question);
+            msgBox.setIcon(QMessageBox::Question);
+            msgBox.setStandardButtons(
+               QMessageBox::Yes | QMessageBox::No
+               );
+
+            if (msgBox.exec() == QMessageBox::Yes)
+                  score->cmdResetAllPositions();
             }
       }
 
@@ -2378,6 +2402,11 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
             timeline()->setScoreView(view);
             }
       ScoreAccessibility::instance()->updateAccessibilityInfo();
+
+      if (!scoreWasShown[cs]) {
+            scoreWasShown[cs] = true;
+            askResetOldScorePositions(cs);
+            }
       }
 
 //---------------------------------------------------------
@@ -2881,6 +2910,7 @@ void MuseScore::removeTab(int i)
 
       midiPanelOnCloseFile(score->importedFilePath());
       scoreList.removeAt(i);
+      scoreWasShown.remove(score);
 
       tab1->removeTab(i, /* noCurrentChangedSignals */ true);
       if (tab2)
@@ -7071,8 +7101,6 @@ int main(int argc, char* av[])
             // TODO: delete old session backups
             //
             restoredSession = mscore->restoreSession((preferences.sessionStart() == SessionStart::LAST && (files == 0)));
-            if (!restoredSession || files)
-                  loadScores(argv);
             }
 
       errorMessage = new QErrorMessage(mscore);
@@ -7091,6 +7119,9 @@ int main(int argc, char* av[])
 
       mscore->changeState(mscore->noScore() ? STATE_DISABLED : STATE_NORMAL);
       mscore->show();
+
+      if (!restoredSession || files)
+            loadScores(argv);
 
 #ifndef MSCORE_NO_UPDATE_CHECKER
       if (mscore->hasToCheckForUpdate())

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -221,6 +221,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       QSettings settings;
       ScoreView* cv                        { 0 };
+      QMap<Score*, bool> scoreWasShown; // whether each score in scoreList has ever been shown
       ScoreState _sstate;
       UpdateChecker* ucheck;
       ExtensionsUpdateChecker* packUChecker = nullptr;
@@ -471,6 +472,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void setPlayRepeats(bool repeat);
 
       ScoreTab* createScoreTab();
+      void askResetOldScorePositions(Score* score);
 
       QString getUtmParameters(QString medium) const;
 


### PR DESCRIPTION
This PR implements a suggestion which is described [here](https://musescore.org/en/node/277616). Also `Element::reset` now resets also an element offset.