### PR TITLE
fix #278430: fix layout of chord symbols without chord or rest

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3448,8 +3448,15 @@ System* Score::collectSystem(LayoutContext& lc)
             for (Element* e : s->annotations()) {
                   if (e->isStaffText() || e->isSystemText() || e->isInstrumentChange())
                         e->layout();
-                  if (e->isHarmony())
+                  if (e->isHarmony()) {
+                        Harmony* h = toHarmony(e);
+                        // Layout of harmony seems to be bound currently
+                        // to ChordRest (see ChordRest::shape). But harmony
+                        // can exist without chord or rest too.
+                        if (h->isLayoutInvalid())
+                              h->layout();
                         toHarmony(e)->autoplaceSegmentElement(styleP(Sid::minHarmonyDistance));
+                        }
                   }
             }
 

--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -1879,10 +1879,17 @@ QString TextBase::plainText() const
       {
       QString s;
 
-      if (layoutInvalid)
-            ((Text*)(this))->createLayout();  // ugh!
+      const TextBase* text = this;
+      std::unique_ptr<TextBase> tmpText;
+      if (layoutInvalid) {
+            // Create temporary text object to avoid side effects
+            // of createLayout() call.
+            tmpText.reset(toTextBase(this->clone()));
+            tmpText->createLayout();
+            text = tmpText.get();
+            }
 
-      for (const TextBlock& block : _layout) {
+      for (const TextBlock& block : text->_layout) {
             for (const TextFragment& f : block.fragments())
                   s += f.text;
             if (block.eol())
@@ -1897,9 +1904,16 @@ QString TextBase::plainText() const
 
 QString TextBase::xmlText() const
       {
-      if (textInvalid)
-            ((Text*)(this))->genText();    // ugh!
-      return _text;
+      const TextBase* text = this;
+      std::unique_ptr<TextBase> tmpText;
+      if (textInvalid) {
+            // Create temporary text object to avoid side effects
+            // of genText() call.
+            tmpText.reset(toTextBase(this->clone()));
+            tmpText->genText();
+            text = tmpText.get();
+            }
+      return text->_text;
       }
 
 //---------------------------------------------------------

--- a/mtest/libmscore/layout_elements/layout_elements.mscx
+++ b/mtest/libmscore/layout_elements/layout_elements.mscx
@@ -12,7 +12,7 @@
       <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
       <frameSystemDistance>13</frameSystemDistance>
       <measureSpacing>1.14</measureSpacing>
-      <voltaPosAbove>0</voltaPosAbove>
+      <voltaPosAbove x="0" y="0"/>
       <Spatium>1.564</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
@@ -827,7 +827,6 @@
         <voice>
           <Harmony>
             <root>14</root>
-            <name>hord</name>
             </Harmony>
           <Chord>
             <durationType>whole</durationType>
@@ -844,6 +843,15 @@
               <tpc>18</tpc>
               </Note>
             </Chord>
+          <location>
+            <fractions>-5/8</fractions>
+            </location>
+          <Harmony>
+            <root>16</root>
+            </Harmony>
+          <location>
+            <fractions>5/8</fractions>
+            </location>
           <Rest>
             <durationType>half</durationType>
             </Rest>


### PR DESCRIPTION
Fixes issue https://musescore.org/en/node/278430.

It appears that chord symbols can exist without chords or rests at all, and this behavior was supported in MuseScore 2. However [recent fix](https://github.com/musescore/MuseScore/commit/ce128f3ed8a438fb3854b9684a6f4328fc2e8b94) to another problem didn't take this fact into account which could lead to incorrect layout of such chord symbols which can lead to crashes. This PR checks validity of layout of chord symbols and does this layout if it wasn't previously done properly.

I had also to put some changes in `TextBase::plainText()` and `TextBase::xmlText()` functions to eliminate side effects from them. `TextBase` class definitely needs some refactioring in order to make it possible to do such text retrieving operations without hacks like that one that is proposed by me or that existed previously but I believe this is the quickest solution for now, and it can be used as a temporary solution to the problem of avoiding side effects of constant `plainText()` and `xmlText()` member functions.