### PR TITLE
make it impossible to enable OCR due to licence reasons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,9 @@ option(USE_SYSTEM_FREETYPE "Use system FreeType" OFF)          # requires freety
 option(BUILD_LAME    "Enable MP3 export" ON)                   # Requires libmp3lame (non-free), call CMake with -DBUILD_LAME="OFF" to disable
 option(DOWNLOAD_SOUNDFONT "Download the latest soundfont version as part of the build process" ON)
 
+# licence incompatibility, must never be distributed
+set(OCR OFF)
+
 SET(JACK_LONGNAME "JACK (Jack Audio Connection Kit)")
 SET(JACK_MIN_VERSION "0.98.0")
 option(BUILD_JACK    "Build with support for ${JACK_LONGNAME} audio backend. JACK >= ${JACK_MIN_VERSION} will be needed." ON)


### PR DESCRIPTION
Tesseract is published under the Apache v2 licence, which is incompatible with the GPLv2 MuseScore itself is under.

Let’s not create another situation like https://musescore.org/en/node/277757