### PR TITLE
fix #277861: Multiple fermatas added to chords

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -66,6 +66,19 @@ void Articulation::setSymId(SymId id)
       }
 
 //---------------------------------------------------------
+//   subtype
+//---------------------------------------------------------
+
+int Articulation::subtype() const
+      {
+      QString s = Sym::id2name(_symId);
+      if (s.endsWith("Below"))
+            return int(Sym::name2id(s.left(s.size() - 5) + "Above"));
+      else
+            return int(_symId);
+      }
+
+//---------------------------------------------------------
 //   setUp
 //---------------------------------------------------------
 

--- a/libmscore/articulation.h
+++ b/libmscore/articulation.h
@@ -79,7 +79,7 @@ class Articulation final : public Element {
 
       SymId symId() const                       { return _symId; }
       void setSymId(SymId id);
-      virtual int subtype() const override      { return int(_symId); }
+      virtual int subtype() const override;
       QString userName() const;
       const char* articulationName() const;  // type-name of articulation; used for midi rendering
       static const char* symId2ArticulationName(SymId symId);

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2654,7 +2654,7 @@ bool Chord::setProperty(Pid propertyId, const QVariant& v)
 Articulation* Chord::hasArticulation(const Articulation* aa)
       {
       for (Articulation* a : _articulations) {
-            if (a->articulationName() == aa->articulationName())
+            if (a->subtype() == aa->subtype())
                   return a;
             }
       return 0;

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -471,12 +471,28 @@ Element* ChordRest::drop(EditData& data)
                         return 0;
                         }
 
+            case ElementType::FERMATA:
+                  for (Element* el: segment()->annotations())
+                        if (el->isFermata() && (el->track() == track())) {
+                              if (el->subtype() == e->subtype()) {
+                                    delete e;
+                                    return el;
+                                    }
+                              else {
+                                    if (el->placeBelow())
+                                          e->setPlacement(Placement::BELOW);
+                                    e->setTrack(track());
+                                    e->setParent(segment());
+                                    score()->undoChangeElement(el, e);
+                                    return e;
+                                    }
+                              }
+                  // fall through
             case ElementType::TEMPO_TEXT:
             case ElementType::DYNAMIC:
             case ElementType::FRET_DIAGRAM:
             case ElementType::TREMOLOBAR:
             case ElementType::SYMBOL:
-            case ElementType::FERMATA:
                   e->setTrack(track());
                   e->setParent(segment());
                   score()->undoAddElement(e);

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4048,6 +4048,7 @@ void Score::undoAddElement(Element* element)
          && et != ElementType::SYMBOL
          && et != ElementType::TREMOLOBAR
          && et != ElementType::FRET_DIAGRAM
+         && et != ElementType::FERMATA
          && et != ElementType::HARMONY)
             ) {
             undo(new AddElement(element));
@@ -4183,6 +4184,7 @@ void Score::undoAddElement(Element* element)
                      || element->isDynamic()
                      || element->isStaffText()
                      || element->isFretDiagram()
+                     || element->isFermata()
                      || element->isHarmony()) {
                         Segment* segment = toSegment(element->parent());
                         int tick         = segment->tick();

--- a/libmscore/fermata.cpp
+++ b/libmscore/fermata.cpp
@@ -114,6 +114,19 @@ void Fermata::write(XmlWriter& xml) const
       }
 
 //---------------------------------------------------------
+//   subtype
+//---------------------------------------------------------
+
+int Fermata::subtype() const
+      {
+      QString s = Sym::id2name(_symId);
+      if (s.endsWith("Below"))
+            return int(Sym::name2id(s.left(s.size() - 5) + "Above"));
+      else
+            return int(_symId);
+      }
+
+//---------------------------------------------------------
 //   userName
 //---------------------------------------------------------
 

--- a/libmscore/fermata.h
+++ b/libmscore/fermata.h
@@ -50,7 +50,7 @@ class Fermata final : public Element {
 
       SymId symId() const                   { return _symId; }
       void setSymId(SymId id)               { _symId  = id;  }
-      virtual int subtype() const override  { return int(_symId); }
+      virtual int subtype() const override;
       QString userName() const;
 
       virtual void layout() override;


### PR DESCRIPTION
See https://musescore.org/en/node/277861.

This will prevent multiple fermatas from being added to a chord if multiple notes in the chord are selected when the palette drop is applied. It will also prevent the user from being able to add multiple fermatas to a chord. If a chord already has a fermata, attempting to add another fermata of the same type will result in the existing fermata being selected (just like in MuseScore 2). However, contrary to MuseScore 2 behavior, if a chord already has a fermata, adding a fermata of a different type will result in the old fermata being replaced with the new one.

This patch also fixes the bug that prevented fermatas from being added to linked parts when added to the main score.

This also provides a better fix for https://musescore.org/en/node/276441.