### PR TITLE
fix #269507: fix numeric shortcuts for AZERTY layout

### DIFF
--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -191,6 +191,7 @@
   <SC>
     <key>rest</key>
     <seq>0</seq>
+    <seq>À</seq> <!-- AZERTY for 0 -->
     </SC>
   <SC>
     <key>realtime-advance</key>
@@ -457,38 +458,47 @@
   <SC>
     <key>note-longa</key>
     <seq>9</seq>
+    <seq>Ç</seq> <!-- AZERTY for 9 -->
     </SC>
   <SC>
     <key>note-breve</key>
     <seq>8</seq>
+    <seq>_</seq> <!-- AZERTY for 8 -->
     </SC>
   <SC>
     <key>pad-note-1</key>
     <seq>7</seq>
+    <seq>È</seq> <!-- AZERTY for 7 -->
     </SC>
   <SC>
     <key>pad-note-2</key>
     <seq>6</seq>
+    <seq>-</seq> <!-- AZERTY for 6 -->
     </SC>
   <SC>
     <key>pad-note-4</key>
     <seq>5</seq>
+    <seq>(</seq> <!-- AZERTY for 5 -->
     </SC>
   <SC>
     <key>pad-note-8</key>
     <seq>4</seq>
+    <seq>'</seq> <!-- AZERTY for 4 -->
     </SC>
   <SC>
     <key>pad-note-16</key>
     <seq>3</seq>
+    <seq>&quot;</seq> <!-- AZERTY for 3 -->
     </SC>
   <SC>
     <key>pad-note-32</key>
     <seq>2</seq>
+    <seq>É</seq> <!-- AZERTY for 2 -->
     </SC>
   <SC>
     <key>pad-note-64</key>
     <seq>1</seq>
+    <seq>&amp;</seq> <!-- AZERTY for 1 -->
     </SC>
   <SC>
     <key>pad-dot</key>
@@ -768,52 +778,52 @@
 <!-- TAB specific shortcuts -->
   <SC>
     <key>note-longa-TAB</key>
-    <seq>Shift+9</seq>
+    <seq>9</seq> <!-- AZERTY for Shift+9 -->
     <seq>NumPad+9</seq>
     </SC>
   <SC>
     <key>note-breve-TAB</key>
-    <seq>Shift+8</seq>
+    <seq>8</seq> <!-- AZERTY for Shift+8 -->
     <seq>NumPad+8</seq>
     </SC>
   <SC>
     <key>pad-note-1-TAB</key>
-    <seq>Shift+7</seq>
+    <seq>7</seq> <!-- AZERTY for Shift+7 -->
     <seq>NumPad+7</seq>
     </SC>
   <SC>
     <key>pad-note-2-TAB</key>
-    <seq>Shift+6</seq>
+    <seq>6</seq> <!-- AZERTY for Shift+6 -->
     <seq>NumPad+6</seq>
     </SC>
   <SC>
     <key>pad-note-4-TAB</key>
-    <seq>Shift+5</seq>
+    <seq>5</seq> <!-- AZERTY for Shift+5 -->
     <seq>NumPad+5</seq>
     </SC>
   <SC>
     <key>pad-note-8-TAB</key>
-    <seq>Shift+4</seq>
+    <seq>4</seq> <!-- AZERTY for Shift+4 -->
     <seq>NumPad+4</seq>
     </SC>
   <SC>
     <key>pad-note-16-TAB</key>
-    <seq>Shift+3</seq>
+    <seq>3</seq> <!-- AZERTY for Shift+3 -->
     <seq>NumPad+3</seq>
     </SC>
   <SC>
     <key>pad-note-32-TAB</key>
-    <seq>Shift+2</seq>
+    <seq>2</seq> <!-- AZERTY for Shift+2 -->
     <seq>NumPad+2</seq>
     </SC>
   <SC>
     <key>pad-note-64-TAB</key>
-    <seq>Shift+1</seq>
+    <seq>1</seq> <!-- AZERTY for Shift+1 -->
     <seq>NumPad+1</seq>
     </SC>
   <SC>
     <key>pad-note-128-TAB</key>
-    <seq>Shift+0</seq>
+    <seq>0</seq> <!-- AZERTY for Shift+0 -->
     <seq>NumPad+0</seq>
     </SC>
   <SC>
@@ -838,53 +848,53 @@
     </SC>
   <SC>
     <key>fret-0</key>
-    <seq>0</seq>
     <seq>A</seq>
+    <seq>À</seq> <!-- AZERTY for 0 -->
     </SC>
   <SC>
     <key>fret-1</key>
-    <seq>1</seq>
     <seq>B</seq>
+    <seq>&amp;</seq> <!-- AZERTY for 1 -->
     </SC>
   <SC>
     <key>fret-2</key>
-    <seq>2</seq>
     <seq>C</seq>
+    <seq>É</seq> <!-- AZERTY for 2 -->
     </SC>
   <SC>
     <key>fret-3</key>
-    <seq>3</seq>
     <seq>D</seq>
+    <seq>&quot;</seq> <!-- AZERTY for 3 -->
     </SC>
   <SC>
     <key>fret-4</key>
-    <seq>4</seq>
     <seq>E</seq>
+    <seq>'</seq> <!-- AZERTY for 4 -->
     </SC>
   <SC>
     <key>fret-5</key>
-    <seq>5</seq>
     <seq>F</seq>
+    <seq>(</seq> <!-- AZERTY for 5 -->
     </SC>
   <SC>
     <key>fret-6</key>
-    <seq>6</seq>
     <seq>G</seq>
+    <seq>-</seq> <!-- AZERTY for 6 -->
     </SC>
   <SC>
     <key>fret-7</key>
-    <seq>7</seq>
     <seq>H</seq>
+    <seq>È</seq> <!-- AZERTY for 7 -->
     </SC>
   <SC>
     <key>fret-8</key>
-    <seq>8</seq>
     <seq>J</seq>
+    <seq>_</seq> <!-- AZERTY for 8 -->
     </SC>
   <SC>
     <key>fret-9</key>
-    <seq>9</seq>
     <seq>K</seq>
+    <seq>Ç</seq> <!-- AZERTY for 9 -->
     </SC>
   <SC>
     <key>fret-10</key>


### PR DESCRIPTION
In order to fix [this issue](https://musescore.org/en/node/269507) the fastest (and possibly even the best) option is to define specific shortcuts for specific keyboard layouts. We already had some parts of this approach implemented by having a separate `shortcuts_AZERTY.xml` file defining default shortcuts for AZERTY keyboard layout. However that file was not too different from the common `shortcuts.xml` file. Given that the numeric row is somewhat inverted in AZERTY layout using numeric keys in MuseScore, especially in tablature input, may give unexpected results. The situation is even more complicated because of changes in Qt behavior which made shortcuts work partially as expected with old Qt versions (and thus in official MuseScore 2.X builds).

This PR tries to resolve that numeric input issue by explicit definition of keyboard shortcuts for numeric keys for AZERTY layout. This solution should be less dependent on any specific Qt behavior. Still I am not a French user so some accidental mistakes are possible, and it would be good to get a feedback on this from people using AZERTY layout.