### PR TITLE
fix #277572: Stem length change is not undoable

### DIFF
--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -332,8 +332,9 @@ void Arpeggio::startEdit(EditData& ed)
       Element::startEdit(ed);
       ed.grips   = 2;
       ed.curGrip = Grip::END;
-      undoPushProperty(Pid::ARP_USER_LEN1);
-      undoPushProperty(Pid::ARP_USER_LEN2);
+      ElementEditData* eed = ed.getData(this);
+      eed->pushProperty(Pid::ARP_USER_LEN1);
+      eed->pushProperty(Pid::ARP_USER_LEN2);
       }
 
 //---------------------------------------------------------

--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -268,7 +268,8 @@ void Stem::startEdit(EditData& ed)
       Element::startEdit(ed);
       ed.grips   = 1;
       ed.curGrip = Grip::START;
-      undoPushProperty(Pid::USER_LEN);
+      ElementEditData* eed = ed.getData(this);
+      eed->pushProperty(Pid::USER_LEN);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/277572.