### PR TITLE
Fix #276404: Format->Style too large

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -45,6 +45,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       cs = s;
       buttonApplyToAllParts = buttonBox->addButton(tr("Apply to all Parts"), QDialogButtonBox::ApplyRole);
       buttonApplyToAllParts->setEnabled(!cs->isMaster());
+      buttonTogglePagelist->setIcon(QIcon(*icons[int(Icons::goNext_ICON)]));
       setModal(true);
 
       // create button groups for every set of radio button widgets
@@ -789,6 +790,27 @@ void EditStyle::on_comboFBFont_currentIndexChanged(int index)
       }
 
 //---------------------------------------------------------
+//    On buttonTogglePagelist clicked
+//---------------------------------------------------------
+
+void EditStyle::on_buttonTogglePagelist_clicked()
+      {
+
+      if (pageList->isVisible()) {
+            setMaximumWidth(pageStack->minimumWidth() + 15);
+            setMinimumWidth(pageStack->minimumWidth() + 15);
+            move(pos().x() + (pageList->minimumWidth() + 5), pos().y());
+            buttonTogglePagelist->setIcon(QIcon(*icons[int(Icons::goPrevious_ICON)]));
+            }
+      else {
+            setMaximumWidth((pageList->minimumWidth() + 5) + pageStack->minimumWidth() + 15);
+            setMinimumWidth((pageList->minimumWidth() + 5) + pageStack->minimumWidth() + 15);
+            move(pos().x() - (pageList->minimumWidth() + 5), pos().y());
+            pageList->setVisible(true);
+            buttonTogglePagelist->setIcon(QIcon(*icons[int(Icons::goNext_ICON)]));
+            }
+      }		  
+//---------------------------------------------------------
 //   applyToAllParts
 //---------------------------------------------------------
 
@@ -1429,5 +1451,5 @@ void EditStyle::resetTextStyle(Pid pid)
       textStyleChanged(textStyles->currentRow());     // update GUI
       cs->update();
       }
-}
+} //namespace Ms
 

--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -78,6 +78,7 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       void resetTextStyle(Pid);
       void textStyleValueChanged(Pid, QVariant);
       void on_comboFBFont_currentIndexChanged(int index);
+      void on_buttonTogglePagelist_clicked();
 
 public:
       static const int PAGE_NOTE = 6;

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -6,9 +6,27 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1340</width>
-    <height>908</height>
+    <width>910</width>
+    <height>660</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>910</width>
+    <height>660</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Edit General Style</string>
@@ -32,6 +50,22 @@
       <number>0</number>
      </property>
      <item>
+      <widget class="QPushButton" name="buttonTogglePagelist">
+       <property name="maximumSize">
+        <size>
+         <width>20</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
@@ -46,6 +80,12 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <widget class="QListWidget" name="pageList">
+      <property name="minimumSize">
+       <size>
+        <width>180</width>
+        <height>0</height>
+       </size>
+      </property>
       <property name="alternatingRowColors">
        <bool>true</bool>
       </property>
@@ -224,8 +264,26 @@
       </item>
      </widget>
      <widget class="QStackedWidget" name="pageStack">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>710</width>
+        <height>565</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>710</width>
+        <height>16777215</height>
+       </size>
+      </property>
       <property name="currentIndex">
-       <number>5</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="PageScore">
        <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -671,6 +729,342 @@
            <property name="verticalSpacing">
             <number>2</number>
            </property>
