### PR TITLE
fix #278379: right-click staff menu not accessible on single line staff

### DIFF
--- a/libmscore/stafflines.cpp
+++ b/libmscore/stafflines.cpp
@@ -111,6 +111,11 @@ void StaffLines::layoutForWidth(qreal w)
       qreal y  = pos().y();
       bbox().setRect(x1, -lw * .5 + y, w, (_lines-1) * dist + lw);
 
+      if (_lines == 1) {
+            qreal extraSize = _spatium;
+            bbox().adjust(0, -extraSize, 0, extraSize);
+      }
+
       lines.clear();
       for (int i = 0; i < _lines; ++i) {
             lines.push_back(QLineF(x1, y, x2, y));


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/278379

by adding a spatium above and below to the bbox of a single line staff.