### PR TITLE
Accessibility: New Score Wizard

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -17,6 +17,22 @@
 #  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #=============================================================================
 
+function(prepend_to_list_items # prepend a string to each item in list
+  LIST_INV # input list variable
+  STRING # the string to prepend to each list item
+  LIST_OUTV # input list variable
+  )
+  set(LIST_IN "${${LIST_INV}}")
+  set(LIST_OUT "") # empty list
+  foreach(ITEM IN LISTS LIST_IN)
+    list(APPEND LIST_OUT "${STRING}${ITEM}")
+  endforeach(ITEM)
+  set("${LIST_OUTV}" "${LIST_OUT}" PARENT_SCOPE)
+endfunction(prepend_to_list_items)
+
+add_subdirectory(widgets)
+prepend_to_list_items(WIDGETS_SOURCE_FILES "widgets/" WIDGETS_SOURCE_FILES)
+
 # This is not needed for MSVC compilation
 if (NOT MSVC)
    include (${PROJECT_SOURCE_DIR}/build/gch.cmake)
@@ -51,7 +67,7 @@ QT5_WRAP_UI (ui_headers
       editpitch.ui editstringdata.ui editraster.ui mediadialog.ui albummanager.ui layer.ui
       omrpanel.ui masterpalette.ui harmonyedit.ui pathlistdialog.ui
       note_groups.ui resourceManager.ui stafftypetemplates.ui
-      startcenter.ui scorePreview.ui scoreBrowser.ui
+      startcenter.ui scorePreview.ui scoreBrowser.ui templateBrowser.ui
       logindialog.ui uploadscoredialog.ui breaksdialog.ui
       toolbarEditor.ui workspacedialog.ui
 
@@ -301,7 +317,7 @@ add_executable ( ${ExecutableName}
       sectionbreakprop.h selectdialog.h selectionwindow.h selectnotedialog.h selinstrument.h
       seq.h shortcut.h shortcutcapturedialog.h simplebutton.h splitstaff.h stafftextproperties.h
       startcenter.h startupWizard.h stringutils.h svggenerator.h symboldialog.h synthcontrol.h
-      textcursor.h textpalette.h texttools.h timedialog.h timeline.h timesigproperties.h
+      templateBrowser.h textcursor.h textpalette.h texttools.h timedialog.h timeline.h timesigproperties.h
       toolbarEditor.h toolbuttonmenu.h transposedialog.h tremolobarcanvas.h tremolobarprop.h
       tupletdialog.h updatechecker.h uploadscoredialog.h waveview.h webpage.h workspace.h
 
@@ -425,7 +441,7 @@ add_executable ( ${ExecutableName}
       scorecmp/scorecmp.cpp scorecmp/scorediffmodel.cpp scorecmp/scorelistmodel.cpp
       resourceManager.cpp downloadUtils.cpp
       textcursor.cpp continuouspanel.cpp accessibletoolbutton.cpp scoreaccessibility.cpp
-      startcenter.cpp scoreBrowser.cpp scorePreview.cpp scoreInfo.cpp
+      startcenter.cpp scoreBrowser.cpp scorePreview.cpp scoreInfo.cpp templateBrowser.cpp
       logindialog.cpp loginmanager.cpp uploadscoredialog.cpp breaksdialog.cpp searchComboBox.cpp
       help.cpp help.h
       toolbarEditor.cpp toolbarEditor.h
@@ -436,6 +452,7 @@ add_executable ( ${ExecutableName}
       tourhandler.cpp
       script/script.cpp script/scriptentry.cpp script/testscript.cpp script/recorderwidget.cpp
 
+      ${WIDGETS_SOURCE_FILES}
       ${COCOABRIDGE}
       ${OMR_FILES}
       ${AUDIO}

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -54,6 +54,7 @@ TimesigWizard::TimesigWizard(QWidget* parent)
       connect(tsCommonTime, SIGNAL(toggled(bool)), SLOT(commonTimeToggled(bool)));
       connect(tsCutTime,    SIGNAL(toggled(bool)), SLOT(cutTimeToggled(bool)));
       connect(tsFraction,   SIGNAL(toggled(bool)), SLOT(fractionToggled(bool)));
+      pickupMeasure->setChecked(false); // checked in the UI file to enable screen reader on pickup duration controls
       }
 
 //---------------------------------------------------------
@@ -154,10 +155,10 @@ TitleWizard::TitleWizard(QWidget* parent)
       }
 
 //---------------------------------------------------------
-//   NewWizardPage1
+//   NewWizardInfoPage
 //---------------------------------------------------------
 
-NewWizardPage1::NewWizardPage1(QWidget* parent)
+NewWizardInfoPage::NewWizardInfoPage(QWidget* parent)
    : QWizardPage(parent)
       {
       setTitle(tr("Create New Score"));
@@ -176,17 +177,17 @@ NewWizardPage1::NewWizardPage1(QWidget* parent)
 //   initializePage
 //---------------------------------------------------------
 
-void NewWizardPage1::initializePage()
+void NewWizardInfoPage::initializePage()
       {
       w->title->setText("");
       w->subtitle->setText("");
       }
 
 //---------------------------------------------------------
-//   NewWizardPage2
+//   NewWizardInstrumentsPage
 //---------------------------------------------------------
 
-NewWizardPage2::NewWizardPage2(QWidget* parent)
+NewWizardInstrumentsPage::NewWizardInstrumentsPage(QWidget* parent)
    : QWizardPage(parent)
       {
       setFinalPage(true);
@@ -194,30 +195,30 @@ NewWizardPage2::NewWizardPage2(QWidget* parent)
       setSubTitle(tr("Choose instruments on the left to add to instrument list on the right:"));
       setAccessibleName(title());
       setAccessibleDescription(subTitle());
-      w        = new InstrumentsWidget;
+      instrumentsWidget = new InstrumentsWidget;
       QGridLayout* grid = new QGridLayout;
       grid->setSpacing(0);
       grid->setContentsMargins(0, 0, 0, 0);
-      grid->addWidget(w, 0, 0);
+      grid->addWidget(instrumentsWidget, 0, 0);
       setLayout(grid);
-      connect(w, SIGNAL(completeChanged(bool)), SLOT(setComplete(bool)));
+      connect(instrumentsWidget, SIGNAL(completeChanged(bool)), SLOT(setComplete(bool)));
       }
 
 //---------------------------------------------------------
 //   initializePage
 //---------------------------------------------------------
 
-void NewWizardPage2::initializePage()
+void NewWizardInstrumentsPage::initializePage()
       {
       complete = false;
-      w->init();
+      instrumentsWidget->init();
       }
 
 //---------------------------------------------------------
 //   setComplete
 //---------------------------------------------------------
 
-void NewWizardPage2::setComplete(bool val)
+void NewWizardInstrumentsPage::setComplete(bool val)
       {
       complete = val;
       emit completeChanged();
@@ -227,7 +228,7 @@ void NewWizardPage2::setComplete(bool val)
 //   isComplete
 //---------------------------------------------------------
 
-bool NewWizardPage2::isComplete() const
+bool NewWizardInstrumentsPage::isComplete() const
       {
       return complete;
       }
@@ -236,16 +237,16 @@ bool NewWizardPage2::isComplete() const
 //   createInstruments
 //---------------------------------------------------------
 
-void NewWizardPage2::createInstruments(Score* s)
+void NewWizardInstrumentsPage::createInstruments(Score* s)
       {
-      w->createInstruments(s);
+      instrumentsWidget->createInstruments(s);
       }
 
 //---------------------------------------------------------
-//   NewWizardPage3
+//   NewWizardTimesigPage
 //---------------------------------------------------------
 
-NewWizardPage3::NewWizardPage3(QWidget* parent)
+NewWizardTimesigPage::NewWizardTimesigPage(QWidget* parent)
    : QWizardPage(parent)
       {
       setFinalPage(true);
@@ -261,10 +262,10 @@ NewWizardPage3::NewWizardPage3(QWidget* parent)
       }
 
 //---------------------------------------------------------
-//   NewWizardPage4
+//   NewWizardTemplatePage
 //---------------------------------------------------------
 
-NewWizardPage4::NewWizardPage4(QWidget* parent)
+NewWizardTemplatePage::NewWizardTemplatePage(QWidget* parent)
    : QWizardPage(parent)
       {
       setFinalPage(true);
@@ -281,12 +282,14 @@ NewWizardPage4::NewWizardPage4(QWidget* parent)
 
       QVBoxLayout* layout = new QVBoxLayout;
       QHBoxLayout* searchLayout = new QHBoxLayout;
-      QLineEdit* search = new QLineEdit;
-      search->setPlaceholderText(tr("Search"));
-      search->setClearButtonEnabled(true);
-      search->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+      QLineEdit* searchBox = new QLineEdit;
+      searchBox->setPlaceholderText(tr("Search"));
+      searchBox->setAccessibleName(searchBox->placeholderText());
+      searchBox->setAccessibleDescription(tr("Filter templates by name"));
+      searchBox->setClearButtonEnabled(true);
+      searchBox->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
       searchLayout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::MinimumExpanding, QSizePolicy::Maximum));
-      searchLayout->addWidget(search);
+      searchLayout->addWidget(searchBox);
 
       layout->addLayout(searchLayout);
       layout->addWidget(templateFileBrowser);
@@ -294,7 +297,7 @@ NewWizardPage4::NewWizardPage4(QWidget* parent)
 
       connect(templateFileBrowser, SIGNAL(scoreSelected(const QString&)), SLOT(templateChanged(const QString&)));
       connect(templateFileBrowser, SIGNAL(scoreActivated(const QString&)), SLOT(fileAccepted(const QString&)));
-      connect(search, &QLineEdit::textChanged, [this] (const QString& searchString) {
+      connect(searchBox, &QLineEdit::textChanged, [this] (const QString& searchString) {
             this->templateFileBrowser->filter(searchString);
             });
       }
@@ -303,7 +306,7 @@ NewWizardPage4::NewWizardPage4(QWidget* parent)
 //   initializePage
 //---------------------------------------------------------
 
-void NewWizardPage4::initializePage()
+void NewWizardTemplatePage::initializePage()
       {
       templateFileBrowser->show();
       path.clear();
@@ -313,7 +316,7 @@ void NewWizardPage4::initializePage()
 //   buildTemplatesList
 //---------------------------------------------------------
 
-void NewWizardPage4::buildTemplatesList()
+void NewWizardTemplatePage::buildTemplatesList()
       {
 
       QDir dir(mscoreGlobalShare + "/templates");
@@ -338,7 +341,7 @@ void NewWizardPage4::buildTemplatesList()
 //   isComplete
 //---------------------------------------------------------
 
-bool NewWizardPage4::isComplete() const
+bool NewWizardTemplatePage::isComplete() const
       {
       return !path.isEmpty();
       }
@@ -347,7 +350,7 @@ bool NewWizardPage4::isComplete() const
 //   fileAccepted
 //---------------------------------------------------------
 
-void NewWizardPage4::fileAccepted(const QString& s)
+void NewWizardTemplatePage::fileAccepted(const QString& s)
       {
       path = s;
       templateFileBrowser->show();
@@ -359,7 +362,7 @@ void NewWizardPage4::fileAccepted(const QString& s)
 //   templateChanged
 //---------------------------------------------------------
 
-void NewWizardPage4::templateChanged(const QString& s)
+void NewWizardTemplatePage::templateChanged(const QString& s)
       {
       path = s;
       emit completeChanged();
@@ -369,16 +372,16 @@ void NewWizardPage4::templateChanged(const QString& s)
 //   templatePath
 //---------------------------------------------------------
 
-QString NewWizardPage4::templatePath() const
+QString NewWizardTemplatePage::templatePath() const
       {
       return path;
       }
 
 //---------------------------------------------------------
-//   NewWizardPage5
+//   NewWizardKeysigPage
 //---------------------------------------------------------
 
-NewWizardPage5::NewWizardPage5(QWidget* parent)
+NewWizardKeysigPage::NewWizardKeysigPage(QWidget* parent)
    : QWizardPage(parent)
       {
       setFinalPage(true);
@@ -389,7 +392,8 @@ NewWizardPage5::NewWizardPage5(QWidget* parent)
 
       QGroupBox* b1 = new QGroupBox;
       b1->setTitle(tr("Key Signature"));
-      b1->setAccessibleName(title());
+      b1->setAccessibleName(b1->title());
+      b1->setAccessibleDescription(tr("Choose a key signature"));
       sp = MuseScore::newKeySigPalette();
       sp->setMoreElements(false);
       sp->setShowContextMenu(false);
@@ -405,6 +409,8 @@ NewWizardPage5::NewWizardPage5(QWidget* parent)
       tempoGroup->setCheckable(true);
       tempoGroup->setChecked(false);
       tempoGroup->setTitle(tr("Tempo"));
+      tempoGroup->setAccessibleName(tempoGroup->title());
+      tempoGroup->setAccessibleDescription(tr("Add tempo marking to score"));
       QLabel* bpm = new QLabel;
       bpm->setText(tr("BPM:"));
       _tempo = new QDoubleSpinBox;
@@ -430,7 +436,7 @@ NewWizardPage5::NewWizardPage5(QWidget* parent)
 //   keysig
 //---------------------------------------------------------
 
-KeySigEvent NewWizardPage5::keysig() const
+KeySigEvent NewWizardKeysigPage::keysig() const
       {
       int idx    = sp->getSelectedIdx();
       Element* e = sp->element(idx);
@@ -461,19 +467,19 @@ NewWizard::NewWizard(QWidget* parent)
       setOption(QWizard::HaveFinishButtonOnEarlyPages, true);
       setOption(QWizard::HaveNextButtonOnLastPage, true);
 
-      p1 = new NewWizardPage1;
-      p2 = new NewWizardPage2;
-      p3 = new NewWizardPage3;
-      p4 = new NewWizardPage4;
-      p5 = new NewWizardPage5;
+      infoPage = new NewWizardInfoPage;
+      instrumentsPage = new NewWizardInstrumentsPage;
+      timesigPage = new NewWizardTimesigPage;
+      templatePage = new NewWizardTemplatePage;
+      keysigPage = new NewWizardKeysigPage;
 
 //  enum Page { Invalid = -1, Type, Instruments, Template, Keysig, Timesig};
 
-      setPage(Page::Type,        p1);
-      setPage(Page::Instruments, p2);
-      setPage(Page::Template,    p4);
-      setPage(Page::Keysig,      p5);
-      setPage(Page::Timesig,     p3);
+      setPage(Page::Type,        infoPage);
+      setPage(Page::Instruments, instrumentsPage);
+      setPage(Page::Template,    templatePage);
+      setPage(Page::Keysig,      keysigPage);
+      setPage(Page::Timesig,     timesigPage);
 
       resize(QSize(840, 560)); //ensure default size if no geometry in settings
       MuseScore::restoreGeometry(this);
@@ -523,7 +529,7 @@ int NewWizard::nextId() const
 
 bool NewWizard::emptyScore() const
       {
-      QString p = p4->templatePath();
+      QString p = templatePage->templatePath();
       QFileInfo fi(p);
       bool val = fi.completeBaseName() == "00-Blank";
       return val;
@@ -536,7 +542,7 @@ bool NewWizard::emptyScore() const
 void NewWizard::updateValues() const
       {
       //p2->buildInstrumentsList();
-      p4->buildTemplatesList();
+      templatePage->buildTemplatesList();
       }
 
 //---------------------------------------------------------

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -23,7 +23,7 @@
 #include "preferences.h"
 #include "palette.h"
 #include "instrdialog.h"
-#include "scoreBrowser.h"
+#include "templateBrowser.h"
 #include "extension.h"
 
 #include "libmscore/instrtemplate.h"
@@ -274,31 +274,15 @@ NewWizardTemplatePage::NewWizardTemplatePage(QWidget* parent)
       setAccessibleName(title());
       setAccessibleDescription(subTitle());
 
-      templateFileBrowser = new ScoreBrowser;
+      templateFileBrowser = new TemplateBrowser(this);
       templateFileBrowser->setStripNumbers(true);
-      buildTemplatesList();
-      // templateFileBrowser->setShowCustomCategory(true);
-      // templateFileBrowser->setSizePolicy(QSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored));
 
       QVBoxLayout* layout = new QVBoxLayout;
-      QHBoxLayout* searchLayout = new QHBoxLayout;
-      QLineEdit* searchBox = new QLineEdit;
-      searchBox->setPlaceholderText(tr("Search"));
-      searchBox->setAccessibleName(tr("Template search"));
-      searchBox->setAccessibleDescription(tr("Filter template scores by name or category"));
-      searchBox->setClearButtonEnabled(true);
-      searchBox->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
-      searchLayout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::MinimumExpanding, QSizePolicy::Maximum));
-      searchLayout->addWidget(searchBox);
-
-      layout->addLayout(searchLayout);
       layout->addWidget(templateFileBrowser);
       setLayout(layout);
 
       connect(templateFileBrowser, SIGNAL(scoreSelected(const QString&)), SLOT(templateChanged(const QString&)));
-      connect(searchBox, &QLineEdit::textChanged, [this] (const QString& searchString) {
-            this->templateFileBrowser->filter(searchString);
-            });
+      buildTemplatesList();
       }
 
 //---------------------------------------------------------
@@ -307,8 +291,7 @@ NewWizardTemplatePage::NewWizardTemplatePage(QWidget* parent)
 
 void NewWizardTemplatePage::initializePage()
       {
-      templateFileBrowser->show();
-      path.clear();
+
       }
 
 //---------------------------------------------------------

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -276,16 +276,16 @@ NewWizardTemplatePage::NewWizardTemplatePage(QWidget* parent)
 
       templateFileBrowser = new ScoreBrowser;
       templateFileBrowser->setStripNumbers(true);
-      templateFileBrowser->setShowCustomCategory(true);
-      templateFileBrowser->setSizePolicy(QSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored));
       buildTemplatesList();
+      // templateFileBrowser->setShowCustomCategory(true);
+      // templateFileBrowser->setSizePolicy(QSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored));
 
       QVBoxLayout* layout = new QVBoxLayout;
       QHBoxLayout* searchLayout = new QHBoxLayout;
       QLineEdit* searchBox = new QLineEdit;
       searchBox->setPlaceholderText(tr("Search"));
-      searchBox->setAccessibleName(searchBox->placeholderText());
-      searchBox->setAccessibleDescription(tr("Filter templates by name"));
+      searchBox->setAccessibleName(tr("Template search"));
+      searchBox->setAccessibleDescription(tr("Filter template scores by name or category"));
       searchBox->setClearButtonEnabled(true);
       searchBox->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
       searchLayout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::MinimumExpanding, QSizePolicy::Maximum));
@@ -296,7 +296,6 @@ NewWizardTemplatePage::NewWizardTemplatePage(QWidget* parent)
       setLayout(layout);
 
       connect(templateFileBrowser, SIGNAL(scoreSelected(const QString&)), SLOT(templateChanged(const QString&)));
-      connect(templateFileBrowser, SIGNAL(scoreActivated(const QString&)), SLOT(fileAccepted(const QString&)));
       connect(searchBox, &QLineEdit::textChanged, [this] (const QString& searchString) {
             this->templateFileBrowser->filter(searchString);
             });
@@ -399,8 +398,14 @@ NewWizardKeysigPage::NewWizardKeysigPage(QWidget* parent)
       sp->setShowContextMenu(false);
       sp->setSelectable(true);
       sp->setDisableDoubleClick(true);
-      sp->setSelected(14);
+      int keysigCMajorIdx = 14;
+      sp->setSelected(keysigCMajorIdx);
       PaletteScrollArea* sa = new PaletteScrollArea(sp);
+      // set widget name to include name of selected key signature
+      // we could set the description, but some screen readers ignore it
+      sa->setAccessibleName(tr("Key Signature: %1").arg(qApp->translate("Palette", sp->cellAt(keysigCMajorIdx)->name.toUtf8())));
+      QAccessibleEvent event(sa, QAccessible::NameChanged);
+      QAccessible::updateAccessibility(&event);
       QVBoxLayout* l1 = new QVBoxLayout;
       l1->addWidget(sa);
       b1->setLayout(l1);

--- a/mscore/newwizard.h
+++ b/mscore/newwizard.h
@@ -69,16 +69,17 @@ class TitleWizard : public QWidget, public Ui::NewWizard {
       };
 
 //---------------------------------------------------------
-//   NewWizardPage1
+//   NewWizardInfoPage
+//    Enter score information such as title and composer
 //---------------------------------------------------------
 
-class NewWizardPage1 : public QWizardPage {
+class NewWizardInfoPage : public QWizardPage {
       Q_OBJECT
 
       TitleWizard* w;
 
    public:
-      NewWizardPage1(QWidget* parent = 0);
+      NewWizardInfoPage(QWidget* parent = 0);
       QString title() const              { return w->title->text();      }
       QString subtitle() const           { return w->subtitle->text();   }
       QString composer() const           { return w->composer->text();   }
@@ -88,36 +89,38 @@ class NewWizardPage1 : public QWizardPage {
       };
 
 //---------------------------------------------------------
-//   NewWizardPage2
+//   NewWizardInstrumentsPage
+//    Choose instruments to appear in the score
 //---------------------------------------------------------
 
-class NewWizardPage2 : public QWizardPage {
+class NewWizardInstrumentsPage : public QWizardPage {
       Q_OBJECT
 
       bool complete;
-      InstrumentsWidget* w;
+      InstrumentsWidget* instrumentsWidget;
 
    public slots:
       void setComplete(bool);
 
    public:
-      NewWizardPage2(QWidget* parent = 0);
+      NewWizardInstrumentsPage(QWidget* parent = 0);
       virtual bool isComplete() const override;
       void createInstruments(Score* s);
       virtual void initializePage() override;
       };
 
 //---------------------------------------------------------
-//   NewWizardPage3
+//   NewWizardTimesigPage
+//    Choose time signature for the score
 //---------------------------------------------------------
 
-class NewWizardPage3 : public QWizardPage {
+class NewWizardTimesigPage : public QWizardPage {
       Q_OBJECT
 
       TimesigWizard* w;
 
    public:
-      NewWizardPage3(QWidget* parent = 0);
+      NewWizardTimesigPage(QWidget* parent = 0);
       int measures() const                     { return w->measures();   }
       Fraction timesig() const                 { return w->timesig();    }
       bool pickupMeasure(int* z, int* n) const { return w->pickup(z, n); }
@@ -125,11 +128,11 @@ class NewWizardPage3 : public QWizardPage {
       };
 
 //---------------------------------------------------------
-//   NewWizardPage4
-//    request template file
+//   NewWizardTemplatePage
+//    Choose a template on which to base the score
 //---------------------------------------------------------
 
-class NewWizardPage4 : public QWizardPage {
+class NewWizardTemplatePage : public QWizardPage {
       Q_OBJECT
 
       ScoreBrowser* templateFileBrowser;
@@ -140,7 +143,7 @@ class NewWizardPage4 : public QWizardPage {
       void fileAccepted(const QString&);
 
    public:
-      NewWizardPage4(QWidget* parent = 0);
+      NewWizardTemplatePage(QWidget* parent = 0);
       virtual bool isComplete() const override;
       QString templatePath() const;
       virtual void initializePage();
@@ -148,10 +151,11 @@ class NewWizardPage4 : public QWizardPage {
       };
 
 //---------------------------------------------------------
-//   NewWizardPage5
+//   NewWizardKeysigPage
+//    Choose key signature for the score
 //---------------------------------------------------------
 
-class NewWizardPage5 : public QWizardPage {
+class NewWizardKeysigPage : public QWizardPage {
       Q_OBJECT
 
       Palette* sp;
@@ -159,7 +163,7 @@ class NewWizardPage5 : public QWizardPage {
       QGroupBox* tempoGroup;
 
    public:
-      NewWizardPage5(QWidget* parent = 0);
+      NewWizardKeysigPage(QWidget* parent = 0);
       virtual bool isComplete() const override { return true; }
       KeySigEvent keysig() const;
       double tempo() const            { return _tempo->value(); }
@@ -169,16 +173,17 @@ class NewWizardPage5 : public QWizardPage {
 
 //---------------------------------------------------------
 //   NewWizard
+//    New Score Wizard - create a new score
 //---------------------------------------------------------
 
 class NewWizard : public QWizard {
       Q_OBJECT
 
-      NewWizardPage1* p1;
-      NewWizardPage2* p2;
-      NewWizardPage3* p3;
-      NewWizardPage4* p4;
-      NewWizardPage5* p5;
+      NewWizardInfoPage* infoPage;
+      NewWizardInstrumentsPage* instrumentsPage;
+      NewWizardTimesigPage* timesigPage;
+      NewWizardTemplatePage* templatePage;
+      NewWizardKeysigPage* keysigPage;
 
       virtual void hideEvent(QHideEvent*);
 
@@ -192,20 +197,20 @@ class NewWizard : public QWizard {
 
       enum Page { Invalid = -1, Type, Instruments, Template, Keysig, Timesig};
 
-      QString templatePath() const       { return p4->templatePath(); }
-      int measures() const               { return p3->measures();    }
-      Fraction timesig() const           { return p3->timesig();     }
-      void createInstruments(Score* s)   { p2->createInstruments(s); }
-      QString title() const              { return p1->title();       }
-      QString subtitle() const           { return p1->subtitle();    }
-      QString composer() const           { return p1->composer();    }
-      QString poet() const               { return p1->poet();        }
-      QString copyright() const          { return p1->copyright();   }
-      KeySigEvent keysig() const         { return p5->keysig();      }
-      bool pickupMeasure(int* z, int* n) const { return p3->pickupMeasure(z, n); }
-      TimeSigType timesigType() const     { return p3->timesigType();       }
-      double tempo() const                { return p5->tempo();       }
-      bool createTempo() const            { return p5->createTempo(); }
+      QString templatePath() const       { return templatePage->templatePath(); }
+      int measures() const               { return timesigPage->measures();    }
+      Fraction timesig() const           { return timesigPage->timesig();     }
+      void createInstruments(Score* s)   { instrumentsPage->createInstruments(s); }
+      QString title() const              { return infoPage->title();       }
+      QString subtitle() const           { return infoPage->subtitle();    }
+      QString composer() const           { return infoPage->composer();    }
+      QString poet() const               { return infoPage->poet();        }
+      QString copyright() const          { return infoPage->copyright();   }
+      KeySigEvent keysig() const         { return keysigPage->keysig();      }
+      bool pickupMeasure(int* z, int* n) const { return timesigPage->pickupMeasure(z, n); }
+      TimeSigType timesigType() const     { return timesigPage->timesigType();       }
+      double tempo() const                { return keysigPage->tempo();       }
+      bool createTempo() const            { return keysigPage->createTempo(); }
       bool emptyScore() const;
       void updateValues() const;
       };

--- a/mscore/newwizard.h
+++ b/mscore/newwizard.h
@@ -35,7 +35,7 @@ class Score;
 class Palette;
 class StaffListItem;
 class InstrumentsWidget;
-class ScoreBrowser;
+class TemplateBrowser;
 
 //---------------------------------------------------------
 //   TimesigWizard
@@ -135,7 +135,7 @@ class NewWizardTimesigPage : public QWizardPage {
 class NewWizardTemplatePage : public QWizardPage {
       Q_OBJECT
 
-      ScoreBrowser* templateFileBrowser;
+      TemplateBrowser* templateFileBrowser;
       QString path;
 
    private slots:

--- a/mscore/newwizard.ui
+++ b/mscore/newwizard.ui
@@ -27,7 +27,7 @@
       <string>Title</string>
      </property>
      <property name="accessibleDescription">
-      <string>Insert title here</string>
+      <string>Enter score title</string>
      </property>
     </widget>
    </item>
@@ -44,7 +44,7 @@
       <string>Subtitle</string>
      </property>
      <property name="accessibleDescription">
-      <string>Insert subtitle here</string>
+      <string>Enter score subtitle</string>
      </property>
     </widget>
    </item>
@@ -61,7 +61,7 @@
       <string>Composer</string>
      </property>
      <property name="accessibleDescription">
-      <string>Insert composer's name here</string>
+      <string>Enter the composer's name</string>
      </property>
     </widget>
    </item>
@@ -78,7 +78,7 @@
       <string>Lyricist</string>
      </property>
      <property name="accessibleDescription">
-      <string>Insert lyricist's name here</string>
+      <string>Enter the lyricist's name</string>
      </property>
     </widget>
    </item>
@@ -95,7 +95,7 @@
       <string>Copyright</string>
      </property>
      <property name="accessibleDescription">
-      <string>Insert copyright here</string>
+      <string>Enter copyright information</string>
      </property>
     </widget>
    </item>

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -720,29 +720,33 @@ void PaletteScrollArea::keyPressEvent(QKeyEvent* event)
       {
       QWidget* w = this->widget();
       Palette* p = static_cast<Palette*>(w);
-      if (event->key() == Qt::Key_Right) {
-            int i = p->getSelectedIdx();
-            if (i == -1)
-                  p->setSelected(0);
-            i++;
-            if (i >= 0 && i < p->size())
-                  p->setSelected(i);
-            else
-                  p->setSelected(0);
-
-            p->update();
-            }
-      else if (event->key() == Qt::Key_Left) {
-            int i = p->getSelectedIdx();
-            if (i == -1)
-                  p->setSelected(p->size()-1);
-            i--;
-            if (i >= 0 && i < p->size())
-                  p->setSelected(i);
-            else
-                  p->setSelected(p->size()-1);
-
-            p->update();
+      int pressedKey = event->key();
+      switch (pressedKey) {
+            case Qt::Key_Right:
+            case Qt::Key_Left:
+            case Qt::Key_Up:
+            case Qt::Key_Down:
+                  {
+                  int idx = p->getSelectedIdx();
+                  if (pressedKey == Qt::Key_Left || pressedKey == Qt::Key_Up)
+                        idx--;
+                  else
+                        idx++;
+                  if (idx < 0)
+                        idx = p->size() - 1;
+                  else if (idx >= p->size())
+                        idx = 0;
+                  p->setSelected(idx);
+                  // Set widget name to name of selected key signature. We could
+                  // set the description, but some screen readers ignore it.
+                  setAccessibleName(qApp->translate("Palette", p->cellAt(idx)->name.toUtf8()));
+                  QAccessibleEvent event(this, QAccessible::NameChanged);
+                  QAccessible::updateAccessibility(&event);
+                  p->update();
+                  break;
+                  }
+            default:
+                  break;
             }
       QScrollArea::keyPressEvent(event);
       }

--- a/mscore/scorePreview.cpp
+++ b/mscore/scorePreview.cpp
@@ -24,7 +24,18 @@ namespace Ms {
 ScorePreview::ScorePreview(QWidget* parent)
    : QWidget(parent)
       {
+      messageNothingToShow = tr("Nothing selected");
       setupUi(this);
+      icon->setText(messageNothingToShow);
+      }
+
+//---------------------------------------------------------
+//   displayInfo
+//---------------------------------------------------------
+
+void ScorePreview::displayInfo(bool show)
+      {
+      info->setVisible(show);
       }
 
 //---------------------------------------------------------
@@ -48,6 +59,22 @@ void ScorePreview::setScore(const ScoreInfo& si)
       creationDate->setEnabled(true);
       fileSize->setEnabled(true);
       icon->setPixmap(si.pixmap());
+      }
+
+//---------------------------------------------------------
+//   unsetScore
+//---------------------------------------------------------
+
+void ScorePreview::unsetScore()
+      {
+      scoreInfo = ScoreInfo();
+      name->setText("");
+      creationDate->setText("");
+      fileSize->setText("");
+      name->setEnabled(false);
+      creationDate->setEnabled(true);
+      fileSize->setEnabled(true);
+      icon->setText(messageNothingToShow);
       }
 }
 

--- a/mscore/scorePreview.h
+++ b/mscore/scorePreview.h
@@ -27,18 +27,21 @@ class ScorePreview : public QWidget, public Ui::ScorePreview
       Q_OBJECT
 
       ScoreInfo scoreInfo;
+      QString messageNothingToShow;
 
       virtual void mouseDoubleClickEvent(QMouseEvent*) override { emit doubleClicked(scoreInfo.filePath()); }
 
    public slots:
       void setScore(const QString&);
       void setScore(const ScoreInfo&);
+      void unsetScore();
 
    signals:
       void doubleClicked(QString);
 
    public:
       ScorePreview(QWidget* parent = 0);
+      void displayInfo(bool show);
       };
 }
 

--- a/mscore/scorePreview.ui
+++ b/mscore/scorePreview.ui
@@ -40,8 +40,8 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="text">
-      <string>Nothing selected</string>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
      </property>
      <property name="scaledContents">
       <bool>false</bool>
@@ -68,128 +68,130 @@
     </spacer>
    </item>
    <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="font">
-        <font>
-         <weight>50</weight>
-         <bold>false</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Size:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Created: </string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="creationDate">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::PlainText</enum>
-       </property>
-       <property name="readOnly" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="fileSize">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::PlainText</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Name:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="name">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::PlainText</enum>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="readOnly" stdset="0">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QWidget" name="info" native="true">
+     <layout class="QGridLayout" name="infoGrid">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="font">
+         <font>
+          <weight>50</weight>
+          <bold>false</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Size:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Created: </string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="creationDate">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="readOnly" stdset="0">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="fileSize">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Name:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="name">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::PlainText</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="readOnly" stdset="0">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/mscore/templateBrowser.cpp
+++ b/mscore/templateBrowser.cpp
@@ -1,0 +1,215 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2014 Werner Schweer
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "templateBrowser.h"
+#include "musescore.h"
+#include "icons.h"
+#include "libmscore/score.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   TemplateItem
+//---------------------------------------------------------
+
+class TemplateItem : public QTreeWidgetItem
+      {
+      ScoreInfo _info;
+
+   public:
+      TemplateItem(const ScoreInfo& i, QTreeWidgetItem* parent = 0);
+      const ScoreInfo& info() const { return _info; }
+      };
+
+TemplateItem::TemplateItem(const ScoreInfo &i, QTreeWidgetItem *parent) : QTreeWidgetItem(parent, 0), _info(i)
+      {
+      setFlags(Qt::ItemFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemNeverHasChildren));
+      }
+
+//---------------------------------------------------------
+//   TemplateCategory
+//---------------------------------------------------------
+
+class TemplateCategory : public QTreeWidgetItem
+      {
+
+   public:
+      TemplateCategory(QString name, QTreeWidget* parent = 0);
+      };
+
+TemplateCategory::TemplateCategory(QString name, QTreeWidget *parent)
+   : QTreeWidgetItem(parent, 0)
+      {
+      const int nameCol = 0;
+      setText(nameCol, name);
+      // provide feedback to blind users that they have selected a category rather than a template
+      setData(nameCol, Qt::AccessibleTextRole, QVariant(QObject::tr("%1 category").arg(name))); // spoken by screen readers
+      QFont nameFont = QFont();
+      nameFont.setBold(true);
+      setFont(nameCol, nameFont);
+      setFlags(Qt::ItemIsEnabled);
+      }
+
+//---------------------------------------------------------
+//   TemplateBrowser
+//---------------------------------------------------------
+
+TemplateBrowser::TemplateBrowser(QWidget* parent)
+   : QWidget(parent)
+      {
+      setupUi(this);
+      if (_showPreview) {
+            preview->displayInfo(false);
+            connect(preview, SIGNAL(doubleClicked(QString)), SIGNAL(scoreActivated(QString)));
+            }
+      else
+            preview->setVisible(false);
+      connect(templateTree, &QTreeWidget::itemSelectionChanged, this, &TemplateBrowser::scoreClicked);
+      templateSearch->setFilterableView(templateTree);
+      }
+
+//---------------------------------------------------------
+//   genTemplateItem
+//---------------------------------------------------------
+
+TemplateItem* TemplateBrowser::genTemplateItem(QTreeWidgetItem* p, const QFileInfo& fi)
+      {
+      ScoreInfo si(fi);
+      QPixmap pm(QSize(181,256));
+      if (!QPixmapCache::find(fi.filePath(), &pm)) {
+            //load and scale pixmap
+            QPixmap pixmap = mscore->extractThumbnail(fi.filePath());
+            if (pixmap.isNull())
+                  pixmap = icons[int(Icons::file_ICON)]->pixmap(QSize(50,60));
+            // draw pixmap and add border
+            pm.fill(Qt::transparent);
+            QPainter painter( &pm );
+            painter.setRenderHint(QPainter::Antialiasing);
+            painter.setRenderHint(QPainter::TextAntialiasing);
+            painter.drawPixmap(0, 0, pixmap);
+            painter.setPen(QPen(QColor(0, 0, 0, 128), 1));
+            painter.setBrush(Qt::white);
+            if (fi.completeBaseName() == "00-Blank" || fi.completeBaseName() == "Create_New_Score") {
+                  qreal round = 8.0 * qApp->devicePixelRatio();
+                  painter.drawRoundedRect(QRectF(0, 0, pm.width() - 1 , pm.height() - 1), round, round);
+                  }
+            else
+                  painter.drawRect(0, 0, pm.width()  - 1, pm.height()  - 1);
+            if (fi.completeBaseName() != "00-Blank")
+                  painter.drawPixmap(1, 1, pixmap);
+            painter.end();
+            QPixmapCache::insert(fi.filePath(), pm);
+            }
+
+      si.setPixmap(pm);
+      TemplateItem* item = new TemplateItem(si, p);
+
+      if (fi.completeBaseName() == "00-Blank") {
+            item->setText(0, tr("Choose Instruments"));
+            }
+      else if (fi.completeBaseName() == "Create_New_Score") {
+            item->setText(0, tr("Create New Score..."));
+            }
+      else {
+            QString s(si.completeBaseName());
+            if (!s.isEmpty() && s[0].isNumber() && _stripNumbers)
+                  s = s.mid(3);
+            s = s.replace('_', ' ');
+            item->setText(0, s);
+            }
+      return item;
+      }
+
+//---------------------------------------------------------
+//   setScores
+//---------------------------------------------------------
+
+void TemplateBrowser::setScores(QFileInfoList& s)
+      {
+      QStringList filter = { "*.mscz", "*.mscx" };
+      templateTree->clear(); // empty the tree
+
+      if (_showCustomCategory)
+            std::sort(s.begin(), s.end(), [](QFileInfo a, QFileInfo b)->bool { return a.fileName() < b.fileName(); });
+
+      TemplateCategory* customCategory = new TemplateCategory(tr("Custom Templates"));
+
+      QSet<QString> entries; //to avoid duplicates
+      for (const QFileInfo& fil : s) {
+            if (fil.isDir()) {
+                  QString st(fil.fileName());
+                  if (!st.isEmpty() && st[0].isNumber() && _stripNumbers)
+                        st = st.mid(3);
+                  st = st.replace('_', ' ');
+                  TemplateCategory* category = new TemplateCategory(st, templateTree);
+                  QDir dir(fil.filePath());
+                  unsigned childCount = 0; //nbr of entries added
+                  for (const QFileInfo& fi : dir.entryInfoList(filter, QDir::Files, QDir::Name)) {
+                        if (entries.contains(fi.filePath()))
+                              continue;
+                        genTemplateItem(category, fi);
+                        childCount++;
+                        entries.insert(fi.filePath());
+                        }
+                  if (childCount == 0) {
+                        // delete any unnecessary categories
+                        delete category;
+                        }
+                  }
+            else if (fil.isFile()) {
+                  QString st = fil.filePath();
+                  if (entries.contains(st))
+                        continue;
+                  if (st.endsWith(".mscz") || st.endsWith(".mscx")) {
+                        genTemplateItem(customCategory, fil);
+                        entries.insert(st);
+                        }
+                  }
+            }
+      if (customCategory->childCount() > 0)
+            templateTree->insertTopLevelItem(1, customCategory);
+      templateTree->toInitialState();
+      templateTree->selectFirst();
+      }
+
+//---------------------------------------------------------
+//   filter
+//      filter which scores are visible based on searchString
+//---------------------------------------------------------
+void TemplateBrowser::filter(const QString &searchString)
+      {
+      templateTree->filter(searchString);
+      }
+
+//---------------------------------------------------------
+//   scoreClicked
+//---------------------------------------------------------
+
+void TemplateBrowser::scoreClicked()
+      {
+      QList<QTreeWidgetItem*> selectedItems = templateTree->selectedItems();
+      if (!selectedItems.isEmpty()) {
+            QTreeWidgetItem* selectedItem = selectedItems.first();
+            if (selectedItem) {
+                  TemplateItem* selectedScore = static_cast<TemplateItem*>(selectedItem);
+                  if (_showPreview)
+                        preview->setScore(selectedScore->info());
+                  emit scoreSelected(selectedScore->info().filePath());
+                  return;
+                  }
+            }
+      if (_showPreview)
+            preview->unsetScore();
+      emit scoreSelected(""); // no score selected
+      }
+
+}

--- a/mscore/templateBrowser.h
+++ b/mscore/templateBrowser.h
@@ -1,0 +1,53 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2014 Werner Schweer
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __TEMPLATEBROWSER_H__
+#define __TEMPLATEBROWSER_H__
+
+#include "ui_templateBrowser.h"
+#include "scoreInfo.h"
+
+namespace Ms {
+
+class TemplateItem;
+class TemplateCategory;
+
+//---------------------------------------------------------
+//   TemplateBrowser
+//---------------------------------------------------------
+
+class TemplateBrowser : public QWidget, public Ui::TemplateBrowser
+      {
+      Q_OBJECT
+
+      bool _stripNumbers  { false }; // remove number prefix from filenames
+      bool _showPreview   { true  }; // show preview of templates
+      bool _showCustomCategory  { false }; // show a custom category for user's own templates
+
+      TemplateItem* genTemplateItem(QTreeWidgetItem*, const QFileInfo&);
+
+   private slots:
+      void scoreClicked();
+
+   signals:
+      void leave();
+      void scoreSelected(QString);
+
+   public:
+      TemplateBrowser(QWidget* parent = 0);
+      void setScores(QFileInfoList&);
+      void setStripNumbers(bool val) { _stripNumbers = val; }
+      void filter(const QString&);
+      };
+}
+
+#endif

--- a/mscore/templateBrowser.ui
+++ b/mscore/templateBrowser.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TemplateBrowser</class>
+ <widget class="QWidget" name="TemplateBrowser">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>424</width>
+    <height>302</height>
+   </rect>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="Ms::SearchBox" name="templateSearch">
+       <property name="accessibleName">
+        <string>Template search</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>Filter template scores by name or category</string>
+       </property>
+       <property name="placeholderText">
+        <string>Search</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Ms::FilterableTreeWidget" name="templateTree">
+       <property name="accessibleName">
+        <string>Template list</string>
+       </property>
+       <property name="accessibleDescription">
+        <string>Choose a template to use as a starting point for your score</string>
+       </property>
+       <property name="uniformRowHeights">
+        <bool>true</bool>
+       </property>
+       <property name="expandsOnDoubleClick">
+        <bool>false</bool>
+       </property>
+       <property name="columnCount">
+        <number>1</number>
+       </property>
+       <attribute name="headerVisible">
+        <bool>false</bool>
+       </attribute>
+       <column>
+        <property name="text">
+         <string notr="true">1</string>
+        </property>
+       </column>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Ms::ScorePreview" name="preview" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Ms::ScorePreview</class>
+   <extends>QWidget</extends>
+   <header>scorePreview.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Ms::FilterableTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>widgets/filterabletreeview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Ms::SearchBox</class>
+   <extends>QLineEdit</extends>
+   <header>widgets/searchbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/mscore/timesigwizard.ui
+++ b/mscore/timesigwizard.ui
@@ -25,6 +25,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="accessibleDescription">
+      <string>Enter a numerical time signature or choose one of the time signature symbols</string>
+     </property>
      <property name="title">
       <string>Enter Time Signature:</string>
      </property>
@@ -36,6 +39,15 @@
         </property>
         <item>
          <widget class="QRadioButton" name="tsFraction">
+          <property name="toolTip">
+           <string>Custom numerical time signature</string>
+          </property>
+          <property name="accessibleName">
+           <string>Custom numerical time signature</string>
+          </property>
+          <property name="accessibleDescription">
+           <string>Enter a numerical time signature such as four-four or six-eight</string>
+          </property>
           <property name="text">
            <string notr="true"/>
           </property>
@@ -46,8 +58,14 @@
         </item>
         <item>
          <widget class="QSpinBox" name="timesigZ">
+          <property name="toolTip">
+           <string>Beats in a measure</string>
+          </property>
           <property name="accessibleName">
            <string>Beats in a measure</string>
+          </property>
+          <property name="accessibleDescription">
+           <string>The numerator, or upper number, in the time signature</string>
           </property>
           <property name="minimum">
            <number>1</number>
@@ -78,8 +96,14 @@
         </item>
         <item>
          <widget class="QComboBox" name="timesigN">
+          <property name="toolTip">
+           <string>Beat unit</string>
+          </property>
           <property name="accessibleName">
            <string>Beat unit</string>
+          </property>
+          <property name="accessibleDescription">
+           <string>The denominator, or lower number, in the time signature</string>
           </property>
           <property name="currentIndex">
            <number>2</number>
@@ -137,23 +161,6 @@
        </layout>
       </item>
       <item>
-       <widget class="QRadioButton" name="tsCutTime">
-        <property name="toolTip">
-         <string>Cut time</string>
-        </property>
-        <property name="accessibleName">
-         <string>Cut Time</string>
-        </property>
-        <property name="text">
-         <string notr="true"/>
-        </property>
-        <property name="icon">
-         <iconset resource="musescore.qrc">
-          <normaloff>:/data/icons/timesig_allabreve.svg</normaloff>:/data/icons/timesig_allabreve.svg</iconset>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QRadioButton" name="tsCommonTime">
         <property name="toolTip">
          <string>Common time</string>
@@ -161,12 +168,35 @@
         <property name="accessibleName">
          <string>Common Time</string>
         </property>
+        <property name="accessibleDescription">
+         <string>Use the common time symbol, the letter C, and a four-four meter</string>
+        </property>
         <property name="text">
          <string notr="true"/>
         </property>
         <property name="icon">
-         <iconset resource="musescore.qrc">
+         <iconset>
           <normaloff>:/data/icons/timesig_common.svg</normaloff>:/data/icons/timesig_common.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="tsCutTime">
+        <property name="toolTip">
+         <string>Cut time</string>
+        </property>
+        <property name="accessibleName">
+         <string>Cut Time</string>
+        </property>
+        <property name="accessibleDescription">
+         <string>Use the cut time symbol, the letter C with a vertical line through it, and a two-two meter</string>
+        </property>
+        <property name="text">
+         <string notr="true"/>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/data/icons/timesig_allabreve.svg</normaloff>:/data/icons/timesig_allabreve.svg</iconset>
         </property>
        </widget>
       </item>
@@ -178,6 +208,9 @@
      <property name="accessibleName">
       <string>Pickup Measure</string>
      </property>
+     <property name="accessibleDescription">
+      <string>Begin the score with an incomplete measure</string>
+     </property>
      <property name="title">
       <string>Pickup Measure</string>
      </property>
@@ -185,7 +218,7 @@
       <bool>true</bool>
      </property>
      <property name="checked">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <layout class="QHBoxLayout">
       <item>
@@ -197,8 +230,14 @@
       </item>
       <item>
        <widget class="QSpinBox" name="pickupTimesigZ">
+        <property name="toolTip">
+         <string>Number of beats in the pickup measure</string>
+        </property>
         <property name="accessibleName">
-         <string>Beats in a measure</string>
+         <string>Pickup beats</string>
+        </property>
+        <property name="accessibleDescription">
+         <string>Number of beats in the pickup measure</string>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -229,8 +268,14 @@
       </item>
       <item>
        <widget class="QComboBox" name="pickupTimesigN">
+        <property name="statusTip">
+         <string>Beat unit for the pickup measure</string>
+        </property>
         <property name="accessibleName">
-         <string>Beat unit</string>
+         <string>Pickup beat unit</string>
+        </property>
+        <property name="accessibleDescription">
+         <string>Beat unit for the pickup measure</string>
         </property>
         <property name="currentIndex">
          <number>2</number>
@@ -293,6 +338,9 @@
      <property name="accessibleName">
       <string>Enter Number of Measures</string>
      </property>
+     <property name="accessibleDescription">
+      <string>Hint: You can also add or remove measures after creation of the score.</string>
+     </property>
      <property name="title">
       <string>Enter Number of Measures:</string>
      </property>
@@ -315,11 +363,14 @@
       </item>
       <item row="1" column="1">
        <widget class="QSpinBox" name="measureCount">
+        <property name="toolTip">
+         <string>Number of measures</string>
+        </property>
         <property name="accessibleName">
          <string>Measures</string>
         </property>
         <property name="accessibleDescription">
-         <string>Hint: You can also add or remove measures after creation of the score.</string>
+         <string>The number of measures initially present in the score</string>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -365,17 +416,15 @@
  </widget>
  <tabstops>
   <tabstop>tsFraction</tabstop>
+  <tabstop>tsCommonTime</tabstop>
+  <tabstop>tsCutTime</tabstop>
   <tabstop>timesigZ</tabstop>
   <tabstop>timesigN</tabstop>
-  <tabstop>tsCutTime</tabstop>
-  <tabstop>tsCommonTime</tabstop>
   <tabstop>pickupMeasure</tabstop>
   <tabstop>pickupTimesigZ</tabstop>
   <tabstop>pickupTimesigN</tabstop>
   <tabstop>measureCount</tabstop>
  </tabstops>
- <resources>
-  <include location="musescore.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/mscore/widgets/CMakeLists.txt
+++ b/mscore/widgets/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(WIDGETS_SOURCE_FILES
+    filterabletreeview.cpp
+    searchbox.cpp
+    )
+
+# expose variables to CMakeLists.txt in parent directory
+set(WIDGETS_SOURCE_FILES "${WIDGETS_SOURCE_FILES}" PARENT_SCOPE)

--- a/mscore/widgets/README.md
+++ b/mscore/widgets/README.md
@@ -1,0 +1,62 @@
+Widgets
+=======
+
+The files in this directory define drop-in replacements for Qt's built-in
+widgets. These can be [used in QtCreator's Design mode][promoting-widgets]
+(i.e. in `.ui` files) or in ordinary `.h` and `.cpp` source files.
+
+[promoting-widgets]: http://doc.qt.io/qt-5/designer-using-custom-widgets.html#promoting-widgets
+
+## When to use
+
+Consider using or adapting these widgets if you can rather than creating your
+own. Doing this has the following benefits:
+
+- Saves time and effort
+- Easier to maintain
+- Ensures consistency in design
+- Reduces MuseScore's size and memory footprint
+- Benefit from extra features that you may not know how to implement yourself
+  (e.g. accessibility).
+
+If none of the existing widgets suit your particular need then consider
+creating your own and adding it to this directory. You can use one of the
+existing ones as a template, and even inherit from it if appropriate. Try to
+give the functions and classes names that are as generic as possible. Make
+sure you add comments where appropriate to help other people understand how
+to use the widgets, and to provide any details about the implementation that
+are not immediately obvious from the code.
+
+## Example
+
+`searchbox.h` defines SearchBox, a drop-in replacement for a QLineEdit, and
+`filterabletreeview.h` defines FilterableTreeView, which is a drop-in
+replacement for a QTreeView. When used together, these classes allow you to
+create a tree view to display hierarchical lists of items (e.g. books grouped
+by genre) and use the line edit to search in the view.
+
+You can use SearchBox and FilterableTreeView inside any of MuseScore's `.ui`
+files like this:
+
+1. Open the UI file (e.g. `startcenter.ui`) in Qt Creator's Design mode.
+2. Drag an instance of each of the base classes (QLineEdit and QTreeView) onto
+  the canvas (or find an existing instance).
+3. Right-click the QLineEdit, choose "Promote to...", and enter the following:
+    - Promoted class name: `Ms::SearchBox` (`Ms` is the namespace)
+    - Header file: `widgets/searchbox.h`
+4. Now do the same for the QTreeView:
+    - Promoted class name: `Ms::FilterableTreeView`
+    - Header file: `widgets/filterabletreeview.h`
+5. Find the widgets' object names in the properties panel on the right.
+    - These are the names you will use to refer to the widgets in the code.
+    - Defaults are `treeView` and `lineEdit`. You might want to change them to
+      something more easily identifiable (e.g. `bookTree` and `bookSearch`).
+
+For many widgets that is all you need to do, but some will require additional
+setting-up to be done in the UI file's corresponding code files (in this case
+`startcenter.h` and `startcenter.cpp`). Look in those files for the line
+`setupUi(this);` and do whatever you have to do immediately after that line.
+The widget's source files (i.e. `searchbox.h`, `searchbox.cpp`, etc.) should
+tell you what you need to do. In this case, you just need to call the
+SearchBox's `setFilterableView(*view)` function with a pointer to the view
+that you want to search (i.e. `bookSearch->setFilterableView(bookTree);`).

--- a/mscore/widgets/filterabletreeview.cpp
+++ b/mscore/widgets/filterabletreeview.cpp
@@ -1,0 +1,238 @@
+//=============================================================================
+//  FilterableTreeView
+//
+//  Copyright (C) 2018 Peter Jonas
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "filterabletreeview.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   FilterableTreeViewTemplate
+//---------------------------------------------------------
+
+template <typename T>
+FilterableTreeViewTemplate<T>::FilterableTreeViewTemplate(QWidget* parent)
+   : T(parent)
+      {
+      FilterableTreeViewTemplate<T>::connect(this, &FilterableTreeViewTemplate<T>::clicked, this, &FilterableTreeViewTemplate<T>::toggleExpanded); // expand categories on click
+      FilterableTreeViewTemplate<T>::connect(this, &FilterableTreeViewTemplate<T>::activated, this, &FilterableTreeViewTemplate<T>::toggleExpanded); // expand categories on Enter
+      }
+
+// to avoid linker errors, we must explicity instantiate constructors for the types we need
+template FilterableTreeViewTemplate<QTreeView>::FilterableTreeViewTemplate(QWidget* parent);
+template FilterableTreeViewTemplate<QTreeWidget>::FilterableTreeViewTemplate(QWidget* parent);
+
+//---------------------------------------------------------
+//   keyPressEvent
+//---------------------------------------------------------
+
+template <typename T>
+void FilterableTreeViewTemplate<T>::keyPressEvent(QKeyEvent* event)
+      {
+      switch(event->key()) {
+            case Qt::Key_Space:
+                  toggleExpanded(FilterableTreeViewTemplate<T>::currentIndex()); // expand categories on Space
+                  break;
+            default:
+                  T::keyPressEvent(event);
+            }
+      }
+
+//---------------------------------------------------------
+//   toggleExpanded
+//    Expand or collapse a category in the tree view
+//---------------------------------------------------------
+
+template <typename T>
+void FilterableTreeViewTemplate<T>::toggleExpanded(const QModelIndex& node)
+      {
+      FilterableTreeViewTemplate<T>::setExpanded(node, !FilterableTreeViewTemplate<T>::isExpanded(node));
+      }
+
+//---------------------------------------------------------
+//   selectFirst
+// Select the first selectable node in the tree. Make sure you have disabled
+// the Qt::ItemIsSelectable flag for any items that shouldn't be selectable.
+// Often you will want leaf nodes to be selectable but not branch nodes.
+//---------------------------------------------------------
+
+template <typename T>
+void FilterableTreeViewTemplate<T>::selectFirst()
+      {
+      const auto lambdaNodeIsSelectable = [](QModelIndex idx) -> bool {
+            return idx.flags() & Qt::ItemIsSelectable;
+            };
+      QModelIndex node = recurse(lambdaNodeIsSelectable);
+      FilterableTreeViewTemplate<T>::setCurrentIndex(node);
+      }
+
+//---------------------------------------------------------
+//   selectNext
+// Select the next selectable node in the tree after the current one.
+//---------------------------------------------------------
+
+template <typename T>
+void FilterableTreeViewTemplate<T>::selectNext()
+      {
+      QModelIndex current = FilterableTreeViewTemplate<T>::currentIndex();
+//      if (!current.isValid())
+//            selectFirst();
+      const auto lambdaNodeIsVisibleSelectable = [this](QModelIndex idx) -> bool {
+            return idx.flags() & Qt::ItemIsSelectable && !FilterableTreeViewTemplate<T>::isIndexHidden(idx);
+            };
+      // try decendents of current index
+      QModelIndex node = recurseUnder(lambdaNodeIsVisibleSelectable, current);
+      if (node.isValid()) {
+            // found a suitable decendant of current index
+            FilterableTreeViewTemplate<T>::setCurrentIndex(node);
+            return;
+            }
+      // otherwise keep looking
+      for (; current.isValid(); current = current.parent()) {
+            for (
+                 QModelIndex youngerSibling = current.sibling(current.row() + 1, 0);
+                 youngerSibling.isValid();
+                 youngerSibling = youngerSibling.sibling(youngerSibling.row() + 1, 0)
+                 ) {
+                  // try sibling and its decendants
+                  node = recurse(lambdaNodeIsVisibleSelectable, youngerSibling);
+                  if (node.isValid()) {
+                        // found a suitable decendant of sibling
+                        FilterableTreeViewTemplate<T>::setCurrentIndex(node);
+                        return;
+                        }
+                  }
+            // otherwise go up a level and check parent's younger siblings
+            }
+      }
+
+//---------------------------------------------------------
+//   selectPrevious
+// Select the previous selectable node in the tree after the current one.
+//---------------------------------------------------------
+
+template <typename T>
+void FilterableTreeViewTemplate<T>::selectPrevious()
+      {
+      QModelIndex current = FilterableTreeViewTemplate<T>::currentIndex();
+//      if (!current.isValid())
+//            selectFirst();
+      const auto lambdaNodeIsVisibleSelectable = [this](QModelIndex idx) -> bool {
+            return idx.flags() & Qt::ItemIsSelectable && !FilterableTreeViewTemplate<T>::isIndexHidden(idx);
+            };
+      while (current.isValid()) {
+            for (
+                 QModelIndex olderSibling = current.sibling(current.row() - 1, 0);
+                 olderSibling.isValid();
+                 olderSibling = olderSibling.sibling(olderSibling.row() - 1, 0)
+                 ) {
+                  // try sibling and its decendants in reverse order
+                  QModelIndex node = recurse(lambdaNodeIsVisibleSelectable, olderSibling, true);
+                  if (node.isValid()) {
+                        // found a suitable decendant of sibling
+                        FilterableTreeViewTemplate<T>::setCurrentIndex(node);
+                        return;
+                        }
+                  }
+            // otherwise check parent (don't check decendants)
+            current = current.parent();
+            if (lambdaNodeIsVisibleSelectable(current)) {
+                  // parent is suitable
+                  FilterableTreeViewTemplate<T>::setCurrentIndex(current);
+                  return;
+                  }
+            // otherwise loop to check parent's older siblings
+            }
+      }
+
+//---------------------------------------------------------
+//   toInitialState
+//    Make all items visible but collapse all categories
+//---------------------------------------------------------
+
+template <typename T>
+void FilterableTreeViewTemplate<T>::toInitialState(const QModelIndex& node)
+      {
+      const auto lambda = [this](QModelIndex idx) -> bool {
+            FilterableTreeViewTemplate<T>::setRowHidden(idx.row(), idx.parent(), false);
+            FilterableTreeViewTemplate<T>::setExpanded(idx, false);
+            return false;
+            };
+      recurse(lambda, node);
+      }
+
+//---------------------------------------------------------
+//   filter
+// Show leaves and branches that match a search string and hide the rest.
+//---------------------------------------------------------
+
+template <typename T>
+bool FilterableTreeViewTemplate<T>::filter(const QString& searchString, const QModelIndex& node)
+      {
+      if (searchString.isEmpty()) {
+            toInitialState();
+            return true;
+            }
+      bool found = false;
+      const auto lambdaShowNode = [this](QModelIndex idx) -> bool {
+            FilterableTreeViewTemplate<T>::setRowHidden(idx.row(), idx.parent(), false);
+            FilterableTreeViewTemplate<T>::setExpanded(idx, false);
+            return false;
+            };
+      QAbstractItemModel* mod = FilterableTreeViewTemplate<T>::model();
+      for (int row = 0; row < mod->rowCount(node); row++) {
+            const QModelIndex child = mod->index(row, 0, node);
+            bool match = child.data().toString().contains(searchString, Qt::CaseInsensitive);
+            if (match)
+                  recurse(lambdaShowNode, child); // branch matches so show all decendants
+            else
+                  match = filter(searchString, child); // check decendants
+            FilterableTreeViewTemplate<T>::setExpanded(child, match);
+            FilterableTreeViewTemplate<T>::setRowHidden(row, node, !match);
+            if (match)
+                  found = true;
+            }
+      return found;
+      }
+
+//---------------------------------------------------------
+//   recurseUnder
+// Apply a callable (e.g. a function or lambda) to all decendants of a node,
+// but not the node itself (use `CategoryTree<T>::recurse` to include the
+// original node). If the callable returns true for any decendant then
+// recursing stops immediately and that decendant's index is returned.
+//
+// If you want to do something to all decendents simply provide a callable
+// expression that always returns false.
+//---------------------------------------------------------
+
+template <typename T>
+template <typename F>
+QModelIndex FilterableTreeViewTemplate<T>::recurseUnder(const F& func, const QModelIndex& node, const bool backwards)
+      {
+      const QAbstractItemModel* mod = FilterableTreeViewTemplate<T>::model();
+      const int start = backwards ? mod->rowCount(node) - 1 : 0;
+      const int step = backwards ? -1 : 1;
+      for (
+           QModelIndex child = mod->index(start, 0, node);
+           child.isValid();
+           child = child.sibling(child.row() + step, 0)
+           ) {
+            if (func(child)) // test the child (call the callable on it)
+                  return child; // callable returned true for child
+            // otherwise test the decendents of child
+            QModelIndex trueNode = recurseUnder(func, child, backwards);
+            if (trueNode.isValid())
+                  return trueNode; // callable returned true for a decendant
+            }
+      // callable returned false for all decendants
+      return QModelIndex(); // return invalid index
+      }
+}

--- a/mscore/widgets/filterabletreeview.h
+++ b/mscore/widgets/filterabletreeview.h
@@ -1,0 +1,69 @@
+//=============================================================================
+//  FilterableTreeView
+//
+//  Copyright (C) 2018 Peter Jonas
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __FILTERABLETREEVIEW_H__
+#define __FILTERABLETREEVIEW_H__
+
+#include "filterableview.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   FilterableTreeViewTemplate
+// We use this class template to create a class called FilterableTreeView
+// that extends QTreeView, and a class called FilterableTreeWidget that
+// extends QTreeWidget. The template allows us to create both at once without
+// encountering inheritance problems or resorting to preprocessor hacks.
+//---------------------------------------------------------
+
+template <typename T>
+class FilterableTreeViewTemplate : public T, public FilterableView
+      {
+
+   private:
+      void toggleExpanded(const QModelIndex& node);
+      template <typename F> inline QModelIndex recurse(const F& func, const bool backwards = false) {
+            return recurseUnder(func, FilterableTreeViewTemplate<T>::rootIndex(), backwards);
+            }
+      template <typename F> inline QModelIndex recurse(const F& func, const QModelIndex& node, const bool backwards = false) {
+            if (node.isValid() && func(node))
+                  return node; // test the node unless it is the root (root is invalid but can have decendants)
+            return recurseUnder(func, node, backwards); // test decendants of node
+            }
+      template <typename F> QModelIndex recurseUnder(const F& func, const QModelIndex& node, const bool backwards = false);
+
+   protected:
+      virtual void keyPressEvent(QKeyEvent* event) override;
+
+   public:
+      FilterableTreeViewTemplate(QWidget* parent = nullptr);
+      virtual void selectFirst() override;
+      virtual void selectNext() override;
+      virtual void selectPrevious() override;
+      inline virtual void toInitialState() override {
+            toInitialState(FilterableTreeViewTemplate<T>::rootIndex());
+            }
+      virtual void toInitialState(const QModelIndex& node);
+      inline virtual bool filter(const QString& searchString) override {
+            return filter(searchString, FilterableTreeViewTemplate<T>::rootIndex());
+            }
+      virtual bool filter(const QString& searchString, const QModelIndex& node);
+      };
+
+// Define aliases to hide scary template syntax
+using FilterableTreeView = FilterableTreeViewTemplate<QTreeView>;
+using FilterableTreeWidget = FilterableTreeViewTemplate<QTreeWidget>;
+
+// Now you can promote QTreeView to FilterableTreeView and QTreeWidget to FilterableTreeWidget
+
+}
+
+#endif // __FILTERABLETREEVIEW_H__

--- a/mscore/widgets/filterableview.h
+++ b/mscore/widgets/filterableview.h
@@ -1,0 +1,38 @@
+//=============================================================================
+//  FilterableView
+//
+//  Copyright (C) 2018 Peter Jonas
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __FILTERABLEVIEW_H__
+#define __FILTERABLEVIEW_H__
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   FilterableView
+// Interface / abstract class to declare some methods that we would like
+// to be able to use with item views. Later we will extend Qt's item view
+// classes (QTreeView, etc.) to implement these virtual methods.
+//---------------------------------------------------------
+
+class FilterableView
+      {
+
+   public:
+      virtual void selectFirst() = 0;
+      virtual void selectNext() = 0;
+      virtual void selectPrevious() = 0;
+      virtual void toInitialState() = 0;
+      virtual void toInitialState(const QModelIndex& node) = 0;
+      virtual bool filter(const QString& searchString) = 0;
+      };
+
+}
+
+#endif // __FILTERABLEVIEW_H__

--- a/mscore/widgets/searchbox.cpp
+++ b/mscore/widgets/searchbox.cpp
@@ -1,0 +1,68 @@
+//=============================================================================
+//  SearchBox
+//
+//  Copyright (C) 2018 Peter Jonas
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "searchbox.h"
+#include "filterableview.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   SearchBox
+//---------------------------------------------------------
+
+SearchBox::SearchBox(QWidget* parent)
+   : QLineEdit(parent)
+      {
+      connect(this, &SearchBox::textChanged, this, &SearchBox::search);
+      }
+
+//---------------------------------------------------------
+//   search
+// Search the connected view.
+//---------------------------------------------------------
+
+void SearchBox::search(const QString& str)
+      {
+      Q_ASSERT(_view);
+      _view->filter(str);
+      }
+
+//---------------------------------------------------------
+//   setFilterableView
+// Hook the searchbox up to the view you want to search.
+//---------------------------------------------------------
+
+void SearchBox::setFilterableView(FilterableView* view)
+      {
+      Q_ASSERT(view);
+      _view = view;
+      }
+
+//---------------------------------------------------------
+//   keyPressEvent
+//---------------------------------------------------------
+
+void SearchBox::keyPressEvent(QKeyEvent* event)
+      {
+      Q_ASSERT(_view);
+      switch(event->key()) {
+            case Qt::Key_Up:
+                  _view->selectPrevious();
+                  break;
+            case Qt::Key_Down:
+                  _view->selectNext();
+                  break;
+            default:
+                  QLineEdit::keyPressEvent(event);
+            }
+      }
+
+}

--- a/mscore/widgets/searchbox.h
+++ b/mscore/widgets/searchbox.h
@@ -1,0 +1,41 @@
+//=============================================================================
+//  SearchBox
+//
+//  Copyright (C) 2018 Peter Jonas
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __SEARCHBOX_H__
+#define __SEARCHBOX_H__
+
+namespace Ms {
+
+class FilterableView;
+
+//---------------------------------------------------------
+//   SearchBox
+// Extends QLineEdit to provide methods to search an item view.
+//---------------------------------------------------------
+
+class SearchBox : public QLineEdit
+      {
+      Q_OBJECT
+
+      FilterableView* _view = nullptr;
+
+   protected:
+      virtual void keyPressEvent(QKeyEvent* event) override;
+
+   public:
+      SearchBox(QWidget* parent = nullptr);
+      void setFilterableView(FilterableView* view);
+      void search(const QString& str);
+      };
+
+}
+
+#endif // __SEARCHBOX_H__


### PR DESCRIPTION
This makes the New Score Wizard fully accessible to screen readers keyboard controls, for the benefit of users who are blind, partially sighted, motor impaired, or otherwise prefer to use the keyboard rather than the mouse.

None of the changes affect sighted mouse users, except the new appearance of the template chooser as a Tree View (pictured below), and the recent scores widget in the start centre (which also renders scores using the same ScoreBrowser widget as the template chooser).

![image](https://user-images.githubusercontent.com/11011881/48917261-cc41ff00-ee7d-11e8-95d9-4b3bc020d1a8.png)

The Tree View is necessary in the New Score Wizard to allow keyboard users to explore the template categories. The downside is that sighted users now need to click on a template to see the preview, but this is a minor inconvenience, especially considering that all templates just show an empty score (albeit with a different number of staves). More information could be displayed on each row of the Tree View, such as the number of instruments in the score.

The Tree View is not necessary for the Start Center, so I could return the Start Center to using a Grid View if required. The reason I have not yet done this is that grids do not make sense to blind users, since they could be forever searching for their score in a single row/column without realising that other rows/columns are available, though there are ways around this issue. Alternatively, it is possible to display icon thumbnails in the TreeView itself.

I would appreciate if if @MarcSabatella could take a look at this. (Hopefully you can just download the AppVeyor build.)

This PR reimplements all features from #3425 that are related to the New Score Wizard (but no other features).