+           <item row="0" column="1">
+            <widget class="QDoubleSpinBox" name="staffUpperBorder">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>-1000.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_77">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Last system fill threshold:</string>
+             </property>
+             <property name="buddy">
+              <cstring>lastSystemFillThreshold</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0">
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>137</width>
+               <height>21</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="6" column="0">
+            <spacer name="verticalSpacer_9">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="2" column="6">
+            <widget class="QDoubleSpinBox" name="maxSystemDistance">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>0.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="5">
+            <widget class="QLabel" name="label_191">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Max. system distance:</string>
+             </property>
+             <property name="buddy">
+              <cstring>maxSystemDistance</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QSpinBox" name="lastSystemFillThreshold">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string notr="true">%</string>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="value">
+              <number>70</number>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="5">
+            <widget class="QCheckBox" name="genCourtesyTimesig">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Create courtesy time signatures</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0">
+            <widget class="QCheckBox" name="genKeysig">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Create key signature for all systems</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="5">
+            <widget class="QCheckBox" name="genCourtesyKeysig">
+             <property name="text">
+              <string>Create courtesy key signatures</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="0">
+            <widget class="QCheckBox" name="genCourtesyClef">
+             <property name="text">
+              <string>Create courtesy clefs</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="7">
+            <widget class="QToolButton" name="resetMaxSystemDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Max. system distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="3">
+            <widget class="QToolButton" name="resetLastSystemFillThreshold">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Last system fill threshold' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="3">
+            <widget class="QToolButton" name="resetMinSystemDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Min. system distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="7">
+            <widget class="QToolButton" name="resetFrameSystemDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Vertical frame bottom margin' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="7">
+            <widget class="QToolButton" name="resetAkkoladeDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Grand staff distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="7">
+            <widget class="QToolButton" name="resetStaffLowerBorder">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Music bottom margin' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="QToolButton" name="resetStaffDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Staff distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="4">
+            <spacer name="horizontalSpacer_43">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="3">
+            <widget class="QToolButton" name="resetStaffUpperBorder">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Music top margin' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="3">
+            <widget class="QToolButton" name="resetSystemFrameDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Vertical frame top margin' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="0">
             <widget class="QLabel" name="label_76">
              <property name="sizePolicy">
@@ -687,8 +1081,8 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QDoubleSpinBox" name="staffUpperBorder">
+           <item row="0" column="6">
+            <widget class="QDoubleSpinBox" name="staffLowerBorder">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -725,7 +1119,7 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="4">
+           <item row="0" column="5">
             <widget class="QLabel" name="label_78">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -741,28 +1135,19 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="5">
-            <widget class="QDoubleSpinBox" name="staffLowerBorder">
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_73">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="suffix">
-              <string>sp</string>
+             <property name="text">
+              <string>Min. system distance:</string>
              </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="minimum">
-              <double>-1000.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>1000.000000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>0.500000000000000</double>
+             <property name="buddy">
+              <cstring>minSystemDistance</cstring>
              </property>
             </widget>
            </item>
@@ -782,48 +1167,7 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
-            <widget class="QDoubleSpinBox" name="staffDistance">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="suffix">
-              <string>sp</string>
-             </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="minimum">
-              <double>-1000.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>1000.000000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>0.500000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="4">
-            <widget class="QLabel" name="label_70">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Grand staff distance:</string>
-             </property>
-             <property name="buddy">
-              <cstring>akkoladeDistance</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="5">
+           <item row="1" column="6">
             <widget class="QDoubleSpinBox" name="akkoladeDistance">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -848,8 +1192,8 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_73">
+           <item row="1" column="5">
+            <widget class="QLabel" name="label_70">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -857,35 +1201,10 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Min. system distance:</string>
+              <string>Grand staff distance:</string>
              </property>
              <property name="buddy">
-              <cstring>minSystemDistance</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QDoubleSpinBox" name="minSystemDistance">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="suffix">
-              <string>sp</string>
-             </property>
-             <property name="decimals">
-              <number>1</number>
-             </property>
-             <property name="minimum">
-              <double>-1000.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>1000.000000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>0.500000000000000</double>
+              <cstring>akkoladeDistance</cstring>
              </property>
             </widget>
            </item>
@@ -930,7 +1249,7 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="4">
+           <item row="4" column="5">
             <widget class="QLabel" name="label_75">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -949,7 +1268,32 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="5">
+           <item row="2" column="1">
+            <widget class="QDoubleSpinBox" name="minSystemDistance">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
+             <property name="minimum">
+              <double>-1000.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.500000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="6">
             <widget class="QDoubleSpinBox" name="frameSystemDistance">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -971,36 +1315,7 @@
              </property>
             </widget>
            </item>
-           <item row="10" column="0">
-            <spacer>
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>137</width>
-               <height>21</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="6" column="0">
-            <spacer name="verticalSpacer_9">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Fixed</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="3" column="0" colspan="6">
+           <item row="3" column="0" colspan="7">
             <widget class="QFrame" name="frame_3">
              <property name="frameShape">
               <enum>QFrame::HLine</enum>
