### PR TITLE
fix #269309: handle MMRest properly on "Save selection" operation

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -185,6 +185,8 @@ void Score::writeMovement(XmlWriter& xml, bool selectionOnly)
             staffStart = staffIdx(sPart);
             staffEnd = staffIdx(ePart) + ePart->nstaves();
             measureStart = _selection.startSegment()->measure();
+            if (measureStart->isMeasure() && toMeasure(measureStart)->isMMRest())
+                  measureStart = toMeasure(measureStart)->mmRestFirst();
             if (_selection.endSegment())
                   measureEnd   = _selection.endSegment()->measure()->next();
             else


### PR DESCRIPTION
See https://musescore.org/en/node/269309

Currently any range being written must start with a usual measure, that measure has MM rest it will trigger its writing. This patch assures this assumption for selection writing.