### PR TITLE
fix #277864: Exchange voice does not add rests to complete voice 1

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3767,6 +3767,11 @@ void Score::undoExchangeVoice(Measure* measure, int v1, int v2, int staff1, int 
                         ChordRest* cr = toChordRest(s->element(track));
                         if (cr == 0)
                               continue;
+                        if (cr->isRest()) {
+                              Rest* r = toRest(cr);
+                              if (r->isGap())
+                                    r->undoChangeProperty(Pid::GAP, false);
+                              }
                         if (ctick < s->tick()) {
                               // fill gap
                               int ticks = s->tick() - ctick;

--- a/mtest/libmscore/exchangevoices/exchangevoices-gliss-ref.mscx
+++ b/mtest/libmscore/exchangevoices/exchangevoices-gliss-ref.mscx
@@ -80,9 +80,9 @@
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
-          <location>
-            <fractions>1/2</fractions>
-            </location>
+          <Rest>
+            <durationType>half</durationType>
+            </Rest>
           <Chord>
             <durationType>quarter</durationType>
             <Note>


### PR DESCRIPTION
See https://musescore.org/en/node/277864.