### PR TITLE
fix #275813: handle linked parts in cmdJoinMeasure

### DIFF
--- a/libmscore/joinMeasure.cpp
+++ b/libmscore/joinMeasure.cpp
@@ -49,23 +49,28 @@ void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
                   s->setEndElement(0);
             }
 
-      undoRemoveMeasures(m1, m2);
-      Measure* m = new Measure(this);
-//TODO      m->setEndBarLineType(m2->endBarLineType(), m2->endBarLineGenerated(),
-//         m2->endBarLineVisible(), m2->endBarLineColor());
+      deleteMeasures(m1, m2);
 
-      m->setTick(m1->tick());
-      m->setTimesig(m1->timesig());
-      Fraction f;
+      MeasureBase* next = m2->next();
+      const Fraction newTimesig = m1->timesig();
+      Fraction newLen;
       for (Measure* mm = m1; mm; mm = mm->nextMeasure())  {
-            f += mm->len();
+            newLen += mm->len();
             if (mm == m2)
                   break;
             }
-      m->setLen(f);
-      m->setNext(m2->next());
-      m->setPrev(m2->next() ? m2->next()->prev() : last());
-      undo(new InsertMeasures(m, m));
+      insertMeasure(ElementType::MEASURE, next, /* createEmptyMeasures*/ true);
+      // The loop since measures are not currently linked in MuseScore
+      for (Score* s : masterScore()->scoreList()) {
+            Measure* ins = s->tick2measure(tick1);
+            ins->undoChangeProperty(Pid::TIMESIG_NOMINAL, newTimesig);
+//             TODO: there was a commented chunk of code regarding setting bar
+//             line types. Should we handle them here too?
+//             m->setEndBarLineType(m2->endBarLineType(), m2->endBarLineGenerated(),
+//             m2->endBarLineVisible(), m2->endBarLineColor());
+            }
+      Measure* inserted = (next ? next->prevMeasure() : lastMeasure());
+      inserted->adjustToLen(newLen, /* appendRests... */ false);
 
       range.write(this, m1->tick());
 


### PR DESCRIPTION
This pull request should fix this issue: https://musescore.org/en/node/275813
I couldn't reproduce any crash but score appeared to be in a corrupted state after joining measures when several linked parts were present. I rewrote `cmdJoinMeasure` using functions aware of linked parts thus correctly handling measures join operation for linked parts. However there are some other problems concerning both measure join operation (try to insert different time signatures into two measures and join them) and handling measure length for linked parts (timewise insert/delete operations work do not reflect in parts as far as measure length changes are involved). This pull request doesn't fix these issues and they are still to be worked on later. I will probably file the corresponding bug reports soon.