### PR TITLE
fix#278076 no audio after removal of instrument

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1387,7 +1387,6 @@ void Score::addElement(Element* element)
                   ic->part()->setInstrument(ic->instrument(), tickStart);
                   transpositionChanged(ic->part(), oldV, tickStart, tickEnd);
 #endif
-                  masterScore()->rebuildMidiMapping();
                   cmdState()._instrumentsChanged = true;
                   }
                   break;
@@ -1553,7 +1552,6 @@ void Score::removeElement(Element* element)
                   ic->part()->removeInstrument(tickStart);
                   transpositionChanged(ic->part(), oldV, tickStart, tickEnd);
 #endif
-                  masterScore()->rebuildMidiMapping();
                   cmdState()._instrumentsChanged = true;
                   }
                   break;
@@ -2130,7 +2128,6 @@ void Score::splitStaff(int staffIdx, int splitPoint)
 
       undoChangeKeySig(ns, 0, st->keySigEvent(0));
 
-      masterScore()->rebuildMidiMapping();
       cmdState()._instrumentsChanged = true;
       doLayout();
 
@@ -2265,6 +2262,7 @@ void Score::cmdRemovePart(Part* part)
             cmdRemoveStaff(sidx);
 
       undoRemovePart(part, sidx);
+      masterScore()->setInstrumentsChanged(true);
       }
 
 //---------------------------------------------------------
@@ -2282,6 +2280,7 @@ void Score::insertPart(Part* part, int idx)
             staff += (*i)->nstaves();
             }
       _parts.push_back(part);
+      masterScore()->setInstrumentsChanged(true);
       }
 
 //---------------------------------------------------------
@@ -3507,7 +3506,6 @@ void Score::appendPart(const QString& name)
       part->staves()->front()->setBarLineSpan(part->nstaves());
       undoInsertPart(part, n);
       fixTicks();
-      masterScore()->rebuildMidiMapping();
       }
 
 //---------------------------------------------------------

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1368,7 +1368,7 @@ void ChangeStaff::flip(EditData*)
                   m->staffLines(staffIdx)->setVisible(!staff->invisible());
             }
       staff->score()->setLayoutAll();
-      staff->masterScore()->rebuildMidiMapping();
+      staff->score()->setInstrumentsChanged(true);
       staff->score()->setPlaylistDirty();
       }
 
@@ -1411,7 +1411,6 @@ void ChangePart::flip(EditData*)
       part->setPartName(partName);
 
       Score* score = part->score();
-      score->masterScore()->rebuildMidiMapping();
       score->setInstrumentsChanged(true);
       score->setPlaylistDirty();
 
@@ -1818,7 +1817,6 @@ void ChangeInstrument::flip(EditData*)
       part->setInstrument(instrument, tickStart);
 
       // update score
-      is->masterScore()->rebuildMidiMapping();
       is->masterScore()->updateChannel();
       is->score()->setInstrumentsChanged(true);
       is->score()->setLayoutAll();

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -758,6 +758,7 @@ MasterScore* MuseScore::getNewFile()
       if (!copyright.isEmpty())
             score->setMetaTag("copyright", copyright);
 
+      // TODO: Can we exclude this for the thumbnail loading on startup?
       score->rebuildMidiMapping();
 
       {

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -519,10 +519,9 @@ void MuseScore::editInstrList()
                         }
                   }
             }
-
       masterScore->setLayoutAll();
+      masterScore->setInstrumentsChanged(true);
       masterScore->endCmd();
-      masterScore->rebuildMidiMapping();
       seq->initInstruments();
       }
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5519,6 +5519,7 @@ void MuseScore::endCmd()
                   if (!noSeq && (seq && seq->isRunning()))
                         seq->initInstruments();
                   instrumentChanged();                // update mixer
+                  ms->rebuildMidiMapping();
                   ms->setInstrumentsChanged(false);
                   }
             if (cs->selectionChanged()) {


### PR DESCRIPTION
This PR refers to [Issue 278076](https://musescore.org/en/node/278076). I noticed that this is a bigger issue because the instrument showed up in the mixer after undoing the removal but on loading the details it crashed. 
The fix itself was to add `rebuildMidiMapping()` to the `endCmd` cleanup if an instrument was changed. Due to multiple calls I made small changes on when `rebuildMidiMapping()` is called:
**Before**: Always call in function that causes need of rebuild.
**Now**: These functions trigger that action by setting `setInstrumentsChanged(true)`.
This change is needed because if rebuildMidiMapping() is added directly to the undo Method (`RemovePart::undo`) it causes multiple unnecessary rebuilds if multiple parts are deleted at once.
So the remaining rebuild calls are replaced by triggering the `endCmd()`.