### PR TITLE
fix #277745: reset pointers to Score and ScoreView in Timeline when they are destroyed

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -2230,6 +2230,7 @@ void Timeline::setScore(Score* s)
       scene()->clear();
 
       if (_score) {
+            connect(_score, &QObject::destroyed, this, &Timeline::objectDestroyed, Qt::UniqueConnection);
             drawGrid(nstaves(), _score->nmeasures());
             changeSelection(SelState::NONE);
             row_names->updateLabels(getLabels(), grid_height);
@@ -2257,10 +2258,23 @@ void Timeline::setScoreView(ScoreView* v)
       {
       _cv = v;
       if (_cv) {
-            connect(_cv, SIGNAL(sizeChanged()), this, SLOT(updateView()));
-            connect(_cv, SIGNAL(viewRectChanged()), this, SLOT(updateView()));
+            connect(_cv, &ScoreView::sizeChanged, this, &Timeline::updateView, Qt::UniqueConnection);
+            connect(_cv, &ScoreView::viewRectChanged, this, &Timeline::updateView, Qt::UniqueConnection);
+            connect(_cv, &QObject::destroyed, this, &Timeline::objectDestroyed, Qt::UniqueConnection);
             updateView();
             }
+      }
+
+//---------------------------------------------------------
+//   objectDestroyed
+//---------------------------------------------------------
+
+void Timeline::objectDestroyed(QObject* obj)
+      {
+      if (_cv == obj)
+            setScoreView(nullptr);
+      else if (_score == obj)
+            setScore(nullptr);
       }
 
 //---------------------------------------------------------

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -176,6 +176,7 @@ class Timeline : public QGraphicsView {
    private slots:
       void handle_scroll(int value);
       void updateView();
+      void objectDestroyed(QObject*);
 
    public slots:
       void changeSelection(SelState);


### PR DESCRIPTION
This pull request fixes [this issue](https://musescore.org/en/node/277745). The problem lays in not resetting pointer to ScoreView inside Timeline when the view is destroyed. When showing excerpts tab after closing other score the view inside it emits `sizeChanged` signal which triggers an `Timeline::updateView` slot which tries to operate on `_cv` pointer which already became invalid. Resetting a pointer on view destruction resolves the problem. Perhaps we could consider also disconnecting `Timeline` from the old view's signals when switching score and not updating Timeline when it is invisible but these are separate issues which are not addressed in this PR.