### PR TITLE
remove RCS IDs from (almost) all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2012 by Werner Schweer and others
 #

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2007 by Werner Schweer and others
 #

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2007 by Werner Schweer and others
 #

--- a/aeolus/CMakeLists.txt
+++ b/aeolus/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2010 by Werner Schweer and others
 #

--- a/aeolus/aeolus.h
+++ b/aeolus/aeolus.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/aeolus/sparm.cpp
+++ b/aeolus/sparm.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/aeolus/sparm.h
+++ b/aeolus/sparm.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/aeolus/sparm_p.h
+++ b/aeolus/sparm_p.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/all.cpp
+++ b/all.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE
 //  Linux Music Score Editor
-//  $Id: allqt.h,v 1.24 2006/03/02 17:08:30 wschweer Exp $
 //
 //  Copyright (C) 2004-2011 Werner Schweer (ws@seh.de)
 //

--- a/all.h
+++ b/all.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE
 //  Linux Music Score Editor
-//  $Id: allqt.h,v 1.24 2006/03/02 17:08:30 wschweer Exp $
 //
 //  Copyright (C) 2004-2011 Werner Schweer (ws@seh.de)
 //

--- a/awl/CMakeLists.txt
+++ b/awl/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2016 by Werner Schweer and others
 #

--- a/awl/aslider.cpp
+++ b/awl/aslider.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/aslider.h
+++ b/awl/aslider.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/awlplugin.cpp
+++ b/awl/awlplugin.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2009 by Werner Schweer and others
 //

--- a/awl/awlplugin.h
+++ b/awl/awlplugin.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/colorlabel.cpp
+++ b/awl/colorlabel.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/colorlabel.h
+++ b/awl/colorlabel.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2007 by Werner Schweer and others
 //

--- a/awl/denomspinbox.cpp
+++ b/awl/denomspinbox.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2009 by Werner Schweer and others
 //

--- a/awl/denomspinbox.h
+++ b/awl/denomspinbox.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2009 by Werner Schweer and others
 //

--- a/awl/knob.cpp
+++ b/awl/knob.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/knob.h
+++ b/awl/knob.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/midipanknob.cpp
+++ b/awl/midipanknob.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/midipanknob.h
+++ b/awl/midipanknob.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/mslider.cpp
+++ b/awl/mslider.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/mslider.h
+++ b/awl/mslider.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/panknob.cpp
+++ b/awl/panknob.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/panknob.h
+++ b/awl/panknob.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/pitchedit.cpp
+++ b/awl/pitchedit.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/pitchedit.h
+++ b/awl/pitchedit.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/pitchlabel.cpp
+++ b/awl/pitchlabel.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/pitchlabel.h
+++ b/awl/pitchlabel.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/posedit.cpp
+++ b/awl/posedit.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/posedit.h
+++ b/awl/posedit.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/poslabel.cpp
+++ b/awl/poslabel.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/poslabel.h
+++ b/awl/poslabel.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2009 by Werner Schweer and others
 //

--- a/awl/slider.cpp
+++ b/awl/slider.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/slider.h
+++ b/awl/slider.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/utils.cpp
+++ b/awl/utils.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/utils.h
+++ b/awl/utils.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/volknob.cpp
+++ b/awl/volknob.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/volknob.h
+++ b/awl/volknob.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/volslider.cpp
+++ b/awl/volslider.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/awl/volslider.h
+++ b/awl/volslider.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  Awl
 //  Audio Widget Library
-//  $Id:$
 //
 //  Copyright (C) 2002-2006 by Werner Schweer and others
 //

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE
 //  Linux Music Editor
-//  $Id:$
 //
 //  Copyright (C) 2002-2010 by Werner Schweer and others
 //

--- a/build/gch.cmake
+++ b/build/gch.cmake
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2011 by Werner Schweer and others
 #

--- a/bww2mxml/CMakeLists.txt
+++ b/bww2mxml/CMakeLists.txt
@@ -2,7 +2,6 @@
 #  BWW to MusicXML converter
 #  Part of MusE Score
 #  Linux Music Score Editor
-#  $Id: CMakeLists.txt 5560 2012-04-19 11:39:34Z lasconic $
 #
 #  Copyright (C) 2002-2010 by Werner Schweer and others
 #

--- a/bww2mxml/bww2mxml.pro
+++ b/bww2mxml/bww2mxml.pro
@@ -2,7 +2,6 @@
 #  BWW to MusicXML converter
 #  Part of MusE Score
 #  Linux Music Score Editor
-#  $Id: bww2mxml.pro 3115 2010-05-30 14:17:03Z lvinken $
 #
 #  Copyright (C) 2002-2010 by Werner Schweer and others
 #

--- a/bww2mxml/lexer.cpp
+++ b/bww2mxml/lexer.cpp
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: lexer.cpp 4873 2011-10-19 19:33:04Z lvinken $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/bww2mxml/lexer.h
+++ b/bww2mxml/lexer.h
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: lexer.h 4873 2011-10-19 19:33:04Z lvinken $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/bww2mxml/main.cpp
+++ b/bww2mxml/main.cpp
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: main.cpp 3166 2010-06-14 15:31:37Z lasconic $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/bww2mxml/mxmlwriter.cpp
+++ b/bww2mxml/mxmlwriter.cpp
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: mxmlwriter.cpp 4873 2011-10-19 19:33:04Z lvinken $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/bww2mxml/mxmlwriter.h
+++ b/bww2mxml/mxmlwriter.h
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: mxmlwriter.h 4873 2011-10-19 19:33:04Z lvinken $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/bww2mxml/parser.cpp
+++ b/bww2mxml/parser.cpp
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: parser.cpp 4873 2011-10-19 19:33:04Z lvinken $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/bww2mxml/parser.h
+++ b/bww2mxml/parser.h
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: parser.h 4873 2011-10-19 19:33:04Z lvinken $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/bww2mxml/symbols.cpp
+++ b/bww2mxml/symbols.cpp
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: symbols.cpp 4873 2011-10-19 19:33:04Z lvinken $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/bww2mxml/symbols.h
+++ b/bww2mxml/symbols.h
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: symbols.h 4873 2011-10-19 19:33:04Z lvinken $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/bww2mxml/writer.cpp
+++ b/bww2mxml/writer.cpp
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: writer.cpp 3166 2010-06-14 15:31:37Z lasconic $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/bww2mxml/writer.h
+++ b/bww2mxml/writer.h
@@ -2,7 +2,6 @@
 //  BWW to MusicXML converter
 //  Part of MusE Score
 //  Linux Music Score Editor
-//  $Id: writer.h 4873 2011-10-19 19:33:04Z lvinken $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2008 by Werner Schweer and others
 #

--- a/fluid/CMakeLists.txt
+++ b/fluid/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2007 by Werner Schweer and others
 #

--- a/fonttools/CMakeLists.txt
+++ b/fonttools/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/libmscore/CMakeLists.txt
+++ b/libmscore/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2016 Werner Schweer
 #

