### PR TITLE
Make tab1 active by default

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1141,6 +1141,7 @@ MuseScore::MuseScore()
       splitter = new QSplitter;
       tab1 = createScoreTab();
       splitter->addWidget(tab1);
+      ctab = tab1; // make tab1 active by default.
 
       if (splitScreen()) {
             tab2 = createScoreTab();


### PR DESCRIPTION
Trying to address issues related to correct setting a currently active score view I made `MuseScore` track the currently active tab via `MuseScore::ctab` field (see #4004). However I forgot to initialize that field correctly which led to issues with setting active score view in case MuseScore was launched with no scores opened at all (which can happen if "Start empty" or "Continue last session" options are chosen in Preferences). This led, for example, to incorrect behavior of "reset positions" dialog for old scores in such cases (#4085, #4091) which is exactly the issue which @Jojo-Schmitz initially found and told me about.

This PR adds the forgotten initialization and thus fixes the mentioned issue.