### PR TITLE
fix #276684: always display nominal time signature after adding staves

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1142,9 +1142,9 @@ void Measure::cmdAddStaves(int sStaff, int eStaff, bool createRest)
                               }
                         }
                   if (!ots) {
-                        // no time signature found; use measure length to construct one
+                        // no time signature found; use measure timesig to construct one
                         ots = new TimeSig(score());
-                        ots->setSig(len());
+                        ots->setSig(timesig());
                         constructed = true;
                         }
                   // do no replicate local time signatures


### PR DESCRIPTION
The relevant issue: https://musescore.org/en/node/276684

On staves addition MuseScore tries to find an existing time signature object to copy its properties and constructs the new one if no existing time signature object found. However it used actual measure length for constructing time signature rather than nominal one which should be used for displaying instead. This patch corrects this.