### PR TITLE
Do not show dialog asking for resetting positions for excerpts

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2417,9 +2417,10 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
             }
       ScoreAccessibility::instance()->updateAccessibilityInfo();
 
-      if (!scoreWasShown[cs]) {
-            scoreWasShown[cs] = true;
-            askResetOldScorePositions(cs);
+      MasterScore* master = cs->masterScore();
+      if (!scoreWasShown[master]) {
+            scoreWasShown[master] = true;
+            askResetOldScorePositions(master);
             }
       }
 

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -222,7 +222,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QSettings settings;
       ScoreView* cv                        { 0 };
       ScoreTab* ctab                       { 0 };
-      QMap<Score*, bool> scoreWasShown; // whether each score in scoreList has ever been shown
+      QMap<MasterScore*, bool> scoreWasShown; // whether each score in scoreList has ever been shown
       ScoreState _sstate;
       UpdateChecker* ucheck;
       ExtensionsUpdateChecker* packUChecker = nullptr;


### PR DESCRIPTION
This small PR makes dialog asking for resetting positions be not shown when switching between excerpts of the opened old score. Unfortunately when making #4085 I forgot that we want to operate on master scores in this case so produced this error.