### PR TITLE
fix #277255: render chord symbol changes on transposing

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1160,6 +1160,7 @@ void TransposeHarmony::flip(EditData*)
       harmony->setBaseTpc(baseTpc);
       harmony->setRootTpc(rootTpc);
       harmony->setXmlText(harmony->harmonyName());
+      harmony->render();
       rootTpc = rootTpc1;
       baseTpc = baseTpc1;
       }


### PR DESCRIPTION
This PR just makes changes made to chord symbols be reflected in its text by calling `render()` for it.

Fixes https://musescore.org/en/node/277255