### PR TITLE
Fix layout of unmanaged spanners at the layout range start

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -308,6 +308,10 @@ void Lyrics::layout()
                   }
             _separator->setParent(this);
             _separator->setTick(cr->tick());
+            // HACK separator should have non-zero length to get its layout
+            // always triggered. A proper ticks length will be set later on the
+            // separator layout.
+            _separator->setTicks(1);
             _separator->setTrack(track());
             _separator->setTrack2(track());
             // bbox().setWidth(bbox().width());  // ??


### PR DESCRIPTION
This pull request fixes the problem with entering the first dash described in [this issue](https://musescore.org/en/node/277693). As far as I understand the layout engine it is always assumed that layout is done in the range [start, end), so that the start tick is always included in the range. Violating this rule in the check for layout of unmanaged spanners leads to missing layout of the first dash.