@@ -1010,8 +1325,8 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="5">
-            <widget class="QDoubleSpinBox" name="maxSystemDistance">
+           <item row="1" column="1">
+            <widget class="QDoubleSpinBox" name="staffDistance">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -1025,7 +1340,7 @@
               <number>1</number>
              </property>
              <property name="minimum">
-              <double>0.000000000000000</double>
+              <double>-1000.000000000000000</double>
              </property>
              <property name="maximum">
               <double>1000.000000000000000</double>
@@ -1034,263 +1349,6 @@
               <double>0.500000000000000</double>
              </property>
             </widget>
-           </item>
-           <item row="2" column="4">
-            <widget class="QLabel" name="label_191">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Max. system distance:</string>
-             </property>
-             <property name="buddy">
-              <cstring>maxSystemDistance</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="label_77">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Last system fill threshold:</string>
-             </property>
-             <property name="buddy">
-              <cstring>lastSystemFillThreshold</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="0">
-            <widget class="QCheckBox" name="genKeysig">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Create key signature for all systems</string>
-             </property>
-            </widget>
-           </item>
-           <item row="9" column="0">
-            <widget class="QCheckBox" name="genCourtesyClef">
-             <property name="text">
-              <string>Create courtesy clefs</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="4">
-            <widget class="QCheckBox" name="genCourtesyTimesig">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Create courtesy time signatures</string>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="4">
-            <widget class="QCheckBox" name="genCourtesyKeysig">
-             <property name="text">
-              <string>Create courtesy key signatures</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QSpinBox" name="lastSystemFillThreshold">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="suffix">
-              <string notr="true">%</string>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="value">
-              <number>70</number>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="2">
-            <widget class="QToolButton" name="resetLastSystemFillThreshold">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Last system fill threshold' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="6">
-            <widget class="QToolButton" name="resetMaxSystemDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Max. system distance' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="6">
-            <widget class="QToolButton" name="resetFrameSystemDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Vertical frame bottom margin' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="2">
-            <widget class="QToolButton" name="resetMinSystemDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Min. system distance' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="6">
-            <widget class="QToolButton" name="resetAkkoladeDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Grand staff distance' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="2">
-            <widget class="QToolButton" name="resetStaffDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Staff distance' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="6">
-            <widget class="QToolButton" name="resetStaffLowerBorder">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Music bottom margin' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="QToolButton" name="resetStaffUpperBorder">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Music top margin' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="2">
-            <widget class="QToolButton" name="resetSystemFrameDistance">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Vertical frame top margin' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="3">
-            <spacer name="horizontalSpacer_43">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
            </item>
           </layout>
          </widget>
@@ -2121,6 +2179,12 @@
        </layout>
       </widget>
       <widget class="QWidget" name="PageSystem">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>620</height>
+        </size>
+       </property>
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <property name="spacing">
          <number>0</number>
@@ -2209,61 +2273,66 @@
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="label_92">
+               </layout>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_49">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <layout class="QFormLayout" name="formLayout_2">
+                <item row="0" column="0">
+                 <widget class="QLabel" name="braceThicknessLabel">
                   <property name="text">
                    <string>Brace thickness:</string>
                   </property>
-                  <property name="buddy">
-                   <cstring>akkoladeWidth</cstring>
-                  </property>
                  </widget>
                 </item>
-                <item row="2" column="1">
+                <item row="0" column="1">
                  <widget class="QDoubleSpinBox" name="akkoladeWidth">
-                  <property name="suffix">
-                   <string extracomment="spatium unit">sp</string>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
                   </property>
-                  <property name="decimals">
-                   <number>2</number>
-                  </property>
-                  <property name="minimum">
-                   <double>-1000.000000000000000</double>
-                  </property>
-                  <property name="maximum">
-                   <double>1000.000000000000000</double>
-                  </property>
-                  <property name="singleStep">
-                   <double>0.100000000000000</double>
+                  <property name="minimumSize">
+                   <size>
+                    <width>80</width>
+                    <height>0</height>
+                   </size>
                   </property>
                  </widget>
                 </item>
-                <item row="3" column="0">
-                 <widget class="QLabel" name="label_90">
+                <item row="1" column="0">
+                 <widget class="QLabel" name="braceDistanceLabel">
                   <property name="text">
                    <string>Brace distance:</string>
                   </property>
-                  <property name="buddy">
-                   <cstring>akkoladeBarDistance</cstring>
-                  </property>
                  </widget>
                 </item>
