### PR TITLE
fix #277797: fix undo figured bass on consecutive notes

### DIFF
--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -1169,6 +1169,16 @@ void FiguredBass::layoutLines()
       int sysIdx1 = systems.indexOf(s1);
       int sysIdx2 = systems.indexOf(s2);
 
+      if (sysIdx2 < sysIdx1) {
+            sysIdx2 = sysIdx1;
+            nextSegm = segment()->next1();
+            // TODO
+            // During layout of figured bass next systems' numbers may be still
+            // undefined (then sysIdx2 == -1) or change in the future.
+            // A layoutSystem() approach similar to that for spanners should
+            // probably be implemented.
+            }
+
       int i, len ,segIdx;
       for (i = sysIdx1, segIdx = 0; i <= sysIdx2; ++i, ++segIdx) {
             len = 0;

--- a/mscore/editfiguredbass.cpp
+++ b/mscore/editfiguredbass.cpp
@@ -101,12 +101,14 @@ void ScoreView::figuredBassTab(bool bMeas, bool bBack)
       bool bNew;
       // add a (new) FB element, using chord duration as default duration
       FiguredBass * fbNew = FiguredBass::addFiguredBassToSegment(nextSegm, track, 0, &bNew);
-      if (bNew)
+      if (bNew) {
+            _score->startCmd();
             _score->undoAddElement(fbNew);
+            _score->endCmd();
+            }
       _score->select(fbNew, SelectType::SINGLE, 0);
       startEdit(fbNew, Grip::NO_GRIP);
 
-      _score->startCmd();
       mscore->changeState(mscoreState());
       adjustCanvasPosition(fbNew, false);
       fbNew->cursor(editData)->moveCursorToEnd();
@@ -150,16 +152,20 @@ void ScoreView::figuredBassTicksTab(int ticks)
                   qDebug("figuredBassTicksTab: no next segment");
                   return;
                   }
+            _score->startCmd();
             _score->undoAddElement(nextSegm);
+            _score->endCmd();
             }
 
       changeState(ViewState::NORMAL);
 
-      _score->startCmd();
       bool bNew;
       FiguredBass * fbNew = FiguredBass::addFiguredBassToSegment(nextSegm, track, ticks, &bNew);
-      if (bNew)
+      if (bNew) {
+            _score->startCmd();
             _score->undoAddElement(fbNew);
+            _score->endCmd();
+            }
       _score->select(fbNew, SelectType::SINGLE, 0);
       startEdit(fbNew, Grip::NO_GRIP);
       mscore->changeState(mscoreState());


### PR DESCRIPTION
Fixes https://musescore.org/en/node/277797

This commit ensures that figured bass adding actions that happen during figured bass editing are properly added to undo stack. This also fixes not drawing (and sometimes crashing on redo operations) figured bass line in some cases when the next figured bass label is situated in the next systems. This is not a complete fix, and I have added a TODO mark to describe the probable solution of this issue but this is still better than nothing.