### PR TITLE
fix XML syntax: close every tag opened

### DIFF
--- a/build/Linux+BSD/mscore.appdata.xml.in
+++ b/build/Linux+BSD/mscore.appdata.xml.in
@@ -102,7 +102,7 @@
   </kudos>
 
   <releases>
-    <release version="3.0">
+    <release version="3.0"/>
     <release version="2.3.2" date="2018-07-31">
       <description>
         <p>


### PR DESCRIPTION
I understand that this will later be extended with the changes once 3.0 is released, but please let’s keep files not invalid