### PR TITLE
fix #278023: text style usability issues

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -50,6 +50,13 @@ struct StyleType {
       const QVariant&  defaultValue() const { return _defaultValue; }
       };
 
+//---------------------------------------------------------
+//   styleTypes
+//
+//    Keep in sync with sid in style.h
+//---------------------------------------------------------
+
+
 static const StyleType styleTypes[] {
       { Sid::pageWidth,               "pageWidth",               210.0/INCH },
       { Sid::pageHeight,              "pageHeight",              297.0/INCH }, // A4
@@ -1171,7 +1178,7 @@ const TextStyle composerTextStyle {{
 const TextStyle lyricistTextStyle {{
       { Sid::lyricistFontFace,                   Pid::FONT_FACE              },
       { Sid::lyricistFontSize,                   Pid::FONT_SIZE              },
-      { Sid::defaultFontSpatiumDependent,        Pid::SIZE_SPATIUM_DEPENDENT },
+      { Sid::lyricistFontSpatiumDependent,       Pid::SIZE_SPATIUM_DEPENDENT },
       { Sid::lyricistFontBold,                   Pid::FONT_BOLD              },
       { Sid::lyricistFontItalic,                 Pid::FONT_ITALIC            },
       { Sid::lyricistFontUnderline,              Pid::FONT_UNDERLINE         },
@@ -1382,7 +1389,7 @@ const TextStyle tempoTextStyle {{
       { Sid::tempoFontItalic,                    Pid::FONT_ITALIC            },
       { Sid::tempoFontUnderline,                 Pid::FONT_UNDERLINE         },
       { Sid::tempoAlign,                         Pid::ALIGN                  },
-      { Sid::tempoOffset,                        Pid::OFFSET                 },
+      { Sid::tempoPosAbove,                      Pid::OFFSET                 },
       { Sid::tempoFrameType,                     Pid::FRAME_TYPE             },
       { Sid::tempoFramePadding,                  Pid::FRAME_PADDING          },
       { Sid::tempoFrameWidth,                    Pid::FRAME_WIDTH            },
@@ -2024,6 +2031,67 @@ QString textStyleUserName(Tid idx)
       {
       Q_ASSERT(idx == textStyles[int(idx)].tid);
       return qApp->translate("TextStyle", textStyleName(idx));
+      }
+
+static std::vector<Tid> _allTextStyles;
+
+static const std::vector<Tid> _primaryTextStyles = {
+      Tid::TITLE,
+      Tid::SUBTITLE,
+      Tid::COMPOSER,
+      Tid::POET,
+      Tid::TRANSLATOR,
+      Tid::FRAME,
+      Tid::HEADER,
+      Tid::FOOTER,
+      Tid::MEASURE_NUMBER,
+      Tid::INSTRUMENT_EXCERPT,
+      Tid::INSTRUMENT_CHANGE,
+      Tid::STAFF,
+      Tid::SYSTEM,
+      Tid::EXPRESSION,
+      Tid::DYNAMICS,
+      Tid::HAIRPIN,
+      Tid::TEMPO,
+      Tid::REHEARSAL_MARK,
+      Tid::REPEAT_LEFT,
+      Tid::REPEAT_RIGHT,
+      Tid::LYRICS_ODD,
+      Tid::LYRICS_EVEN,
+      Tid::HARMONY_A,
+      Tid::HARMONY_B,
+      Tid::USER1,
+      Tid::USER2,
+      Tid::USER3,
+      Tid::USER4,
+      Tid::USER5,
+      Tid::USER6
+      };
+
+//---------------------------------------------------------
+//   allTextStyles
+//---------------------------------------------------------
+
+const std::vector<Tid>& allTextStyles()
+      {
+      if (_allTextStyles.empty()) {
+            _allTextStyles.reserve(int(Tid::TEXT_STYLES));
+            for (const auto& s : textStyles) {
+                  if (s.tid == Tid::DEFAULT)
+                        continue;
+                  _allTextStyles.push_back(s.tid);
+                  }
+            }
+      return _allTextStyles;
+      }
+
+//---------------------------------------------------------
+//   primaryTextStyles
+//---------------------------------------------------------
+
+const std::vector<Tid>& primaryTextStyles()
+      {
+      return _primaryTextStyles;
       }
 
 //---------------------------------------------------------

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1197,6 +1197,9 @@ const char* textStyleName(Tid);
 QString textStyleUserName(Tid);
 Tid textStyleFromName(const QString&);
 
+const std::vector<Tid>& allTextStyles();
+const std::vector<Tid>& primaryTextStyles();
+
 #ifndef NDEBUG
 extern void checkStyles();
 #endif

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -600,32 +600,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       connect(mapper,  SIGNAL(mapped(int)), SLOT(resetStyleValue(int)));
       connect(mapper2, SIGNAL(mapped(int)), SLOT(valueChanged(int)));
       textStyles->clear();
-      for (auto ss : {
-         Tid::SYSTEM,
-         Tid::STAFF,
-         Tid::TEMPO,
-         Tid::METRONOME,
-         Tid::REHEARSAL_MARK,
-         Tid::EXPRESSION,
-         Tid::REPEAT_LEFT,
-         Tid::REPEAT_RIGHT,
-         Tid::FRAME,
-         Tid::TITLE,
-         Tid::SUBTITLE,
-         Tid::COMPOSER,
-         Tid::POET,
-         Tid::INSTRUMENT_EXCERPT,
-         Tid::TRANSLATOR,
-         Tid::HEADER,
-         Tid::FOOTER,
-         Tid::USER1,
-         Tid::USER2,
-         Tid::USER3,
-         Tid::USER4,
-         Tid::USER5,
-         Tid::USER6
-         } )
-            {
+      for (auto ss : allTextStyles()) {
             QListWidgetItem* item = new QListWidgetItem(textStyleUserName(ss));
             item->setData(Qt::UserRole, int(ss));
             textStyles->addItem(item);

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -320,6 +320,7 @@ void Inspector::update(Score* s)
                         case ElementType::STAFF_TEXT:
                         case ElementType::SYSTEM_TEXT:
                         case ElementType::REHEARSAL_MARK:
+                        case ElementType::INSTRUMENT_CHANGE:
                               ie = new InspectorStaffText(this);
                               break;
                         case ElementType::MEASURE_NUMBER:
@@ -348,9 +349,6 @@ void Inspector::update(Score* s)
                               break;
                         case ElementType::NOTEDOT:
                               ie = new InspectorNoteDot(this);
-                              break;
-                        case ElementType::INSTRUMENT_CHANGE:
-                              ie = new InspectorInstrumentChange(this);
                               break;
                         default:
                               if (element()->isText())
@@ -1006,12 +1004,18 @@ InspectorTempoText::InspectorTempoText(QWidget* parent)
       const std::vector<InspectorItem> il = {
             { Pid::TEMPO,             0, tt.tempo,       tt.resetTempo       },
             { Pid::TEMPO_FOLLOW_TEXT, 0, tt.followText,  tt.resetFollowText  },
+            { Pid::SUB_STYLE,         0, tt.style,       tt.resetStyle       },
             { Pid::PLACEMENT,         0, tt.placement,   tt.resetPlacement   }
             };
       const std::vector<InspectorPanel> ppList = {
             { tt.title, tt.panel }
             };
       populatePlacement(tt.placement);
+
+      tt.style->clear();
+      for (auto ss : primaryTextStyles())
+            tt.style->addItem(textStyleUserName(ss), int(ss));
+
       mapSignals(il, ppList);
       connect(tt.followText, SIGNAL(toggled(bool)), tt.tempo, SLOT(setDisabled(bool)));
       }
@@ -1038,13 +1042,19 @@ InspectorLyric::InspectorLyric(QWidget* parent)
       l.setupUi(addWidget());
 
       const std::vector<InspectorItem> il = {
-            { Pid::PLACEMENT,          0, l.placement,    l.resetPlacement    },
-            { Pid::VERSE,              0, l.verse,        l.resetVerse        }
+            { Pid::VERSE,              0, l.verse,        l.resetVerse        },
+            { Pid::SUB_STYLE,          0, l.style,        l.resetStyle        },
+            { Pid::PLACEMENT,          0, l.placement,    l.resetPlacement    }
             };
       const std::vector<InspectorPanel> ppList = {
             { l.title, l.panel }
             };
       populatePlacement(l.placement);
+
+      l.style->clear();
+      for (auto ss : primaryTextStyles())
+            l.style->addItem(textStyleUserName(ss), int(ss));
+
       mapSignals(il, ppList);
       connect(t.resetToStyle, SIGNAL(clicked()), SLOT(resetToStyle()));
       }
@@ -1062,17 +1072,17 @@ InspectorStaffText::InspectorStaffText(QWidget* parent)
       bool sameTypes = true;
 
       for (const auto& ee : *inspector->el()) {
-            if (el->isSystemText() != ee->isSystemText()) {
+            if (el->type() != ee->type() || el->isSystemText() != ee->isSystemText()) {
                   sameTypes = false;
                   break;
                   }
             }
       if (sameTypes)
-            s.title->setText(el->isSystemText() ? tr("System Text") : tr("Staff Text"));
+            s.title->setText(el->userName());
 
       const std::vector<InspectorItem> il = {
-            { Pid::PLACEMENT,  0, s.placement, s.resetPlacement },
-            { Pid::SUB_STYLE,  0, s.style,     s.resetStyle     }
+            { Pid::SUB_STYLE,  0, s.style,     s.resetStyle     },
+            { Pid::PLACEMENT,  0, s.placement, s.resetPlacement }
             };
       const std::vector<InspectorPanel> ppList = {
             { s.title, s.panel }
@@ -1080,34 +1090,8 @@ InspectorStaffText::InspectorStaffText(QWidget* parent)
       populatePlacement(s.placement);
 
       s.style->clear();
-      for (auto ss : {
-         Tid::SYSTEM,
-         Tid::STAFF,
-         Tid::TEMPO,
-         Tid::METRONOME,
-         Tid::REHEARSAL_MARK,
-         Tid::EXPRESSION,
-         Tid::REPEAT_LEFT,
-         Tid::REPEAT_RIGHT,
-         Tid::FRAME,
-         Tid::TITLE,
-         Tid::SUBTITLE,
-         Tid::COMPOSER,
-         Tid::POET,
-         Tid::INSTRUMENT_EXCERPT,
-         Tid::TRANSLATOR,
-         Tid::HEADER,
-         Tid::FOOTER,
-         Tid::USER1,
-         Tid::USER2,
-         Tid::USER3,
-         Tid::USER4,
-         Tid::USER5,
-         Tid::USER6
-         } )
-            {
+      for (auto ss : primaryTextStyles())
             s.style->addItem(textStyleUserName(ss), int(ss));
-            }
 
       mapSignals(il, ppList);
       }

--- a/mscore/inspector/inspectorDynamic.cpp
+++ b/mscore/inspector/inspectorDynamic.cpp
@@ -28,12 +28,18 @@ InspectorDynamic::InspectorDynamic(QWidget* parent)
       const std::vector<InspectorItem> il = {
             { Pid::DYNAMIC_RANGE,    0, d.dynRange,     d.resetDynRange     },
             { Pid::VELOCITY,         0, d.velocity,     0                   },
+            { Pid::SUB_STYLE,        0, d.style,        d.resetStyle        },
             { Pid::PLACEMENT,        0, d.placement,    d.resetPlacement    }
             };
       const std::vector<InspectorPanel> ppList = {
             { d.title, d.panel }
             };
       populatePlacement(d.placement);
+
+      d.style->clear();
+      for (auto ss : primaryTextStyles())
+            d.style->addItem(textStyleUserName(ss), int(ss));
+
       mapSignals(il, ppList);
       }
 

--- a/mscore/inspector/inspectorFingering.cpp
+++ b/mscore/inspector/inspectorFingering.cpp
@@ -35,9 +35,7 @@ InspectorFingering::InspectorFingering(QWidget* parent)
 
       f.style->clear();
       for (auto ss : { Tid::FINGERING, Tid::LH_GUITAR_FINGERING, Tid::RH_GUITAR_FINGERING, Tid::STRING_NUMBER } )
-            {
             f.style->addItem(textStyleUserName(ss), int(ss));
-            }
 
       mapSignals(iiList, ppList);
       }

--- a/mscore/inspector/inspectorHarmony.cpp
+++ b/mscore/inspector/inspectorHarmony.cpp
@@ -36,9 +36,8 @@ InspectorHarmony::InspectorHarmony(QWidget* parent)
             };
 
       h.style->clear();
-      for (auto ss : { Tid::HARMONY_A, Tid::HARMONY_B } ) {
+      for (auto ss : primaryTextStyles())
             h.style->addItem(textStyleUserName(ss), int(ss));
-            }
 
       t.resetToStyle->setVisible(false);
 

--- a/mscore/inspector/inspectorText.cpp
+++ b/mscore/inspector/inspectorText.cpp
@@ -35,26 +35,8 @@ InspectorText::InspectorText(QWidget* parent)
             };
 
       f.style->clear();
-      for (auto ss : {
-         Tid::FRAME,
-         Tid::TITLE,
-         Tid::SUBTITLE,
-         Tid::COMPOSER,
-         Tid::POET,
-         Tid::INSTRUMENT_EXCERPT,
-         Tid::TRANSLATOR,
-         Tid::HEADER,
-         Tid::FOOTER,
-         Tid::USER1,
-         Tid::USER2,
-         Tid::USER3,
-         Tid::USER4,
-         Tid::USER5,
-         Tid::USER6
-         } )
-            {
+      for (auto ss : primaryTextStyles())
             f.style->addItem(textStyleUserName(ss), int(ss));
-            }
 
       mapSignals(iiList, ppList);
       }

--- a/mscore/inspector/inspector_dynamic.ui
+++ b/mscore/inspector/inspector_dynamic.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>InspectorDynamic</class>
  <widget class="QWidget" name="InspectorDynamic">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>178</width>
+    <height>141</height>
+   </rect>
+  </property>
   <property name="accessibleName">
    <string>Dynamic Inspector</string>
   </property>
@@ -140,7 +148,41 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Style:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>style</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="style">
+        <property name="accessibleName">
+         <string>Style</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="2">
+       <widget class="QToolButton" name="resetStyle">
+        <property name="toolTip">
+         <string>Reset to default</string>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Style' value</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../musescore.qrc">
+          <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
        <widget class="QToolButton" name="resetPlacement">
         <property name="toolTip">
          <string>Reset to default</string>
@@ -154,7 +196,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="placement">
         <property name="accessibleName">
          <string>Placement</string>
@@ -171,7 +213,7 @@
         </item>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Placement:</string>
@@ -190,10 +232,11 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>title</tabstop>
   <tabstop>dynRange</tabstop>
   <tabstop>resetDynRange</tabstop>
   <tabstop>velocity</tabstop>
+  <tabstop>style</tabstop>
+  <tabstop>resetStyle</tabstop>
   <tabstop>placement</tabstop>
   <tabstop>resetPlacement</tabstop>
  </tabstops>

--- a/mscore/inspector/inspector_lyric.ui
+++ b/mscore/inspector/inspector_lyric.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>InspectorLyric</class>
  <widget class="QWidget" name="InspectorLyric">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>155</width>
+    <height>118</height>
+   </rect>
+  </property>
   <property name="accessibleName">
    <string>Lyrics Inspector</string>
   </property>
@@ -68,7 +76,41 @@
       <property name="verticalSpacing">
        <number>0</number>
       </property>
-      <item row="0" column="0">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Style:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>style</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="style">
+        <property name="accessibleName">
+         <string>Style</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QToolButton" name="resetStyle">
+        <property name="toolTip">
+         <string>Reset to default</string>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Style' value</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../musescore.qrc">
+          <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Placement:</string>
@@ -81,7 +123,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="2" column="1">
        <widget class="QComboBox" name="placement">
         <property name="accessibleName">
          <string>Placement</string>
@@ -98,30 +140,7 @@
         </item>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Verse:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>verse</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="verse">
-        <property name="accessibleName">
-         <string>Verse</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
+      <item row="2" column="2">
        <widget class="QToolButton" name="resetPlacement">
         <property name="toolTip">
          <string>Reset to default</string>
@@ -135,7 +154,30 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Verse:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>verse</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="verse">
+        <property name="accessibleName">
+         <string>Verse</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
        <widget class="QToolButton" name="resetVerse">
         <property name="toolTip">
          <string>Reset to default</string>
@@ -155,11 +197,12 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>title</tabstop>
-  <tabstop>placement</tabstop>
-  <tabstop>resetPlacement</tabstop>
   <tabstop>verse</tabstop>
   <tabstop>resetVerse</tabstop>
+  <tabstop>style</tabstop>
+  <tabstop>resetStyle</tabstop>
+  <tabstop>placement</tabstop>
+  <tabstop>resetPlacement</tabstop>
  </tabstops>
  <resources>
   <include location="../musescore.qrc"/>

--- a/mscore/inspector/inspector_tempotext.ui
+++ b/mscore/inspector/inspector_tempotext.ui
@@ -142,6 +142,40 @@
        </widget>
       </item>
       <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Style:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>style</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="style">
+        <property name="accessibleName">
+         <string>Style</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QToolButton" name="resetStyle">
+        <property name="toolTip">
+         <string>Reset to default</string>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Style' value</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../musescore.qrc">
+          <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Placement:</string>
@@ -154,7 +188,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="placement">
         <property name="accessibleName">
          <string>Placement</string>
@@ -171,7 +205,7 @@
         </item>
        </widget>
       </item>
-      <item row="2" column="2">
+      <item row="3" column="2">
        <widget class="QToolButton" name="resetPlacement">
         <property name="toolTip">
          <string>Reset to default</string>
@@ -191,11 +225,14 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>title</tabstop>
   <tabstop>followText</tabstop>
   <tabstop>resetFollowText</tabstop>
   <tabstop>tempo</tabstop>
   <tabstop>resetTempo</tabstop>
+  <tabstop>style</tabstop>
+  <tabstop>resetStyle</tabstop>
+  <tabstop>placement</tabstop>
+  <tabstop>resetPlacement</tabstop>
  </tabstops>
  <resources>
   <include location="../musescore.qrc"/>

--- a/mtest/libmscore/compat114/textstyles-ref.mscx
+++ b/mtest/libmscore/compat114/textstyles-ref.mscx
@@ -1687,7 +1687,7 @@
           </Text>
         <Text>
           <style>Lyricist</style>
-          <text><font size="10.5833"/><font face="MuseJazz"/>Lyricist</text>
+          <text><font face="MuseJazz"/>Lyricist</text>
           </Text>
         </VBox>
       <Measure>


### PR DESCRIPTION
See https://musescore.org/en/node/278023.  Now that Werner has added the "missing" style values (looks like he got them all except perhaps spatiumdependent and offsettype, which maybe we don't need), I have gone in and cleaned up the style editor and inspector to be more consistent.  See my comments in issue tracker regarding what I did and haven't done.  To me this is usable as is, more would be gravy and someone else can maybe deal with it if desired.