### PR TITLE
fix #278499 Crash when moving mixer channel volume

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -430,11 +430,6 @@ Channel::Channel()
 
 Channel::~Channel()
       {
-      QList<ChannelListener *> list(listeners);
-
-      for (ChannelListener * l: list) {
-            l->disconnectChannelListener();
-            }
       }
 
 //---------------------------------------------------------
@@ -443,9 +438,14 @@ Channel::~Channel()
 
 void Channel::firePropertyChanged(Channel::Prop prop)
       {
-      QList<ChannelListener *> list(listeners);
+      QList<QPointer<QObject>> list(listeners);
 
-      for (ChannelListener * l: list) {
+      for (QPointer<QObject> ptr: list) {
+            ChannelListener *l = dynamic_cast<ChannelListener *>(ptr.data());
+            if (!l) {
+                  listeners.removeOne(ptr);
+                  continue;
+                  }
             l->propertyChanged(prop);
             }
       }

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -260,7 +260,7 @@ void Mixer::setScore(MasterScore* score)
 
 void Mixer::updateTracks()
       {
-      MixerTrackItem* oldSel = mixerDetails->track().get();
+      MixerTrackItem* oldSel = mixerDetails->track();
 
       Part* selPart = oldSel ? oldSel->part() : 0;
       Channel* selChan = oldSel ? oldSel->chan() : 0;
@@ -276,12 +276,16 @@ void Mixer::updateTracks()
             }
 
 
+      //Delete old objects
       if (trackHolder) {
             trackAreaLayout->removeWidget(trackHolder);
             trackHolder->deleteLater();
             trackHolder = 0;
             }
 
+      for (MixerTrack* track: trackList) {
+            delete track->mti();
+            }
       trackList.clear();
       mixerDetails->setTrack(0);
 
@@ -309,8 +313,8 @@ void Mixer::updateTracks()
                   proxyChan = proxyInstr->channel(0);
                   }
 
-            MixerTrackItemPtr mti = std::make_shared<MixerTrackItem>(
-                              MixerTrackItem::TrackType::PART, part, proxyInstr, proxyChan);
+            MixerTrackItem* mti = new MixerTrackItem(
+                              MixerTrackItem::TrackType::PART, part, proxyInstr, proxyChan, this);
 
             MixerTrackPart* track = new MixerTrackPart(this, mti, expanded);
             track->setGroup(this);
