### PR TITLE
fix #277693: Fix melisma intersecting with lyrics syllables

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -545,31 +545,36 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                     if (e)
                                           cr = toChordRest(e);
                                     }
+
                               // layout to right edge of CR
-                              // if next segment is not a chord with lyrics which spans to the left
-                              if (cr) {
-                                    bool extendToRight = true;
+                              bool extendToEnd = true; // extend to end or start element?
+                              if (cr == toChordRest(startElement()))
+                                    extendToEnd = false;
+                              else if (cr) {
+                                    // if next segment is a chord with lyrics which spans to the left
+                                    // then do not extend to the right edge of end element.
                                     Segment* seg = cr->segment();
                                     seg = seg->next(SegmentType::ChordRest);
                                     if (seg) {
                                           ChordRest* cr2 = seg->cr(cr->track());
                                           if (cr2 && !cr2->lyrics().empty())
-                                                extendToRight = false;
+                                                extendToEnd = false;
                                           }
-                                    if (extendToRight) {
-                                          qreal maxRight = 0.0;
-                                          if (cr->isChord()) {
-                                                // chord bbox() is unreliable, look at notes
-                                                // this also allows us to more easily ignore ledger lines
-                                                for (Note* n : toChord(cr)->notes())
-                                                      maxRight = qMax(maxRight, cr->x() + n->x() + n->bboxRightPos());
-                                                }
-                                          else {
-                                                // rest - won't normally happen
-                                                maxRight = cr->x() + cr->width();
-                                                }
-                                          x = maxRight; // cr->width()
+                                    }
+                              ChordRest* right = extendToEnd ? cr : toChordRest(startElement());
+                              if (right) {
+                                    qreal maxRight = 0.0;
+                                    if (right->isChord()) {
+                                          // chord bbox() is unreliable, look at notes
+                                          // this also allows us to more easily ignore ledger lines
+                                          for (Note* n : toChord(right)->notes())
+                                                maxRight = qMax(maxRight, right->x() + n->x() + n->bboxRightPos());
                                           }
+                                    else {
+                                          // rest - won't normally happen
+                                          maxRight = right->x() + right->width();
+                                          }
+                                    x = maxRight;
                                     }
                              }
                         else if (isHairpin() || isTrill() || isVibrato() || isTextLine() || isLyricsLine()) {

--- a/libmscore/lyricsline.cpp
+++ b/libmscore/lyricsline.cpp
@@ -165,14 +165,6 @@ void LyricsLine::layout()
             // do layout with non-0 duration
             if (tempMelismaTicks)
                   lyrics()->setTicks(Lyrics::TEMP_MELISMA_TICKS);
-#if 0
-            SLine::layout();
-            // if temp melisma and there is a first line segment,
-            // extend it to be after the lyrics syllable (otherwise
-            // the melisma segment will be often covered by the syllable itself)
-            if (tempMelismaTicks && segments.size() > 0)
-                  segmentAt(0)->rxpos2() += lyrics()->width();
-#endif
             }
       }
 
@@ -290,6 +282,12 @@ SpannerSegment* LyricsLine::layoutSystem(System* system)
                   break;
             }
       lineSegm->layout();
+      // if temp melisma extend the first line segment to be
+      // after the lyrics syllable (otherwise the melisma segment
+      // will be too short).
+      const bool tempMelismaTicks = (lyrics()->ticks() == Lyrics::TEMP_MELISMA_TICKS);
+      if (tempMelismaTicks && segments.size() > 0 && segments.front() == lineSegm)
+            lineSegm->rxpos2() += lyrics()->width();
 #if 0
       QList<SpannerSegment*> sl;
       for (SpannerSegment* ss : segments) {


### PR DESCRIPTION
This pull request aims to resolve to some extent the part of [this issue](https://musescore.org/en/node/277693) concerning melisma placement. There was a code that probably addressed this problem previously, enabling it again and moving to correct location resolves the issue with melismas crossing lyrics syllables. However layout of melisma is not really good yet as its length somehow changes depending on lyrics editing state and layout may eventually result in a very short melisma line. Still it doesn't cross syllables as far as observed.