### PR TITLE
Fix welcome tour not appearing after closing start center by Esc key

### DIFF
--- a/mscore/startcenter.cpp
+++ b/mscore/startcenter.cpp
@@ -118,9 +118,10 @@ void Startcenter::newScore()
 //   closeEvent
 //---------------------------------------------------------
 
-void Startcenter::closeEvent(QCloseEvent*)
+void Startcenter::closeEvent(QCloseEvent* event)
       {
       emit closed(false);
+      AbstractDialog::closeEvent(event);
       }
 
 //---------------------------------------------------------
@@ -165,14 +166,28 @@ void Startcenter::readSettings()
       }
 
 //---------------------------------------------------------
+//   keyPressEvent
+//---------------------------------------------------------
+
+void Startcenter::keyPressEvent(QKeyEvent *event)
+      {
+      if(event->key() == Qt::Key_Escape)
+            event->ignore(); // will handle it on key release.
+      else
+            AbstractDialog::keyPressEvent(event);
+      }
+
+//---------------------------------------------------------
 //   keyReleaseEvent
 //---------------------------------------------------------
 
-void Startcenter::keyReleaseEvent(QKeyEvent *event) 
+void Startcenter::keyReleaseEvent(QKeyEvent *event)
       {
       if(event->key() == Qt::Key_Escape) {
             close();
             }
+      else
+            AbstractDialog::keyReleaseEvent(event);
       }
 
 #ifdef USE_WEBENGINE

--- a/mscore/startcenter.h
+++ b/mscore/startcenter.h
@@ -94,7 +94,8 @@ class Startcenter : public AbstractDialog, public Ui::Startcenter {
       void updateRecentScores();
       void writeSettings();
       void readSettings();
-      virtual void keyReleaseEvent(QKeyEvent*);
+      void keyPressEvent(QKeyEvent*) override;
+      void keyReleaseEvent(QKeyEvent*) override;
       };
 }
 #endif //__STARTCENTER_H__


### PR DESCRIPTION
This PR fixes the issue mentioned in the title and adds somewhat more accurate handling of some events to `Startcenter` class. As far as I know, there is no a corresponding issue in the issue tracker, this topic appeared in a Telegram chat discussion.