### PR TITLE
fix #277995: use tempoPosAbove/Below instead of tempoOffset in styles

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -713,7 +713,6 @@ static const StyleType styleTypes[] {
       { Sid::tempoFontItalic,               "tempoFontItalic",              false },
       { Sid::tempoFontUnderline,            "tempoFontUnderline",           false },
       { Sid::tempoAlign,                    "tempoAlign",                   QVariant::fromValue(Align::LEFT | Align::BASELINE) },
-      { Sid::tempoOffset,                   "tempoOffset",                  QPointF(0.0, 0.0) },
       { Sid::tempoSystemFlag,               "tempoSystemFlag",              true },
       { Sid::tempoPlacement,                "tempoPlacement",               int(Placement::ABOVE)  },
       { Sid::tempoPosAbove,                 "tempoPosAbove",                QPointF(.0, -2.0) },
@@ -1382,7 +1381,7 @@ const TextStyle tempoTextStyle {{
       { Sid::tempoFontItalic,                    Pid::FONT_ITALIC            },
       { Sid::tempoFontUnderline,                 Pid::FONT_UNDERLINE         },
       { Sid::tempoAlign,                         Pid::ALIGN                  },
-      { Sid::tempoOffset,                        Pid::OFFSET                 },
+      { Sid::tempoPosAbove,                      Pid::OFFSET                 },
       { Sid::tempoFrameType,                     Pid::FRAME_TYPE             },
       { Sid::tempoFramePadding,                  Pid::FRAME_PADDING          },
       { Sid::tempoFrameWidth,                    Pid::FRAME_WIDTH            },
@@ -2227,6 +2226,29 @@ bool MStyle::readProperties(XmlReader& e)
                         }
                   return true;
                   }
+            }
+      if (readStyleValCompat(e))
+            return true;
+      return false;
+      }
+
+//---------------------------------------------------------
+//   readStyleValCompat
+//    Read obsolete style values which may appear in files
+//    produced by older versions of MuseScore.
+//---------------------------------------------------------
+
+bool MStyle::readStyleValCompat(XmlReader& e)
+      {
+      const QStringRef tag(e.name());
+      if (tag == "tempoOffset") { // pre-3.0-beta
+            const qreal x = e.doubleAttribute("x", 0.0);
+            const qreal y = e.doubleAttribute("y", 0.0);
+            const QPointF val(x, y);
+            set(Sid::tempoPosAbove, val);
+            set(Sid::tempoPosBelow, val);
+            e.readElementText();
+            return true;
             }
       return false;
       }

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -695,7 +695,6 @@ enum class Sid {
       tempoFontItalic,
       tempoFontUnderline,
       tempoAlign,
-      tempoOffset,
       tempoSystemFlag,
       tempoPlacement,
       tempoPosAbove,
@@ -1166,6 +1165,7 @@ class MStyle {
       void load(XmlReader& e);
       void save(XmlWriter& xml, bool optimize);
       bool readProperties(XmlReader&);
+      bool readStyleValCompat(XmlReader&);
 
       void reset(Score*);
 

--- a/libmscore/tempotext.cpp
+++ b/libmscore/tempotext.cpp
@@ -473,5 +473,16 @@ QString TempoText::accessibleInfo() const
             return TextBase::accessibleInfo();
       }
 
+//---------------------------------------------------------
+//   getPropertyStyle
+//---------------------------------------------------------
+
+Sid TempoText::getPropertyStyle(Pid pid) const
+      {
+      if (pid == Pid::OFFSET)
+            return placeAbove() ? Sid::tempoPosAbove : Sid::tempoPosBelow;
+      return TextBase::getPropertyStyle(pid);
+      }
+
 }
 

--- a/libmscore/tempotext.h
+++ b/libmscore/tempotext.h
@@ -68,6 +68,7 @@ class TempoText final : public TextBase  {
       QVariant getProperty(Pid propertyId) const override;
       bool setProperty(Pid propertyId, const QVariant&) override;
       QVariant propertyDefault(Pid id) const override;
+      Sid getPropertyStyle(Pid) const override;
       virtual QString accessibleInfo() const override;
       };
 


### PR DESCRIPTION
See https://musescore.org/en/node/277995 and @MarcSabatella's comments in that issue.