### PR TITLE
Replace remaining EditData::element with EditData::dropElement in drop context

### DIFF
--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -495,7 +495,7 @@ void HBox::layout2()
 bool Box::acceptDrop(EditData& data) const
       {
       ElementType t = data.dropElement->type();
-      if (data.element->flag(ElementFlag::ON_STAFF))
+      if (data.dropElement->flag(ElementFlag::ON_STAFF))
             return false;
       switch (t) {
             case ElementType::LAYOUT_BREAK:

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -446,7 +446,7 @@ Element* Lyrics::drop(EditData& data)
             TextBase::drop(data);
             return 0;
             }
-      if (!data.element->isText()) {
+      if (!data.dropElement->isText()) {
             delete data.dropElement;
             data.dropElement = 0;
             return 0;

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -998,7 +998,7 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view)
                   addRefresh(target->abbox());   // layout() ?!
                   EditData ddata(view);
                   ddata.view       = view;
-                  ddata.element    = nel;
+                  ddata.dropElement    = nel;
                   // ddata.duration   = duration;
                   target->drop(ddata);
                   if (_selection.element())


### PR DESCRIPTION
This is done to prevent crashes after the recent changes to drag&drop system.