### PR TITLE
fix #18400: handle absent score and staff correctly in piano roll editor

### DIFF
--- a/mscore/pianokeyboard.cpp
+++ b/mscore/pianokeyboard.cpp
@@ -67,9 +67,13 @@ void PianoKeyboard::paintEvent(QPaintEvent* /*event*/)
       p.setFont(f);
 
       //Check for drumset, if any
-      Part* part = _staff->part();
-      Drumset* ds = part->instrument()->drumset();
-      Interval transp = part->instrument()->transpose();
+      Drumset* ds = nullptr;
+      Interval transp;
+      if (_staff) {
+            Part* part = _staff->part();
+            ds = part->instrument()->drumset();
+            transp = part->instrument()->transpose();
+            }
 
       p.setPen(QPen(Qt::black, 2));
       

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -333,7 +333,8 @@ void PianorollEditor::setStaff(Staff* st)
       if (staff == st)
             return;
 
-      partLabel->setText("Part: " + st->partName());
+      if (st)
+            partLabel->setText("Part: " + st->partName());
 
       if ((st && st->score() != _score) || (!st && _score)) {
             if (_score) {
@@ -361,6 +362,8 @@ void PianorollEditor::setStaff(Staff* st)
             pos->setContext(tl, sl);
             showWave->setEnabled(_score->audio() != 0);
             }
+      else
+            setWindowTitle(tr("Piano roll editor"));
       ruler->setScore(_score, locator);
       pianoView->setStaff(staff, locator);
       pianoLevels->setScore(_score, locator);
@@ -636,20 +639,13 @@ void PianorollEditor::dataChanged(const QRectF&)
       }
 
 //---------------------------------------------------------
-//   adjustCanvasPosition
-//---------------------------------------------------------
-
-void PianorollEditor::adjustCanvasPosition(const Element*, bool)
-      {
-      }
-
-//---------------------------------------------------------
 //   removeScore
 //---------------------------------------------------------
 
 void PianorollEditor::removeScore()
       {
-      setStaff(0);
+      _score = nullptr;
+      setStaff(nullptr);
       }
 
 //---------------------------------------------------------
@@ -697,22 +693,6 @@ const QTransform& PianorollEditor::matrix() const
       }
 
 //---------------------------------------------------------
-//   setDropRectangle
-//---------------------------------------------------------
-
-void PianorollEditor::setDropRectangle(const QRectF&)
-      {
-      }
-
-//---------------------------------------------------------
-//   cmdAddSlur
-//---------------------------------------------------------
-
-void PianorollEditor::cmdAddSlur(Note*, Note*)
-      {
-      }
-
-//---------------------------------------------------------
 //   startEdit
 //---------------------------------------------------------
 
@@ -744,6 +724,10 @@ Element* PianorollEditor::elementNear(QPointF)
 void PianorollEditor::updateAll()
       {
       startTimer(0);    // delayed update
+      if (staff && staff->idx() == -1) { // staff removed
+            removeScore();
+            return;
+            }
       pianoView->updateNotes();
       pianoLevels->updateNotes();
       }

--- a/mscore/pianoroll.h
+++ b/mscore/pianoroll.h
@@ -98,22 +98,18 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       void focusOnPosition(Position* p);
       void heartBeat(Seq*);
 
-      virtual void dataChanged(const QRectF&);
-      virtual void updateAll();
-      virtual void adjustCanvasPosition(const Element*, bool);
-      virtual void removeScore();
-      virtual void changeEditElement(Element*);
-      virtual QCursor cursor() const;
-      virtual void setCursor(const QCursor&);
-      virtual int gripCount() const;
-      virtual const QTransform& matrix() const;
-      virtual void setDropRectangle(const QRectF&);
-      virtual void cmdAddSlur(Note*, Note*);
-      virtual void cmdAddHairpin(bool) {}
-      virtual void startEdit();
-      virtual void startEdit(Element*, Grip);
-      virtual Element* elementNear(QPointF);
-      virtual void drawBackground(QPainter* /*p*/, const QRectF& /*r*/) const {}
+      virtual void dataChanged(const QRectF&) override;
+      virtual void updateAll() override;
+      virtual void removeScore() override;
+      virtual void changeEditElement(Element*) override;
+      virtual QCursor cursor() const override;
+      virtual void setCursor(const QCursor&) override;
+      virtual int gripCount() const override;
+      const QTransform& matrix() const;
+      virtual void startEdit() override;
+      virtual void startEdit(Element*, Grip) override;
+      virtual Element* elementNear(QPointF) override;
+      virtual void drawBackground(QPainter* /*p*/, const QRectF& /*r*/) const override {}
 
       void setLocator(POS posi, int tick) { locator[int(posi)].setTick(tick); }
 


### PR DESCRIPTION
Fixes https://musescore.org/en/node/18400 (or at least the part of it about the crash)

Basically, piano roll editor handled score deletion mostly correctly by resetting current staff to null pointer. However sometimes pointers to score and staff were accessed without any check. This patch:
1) adds this check
2) removes staff from piano roll editor if staff is removed from the score itself
3) adds also some overrides marks and removes some empty member
functions from `PianorollEditor` class.