### PR TITLE
fix #278389: x command to flip doesn't work for some elements

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1415,7 +1415,7 @@ void Score::cmdFlip()
                   auto tuplet = toTuplet(e);
                   flipOnce(tuplet, [tuplet](){
                         Direction dir = tuplet->isUp() ? Direction::DOWN : Direction::UP;
-                        tuplet->undoChangeProperty(Pid::DIRECTION, QVariant::fromValue<Direction>(dir));
+                        tuplet->undoChangeProperty(Pid::DIRECTION, QVariant::fromValue<Direction>(dir), PropertyFlags::UNSTYLED);
                         });
                   }
             else if (e->isNoteDot() && e->parent()->isNote()) {
@@ -1437,7 +1437,7 @@ void Score::cmdFlip()
                   Placement p = Placement(e->getProperty(Pid::PLACEMENT).toInt());
                   p = (p == Placement::ABOVE) ? Placement::BELOW : Placement::ABOVE;
                   e->undoChangeProperty(Pid::AUTOPLACE, true);
-                  e->undoChangeProperty(Pid::PLACEMENT, int(p));
+                  e->undoChangeProperty(Pid::PLACEMENT, int(p), PropertyFlags::UNSTYLED);
                   }
             }
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/278389

Fairly self-explanatory. A change in these specific properties needs to be marked as unstyled to be saved properly.