### PR TITLE
Fix an infinite loop on barline span handling on 2.X import

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3725,7 +3725,7 @@ Score::FileError MasterScore::read206(XmlReader& e)
                   if (!b)
                         continue;
                   int sp = b->spanStaff();
-                  if (sp == 0)
+                  if (sp <= 0)
                         continue;
                   for (int span = 1; span <= sp; ++span) {
                         BarLine* nb = toBarLine(s->element((staffIdx + span) * VOICES));
@@ -3742,7 +3742,7 @@ Score::FileError MasterScore::read206(XmlReader& e)
       for (int staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
             Staff* s = staff(staffIdx);
             int sp = s->barLineSpan();
-            if (sp == 0)
+            if (sp <= 0)
                   continue;
             for (int span = 1; span <= sp; ++span) {
                   Staff* ns = staff(staffIdx + span);


### PR DESCRIPTION
This PR fixes the problem with hanging on importing the score from [this issue](https://musescore.org/en/node/56526). The issue itself is apparently not about that hanging so I am not adding any `fix...` prefixes to this PR and commit message.