### PR TITLE
fix #278420: ensure score update after selection filter changes

### DIFF
--- a/mscore/selectionwindow.cpp
+++ b/mscore/selectionwindow.cpp
@@ -165,11 +165,12 @@ void SelectionWindow::changeCheckbox(QListWidgetItem* item)
             for (int row = 1; row < numLabels; row++)
                   _score->selectionFilter().setFiltered(static_cast<SelectionFilterType>(1 << (row - 1)), set);
             }
+      _score->startCmd();
       if (_score->selection().isRange())
             _score->selection().updateSelectedElements();
       updateFilteredElements();
-//      _score->setUpdateAll();
-//      _score->end();
+      _score->setUpdateAll();
+      _score->endCmd();
       ScoreAccessibility::instance()->updateAccessibilityInfo();
       }
 


### PR DESCRIPTION
Fixes https://musescore.org/en/node/278420

The problem was probably introduced in [this commit](https://github.com/musescore/MuseScore/commit/3f1aa2ed1f867f757ffa9864c33cab25c3964b62) by disabling score updating after changes in selection filter checkboxes. Enabling it back adapting these lines of code to the recent state of MuseScore fixes the mentioned issue.