### PR TITLE
Fix #105981: Crash when clearing "Show more elements" before adding an element in a new palette

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -258,8 +258,11 @@ void Palette::contextMenuEvent(QContextMenuEvent* event)
 
       if (action == clearAction) {
             PaletteCell* cell = cellAt(i);
-            if (cell)
+            if (cell) {
+                  if(cell->tag == "ShowMore")
+                        _moreElements = false;
                   delete cell;
+            }
             cells[i] = 0;
             emit changed();
             }


### PR DESCRIPTION
https://musescore.org/en/node/105981

The crash is caused by not changing the `_moreElements` flag when deleting `Show More` cell from palette. Then when inserting something else via `Palette::append`, the new index will be subtracted by 2, and become negative.