### PR TITLE
[ready] overhaul -j to make it more flexible, staying 100% compatible

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -142,6 +142,11 @@ static QString createDefaultFileName(QString fn)
       return fn;
       }
 
+QString MuseScore::saveFilename(QString fn)
+      {
+      return createDefaultFileName(fn);
+      }
+
 //---------------------------------------------------------
 //   readScoreError
 //    if "ask" is true, ask to ignore; returns true if

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -707,6 +707,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void exportFile();
       bool exportParts();
       virtual bool saveAs(Score*, bool saveCopy, const QString& path, const QString& ext);
+      QString saveFilename(QString fn);
       bool savePdf(const QString& saveName);
       bool savePdf(Score* cs, const QString& saveName);
       bool savePdf(QList<Score*> cs, const QString& saveName);


### PR DESCRIPTION
## **Update:** This is ready to be merged.

[…] This will also make the `-j` option usable much better and, for the most part, eliminate the need to use `-P` with some of the scores and not use it with the others (see [the doc forum post about `-j`](https://musescore.org/en/node/276949)).

Basically, I can just generate a JSON that lists *all* to-be-converted scores, in both the string and two-element-array function, and the first will generate the main score PDF, and the latter will generate parts PDFs if the score has parts and otherwise be silently ignored. It is also more flexible than adding `-partname` before the file extension as `exportParts()` does. (Besides, `exportParts()` was not exposed to the command line *at all*, and I believe I found a great way to do so.)

Here’s now the commit message:

    overhaul -j to make it more flexible, staying 100% compatible
    
    The previous operation of
    [ { "in": "file.mscz", "out": "file.pdf", "plugin": "foo.qml" } ]
    is still supported, and nothing changes: either “out” or “plugin”
    must be given, and -P appends all parts to PDF and PNG, generating
    parts for ALL instruments if the score has none.
    
    Because people often write this:
    [ { "in": "a.mscz", "out": "a.pdf" },
      { "in": "a.mscz", "out": "a.mid" },
      { "in": "b.mscz", "out": "b.pdf" },
      { "in": "b.mscz", "out": "b.mid" } ]
    
    We now also support shortening it like this:
    [ { "in": "a.mscz", "out": [ "a.pdf", "a.mid" ] },
      { "in": "b.mscz", "out": [ "b.pdf", "b.mid" ] } ]
    
    This new syntax saves the same score twice, i.e. doesn’t reload
    nor re-apply the plugin in between. (We assume that saving does
    not modify the score.)
    
    Finally, there’s a new syntax intended to be used WITHOUT -P:
    [ { "in": "file.mscz", "out": [ [ "file (part for ", ").pdf" ] ] } ]
    
    Explanation: iff “out” is an array (new syntax), and one of its
    elements is again an array, with two string members, then all
    extant parts are exported with the part name inserted between
    the two strings (and if the score has no parts, the entry is
    silently ignored, parts are NOT auto-generated here). This works
    with all file types, not just PNG or PDF, and does NOT export
    the master score, ONLY the parts.
    
    (I also intend to document this in the manual in more detail.)
    
    Intended use is like this:
    [ { "in": "file.mscz", "out": [
            "file.pdf",
            "file.mid",
            "file.musicxml",
            [ "file (part for ", ").pdf" ],
            [ "file (part for ", ").mid" ]
      ] } ]
    
    All these syntacēs can be mixed in the same job file (although
    only if the job is run without the -P option):
    
    [
      {
        "in": "demos/Triumph.mscz",
        "out": "Triumph-coloured.pdf",
        "plugin": "colornotes.qml"
      },
      {
        "in": "demos/Reunion.mscz",
        "out": [
          "Reunion.pdf",
          "Reunion.musicxml",
          "Reunion.mid"
        ]
      },
      {
        "in": "piece.mscz",
        "out": [
          "piece.pdf",
          "piece.mid",
          "piece.musicxml",
          [
            "piece (part for ",
            ").pdf"
          ],
          [
            "piece (part for ",
            ").mid"
          ]
        ]
      }
    ]
