### PR TITLE
fix #278232 Crash when deleting staff while open in PianoRoll

### DIFF
--- a/mscore/pianolevels.cpp
+++ b/mscore/pianolevels.cpp
@@ -546,7 +546,9 @@ void PianoLevels::updateNotes()
             return;
             }
 
-      int staffIdx   = _staff->idx();
+      int staffIdx = _staff->idx();
+      if (staffIdx == -1)
+            return;
 
       SegmentType st = SegmentType::ChordRest;
       for (Segment* s = _staff->score()->firstSegment(st); s; s = s->next1(st)) {

--- a/mscore/pianoview.cpp
+++ b/mscore/pianoview.cpp
@@ -1104,7 +1104,9 @@ void PianoView::updateNotes()
       scene()->clear();
       clearNoteData();
 
-      int staffIdx   = _staff->idx();
+      int staffIdx = _staff->idx();
+      if (staffIdx == -1)
+            return;
 
       SegmentType st = SegmentType::ChordRest;
       for (Segment* s = _staff->score()->firstSegment(st); s; s = s->next1(st)) {


### PR DESCRIPTION
Can now delete a staff while staff is being displayed in Piano Roll Editor.