### PR TITLE
fix #278355: do not select an incorrect range on delayed selection

### DIFF
--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -461,6 +461,11 @@ void Selection::updateSelectedElements()
                                       // are needed to prevent bug #173381.
                                       // This should exclude any segments belonging
                                       // to MM-rest range from the selection.
+            if (s1 && s2 && s1->tick() + s1->ticks() > s2->tick()) {
+                  // can happen with MM rests as tick2measure returns only
+                  // the first segment for them.
+                  return;
+                  }
             setRange(s1, s2, staffStart, staffEnd);
             _plannedTick1 = -1;
             _plannedTick2 = -1;


### PR DESCRIPTION
Fixes https://musescore.org/en/node/278355.
This adds a check on segments range validity when performing a delayed selection introduced in #4133 and does not perform a selection if the resulting range is invalid. It may be better to select to handle MM rest paste operations so that the selection is actually made on the resulting MM rest but the behavior of MuseScore 2.X was like the one introduced by this commit. Maybe it could be changed in the future but to fix the crash this solution is sufficient.