-                <item row="3" column="1">
+                <item row="1" column="1">
                  <widget class="QDoubleSpinBox" name="akkoladeBarDistance">
-                  <property name="suffix">
-                   <string extracomment="spatium unit">sp</string>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
                   </property>
-                  <property name="decimals">
-                   <number>2</number>
-                  </property>
-                  <property name="minimum">
-                   <double>-1000.000000000000000</double>
-                  </property>
-                  <property name="maximum">
-                   <double>1000.000000000000000</double>
-                  </property>
-                  <property name="singleStep">
-                   <double>0.100000000000000</double>
+                  <property name="minimumSize">
+                   <size>
+                    <width>80</width>
+                    <height>0</height>
+                   </size>
                   </property>
                  </widget>
                 </item>
@@ -2319,23 +2388,6 @@
                     <widget class="QComboBox" name="dividerLeftSym"/>
                    </item>
                    <item>
-                    <spacer name="horizontalSpacer_18">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_13">
-                   <item>
                     <widget class="QLabel" name="label_29">
                      <property name="text">
                       <string>Horizontal offset:</string>
@@ -2347,6 +2399,12 @@
                    </item>
                    <item>
                     <widget class="QDoubleSpinBox" name="dividerLeftX">
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>20</height>
+                      </size>
+                     </property>
                      <property name="suffix">
                       <string>sp</string>
                      </property>
@@ -2367,6 +2425,12 @@
                    </item>
                    <item>
                     <widget class="QDoubleSpinBox" name="dividerLeftY">
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>20</height>
+                      </size>
+                     </property>
                      <property name="suffix">
                       <string>sp</string>
                      </property>
@@ -2421,23 +2485,6 @@
                     <widget class="QComboBox" name="dividerRightSym"/>
                    </item>
                    <item>
-                    <spacer name="horizontalSpacer_20">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout_14">
-                   <item>
                     <widget class="QLabel" name="label_67">
                      <property name="text">
                       <string>Horizontal offset:</string>
@@ -2449,6 +2496,12 @@
                    </item>
                    <item>
                     <widget class="QDoubleSpinBox" name="dividerRightX">
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>20</height>
+                      </size>
+                     </property>
                      <property name="suffix">
                       <string>sp</string>
                      </property>
@@ -2469,6 +2522,12 @@
                    </item>
                    <item>
                     <widget class="QDoubleSpinBox" name="dividerRightY">
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>20</height>
+                      </size>
+                     </property>
                      <property name="suffix">
                       <string>sp</string>
                      </property>
@@ -2514,6 +2573,13 @@
                 </property>
                </widget>
               </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_154">
+                <property name="text">
+                 <string>Font style:</string>
+                </property>
+               </widget>
+              </item>
               <item row="0" column="0">
                <widget class="QLabel" name="label_153">
                 <property name="text">
@@ -2524,20 +2590,13 @@
               <item row="0" column="1">
                <widget class="QFontComboBox" name="longInstrumentFontFace">
                 <property name="sizePolicy">
-                 <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
                 <property name="editable">
                  <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_154">
-                <property name="text">
-                 <string>Font style:</string>
                 </property>
                </widget>
               </item>
@@ -2683,16 +2742,6 @@
                 </item>
                </layout>
               </item>
-              <item row="1" column="1">
-               <widget class="QDoubleSpinBox" name="longInstrumentFontSize">
-                <property name="suffix">
-                 <string>sp</string>
-                </property>
-                <property name="minimum">
-                 <double>1.000000000000000</double>
-                </property>
-               </widget>
-              </item>
               <item row="1" column="2">
                <widget class="QToolButton" name="resetLongInstrumentFontSize">
                 <property name="toolTip">
@@ -2727,15 +2776,15 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="0">
-               <widget class="QLabel" name="label_190">
-                <property name="text">
-                 <string>Align:</string>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="longInstrumentFontSize">
+                <property name="suffix">
+                 <string>sp</string>
+                </property>
+                <property name="minimum">
+                 <double>1.000000000000000</double>
                 </property>
                </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="Ms::AlignSelect" name="longInstrumentAlign" native="true"/>
               </item>
               <item row="4" column="2">
                <widget class="QToolButton" name="resetLongInstrumentAlign">
