### PR TITLE
fix #276472: do not move slur if it doesn't intersect staff shape

### DIFF
--- a/libmscore/shape.cpp
+++ b/libmscore/shape.cpp
@@ -243,6 +243,19 @@ bool Shape::intersects(const QRectF& rr) const
       }
 
 //---------------------------------------------------------
+//   intersects
+//---------------------------------------------------------
+
+bool Shape::intersects(const Shape& other) const
+      {
+      for (const QRectF& r : other) {
+            if (intersects(r))
+                  return true;
+            }
+      return false;
+      }
+
+//---------------------------------------------------------
 //   paint
 //---------------------------------------------------------
 

--- a/libmscore/shape.h
+++ b/libmscore/shape.h
@@ -77,6 +77,7 @@ class Shape : public std::vector<ShapeElement> {
 
       bool contains(const QPointF&) const;
       bool intersects(const QRectF& rr) const;
+      bool intersects(const Shape&) const;
       void paint(QPainter&) const;
 
 #ifndef NDEBUG

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -525,6 +525,7 @@ void SlurSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
             Segment* fs = system()->firstMeasure()->first();
             QPointF pp1 = ups(Grip::START).p;
             QPointF pp2 = ups(Grip::END).p;
+            bool intersection = false;
             for (Segment* s = fs; s && s != ls; s = s->next1()) {
                   if (!s->enabled())
                         continue;
@@ -534,20 +535,23 @@ void SlurSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
                         continue;
                   if (pp2.x() < x1)
                         break;
+                  const Shape& segShape = s->staffShape(staffIdx()).translated(s->pos() + s->measure()->pos());
+                  if (!intersection)
+                        intersection = segShape.intersects(_shape);
                   if (up) {
                         //QPointF pt = QPointF(s->x() + s->measure()->x(), s->staffShape(staffIdx()).top() + s->y() + s->measure()->y());
-                        qreal dist = _shape.minVerticalDistance(s->staffShape(staffIdx()).translated(s->pos() + s->measure()->pos()));
+                        qreal dist = _shape.minVerticalDistance(segShape);
                         if (dist > 0.0)
                               gdist = qMax(gdist, dist);
                         }
                   else {
                         //QPointF pt = QPointF(s->x() + s->measure()->x(), s->staffShape(staffIdx()).bottom() + s->y() + s->measure()->y());
-                        qreal dist = s->staffShape(staffIdx()).translated(s->pos() + s->measure()->pos()).minVerticalDistance(_shape);
+                        qreal dist = segShape.minVerticalDistance(_shape);
                         if (dist > 0.0)
                               gdist = qMax(gdist, dist);
                         }
                   }
-            if (gdist > 0.0) {
+            if (intersection && gdist > 0.0) {
                   if (up) {
                         ryoffset() -= (gdist + spatium() * .5);
                         }


### PR DESCRIPTION
This PR tries to resolve issue [276472](https://musescore.org/en/node/276472). This may be not the best solution for all cases but still should cover most common cases of bad layout of slurs due to their moving outside staff shape. The proposed patch checks whether the slur intersects staff shape (that includes only staff elements but not staff lines) and applies the position shift needed to move slur away from the staff shape only if intersection does really take place.

I say that this is not a perfect solution since the applied shift may be much larger than the one actually needed in some cases when staff shape consists of several separate parts. The complete solution could involve some rework of shapes that could allow handling such composed shapes more conveniently and efficiently. For example shape could me made consisted of something like a series of skylines. But this is still the question to consider, and for the nearest time the proposed solution may be good enough.