### PR TITLE
fix #121431: fit hairpins between adjacent dynamics

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -88,7 +88,33 @@ Element* HairpinSegment::drop(EditData& data)
 
 void HairpinSegment::layout()
       {
-      qreal _spatium   = spatium();
+      const qreal _spatium = spatium();
+      const int _track = track();
+      if (autoplace() && !score()->isPalette()) {
+            // Try to fit between adjacent dynamics
+            if (isSingleType() || isBeginType()) {
+                  Segment* start = hairpin()->startSegment();
+                  Dynamic* sd = start ? toDynamic(start->findAnnotation(ElementType::DYNAMIC, _track, _track)) : nullptr;
+                  if (sd) {
+                        const qreal sdRight = sd->bbox().right() + sd->pos().x()
+                                              + sd->segment()->pos().x() + sd->measure()->pos().x();
+                        const qreal dist    = sdRight - pos().x() + score()->styleP(Sid::autoplaceHairpinDynamicsDistance);
+                        rxpos()  += dist;
+                        rxpos2() -= dist;
+                        }
+                  }
+            if (isSingleType() || isEndType()) {
+                  Segment* end = hairpin()->endSegment();
+                  Dynamic* ed = end ? toDynamic(end->findAnnotation(ElementType::DYNAMIC, _track, _track)) : nullptr;
+                  if (ed) {
+                        const qreal edLeft  = ed->bbox().left() + ed->pos().x()
+                                              + ed->segment()->pos().x() + ed->measure()->pos().x();
+                        const qreal dist    = edLeft - pos2().x() - pos().x() - score()->styleP(Sid::autoplaceHairpinDynamicsDistance);
+                        rxpos2() += dist;
+                        }
+                  }
+            }
+
       HairpinType type = hairpin()->hairpinType();
       if (type == HairpinType::DECRESC_LINE || type == HairpinType::CRESC_LINE) {
             twoLines = false;

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -315,16 +315,8 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                               int tick = e.tick();
                               Measure* m = tick2measure(tick);
                               Segment* seg = m->undoGetSegment(SegmentType::ChordRest, tick);
-                              if (seg->findAnnotationOrElement(ElementType::HARMONY, e.track(), e.track())) {
-                                    QList<Element*> elements;
-                                    foreach (Element* el, seg->annotations()) {
-                                          if (el->isHarmony() && el->track() == e.track()) {
-                                                elements.append(el);
-                                                }
-                                          }
-                                    foreach (Element* el, elements)
-                                          undoRemoveElement(el);
-                                    }
+                              for (Element* el : seg->findAnnotations(ElementType::HARMONY, e.track(), e.track()))
+                                    undoRemoveElement(el);
                               harmony->setParent(seg);
                               undoAddElement(harmony);
                               }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -440,6 +440,7 @@ class Score : public QObject, public ScoreElement {
                                                 ///< save a backup file will be created, subsequent
                                                 ///< saves will not overwrite the backup file.
       bool _defaultsRead        { false };      ///< defaults were read at MusicXML import, allow export of defaults in convertermode
+      bool _isPalette           { false };
 
       int _pos[3];                    ///< 0 - current, 1 - left loop, 2 - right loop
 
@@ -904,6 +905,9 @@ class Score : public QObject, public ScoreElement {
       bool defaultsRead() const                      { return _defaultsRead;    }
       void setDefaultsRead(bool b)                   { _defaultsRead = b;       }
       Text* getText(Tid subtype);
+
+      bool isPalette() const { return _isPalette; }
+      void setPaletteMode(bool palette) { _isPalette = palette; }
 
       void lassoSelect(const QRectF&);
       void lassoSelectEnd();

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -940,11 +940,11 @@ bool Segment::operator>(const Segment& s) const
       }
 
 //---------------------------------------------------------
-//   findAnnotationOrElement
+//   hasAnnotationOrElement
 ///  return true if an annotation of type type or and element is found in the track range
 //---------------------------------------------------------
 
-bool Segment::findAnnotationOrElement(ElementType type, int minTrack, int maxTrack)
+bool Segment::hasAnnotationOrElement(ElementType type, int minTrack, int maxTrack) const
       {
       for (const Element* e : _annotations)
             if (e->type() == type && e->track() >= minTrack && e->track() <= maxTrack)
@@ -957,15 +957,31 @@ bool Segment::findAnnotationOrElement(ElementType type, int minTrack, int maxTra
 
 //---------------------------------------------------------
 //   findAnnotation
-///  return true if an annotation of type type
+///  Returns the first found annotation of type type
+///  or nullptr if nothing was found.
 //---------------------------------------------------------
 
-bool Segment::findAnnotation(ElementType type, int minTrack, int maxTrack)
+Element* Segment::findAnnotation(ElementType type, int minTrack, int maxTrack)
       {
-      for (const Element* e : _annotations)
+      for (Element* e : _annotations)
             if (e->type() == type && e->track() >= minTrack && e->track() <= maxTrack)
-                  return true;
-      return false;
+                  return e;
+      return nullptr;
+      }
+
+//---------------------------------------------------------
+//   findAnnotations
+///  Returns the list of found annotations
+///  or nullptr if nothing was found.
+//---------------------------------------------------------
+
+std::vector<Element*> Segment::findAnnotations(ElementType type, int minTrack, int maxTrack)
+      {
+      std::vector<Element*> found;
+      for (Element* e : _annotations)
+            if (e->type() == type && e->track() >= minTrack && e->track() <= maxTrack)
+                  found.push_back(e);
+      return found;
       }
 
 //---------------------------------------------------------

--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -198,8 +198,9 @@ class Segment final : public Element {
       const std::vector<Element*>& annotations() const { return _annotations;        }
       void clearAnnotations();
       void removeAnnotation(Element* e);
-      bool findAnnotationOrElement(ElementType type, int minTrack, int maxTrack);
-      bool findAnnotation(ElementType type, int minTrack, int maxTrack);
+      bool hasAnnotationOrElement(ElementType type, int minTrack, int maxTrack) const;
+      Element* findAnnotation(ElementType type, int minTrack, int maxTrack);
+      std::vector<Element*> findAnnotations(ElementType type, int minTrack, int maxTrack);
 
 
       qreal dotPosX(int staffIdx) const          { return _dotPosX[staffIdx];  }

--- a/mscore/editfiguredbass.cpp
+++ b/mscore/editfiguredbass.cpp
@@ -85,7 +85,7 @@ void ScoreView::figuredBassTab(bool bMeas, bool bBack)
             int maxTrack = minTrack + (VOICES-1);
 
             while (nextSegm) {                   // look for a ChordRest in the compatible track range
-                  if(nextSegm->findAnnotationOrElement(ElementType::FIGURED_BASS, minTrack, maxTrack))
+                  if(nextSegm->hasAnnotationOrElement(ElementType::FIGURED_BASS, minTrack, maxTrack))
                         break;
                   nextSegm = bBack ? nextSegm->prev1(SegmentType::ChordRest) : nextSegm->next1(SegmentType::ChordRest);
                   }

--- a/mscore/editharmony.cpp
+++ b/mscore/editharmony.cpp
@@ -154,7 +154,7 @@ void ScoreView::harmonyBeatsTab(bool noterest, bool back)
             if (noterest) {
                   int minTrack = (track / VOICES ) * VOICES;
                   int maxTrack = minTrack + (VOICES-1);
-                  if (segment->findAnnotationOrElement(ElementType::HARMONY, minTrack, maxTrack))
+                  if (segment->hasAnnotationOrElement(ElementType::HARMONY, minTrack, maxTrack))
                         break;
                   }
             }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7106,6 +7106,7 @@ int main(int argc, char* av[])
       mscore = new MuseScore();
       // create a score for internal use
       gscore = new MasterScore();
+      gscore->setPaletteMode(true);
       gscore->setMovements(new Movements());
       gscore->setStyle(MScore::baseStyle());
 


### PR DESCRIPTION
Adjusts horizontal dimensions of hairpins to fit between adjacent
dynamics, if any exist. No vertical aligning included, as it is
already available in the form of begin/end text for hairpins.
Still for some common cases the logic added by this commit is
good enough.

Dimensions calculation code is taken (with some adjustments) from
8bdd1af0bef02353f46df53107a4472bfb04f98a

Also includes:
 - Rename/update Segment::findAnnotation[orElement]
 - Add Score::isPalette() to make it easier to distinguish between
   palette and normal scores on layout stage.