### PR TITLE
fix #77376: don't render those tied notes which are handled on rendering previous notes

### DIFF
--- a/libmscore/noteevent.h
+++ b/libmscore/noteevent.h
@@ -28,7 +28,9 @@ class NoteEvent {
       int _len;     // 1/1000 of nominal note len
 
    public:
-      NoteEvent() : _pitch(0), _ontime(0), _len(1000) {}
+      constexpr static int NOTE_LENGTH = 1000;
+
+      NoteEvent() : _pitch(0), _ontime(0), _len(NOTE_LENGTH) {}
       NoteEvent(int a, int b, int c) : _pitch(a), _ontime(b), _len(c) {}
 
       void read(XmlReader&);
@@ -51,6 +53,8 @@ class NoteEvent {
 class NoteEventList : public QList<NoteEvent> {
    public:
       NoteEventList();
+
+      int offtime() { return empty() ? 0 : std::max_element(cbegin(), cend(), [](const NoteEvent& n1, const NoteEvent& n2) { return n1.offtime() < n2.offtime(); })->offtime(); }
       };
 
 

--- a/mtest/libmscore/midi/testTieTrill-ref.txt
+++ b/mtest/libmscore/midi/testTieTrill-ref.txt
@@ -65,6 +65,7 @@ Tick  =   1795   Type  =   144   Pitch  =    72   Velocity  =     0   Channel  =
 Tick  =   1800   Type  =   144   Pitch  =    74   Velocity  =    80   Channel  =     0    
 Tick  =   1855   Type  =   144   Pitch  =    74   Velocity  =     0   Channel  =     0    
 Tick  =   1860   Type  =   144   Pitch  =    72   Velocity  =    80   Channel  =     0    
+Tick  =   1915   Type  =   144   Pitch  =    72   Velocity  =     0   Channel  =     0    
 Tick  =   1920   Type  =   144   Pitch  =    69   Velocity  =    80   Channel  =     0    
 Tick  =   1920   Type  =     3   Pitch  =     0   Velocity  =   127   Channel  =     0    
 Tick  =   1975   Type  =   144   Pitch  =    69   Velocity  =     0   Channel  =     0    
@@ -113,9 +114,9 @@ Tick  =   3175   Type  =   144   Pitch  =    69   Velocity  =     0   Channel  =
 Tick  =   3180   Type  =   144   Pitch  =    71   Velocity  =    80   Channel  =     0    
 Tick  =   3235   Type  =   144   Pitch  =    71   Velocity  =     0   Channel  =     0    
 Tick  =   3240   Type  =   144   Pitch  =    69   Velocity  =    80   Channel  =     0    
-Tick  =   3283   Type  =   144   Pitch  =    72   Velocity  =     0   Channel  =     0    
 Tick  =   3295   Type  =   144   Pitch  =    69   Velocity  =     0   Channel  =     0    
 Tick  =   3300   Type  =   144   Pitch  =    71   Velocity  =    80   Channel  =     0    
+Tick  =   3355   Type  =   144   Pitch  =    71   Velocity  =     0   Channel  =     0    
 Tick  =   3360   Type  =     4   Pitch  =     0   Velocity  =    80   Channel  =     0    
 Tick  =   3840   Type  =   144   Pitch  =    60   Velocity  =    80   Channel  =     0    
 Tick  =   3840   Type  =     3   Pitch  =     0   Velocity  =   127   Channel  =     0    
@@ -125,8 +126,7 @@ Tick  =   3955   Type  =   144   Pitch  =    62   Velocity  =     0   Channel  =
 Tick  =   3960   Type  =   144   Pitch  =    64   Velocity  =    80   Channel  =     0    
 Tick  =   4015   Type  =   144   Pitch  =    64   Velocity  =     0   Channel  =     0    
 Tick  =   4020   Type  =   144   Pitch  =    62   Velocity  =    80   Channel  =     0    
-Tick  =   4267   Type  =   144   Pitch  =    71   Velocity  =     0   Channel  =     0    
 Tick  =   4320   Type  =     4   Pitch  =     0   Velocity  =    80   Channel  =     0    
 Tick  =   4800   Type  =     4   Pitch  =     0   Velocity  =   127   Channel  =     0    
+Tick  =   5215   Type  =   144   Pitch  =    62   Velocity  =     0   Channel  =     0    
 Tick  =   5280   Type  =     4   Pitch  =     0   Velocity  =    80   Channel  =     0    
-Tick  =   6127   Type  =   144   Pitch  =    62   Velocity  =     0   Channel  =     0    


### PR DESCRIPTION
Fixes [this issue](https://musescore.org/en/node/77376).

The proposed patch adds a check for tied notes on whether they have already been rendered previously on rendering other tied notes. Most rendering functions act chord-wise rather than note-wise so to make the solution less complex this patch usually cleans up already created events instead of preventing their creation.