### PR TITLE
add Help / Tours submenu

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -451,6 +451,7 @@ void MuseScore::preferencesChanged(bool fromWorkspace)
       getAction("follow")->setChecked(preferences.getBool(PREF_APP_PLAYBACK_FOLLOWSONG));
       getAction("midi-on")->setEnabled(preferences.getBool(PREF_IO_MIDI_ENABLEINPUT));
       getAction("toggle-statusbar")->setChecked(preferences.getBool(PREF_UI_APP_SHOWSTATUSBAR));
+      getAction("show-tours")->setChecked(preferences.getBool(PREF_UI_APP_STARTUP_SHOWTOURS));
       _statusBar->setVisible(preferences.getBool(PREF_UI_APP_SHOWSTATUSBAR));
 
       MuseScore::updateUiStyleAndTheme();
@@ -1733,6 +1734,13 @@ MuseScore::MuseScore()
       menuHelp->addAction(onlineHandbookAction);
       Workspace::addActionAndString(onlineHandbookAction, "online-handbook");
 
+      menuTours = new QMenu();
+      a = getAction("show-tours");
+      a->setChecked(preferences.getBool(PREF_UI_APP_STARTUP_SHOWTOURS));
+      menuTours->addAction(a);
+      menuTours->addAction(getAction("reset-tours"));
+      menuHelp->addMenu(menuTours);
+
       menuHelp->addSeparator();
 
       aboutAction = new QAction("", 0);
@@ -1810,6 +1818,7 @@ MuseScore::MuseScore()
       Workspace::addMenuAndString(menuVoices, "menu-voices");
       Workspace::addMenuAndString(menuPlugins, "menu-plugins");
       Workspace::addMenuAndString(menuHelp, "menu-help");
+      Workspace::addMenuAndString(menuTours, "menu-tours");
 
       Workspace::writeGlobalMenuBar(mb);
 
@@ -1901,6 +1910,7 @@ void MuseScore::retranslate()
       menuVoices->setTitle(tr("&Voices"));
       menuPlugins->setTitle(tr("&Plugins"));
       menuHelp->setTitle(tr("&Help"));
+      menuTours->setTitle(tr("&Tours"));
 
       aboutAction->setText(tr("&About..."));
       aboutQtAction->setText(tr("About &Qt..."));
@@ -5865,6 +5875,10 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
                         switchLayoutMode(LayoutMode::PAGE);
                   }
             }
+      else if (cmd == "show-tours")
+            preferences.setPreference(PREF_UI_APP_STARTUP_SHOWTOURS, a->isChecked());
+      else if (cmd == "reset-tours")
+            tourHandler()->resetCompletedTours();
       else if (cmd == "report-bug")
             reportBug("panel");
       else if (cmd == "leave-feedback")

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -309,6 +309,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       QMenu* menuPlugins;
       QMenu* menuHelp;
+      QMenu* menuTours;
       AlbumManager* albumManager           { 0 };
 
       QWidget* _searchDialog               { 0 };

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3566,6 +3566,27 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::MAIN_WINDOW,
          STATE_ALL,
+         "show-tours",
+         QT_TRANSLATE_NOOP("action", "Show Tours"),
+         QT_TRANSLATE_NOOP("action", "Show tours"),
+         QT_TRANSLATE_NOOP("action", "Toggle display of tours"),
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CHECKABLE
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_ALL,
+         "reset-tours",
+         QT_TRANSLATE_NOOP("action", "Reset Tours"),
+         QT_TRANSLATE_NOOP("action", "Reset tours"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_ALL,
          "report-bug",
          QT_TRANSLATE_NOOP("action", "Report a Bug"),
          QT_TRANSLATE_NOOP("action", "Report a bug"),

--- a/mscore/tourhandler.cpp
+++ b/mscore/tourhandler.cpp
@@ -170,6 +170,16 @@ void TourHandler::loadTour(XmlReader& tourXml)
       }
 
 //---------------------------------------------------------
+//   resetCompletedTours
+//---------------------------------------------------------
+
+void TourHandler::resetCompletedTours()
+      {
+      for (auto tour : allTours)
+            tour->setCompleted(false);
+      }
+
+//---------------------------------------------------------
 //   readCompletedTours
 //---------------------------------------------------------
 
@@ -426,9 +436,9 @@ void TourHandler::displayTour(Tour* tour)
             // Add text (translation?)
             mbox->setText(tourMessages[i].message);
 
-            // Add "Do not show again" checkbox
-            QCheckBox* showToursBox = new QCheckBox(tr("Do not show me tours"), mbox);
-            showToursBox->setChecked(!showTours);
+            // Add checkbox to show tours
+            QCheckBox* showToursBox = new QCheckBox(tr("Continue showing tours"), mbox);
+            showToursBox->setChecked(showTours);
             mbox->setCheckBox(showToursBox);
 
             // Display the message box, position it if needed
@@ -443,7 +453,7 @@ void TourHandler::displayTour(Tour* tour)
             overlay->show();
             mbox->exec();
             overlay->hide();
-            showTours = !(showToursBox->isChecked());
+            showTours = showToursBox->isChecked();
 
             // Handle the button presses
             if (mbox->clickedButton() == nextButton) {

--- a/mscore/tourhandler.h
+++ b/mscore/tourhandler.h
@@ -87,6 +87,7 @@ public slots:
 public:
       TourHandler(QObject* parent) : QObject(parent) {}
       void loadTours();
+      void resetCompletedTours();
       void readCompletedTours();
       void writeCompletedTours();
 


### PR DESCRIPTION
This is a first step towards addressing https://musescore.org/en/node/278488.  The tours are higher priority to get ready for beta, so I will work on the "online help center" aspect later.

This PR also includes code that serves the same function as the first commit from Isaac Weiss' #4180, to invert the sense of the checkbox within the tour, but with more accurate wording.  I propose merging m PR here, and then I take the text changes from Isaacs second commit and incorporate them into the changes I am making myself.  In other words, I suggest not merging #4180; I will incorporate those changes into my own work.