--- a/libmscore/mcursor.cpp
+++ b/libmscore/mcursor.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/libmscore/mcursor.h
+++ b/libmscore/mcursor.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/manual/CMakeLists.txt
+++ b/manual/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mscore/abstractdialog.cpp
+++ b/mscore/abstractdialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: abstractdialog.cpp 4220 2011-04-22 10:31:26Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/abstractdialog.h
+++ b/mscore/abstractdialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: abstractdialog.h 4220 2011-04-22 10:31:26Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/alsa.cpp
+++ b/mscore/alsa.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: alsa.cpp 5660 2012-05-22 14:17:39Z wschweer $
 //
 //  AlsaDriver based on code from Fons Adriaensen (clalsadr.cc)
 //    Copyright (C) 2003 Fons Adriaensen

--- a/mscore/alsa.h
+++ b/mscore/alsa.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: alsa.h 5660 2012-05-22 14:17:39Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/alsamidi.h
+++ b/mscore/alsamidi.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: alsamidi.h 1840 2009-05-20 11:57:51Z wschweer $
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/analyse.h
+++ b/mscore/analyse.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: analyse.h 1840 2009-05-20 11:57:51Z wschweer $
 //
 //  Copyright (C) 2007-2009 Werner Schweer and others
 //

--- a/mscore/articulationprop.cpp
+++ b/mscore/articulationprop.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: articulation.cpp -1   $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/articulationprop.h
+++ b/mscore/articulationprop.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: articulation.h -1   $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/bb.cpp
+++ b/mscore/bb.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: bb.cpp 5427 2012-03-07 12:41:34Z wschweer $
 //
 //  Copyright (C) 2008-2011 Werner Schweer
 //

--- a/mscore/bb.h
+++ b/mscore/bb.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: bb.h 4823 2011-09-28 16:38:17Z wschweer $
 //
 //  Copyright (C) 2009-2011 Werner Schweer
 //

--- a/mscore/bendcanvas.h
+++ b/mscore/bendcanvas.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/bendproperties.cpp
+++ b/mscore/bendproperties.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010-2011 Werner Schweer and others
 //

--- a/mscore/bendproperties.h
+++ b/mscore/bendproperties.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/breaksdialog.cpp
+++ b/mscore/breaksdialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: breaks.cpp -1   $
 //
 //  Copyright (C) 2008-2011 Werner Schweer and others
 //

--- a/mscore/breaksdialog.h
+++ b/mscore/breaksdialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: breaksdialog -1   $
 //
 //  Copyright (C) 2008-2014 Werner Schweer and others
 //

--- a/mscore/capella.cpp
+++ b/mscore/capella.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: capella.cpp 5637 2012-05-16 14:23:09Z wschweer $
 //
 //  Copyright (C) 2009-2013 Werner Schweer and others
 //

--- a/mscore/capella.h
+++ b/mscore/capella.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: capella.h 3833 2011-01-04 13:55:40Z wschweer $
 //
 //  Copyright (C) 2009-2013 Werner Schweer and others
 //

