### PR TITLE
fix #276354: lookup character codes in SMuFL code table if no font-specific symbol is found

### DIFF
--- a/libmscore/sym.h
+++ b/libmscore/sym.h
@@ -2778,7 +2778,7 @@ class ScoreFont {
       mutable QFont* font { 0 };
 
       static QVector<ScoreFont> _scoreFonts;
-      static QJsonObject _glyphnamesJson;
+      static std::array<uint, size_t(SymId::lastSym)+1> _mainSymCodeTable;
       void load();
       void computeMetrics(Sym* sym, int code);
 
@@ -2802,8 +2802,7 @@ class ScoreFont {
       static ScoreFont* fallbackFont();
       static const char* fallbackTextFont();
       static const QVector<ScoreFont>& scoreFonts() { return _scoreFonts; }
-      static bool initGlyphNamesJson();
-      static const QJsonObject& glyphNamesJson() { return _glyphnamesJson; }
+      static QJsonObject initGlyphNamesJson();
 
       QString toString(SymId) const;
       QPixmap sym2pixmap(SymId, qreal) { return QPixmap(); }      // TODOxxxx
@@ -2838,6 +2837,8 @@ class ScoreFont {
       bool useFallbackFont(SymId id) const;
 
       const Sym& sym(SymId id) const { return _symbols[int(id)]; }
+
+      friend void initScoreFonts();
       };
 
 extern void initScoreFonts();


### PR DESCRIPTION
Fixes https://musescore.org/en/node/276354.

This commit does three things:
1) Constructs a code table for SMuFL symbols that is common to all
used fonts. The table is constructed from fonts/smufl/glyphnames.json
2) Replaces repeated calls to the object representing that json file
by a lookup in the code table obtained from that file. This is simpler
to reuse and avoids unnecessary repeated string parsing operations.
3) The fix itself: ScoreFont::toString now looks for a symbol
in the common SMuFL table if nothing is found in the font itself.
That way a correct code for the queried symbol can be returned even
if the font itself is not able to render it.
Previously -1 was returned which led to adding symbols which cannot
be correctly displayed by any font at all.