### PR TITLE
fix #278166: chord symbols don't have above/below like other text types

### DIFF
--- a/mscore/inspector/inspectorHarmony.cpp
+++ b/mscore/inspector/inspectorHarmony.cpp
@@ -28,7 +28,8 @@ InspectorHarmony::InspectorHarmony(QWidget* parent)
       h.setupUi(addWidget());
 
       const std::vector<InspectorItem> iiList = {
-            { Pid::SUB_STYLE, 0, h.style, h.resetStyle       },
+            { Pid::SUB_STYLE, 0, h.style,       h.resetStyle      },
+            { Pid::PLACEMENT, 0, h.placement,   h.resetPlacement  }
             };
 
       const std::vector<InspectorPanel> ppList = {

--- a/mscore/inspector/inspector_harmony.ui
+++ b/mscore/inspector/inspector_harmony.ui
@@ -99,6 +99,50 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Placement:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>placement</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="placement">
+        <property name="accessibleName">
+         <string>Placement</string>
+        </property>
+        <item>
+         <property name="text">
+          <string notr="true">Above</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">Below</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QToolButton" name="resetPlacement">
+        <property name="toolTip">
+         <string>Reset to default</string>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Placement' value</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../musescore.qrc">
+          <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/278166