### PR TITLE
fix #126641: correct check on spanner segment on element drag

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3386,8 +3386,8 @@ void ScoreView::cloneElement(Element* e)
             return;
       QDrag* drag = new QDrag(this);
       QMimeData* mimeData = new QMimeData;
-      if (e->isSegment())
-            e = static_cast<SpannerSegment*>(e)->spanner();
+      if (e->isSpannerSegment())
+            e = toSpannerSegment(e)->spanner();
       mimeData->setData(mimeSymbolFormat, e->mimeData(QPointF()));
       drag->setMimeData(mimeData);
       drag->setPixmap(QPixmap());


### PR DESCRIPTION
See https://musescore.org/en/node/126641.