--- a/mscore/click.h
+++ b/mscore/click.h
@@ -14,8 +14,6 @@
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-    $Id: default_click.h,v 1.1.2.1 2004/11/15 23:25:51 spamatica Exp $
 */
 
 static const double tack[] = {

--- a/mscore/debugger/debugger.cpp
+++ b/mscore/debugger/debugger.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: debugger.cpp 5656 2012-05-21 15:36:47Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/debugger/debugger.h
+++ b/mscore/debugger/debugger.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: debugger.h 5383 2012-02-27 07:38:15Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2002-2011 Werner Schweer
 //

--- a/mscore/dragelement.cpp
+++ b/mscore/dragelement.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer
 //

--- a/mscore/driver.h
+++ b/mscore/driver.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: driver.h 5660 2012-05-22 14:17:39Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/drumroll.cpp
+++ b/mscore/drumroll.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/drumroll.h
+++ b/mscore/drumroll.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/drumtools.cpp
+++ b/mscore/drumtools.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: drumtools.cpp
 //
 //  Copyright (C) 2010-2016 Werner Schweer and others
 //

--- a/mscore/drumtools.h
+++ b/mscore/drumtools.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$ drumtools.h
 //
 //  Copyright (C) 2010-2016 Werner Schweer and others
 //

--- a/mscore/drumview.cpp
+++ b/mscore/drumview.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/drumview.h
+++ b/mscore/drumview.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/editdrumset.cpp
+++ b/mscore/editdrumset.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: editdrumset.cpp 5384 2012-02-27 12:21:49Z wschweer $
 //
 //  Copyright (C) 2002-2007 Werner Schweer and others
 //

--- a/mscore/editdrumset.h
+++ b/mscore/editdrumset.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: editdrumset.h 4388 2011-06-18 13:17:58Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/editinstrument.cpp
+++ b/mscore/editinstrument.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: editinstrument.cpp 4874 2011-10-21 12:18:42Z wschweer $
 //
 //  Copyright (C) 2002-2007 Werner Schweer and others
 //

--- a/mscore/editinstrument.h
+++ b/mscore/editinstrument.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: editinstrument.h 4052 2011-02-23 15:29:16Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/editpitch.cpp
+++ b/mscore/editpitch.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: editpitch.cpp 3775 2010-12-17 23:55:35Z miwarre $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/editpitch.h
+++ b/mscore/editpitch.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: editpitch.h 3775 2010-12-17 23:55:35Z miwarre $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/editraster.cpp
+++ b/mscore/editraster.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: mscore.cpp 4014 2011-02-14 14:30:49Z wschweer $
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/editraster.h
+++ b/mscore/editraster.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: mscore.cpp 4014 2011-02-14 14:30:49Z wschweer $
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: editstaff.cpp 5149 2011-12-29 08:38:43Z wschweer $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/editstaff.h
+++ b/mscore/editstaff.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: editstaff.h 4953 2011-11-04 13:04:28Z wschweer $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/editstringdata.cpp
+++ b/mscore/editstringdata.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: editstringdata.cpp 5392 2012-02-28 11:41:52Z miwarre $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: editstyle.h 5403 2012-03-03 00:01:53Z miwarre $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/excerptsdialog.cpp
+++ b/mscore/excerptsdialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: excerptsdialog.cpp 5497 2012-03-26 10:59:16Z lasconic $
 //
 //  Copyright (C) 2008 Werner Schweer and others
 //

--- a/mscore/excerptsdialog.h
+++ b/mscore/excerptsdialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: excerptsdialog.h 5254 2012-01-26 10:03:53Z wschweer $
 //
 //  Copyright (C) 2008-2009 Werner Schweer and others
 //

--- a/mscore/exportaudio.cpp
+++ b/mscore/exportaudio.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: exportaudio.cpp 5660 2012-05-22 14:17:39Z wschweer $
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/exportly.cpp
+++ b/mscore/exportly.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: exportly.cpp 5510 2012-03-30 14:51:09Z wschweer $
 //
 //  Copyright (C) 2007 Werner Schweer and others
 //

--- a/mscore/exportmp3.cpp
+++ b/mscore/exportmp3.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: MP3Exporter.cpp 2992 2010-04-22 14:42:39Z lasconic $
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/exportmp3.h
+++ b/mscore/exportmp3.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: exportxml.cpp 5598 2012-04-30 07:20:39Z lvinken $
 //
 //  Copyright (C) 2002-2013 Werner Schweer and others
 //

--- a/mscore/extension.cpp
+++ b/mscore/extension.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2018 Werner Schweer and others
 //

--- a/mscore/extension.h
+++ b/mscore/extension.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2018 Werner Schweer and others
 //

--- a/mscore/file.h
+++ b/mscore/file.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: file.h 5009 2011-11-18 21:46:17Z lasconic $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/fretcanvas.h
+++ b/mscore/fretcanvas.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/fretproperties.cpp
+++ b/mscore/fretproperties.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010-2011 Werner Schweer and others
 //

--- a/mscore/fretproperties.h
+++ b/mscore/fretproperties.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/globals.h
+++ b/mscore/globals.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: globals.h 5576 2012-04-24 19:15:22Z wschweer $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/harmonycanvas.h
+++ b/mscore/harmonycanvas.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009-2011 Werner Schweer and others
 //

--- a/mscore/harmonyedit.cpp
+++ b/mscore/harmonyedit.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009-2011 Werner Schweer and others
 //

--- a/mscore/harmonyedit.h
+++ b/mscore/harmonyedit.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009-2011 Werner Schweer and others
 //

--- a/mscore/icons.cpp
+++ b/mscore/icons.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: icons.cpp 5246 2012-01-24 18:48:55Z wschweer $
 //
 //  Copyright (C) 2002-2007 Werner Schweer and others
 //

--- a/mscore/icons.h
+++ b/mscore/icons.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: icons.h 5246 2012-01-24 18:48:55Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/importbww.cpp
+++ b/mscore/importbww.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: importbww.cpp 5427 2012-03-07 12:41:34Z wschweer $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/importgtp.h
+++ b/mscore/importgtp.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/importove.cpp
+++ b/mscore/importove.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: importove.cpp 3763 2010-12-15 15:50:09Z vanferry $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: inspector.cpp
 //
 //  Copyright (C) 2011-2016 Werner Schweer
 //

--- a/mscore/inspector/inspectorArpeggio.cpp
+++ b/mscore/inspector/inspectorArpeggio.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2013 Werner Schweer
 //

--- a/mscore/inspector/inspectorBarline.h
+++ b/mscore/inspector/inspectorBarline.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: inspector.h
 //
 //  Copyright (C) 2016 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011-2013 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorBase.h
+++ b/mscore/inspector/inspectorBase.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorBeam.cpp
+++ b/mscore/inspector/inspectorBeam.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorBeam.h
+++ b/mscore/inspector/inspectorBeam.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorGlissando.cpp
+++ b/mscore/inspector/inspectorGlissando.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2013 Werner Schweer
 //

--- a/mscore/inspector/inspectorGlissando.h
+++ b/mscore/inspector/inspectorGlissando.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2013 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorGroupElement.cpp
+++ b/mscore/inspector/inspectorGroupElement.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorGroupElement.h
+++ b/mscore/inspector/inspectorGroupElement.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorHairpin.cpp
+++ b/mscore/inspector/inspectorHairpin.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mscore/inspector/inspectorHairpin.h
+++ b/mscore/inspector/inspectorHairpin.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorHarmony.cpp
+++ b/mscore/inspector/inspectorHarmony.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorHarmony.h
+++ b/mscore/inspector/inspectorHarmony.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorImage.cpp
+++ b/mscore/inspector/inspectorImage.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorImage.h
+++ b/mscore/inspector/inspectorImage.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorJump.h
+++ b/mscore/inspector/inspectorJump.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2013 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorLasso.cpp
+++ b/mscore/inspector/inspectorLasso.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorLasso.h
+++ b/mscore/inspector/inspectorLasso.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorMarker.h
+++ b/mscore/inspector/inspectorMarker.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2013 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorOttava.cpp
+++ b/mscore/inspector/inspectorOttava.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mscore/inspector/inspectorOttava.h
+++ b/mscore/inspector/inspectorOttava.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorTrill.cpp
+++ b/mscore/inspector/inspectorTrill.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mscore/inspector/inspectorTrill.h
+++ b/mscore/inspector/inspectorTrill.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer and others
 //

--- a/mscore/inspector/inspectorVibrato.cpp
+++ b/mscore/inspector/inspectorVibrato.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mscore/inspector/inspectorVolta.cpp
+++ b/mscore/inspector/inspectorVolta.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mscore/inspector/inspectorVolta.h
+++ b/mscore/inspector/inspectorVolta.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer and others
 //

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: instrdialog.cpp 5580 2012-04-27 15:36:57Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: instrdialog.cpp 5580 2012-04-27 15:36:57Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/jackaudio.cpp
+++ b/mscore/jackaudio.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: jackaudio.cpp 5660 2012-05-22 14:17:39Z wschweer $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/jackaudio.h
+++ b/mscore/jackaudio.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: jackaudio.h 4147 2011-04-07 14:39:44Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/jackweakapi.cpp
+++ b/mscore/jackweakapi.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:
 //
 //  jackWeakAPI based on code from Stéphane Letz (Grame)
 //  partly based on Julien Pommier (PianoTeq : http://www.pianoteq.com/) code.

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: keyb.cpp 5658 2012-05-21 18:40:58Z wschweer $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/keycanvas.h
+++ b/mscore/keycanvas.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/keyedit.cpp
+++ b/mscore/keyedit.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009-2011 Werner Schweer and others
 //

--- a/mscore/keyedit.h
+++ b/mscore/keyedit.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/layer.cpp
+++ b/mscore/layer.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: mscore.cpp 4220 2011-04-22 10:31:26Z wschweer $
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/layer.h
+++ b/mscore/layer.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: mscore.cpp 4220 2011-04-22 10:31:26Z wschweer $
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/magbox.cpp
+++ b/mscore/magbox.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: magbox.cpp 5568 2012-04-22 10:08:43Z wschweer $
 //
 //  Copyright (C) 2002-2008 Werner Schweer and others
 //

--- a/mscore/magbox.h
+++ b/mscore/magbox.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: magbox.h 2460 2009-12-15 18:01:39Z wschweer $
 //
 //  Copyright (C) 2008-2009 Werner Schweer and others
 //

--- a/mscore/masterpalette.cpp
+++ b/mscore/masterpalette.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: masterpalette.cpp
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/masterpalette.h
+++ b/mscore/masterpalette.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: masterpalette.h 5242 2012-01-23 17:25:56Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer
 //

--- a/mscore/measureproperties.cpp
+++ b/mscore/measureproperties.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: measureproperties.cpp 5628 2012-05-15 07:46:43Z wschweer $
 //
 //  Copyright (C) 2007 Werner Schweer and others
 //

--- a/mscore/measureproperties.h
+++ b/mscore/measureproperties.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: measureproperties.h 4720 2011-08-31 18:10:05Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/mediadialog.cpp
+++ b/mscore/mediadialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 20011 Werner Schweer and others
 //

--- a/mscore/mediadialog.h
+++ b/mscore/mediadialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: menus.cpp 5651 2012-05-19 15:57:26Z lasconic $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/metaedit.cpp
+++ b/mscore/metaedit.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: metaedit.cpp 5290 2012-02-07 16:27:27Z wschweer $
 //
 //  Copyright (C) 2002-2008 Werner Schweer and others
 //

--- a/mscore/metaedit.h
+++ b/mscore/metaedit.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: metaedit.h 5290 2012-02-07 16:27:27Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/mididriver.cpp
+++ b/mscore/mididriver.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: mididriver.cpp 5568 2012-04-22 10:08:43Z wschweer $
 //
 //  Copyright (C) 2008 Werner Schweer and others
 //

--- a/mscore/mididriver.h
+++ b/mscore/mididriver.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: mididriver.h 2154 2009-10-03 14:31:53Z wschweer $
 //
 //  Copyright (C) 2008-2009 Werner Schweer and others
 //

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: mixer.cpp 5651 2012-05-19 15:57:26Z lasconic $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/mixer.h
+++ b/mscore/mixer.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: mixer.h 4388 2011-06-18 13:17:58Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/musedata.cpp
+++ b/mscore/musedata.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: musedata.cpp 5497 2012-03-26 10:59:16Z lasconic $
 //
 //  Copyright (C) 2007 Werner Schweer and others
 //

--- a/mscore/musedata.h
+++ b/mscore/musedata.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: musedata.h 1840 2009-05-20 11:57:51Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: musescore.h 5657 2012-05-21 15:46:06Z lasconic $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/musicxmlsupport.cpp
+++ b/mscore/musicxmlsupport.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: musicxmlsupport.cpp 5595 2012-04-29 15:30:32Z lvinken $
 //
 //  Copyright (C) 2012 Werner Schweer and others
 //

--- a/mscore/musicxmlsupport.h
+++ b/mscore/musicxmlsupport.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: musicxmlsupport.h 5595 2012-04-29 15:30:32Z lvinken $
 //
 //  Copyright (C) 2012 Werner Schweer and others
 //

--- a/mscore/navigator.h
+++ b/mscore/navigator.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: navigator.h 4785 2011-09-14 10:06:35Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -2,7 +2,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: newwizard.cpp 5626 2012-05-13 18:33:52Z lasconic $
 //
 //  Copyright (C) 2008 Werner Schweer and others
 //

--- a/mscore/newwizard.h
+++ b/mscore/newwizard.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: newwizard.h 5149 2011-12-29 08:38:43Z wschweer $
 //
 //  Copyright (C) 2008-2009 Werner Schweer and others
 //

--- a/mscore/omrpanel.cpp
+++ b/mscore/omrpanel.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/omrpanel.h
+++ b/mscore/omrpanel.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/osc.cpp
+++ b/mscore/osc.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: musescore.cpp 4961 2011-11-11 16:24:17Z lasconic $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/ove.cpp
+++ b/mscore/ove.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: importove.cpp 4287 2011-05-17 14:50:09Z vanferry $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/ove.h
+++ b/mscore/ove.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: importove.cpp 3763 2010-12-15 15:52:09Z vanferry $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/pa.cpp
+++ b/mscore/pa.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: pa.cpp 5662 2012-05-23 07:35:47Z wschweer $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/pa.h
+++ b/mscore/pa.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: pa.h 4147 2011-04-07 14:39:44Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: palette.cpp 5576 2012-04-24 19:15:22Z wschweer $
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/palette.h
+++ b/mscore/palette.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: palette.h 5395 2012-02-28 18:09:57Z wschweer $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/palettebox.cpp
+++ b/mscore/palettebox.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: palettebox.cpp 5576 2012-04-24 19:15:22Z wschweer $
 //
 //  Copyright (C) 2011-2016 Werner Schweer and others
 //

--- a/mscore/palettebox.h
+++ b/mscore/palettebox.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: palettebox.h 5576 2012-04-24 19:15:22Z wschweer $
 //
 //  Copyright (C) 2011-2016 Werner Schweer and others
 //

--- a/mscore/partedit.h
+++ b/mscore/partedit.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: partedit.h 2278 2009-10-30 16:56:11Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/piano.cpp
+++ b/mscore/piano.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/piano.h
+++ b/mscore/piano.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/pianokeyboard.cpp
+++ b/mscore/pianokeyboard.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/pianokeyboard.h
+++ b/mscore/pianokeyboard.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/pianolevels.cpp
+++ b/mscore/pianolevels.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/pianolevels.h
+++ b/mscore/pianolevels.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/pianolevelschooser.h
+++ b/mscore/pianolevelschooser.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/pianolevelsfilter.h
+++ b/mscore/pianolevelsfilter.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/pianoruler.cpp
+++ b/mscore/pianoruler.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/pianoruler.h
+++ b/mscore/pianoruler.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2011-2016 Werner Schweer and others
 //

--- a/mscore/pianotools.h
+++ b/mscore/pianotools.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2011-2016 Werner Schweer and others
 //

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: playpanel.cpp 4775 2011-09-12 14:25:31Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/playpanel.h
+++ b/mscore/playpanel.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: playpanel.h 4722 2011-09-01 12:26:07Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/pluginManager.cpp
+++ b/mscore/pluginManager.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: palette.cpp 5576 2012-04-24 19:15:22Z wschweer $
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/pluginManager.h
+++ b/mscore/pluginManager.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: palette.cpp 5576 2012-04-24 19:15:22Z wschweer $
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/pm.cpp
+++ b/mscore/pm.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: pm.cpp 4874 2011-10-21 12:18:42Z wschweer $
 //
 //  Copyright (C) 2002-2007 Werner Schweer and others
 //

--- a/mscore/pm.h
+++ b/mscore/pm.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: pm.h 2936 2010-04-04 11:42:11Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: preferences.cpp 5660 2012-05-22 14:17:39Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: preferences.h 5660 2012-05-22 14:17:39Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/prefsdialog.h
+++ b/mscore/prefsdialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/recordbutton.h
+++ b/mscore/recordbutton.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE
 //  Linux Music Editor
-//  $Id: recordbutton.h 1840 2009-05-20 11:57:51Z wschweer $
 //
 //  Copyright (C) 2002-2009 by Werner Schweer and others
 //

--- a/mscore/ruler.cpp
+++ b/mscore/ruler.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/ruler.h
+++ b/mscore/ruler.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/savePositions.cpp
+++ b/mscore/savePositions.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/scoretab.cpp
+++ b/mscore/scoretab.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009-2010 Werner Schweer and others
 //

--- a/mscore/scoretab.h
+++ b/mscore/scoretab.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/sectionbreakprop.cpp
+++ b/mscore/sectionbreakprop.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: layoutbreak.cpp -1   $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/sectionbreakprop.h
+++ b/mscore/sectionbreakprop.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: layoutbreak.h -1   $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/selectdialog.cpp
+++ b/mscore/selectdialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: select.cpp -1   $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/selectdialog.h
+++ b/mscore/selectdialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: select.h 3779 2010-12-19 11:39:26Z wschweer $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/selectionwindow.cpp
+++ b/mscore/selectionwindow.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: selectionwindow.cpp 4775 2011-09-12 14:25:31Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/selectionwindow.h
+++ b/mscore/selectionwindow.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: selectionwindow.h 4775 2011-09-12 14:25:31Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/selectnotedialog.cpp
+++ b/mscore/selectnotedialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: select.cpp -1   $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/selectnotedialog.h
+++ b/mscore/selectnotedialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: select.h 3779 2010-12-19 11:39:26Z wschweer $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/selinstrument.cpp
+++ b/mscore/selinstrument.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: editstaff.cpp 3629 2010-10-26 10:40:47Z wschweer $
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/selinstrument.h
+++ b/mscore/selinstrument.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: editstaff.h 3629 2010-10-26 10:40:47Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: seq.cpp 5660 2012-05-22 14:17:39Z wschweer $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/seq.h
+++ b/mscore/seq.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: seq.h 5660 2012-05-22 14:17:39Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011-2016 Werner Schweer and others
 //

--- a/mscore/shortcut.h
+++ b/mscore/shortcut.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2011-2016 Werner Schweer and others
 //

--- a/mscore/shortcutcapturedialog.cpp
+++ b/mscore/shortcutcapturedialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: shortcutcapturedialog.cpp 5537 2012-04-16 07:55:10Z wschweer $
 //
 //  Copyright (C) 2002-2007 Werner Schweer and others
 //  Copyright (C) 2003 Mathias Lundgren (lunar_shuttle@users.sourceforge.net)

--- a/mscore/shortcutcapturedialog.h
+++ b/mscore/shortcutcapturedialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: shortcutcapturedialog.h 5537 2012-04-16 07:55:10Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //  Copyright (C) 2003 Mathias Lundgren <lunar_shuttle@users.sourceforge.net>

--- a/mscore/simplebutton.cpp
+++ b/mscore/simplebutton.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE
 //  Linux Music Editor
-//  $Id: simplebutton.cpp 3437 2010-09-04 18:18:49Z wschweer $
 //
 //  Copyright (C) 2002-2007 by Werner Schweer and others
 //

--- a/mscore/splitstaff.cpp
+++ b/mscore/splitstaff.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2009 Werner Schweer and others
 //

--- a/mscore/splitstaff.h
+++ b/mscore/splitstaff.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: editstaff.h 1840 2009-05-20 11:57:51Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/stafftextproperties.cpp
+++ b/mscore/stafftextproperties.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: stafftext.cpp -1   $
 //
 //  Copyright (C) 2008-2010 Werner Schweer and others
 //

--- a/mscore/stafftextproperties.h
+++ b/mscore/stafftextproperties.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: stafftext.h -1   $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/symboldialog.cpp
+++ b/mscore/symboldialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: symboldialog.cpp 5384 2012-02-27 12:21:49Z wschweer $
 //
 //  Copyright (C) 2007-2016 Werner Schweer and others
 //

--- a/mscore/symboldialog.h
+++ b/mscore/symboldialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: symboldialog.h 4341 2011-06-06 08:18:18Z lasconic $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/synthcontrol.h
+++ b/mscore/synthcontrol.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: synthcontrol.h 2047 2009-08-26 18:33:38Z wschweer $
 //
 //  Copyright (C) 2002-2016 Werner Schweer and others
 //

--- a/mscore/textpalette.cpp
+++ b/mscore/textpalette.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: textpalette.cpp 4612 2011-07-27 13:14:35Z wschweer $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/textpalette.h
+++ b/mscore/textpalette.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: textpalette.h 3734 2010-12-01 10:47:29Z wschweer $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/texttools.cpp
+++ b/mscore/texttools.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: textpalette.cpp 3592 2010-10-18 17:24:18Z wschweer $
 //
 //  Copyright (C) 2002-2010 Werner Schweer and others
 //

--- a/mscore/texttools.h
+++ b/mscore/texttools.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2002-2011 Werner Schweer
 //

--- a/mscore/timedialog.cpp
+++ b/mscore/timedialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: timedialog.cpp 4391 2011-06-18 14:28:24Z wschweer $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: timeline.h 4785 2011-09-14 10:06:35Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/timesigproperties.cpp
+++ b/mscore/timesigproperties.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: restproperties.cpp 1840 2009-05-20 11:57:51Z wschweer $
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/timesigproperties.h
+++ b/mscore/timesigproperties.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: restproperties.h 1840 2009-05-20 11:57:51Z wschweer $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/transposedialog.cpp
+++ b/mscore/transposedialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: transposedialog.cpp 4391 2011-06-18 14:28:24Z wschweer $
 //
 //  Copyright (C) 2008-2010 Werner Schweer and others
 //

--- a/mscore/transposedialog.h
+++ b/mscore/transposedialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: transposedialog.h 4388 2011-06-18 13:17:58Z wschweer $
 //
 //  Copyright (C) 2008-2009 Werner Schweer and others
 //

--- a/mscore/tremolobarcanvas.h
+++ b/mscore/tremolobarcanvas.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/tremolobarprop.cpp
+++ b/mscore/tremolobarprop.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010-2011 Werner Schweer and others
 //

--- a/mscore/tremolobarprop.h
+++ b/mscore/tremolobarprop.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2010 Werner Schweer and others
 //

--- a/mscore/tupletdialog.cpp
+++ b/mscore/tupletdialog.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: tuplet.cpp -1   $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/mscore/tupletdialog.h
+++ b/mscore/tupletdialog.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: tuplet.h -1   $
 //
 //  Copyright (C) 2002-2009 Werner Schweer and others
 //

--- a/mscore/webpage.cpp
+++ b/mscore/webpage.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  The webview is shown on startup with a local file inviting user
 //  to start connecting with the community. They can press start and

--- a/mscore/webpage.h
+++ b/mscore/webpage.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011-2016 Werner Schweer
 #

--- a/mtest/biab/CMakeLists.txt
+++ b/mtest/biab/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2013 Werner Schweer
 #

--- a/mtest/biab/tst_biab.cpp
+++ b/mtest/biab/tst_biab.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2013 Werner Schweer
 //

--- a/mtest/capella/CMakeLists.txt
+++ b/mtest/capella/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2012 Werner Schweer
 #

--- a/mtest/capella/io/CMakeLists.txt
+++ b/mtest/capella/io/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2013 Werner Schweer
 #

--- a/mtest/capella/io/tst_capella_io.cpp
+++ b/mtest/capella/io/tst_capella_io.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2013 Werner Schweer
 //

--- a/mtest/cmake.inc
+++ b/mtest/cmake.inc
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/config.h
+++ b/mtest/config.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE
 //  Linux Music Editor
-//  $Id:$
 //
 //  Copyright (C) 2002-2010 by Werner Schweer and others
 //

--- a/mtest/guitarpro/CMakeLists.txt
+++ b/mtest/guitarpro/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2013 Werner Schweer
 #

--- a/mtest/guitarpro/tst_guitarpro.cpp
+++ b/mtest/guitarpro/tst_guitarpro.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2013 Werner Schweer
 //

--- a/mtest/importmidi/CMakeLists.txt
+++ b/mtest/importmidi/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/beam/CMakeLists.txt
+++ b/mtest/libmscore/beam/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/beam/tst_beam.cpp
+++ b/mtest/libmscore/beam/tst_beam.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/breath/CMakeLists.txt
+++ b/mtest/libmscore/breath/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/breath/tst_breath.cpp
+++ b/mtest/libmscore/breath/tst_breath.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/chordsymbol/CMakeLists.txt
+++ b/mtest/libmscore/chordsymbol/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/chordsymbol/tst_chordsymbol.cpp
+++ b/mtest/libmscore/chordsymbol/tst_chordsymbol.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/compat114/CMakeLists.txt
+++ b/mtest/libmscore/compat114/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/compat114/tst_compat114.cpp
+++ b/mtest/libmscore/compat114/tst_compat114.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/compat206/CMakeLists.txt
+++ b/mtest/libmscore/compat206/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/compat206/tst_compat206.cpp
+++ b/mtest/libmscore/compat206/tst_compat206.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/concertpitch/CMakeLists.txt
+++ b/mtest/libmscore/concertpitch/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/concertpitch/tst_concertpitchbenchmark.cpp
+++ b/mtest/libmscore/concertpitch/tst_concertpitchbenchmark.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/copypaste/CMakeLists.txt
+++ b/mtest/libmscore/copypaste/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/copypaste/tst_copypaste.cpp
+++ b/mtest/libmscore/copypaste/tst_copypaste.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/copypastesymbollist/CMakeLists.txt
+++ b/mtest/libmscore/copypastesymbollist/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/copypastesymbollist/tst_copypastesymbollist.cpp
+++ b/mtest/libmscore/copypastesymbollist/tst_copypastesymbollist.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2013 Werner Schweer
 //

--- a/mtest/libmscore/cursor/CMakeLists.txt
+++ b/mtest/libmscore/cursor/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/durationtype/CMakeLists.txt
+++ b/mtest/libmscore/durationtype/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2017 Werner Schweer
 #

--- a/mtest/libmscore/durationtype/tst_durationtype.cpp
+++ b/mtest/libmscore/durationtype/tst_durationtype.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/dynamic/CMakeLists.txt
+++ b/mtest/libmscore/dynamic/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2012 Werner Schweer
 #

--- a/mtest/libmscore/dynamic/tst_dynamic.cpp
+++ b/mtest/libmscore/dynamic/tst_dynamic.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/element/CMakeLists.txt
+++ b/mtest/libmscore/element/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/element/tst_element.cpp
+++ b/mtest/libmscore/element/tst_element.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/exchangevoices/CMakeLists.txt
+++ b/mtest/libmscore/exchangevoices/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/exchangevoices/tst_exchangevoices.cpp
+++ b/mtest/libmscore/exchangevoices/tst_exchangevoices.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/hairpin/CMakeLists.txt
+++ b/mtest/libmscore/hairpin/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/hairpin/tst_hairpin.cpp
+++ b/mtest/libmscore/hairpin/tst_hairpin.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/implode_explode/CMakeLists.txt
+++ b/mtest/libmscore/implode_explode/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/implode_explode/tst_implodeExplode.cpp
+++ b/mtest/libmscore/implode_explode/tst_implodeExplode.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/instrumentchange/CMakeLists.txt
+++ b/mtest/libmscore/instrumentchange/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/instrumentchange/tst_instrumentchange.cpp
+++ b/mtest/libmscore/instrumentchange/tst_instrumentchange.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/join/CMakeLists.txt
+++ b/mtest/libmscore/join/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/join/tst_join.cpp
+++ b/mtest/libmscore/join/tst_join.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/keysig/CMakeLists.txt
+++ b/mtest/libmscore/keysig/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/keysig/tst_keysig.cpp
+++ b/mtest/libmscore/keysig/tst_keysig.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/layout/CMakeLists.txt
+++ b/mtest/libmscore/layout/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/layout/tst_benchmark.cpp
+++ b/mtest/libmscore/layout/tst_benchmark.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/layout_elements/CMakeLists.txt
+++ b/mtest/libmscore/layout_elements/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/layout_elements/tst_layout_elements.cpp
+++ b/mtest/libmscore/layout_elements/tst_layout_elements.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/links/CMakeLists.txt
+++ b/mtest/libmscore/links/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/links/tst_links.cpp
+++ b/mtest/libmscore/links/tst_links.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/measure/CMakeLists.txt
+++ b/mtest/libmscore/measure/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/measure/tst_measure.cpp
+++ b/mtest/libmscore/measure/tst_measure.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/midi/CMakeLists.txt
+++ b/mtest/libmscore/midi/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/midi/tst_midi.cpp
+++ b/mtest/libmscore/midi/tst_midi.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/midimapping/CMakeLists.txt
+++ b/mtest/libmscore/midimapping/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/midimapping/tst_midimapping.cpp
+++ b/mtest/libmscore/midimapping/tst_midimapping.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/note/CMakeLists.txt
+++ b/mtest/libmscore/note/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/note/tst_note.cpp
+++ b/mtest/libmscore/note/tst_note.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/parts/CMakeLists.txt
+++ b/mtest/libmscore/parts/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/parts/tst_parts.cpp
+++ b/mtest/libmscore/parts/tst_parts.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/remove/CMakeLists.txt
+++ b/mtest/libmscore/remove/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/remove/tst_remove.cpp
+++ b/mtest/libmscore/remove/tst_remove.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/repeat/CMakeLists.txt
+++ b/mtest/libmscore/repeat/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/repeat/tst_repeat.cpp
+++ b/mtest/libmscore/repeat/tst_repeat.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/rhythmicGrouping/CMakeLists.txt
+++ b/mtest/libmscore/rhythmicGrouping/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/rhythmicGrouping/tst_rhythmicGrouping.cpp
+++ b/mtest/libmscore/rhythmicGrouping/tst_rhythmicGrouping.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/selectionfilter/CMakeLists.txt
+++ b/mtest/libmscore/selectionfilter/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2014 Werner Schweer
 #

--- a/mtest/libmscore/selectionfilter/tst_selectionfilter.cpp
+++ b/mtest/libmscore/selectionfilter/tst_selectionfilter.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/selectionrangedelete/CMakeLists.txt
+++ b/mtest/libmscore/selectionrangedelete/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/selectionrangedelete/tst_selectionrangedelete.cpp
+++ b/mtest/libmscore/selectionrangedelete/tst_selectionrangedelete.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2014 Werner Schweer
 //

--- a/mtest/libmscore/split/CMakeLists.txt
+++ b/mtest/libmscore/split/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/split/tst_split.cpp
+++ b/mtest/libmscore/split/tst_split.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/splitstaff/CMakeLists.txt
+++ b/mtest/libmscore/splitstaff/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/splitstaff/tst_splitstaff.cpp
+++ b/mtest/libmscore/splitstaff/tst_splitstaff.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/text/CMakeLists.txt
+++ b/mtest/libmscore/text/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/timesig/CMakeLists.txt
+++ b/mtest/libmscore/timesig/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/timesig/tst_timesig.cpp
+++ b/mtest/libmscore/timesig/tst_timesig.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/tools/CMakeLists.txt
+++ b/mtest/libmscore/tools/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/transpose/CMakeLists.txt
+++ b/mtest/libmscore/transpose/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/transpose/tst_transpose.cpp
+++ b/mtest/libmscore/transpose/tst_transpose.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/tuplet/CMakeLists.txt
+++ b/mtest/libmscore/tuplet/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2013 Werner Schweer
 #

--- a/mtest/libmscore/tuplet/tst_tuplet.cpp
+++ b/mtest/libmscore/tuplet/tst_tuplet.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/libmscore/utils/CMakeLists.txt
+++ b/mtest/libmscore/utils/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/libmscore/utils/tst_utils.cpp
+++ b/mtest/libmscore/utils/tst_utils.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2018 Werner Schweer
 //

--- a/mtest/musicxml/CMakeLists.txt
+++ b/mtest/musicxml/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2012 Werner Schweer
 #

--- a/mtest/musicxml/io/CMakeLists.txt
+++ b/mtest/musicxml/io/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2012 Werner Schweer
 #

--- a/mtest/musicxml/io/tst_mxml_io.cpp
+++ b/mtest/musicxml/io/tst_mxml_io.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012-2014 Werner Schweer
 //

--- a/mtest/omr/CMakeLists.txt
+++ b/mtest/omr/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/omr/notes/CMakeLists.txt
+++ b/mtest/omr/notes/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/omr/notes/tst_notes.cpp
+++ b/mtest/omr/notes/tst_notes.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/scripting/CMakeLists.txt
+++ b/mtest/scripting/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/stringutils/CMakeLists.txt
+++ b/mtest/stringutils/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2018 Werner Schweer
 #

--- a/mtest/stringutils/tst_stringutils.cpp
+++ b/mtest/stringutils/tst_stringutils.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  Copyright (C) 2018 Werner Schweer
 //

--- a/mtest/testoves/CMakeLists.txt
+++ b/mtest/testoves/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2015 Werner Schweer and others
 #

--- a/mtest/testoves/bdat/CMakeLists.txt
+++ b/mtest/testoves/bdat/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2015 Werner Schweer and others
 #

--- a/mtest/testoves/ove3/CMakeLists.txt
+++ b/mtest/testoves/ove3/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2015 Werner Schweer and others
 #

--- a/mtest/testoves/structure/CMakeLists.txt
+++ b/mtest/testoves/structure/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2015 Werner Schweer and others
 #

--- a/mtest/testutils.h
+++ b/mtest/testutils.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: score.cpp 5149 2011-12-29 08:38:43Z wschweer $
 //
 //  Copyright (C) 2012 Werner Schweer
 //

--- a/mtest/zerberus/comments/CMakeLists.txt
+++ b/mtest/zerberus/comments/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/zerberus/comments/tst_sfzcomments.cpp
+++ b/mtest/zerberus/comments/tst_sfzcomments.cpp
@@ -2,7 +2,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2

--- a/mtest/zerberus/envelopes/CMakeLists.txt
+++ b/mtest/zerberus/envelopes/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/zerberus/envelopes/tst_sfzenvelopes.cpp
+++ b/mtest/zerberus/envelopes/tst_sfzenvelopes.cpp
@@ -2,7 +2,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2

--- a/mtest/zerberus/global/CMakeLists.txt
+++ b/mtest/zerberus/global/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/zerberus/global/tst_sfzglobal.cpp
+++ b/mtest/zerberus/global/tst_sfzglobal.cpp
@@ -2,7 +2,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2

--- a/mtest/zerberus/includes/CMakeLists.txt
+++ b/mtest/zerberus/includes/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/zerberus/includes/tst_sfzincludes.cpp
+++ b/mtest/zerberus/includes/tst_sfzincludes.cpp
@@ -2,7 +2,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2

--- a/mtest/zerberus/inputControls/CMakeLists.txt
+++ b/mtest/zerberus/inputControls/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/zerberus/inputControls/tst_sfzinputcontrols.cpp
+++ b/mtest/zerberus/inputControls/tst_sfzinputcontrols.cpp
@@ -2,7 +2,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2

--- a/mtest/zerberus/loop/CMakeLists.txt
+++ b/mtest/zerberus/loop/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/zerberus/loop/tst_sfzloop.cpp
+++ b/mtest/zerberus/loop/tst_sfzloop.cpp
@@ -2,7 +2,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2

--- a/mtest/zerberus/opcodeparse/CMakeLists.txt
+++ b/mtest/zerberus/opcodeparse/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2011 Werner Schweer
 #

--- a/mtest/zerberus/opcodeparse/tst_sfzopcodes.cpp
+++ b/mtest/zerberus/opcodeparse/tst_sfzopcodes.cpp
@@ -2,7 +2,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id:$
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2

--- a/omr/CMakeLists.txt
+++ b/omr/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2006 by Werner Schweer and others
 #

--- a/omr/image.h
+++ b/omr/image.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/importpdf.cpp
+++ b/omr/importpdf.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: importmidi.cpp 2721 2010-02-15 19:41:28Z wschweer $
 //
 //  Copyright (C) 2002-2011 Werner Schweer and others
 //

--- a/omr/importpdf.h
+++ b/omr/importpdf.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id: importmidi.cpp 2721 2010-02-15 19:41:28Z wschweer $
 //
 //  Copyright (C) 2012 Werner Schweer and others
 //

--- a/omr/ocr.cpp
+++ b/omr/ocr.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/ocr.h
+++ b/omr/ocr.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/omr.cpp
+++ b/omr/omr.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/omr.h
+++ b/omr/omr.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/omrpage.cpp
+++ b/omr/omrpage.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010-2011 Werner Schweer
 //

--- a/omr/omrpage.h
+++ b/omr/omrpage.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/omrview.cpp
+++ b/omr/omrview.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/omrview.h
+++ b/omr/omrview.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Linux Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/pattern.cpp
+++ b/omr/pattern.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010-2011 Werner Schweer
 //

--- a/omr/pattern.h
+++ b/omr/pattern.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/pdf.cpp
+++ b/omr/pdf.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/pdf.h
+++ b/omr/pdf.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/skew.cpp
+++ b/omr/skew.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/utils.cpp
+++ b/omr/utils.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/omr/utils.h
+++ b/omr/utils.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Reader
 //  Linux Music Score Reader
-//  $Id$
 //
 //  Copyright (C) 2010 Werner Schweer
 //

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2006 by Werner Schweer and others
 #

--- a/share/instruments/CMakeLists.txt
+++ b/share/instruments/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2008 by Werner Schweer and others
 #

--- a/share/manual/CMakeLists.txt
+++ b/share/manual/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2012 by Werner Schweer and others
 #

--- a/share/plugins/run.qml
+++ b/share/plugins/run.qml
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Linux Music Score Editor
-//  $Id:$
 //
 //  Color notehead plugin
 //	Noteheads are colored according to pitch. User can change to color by

--- a/share/sound/CMakeLists.txt
+++ b/share/sound/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2008 by Werner Schweer and others
 #

--- a/share/styles/CMakeLists.txt
+++ b/share/styles/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2010 by Werner Schweer and others
 #

--- a/share/styles/cchords_muse.xml
+++ b/share/styles/cchords_muse.xml
@@ -5,7 +5,6 @@
 =====================================================================
     MuseScore
     Linux Music Score Editor
-    $Id: mscore.cpp 1850 2009-05-25 07:44:35Z wschweer $
 
     Copyright (C) 2009 Werner Schweer and others
 

--- a/share/styles/cchords_nrb.xml
+++ b/share/styles/cchords_nrb.xml
@@ -5,7 +5,6 @@
 =====================================================================
     MuseScore
     Linux Music Score Editor
-    $Id: mscore.cpp 1850 2009-05-25 07:44:35Z wschweer $
 
     Copyright (C) 2009 Werner Schweer and others
 

--- a/share/styles/cchords_rb.xml
+++ b/share/styles/cchords_rb.xml
@@ -5,7 +5,6 @@
 =====================================================================
     MuseScore
     Linux Music Score Editor
-    $Id: mscore.cpp 1850 2009-05-25 07:44:35Z wschweer $
 
     Copyright (C) 2009 Werner Schweer and others
 

--- a/share/styles/cchords_sym.xml
+++ b/share/styles/cchords_sym.xml
@@ -5,7 +5,6 @@
 =====================================================================
     MuseScore
     Linux Music Score Editor
-    $Id: mscore.cpp 1850 2009-05-25 07:44:35Z wschweer $
 
     Copyright (C) 2009 Werner Schweer and others
 

--- a/share/styles/chords.xml
+++ b/share/styles/chords.xml
@@ -5,7 +5,6 @@
 =====================================================================
     MuseScore
     Linux Music Score Editor
-    $Id: mscore.cpp 1850 2009-05-25 07:44:35Z wschweer $
 
     Copyright (C) 2009 Werner Schweer and others
 

--- a/share/styles/chords_jazz.xml
+++ b/share/styles/chords_jazz.xml
@@ -5,7 +5,6 @@
 =====================================================================
     MuseScore
     Linux Music Score Editor
-    $Id: mscore.cpp 1850 2009-05-25 07:44:35Z wschweer $
 
     Copyright (C) 2009 Werner Schweer and others
 

--- a/share/styles/chords_std.xml
+++ b/share/styles/chords_std.xml
@@ -4,7 +4,6 @@
 =====================================================================
     MuseScore
     Linux Music Score Editor
-    $Id: mscore.cpp 1850 2009-05-25 07:44:35Z wschweer $
 
     Copyright (C) 2009 Werner Schweer and others
 

--- a/share/styles/jazzchords.xml
+++ b/share/styles/jazzchords.xml
@@ -5,7 +5,6 @@
 =====================================================================
     MuseScore
     Linux Music Score Editor
-    $Id: mscore.cpp 1850 2009-05-25 07:44:35Z wschweer $
 
     Copyright (C) 2009 Werner Schweer and others
 

--- a/share/styles/stdchords.xml
+++ b/share/styles/stdchords.xml
@@ -5,7 +5,6 @@
 =====================================================================
     MuseScore
     Linux Music Score Editor
-    $Id: mscore.cpp 1850 2009-05-25 07:44:35Z wschweer $
 
     Copyright (C) 2009 Werner Schweer and others
 

--- a/share/templates/CMakeLists.txt
+++ b/share/templates/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2008 by Werner Schweer and others
 #

--- a/share/tours/CMakeLists.txt
+++ b/share/tours/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2008 by Werner Schweer and others
 #

--- a/share/wallpaper/CMakeLists.txt
+++ b/share/wallpaper/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2008 by Werner Schweer and others
 #

--- a/share/workspaces/CMakeLists.txt
+++ b/share/workspaces/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2002-2008 by Werner Schweer and others
 #

--- a/synthesizer/event.cpp
+++ b/synthesizer/event.cpp
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MuseScore
 //  Music Composition & Notation
-//  $Id: event.cpp 4926 2011-10-29 18:13:35Z wschweer $
 //
 //  Copyright (C) 2008-2011 Werner Schweer
 //

--- a/synthesizer/midipatch.h
+++ b/synthesizer/midipatch.h
@@ -1,7 +1,6 @@
 //=============================================================================
 //  MusE Score
 //  Linux Music Score Editor
-//  $Id: synti.h 4917 2011-10-29 13:30:40Z wschweer $
 //
 //  Copyright (C) 2011 Werner Schweer and others
 //

--- a/thirdparty/kQOAuth/CMakeLists.txt
+++ b/thirdparty/kQOAuth/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2010 by Werner Schweer and others
 #

--- a/thirdparty/ofqf/CMakeLists.txt
+++ b/thirdparty/ofqf/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MusE
 #  Linux Music Editor
-#  $Id:$
 #
 #  Copyright (C) 2010 by Werner Schweer and others
 #

--- a/thirdparty/portmidi/CMakeLists.txt
+++ b/thirdparty/portmidi/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2008 by Werner Schweer and others
 #

--- a/thirdparty/qzip/CMakeLists.txt
+++ b/thirdparty/qzip/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  MuseScore
 #  Music Composition & Notation
-#  $Id:$
 #
 #  Copyright (C) 2014 Werner Schweer
 #

--- a/thirdparty/rtf2html/CMakeLists.txt
+++ b/thirdparty/rtf2html/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2009 by Werner Schweer and others
 #

--- a/thirdparty/singleapp/CMakeLists.txt
+++ b/thirdparty/singleapp/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2009 by Werner Schweer and others
 #

--- a/thirdparty/singleapp/src/CMakeLists.txt
+++ b/thirdparty/singleapp/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 #=============================================================================
 #  Mscore
 #  Linux Music Score Editor
-#  $Id:$
 #
 #  Copyright (C) 2009 by Werner Schweer and others
 #


### PR DESCRIPTION
they do not make any sense, nor do they get updated, if the source code is kept in git instead of CVS (or Subversion)