### PR TITLE
fix #276461: Custom text styles in previous versions of MS changed to User-1, User-2 etc.

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -615,6 +615,13 @@ void readTextStyle206(MStyle* style, XmlReader& e)
                   qDebug("unhandled substyle <%s>", qPrintable(name));
                   return;
                   }
+            int idx = int(ss) - int(Tid::USER1);
+            if ((idx < 0) || (idx > 5)) {
+                  qDebug("User style index %d outside of range [0,5].", idx);
+                  return;
+                  }
+            Sid sid[] = { Sid::user1Name, Sid::user2Name, Sid::user3Name, Sid::user4Name, Sid::user5Name, Sid::user6Name };
+            style->set(sid[idx], name);
             }
 
       for (const auto& i : *textStyle(ss)) {

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4302,6 +4302,23 @@ void Score::setStyle(const MStyle& s)
       }
 
 //---------------------------------------------------------
+//   getTextStyleUserName
+//---------------------------------------------------------
+
+QString Score::getTextStyleUserName(Tid tid)
+      {
+      QString name = "";
+      if (int(tid) >= int(Tid::USER1) && int(tid) <= int(Tid::USER6)) {
+            int idx = int(tid) - int(Tid::USER1);
+            Sid sid[] = { Sid::user1Name, Sid::user2Name, Sid::user3Name, Sid::user4Name, Sid::user5Name, Sid::user6Name };
+            name = styleSt(sid[idx]);
+            }
+      if (name == "")
+            name = textStyleUserName(tid);
+      return name;
+      }
+
+//---------------------------------------------------------
 //   MasterScore
 //---------------------------------------------------------
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -843,6 +843,7 @@ class Score : public QObject, public ScoreElement {
       int      styleI(Sid idx) const  { Q_ASSERT(!strcmp(MStyle::valueType(idx),"int"));         return style().value(idx).toInt();  }
 
       void setStyleValue(Sid sid, QVariant value) { style().set(sid, value);     }
+      QString getTextStyleUserName(Tid tid);
       qreal spatium() const                    { return styleD(Sid::spatium);    }
       void setSpatium(qreal v)                 { setStyleValue(Sid::spatium, v); }
 

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -886,6 +886,7 @@ static const StyleType styleTypes[] {
       { Sid::figuredBassFontSize,           "figuredBassFontSize",          8.0 },
       { Sid::figuredBassFontStyle,          "figuredBassFontStyle",         int(FontStyle::Normal) },
 
+      { Sid::user1Name,                     "user1Name",                    "" },
       { Sid::user1FontFace,                 "user1FontFace",                "FreeSerif" },
       { Sid::user1FontSize,                 "user1FontSize",                10.0 },
       { Sid::user1FontStyle,                "user1FontStyle",               int(FontStyle::Normal) },
@@ -899,6 +900,7 @@ static const StyleType styleTypes[] {
       { Sid::user1FrameFgColor,             "user1FrameFgColor",            QColor(0, 0, 0, 255) },
       { Sid::user1FrameBgColor,             "user1FrameBgColor",            QColor(255, 255, 255, 0) },
 
+      { Sid::user2Name,                     "user2Name",                    "" },
       { Sid::user2FontFace,                 "user2FontFace",                "FreeSerif" },
       { Sid::user2FontSize,                 "user2FontSize",                10.0 },
       { Sid::user2FontStyle,                "user2FontStyle",               int(FontStyle::Normal) },
@@ -912,6 +914,7 @@ static const StyleType styleTypes[] {
       { Sid::user2FrameFgColor,             "user2FrameFgColor",            QColor(0, 0, 0, 255) },
       { Sid::user2FrameBgColor,             "user2FrameBgColor",            QColor(255, 255, 255, 0) },
 
+      { Sid::user3Name,                     "user3Name",                    "" },
       { Sid::user3FontFace,                 "user3FontFace",                "FreeSerif" },
       { Sid::user3FontSize,                 "user3FontSize",                10.0 },
       { Sid::user3FontStyle,                "user3FontStyle",               int(FontStyle::Normal) },
@@ -925,6 +928,7 @@ static const StyleType styleTypes[] {
       { Sid::user3FrameFgColor,             "user3FrameFgColor",            QColor(0, 0, 0, 255) },
       { Sid::user3FrameBgColor,             "user3FrameBgColor",            QColor(255, 255, 255, 0) },
 
+      { Sid::user4Name,                     "user4Name",                    "" },
       { Sid::user4FontFace,                 "user4FontFace",                "FreeSerif" },
       { Sid::user4FontSize,                 "user4FontSize",                10.0 },
       { Sid::user4FontStyle,                "user4FontStyle",               int(FontStyle::Normal) },
@@ -938,6 +942,7 @@ static const StyleType styleTypes[] {
       { Sid::user4FrameFgColor,             "user4FrameFgColor",            QColor(0, 0, 0, 255) },
       { Sid::user4FrameBgColor,             "user4FrameBgColor",            QColor(255, 255, 255, 0) },
 
+      { Sid::user5Name,                     "user5Name",                    "" },
       { Sid::user5FontFace,                 "user5FontFace",                "FreeSerif" },
       { Sid::user5FontSize,                 "user5FontSize",                10.0 },
       { Sid::user5FontStyle,                "user5FontStyle",               int(FontStyle::Normal) },
@@ -951,6 +956,7 @@ static const StyleType styleTypes[] {
       { Sid::user5FrameFgColor,             "user5FrameFgColor",            QColor(0, 0, 0, 255) },
       { Sid::user5FrameBgColor,             "user5FrameBgColor",            QColor(255, 255, 255, 0) },
 
+      { Sid::user6Name,                     "user6Name",                    "" },
       { Sid::user6FontFace,                 "user6FontFace",                "FreeSerif" },
       { Sid::user6FontSize,                 "user6FontSize",                10.0 },
       { Sid::user6FontStyle,                "user6FontStyle",               int(FontStyle::Normal) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -861,6 +861,7 @@ enum class Sid {
       figuredBassFontSize,
       figuredBassFontStyle,
 
+      user1Name,
       user1FontFace,
       user1FontSize,
       user1FontStyle,
@@ -874,6 +875,7 @@ enum class Sid {
       user1FrameFgColor,
       user1FrameBgColor,
 
+      user2Name,
       user2FontFace,
       user2FontSize,
       user2FontStyle,
@@ -887,6 +889,7 @@ enum class Sid {
       user2FrameFgColor,
       user2FrameBgColor,
 
+      user3Name,
       user3FontFace,
       user3FontSize,
       user3FontStyle,
@@ -900,6 +903,7 @@ enum class Sid {
       user3FrameFgColor,
       user3FrameBgColor,
 
+      user4Name,
       user4FontFace,
       user4FontSize,
       user4FontStyle,
@@ -913,6 +917,7 @@ enum class Sid {
       user4FrameFgColor,
       user4FrameBgColor,
 
+      user5Name,
       user5FontFace,
       user5FontSize,
       user5FontStyle,
@@ -926,6 +931,7 @@ enum class Sid {
       user5FrameFgColor,
       user5FrameBgColor,
 
+      user6Name,
       user6FontFace,
       user6FontSize,
       user6FontStyle,

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -2104,7 +2104,7 @@ QString TextBase::accessibleInfo() const
             case Tid::POET:
             case Tid::TRANSLATOR:
             case Tid::MEASURE_NUMBER:
-                  rez = textStyleUserName(tid());
+                  rez = score() ? score()->getTextStyleUserName(tid()) : textStyleUserName(tid());
                   break;
             default:
                   rez = Element::accessibleInfo();
@@ -2133,7 +2133,7 @@ QString TextBase::screenReaderInfo() const
             case Tid::POET:
             case Tid::TRANSLATOR:
             case Tid::MEASURE_NUMBER:
-                  rez = textStyleUserName(tid());
+                  rez = score() ? score()->getTextStyleUserName(tid()) : textStyleUserName(tid());
                   break;
             default:
                   rez = Element::accessibleInfo();
@@ -2158,7 +2158,7 @@ int TextBase::subtype() const
 
 QString TextBase::subtypeName() const
       {
-      return textStyleUserName(tid());
+      return score() ? score()->getTextStyleUserName(tid()) : textStyleUserName(tid());
       }
 
 //---------------------------------------------------------

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -572,10 +572,20 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       connect(mapper2, SIGNAL(mapped(int)), SLOT(valueChanged(int)));
       textStyles->clear();
       for (auto ss : allTextStyles()) {
-            QListWidgetItem* item = new QListWidgetItem(textStyleUserName(ss));
+            QListWidgetItem* item = new QListWidgetItem(s->getTextStyleUserName(ss));
             item->setData(Qt::UserRole, int(ss));
             textStyles->addItem(item);
             }
+
+      textStyleFrameType->clear();
+      textStyleFrameType->addItem(tr("No frame"), int(FrameType::NO_FRAME));
+      textStyleFrameType->addItem(tr("Square"),   int(FrameType::SQUARE));
+      textStyleFrameType->addItem(tr("Circle"),   int(FrameType::CIRCLE));
+
+      resetTextStyleName->setIcon(*icons[int(Icons::reset_ICON)]);
+      connect(resetTextStyleName, &QToolButton::clicked, [=](){ resetUserStyleName(); });
+      connect(styleName, &QLineEdit::textEdited, [=]() { editUserStyleName(); });
+      connect(styleName, &QLineEdit::editingFinished, [=]() { endEditUserStyleName(); });
 
       // font face
       resetTextStyleFontFace->setIcon(*icons[int(Icons::reset_ICON)]);
@@ -1335,7 +1345,10 @@ void EditStyle::textStyleChanged(int row)
                         break;
                   }
             }
-      }
+      styleName->setText(cs->getTextStyleUserName(tid));
+      styleName->setEnabled(int(tid) >= int(Tid::USER1));
+      resetTextStyleName->setEnabled(styleName->text() != textStyleUserName(tid));
+     }
 
 //---------------------------------------------------------
 //   textStyleValueChanged
@@ -1374,5 +1387,52 @@ void EditStyle::resetTextStyle(Pid pid)
       textStyleChanged(textStyles->currentRow());     // update GUI
       cs->update();
       }
+
+//---------------------------------------------------------
+//   editUserStyleName
+//---------------------------------------------------------
+
+void EditStyle::editUserStyleName()
+      {
+      int row = textStyles->currentRow();
+      Tid tid = Tid(textStyles->item(row)->data(Qt::UserRole).toInt());
+      textStyles->item(row)->setText(styleName->text());
+      resetTextStyleName->setEnabled(styleName->text() != textStyleUserName(tid));
+      }
+
+//---------------------------------------------------------
+//   endEditUserStyleName
+//---------------------------------------------------------
+
+void EditStyle::endEditUserStyleName()
+      {
+      int row = textStyles->currentRow();
+      Tid tid = Tid(textStyles->item(row)->data(Qt::UserRole).toInt());
+      int idx = int(tid) - int(Tid::USER1);
+      if ((idx < 0) || (idx > 5)) {
+            qDebug("User style index %d outside of range [0,5].", idx);
+            return;
+            }
+      Sid sid[] = { Sid::user1Name, Sid::user2Name, Sid::user3Name, Sid::user4Name, Sid::user5Name, Sid::user6Name };
+      QString name = styleName->text();
+      cs->undoChangeStyleVal(sid[idx], name);
+      if (name == "") {
+            name = textStyleUserName(tid);
+            styleName->setText(name);
+            textStyles->item(row)->setText(name);
+            resetTextStyleName->setEnabled(false);
+            }
+      MuseScoreCore::mscoreCore->updateInspector();
+      }
+//---------------------------------------------------------
+//   resetUserStyleName
+//---------------------------------------------------------
+
+void EditStyle::resetUserStyleName()
+      {
+      styleName->clear();
+      endEditUserStyleName();
+      }
+
 } //namespace Ms
 

--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -79,6 +79,9 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       void textStyleValueChanged(Pid, QVariant);
       void on_comboFBFont_currentIndexChanged(int index);
       void on_buttonTogglePagelist_clicked();
+      void editUserStyleName();
+      void endEditUserStyleName();
+      void resetUserStyleName();
 
 public:
       static const int PAGE_NOTE = 6;

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -10362,13 +10362,6 @@
              </property>
             </widget>
            </item>
-           <item row="6" column="0" colspan="2">
-            <widget class="QCheckBox" name="textStyleSpatiumDependent">
-             <property name="text">
-              <string>Size changes with staff space setting</string>
-             </property>
-            </widget>
-           </item>
           </layout>
          </widget>
         </item>
@@ -10689,6 +10682,34 @@
            <property name="spacing">
             <number>0</number>
            </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="labelStyleName">
+             <property name="text">
+              <string>Name:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="styleName">
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QToolButton" name="resetTextStyleName">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Name'</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
            <item row="7" column="1">
             <widget class="QComboBox" name="textStyleFrameType"/>
            </item>
@@ -10845,10 +10866,18 @@
             <widget class="QDoubleSpinBox" name="textStyleFrameBorder"/>
            </item>
            <item row="8" column="1">
-            <widget class="Awl::ColorLabel" name="textStyleFrameForeground"/>
+            <widget class="Awl::ColorLabel" name="textStyleFrameForeground">
+             <property name="frameShape">
+              <enum>QFrame::Box</enum>
+             </property>
+            </widget>
            </item>
            <item row="9" column="1">
-            <widget class="Awl::ColorLabel" name="textStyleFrameBackground"/>
+            <widget class="Awl::ColorLabel" name="textStyleFrameBackground">
+             <property name="frameShape">
+              <enum>QFrame::Box</enum>
+             </property>
+            </widget>
            </item>
            <item row="12" column="0">
             <widget class="QLabel" name="label_212">
@@ -10993,6 +11022,13 @@
              <property name="icon">
               <iconset resource="musescore.qrc">
                <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0" colspan="2">
+            <widget class="QCheckBox" name="textStyleSpatiumDependent">
+             <property name="text">
+              <string>Size changes with staff space setting</string>
              </property>
             </widget>
            </item>

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -1001,11 +1001,7 @@ InspectorTempoText::InspectorTempoText(QWidget* parent)
             { tt.title, tt.panel }
             };
       populatePlacement(tt.placement);
-
-      tt.style->clear();
-      for (auto ss : primaryTextStyles())
-            tt.style->addItem(textStyleUserName(ss), int(ss));
-
+      populateStyle(tt.style);
       mapSignals(il, ppList);
       connect(tt.followText, SIGNAL(toggled(bool)), tt.tempo, SLOT(setDisabled(bool)));
       }
@@ -1040,11 +1036,7 @@ InspectorLyric::InspectorLyric(QWidget* parent)
             { l.title, l.panel }
             };
       populatePlacement(l.placement);
-
-      l.style->clear();
-      for (auto ss : primaryTextStyles())
-            l.style->addItem(textStyleUserName(ss), int(ss));
-
+      populateStyle(l.style);
       mapSignals(il, ppList);
       connect(t.resetToStyle, SIGNAL(clicked()), SLOT(resetToStyle()));
       }
@@ -1078,11 +1070,7 @@ InspectorStaffText::InspectorStaffText(QWidget* parent)
             { s.title, s.panel }
             };
       populatePlacement(s.placement);
-
-      s.style->clear();
-      for (auto ss : primaryTextStyles())
-            s.style->addItem(textStyleUserName(ss), int(ss));
-
+      populateStyle(s.style);
       mapSignals(il, ppList);
       }
 

--- a/mscore/inspector/inspectorDynamic.cpp
+++ b/mscore/inspector/inspectorDynamic.cpp
@@ -35,11 +35,7 @@ InspectorDynamic::InspectorDynamic(QWidget* parent)
             { d.title, d.panel }
             };
       populatePlacement(d.placement);
-
-      d.style->clear();
-      for (auto ss : primaryTextStyles())
-            d.style->addItem(textStyleUserName(ss), int(ss));
-
+      populateStyle(d.style);
       mapSignals(il, ppList);
       }
 

