### PR TITLE
fix #278466: Select similar/in range for rests no longer works

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3108,6 +3108,7 @@ void Score::selectSimilar(Element* e, bool sameStaff)
       pattern.staffEnd = sameStaff ? e->staffIdx() + 1 : -1;
       pattern.voice   = -1;
       pattern.system  = 0;
+      pattern.durationTicks = -1;
 
       score->scanElements(&pattern, collectMatch);
 
@@ -3140,6 +3141,7 @@ void Score::selectSimilarInRange(Element* e)
       pattern.staffEnd = selection().staffEnd();
       pattern.voice   = -1;
       pattern.system  = 0;
+      pattern.durationTicks = -1;
 
       score->scanElementsInRange(&pattern, collectMatch);
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/277912

Follow-on from: #4127

Hopefully the changes are fairly self-explanatory. Just sets a default value, which means that duration is ignored by default.