@@ -2753,6 +2802,29 @@
                   <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                 </property>
                </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="label_190">
+                <property name="text">
+                 <string>Align:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="Ms::AlignSelect" name="longInstrumentAlign" native="true"/>
+              </item>
+              <item row="1" column="3">
+               <spacer name="horizontalSpacer_18">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
              </layout>
             </widget>
@@ -2780,19 +2852,6 @@
                <widget class="QLabel" name="label_157">
                 <property name="text">
                  <string>Font style:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QFontComboBox" name="shortInstrumentFontFace">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="editable">
-                 <bool>false</bool>
                 </property>
                </widget>
               </item>
@@ -2938,6 +2997,13 @@
                 </item>
                </layout>
               </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_156">
+                <property name="text">
+                 <string>Font face:</string>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="2">
                <widget class="QToolButton" name="resetShortInstrumentFontSize">
                 <property name="toolTip">
@@ -2972,13 +3038,6 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_156">
-                <property name="text">
-                 <string>Font face:</string>
-                </property>
-               </widget>
-              </item>
               <item row="1" column="0">
                <widget class="QLabel" name="label_155">
                 <property name="text">
@@ -2992,9 +3051,6 @@
                  <string>Align:</string>
                 </property>
                </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="Ms::AlignSelect" name="shortInstrumentAlign" native="true"/>
               </item>
               <item row="3" column="2">
                <widget class="QToolButton" name="resetShortInstrumentAlign">
@@ -3013,6 +3069,35 @@
                 </property>
                </widget>
               </item>
+              <item row="3" column="1">
+               <widget class="Ms::AlignSelect" name="shortInstrumentAlign" native="true"/>
+              </item>
+              <item row="0" column="1">
+               <widget class="QFontComboBox" name="shortInstrumentFontFace">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="editable">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <spacer name="horizontalSpacer_20">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
              </layout>
             </widget>
            </item>
@@ -3024,7 +3109,7 @@
              <property name="sizeHint" stdset="0">
               <size>
                <width>20</width>
-               <height>177</height>
+               <height>40</height>
               </size>
              </property>
             </spacer>
@@ -4076,6 +4161,13 @@
              </property>
             </widget>
            </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_146">
+             <property name="text">
+              <string>Font size:</string>
+             </property>
+            </widget>
+           </item>
            <item row="2" column="0">
             <layout class="QHBoxLayout" name="horizontalLayout_8">
              <item>
@@ -4099,13 +4191,6 @@
               </widget>
              </item>
             </layout>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_146">
-             <property name="text">
-              <string>Font size:</string>
-             </property>
-            </widget>
            </item>
            <item row="3" column="0">
             <widget class="QLabel" name="label_145">
@@ -4134,6 +4219,40 @@
              </property>
              <property name="editable">
               <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QDoubleSpinBox" name="measureNumberFontSize">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="minimum">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="label_201">
+             <property name="text">
+              <string>Align:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="2">
+            <widget class="QToolButton" name="resetMeasureNumberFontFace">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Font face' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
            </item>
@@ -4279,72 +4398,8 @@
              </item>
             </layout>
            </item>
-           <item row="3" column="2">
-            <widget class="QToolButton" name="resetMeasureNumberFontFace">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Font face' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
            <item row="4" column="2">
             <widget class="QToolButton" name="resetMeasureNumberFontSize">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Font size' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QDoubleSpinBox" name="measureNumberFontSize">
-             <property name="suffix">
-              <string>sp</string>
-             </property>
-             <property name="minimum">
-              <double>1.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="label_201">
-             <property name="text">
-              <string>Align:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="0">
-            <widget class="QLabel" name="label_211">
-             <property name="text">
-              <string>Offset:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="1">
-            <widget class="Ms::AlignSelect" name="measureNumberAlign" native="true"/>
-           </item>
-           <item row="7" column="1">
-            <widget class="Ms::OffsetSelect" name="measureNumberOffset" native="true"/>
-           </item>
-           <item row="6" column="2">
-            <widget class="QToolButton" name="resetMeasureNumberAlign">
              <property name="toolTip">
               <string>Reset to default</string>
              </property>
@@ -4376,6 +4431,49 @@
                <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="label_211">