--- a/mscore/inspector/inspectorHarmony.cpp
+++ b/mscore/inspector/inspectorHarmony.cpp
@@ -36,12 +36,8 @@ InspectorHarmony::InspectorHarmony(QWidget* parent)
             { h.title, h.panel }
             };
 
-      h.style->clear();
-      for (auto ss : primaryTextStyles())
-            h.style->addItem(textStyleUserName(ss), int(ss));
-
+      populateStyle(h.style);
       t.resetToStyle->setVisible(false);
-
       mapSignals(iiList, ppList);
       }
 

--- a/mscore/inspector/inspectorText.cpp
+++ b/mscore/inspector/inspectorText.cpp
@@ -34,10 +34,7 @@ InspectorText::InspectorText(QWidget* parent)
             { f.title, f.panel }
             };
 
-      f.style->clear();
-      for (auto ss : primaryTextStyles())
-            f.style->addItem(textStyleUserName(ss), int(ss));
-
+      populateStyle(f.style);
       mapSignals(iiList, ppList);
       }
 

--- a/mscore/inspector/inspectorTextBase.cpp
+++ b/mscore/inspector/inspectorTextBase.cpp
@@ -13,6 +13,7 @@
 #include "inspector.h"
 #include "inspectorTextBase.h"
 #include "libmscore/text.h"