@@ -330,8 +334,8 @@ void Mixer::updateTracks()
                         Instrument* instr = it->second;
                         for (int i = 0; i < instr->channel().size(); ++i) {
                               Channel *chan = instr->channel()[i];
-                              MixerTrackItemPtr mti1 = std::make_shared<MixerTrackItem>(
-                                                MixerTrackItem::TrackType::CHANNEL, part, instr, chan);
+                              MixerTrackItem* mti1 = new MixerTrackItem(
+                                                MixerTrackItem::TrackType::CHANNEL, part, instr, chan, this);
 //                              MixerTrackItemPtr mti = new MixerTrackItem(
 //                                                MixerTrackItem::TrackType::CHANNEL, part, instr, chan);
                               MixerTrackChannel* track1 = new MixerTrackChannel(this, mti1);

--- a/mscore/mixerdetails.cpp
+++ b/mscore/mixerdetails.cpp
@@ -78,7 +78,7 @@ MixerDetails::~MixerDetails()
 //   setTrack
 //---------------------------------------------------------
 
-void MixerDetails::setTrack(MixerTrackItemPtr track)
+void MixerDetails::setTrack(MixerTrackItem* track)
       {
       if (_mti) {
             //Remove old attachment

--- a/mscore/mixerdetails.h
+++ b/mscore/mixerdetails.h
@@ -25,6 +25,8 @@
 #include "libmscore/instrument.h"
 #include "mixertrackitem.h"
 
+#include <QPointer>
+
 namespace Ms {
 
 
@@ -39,7 +41,7 @@ class MixerDetails : public QWidget, public Ui::MixerDetails, public ChannelList
       {
       Q_OBJECT
 
-      MixerTrackItemPtr _mti;
+      QPointer<MixerTrackItem> _mti;
 
       void updateFromTrack();
 
@@ -58,8 +60,8 @@ public:
       explicit MixerDetails(QWidget *parent);
       ~MixerDetails() override;
 
-      MixerTrackItemPtr track() { return _mti; }
-      void setTrack(MixerTrackItemPtr track);
+      MixerTrackItem* track() { return _mti; }
+      void setTrack(MixerTrackItem* track);
       void propertyChanged(Channel::Prop property) override;
       void disconnectChannelListener() override;
 

--- a/mscore/mixertrack.h
+++ b/mscore/mixertrack.h
@@ -33,7 +33,7 @@ public:
       virtual ~MixerTrack() {}
       virtual QWidget* getWidget() = 0;
       virtual MixerTrackGroup* group() = 0;
-      virtual MixerTrackItemPtr mti() = 0;
+      virtual MixerTrackItem* mti() = 0;
       virtual bool selected() = 0;
       virtual void setSelected(bool) = 0;
       };

--- a/mscore/mixertrackchannel.cpp
+++ b/mscore/mixertrackchannel.cpp
@@ -78,7 +78,7 @@ const QString MixerTrackChannel::selStyleDark = "#controlWidget {"
 //   MixerTrack
 //---------------------------------------------------------
 
-MixerTrackChannel::MixerTrackChannel(QWidget *parent, MixerTrackItemPtr mti) :
+MixerTrackChannel::MixerTrackChannel(QWidget *parent, MixerTrackItem* mti) :
       QWidget(parent), _mti(mti), _selected(false), _group(0)
       {
       setupUi(this);

--- a/mscore/mixertrackchannel.h
+++ b/mscore/mixertrackchannel.h
@@ -27,6 +27,8 @@
 #include "mixertrackitem.h"
 #include "libmscore/instrument.h"
 
+#include <QPointer>
+
 namespace Ms {
 
 struct MidiMapping;
@@ -40,7 +42,7 @@ class MixerTrackChannel : public QWidget, public Ui::MixerTrackChannel, public C
       {
       Q_OBJECT
 
-      MixerTrackItemPtr _mti;
+      QPointer<MixerTrackItem> _mti;
 
       bool _selected;
       static const QString unselStyleLight;
@@ -71,13 +73,13 @@ protected:
       void disconnectChannelListener() override;
 
 public:
-      explicit MixerTrackChannel(QWidget *parent, MixerTrackItemPtr trackItem);
+      explicit MixerTrackChannel(QWidget *parent, MixerTrackItem* trackItem);
       ~MixerTrackChannel() override;
 
       bool selected() override { return _selected; }
       QWidget* getWidget() override { return this; }
       MixerTrackGroup* group() override { return _group; }
-      MixerTrackItemPtr mti() override { return _mti; }
+      MixerTrackItem* mti() override { return _mti; }
       void setGroup(MixerTrackGroup* group) { _group = group; }
       void paintEvent(QPaintEvent* evt) override;
       };

--- a/mscore/mixertrackitem.cpp
+++ b/mscore/mixertrackitem.cpp
@@ -30,8 +30,8 @@ namespace Ms {
 //   MixerTrackItem
 //---------------------------------------------------------
 
-MixerTrackItem::MixerTrackItem(TrackType tt, Part* part, Instrument* instr, Channel *chan)
-      :_trackType(tt), _part(part), _instr(instr), _chan(chan)
+MixerTrackItem::MixerTrackItem(TrackType tt, Part* part, Instrument* instr, Channel *chan, QObject* parent)
+      :QObject(parent), _trackType(tt), _part(part), _instr(instr), _chan(chan)
       {
       }
 

--- a/mscore/mixertrackitem.h
+++ b/mscore/mixertrackitem.h
@@ -22,7 +22,7 @@
 #define __MIXERTRACKITEM_H__
 
 #include "libmscore/instrument.h"
-#include <memory>
+#include <QObject>
 
 namespace Ms {
 
@@ -32,17 +32,18 @@ class Channel;
 struct MidiMapping;
 class MixerTrackItem;
 
-typedef std::shared_ptr<MixerTrackItem> MixerTrackItemPtr;
-//typedef MixerTrackItem* MixerTrackItemPtr;
 
 //---------------------------------------------------------
 //   MixerTrackItem
 //---------------------------------------------------------
 
-class MixerTrackItem
+class MixerTrackItem : public QObject
       {
+      Q_OBJECT
+
 public:
       enum class TrackType { PART, CHANNEL };
+      Q_ENUM(TrackType)
 
 private:
       TrackType _trackType;
@@ -52,7 +53,7 @@ private:
       Channel* _chan;
 
 public:
-      MixerTrackItem(TrackType tt, Part* part, Instrument* _instr, Channel* _chan);
+      MixerTrackItem(TrackType tt, Part* part, Instrument* _instr, Channel* _chan, QObject* parent = nullptr);
 
       TrackType trackType() { return _trackType; }
       Part* part() { return _part; }
@@ -62,6 +63,7 @@ public:
       MidiMapping *midiMap();
       int color();
 
+public slots:
       void setColor(int valueRgb);
       void setVolume(char value);
       void setPan(char value);

--- a/mscore/mixertrackpart.cpp
+++ b/mscore/mixertrackpart.cpp
@@ -79,7 +79,7 @@ const QString MixerTrackPart::selStyleDark = "#controlWidget {"
 //   MixerTrack
 //---------------------------------------------------------
 
-MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItemPtr mti, bool expanded) :
+MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItem* mti, bool expanded) :
       QWidget(parent), _mti(mti), _selected(false), _group(0)
       {
       setupUi(this);

--- a/mscore/mixertrackpart.h
+++ b/mscore/mixertrackpart.h
@@ -27,6 +27,8 @@
 #include "mixertrackitem.h"
 #include "libmscore/instrument.h"
 
+#include <QPointer>
+
 namespace Ms {
 
 struct MidiMapping;
@@ -40,7 +42,7 @@ class MixerTrackPart : public QWidget, public Ui::MixerTrackPart, public Channel
       {
       Q_OBJECT
 
-      MixerTrackItemPtr _mti;
+      QPointer<MixerTrackItem> _mti;
 
       bool _selected;
       static const QString unselStyleDark;
@@ -72,13 +74,13 @@ protected:
       void disconnectChannelListener() override;
 
 public:
-      explicit MixerTrackPart(QWidget *parent, MixerTrackItemPtr trackItem, bool expanded);
+      explicit MixerTrackPart(QWidget *parent, MixerTrackItem* trackItem, bool expanded);
       ~MixerTrackPart() override;
 
       bool selected() override { return _selected; }
       QWidget* getWidget() override { return this; }
       MixerTrackGroup* group() override { return _group; }
-      MixerTrackItemPtr mti() override { return _mti; }
+      MixerTrackItem* mti() override { return _mti; }
       void setGroup(MixerTrackGroup* group) { _group = group; }
       void paintEvent(QPaintEvent* evt) override;
       };


### PR DESCRIPTION
Turning MixerTrackItem into QObject.

Using QPointers to track listeners in Channel now.