+             <property name="text">
+              <string>Offset:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="2">
+            <widget class="QToolButton" name="resetMeasureNumberAlign">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Font size' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1">
+            <widget class="Ms::OffsetSelect" name="measureNumberOffset" native="true"/>
+           </item>
+           <item row="6" column="1">
+            <widget class="Ms::AlignSelect" name="measureNumberAlign" native="true"/>
+           </item>
+           <item row="4" column="3">
+            <spacer name="horizontalSpacer_50">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
          </widget>
@@ -10506,38 +10604,6 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="3">
-               <spacer name="horizontalSpacer_26">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_115">
-                <property name="text">
-                 <string>Number Type:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="margin">
-                 <number>0</number>
-                </property>
-                <property name="indent">
-                 <number>10</number>
-                </property>
-                <property name="buddy">
-                 <cstring>tupletNumberType</cstring>
-                </property>
-               </widget>
-              </item>
               <item row="0" column="1">
                <widget class="QComboBox" name="tupletDirection">
                 <item>
@@ -10553,63 +10619,6 @@
                 <item>
                  <property name="text">
                   <string>Down</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_116">
-                <property name="text">
-                 <string>Bracket Type:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="margin">
-                 <number>0</number>
-                </property>
-                <property name="indent">
-                 <number>10</number>
-                </property>
-                <property name="buddy">
-                 <cstring>tupletBracketType</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QComboBox" name="tupletNumberType">
-                <item>
-                 <property name="text">
-                  <string>Number</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Ratio</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Nothing</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QComboBox" name="tupletBracketType">
-                <item>
-                 <property name="text">
-                  <string>Automatic</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Bracket</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>Nothing</string>
                  </property>
                 </item>
                </widget>
@@ -10637,7 +10646,106 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="2">
+              <item row="0" column="4">
+               <widget class="QComboBox" name="tupletNumberType">
+                <item>
+                 <property name="text">
+                  <string>Number</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Ratio</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Nothing</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QLabel" name="label_115">
+                <property name="text">
+                 <string>Number Type:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="margin">
+                 <number>0</number>
+                </property>
+                <property name="indent">
+                 <number>10</number>
+                </property>
+                <property name="buddy">
+                 <cstring>tupletNumberType</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="8">
+               <widget class="QToolButton" name="resetTupletBracketType">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="toolTip">
+                 <string>Reset to default</string>
+                </property>
+                <property name="accessibleName">
+                 <string>Reset 'Bracket Type' setting</string>
+                </property>
+                <property name="text">
+                 <string notr="true"/>
+                </property>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="7">
+               <widget class="QComboBox" name="tupletBracketType">
+                <item>
+                 <property name="text">
+                  <string>Automatic</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Bracket</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Nothing</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <widget class="QLabel" name="label_116">
+                <property name="text">
+                 <string>Bracket Type:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="margin">
+                 <number>0</number>
+                </property>
+                <property name="indent">
+                 <number>10</number>
+                </property>
+                <property name="buddy">
+                 <cstring>tupletBracketType</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
                <widget class="QToolButton" name="resetTupletNumberType">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -10660,28 +10768,18 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="2">
-               <widget class="QToolButton" name="resetTupletBracketType">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+              <item row="0" column="9">
+               <spacer name="horizontalSpacer_26">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
                 </property>
-                <property name="toolTip">
-                 <string>Reset to default</string>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
                 </property>
-                <property name="accessibleName">
-                 <string>Reset 'Bracket Type' setting</string>
-                </property>
-                <property name="text">
-                 <string notr="true"/>
-                </property>
-                <property name="icon">
-                 <iconset resource="musescore.qrc">
-                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-                </property>
-               </widget>
+               </spacer>
               </item>
              </layout>
             </widget>
@@ -10990,12 +11088,8 @@
            <string>Lyrics Melisma</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_25">
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_188">
-             <property name="text">
-              <string>Pad:</string>
-             </property>
-            </widget>
+           <item row="2" column="1">
+            <widget class="Ms::AlignSelect" name="lyricsMelismaAlign" native="true"/>
            </item>
            <item row="1" column="2">
             <widget class="QToolButton" name="resetLyricsMelismaPad">
@@ -11014,10 +11108,17 @@
              </property>
             </widget>
            </item>
-           <item row="7" column="0">
-            <widget class="QLabel" name="label_119">
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_188">
              <property name="text">
-              <string/>
+              <string>Pad:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_80">
+             <property name="text">
+              <string>Thickness:</string>
              </property>
             </widget>
            </item>
