### PR TITLE
fix #278339 Fix crash when note entered in piano roll

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -184,7 +184,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_PIANOROLL_DARK_BG_KEY_BLACK_COLOR,            new ColorPreference(QColor("#262626"))},
             {PREF_UI_PIANOROLL_DARK_BG_GRIDLINE_COLOR,             new ColorPreference(QColor("#111111"))},
             {PREF_UI_PIANOROLL_DARK_BG_TEXT_COLOR,                 new ColorPreference(QColor("#999999"))},
-            {PREF_UI_PIANOROLL_DARK_SELECTION_BOX_COLOR,           new ColorPreference(QColor("#0cebff"))},
+            {PREF_UI_PIANOROLL_LIGHT_SELECTION_BOX_COLOR,          new ColorPreference(QColor("#2085c3"))},
             {PREF_UI_PIANOROLL_LIGHT_NOTE_UNSEL_COLOR,             new ColorPreference(QColor("#1dcca0"))},
             {PREF_UI_PIANOROLL_LIGHT_NOTE_SEL_COLOR,               new ColorPreference(QColor("#ffff00"))},
             {PREF_UI_PIANOROLL_LIGHT_BG_BASE_COLOR,                new ColorPreference(QColor("#e0e0e7"))},


### PR DESCRIPTION
Fixing crash when note is entered in piano roll editor before any has been selected or a note duration has been chosen.

Can now use piano roll editor to enter notes in 'gap' spaces with no chord or rest.

Selection box color now reading properly from preferences.

Rearranging mousewheel section to be in more logical order.  Also swapping ctrl and ctrl-shift effects.