### PR TITLE
Barline styles

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -112,13 +112,13 @@ static const StyleType styleTypes[] {
       { Sid::systemFrameDistance,     "systemFrameDistance",     Spatium(7.0) },
       { Sid::frameSystemDistance,     "frameSystemDistance",     Spatium(7.0) },
       { Sid::minMeasureWidth,         "minMeasureWidth",         Spatium(5.0) },
-      { Sid::barWidth,                "barWidth",                Spatium(0.16) },      // 0.1875
+      { Sid::barWidth,                "barWidth",                Spatium(0.16) },
       { Sid::doubleBarWidth,          "doubleBarWidth",          Spatium(0.16) },
 
-      { Sid::endBarWidth,             "endBarWidth",             Spatium(0.5) },       // 0.5
-      { Sid::doubleBarDistance,       "doubleBarDistance",       Spatium(0.46) },      // 0.3
-      { Sid::endBarDistance,          "endBarDistance",          Spatium(.40 + (.5) * .5) },     // 0.3
-      { Sid::repeatBarlineDotSeparation, "repeatBarlineDotSeparation", Spatium(.40 + .16 * .5) },
+      { Sid::endBarWidth,             "endBarWidth",             Spatium(0.5) },
+      { Sid::doubleBarDistance,       "doubleBarDistance",       Spatium(.40 + .16) },
+      { Sid::endBarDistance,          "endBarDistance",          Spatium(.40 + (.16 + .50) * .5) },
+      { Sid::repeatBarlineDotSeparation, "repeatBarlineDotSeparation", Spatium(.40 + .46 * .5) },
       { Sid::repeatBarTips,           "repeatBarTips",           QVariant(false) },
       { Sid::startBarlineSingle,      "startBarlineSingle",      QVariant(false) },
       { Sid::startBarlineMultiple,    "startBarlineMultiple",    QVariant(true) },

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -1246,8 +1246,8 @@ void EditStyle::valueChanged(int i)
       QVariant val  = getValue(idx);
       bool setValue = false;
       if (idx == Sid::MusicalSymbolFont && optimizeStyleCheckbox->isChecked()) {
-              ScoreFont* scoreFont = ScoreFont::fontFactory(val.toString());
-              if (scoreFont) {
+            ScoreFont* scoreFont = ScoreFont::fontFactory(val.toString());
+            if (scoreFont) {
                   for (auto j : scoreFont->engravingDefaults()) {
 #if 0  // debug
                         if (cs->styleV(j.first) != j.second) {
@@ -1267,20 +1267,23 @@ void EditStyle::valueChanged(int i)
                   cs->undo(new ChangeStyleVal(cs, Sid::endBarDistance,
                     cs->styleV(Sid::endBarDistance).toDouble()
                     + (cs->styleV(Sid::barWidth).toDouble() + cs->styleV(Sid::endBarWidth).toDouble()) * .5));
+                  cs->undo(new ChangeStyleVal(cs, Sid::doubleBarDistance,
+                    cs->styleV(Sid::doubleBarDistance).toDouble()
+                    + (cs->styleV(Sid::barWidth).toDouble() + cs->styleV(Sid::barWidth).toDouble()) * .5));
 
                   // guess the repeat dot width = spatium * .3
                   cs->undo(new ChangeStyleVal(cs, Sid::repeatBarlineDotSeparation,
                     cs->styleV(Sid::repeatBarlineDotSeparation).toDouble()
                     + (cs->styleV(Sid::barWidth).toDouble() + .3) * .5));
 
-                    if (scoreFont->textEnclosureThickness()) {
-//                           TextStyle ts = cs->textStyle(TextStyleType::REHEARSAL_MARK);
-//                           ts.setFrameWidth(Spatium(scoreFont->textEnclosureThickness()));
-//TODO                           cs->undo(new ChangeTextStyle(cs, ts));
-                           }
-                    }
-              setValue = true;
-              }
+//                  if (scoreFont->textEnclosureThickness()) {
+//                        TextStyle ts = cs->textStyle(TextStyleType::REHEARSAL_MARK);
+//                        ts.setFrameWidth(Spatium(scoreFont->textEnclosureThickness()));
+//TODO                        cs->undo(new ChangeTextStyle(cs, ts));
+//                        }
+                  }
+            setValue = true;
+            }
       cs->undo(new ChangeStyleVal(cs, idx, val));
       cs->update();
       if (setValue)

--- a/mtest/libmscore/compat206/accidentals-ref.mscx
+++ b/mtest/libmscore/compat206/accidentals-ref.mscx
@@ -6,6 +6,8 @@
     <Division>480</Division>
     <Style>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/ambitus-ref.mscx
+++ b/mtest/libmscore/compat206/ambitus-ref.mscx
@@ -6,6 +6,8 @@
     <Division>480</Division>
     <Style>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/articulations-double-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-double-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/articulations-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-ref.mscx
@@ -6,6 +6,8 @@
     <Division>480</Division>
     <Style>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/barlines-ref.mscx
+++ b/mtest/libmscore/compat206/barlines-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/breath-ref.mscx
+++ b/mtest/libmscore/compat206/breath-ref.mscx
@@ -6,6 +6,8 @@
     <Division>480</Division>
     <Style>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/clefs-ref.mscx
+++ b/mtest/libmscore/compat206/clefs-ref.mscx
@@ -6,6 +6,8 @@
     <Division>480</Division>
     <Style>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/drumset-ref.mscx
+++ b/mtest/libmscore/compat206/drumset-ref.mscx
@@ -6,6 +6,8 @@
     <Division>480</Division>
     <Style>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/fermata-ref.mscx
+++ b/mtest/libmscore/compat206/fermata-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/hairpin-ref.mscx
+++ b/mtest/libmscore/compat206/hairpin-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/intrumentNameAlign-ref.mscx
+++ b/mtest/libmscore/compat206/intrumentNameAlign-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/lidemptytext-ref.mscx
+++ b/mtest/libmscore/compat206/lidemptytext-ref.mscx
@@ -6,6 +6,8 @@
     <Division>480</Division>
     <Style>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/markers-ref.mscx
+++ b/mtest/libmscore/compat206/markers-ref.mscx
@@ -6,6 +6,8 @@
     <Division>480</Division>
     <Style>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/noteheads-ref.mscx
+++ b/mtest/libmscore/compat206/noteheads-ref.mscx
@@ -6,6 +6,8 @@
     <Division>480</Division>
     <Style>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/textstyles-ref.mscx
+++ b/mtest/libmscore/compat206/textstyles-ref.mscx
@@ -23,6 +23,8 @@
       <lyricsEvenFontFace>MuseJazz Text</lyricsEvenFontFace>
       <lyricsEvenOffset x="0" y="6"/>
       <repeatBarTips>1</repeatBarTips>
+      <doubleBarDistance>0.54</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <stemWidth>0.16</stemWidth>

--- a/mtest/libmscore/compat206/tuplets-ref.mscx
+++ b/mtest/libmscore/compat206/tuplets-ref.mscx
@@ -6,6 +6,8 @@
     <Division>480</Division>
     <Style>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/split/split183846-irregular-hn-hn-qn-qn-hn-hn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-hn-hn-qn-qn-hn-hn-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/split/split183846-irregular-qn-qn-wn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-qn-qn-wn-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/split/split183846-irregular-verylong-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-verylong-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/split/split183846-irregular-wn-wn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wn-wn-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/split/split183846-irregular-wn-wr-wn-hr-qr-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wn-wr-wn-hr-qr-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/split/split183846-irregular-wr-wn-wr-hn-qn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wr-wn-wr-hn-qn-ref.mscx
@@ -15,6 +15,8 @@
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <doubleBarDistance>0.46</doubleBarDistance>
+      <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>
       <barNoteDistance>1.2</barNoteDistance>


### PR DESCRIPTION
* related to fix #277991: adjust barline style defaults to those of Emmentaler
    Emmentaler is the default Musical font, but the defaults for these barline styles are different from their settings in Emmentaler's metadata.json.
* fix #278219: MuseJazz: Double barline distance is much too small
   this is a Bug in MuseScore in the interpretation of barlineSeparation.
   If we look in the SMuFL spec we see:

   "barlineSeparation": The default distance between multiple barlines when locked together, e.g. between two thin barlines making a double barline, or a thin and a thick barline making a final barline, measured from the right-hand edge of the left barline to the left-hand edge of the right barline.

   MuseScore takes the distance as distance between the center of these. This means we have to add one thinBarlineThickness to this distance to get it right.