### PR TITLE
fix #278080: Request to show empty page rather than no page for score with no content

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3708,6 +3708,9 @@ void Score::doLayoutRange(int stick, int etick)
             _systems.clear();
             qDeleteAll(pages());
             pages().clear();
+            LayoutContext lc;
+            lc.score = this;
+            lc.getNextPage();
             return;
             }
 // qDebug("%p %d-%d %s systems %d", this, stick, etick, isMaster() ? "Master" : "Part", int(_systems.size()));


### PR DESCRIPTION
See https://musescore.org/en/node/278080.

By popular demand, this will make sure that there is at least one page, even if the score has no measures and no frames.