### PR TITLE
fix #277719: add a buffer space at the end of continuous view page

### DIFF
--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -461,7 +461,11 @@ void LayoutContext::layoutLinear()
       page->setPos(0, 0);
       system->setPos(page->lm(), page->tm() + score->styleP(Sid::staffUpperBorder));
       page->setWidth(system->width() + system->pos().x());
-      page->setHeight(system->height() + system->pos().y());
+      // Set buffer space after the last system to avoid problems with mouse input.
+      // Mouse input divides space between systems equally (see Score::searchSystem),
+      // hence the choice of the value.
+      const qreal buffer = 0.5 * score->styleS(Sid::maxSystemDistance).val() * score->spatium();
+      page->setHeight(system->height() + system->pos().y() + buffer);
       page->rebuildBspTree();
       }
 


### PR DESCRIPTION
Fixes https://musescore.org/en/node/277719
The problem was apparently introduced in [this commit](https://github.com/musescore/MuseScore/commit/eceb5d71a0c235cda8d755e7ad204c1df95bf199) which fixed another problem with continuous view page size. Adding a buffer space after the last system resolves the new problem not breaking the previous problem's solution.