### PR TITLE
fix #277821: calculate min measure width consistently with MM rests

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3877,6 +3877,16 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
       bool first  = system()->firstMeasure() == this;
       const Shape ls(first ? QRectF(0.0, -1000000.0, 0.0, 2000000.0) : QRectF(0.0, 0.0, 0.0, spatium() * 4));
 
+      if (isMMRest()) {
+            // Reset MM rest to initial size and position
+            Rest* mmRest = toRest(findChordRest(tick(), 0));
+            if (mmRest) {
+                  mmRest->rxpos() = 0;
+                  mmRest->layoutMMRest(score()->styleP(Sid::minMMRestWidth) * mag());
+                  mmRest->segment()->createShapes();
+                  }
+            }
+
       while (s) {
             s->rxpos() = x;
             if (!s->enabled()) {


### PR DESCRIPTION
Fixes this issue: https://musescore.org/en/node/277821

This bug is really interesting. It seems that MM rest that is placed right after system header (first system's measure's time signature etc.) takes part of place that is intended to be a "gap" between that time signature and other measure's elements. That way MM rest gets negative position relative to its segment which causes, after intersections checks, moving that segment a bit right. After that MM rest gains an ability to get even more space, gets even larger negative positions and causes its segment be moved even further to the right. Although I do not still understand some details of this funny process I generally see several ways to stop it. This pull request implements one of this options which makes MM rest size and position be reset before each calculation of the measure's minimum width. This prevents this segment moving process from happening though that measure's width may appear to be slightly larger than the truly minimal. Though this doesn't seem to spoil the layout — at least it definitely looks not worse than before applying the patch.