### PR TITLE
fix #278215 Crash when inserting note in Piano Roll Editor

### DIFF
--- a/mscore/pianoview.cpp
+++ b/mscore/pianoview.cpp
@@ -676,7 +676,7 @@ void PianoView::mouseReleaseEvent(QMouseEvent* event)
 
 
                         ChordRest* e = score->findCR(roundedTick, track);
-                        if (!e->tuplet() && _tuplet == 1) {
+                        if (e && !e->tuplet() && _tuplet == 1) {
                               //Ignore tuplets
                               score->startCmd();
                               score->expandVoice(e->segment(), track);
@@ -742,7 +742,7 @@ void PianoView::mouseReleaseEvent(QMouseEvent* event)
                         int roundedTick = (pickTick / subbeatTicks) * subbeatTicks;
 
                         ChordRest* e = score->findCR(roundedTick, track);
-                        if (!e->tuplet() && _tuplet == 1) {
+                        if (e && !e->tuplet() && _tuplet == 1) {
                               score->startCmd();
                               score->expandVoice(e->segment(), track);
                               int startTick = e->tick();


### PR DESCRIPTION
Handling a null pointer that can occur when adding notes past the end of the current note range.