+#include "libmscore/score.h"
 #include "icons.h"
 
 namespace Ms {
@@ -25,6 +26,7 @@ InspectorTextBase::InspectorTextBase(QWidget* parent)
    : InspectorElementBase(parent)
       {
       t.setupUi(addWidget());
+      style = nullptr;
 
       const std::vector<InspectorItem> iiList = {
             { Pid::FONT_FACE,         0, t.fontFace,     t.resetFontFace     },
@@ -88,6 +90,26 @@ void InspectorTextBase::setElement()
       updateFrame();
       TextBase* text = toTextBase(inspector->element());
       t.resetToStyle->setEnabled(text->hasCustomFormatting());
+      populateStyle(style);
+      }
+
+//---------------------------------------------------------
+//   populateStyle
+//---------------------------------------------------------
+
+void InspectorTextBase::populateStyle(QComboBox* style)
+      {
+      if (style) {
+            this->style = style;
+            Score* score = inspector->element()->score();
+            style->blockSignals(true);
+            int idx = style->currentIndex();
+            style->clear();
+            for (auto ss : primaryTextStyles())
+                  style->addItem(score->getTextStyleUserName(ss), int(ss));
+            style->setCurrentIndex(idx);
+            style->blockSignals(false);
+            }
       }
 
 } // namespace Ms

--- a/mscore/inspector/inspectorTextBase.h
+++ b/mscore/inspector/inspectorTextBase.h
@@ -27,6 +27,7 @@ class InspectorTextBase : public InspectorElementBase {
 
       virtual void valueChanged(int, bool) override;
       void updateFrame();
+      QComboBox* style;
 
    protected:
       Ui::InspectorText t;
@@ -34,6 +35,7 @@ class InspectorTextBase : public InspectorElementBase {
    public:
       InspectorTextBase(QWidget* parent);
       virtual void setElement() override;
+      void populateStyle(QComboBox* style);
       };
 
 } // namespace Ms


### PR DESCRIPTION
See https://musescore.org/en/node/276461.

This allows user text styles to be renamed, and preserves user text style names imported from 2.x.