### PR TITLE
fix #278014: fix lyrics lines Y aligning

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2900,18 +2900,6 @@ void Score::layoutLyrics(System* system)
                         }
                   break;
             }
-      // align lyrics line segments
-      for (SpannerSegment* ss : system->spannerSegments()) {
-            if (ss->isLyricsLineSegment()) {
-                  LyricsLineSegment* lls = toLyricsLineSegment(ss);
-                  lls->layout();
-                  if (ss->isSingleBeginType())
-                        lls->ryoffset() = lls->lyrics()->ryoffset();
-                  else {
-                        ;// how to align?
-                        }
-                  }
-            }
       }
 
 //---------------------------------------------------------
@@ -3390,12 +3378,6 @@ System* Score::collectSystem(LayoutContext& lc)
                   }
             }
 
-      for (Spanner* sp : _unmanagedSpanner) {
-            if (sp->tick() >= etick || sp->tick2() <= stick)
-                  continue;
-            sp->layoutSystem(system);
-            }
-
       //-------------------------------------------------------------
       // TempoText, Fermata, TremoloBar
       //-------------------------------------------------------------
@@ -3414,6 +3396,13 @@ System* Score::collectSystem(LayoutContext& lc)
             }
 
       layoutLyrics(system);
+
+      // here are lyrics dashes and melisma
+      for (Spanner* sp : _unmanagedSpanner) {
+            if (sp->tick() >= etick || sp->tick2() <= stick)
+                  continue;
+            sp->layoutSystem(system);
+            }
 
       //-------------------------------------------------------------
       // Jump, Marker

--- a/libmscore/lyricsline.cpp
+++ b/libmscore/lyricsline.cpp
@@ -424,15 +424,21 @@ void LyricsLineSegment::layout()
             }
 
       // VERTICAL POSITION: at the base line of the syllable text
-      if (!isEndType())
+      if (!isEndType()) {
             rypos() = lyr->ipos().y();
+            ryoffset() = lyr->offset().y();
+            }
       else {
             // use Y position of *next* syllable if there is one on same system
             Lyrics* nextLyr1 = searchNextLyrics(lyr->segment(), lyr->staffIdx(), lyr->no(), lyr->placement());
-            if (nextLyr1 && nextLyr1->segment()->system() == system())
+            if (nextLyr1 && nextLyr1->segment()->system() == system()) {
                   rypos() = nextLyr1->ipos().y();
-            else
+                  ryoffset() = nextLyr1->offset().y();
+                  }
+            else {
                   rypos() = lyr->ipos().y();
+                  ryoffset() = lyr->offset().y();
+                  }
             }
 
       // MELISMA vs. DASHES


### PR DESCRIPTION
This PR fixes [this issue](https://musescore.org/en/node/278014) and makes some changes to lyrics line layout system to put all Y aligning logic to `LyricsLineSegment::layout` function. Basically changes are the following:
1) Move layout of lyrics lines segments to happen after vertical layout of lyrics. We can do that safely as lyrics lines layout does not interfere anyway with TempoText, Fermata and TremoloBar layout that happened between layout of lyrics lines segments and vertical lyrics layout.
2) Remove the partial implementation of lyrics lines segments from `Score::layoutLyrics`.
3) Complete the existed implementation of lyrics lines segments layout in `LyricsLineSegment::layout`. That is done by assigning both position and offset taken from the corresponding lyrics syllable to the current lyrics line segment.