@@ -11038,13 +11139,6 @@
              </property>
             </widget>
            </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="label_93">
-             <property name="text">
-              <string/>
-             </property>
-            </widget>
-           </item>
            <item row="0" column="1">
             <widget class="QDoubleSpinBox" name="lyricsLineThickness">
              <property name="suffix">
@@ -11061,17 +11155,20 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_80">
-             <property name="text">
-              <string>Thickness:</string>
+           <item row="2" column="2">
+            <widget class="QToolButton" name="resetLyricsMelismaAlign">
+             <property name="toolTip">
+              <string>Reset to default</string>
              </property>
-            </widget>
-           </item>
-           <item row="8" column="0">
-            <widget class="QLabel" name="label_123">
+             <property name="accessibleName">
+              <string>Reset 'Melisma pad' value</string>
+             </property>
              <property name="text">
-              <string/>
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
            </item>
@@ -11095,26 +11192,6 @@
             <widget class="QLabel" name="label_198">
              <property name="text">
               <string>Align:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="Ms::AlignSelect" name="lyricsMelismaAlign" native="true"/>
-           </item>
-           <item row="2" column="2">
-            <widget class="QToolButton" name="resetLyricsMelismaAlign">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Melisma pad' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
            </item>
@@ -11418,16 +11495,6 @@
            <property name="spacing">
             <number>0</number>
            </property>
-           <item row="1" column="3">
-            <widget class="QLabel" name="label_171">
-             <property name="text">
-              <string>Size:</string>
-             </property>
-             <property name="indent">
-              <number>10</number>
-             </property>
-            </widget>
-           </item>
            <item row="1" column="7">
             <layout class="QHBoxLayout" name="horizontalLayout_23">
              <item>
@@ -11531,33 +11598,10 @@
              </item>
             </layout>
            </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_170">
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_199">
              <property name="text">
-              <string>Font face:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="4">
-            <widget class="QDoubleSpinBox" name="lyricsEvenFontSize">
-             <property name="suffix">
-              <string>sp</string>
-             </property>
-             <property name="minimum">
-              <double>1.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QFontComboBox" name="lyricsEvenFontFace">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="editable">
-              <bool>false</bool>
+              <string>Align:</string>
              </property>
             </widget>
            </item>
@@ -11571,8 +11615,8 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="2">
-            <widget class="QToolButton" name="resetLyricsEvenFontFace">
+           <item row="2" column="2">
+            <widget class="QToolButton" name="resetLyricsEvenAlign">
              <property name="toolTip">
               <string>Reset to default</string>
              </property>
@@ -11587,6 +11631,29 @@
                <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
+           </item>
+           <item row="1" column="4">
+            <widget class="QDoubleSpinBox" name="lyricsEvenFontSize">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="minimum">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="QLabel" name="label_171">
+             <property name="text">
+              <string>Size:</string>
+             </property>
+             <property name="indent">
+              <number>10</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="Ms::AlignSelect" name="lyricsEvenAlign" native="true"/>
            </item>
            <item row="1" column="5">
             <widget class="QToolButton" name="resetLyricsEvenFontSize">
@@ -11605,18 +11672,28 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_199">
-             <property name="text">
-              <string>Align:</string>
+           <item row="1" column="1">
+            <widget class="QFontComboBox" name="lyricsEvenFontFace">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="editable">
+              <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
-            <widget class="Ms::AlignSelect" name="lyricsEvenAlign" native="true"/>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_170">
+             <property name="text">
+              <string>Font face:</string>
+             </property>
+            </widget>
            </item>
-           <item row="2" column="2">
-            <widget class="QToolButton" name="resetLyricsEvenAlign">
+           <item row="1" column="2">
+            <widget class="QToolButton" name="resetLyricsEvenFontFace">
              <property name="toolTip">
               <string>Reset to default</string>
              </property>
@@ -11648,6 +11725,19 @@
              </property>
              <property name="minimum">
               <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QFontComboBox" name="lyricsOddFontFace">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="editable">
+              <bool>false</bool>
              </property>
             </widget>
            </item>
@@ -11754,6 +11844,16 @@
              </item>
             </layout>
            </item>
