### PR TITLE
fix #276378: fix Y layout of double articulations

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -258,6 +258,18 @@ void Articulation::layout()
       }
 
 //---------------------------------------------------------
+//   layoutCloseToNote
+//    Needed to figure out the layout policy regarding
+//    distance to the note and placement in relation to
+//    slur.
+//---------------------------------------------------------
+
+bool Articulation::layoutCloseToNote() const
+      {
+      return (isStaccato() || isTenuto()) && !isDouble();
+      }
+
+//---------------------------------------------------------
 //   dragAnchor
 //---------------------------------------------------------
 
@@ -519,6 +531,12 @@ bool Articulation::isMarcato() const
       {
       return _symId == SymId::articMarcatoAbove         || _symId == SymId::articMarcatoBelow
           || _symId == SymId::articMarcatoStaccatoAbove || _symId == SymId::articMarcatoStaccatoBelow
+          || _symId == SymId::articMarcatoTenutoAbove   || _symId == SymId::articMarcatoTenutoBelow;
+      }
+
+bool Articulation::isDouble() const {
+      return _symId == SymId::articMarcatoStaccatoAbove || _symId == SymId::articMarcatoStaccatoBelow
+          || _symId == SymId::articAccentStaccatoAbove  || _symId == SymId::articAccentStaccatoBelow
           || _symId == SymId::articMarcatoTenutoAbove   || _symId == SymId::articMarcatoTenutoBelow;
       }
 

--- a/libmscore/articulation.h
+++ b/libmscore/articulation.h
@@ -85,6 +85,7 @@ class Articulation final : public Element {
       static const char* symId2ArticulationName(SymId symId);
 
       virtual void layout() override;
+      bool layoutCloseToNote() const;
 
       virtual void read(XmlReader&) override;
       virtual void write(XmlWriter& xml) const override;
@@ -123,6 +124,7 @@ class Articulation final : public Element {
 
       QString accessibleInfo() const override;
 
+      bool isDouble() const;
       bool isTenuto() const;
       bool isStaccato() const;
       bool isAccent() const;

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3253,8 +3253,7 @@ void Chord::layoutArticulations()
                   else
                         a->setUp(a->anchor() == ArticulationAnchor::TOP_STAFF || a->anchor() == ArticulationAnchor::TOP_CHORD);
                   }
-            bool isStaccato = a->isStaccato();
-            if (!(isStaccato || a->isTenuto()))
+            if (!a->layoutCloseToNote())
                   continue;
 
             ArticulationAnchor aa = a->anchor();
@@ -3386,7 +3385,7 @@ void Chord::layoutArticulations2()
             if (aa != ArticulationAnchor::CHORD && aa != ArticulationAnchor::TOP_CHORD && aa != ArticulationAnchor::BOTTOM_CHORD)
                   continue;
 
-            if (a->isStaccato() || a->isTenuto())
+            if (a->layoutCloseToNote())
                   continue;
             a->layout();
             dy += distance1;

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -587,14 +587,14 @@ static qreal fixArticulations(qreal yo, Chord* c, qreal _up)
             Articulation* a = al.at(1);
             if (a->up() == c->up())
                   return yo;
-            else if (a->isTenuto() || a->isStaccato())
+            else if (a->layoutCloseToNote())
                   return a->y() + (a->height() + c->score()->spatium() * .3) * _up;
             }
       else if (al.size() >= 1) {
             Articulation* a = al.at(0);
             if (a->up() == c->up())
                   return yo;
-            else if (a->isTenuto() || a->isStaccato())
+            else if (a->layoutCloseToNote())
                   return a->y() + (a->height() + c->score()->spatium() * .3) * _up;
             }
 #endif


### PR DESCRIPTION
Fixes https://musescore.org/en/node/276378
MuseScore apparently has a way to layout articulations properly but such a way of layout should not be applied to some types of articulations (staccato and tenuto). These exceptions apparently do not include double articulations so this patch expresses this in layout code.