### PR TITLE
Fixes related to recent preferences and workspaces changes

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -452,6 +452,7 @@ void MuseScore::preferencesChanged(bool fromWorkspace)
       _statusBar->setVisible(preferences.getBool(PREF_UI_APP_SHOWSTATUSBAR));
 
       MuseScore::updateUiStyleAndTheme();
+      updateIcons();
 
       QString fgWallpaper = preferences.getString(PREF_UI_CANVAS_FG_WALLPAPER);
       for (int i = 0; i < tab1->count(); ++i) {
@@ -6964,8 +6965,6 @@ int main(int argc, char* av[])
             MuseScore::updateUiStyleAndTheme();
       else
             noSeq = true;
-
-      genIcons();
 
       // Do not create sequencer and audio drivers if run with '-s'
       if (!noSeq) {

--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -1115,15 +1115,6 @@ void PreferenceDialog::apply()
             MScore::defaultStyleForPartsHasChanged();
             }
 
-      genIcons();
-
-      mscore->setIconSize(QSize(preferences.getInt(PREF_UI_THEME_ICONWIDTH) * guiScaling, preferences.getInt(PREF_UI_THEME_ICONHEIGHT) * guiScaling));
-      QString style = QString("*, QSpinBox { font: %1pt \"%2\" } ")
-                  .arg(QString::number(preferences.getInt(PREF_UI_THEME_FONTSIZE)), preferences.getString(PREF_UI_THEME_FONTFAMILY))
-                  + qApp->styleSheet();
-      qApp->setStyleSheet(style);
-      mscore->updateIcons();
-
       emit preferencesChanged();
       preferences.save();
       mscore->startAutoSave();

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -183,12 +183,13 @@ void MuseScore::changeWorkspace(Workspace* p, bool first)
 
 void MuseScore::updateIcons()
       {
-      mscore->setIconSize(QSize(preferences.getInt(PREF_UI_THEME_ICONWIDTH) * guiScaling, preferences.getInt(PREF_UI_THEME_ICONHEIGHT) * guiScaling));
+      setIconSize(QSize(preferences.getInt(PREF_UI_THEME_ICONWIDTH) * guiScaling, preferences.getInt(PREF_UI_THEME_ICONHEIGHT) * guiScaling));
       for (QAction* a : fileTools->actions()) {
             QWidget* widget = fileTools->widgetForAction(a);
             QString className = widget->metaObject()->className();
-            if (className != "Ms::AccessibleToolButton" || className != "QToolBarSeparator")
+            if (className != "Ms::AccessibleToolButton" && className != "QToolBarSeparator")
                   widget->setFixedHeight(preferences.getInt(PREF_UI_THEME_ICONHEIGHT) + 8);  // hack
+                  // apparently needed for viewModeCombo, see MuseScore::populateFileOperations
             }
       }
 

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -976,14 +976,15 @@ QList<Workspace*>& Workspace::workspaces()
                               p = new Workspace;
                         p->setPath(s + "/" + entry);
                         p->setName(name);
-                        p->setTranslate(translate);
+                        if (translate)
+                              p->setTranslatableName(name);
                         p->setReadOnly(!fi.isWritable());
                         _workspaces.append(p);
                         }
                   }
             // hack
             for (int i = 0; i < _workspaces.size(); i++) {
-                  if (_workspaces[i]->name() == "Basic") {
+                  if (_workspaces[i]->translatableName() == "Basic") {
                         _workspaces.move(i, 0);
                         break;
                         }
@@ -1014,8 +1015,8 @@ void Workspace::retranslate(QList<Workspace*>* workspacesList)
       if (!workspacesList)
             workspacesList = &workspaces();
       for (auto w : *workspacesList) {
-            if (w->translate())
-                  w->setName(tr(w->name().toLatin1().data()));
+            if (!w->translatableName().isEmpty())
+                  w->setName(tr(w->translatableName().toLatin1().constData()));
             }
       }
 

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -51,10 +51,10 @@ class Workspace : public QObject {
       static QString findStringFromMenu(QMenu* menu);
 
       QString _name;
+      QString _translatableName;
       QString _path;
       bool _dirty;
       bool _readOnly;
-      bool _translate;
 
       bool saveComponents;
       bool saveToolbars;
@@ -76,6 +76,8 @@ class Workspace : public QObject {
       void setPath(const QString& s) { _path = s;     }
       QString name() const           { return _name;  }
       void setName(const QString& s) { _name = s;     }
+      const QString& translatableName() const  { return _translatableName;    }
+      void setTranslatableName(QString trName) { _translatableName = trName;  }
       void rename(const QString& s);
       bool dirty() const             { return _dirty; }
 
@@ -85,8 +87,6 @@ class Workspace : public QObject {
       void read();
       bool readOnly() const          { return _readOnly;  }
       void setReadOnly(bool val)     { _readOnly = val;   }
-      bool translate() const         { return _translate; }
-      void setTranslate(bool val)    { _translate = val;  }
 
       static void initWorkspace();
       static Workspace* currentWorkspace;


### PR DESCRIPTION
This pull request contains fixes for two issues appeared after merging #4079. The first commit removes redundant operations on updating styles and icons and moves `updateIcons()` call to the more appropriate place. One of these operations, namely updating the stylesheet [here](https://github.com/musescore/MuseScore/commit/9fb454967697737f1d86ad30f2736d1bc0532083#diff-e1c31b5b3c39484d8087f34ad3afdcf6R1124) leads to a crash described [in the issue tracker](https://musescore.org/en/node/277697). Unfortunately I am not currently able to describe in details why it happens but since that call should anyway be redundant (as it is done later inside `MuseScore::updateUiStyleAndTheme`) I believe we can remove it from that place.

The second commit fixes a problem with workspaces translations which also [led to MuseScore crash](https://musescore.org/en/node/277747).