### PR TITLE
Fix #278528: Crash on saving a workspace if Palettes search field is …

### DIFF
--- a/mscore/workspacedialog.cpp
+++ b/mscore/workspacedialog.cpp
@@ -71,6 +71,7 @@ WorkspaceDialog::WorkspaceDialog(QWidget* parent)
 
 void WorkspaceDialog::display()
       {
+      mscore->getPaletteBox()->searchBox()->clear();
       if (editMode) {
             componentsCheck->setChecked(Workspace::currentWorkspace->getSaveComponents());
             toolbarsCheck->setChecked(Workspace::currentWorkspace->getSaveToolbars());


### PR DESCRIPTION
…not empty

This change clears the search field when the user clicks the "+" for a new workspace.