### PR TITLE
fix 278240 Removing unused mixer code

### DIFF
--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -127,7 +127,7 @@ Mixer::Mixer(QWidget* parent)
 //   synthGainChanged
 //---------------------------------------------------------
 
-void Mixer::synthGainChanged(float val)
+void Mixer::synthGainChanged(float)
       {
       float decibels = qBound(minDecibels, log10f(synti->gain()), 0.0f);
 
@@ -391,8 +391,6 @@ void Mixer::notifyTrackSelected(MixerTrack* track)
                   }
             }
       mixerDetails->setTrack(track->mti());
-//      selPart = track->mti()->part();
-//      selChan = track->mti()->chan();
       }
 
 
@@ -430,8 +428,8 @@ void MuseScore::showMixer(bool val)
             mixer = new Mixer(this);
             mscore->stackUnder(mixer);
             if (synthControl)
-                  connect(synthControl, SIGNAL(soundFontChanged()), mixer, SLOT(patchListChanged()));
-            connect(synti, SIGNAL(soundFontChanged()), mixer, SLOT(patchListChanged()));
+                  connect(synthControl, SIGNAL(soundFontChanged()), mixer, SLOT(updateTrack()));
+            connect(synti, SIGNAL(soundFontChanged()), mixer, SLOT(updateTracks()));
             connect(mixer, SIGNAL(closed(bool)), a, SLOT(setChecked(bool)));
             }
       mixer->setScore(cs->masterScore());

--- a/mscore/mixer.h
+++ b/mscore/mixer.h
@@ -79,9 +79,9 @@ class Mixer : public QWidget, public Ui::Mixer, public MixerTrackGroup
       virtual bool eventFilter(QObject*, QEvent*) override;
       virtual void keyPressEvent(QKeyEvent*) override;
       void readSettings();
-      void updateTracks();
 
    public slots:
+      void updateTracks();
       void midiPrefsChanged(bool showMidiControls);
       void masterVolumeChanged(double val);
       void synthGainChanged(float val);

--- a/mscore/mixerdetails.cpp
+++ b/mscore/mixerdetails.cpp
@@ -276,9 +276,6 @@ void MixerDetails::partNameChanged()
 
 void MixerDetails::trackColorChanged(QColor col)
       {
-      Part* part = _mti->midiMap()->part;
-      Channel* channel = _mti->midiMap()->articulation;
-
       if (trackColorLabel->color() != col) {
             trackColorLabel->blockSignals(true);
             trackColorLabel->setColor(col);
@@ -359,6 +356,16 @@ void MixerDetails::propertyChanged(Channel::Prop property)
                   trackColorChanged(chan->color());
                   break;
                   }
+            case Channel::Prop::NAME: {
+                  partNameLineEdit->blockSignals(true);
+                  Part* part = _mti->part();
+                  QString partName = part->partName();
+                  partNameLineEdit->setText(partName);
+                  partNameLineEdit->blockSignals(false);
+                  break;
+                  }
+            default:
+                  break;
             }
       }
 
@@ -448,7 +455,6 @@ void MixerDetails::drumkitToggled(bool val)
       if (_mti == 0)
             return;
 
-      MidiMapping* midiMap = _mti->midiMap();
       Part* part = _mti->part();
       Channel* channel = _mti->focusedChan();
 

--- a/mscore/mixertrackchannel.cpp
+++ b/mscore/mixertrackchannel.cpp
@@ -226,7 +226,7 @@ void MixerTrackChannel::updateNameLabel()
 //   paintEvent
 //---------------------------------------------------------
 
-void MixerTrackChannel::paintEvent(QPaintEvent* evt)
+void MixerTrackChannel::paintEvent(QPaintEvent*)
       {
       applyStyle();
       }
@@ -337,7 +337,7 @@ void MixerTrackChannel::controlSelected()
 //   mouseReleaseEvent
 //---------------------------------------------------------
 
-void MixerTrackChannel::mouseReleaseEvent(QMouseEvent * event)
+void MixerTrackChannel::mouseReleaseEvent(QMouseEvent*)
       {
       setSelected(true);
       }

--- a/mscore/mixertrackitem.h
+++ b/mscore/mixertrackitem.h
@@ -50,8 +50,6 @@ private:
 
       Instrument* _instr;
       Channel* _chan;
-//      int _instrIdx;
-//      int _chanIdx;  //If -1, this track handles all channels attached to this part
 
 public:
       MixerTrackItem(TrackType tt, Part* part, Instrument* _instr, Channel* _chan);
@@ -61,7 +59,6 @@ public:
       Instrument* instrument() { return _instr; }
       Channel* chan() { return _chan; }
       Channel* focusedChan();
-//      int chanIdx() { return _chanIdx; }
       MidiMapping *midiMap();
       int color();
 

--- a/mscore/mixertrackpart.cpp
+++ b/mscore/mixertrackpart.cpp
@@ -84,6 +84,15 @@ MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItemPtr mti, bool expa
       {
       setupUi(this);
 
+      int numChannels = 0;
+      Part* part = _mti->part();
+      const InstrumentList* il = part->instruments();
+      for (auto it = il->begin(); it != il->end(); ++it) {
+            Instrument* instr = it->second;
+            numChannels += instr->channel().size();
+            }
+
+      expandBn->setEnabled(numChannels > 1);
       expandBn->setChecked(expanded);
 
       connect(expandBn, SIGNAL(toggled(bool)), SLOT(expandToggled(bool)));
@@ -218,7 +227,7 @@ void MixerTrackPart::updateNameLabel()
 //   paintEvent
 //---------------------------------------------------------
 
-void MixerTrackPart::paintEvent(QPaintEvent* evt)
+void MixerTrackPart::paintEvent(QPaintEvent*)
       {
       applyStyle();
       }
@@ -329,7 +338,7 @@ void MixerTrackPart::controlSelected()
 //   mouseReleaseEvent
 //---------------------------------------------------------
 
-void MixerTrackPart::mouseReleaseEvent(QMouseEvent * event)
+void MixerTrackPart::mouseReleaseEvent(QMouseEvent*)
       {
       setSelected(true);
       }


### PR DESCRIPTION
Removing unused code.

Disabling part expansion button if number of member tracks is 1.