+           <item row="0" column="3">
+            <widget class="QLabel" name="label_174">
+             <property name="text">
+              <string>Size:</string>
+             </property>
+             <property name="indent">
+              <number>10</number>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="0">
             <widget class="QLabel" name="label_173">
              <property name="text">
@@ -11761,16 +11861,44 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QFontComboBox" name="lyricsOddFontFace">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+           <item row="0" column="5">
+            <widget class="QToolButton" name="resetLyricsOddFontSize">
+             <property name="toolTip">
+              <string>Reset to default</string>
              </property>
-             <property name="editable">
-              <bool>false</bool>
+             <property name="accessibleName">
+              <string>Reset 'Font size' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_200">
+             <property name="text">
+              <string>Align:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QToolButton" name="resetLyricsOddAlign">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Font face' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
              </property>
             </widget>
            </item>
@@ -11801,32 +11929,8 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="5">
-            <widget class="QToolButton" name="resetLyricsOddFontSize">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Font size' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="3">
-            <widget class="QLabel" name="label_174">
-             <property name="text">
-              <string>Size:</string>
-             </property>
-             <property name="indent">
-              <number>10</number>
-             </property>
-            </widget>
+           <item row="1" column="1">
+            <widget class="Ms::AlignSelect" name="lyricsOddAlign" native="true"/>
            </item>
            <item row="2" column="0">
             <spacer name="verticalSpacer_17">
@@ -11840,33 +11944,6 @@
               </size>
              </property>
             </spacer>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_200">
-             <property name="text">
-              <string>Align:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="Ms::AlignSelect" name="lyricsOddAlign" native="true"/>
-           </item>
-           <item row="1" column="2">
-            <widget class="QToolButton" name="resetLyricsOddAlign">
-             <property name="toolTip">
-              <string>Reset to default</string>
-             </property>
-             <property name="accessibleName">
-              <string>Reset 'Font face' value</string>
-             </property>
-             <property name="text">
-              <string notr="true"/>
-             </property>
-             <property name="icon">
-              <iconset resource="musescore.qrc">
-               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-             </property>
-            </widget>
            </item>
           </layout>
          </widget>
@@ -12387,7 +12464,6 @@
   <tabstop>swingBox</tabstop>
   <tabstop>autoplaceVerticalAlignRange</tabstop>
   <tabstop>resetAutoplaceVerticalAlignRange</tabstop>
-  <tabstop>staffUpperBorder</tabstop>
   <tabstop>staffLowerBorder</tabstop>
   <tabstop>staffDistance</tabstop>
   <tabstop>akkoladeDistance</tabstop>
@@ -12421,16 +12497,10 @@
   <tabstop>evenFooterR</tabstop>
   <tabstop>bracketWidth</tabstop>
   <tabstop>bracketDistance</tabstop>
-  <tabstop>akkoladeWidth</tabstop>
-  <tabstop>akkoladeBarDistance</tabstop>
   <tabstop>dividerLeft</tabstop>
   <tabstop>dividerLeftSym</tabstop>
-  <tabstop>dividerLeftX</tabstop>
-  <tabstop>dividerLeftY</tabstop>
   <tabstop>dividerRight</tabstop>
   <tabstop>dividerRightSym</tabstop>
-  <tabstop>dividerRightX</tabstop>
-  <tabstop>dividerRightY</tabstop>
   <tabstop>minMeasureWidth_2</tabstop>
   <tabstop>resetMinMeasureWidth</tabstop>
   <tabstop>measureSpacing</tabstop>
@@ -12588,10 +12658,6 @@
   <tabstop>resetTupletBracketWidth</tabstop>
   <tabstop>tupletDirection</tabstop>
   <tabstop>resetTupletDirection</tabstop>
-  <tabstop>tupletNumberType</tabstop>
-  <tabstop>resetTupletNumberType</tabstop>
-  <tabstop>tupletBracketType</tabstop>
-  <tabstop>resetTupletBracketType</tabstop>
   <tabstop>lyricsPlacement</tabstop>
   <tabstop>resetLyricsPlacement</tabstop>
   <tabstop>resetLyricsPosAbove</tabstop>


### PR DESCRIPTION
Layout of System and Tuplet pages changed to make pagesizes more even.
Size constraints and policies changed to ensure dialogue is opened at minimum required size.
Tool button added to allow PageList to be hidden/shown, thereby providing more screenspace to see effect of changes to style.