### PR TITLE
fix #11645: Backspace and directional keys non-responsive in shortcuts

### DIFF
--- a/mscore/shortcutcapturedialog.cpp
+++ b/mscore/shortcutcapturedialog.cpp
@@ -49,6 +49,16 @@ ShortcutCaptureDialog::ShortcutCaptureDialog(Shortcut* _s, QMap<QString, Shortcu
 
       nshrtLabel->installEventFilter(this);
       MuseScore::restoreGeometry(this);
+
+      // Force the focus onto this dialog. This is required in osx to get command+backspace
+      setFocus();
+      }
+
+// We don't allow the dialog to loose focus as on osx. if we would allow, on osx command-backspace
+// couldn't be tracked.
+void ShortcutCaptureDialog::focusOutEvent (QFocusEvent* /*event*/)
+      {
+      setFocus();
       }
 
 //---------------------------------------------------------

--- a/mscore/shortcutcapturedialog.h
+++ b/mscore/shortcutcapturedialog.h
@@ -55,6 +55,9 @@ class ShortcutCaptureDialog : public QDialog, public Ui::ShortcutCaptureDialogBa
       ShortcutCaptureDialog(Shortcut* s, QMap<QString, Shortcut*> localShortcuts, QWidget* parent = 0);
       ~ShortcutCaptureDialog();
       QKeySequence getKey() const { return key; }
+
+    protected:
+      virtual void focusOutEvent (QFocusEvent*);
       };
 
 } // namespace Ms


### PR DESCRIPTION
code taken from https://musescore.org/en/node/11645#comment-53835, no idea whether it is good or not or the problem even still exists, it is 6 years old