### PR TITLE
fix #277912: select/more for rests broken

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3043,7 +3043,7 @@ void Score::collectMatch(void* data, Element* e)
                   } while (ee);
             }
 
-      if (e->isRest()) {
+      if (e->isRest() && p->durationTicks != -1) {
             const Rest* r = toRest(e);
             if (p->durationTicks != r->actualTicks())
                   return;

--- a/mscore/selectdialog.cpp
+++ b/mscore/selectdialog.cpp
@@ -100,6 +100,8 @@ void SelectDialog::setPattern(ElementPattern* p)
             const Rest* r = toRest(e);
             p->durationTicks = r->actualTicks();
             }
+      else
+            p->durationTicks = -1;
 
       p->voice   = sameVoice->isChecked() ? e->voice() : -1;
       p->subtypeValid = sameSubtype->isChecked();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/277912

With this fix, if duration is not checked, then the value will be set to - 1 (an impossible duration value). When matching rests, if duration is -1 then duration as a term for matching is skipped and ignored. 