### PR TITLE
fix #277569: add "All symbols" entry to Symbols master palette

### DIFF
--- a/mscore/editdrumset.cpp
+++ b/mscore/editdrumset.cpp
@@ -18,6 +18,7 @@
 //=============================================================================
 
 #include "editdrumset.h"
+#include "menus.h"
 #include "musescore.h"
 #include "libmscore/xml.h"
 #include "libmscore/utils.h"
@@ -27,8 +28,6 @@
 #include "libmscore/stem.h"
 
 namespace Ms {
-
-extern QMap<QString, QStringList>* smuflRanges();
 
 enum Column : char { PITCH, NOTE, SHORTCUT, NAME };
 

--- a/mscore/masterpalette.cpp
+++ b/mscore/masterpalette.cpp
@@ -12,6 +12,7 @@
 
 #include "musescore.h"
 #include "masterpalette.h"
+#include "menus.h"
 #include "symboldialog.h"
 #include "palette.h"
 #include "keyedit.h"
@@ -39,13 +40,6 @@
 #include "timedialog.h"
 
 namespace Ms {
-
-extern void populateIconPalette(Palette* p, const IconAction* a);
-extern Palette* newKeySigPalette();
-extern Palette* newBarLinePalette(bool);
-extern Palette* newLinesPalette(bool);
-extern Palette* newAccidentalsPalette();
-extern QMap<QString, QStringList>* smuflRanges();
 
 //---------------------------------------------------------
 //   showMasterPalette
@@ -196,11 +190,20 @@ MasterPalette::MasterPalette(QWidget* parent)
       addPalette(MuseScore::newBeamPalette());
 
       symbolItem = new QTreeWidgetItem();
-      symbolItem->setData(0, Qt::UserRole, -1);
+      idxAllSymbols = stack->count();
+      symbolItem->setData(0, Qt::UserRole, idxAllSymbols);
       symbolItem->setText(0, QT_TRANSLATE_NOOP("MasterPalette", "Symbols"));
       treeWidget->addTopLevelItem(symbolItem);
+      stack->addWidget(new SymbolDialog(SMUFL_ALL_SYMBOLS));
+
+      // Add "All symbols" entry to be first in the list of categories
+      QTreeWidgetItem* child = new QTreeWidgetItem(QStringList(SMUFL_ALL_SYMBOLS));
+      child->setData(0, Qt::UserRole, idxAllSymbols);
+      symbolItem->addChild(child);
 
       for (const QString& s : smuflRanges()->keys()) {
+            if (s == SMUFL_ALL_SYMBOLS)
+                  continue;
             QTreeWidgetItem* child = new QTreeWidgetItem(QStringList(s));
             child->setData(0, Qt::UserRole, stack->count());
             symbolItem->addChild(child);
@@ -245,8 +248,11 @@ void MasterPalette::currentChanged(QTreeWidgetItem* item, QTreeWidgetItem*)
 void MasterPalette::clicked(QTreeWidgetItem* item, int)
       {
       int idx = item->data(0, Qt::UserRole).toInt();
-      if (idx == -1)
+      if (idx == idxAllSymbols) {
             item->setExpanded(!item->isExpanded());
+            if (idx != -1)
+                  stack->setCurrentIndex(idx);
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/masterpalette.h
+++ b/mscore/masterpalette.h
@@ -35,6 +35,8 @@ class MasterPalette : public QWidget, Ui::MasterPalette
       QTreeWidgetItem* timeItem;
       QTreeWidgetItem* symbolItem;
 
+      int idxAllSymbols = -1;
+
       virtual void closeEvent(QCloseEvent*);
       Palette* createPalette(int w, int h, bool grid, double mag = 1.0);
       void addPalette(Palette* sp);

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -19,6 +19,7 @@
 
 // For menus in the menu bar, like File, Edit, and View, see mscore/musescore.cpp
 
+#include "menus.h"
 #include <tuple>
 #include "libmscore/score.h"
 #include "palette.h"
@@ -1506,6 +1507,7 @@ void MuseScore::addTempo()
 QMap<QString, QStringList>* smuflRanges()
       {
       static QMap<QString, QStringList> ranges;
+      QStringList allSymbols;
 
       if (ranges.empty()) {
             QFile fi(":fonts/smufl/ranges.json");
@@ -1526,8 +1528,10 @@ QMap<QString, QStringList>* smuflRanges()
                         for (QJsonValue g : glyphs)
                               glyphNames.append(g.toString());
                         ranges.insert(desc, glyphNames);
+                        allSymbols << glyphNames;
                         }
                   }
+            ranges.insert(SMUFL_ALL_SYMBOLS, allSymbols); // TODO: make translatable as well as ranges.json
             }
       return &ranges;
       }

--- a/mscore/menus.h
+++ b/mscore/menus.h
@@ -1,0 +1,34 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2018 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __MENUS_H__
+#define __MENUS_H__
+
+namespace Ms {
+
+class IconAction;
+class Palette;
+
+extern QMap<QString, QStringList>* smuflRanges();
+constexpr const char* SMUFL_ALL_SYMBOLS = "All symbols";
+extern void populateIconPalette(Palette* p, const IconAction* a);
+
+} // namespace Ms
+
+#endif

--- a/mscore/noteGroups.cpp
+++ b/mscore/noteGroups.cpp
@@ -19,11 +19,10 @@
 #include "libmscore/key.h"
 #include "libmscore/icon.h"
 #include "libmscore/staff.h"
+#include "menus.h"
 #include "musescore.h"
 
 namespace Ms {
-
-extern void populateIconPalette(Palette* p, const IconAction* a);
 
 //---------------------------------------------------------
 //   createScore

--- a/mscore/symboldialog.cpp
+++ b/mscore/symboldialog.cpp
@@ -18,6 +18,7 @@
 //=============================================================================
 
 #include "symboldialog.h"
+#include "menus.h"
 #include "palette.h"
 #include "musescore.h"
 #include "libmscore/score.h"
@@ -30,7 +31,6 @@
 namespace Ms {
 
 extern MasterScore* gscore;
-extern QMap<QString, QStringList>* smuflRanges();
 
 //---------------------------------------------------------
 //   createSymbolPalette

--- a/mscore/textpalette.cpp
+++ b/mscore/textpalette.cpp
@@ -18,6 +18,7 @@
 //=============================================================================
 
 #include "palette.h"
+#include "menus.h"
 #include "textpalette.h"
 #include "icons.h"
 #include "libmscore/text.h"
@@ -29,8 +30,6 @@
 #include "musescore.h"
 
 namespace Ms {
-
-extern QMap<QString, QStringList>* smuflRanges();
 
 //const int buttonSize = 40;
 //const int iconSize   = 20;

--- a/mscore/timesigproperties.cpp
+++ b/mscore/timesigproperties.cpp
@@ -26,12 +26,11 @@
 #include "libmscore/measure.h"
 #include "libmscore/part.h"
 #include "exampleview.h"
+#include "menus.h"
 #include "musescore.h"
 #include "icons.h"
 
 namespace Ms {
-
-extern void populateIconPalette(Palette* p, const IconAction* a);
 
 //---------------------------------------------------------
 //    TimeSigProperties


### PR DESCRIPTION
As requested [here](https://musescore.org/en/node/277569), adds an "All symbols" entry to Symbols master palette and binds that "All symbols" palette to the choice of the whole Symbols category. Relatively large number of changes is due to introducing of `menus.h` file which gathered functions declarations which were previously scattered across files, as well as defines a new `SMUFL_ALL_SYMBOLS` constant used in this patch. 