### PR TITLE
fix #278677: Shortening notes breaks beam vertical positioning

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1458,8 +1458,9 @@ void Beam::computeStemLen(const std::vector<ChordRest*>& cl, qreal& py1, int bea
             bm.l = ll1 - l1;
             }
       else { // if (beamLevels > 4) {
-            static const int t[] = { 0, 0, 4, 4, 8, 12, 16 }; // spatium4 added to stem len
-            int n = t[beamLevels] + 12;
+            //static const int t[] = { 0, 0, 4, 4, 8, 12, 15, 18, 21 }; // spatium4 added to stem len
+            //int n = t[beamLevels] + 12;
+            int n = (3 * (beamLevels - 5)) + 24;
             bm.s = 0;
             if (_up) {
                   bm.l = -n;


### PR DESCRIPTION
See https://musescore.org/en/node/278677.

The bad layout is a result of indexing an array outside of its bounds. But there is something strange about the array. Since at this point beamLevels is greater than 4, the first 5 entries in the array are never used. Once I found values for when beamLevels is in the range [6,8], I was able to rewrite the formula without using the array at all.

For beamLevels <= 4, there is code to prevent horizontal beams from being drawn in the middle of a space (see _Behind Bars_, 17-18). I would like to see the same done for beamLevels > 4 if possible, but it is not immediately obvious to me how to do it. Gould does say that an exception can be made in the case of 4 beams, and she does not even mention the possibility of more than 4 beams, so I would not make it a high priority.