### PR TITLE
fix #278499 Crash when listening to events fired from mixer objects

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4353,10 +4353,11 @@ void Score::undoAddElement(Element* element)
                         Part* part = nis->part();
                         Interval oldV = nis->part()->instrument(tickStart)->transpose();
                         // ws: instrument should not be changed here
-                        if (is->instrument()->channel().empty() || is->instrument()->channel(0)->program() == -1)
-                              nis->setInstrument(*staff->part()->instrument(s1->tick()));
+                        if (is->instrument()->channel().empty()
+                            || is->instrument()->channel(0)->program() == -1)
+                              nis->setInstrument(staff->part()->instrument(s1->tick()));
                         else if (nis != is)
-                              nis->setInstrument(*is->instrument());
+                              nis->setInstrument(is->instrument());
                         undo(new AddElement(nis));
                         // transpose root score; parts will follow
                         if (score->isMaster() && part->instrument(tickStart)->transpose() != oldV) {

--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -155,9 +155,11 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
       score->setPageNumberOffset(oscore->pageNumberOffset());
 
       // Set instruments and create linked staffs
-      for (const Part* part : parts) {
+      for (Part* part : parts) {
             Part* p = new Part(score);
-            p->setInstrument(*part->instrument());
+            Instrument* newInstr = new Instrument(p);
+            newInstr->set(part->instrument());
+            p->setInstrument(newInstr);
             p->setPartName(part->partName());
 
             for (Staff* staff : *part->staves()) {

--- a/libmscore/instrchange.cpp
+++ b/libmscore/instrchange.cpp
@@ -42,17 +42,19 @@ InstrumentChange::InstrumentChange(Score* s)
       _instrument = new Instrument();
       }
 
-InstrumentChange::InstrumentChange(const Instrument& i, Score* s)
+InstrumentChange::InstrumentChange(Instrument* i, Score* s)
    : TextBase(s, Tid::INSTRUMENT_CHANGE, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
       {
       initElementStyle(&instrumentChangeStyle);
-      _instrument = new Instrument(i);
+      _instrument = new Instrument();
+      _instrument->set(i);
       }
 
 InstrumentChange::InstrumentChange(const InstrumentChange& is)
    : TextBase(is)
       {
-      _instrument = new Instrument(*is._instrument);
+      _instrument = new Instrument();
+      _instrument->set(is._instrument);
       }
 
 InstrumentChange::~InstrumentChange()
@@ -60,12 +62,12 @@ InstrumentChange::~InstrumentChange()
       delete _instrument;
       }
 
-void InstrumentChange::setInstrument(const Instrument& i)
-      {
-      *_instrument = i;
-      //delete _instrument;
-      //_instrument = new Instrument(i);
-      }
+//void InstrumentChange::setInstrument(const Instrument& i)
+//      {
+//      *_instrument = i;
+//      //delete _instrument;
+//      //_instrument = new Instrument(i);
+//      }
 
 //---------------------------------------------------------
 //   write

--- a/libmscore/instrchange.h
+++ b/libmscore/instrchange.h
@@ -27,7 +27,7 @@ class InstrumentChange final : public TextBase  {
 
    public:
       InstrumentChange(Score*);
-      InstrumentChange(const Instrument&, Score*);
+      InstrumentChange(Instrument*, Score*);
       InstrumentChange(const InstrumentChange&);
       ~InstrumentChange();
 
@@ -39,8 +39,8 @@ class InstrumentChange final : public TextBase  {
 
       Instrument* instrument() const        { return _instrument;  }
       void setInstrument(Instrument* i)     { _instrument = i;     }
-      void setInstrument(Instrument&& i)    { *_instrument = i;    }
-      void setInstrument(const Instrument& i);
+//      void setInstrument(Instrument&& i)    { *_instrument = i;    }
+//      void setInstrument(const Instrument& i);
 
       Segment* segment() const              { return toSegment(parent()); }
 

--- a/libmscore/instrtemplate.cpp
+++ b/libmscore/instrtemplate.cpp
@@ -445,8 +445,8 @@ void InstrumentTemplate::read(XmlReader& e)
                   midiActions.append(a);
                   }
             else if (tag == "Channel" || tag == "channel") {
-                  Channel a;
-                  a.read(e, nullptr);
+                  Channel* a = new Channel();
+                  a->read(e, nullptr);
                   channel.append(a);
                   }
             else if (tag == "Articulation") {
@@ -500,20 +500,20 @@ void InstrumentTemplate::read(XmlReader& e)
                   e.unknown();
             }
       if (channel.empty()) {
-            Channel a;
-            a.setChorus(0);
-            a.setReverb(0);
-            a.setName("normal");
-            a.setProgram(0);
-            a.setBank(0);
-            a.setVolume(90);
-            a.setPan(0);
+            Channel* a = new Channel();
+            a->setChorus(0);
+            a->setReverb(0);
+            a->setName("normal");
+            a->setProgram(0);
+            a->setBank(0);
+            a->setVolume(90);
+            a->setPan(0);
             channel.append(a);
             }
       if (useDrumset) {
-            if (channel[0].bank() == 0 && channel[0].synti().toLower() != "zerberus")
-                  channel[0].setBank(128);
-            channel[0].updateInitList();
+            if (channel[0]->bank() == 0 && channel[0]->synti().toLower() != "zerberus")
+                  channel[0]->setBank(128);
+            channel[0]->updateInitList();
             }
       if (trackName.isEmpty() && !longNames.isEmpty())
             trackName = longNames[0].name();
@@ -790,7 +790,7 @@ ClefType defaultClef(int program)
 
       for (InstrumentGroup* g : instrumentGroups) {
             for (InstrumentTemplate* it : g->instrumentTemplates) {
-                  if (it->channel[0].bank() == 0 && it->channel[0].program() == program){
+                  if (it->channel[0]->bank() == 0 && it->channel[0]->program() == program){
                         return (it->clefTypes[0]._concertClef);
                         }
                   }

--- a/libmscore/instrtemplate.h
+++ b/libmscore/instrtemplate.h
@@ -72,7 +72,7 @@ class InstrumentTemplate {
 
       QList<NamedEventList>   midiActions;
       QList<MidiArticulation> articulation;
-      QList<Channel>          channel;
+      QList<Channel*>         channel;
       QList<InstrumentGenre*> genres;     //; list of genres this instrument belongs to
 
       ClefTypeList clefTypes[MAX_STAVES];

--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -82,7 +82,8 @@ bool MidiArticulation::operator==(const MidiArticulation& i) const
 //   Instrument
 //---------------------------------------------------------
 
-Instrument::Instrument()
+Instrument::Instrument(QObject* parent)
+      :QObject(parent)
       {
       Channel* a = new Channel;
       a->setName(Channel::DEFAULT_NAME);
@@ -96,55 +97,55 @@ Instrument::Instrument()
       _drumset     = 0;
       }
 
-Instrument::Instrument(const Instrument& i)
-      {
-      _longNames    = i._longNames;
-      _shortNames   = i._shortNames;
-      _trackName    = i._trackName;
-      _minPitchA    = i._minPitchA;
-      _maxPitchA    = i._maxPitchA;
-      _minPitchP    = i._minPitchP;
-      _maxPitchP    = i._maxPitchP;
-      _transpose    = i._transpose;
-      _instrumentId = i._instrumentId;
-      _stringData   = i._stringData;
-      _drumset      = 0;
-      setDrumset(i._drumset);
-      _useDrumset   = i._useDrumset;
-      _stringData   = i._stringData;
-      _midiActions  = i._midiActions;
-      _articulation = i._articulation;
-      for (Channel* c : i._channel)
-            _channel.append(new Channel(*c));
-      _clefType     = i._clefType;
-      }
+//Instrument::Instrument(const Instrument& i)
+//      {
+//      _longNames    = i._longNames;
+//      _shortNames   = i._shortNames;
+//      _trackName    = i._trackName;
+//      _minPitchA    = i._minPitchA;
+//      _maxPitchA    = i._maxPitchA;
+//      _minPitchP    = i._minPitchP;
+//      _maxPitchP    = i._maxPitchP;
+//      _transpose    = i._transpose;
+//      _instrumentId = i._instrumentId;
+//      _stringData   = i._stringData;
+//      _drumset      = 0;
+//      setDrumset(i._drumset);
+//      _useDrumset   = i._useDrumset;
+//      _stringData   = i._stringData;
+//      _midiActions  = i._midiActions;
+//      _articulation = i._articulation;
+//      for (Channel* c : i._channel)
+//            _channel.append(new Channel(*c));
+//      _clefType     = i._clefType;
+//      }
 
-void Instrument::operator=(const Instrument& i)
-      {
-      qDeleteAll(_channel);
-      _channel.clear();
-      delete _drumset;
+//void Instrument::operator=(const Instrument& i)
+//      {
+//      qDeleteAll(_channel);
+//      _channel.clear();
+//      delete _drumset;
 
-      _longNames    = i._longNames;
-      _shortNames   = i._shortNames;
-      _trackName    = i._trackName;
-      _minPitchA    = i._minPitchA;
-      _maxPitchA    = i._maxPitchA;
-      _minPitchP    = i._minPitchP;
-      _maxPitchP    = i._maxPitchP;
-      _transpose    = i._transpose;
-      _instrumentId = i._instrumentId;
-      _stringData   = i._stringData;
-      _drumset      = 0;
-      setDrumset(i._drumset);
-      _useDrumset   = i._useDrumset;
-      _stringData   = i._stringData;
-      _midiActions  = i._midiActions;
-      _articulation = i._articulation;
-      for (Channel* c : i._channel)
-            _channel.append(new Channel(*c));
-      _clefType     = i._clefType;
-      }
+//      _longNames    = i._longNames;
+//      _shortNames   = i._shortNames;
+//      _trackName    = i._trackName;
+//      _minPitchA    = i._minPitchA;
+//      _maxPitchA    = i._maxPitchA;
+//      _minPitchP    = i._minPitchP;
+//      _maxPitchP    = i._maxPitchP;
+//      _transpose    = i._transpose;
+//      _instrumentId = i._instrumentId;
+//      _stringData   = i._stringData;
+//      _drumset      = 0;
+//      setDrumset(i._drumset);
+//      _useDrumset   = i._useDrumset;
+//      _stringData   = i._stringData;
+//      _midiActions  = i._midiActions;
+//      _articulation = i._articulation;
+//      for (Channel* c : i._channel)
+//            _channel.append(new Channel(*c));
+//      _clefType     = i._clefType;
+//      }
 
 //---------------------------------------------------------
 //   ~Instrument
@@ -154,6 +155,40 @@ Instrument::~Instrument()
       {
       qDeleteAll(_channel);
       delete _drumset;
+      }
+
+//---------------------------------------------------------
+//   set
+//---------------------------------------------------------
+
+void Instrument::set(const Instrument* i)
+      {
+      qDeleteAll(_channel);
+      _channel.clear();
+      delete _drumset;
+
+      _longNames    = i->_longNames;
+      _shortNames   = i->_shortNames;
+      _trackName    = i->_trackName;
+      _minPitchA    = i->_minPitchA;
+      _maxPitchA    = i->_maxPitchA;
+      _minPitchP    = i->_minPitchP;
+      _maxPitchP    = i->_maxPitchP;
+      _transpose    = i->_transpose;
+      _instrumentId = i->_instrumentId;
+      _stringData   = i->_stringData;
+      _drumset      = 0;
+      setDrumset(i->_drumset);
+      _useDrumset   = i->_useDrumset;
+      _stringData   = i->_stringData;
+      _midiActions  = i->_midiActions;
+      _articulation = i->_articulation;
+      for (Channel* c : i->_channel) {
+            Channel* nc = new Channel(this);
+            nc->set(c);
+            _channel.append(nc);
+            }
+      _clefType     = i->_clefType;
       }
 
 //---------------------------------------------------------
@@ -407,7 +442,8 @@ const char *Channel::DEFAULT_NAME = "normal";
 //   Channel
 //---------------------------------------------------------
 
-Channel::Channel()
+Channel::Channel(QObject* parent)
+      : QObject(parent)
       {
       for(int i = 0; i < int(A::INIT_COUNT); ++i)
             init.push_back(MidiCoreEvent());
@@ -428,75 +464,54 @@ Channel::Channel()
 //      qDebug("construct Channel ");
       }
 
+//---------------------------------------------------------
+//   ~Channel
+//---------------------------------------------------------
+
 Channel::~Channel()
       {
-      QList<ChannelListener *> list(listeners);
+//      QList<ChannelListener *> list(listeners);
 
-      for (ChannelListener * l: list) {
-            l->disconnectChannelListener();
-            }
+//      for (ChannelListener * l: list) {
+//            l->disconnectChannelListener();
+//            }
+//      listeners.clear();
+      }
+
+
+//---------------------------------------------------------
+//   set
+//---------------------------------------------------------
+
+void Channel::set(Channel* c)
+      {
+      _synti    = c->_synti;
+      _channel  = c->_channel;
+      _program  = c->_program;
+      _bank     = c->_bank;
+      _volume   = c->_volume;
+      _pan      = c->_pan;
+      _chorus   = c->_chorus;
+      _reverb   = c->_reverb;
+      _color    = c->_color;
+
+      _mute     = c->_mute;
+      _solo     = c->_solo;
+      _soloMute = c->_soloMute;
       }
 
 //---------------------------------------------------------
 //   firePropertyChanged
 //---------------------------------------------------------
 
-void Channel::firePropertyChanged(Channel::Prop prop)
-      {
-      QList<ChannelListener *> list(listeners);
+//void Channel::firePropertyChanged(Channel::Prop prop)
+//      {
+//      QList<ChannelListener *> list(listeners);
 
-      for (ChannelListener * l: list) {
-            l->propertyChanged(prop);
-            }
-      }
-
-//---------------------------------------------------------
-//   setVolume
-//---------------------------------------------------------
-
-void Channel::setVolume(char value)
-      {
-      if (_volume != value) {
-            _volume = value;
-            firePropertyChanged(Prop::VOLUME);
-            }
-      }
-
-//---------------------------------------------------------
-//   setPan
-//---------------------------------------------------------
-
-void Channel::setPan(char value)
-      {
-      if (_pan != value) {
-            _pan = value;
-            firePropertyChanged(Prop::PAN);
-            }
-      }
-
-//---------------------------------------------------------
-//   setChorus
-//---------------------------------------------------------
-
-void Channel::setChorus(char value)
-      {
-      if (_chorus != value) {
-            _chorus = value;
-            firePropertyChanged(Prop::CHORUS);
-            }
-      }
-
-//---------------------------------------------------------
-//   setReverb
-//---------------------------------------------------------
-
-void Channel::setReverb(char value)
-      {
-      if (_reverb != value) {
-            _reverb = value;
-            firePropertyChanged(Prop::REVERB);
-            }
-      }
+//      for (ChannelListener * l: list) {
+//            l->propertyChanged(prop);
+//            }
+//      }
 
 //---------------------------------------------------------
 //   setName
@@ -506,7 +521,8 @@ void Channel::setName(const QString& value)
       {
       if (_name != value) {
             _name = value;
-            firePropertyChanged(Prop::NAME);
+//            firePropertyChanged(Prop::NAME);
+            emit(nameChanged(value));
             }
       }
 
@@ -518,7 +534,8 @@ void Channel::setDescr(const QString& value)
       {
       if (_descr != value) {
             _descr = value;
-            firePropertyChanged(Prop::DESCR);
+//            firePropertyChanged(Prop::DESCR);
+            emit(descrChanged(value));
             }
       }
 
@@ -530,7 +547,8 @@ void Channel::setSynti(const QString& value)
       {
       if (_synti != value) {
             _synti = value;
-            firePropertyChanged(Prop::SYNTI);
+            emit(syntiChanged(value));
+//            firePropertyChanged(Prop::SYNTI);
             }
       }
 
@@ -542,7 +560,60 @@ void Channel::setColor(int value)
       {
       if (_color != value) {
             _color = value;
-            firePropertyChanged(Prop::COLOR);
+            emit(colorChanged(value));
+//            firePropertyChanged(Prop::COLOR);
+            }
+      }
+
+//---------------------------------------------------------
+//   setVolume
+//---------------------------------------------------------
+
+void Channel::setVolume(char value)
+      {
+      if (_volume != value) {
+            _volume = value;
+            emit(volumeChanged(value));
+//            firePropertyChanged(Prop::VOLUME);
+            }
+      }
+
+//---------------------------------------------------------
+//   setPan
+//---------------------------------------------------------
+
+void Channel::setPan(char value)
+      {
+      if (_pan != value) {
+            _pan = value;
+            emit(panChanged(value));
+//            firePropertyChanged(Prop::PAN);
+            }
+      }
+
+//---------------------------------------------------------
+//   setChorus
+//---------------------------------------------------------
+
+void Channel::setChorus(char value)
+      {
+      if (_chorus != value) {
+            _chorus = value;
+            emit(chorusChanged(value));
+//            firePropertyChanged(Prop::CHORUS);
+            }
+      }
+
+//---------------------------------------------------------
+//   setReverb
+//---------------------------------------------------------
+
+void Channel::setReverb(char value)
+      {
+      if (_reverb != value) {
+            _reverb = value;
+            emit(reverbChanged(value));
+//            firePropertyChanged(Prop::REVERB);
             }
       }
 
@@ -554,7 +625,8 @@ void Channel::setProgram(int value)
       {
       if (_program != value) {
             _program = value;
-            firePropertyChanged(Prop::PROGRAM);
+            emit(programChanged(value));
+//            firePropertyChanged(Prop::PROGRAM);
             }
       }
 
@@ -566,7 +638,8 @@ void Channel::setBank(int value)
       {
       if (_bank != value) {
             _bank = value;
-            firePropertyChanged(Prop::BANK);
+            emit(bankChanged(value));
+//            firePropertyChanged(Prop::BANK);
             }
       }
 
@@ -578,7 +651,8 @@ void Channel::setChannel(int value)
       {
       if (_channel != value) {
             _channel = value;
-            firePropertyChanged(Prop::CHANNEL);
+            emit(channelChanged(value));
+//            firePropertyChanged(Prop::CHANNEL);
             }
       }
 
@@ -590,7 +664,8 @@ void Channel::setSoloMute(bool value)
       {
       if (_soloMute != value) {
             _soloMute = value;
-            firePropertyChanged(Prop::SOLOMUTE);
+            emit(soloMuteChanged(value));
+//            firePropertyChanged(Prop::SOLOMUTE);
             }
       }
 
@@ -602,7 +677,8 @@ void Channel::setMute(bool value)
       {
       if (_mute != value) {
             _mute = value;
-            firePropertyChanged(Prop::MUTE);
+            emit(muteChanged(value));
+//            firePropertyChanged(Prop::MUTE);
             }
       }
 
@@ -614,7 +690,8 @@ void Channel::setSolo(bool value)
       {
       if (_solo != value) {
             _solo = value;
-            firePropertyChanged(Prop::SOLO);
+            emit(soloChanged(value));
+//            firePropertyChanged(Prop::SOLO);
             }
       }
 
@@ -1174,28 +1251,31 @@ void Instrument::setTrackName(const QString& s)
 //   fromTemplate
 //---------------------------------------------------------
 
-Instrument Instrument::fromTemplate(const InstrumentTemplate* t)
+Instrument* Instrument::fromTemplate(const InstrumentTemplate* t, QObject* parent)
       {
-      Instrument instr;
-      instr.setAmateurPitchRange(t->minPitchA, t->maxPitchA);
-      instr.setProfessionalPitchRange(t->minPitchP, t->maxPitchP);
+      Instrument* instr = new Instrument(parent);
+      instr->setAmateurPitchRange(t->minPitchA, t->maxPitchA);
+      instr->setProfessionalPitchRange(t->minPitchP, t->maxPitchP);
       for (StaffName sn : t->longNames)
-            instr.addLongName(StaffName(sn.name(), sn.pos()));
+            instr->addLongName(StaffName(sn.name(), sn.pos()));
       for (StaffName sn : t->shortNames)
-            instr.addShortName(StaffName(sn.name(), sn.pos()));
-      instr.setTrackName(t->trackName);
-      instr.setTranspose(t->transpose);
-      instr.setInstrumentId(t->musicXMLid);
+            instr->addShortName(StaffName(sn.name(), sn.pos()));
+      instr->setTrackName(t->trackName);
+      instr->setTranspose(t->transpose);
+      instr->setInstrumentId(t->musicXMLid);
       if (t->useDrumset)
-            instr.setDrumset(t->drumset ? t->drumset : smDrumset);
+            instr->setDrumset(t->drumset ? t->drumset : smDrumset);
       for (int i = 0; i < t->nstaves(); ++i)
-            instr.setClefType(i, t->clefTypes[i]);
-      instr.setMidiActions(t->midiActions);
-      instr.setArticulation(t->articulation);
-      instr._channel.clear();
-      for (const Channel& c : t->channel)
-            instr._channel.append(new Channel(c));
-      instr.setStringData(t->stringData);
+            instr->setClefType(i, t->clefTypes[i]);
+      instr->setMidiActions(t->midiActions);
+      instr->setArticulation(t->articulation);
+      instr->_channel.clear();
+      for (Channel* c : t->channel) {
+            Channel* nc = new Channel(instr);
+            nc->set(c);
+            instr->_channel.append(c);
+            }
+      instr->setStringData(t->stringData);
       return instr;
       }
 

--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -20,6 +20,7 @@
 #include "clef.h"
 #include <QtGlobal>
 #include <QString>
+#include <QObject>
 
 namespace Ms {
 
@@ -95,7 +96,9 @@ struct MidiArticulation {
 //   Channel
 //---------------------------------------------------------
 
-class Channel {
+class Channel : public QObject {
+      Q_OBJECT
+
       // this are the indexes of controllers which are always present in
       // Channel init EventList (maybe zero)
       QString _name;
@@ -120,7 +123,7 @@ class Channel {
       bool _mute;
       bool _solo;
 
-      QList<ChannelListener *> listeners;
+//      QList<ChannelListener *> listeners;
 
 public:
       static const char* DEFAULT_NAME;
@@ -130,80 +133,107 @@ public:
             INIT_COUNT
             };
 
-      enum class Prop : char {
-            VOLUME, PAN, CHORUS, REVERB, NAME, DESCR, PROGRAM, BANK, COLOR,
-            SOLOMUTE, SOLO, MUTE, SYNTI, CHANNEL
-            };
-
-private:
-      void firePropertyChanged(Channel::Prop prop);
-
-public:
+//      enum class Prop : char {
+//            VOLUME, PAN, CHORUS, REVERB, NAME, DESCR, PROGRAM, BANK, COLOR,
+//            SOLOMUTE, SOLO, MUTE, SYNTI, CHANNEL
+//            };
 
       mutable std::vector<MidiCoreEvent> init;
 
+//private:
+//      void firePropertyChanged(Channel::Prop prop);
+
+public:
+      Channel(QObject* parent = nullptr);
+      ~Channel();
+
+      void set(Channel* c);
 
       QString name() const { return _name; }
-      void setName(const QString& value);
       QString descr() const { return _descr; }
-      void setDescr(const QString& value);
       QString synti() const { return _synti; }
-      void setSynti(const QString& value);
       int color() const { return _color; }
-      void setColor(int value);
 
       char volume() const { return _volume; }
-      void setVolume(char value);
       char pan() const { return _pan; }
-      void setPan(char value);
       char chorus() const { return _chorus; }
-      void setChorus(char value);
       char reverb() const { return _reverb; }
-      void setReverb(char value);
 
       int program() const { return _program; }
-      void setProgram(int value);
       int bank() const { return _bank; }
-      void setBank(int value);
       int channel() const { return _channel; }
-      void setChannel(int value);
 
       bool soloMute() const { return _soloMute; }
-      void setSoloMute(bool value);
       bool mute() const { return _mute; }
-      void setMute(bool value);
       bool solo() const { return _solo; }
-      void setSolo(bool value);
 
       QList<NamedEventList> midiActions;
       QList<MidiArticulation> articulation;
 
-      Channel();
-      ~Channel();
       void write(XmlWriter&, Part *part) const;
       void read(XmlReader&, Part *part);
       void updateInitList() const;
       bool operator==(const Channel& c) { return (_name == c._name) && (_channel == c._channel); }
 
-      void addListener(ChannelListener *l) { listeners.append(l); }
-      void removeListener(ChannelListener *l) { listeners.removeOne(l); }
+//      void addListener(ChannelListener *l) { listeners.append(l); }
+//      void removeListener(ChannelListener *l) { listeners.removeOne(l); }
+
+signals:
+      void nameChanged(QString);
+      void descrChanged(QString);
+      void syntiChanged(QString);
+      void colorChanged(int);
+
+      void volumeChanged(char);
+      void panChanged(char);
+      void chorusChanged(char);
+      void reverbChanged(char);
+
+      void programChanged(int);
+      void bankChanged(int);
+      void channelChanged(int);
+
+      void soloMuteChanged(bool);
+      void muteChanged(bool);
+      void soloChanged(bool);
+
+public slots:
+      void setName(const QString& value);
+      void setDescr(const QString& value);
+      void setSynti(const QString& value);
+      void setColor(int value);
+
+      void setVolume(char value);
+      void setPan(char value);
+      void setChorus(char value);
+      void setReverb(char value);
+
+      void setProgram(int value);
+      void setBank(int value);
+      void setChannel(int value);
+
+      void setSoloMute(bool value);
+      void setMute(bool value);
+      void setSolo(bool value);
       };
 
 //---------------------------------------------------------
 //   ChannelListener
 //---------------------------------------------------------
 
-class ChannelListener {
-public:
-      virtual void propertyChanged(Channel::Prop property) = 0;
-      virtual void disconnectChannelListener() = 0;
-      };
+//class ChannelListener {
+//public:
+//      virtual void propertyChanged(Channel::Prop property) = 0;
+//      virtual void disconnectChannelListener() = 0;
+//      };
 
 //---------------------------------------------------------
 //   Instrument
 //---------------------------------------------------------
 
-class Instrument {
+class Instrument : public QObject {
+      Q_OBJECT
+
       StaffNameList _longNames;
       StaffNameList _shortNames;
       QString _trackName;
@@ -222,11 +252,12 @@ class Instrument {
       QList<ClefTypeList> _clefType;
 
    public:
-      Instrument();
-      Instrument(const Instrument&);
-      void operator=(const Instrument&);
+      Instrument(QObject* parent = nullptr);
+//      Instrument(const Instrument&);
+//      void operator=(const Instrument&);
       ~Instrument();
 
+      void set(const Instrument* master);
       void read(XmlReader&, Part *part);
       bool readProperties(XmlReader&, Part* , bool* customDrumset);
       void write(XmlWriter& xml, Part *part) const;
@@ -289,7 +320,7 @@ class Instrument {
       QList<StaffName>& shortNames();
       QString trackName() const;
       void setTrackName(const QString& s);
-      static Instrument fromTemplate(const InstrumentTemplate* t);
+      static Instrument* fromTemplate(const InstrumentTemplate* t, QObject* parent = nullptr);
       };
 
 //---------------------------------------------------------

--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -46,7 +46,7 @@ Part::Part(Score* s)
 void Part::initFromInstrTemplate(const InstrumentTemplate* t)
       {
       _partName = t->trackName;
-      setInstrument(Instrument::fromTemplate(t));
+      setInstrument(Instrument::fromTemplate(t, this));
       }
 
 //---------------------------------------------------------
@@ -370,14 +370,15 @@ void Part::setInstrument(Instrument* i, int tick)
       _instruments.setInstrument(i, tick);
       }
 
-void Part::setInstrument(const Instrument&& i, int tick)
-      {
-      _instruments.setInstrument(new Instrument(i), tick);
-      }
-void Part::setInstrument(const Instrument& i, int tick)
-      {
-      _instruments.setInstrument(new Instrument(i), tick);
-      }
+//void Part::setInstrument(const Instrument&& i, int tick)
+//      {
+//      _instruments.setInstrument(new Instrument(i), tick);
+//      }
+
+//void Part::setInstrument(const Instrument& i, int tick)
+//      {
+//      _instruments.setInstrument(new Instrument(i), tick);
+//      }
 
 //---------------------------------------------------------
 //   removeInstrument
@@ -678,5 +679,30 @@ bool Part::hasDrumStaff()
             }
       return false;
       }
+
+//---------------------------------------------------------
+//   hasDrumStaff
+//---------------------------------------------------------
+
+void Part::setPartName(const QString& s)
+      {
+      if (s != _partName) {
+            _partName = s;
+            emit(partNameChanged(s));
+            }
+      }
+
+//---------------------------------------------------------
+//   hasDrumStaff
+//---------------------------------------------------------
+
+void Part::setColor(int value)
+      {
+      if (_color != value) {
+            _color = value;
+            emit(colorChanged(value));
+            }
+      }
+
 }
 

--- a/libmscore/part.h
+++ b/libmscore/part.h
@@ -44,7 +44,9 @@ class InstrumentTemplate;
 //   @P volume          int
 //---------------------------------------------------------
 
-class Part final : public ScoreElement {
+class Part final : public QObject, public ScoreElement {
+      Q_OBJECT
+
       QString _partName;            ///< used in tracklist (mixer)
       InstrumentList _instruments;
       QList<Staff*> _staves;
@@ -118,17 +120,15 @@ class Part final : public ScoreElement {
       Instrument* instrument(int tick = -1);
       const Instrument* instrument(int tick = -1) const;
       void setInstrument(Instrument*, int tick = -1);       // transfer ownership
-      void setInstrument(const Instrument&&, int tick = -1);
-      void setInstrument(const Instrument&, int tick = -1);
+//      void setInstrument(const Instrument&&, int tick = -1);
+//      void setInstrument(const Instrument&, int tick = -1);
       void removeInstrument(int tick);
-      const InstrumentList* instruments() const   { return &_instruments;       }
+      const InstrumentList* instruments() const   { return &_instruments; }
 
       void insertTime(int tick, int len);
 
-      QString partName() const                 { return _partName; }
-      void setPartName(const QString& s)       { _partName = s; }
+      QString partName() const { return _partName; }
       int color() const { return _color; }
-      void setColor(int value) { _color = value; }
 
       QVariant getProperty(Pid) const override;
       bool setProperty(Pid, const QVariant&) override;
@@ -138,6 +138,14 @@ class Part final : public ScoreElement {
       bool hasPitchedStaff();
       bool hasTabStaff();
       bool hasDrumStaff();
+
+signals:
+      void colorChanged(int);
+      void partNameChanged(QString);
+
+public slots:
+      void setPartName(const QString& s);
+      void setColor(int value);
       };
 
 }     // namespace Ms

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3481,13 +3481,13 @@ void Score::appendPart(const QString& name)
             }
 
       if (t->channel.empty()) {
-            Channel a;
-            a.setChorus(0);
-            a.setReverb(0);
-            a.setName(Channel::DEFAULT_NAME);
-            a.setBank(0);
-            a.setVolume(90);
-            a.setPan(0);
+            Channel* a = new Channel();
+            a->setChorus(0);
+            a->setReverb(0);
+            a->setName(Channel::DEFAULT_NAME);
+            a->setBank(0);
+            a->setVolume(90);
+            a->setPan(0);
             t->channel.append(a);
             }
       Part* part = new Part(this);

--- a/libmscore/scoreElement.h
+++ b/libmscore/scoreElement.h
@@ -16,6 +16,8 @@
 #include "types.h"
 #include "style.h"
 
+#include <QObject>
+
 namespace Ms {
 
 class ScoreElement;

--- a/libmscore/staffstate.cpp
+++ b/libmscore/staffstate.cpp
@@ -35,7 +35,8 @@ StaffState::StaffState(Score* score)
 StaffState::StaffState(const StaffState& ss)
    : Element(ss)
       {
-      _instrument = new Instrument(*ss._instrument);
+      _instrument = new Instrument();
+      _instrument->set(ss._instrument);
       }
 
 StaffState::~StaffState()

--- a/libmscore/staffstate.h
+++ b/libmscore/staffstate.h
@@ -57,8 +57,8 @@ class StaffState final : public Element {
       virtual void write(XmlWriter&) const;
       virtual void read(XmlReader&);
       Instrument* instrument() const           { return _instrument; }
-      void setInstrument(const Instrument* i)  { *_instrument = *i;    }
-      void setInstrument(const Instrument&& i) { *_instrument = i;    }
+      void setInstrument(Instrument* i)  { _instrument = i;    }
+//      void setInstrument(const Instrument&& i) { *_instrument = i;    }
       Segment* segment()                       { return (Segment*)parent(); }
       };
 

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -87,7 +87,7 @@ void EditStaff::setStaff(Staff* s)
 
       orgStaff = s;
       Part* part        = orgStaff->part();
-      instrument        = *part->instrument(/*tick*/);
+      instrument        = part->instrument(/*tick*/);
       Score* score      = part->score();
       staff             = new Staff(score);
       staff->setStaffType(0, *orgStaff->staffType(0));
@@ -165,33 +165,33 @@ void EditStaff::updateStaffType()
 
 void EditStaff::updateInstrument()
       {
-      updateInterval(instrument.transpose());
+      updateInterval(instrument->transpose());
 
-      QList<StaffName>& snl = instrument.shortNames();
+      QList<StaffName>& snl = instrument->shortNames();
       QString df = snl.isEmpty() ? "" : snl[0].name();
       shortName->setPlainText(df);
 
-      QList<StaffName>& lnl = instrument.longNames();
+      QList<StaffName>& lnl = instrument->longNames();
       df = lnl.isEmpty() ? "" : lnl[0].name();
 
       longName->setPlainText(df);
 
       if (partName->text() == instrumentName->text())    // Updates part name if no custom name has been set before
-            partName->setText(instrument.trackName());
+            partName->setText(instrument->trackName());
 
-      instrumentName->setText(instrument.trackName());
+      instrumentName->setText(instrument->trackName());
 
-      _minPitchA = instrument.minPitchA();
-      _maxPitchA = instrument.maxPitchA();
-      _minPitchP = instrument.minPitchP();
-      _maxPitchP = instrument.maxPitchP();
+      _minPitchA = instrument->minPitchA();
+      _maxPitchA = instrument->maxPitchA();
+      _minPitchP = instrument->minPitchP();
+      _maxPitchP = instrument->maxPitchP();
       minPitchA->setText(midiCodeToStr(_minPitchA));
       maxPitchA->setText(midiCodeToStr(_maxPitchA));
       minPitchP->setText(midiCodeToStr(_minPitchP));
       maxPitchP->setText(midiCodeToStr(_maxPitchP));
 
       // only show string data controls if instrument has strings
-      int numStr = instrument.stringData() ? instrument.stringData()->strings() : 0;
+      int numStr = instrument->stringData() ? instrument->stringData()->strings() : 0;
       stringDataFrame->setVisible(numStr > 0);
       numOfStrings->setText(QString::number(numStr));
       }
@@ -324,18 +324,18 @@ void EditStaff::apply()
 
       if (!upFlag)
             interval.flip();
-      instrument.setTranspose(interval);
+      instrument->setTranspose(interval);
 
-      instrument.setMinPitchA(_minPitchA);
-      instrument.setMaxPitchA(_maxPitchA);
-      instrument.setMinPitchP(_minPitchP);
-      instrument.setMaxPitchP(_maxPitchP);
+      instrument->setMinPitchA(_minPitchA);
+      instrument->setMaxPitchA(_maxPitchA);
+      instrument->setMinPitchP(_minPitchP);
+      instrument->setMaxPitchP(_maxPitchP);
 
-      instrument.setShortName(sn);
-      instrument.setLongName(ln);
+      instrument->setShortName(sn);
+      instrument->setLongName(ln);
 
       bool inv       = invisible->isChecked();
-      ClefTypeList clefType = instrument.clefType(orgStaff->rstaff());
+      ClefTypeList clefType = instrument->clefType(orgStaff->rstaff());
       qreal userDist = spinExtraDistance->value();
       bool ifEmpty   = showIfEmpty->isChecked();
       bool hideSystemBL = hideSystemBarLine->isChecked();
@@ -343,9 +343,9 @@ void EditStaff::apply()
       Staff::HideMode hideEmpty = Staff::HideMode(hideMode->currentIndex());
 
       QString newPartName = partName->text().simplified();
-      if (!(instrument == *part->instrument()) || part->partName() != newPartName) {
+      if (!(*instrument == *part->instrument()) || part->partName() != newPartName) {
             // instrument has changed
-            Interval v1 = instrument.transpose();
+            Interval v1 = instrument->transpose();
             Interval v2 = part->instrument()->transpose();
 
             score->undo(new ChangePart(part, new Instrument(instrument), newPartName));
@@ -385,7 +385,7 @@ void EditStaff::apply()
 void EditStaff::minPitchAClicked()
       {
       int         newCode;
-      EditPitch ep(this, instrument.minPitchA());
+      EditPitch ep(this, instrument->minPitchA());
       ep.setWindowModality(Qt::WindowModal);
       if ( (newCode = ep.exec()) != -1) {
             minPitchA->setText(midiCodeToStr(newCode));
@@ -396,7 +396,7 @@ void EditStaff::minPitchAClicked()
 void EditStaff::maxPitchAClicked()
       {
       int         newCode;
-      EditPitch ep(this, instrument.maxPitchA());
+      EditPitch ep(this, instrument->maxPitchA());
       ep.setWindowModality(Qt::WindowModal);
       if ( (newCode = ep.exec()) != -1) {
             maxPitchA->setText(midiCodeToStr(newCode));
@@ -407,7 +407,7 @@ void EditStaff::maxPitchAClicked()
 void EditStaff::minPitchPClicked()
       {
       int         newCode;
-      EditPitch ep(this, instrument.minPitchP());
+      EditPitch ep(this, instrument->minPitchP());
       ep.setWindowModality(Qt::WindowModal);
       if ( (newCode = ep.exec()) != -1) {
             minPitchP->setText(midiCodeToStr(newCode));
@@ -418,7 +418,7 @@ void EditStaff::minPitchPClicked()
 void EditStaff::maxPitchPClicked()
       {
       int         newCode;
-      EditPitch ep(this, instrument.maxPitchP());
+      EditPitch ep(this, instrument->maxPitchP());
       ep.setWindowModality(Qt::WindowModal);
       if ( (newCode = ep.exec()) != -1) {
             maxPitchP->setText(midiCodeToStr(newCode));
@@ -461,10 +461,10 @@ void EditStaff::showBarlinesChanged()
 
 void EditStaff::showInstrumentDialog()
       {
-      SelectInstrument si(&instrument, this);
+      SelectInstrument si(instrument, this);
       si.setWindowModality(Qt::WindowModal);
       if (si.exec()) {
-            instrument = Instrument::fromTemplate(si.instrTemplate());
+            instrument = Instrument::fromTemplate(si.instrTemplate(), this);
             updateInstrument();
             }
       }
@@ -475,8 +475,8 @@ void EditStaff::showInstrumentDialog()
 
 void EditStaff::editStringDataClicked()
       {
-      int                     frets = instrument.stringData()->frets();
-      QList<instrString>      stringList = instrument.stringData()->stringList();
+      int                     frets = instrument->stringData()->frets();
+      QList<instrString>      stringList = instrument->stringData()->stringList();
 
       EditStringData* esd = new EditStringData(this, &stringList, &frets);
       esd->setWindowModality(Qt::WindowModal);
@@ -495,28 +495,28 @@ void EditStaff::editStringDataClicked()
                         if (str.pitch < lowestStringPitch)  lowestStringPitch  = str.pitch;
                         }
                   // get old string range bottom
-                  for (const instrString& str : instrument.stringData()->stringList())
+                  for (const instrString& str : instrument->stringData()->stringList())
                         if (str.pitch > oldHighestStringPitch) oldHighestStringPitch = str.pitch;
                   // if there were no string, arbitrarely set old top to maxPitchA
                   if (oldHighestStringPitch == INT16_MIN)
-                        oldHighestStringPitch = instrument.maxPitchA();
+                        oldHighestStringPitch = instrument->maxPitchA();
 
                   // range bottom is surely the pitch of the lowest string
-                  instrument.setMinPitchA(lowestStringPitch);
-                  instrument.setMinPitchP(lowestStringPitch);
+                  instrument->setMinPitchA(lowestStringPitch);
+                  instrument->setMinPitchP(lowestStringPitch);
                   // range top should keep the same interval with the highest string it has now
-                  instrument.setMaxPitchA(instrument.maxPitchA() + highestStringPitch - oldHighestStringPitch);
-                  instrument.setMaxPitchP(instrument.maxPitchP() + highestStringPitch - oldHighestStringPitch);
+                  instrument->setMaxPitchA(instrument->maxPitchA() + highestStringPitch - oldHighestStringPitch);
+                  instrument->setMaxPitchP(instrument->maxPitchP() + highestStringPitch - oldHighestStringPitch);
                   // update dlg controls
-                  minPitchA->setText(midiCodeToStr(instrument.minPitchA()));
-                  maxPitchA->setText(midiCodeToStr(instrument.maxPitchA()));
-                  minPitchP->setText(midiCodeToStr(instrument.minPitchP()));
-                  maxPitchP->setText(midiCodeToStr(instrument.maxPitchP()));
+                  minPitchA->setText(midiCodeToStr(instrument->minPitchA()));
+                  maxPitchA->setText(midiCodeToStr(instrument->maxPitchA()));
+                  minPitchP->setText(midiCodeToStr(instrument->minPitchP()));
+                  maxPitchP->setText(midiCodeToStr(instrument->maxPitchP()));
                   // if no longer there is any string, leave everything as it is now
                   }
 
             // update instrument data and dlg controls
-            instrument.setStringData(stringData);
+            instrument->setStringData(stringData);
             numOfStrings->setText(QString::number(stringData.strings()));
             }
       }

--- a/mscore/editstaff.h
+++ b/mscore/editstaff.h
@@ -40,7 +40,7 @@ class EditStaff : public QDialog, private Ui::EditStaffBase {
 
       Staff*      staff;
       Staff*      orgStaff;
-      Instrument  instrument;
+      Instrument* instrument;
       int         _minPitchA, _maxPitchA, _minPitchP, _maxPitchP;
       int         _tickStart, _tickEnd;
 

--- a/mscore/importgtp-gp6.cpp
+++ b/mscore/importgtp-gp6.cpp
@@ -508,7 +508,8 @@ void GuitarPro6::readTracks(QDomNode* track)
                         QString ref = currentNode.attributes().namedItem("ref").toAttr().value();
                         auto it     = instrumentMapping.find(ref);
                         if (it != instrumentMapping.end()) {
-                              part->setInstrument(Instrument::fromTemplate(Ms::searchTemplate(it->second)));
+                              part->setInstrument(
+                                    Instrument::fromTemplate(Ms::searchTemplate(it->second), part));
                               }
                         else
                               qDebug() << "Unknown instrument: " << ref;

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -2845,8 +2845,10 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
             pscore->style().set(Sid::ArpeggioHiddenInStdIfTab, true);
 
             QList<int> stavesMap;
-            Part*   p = new Part(pscore);
-            p->setInstrument(*part->instrument());
+            Part* p = new Part(pscore);
+            Instrument* newInstr = new Instrument(p);
+            newInstr->set(part->instrument());
+            p->setInstrument(newInstr);
 //TODO-ws		pscore->tuning = gp->tunings[counter++];
 
 		Staff* staff = part->staves()->front();

--- a/mscore/importmidi/importmidi_instrument.cpp
+++ b/mscore/importmidi/importmidi_instrument.cpp
@@ -170,10 +170,10 @@ const InstrumentTemplate* findClosestInstrument(const MTrack &track)
                   const bool isDrumTemplate = templ->useDrumset;
                   if (track.mtrack->drumTrack() != isDrumTemplate)
                         continue;
-                  for (const auto &channel: templ->channel) {
-                        if (channel.program() < track.program
-                                    && channel.program() > maxLessProgram) {
-                              maxLessProgram = channel.program();
+                  for (Channel* channel: templ->channel) {
+                        if (channel->program() < track.program
+                                    && channel->program() > maxLessProgram) {
+                              maxLessProgram = channel->program();
                               closestTemplate = templ;
                               break;
                               }
@@ -204,8 +204,8 @@ std::vector<const InstrumentTemplate *> findInstrumentsForProgram(const MTrack &
                   if (isDrumTemplate && templ->drumset)
                         findNotEmptyDrumPitches(drumPitches, templ);
 
-                  for (const auto &channel: templ->channel) {
-                        if (channel.program() == program) {
+                  for (Channel* channel: templ->channel) {
+                        if (channel->program() == program) {
                               if (isDrumTemplate && templ->drumset) {
                                     if (hasNotDefinedDrumPitch(trackPitches, drumPitches))
                                           break;

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -409,9 +409,9 @@ static void initDrumset(Drumset* drumset, const MusicXMLDrumset& mxmlDrumset)
  Create an Instrument based on the information in \a mxmlInstr.
  */
 
-static Instrument createInstrument(const MusicXMLDrumInstrument& mxmlInstr)
+static Instrument* createInstrument(const MusicXMLDrumInstrument& mxmlInstr)
       {
-      Instrument instr;
+      Instrument* instr;
 
       InstrumentTemplate* it {};
       if (!mxmlInstr.sound.isEmpty()) {
@@ -429,19 +429,19 @@ static Instrument createInstrument(const MusicXMLDrumInstrument& mxmlInstr)
             // initialize from template with matching MusicXmlId
             instr = Instrument::fromTemplate(it);
             // reset transpose, as it is determined later from MusicXML data
-            instr.setTranspose(Interval());
+            instr->setTranspose(Interval());
             }
       else {
             // set articulations to default (global articulations)
-            instr.setArticulation(articulation);
+            instr->setArticulation(articulation);
             // set default program
-            instr.channel(0)->setProgram(mxmlInstr.midiProgram >= 0 ? mxmlInstr.midiProgram : 0);
+            instr->channel(0)->setProgram(mxmlInstr.midiProgram >= 0 ? mxmlInstr.midiProgram : 0);
             }
 
       // add / overrule with values read from MusicXML
-      instr.channel(0)->setPan(mxmlInstr.midiPan);
-      instr.channel(0)->setVolume(mxmlInstr.midiVolume);
-      instr.setTrackName(mxmlInstr.name);
+      instr->channel(0)->setPan(mxmlInstr.midiPan);
+      instr->channel(0)->setVolume(mxmlInstr.midiVolume);
+      instr->setTrackName(mxmlInstr.name);
 
       return instr;
       }
@@ -471,7 +471,7 @@ static void setFirstInstrument(MxmlLogger* logger, const QXmlStreamReader* const
                   mxmlInstr = mxmlDrumset.first();
                   }
 
-            Instrument instr = createInstrument(mxmlInstr);
+            Instrument* instr = createInstrument(mxmlInstr);
             part->setInstrument(instr);
             if (mxmlInstr.midiChannel >= 0) part->setMidiChannel(mxmlInstr.midiChannel, mxmlInstr.midiPort);
             // note: setMidiProgram() does more than simply setting the MIDI program
@@ -566,7 +566,7 @@ static void setPartInstruments(MxmlLogger* logger, const QXmlStreamReader* const
                                                .arg(instrId).arg(tick).arg(partId), xmlreader);
                         else {
                               MusicXMLDrumInstrument mxmlInstr = mxmlDrumset.value(instrId);
-                              Instrument instr = createInstrument(mxmlInstr);
+                              Instrument* instr = createInstrument(mxmlInstr);
                               //qDebug("instr %p", &instr);
 
                               InstrumentChange* ic = new InstrumentChange(instr, score);

--- a/mscore/importptb.cpp
+++ b/mscore/importptb.cpp
@@ -1283,7 +1283,9 @@ Score::FileError PowerTab::read()
 
             QList<int> stavesMap;
             Part* p = new Part(pscore);
-            p->setInstrument(*part->instrument());
+            Instrument* newInstr = new Instrument(p);
+            newInstr->set(part->instrument());
+            p->setInstrument(newInstr);
 
             Staff* staff = part->staves()->front();
 

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -260,7 +260,7 @@ void Mixer::setScore(MasterScore* score)
 
 void Mixer::updateTracks()
       {
-      MixerTrackItem* oldSel = mixerDetails->track().get();
+      MixerTrackItem* oldSel = mixerDetails->track();
 
       Part* selPart = oldSel ? oldSel->part() : 0;
       Channel* selChan = oldSel ? oldSel->chan() : 0;
@@ -276,12 +276,16 @@ void Mixer::updateTracks()
             }
 
 
+      //Delete old objects
       if (trackHolder) {
             trackAreaLayout->removeWidget(trackHolder);
             trackHolder->deleteLater();
             trackHolder = 0;
             }
 
+      for (MixerTrack* track: trackList) {
+            delete track->mti();
+            }
       trackList.clear();
       mixerDetails->setTrack(0);
 
@@ -309,8 +313,8 @@ void Mixer::updateTracks()
                   proxyChan = proxyInstr->channel(0);
                   }
 
-            MixerTrackItemPtr mti = std::make_shared<MixerTrackItem>(
-                              MixerTrackItem::TrackType::PART, part, proxyInstr, proxyChan);
+            MixerTrackItem* mti = new MixerTrackItem(
+                              MixerTrackItem::TrackType::PART, part, proxyInstr, proxyChan, this);
 
             MixerTrackPart* track = new MixerTrackPart(this, mti, expanded);
             track->setGroup(this);
@@ -330,8 +334,8 @@ void Mixer::updateTracks()
                         Instrument* instr = it->second;
                         for (int i = 0; i < instr->channel().size(); ++i) {
                               Channel *chan = instr->channel()[i];
-                              MixerTrackItemPtr mti1 = std::make_shared<MixerTrackItem>(
-                                                MixerTrackItem::TrackType::CHANNEL, part, instr, chan);
+                              MixerTrackItem* mti1 = new MixerTrackItem(
+                                                MixerTrackItem::TrackType::CHANNEL, part, instr, chan, this);
 //                              MixerTrackItemPtr mti = new MixerTrackItem(
 //                                                MixerTrackItem::TrackType::CHANNEL, part, instr, chan);
                               MixerTrackChannel* track1 = new MixerTrackChannel(this, mti1);

--- a/mscore/mixerdetails.cpp
+++ b/mscore/mixerdetails.cpp
@@ -68,30 +68,46 @@ MixerDetails::MixerDetails(QWidget *parent) :
 
 MixerDetails::~MixerDetails()
       {
-      if (_mti) {
-            //Remove old attachment
-            _mti->midiMap()->articulation->removeListener(this);
-            }
+//      if (_mti) {
+//            //Remove old attachment
+//            _mti->midiMap()->articulation->removeListener(this);
+//            }
       }
 
 //---------------------------------------------------------
 //   setTrack
 //---------------------------------------------------------
 
-void MixerDetails::setTrack(MixerTrackItemPtr track)
+void MixerDetails::setTrack(MixerTrackItem* track)
       {
       if (_mti) {
             //Remove old attachment
+            Part* part = _mti->part();
             Channel* chan = _mti->focusedChan();
-            chan->removeListener(this);
+//            chan->removeListener(this);
+
+            disconnect(chan, &Channel::volumeChanged, this, &MixerDetails::notifyVolumeChanged);
+            disconnect(chan, &Channel::panChanged, this, &MixerDetails::notifyPanChanged);
+            disconnect(chan, &Channel::chorusChanged, this, &MixerDetails::notifyChorusChanged);
+            disconnect(chan, &Channel::reverbChanged, this, &MixerDetails::notifyReverbChanged);
+            disconnect(chan, &Channel::colorChanged, this, &MixerDetails::notifyColorChanged);
+            disconnect(part, &Part::partNameChanged, this, &MixerDetails::notifyPartNameChanged);
             }
 
       _mti = track;
-
+//vol pan rev cho color name
       if (_mti) {
             //Listen to new track
+            Part* part = _mti->part();
             Channel* chan = _mti->focusedChan();
-            chan->addListener(this);
+//            chan->addListener(this);
+
+            connect(chan, &Channel::volumeChanged, this, &MixerDetails::notifyVolumeChanged);
+            connect(chan, &Channel::panChanged, this, &MixerDetails::notifyPanChanged);
+            connect(chan, &Channel::chorusChanged, this, &MixerDetails::notifyChorusChanged);
+            connect(chan, &Channel::reverbChanged, this, &MixerDetails::notifyReverbChanged);
+            connect(chan, &Channel::colorChanged, this, &MixerDetails::notifyColorChanged);
+            connect(part, &Part::partNameChanged, this, &MixerDetails::notifyPartNameChanged);
             }
       updateFromTrack();
       }
@@ -289,17 +305,87 @@ void MixerDetails::trackColorChanged(QColor col)
 //   disconnectChannelListener
 //---------------------------------------------------------
 
-void MixerDetails::disconnectChannelListener()
-      {
-      //Channel has been destroyed.  Don't remove listener when invoking destructor.
-      _mti = nullptr;
-      }
+//void MixerDetails::disconnectChannelListener()
+//      {
+//      //Channel has been destroyed.  Don't remove listener when invoking destructor.
+//      _mti = nullptr;
+//      }
 
 //---------------------------------------------------------
 //   propertyChanged
 //---------------------------------------------------------
 
-void MixerDetails::propertyChanged(Channel::Prop property)
+//void MixerDetails::propertyChanged(Channel::Prop property)
+//      {
+//      if (!_mti)
+//            return;
+
+//      MidiMapping* _midiMap = _mti->midiMap();
+//      Channel* chan = _midiMap->articulation;
+
+//      switch (property) {
+//            case Channel::Prop::VOLUME: {
+//                  volumeSlider->blockSignals(true);
+//                  volumeSpinBox->blockSignals(true);
+
+//                  volumeSlider->setValue((int)chan->volume());
+//                  volumeSpinBox->setValue(chan->volume());
+
+//                  volumeSlider->blockSignals(false);
+//                  volumeSpinBox->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::PAN: {
+//                  panSlider->blockSignals(true);
+//                  panSpinBox->blockSignals(true);
+
+//                  panSlider->setValue((int)chan->pan());
+//                  panSpinBox->setValue(chan->pan());
+
+//                  panSlider->blockSignals(false);
+//                  panSpinBox->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::CHORUS: {
+//                  chorusSlider->blockSignals(true);
+//                  chorusSpinBox->blockSignals(true);
+
+//                  chorusSlider->setValue((int)chan->chorus());
+//                  chorusSpinBox->setValue(chan->chorus());
+
+//                  chorusSlider->blockSignals(false);
+//                  chorusSpinBox->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::REVERB: {
+//                  reverbSlider->blockSignals(true);
+//                  reverbSpinBox->blockSignals(true);
+
+//                  reverbSlider->setValue((int)chan->reverb());
+//                  reverbSpinBox->setValue(chan->reverb());
+
+//                  reverbSlider->blockSignals(false);
+//                  reverbSpinBox->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::COLOR: {
+//                  trackColorChanged(chan->color());
+//                  break;
+//                  }
+//            case Channel::Prop::NAME: {
+//                  partNameLineEdit->blockSignals(true);
+//                  Part* part = _mti->part();
+//                  QString partName = part->partName();
+//                  partNameLineEdit->setText(partName);
+//                  partNameLineEdit->blockSignals(false);
+//                  break;
+//                  }
+//            default:
+//                  break;
+//            }
+//      }
+
+void MixerDetails::notifyVolumeChanged(char)
       {
       if (!_mti)
             return;
@@ -307,66 +393,100 @@ void MixerDetails::propertyChanged(Channel::Prop property)
       MidiMapping* _midiMap = _mti->midiMap();
       Channel* chan = _midiMap->articulation;
 
-      switch (property) {
-            case Channel::Prop::VOLUME: {
-                  volumeSlider->blockSignals(true);
-                  volumeSpinBox->blockSignals(true);
+      volumeSlider->blockSignals(true);
+      volumeSpinBox->blockSignals(true);
 
-                  volumeSlider->setValue((int)chan->volume());
-                  volumeSpinBox->setValue(chan->volume());
+      volumeSlider->setValue((int)chan->volume());
+      volumeSpinBox->setValue(chan->volume());
 
-                  volumeSlider->blockSignals(false);
-                  volumeSpinBox->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::PAN: {
-                  panSlider->blockSignals(true);
-                  panSpinBox->blockSignals(true);
+      volumeSlider->blockSignals(false);
+      volumeSpinBox->blockSignals(false);
 
-                  panSlider->setValue((int)chan->pan());
-                  panSpinBox->setValue(chan->pan());
+      }
 
-                  panSlider->blockSignals(false);
-                  panSpinBox->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::CHORUS: {
-                  chorusSlider->blockSignals(true);
-                  chorusSpinBox->blockSignals(true);
+void MixerDetails::notifyPanChanged(char)
+      {
+      if (!_mti)
+            return;
 
-                  chorusSlider->setValue((int)chan->chorus());
-                  chorusSpinBox->setValue(chan->chorus());
+      MidiMapping* _midiMap = _mti->midiMap();
+      Channel* chan = _midiMap->articulation;
 
-                  chorusSlider->blockSignals(false);
-                  chorusSpinBox->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::REVERB: {
-                  reverbSlider->blockSignals(true);
-                  reverbSpinBox->blockSignals(true);
+      panSlider->blockSignals(true);
+      panSpinBox->blockSignals(true);
 
-                  reverbSlider->setValue((int)chan->reverb());
-                  reverbSpinBox->setValue(chan->reverb());
+      panSlider->setValue((int)chan->pan());
+      panSpinBox->setValue(chan->pan());
 
-                  reverbSlider->blockSignals(false);
-                  reverbSpinBox->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::COLOR: {
-                  trackColorChanged(chan->color());
-                  break;
-                  }
-            case Channel::Prop::NAME: {
-                  partNameLineEdit->blockSignals(true);
-                  Part* part = _mti->part();
-                  QString partName = part->partName();
-                  partNameLineEdit->setText(partName);
-                  partNameLineEdit->blockSignals(false);
-                  break;
-                  }
-            default:
-                  break;
-            }
+      panSlider->blockSignals(false);
+      panSpinBox->blockSignals(false);
+
+      }
+
+void MixerDetails::notifyChorusChanged(char)
+      {
+      if (!_mti)
+            return;
+
+      MidiMapping* _midiMap = _mti->midiMap();
+      Channel* chan = _midiMap->articulation;
+
+      chorusSlider->blockSignals(true);
+      chorusSpinBox->blockSignals(true);
+
+      chorusSlider->setValue((int)chan->chorus());
+      chorusSpinBox->setValue(chan->chorus());
+
+      chorusSlider->blockSignals(false);
+      chorusSpinBox->blockSignals(false);
+
+      }
+
+void MixerDetails::notifyReverbChanged(char)
+      {
+      if (!_mti)
+            return;
+
+      MidiMapping* _midiMap = _mti->midiMap();
+      Channel* chan = _midiMap->articulation;
+
+      reverbSlider->blockSignals(true);
+      reverbSpinBox->blockSignals(true);
+
+      reverbSlider->setValue((int)chan->reverb());
+      reverbSpinBox->setValue(chan->reverb());
+
+      reverbSlider->blockSignals(false);
+      reverbSpinBox->blockSignals(false);
+
+      }
+
+void MixerDetails::notifyColorChanged(int)
+      {
+      if (!_mti)
+            return;
+
+      MidiMapping* _midiMap = _mti->midiMap();
+      Channel* chan = _midiMap->articulation;
+
+      trackColorChanged(chan->color());
+
+      }
+
+void MixerDetails::notifyPartNameChanged(QString)
+      {
+      if (!_mti)
+            return;
+
+      MidiMapping* _midiMap = _mti->midiMap();
+      Channel* chan = _midiMap->articulation;
+
+      partNameLineEdit->blockSignals(true);
+      Part* part = _mti->part();
+      QString partName = part->partName();
+      partNameLineEdit->setText(partName);
+      partNameLineEdit->blockSignals(false);
+
       }
 
 //---------------------------------------------------------

--- a/mscore/mixerdetails.h
+++ b/mscore/mixerdetails.h
@@ -25,6 +25,8 @@
 #include "libmscore/instrument.h"
 #include "mixertrackitem.h"
 
+#include <QPointer>
+
 namespace Ms {
 
 
@@ -35,11 +37,11 @@ class MixerTrackItem;
 //   MixerDetails
 //---------------------------------------------------------
 
-class MixerDetails : public QWidget, public Ui::MixerDetails, public ChannelListener
+class MixerDetails : public QWidget, public Ui::MixerDetails
       {
       Q_OBJECT
 
-      MixerTrackItemPtr _mti;
+      QPointer<MixerTrackItem> _mti;
 
       void updateFromTrack();
 
@@ -54,14 +56,20 @@ public slots:
       void drumkitToggled(bool);
       void midiChannelChanged(int);
 
+      void notifyVolumeChanged(char);
+      void notifyPanChanged(char);
+      void notifyChorusChanged(char);
+      void notifyReverbChanged(char);
+      void notifyColorChanged(int);
+      void notifyPartNameChanged(QString);
 public:
       explicit MixerDetails(QWidget *parent);
       ~MixerDetails() override;
 
-      MixerTrackItemPtr track() { return _mti; }
-      void setTrack(MixerTrackItemPtr track);
-      void propertyChanged(Channel::Prop property) override;
-      void disconnectChannelListener() override;
+      MixerTrackItem* track() { return _mti; }
+      void setTrack(MixerTrackItem* track);
+//      void propertyChanged(Channel::Prop property) override;
+//      void disconnectChannelListener() override;
 
       };
 

--- a/mscore/mixertrack.h
+++ b/mscore/mixertrack.h
@@ -33,7 +33,7 @@ public:
       virtual ~MixerTrack() {}
       virtual QWidget* getWidget() = 0;
       virtual MixerTrackGroup* group() = 0;
-      virtual MixerTrackItemPtr mti() = 0;
+      virtual MixerTrackItem* mti() = 0;
       virtual bool selected() = 0;
       virtual void setSelected(bool) = 0;
       };

--- a/mscore/mixertrackchannel.cpp
+++ b/mscore/mixertrackchannel.cpp
@@ -78,7 +78,7 @@ const QString MixerTrackChannel::selStyleDark = "#controlWidget {"
 //   MixerTrack
 //---------------------------------------------------------
 
-MixerTrackChannel::MixerTrackChannel(QWidget *parent, MixerTrackItemPtr mti) :
+MixerTrackChannel::MixerTrackChannel(QWidget *parent, MixerTrackItem* mti) :
       QWidget(parent), _mti(mti), _selected(false), _group(0)
       {
       setupUi(this);
@@ -90,10 +90,17 @@ MixerTrackChannel::MixerTrackChannel(QWidget *parent, MixerTrackItemPtr mti) :
 
       //set up rest
       Channel* chan = mti->chan();
+
+      connect(chan, &Channel::volumeChanged, this, &MixerTrackChannel::notifyVolumeChanged);
+      connect(chan, &Channel::panChanged, this, &MixerTrackChannel::notifyPanChanged);
+      connect(chan, &Channel::muteChanged, this, &MixerTrackChannel::notifyMuteChanged);
+      connect(chan, &Channel::soloChanged, this, &MixerTrackChannel::notifySoloChanged);
+      connect(chan, &Channel::colorChanged, this, &MixerTrackChannel::notifyColorChanged);
+
       soloBn->setChecked(chan->solo());
       muteBn->setChecked(chan->mute());
 
-      chan->addListener(this);
+//      chan->addListener(this);
       volumeSlider->setValue(chan->volume());
       volumeSlider->setToolTip(tr("Volume: %1").arg(QString::number(chan->volume())));
       volumeSlider->setMaxValue(127);
@@ -124,10 +131,10 @@ MixerTrackChannel::MixerTrackChannel(QWidget *parent, MixerTrackItemPtr mti) :
 
 MixerTrackChannel::~MixerTrackChannel()
       {
-      if (_mti) {
-            Channel* chan = _mti->chan();
-            chan->removeListener(this);
-            }
+//      if (_mti) {
+//            Channel* chan = _mti->chan();
+//            chan->removeListener(this);
+//            }
       }
 
 //---------------------------------------------------------
@@ -238,55 +245,99 @@ void MixerTrackChannel::paintEvent(QPaintEvent*)
 //   disconnectChannelListener
 //---------------------------------------------------------
 
-void MixerTrackChannel::disconnectChannelListener()
-      {
-      //Channel has been destroyed.  Don't remove listener when invoking destructor.
-      _mti = nullptr;
-      }
+//void MixerTrackChannel::disconnectChannelListener()
+//      {
+//      //Channel has been destroyed.  Don't remove listener when invoking destructor.
+//      _mti = nullptr;
+//      }
 
 //---------------------------------------------------------
 //   propertyChanged
 //---------------------------------------------------------
 
-void MixerTrackChannel::propertyChanged(Channel::Prop property)
+//void MixerTrackChannel::propertyChanged(Channel::Prop property)
+//      {
+//      Channel* chan = _mti->chan();
+
+//      switch (property) {
+//            case Channel::Prop::VOLUME: {
+//                  volumeSlider->blockSignals(true);
+//                  volumeSlider->setValue(chan->volume());
+//                  volumeSlider->setToolTip(tr("Volume: %1").arg(QString::number(chan->volume())));
+//                  volumeSlider->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::PAN: {
+//                  panSlider->blockSignals(true);
+//                  panSlider->setValue(chan->pan());
+//                  panSlider->setToolTip(tr("Pan: %1").arg(QString::number(chan->pan())));
+//                  panSlider->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::MUTE: {
+//                  muteBn->blockSignals(true);
+//                  muteBn->setChecked(chan->mute());
+//                  muteBn->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::SOLO: {
+//                  soloBn->blockSignals(true);
+//                  soloBn->setChecked(chan->solo());
+//                  soloBn->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::COLOR: {
+//                  updateNameLabel();
+//                  break;
+//                  }
+//            default:
+//                  break;
+//            }
+//      }
+
+void MixerTrackChannel::notifyVolumeChanged(char)
       {
       Channel* chan = _mti->chan();
 
-      switch (property) {
-            case Channel::Prop::VOLUME: {
-                  volumeSlider->blockSignals(true);
-                  volumeSlider->setValue(chan->volume());
-                  volumeSlider->setToolTip(tr("Volume: %1").arg(QString::number(chan->volume())));
-                  volumeSlider->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::PAN: {
-                  panSlider->blockSignals(true);
-                  panSlider->setValue(chan->pan());
-                  panSlider->setToolTip(tr("Pan: %1").arg(QString::number(chan->pan())));
-                  panSlider->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::MUTE: {
-                  muteBn->blockSignals(true);
-                  muteBn->setChecked(chan->mute());
-                  muteBn->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::SOLO: {
-                  soloBn->blockSignals(true);
-                  soloBn->setChecked(chan->solo());
-                  soloBn->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::COLOR: {
-                  updateNameLabel();
-                  break;
-                  }
-            default:
-                  break;
-            }
+      volumeSlider->blockSignals(true);
+      volumeSlider->setValue(chan->volume());
+      volumeSlider->setToolTip(tr("Volume: %1").arg(QString::number(chan->volume())));
+      volumeSlider->blockSignals(false);
       }
+
+void MixerTrackChannel::notifyPanChanged(char)
+      {
+      Channel* chan = _mti->chan();
+
+      panSlider->blockSignals(true);
+      panSlider->setValue(chan->pan());
+      panSlider->setToolTip(tr("Pan: %1").arg(QString::number(chan->pan())));
+      panSlider->blockSignals(false);
+      }
+
+void MixerTrackChannel::notifyMuteChanged(bool)
+      {
+      Channel* chan = _mti->chan();
+
+      muteBn->blockSignals(true);
+      muteBn->setChecked(chan->mute());
+      muteBn->blockSignals(false);
+      }
+
+void MixerTrackChannel::notifySoloChanged(bool)
+      {
+      Channel* chan = _mti->chan();
+
+      soloBn->blockSignals(true);
+      soloBn->setChecked(chan->solo());
+      soloBn->blockSignals(false);
+      }
+
+void MixerTrackChannel::notifyColorChanged(int)
+      {
+      updateNameLabel();
+      }
+
 
 //---------------------------------------------------------
 //   volumeChanged

--- a/mscore/mixertrackchannel.h
+++ b/mscore/mixertrackchannel.h
@@ -27,6 +27,8 @@
 #include "mixertrackitem.h"
 #include "libmscore/instrument.h"
 
+#include <QPointer>
+
 namespace Ms {
 
 struct MidiMapping;
@@ -36,11 +38,11 @@ class MixerTrackItem;
 //   MixerTrack
 //---------------------------------------------------------
 
-class MixerTrackChannel : public QWidget, public Ui::MixerTrackChannel, public ChannelListener, public MixerTrack
+class MixerTrackChannel : public QWidget, public Ui::MixerTrackChannel, public MixerTrack
       {
       Q_OBJECT
 
-      MixerTrackItemPtr _mti;
+      QPointer<MixerTrackItem> _mti;
 
       bool _selected;
       static const QString unselStyleLight;
@@ -65,19 +67,25 @@ public slots:
       void controlSelected();
       void applyStyle();
 
+      void notifyVolumeChanged(char);
+      void notifyPanChanged(char);
+      void notifyMuteChanged(bool);
+      void notifySoloChanged(bool);
+      void notifyColorChanged(int);
+
 protected:
       void mouseReleaseEvent(QMouseEvent * event) override;
-      void propertyChanged(Channel::Prop property) override;
-      void disconnectChannelListener() override;
+//      void propertyChanged(Channel::Prop property) override;
+//      void disconnectChannelListener() override;
 
 public:
-      explicit MixerTrackChannel(QWidget *parent, MixerTrackItemPtr trackItem);
+      explicit MixerTrackChannel(QWidget *parent, MixerTrackItem* trackItem);
       ~MixerTrackChannel() override;
 
       bool selected() override { return _selected; }
       QWidget* getWidget() override { return this; }
       MixerTrackGroup* group() override { return _group; }
-      MixerTrackItemPtr mti() override { return _mti; }
+      MixerTrackItem* mti() override { return _mti; }
       void setGroup(MixerTrackGroup* group) { _group = group; }
       void paintEvent(QPaintEvent* evt) override;
       };

--- a/mscore/mixertrackitem.cpp
+++ b/mscore/mixertrackitem.cpp
@@ -30,8 +30,8 @@ namespace Ms {
 //   MixerTrackItem
 //---------------------------------------------------------
 
-MixerTrackItem::MixerTrackItem(TrackType tt, Part* part, Instrument* instr, Channel *chan)
-      :_trackType(tt), _part(part), _instr(instr), _chan(chan)
+MixerTrackItem::MixerTrackItem(TrackType tt, Part* part, Instrument* instr, Channel *chan, QObject* parent)
+      :QObject(parent), _trackType(tt), _part(part), _instr(instr), _chan(chan)
       {
       }
 

--- a/mscore/mixertrackitem.h
+++ b/mscore/mixertrackitem.h
@@ -22,7 +22,7 @@
 #define __MIXERTRACKITEM_H__
 
 #include "libmscore/instrument.h"
-#include <memory>
+#include <QObject>
 
 namespace Ms {
 
@@ -32,17 +32,18 @@ class Channel;
 struct MidiMapping;
 class MixerTrackItem;
 
-typedef std::shared_ptr<MixerTrackItem> MixerTrackItemPtr;
-//typedef MixerTrackItem* MixerTrackItemPtr;
 
 //---------------------------------------------------------
 //   MixerTrackItem
 //---------------------------------------------------------
 
-class MixerTrackItem
+class MixerTrackItem : public QObject
       {
+      Q_OBJECT
+
 public:
       enum class TrackType { PART, CHANNEL };
+      Q_ENUM(TrackType)
 
 private:
       TrackType _trackType;
@@ -52,7 +53,7 @@ private:
       Channel* _chan;
 
 public:
-      MixerTrackItem(TrackType tt, Part* part, Instrument* _instr, Channel* _chan);
+      MixerTrackItem(TrackType tt, Part* part, Instrument* _instr, Channel* _chan, QObject* parent = nullptr);
 
       TrackType trackType() { return _trackType; }
       Part* part() { return _part; }
@@ -62,6 +63,7 @@ public:
       MidiMapping *midiMap();
       int color();
 
+public slots:
       void setColor(int valueRgb);
       void setVolume(char value);
       void setPan(char value);

--- a/mscore/mixertrackpart.cpp
+++ b/mscore/mixertrackpart.cpp
@@ -79,7 +79,7 @@ const QString MixerTrackPart::selStyleDark = "#controlWidget {"
 //   MixerTrack
 //---------------------------------------------------------
 
-MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItemPtr mti, bool expanded) :
+MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItem* mti, bool expanded) :
       QWidget(parent), _mti(mti), _selected(false), _group(0)
       {
       setupUi(this);
@@ -106,10 +106,16 @@ MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItemPtr mti, bool expa
 
       Channel* chan = _mti->focusedChan();
 
+      connect(chan, &Channel::volumeChanged, this, &MixerTrackPart::notifyVolumeChanged);
+      connect(chan, &Channel::panChanged, this, &MixerTrackPart::notifyPanChanged);
+      connect(chan, &Channel::muteChanged, this, &MixerTrackPart::notifyMuteChanged);
+      connect(chan, &Channel::soloChanged, this, &MixerTrackPart::notifySoloChanged);
+      connect(chan, &Channel::colorChanged, this, &MixerTrackPart::notifyColorChanged);
+
       soloBn->setChecked(chan->solo());
       muteBn->setChecked(chan->mute());
 
-      chan->addListener(this);
+//      chan->addListener(this);
       volumeSlider->setValue(chan->volume());
       volumeSlider->setToolTip(tr("Volume: %1").arg(QString::number(chan->volume())));
       volumeSlider->setMaxValue(127);
@@ -140,10 +146,10 @@ MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItemPtr mti, bool expa
 
 MixerTrackPart::~MixerTrackPart()
       {
-      if (_mti) {
-            Channel* chan = _mti->focusedChan();
-            chan->removeListener(this);
-            }
+//      if (_mti) {
+//            Channel* chan = _mti->focusedChan();
+//            chan->removeListener(this);
+//            }
       }
 
 //---------------------------------------------------------
@@ -235,54 +241,98 @@ void MixerTrackPart::paintEvent(QPaintEvent*)
 //   disconnectChannelListener
 //---------------------------------------------------------
 
-void MixerTrackPart::disconnectChannelListener()
-      {
-      //Channel has been destroyed.  Don't remove listener when invoking destructor.
-      _mti = nullptr;
-      }
+//void MixerTrackPart::disconnectChannelListener()
+//      {
+//      //Channel has been destroyed.  Don't remove listener when invoking destructor.
+//      _mti = nullptr;
+//      }
 
 //---------------------------------------------------------
 //   propertyChanged
 //---------------------------------------------------------
 
-void MixerTrackPart::propertyChanged(Channel::Prop property)
-      {
-      Channel* chan = _mti->focusedChan();
+//void MixerTrackPart::propertyChanged(Channel::Prop property)
+//      {
+//      Channel* chan = _mti->focusedChan();
 
-      switch (property) {
-            case Channel::Prop::VOLUME: {
-                  volumeSlider->blockSignals(true);
-                  volumeSlider->setValue(chan->volume());
-                  volumeSlider->setToolTip(tr("Volume: %1").arg(QString::number(chan->volume())));
-                  volumeSlider->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::PAN: {
-                  panSlider->blockSignals(true);
-                  panSlider->setValue(chan->pan());
-                  panSlider->setToolTip(tr("Pan: %1").arg(QString::number(chan->pan())));
-                  panSlider->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::MUTE: {
-                  muteBn->blockSignals(true);
-                  muteBn->setChecked(chan->mute());
-                  muteBn->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::SOLO: {
-                  soloBn->blockSignals(true);
-                  soloBn->setChecked(chan->solo());
-                  soloBn->blockSignals(false);
-                  break;
-                  }
-            case Channel::Prop::COLOR: {
-                  updateNameLabel();
-                  break;
-                  }
-            default:
-                  break;
-            }
+//      switch (property) {
+//            case Channel::Prop::VOLUME: {
+//                  volumeSlider->blockSignals(true);
+//                  volumeSlider->setValue(chan->volume());
+//                  volumeSlider->setToolTip(tr("Volume: %1").arg(QString::number(chan->volume())));
+//                  volumeSlider->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::PAN: {
+//                  panSlider->blockSignals(true);
+//                  panSlider->setValue(chan->pan());
+//                  panSlider->setToolTip(tr("Pan: %1").arg(QString::number(chan->pan())));
+//                  panSlider->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::MUTE: {
+//                  muteBn->blockSignals(true);
+//                  muteBn->setChecked(chan->mute());
+//                  muteBn->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::SOLO: {
+//                  soloBn->blockSignals(true);
+//                  soloBn->setChecked(chan->solo());
+//                  soloBn->blockSignals(false);
+//                  break;
+//                  }
+//            case Channel::Prop::COLOR: {
+//                  updateNameLabel();
+//                  break;
+//                  }
+//            default:
+//                  break;
+//            }
+//      }
+
+
+void MixerTrackPart::notifyVolumeChanged(char)
+      {
+      Channel* chan = _mti->chan();
+
+      volumeSlider->blockSignals(true);
+      volumeSlider->setValue(chan->volume());
+      volumeSlider->setToolTip(tr("Volume: %1").arg(QString::number(chan->volume())));
+      volumeSlider->blockSignals(false);
+      }
+
+void MixerTrackPart::notifyPanChanged(char)
+      {
+      Channel* chan = _mti->chan();
+
+      panSlider->blockSignals(true);
+      panSlider->setValue(chan->pan());
+      panSlider->setToolTip(tr("Pan: %1").arg(QString::number(chan->pan())));
+      panSlider->blockSignals(false);
+      }
+
+void MixerTrackPart::notifyMuteChanged(bool)
+      {
+      Channel* chan = _mti->chan();
+
+      muteBn->blockSignals(true);
+      muteBn->setChecked(chan->mute());
+      muteBn->blockSignals(false);
+      }
+
+void MixerTrackPart::notifySoloChanged(bool)
+      {
+      Channel* chan = _mti->chan();
+
+      soloBn->blockSignals(true);
+      soloBn->setChecked(chan->solo());
+      soloBn->blockSignals(false);
+      }
+
+void MixerTrackPart::notifyColorChanged(int)
+      {
+      updateNameLabel();
       }
 
 //---------------------------------------------------------

--- a/mscore/mixertrackpart.h
+++ b/mscore/mixertrackpart.h
@@ -27,6 +27,8 @@
 #include "mixertrackitem.h"
 #include "libmscore/instrument.h"
 
+#include <QPointer>
+
 namespace Ms {
 
 struct MidiMapping;
@@ -36,11 +38,11 @@ class MixerTrackItem;
 //   MixerTrackPart
 //---------------------------------------------------------
 
-class MixerTrackPart : public QWidget, public Ui::MixerTrackPart, public ChannelListener, public MixerTrack
+class MixerTrackPart : public QWidget, public Ui::MixerTrackPart, public MixerTrack
       {
       Q_OBJECT
 
-      MixerTrackItemPtr _mti;
+      QPointer<MixerTrackItem> _mti;
 
       bool _selected;
       static const QString unselStyleDark;
@@ -66,19 +68,25 @@ public slots:
       void controlSelected();
       void applyStyle();
 
+      void notifyVolumeChanged(char);
+      void notifyPanChanged(char);
+      void notifyMuteChanged(bool);
+      void notifySoloChanged(bool);
+      void notifyColorChanged(int);
+
 protected:
       void mouseReleaseEvent(QMouseEvent * event) override;
-      void propertyChanged(Channel::Prop property) override;
-      void disconnectChannelListener() override;
+//      void propertyChanged(Channel::Prop property) override;
+//      void disconnectChannelListener() override;
 
 public:
-      explicit MixerTrackPart(QWidget *parent, MixerTrackItemPtr trackItem, bool expanded);
+      explicit MixerTrackPart(QWidget *parent, MixerTrackItem* trackItem, bool expanded);
       ~MixerTrackPart() override;
 
       bool selected() override { return _selected; }
       QWidget* getWidget() override { return this; }
       MixerTrackGroup* group() override { return _group; }
-      MixerTrackItemPtr mti() override { return _mti; }
+      MixerTrackItem* mti() override { return _mti; }
       void setGroup(MixerTrackGroup* group) { _group = group; }
       void paintEvent(QPaintEvent* evt) override;
       };

--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -499,7 +499,7 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
                         // change instrument in all linked scores
                         for (ScoreElement* se : ic->linkList()) {
                               InstrumentChange* lic = static_cast<InstrumentChange*>(se);
-                              Instrument* instrument = new Instrument(Instrument::fromTemplate(it));
+                              Instrument* instrument = Instrument::fromTemplate(it);
                               lic->score()->undo(new ChangeInstrument(lic, instrument));
                               }
                         // transpose for current score only


### PR DESCRIPTION
Making Part, Instrument and Channel into QObjects so Qt's signals and slots can be used.