### PR TITLE
Fix #278516: Welcome tour appears alongside with file open dialog if …

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -76,6 +76,7 @@
 #include "scorePreview.h"
 #include "scorecmp/scorecmp.h"
 #include "extension.h"
+#include "tourhandler.h"
 
 #ifdef OMR
 #include "omr/omr.h"
@@ -297,6 +298,7 @@ void MuseScore::loadFiles(bool switchTab, bool singleFile)
          );
       for (const QString& s : files)
             openScore(s, switchTab);
+      mscore->tourHandler()->showDelayedWelcomeTour();
       }
 
 //---------------------------------------------------------
@@ -787,6 +789,7 @@ void MuseScore::newFile()
       MasterScore* score = getNewFile();
       if (score)
             setCurrentScoreView(appendScore(score));
+      mscore->tourHandler()->showDelayedWelcomeTour();
       }
 
 //---------------------------------------------------------

--- a/mscore/startcenter.cpp
+++ b/mscore/startcenter.cpp
@@ -109,6 +109,7 @@ void Startcenter::loadScore(QString s)
 
 void Startcenter::newScore()
       {
+      mscore->tourHandler()->delayWelcomeTour();
       close();
       getAction("file-new")->trigger();
       }
@@ -142,6 +143,7 @@ void Startcenter::updateRecentScores()
 
 void Startcenter::openScoreClicked()
       {
+      mscore->tourHandler()->delayWelcomeTour();
       close();
       getAction("file-open")->trigger();
       }

--- a/mscore/tourhandler.cpp
+++ b/mscore/tourhandler.cpp
@@ -95,7 +95,21 @@ void OverlayWidget::paintEvent(QPaintEvent *)
 
 void TourHandler::showWelcomeTour()
       {
-      startTour("welcome");
+      if (!delayedWelcomeTour)
+            startTour("welcome");
+      }
+
+//---------------------------------------------------------
+//   showDelayedWelcomeTour
+//   delays showing the welcome tour when the user
+//   attempts to open a score or create a new score
+//---------------------------------------------------------
+
+void TourHandler::showDelayedWelcomeTour()
+      {
+      if (delayedWelcomeTour)
+            startTour("welcome");
+      delayedWelcomeTour = false;
       }
 
 //---------------------------------------------------------

--- a/mscore/tourhandler.h
+++ b/mscore/tourhandler.h
@@ -81,6 +81,8 @@ class TourHandler : public QObject
       static QMap<QString, QMap<QString, QString>*> eventNameLookup;
       static QList<QWidget*> getWidgetsByNames(Tour* tour, QList<QString> names);
 
+      bool delayedWelcomeTour = false;
+
 public slots:
       void showWelcomeTour();
 
@@ -99,6 +101,9 @@ public:
       static void clearWidgetsFromTour(QString tourName);
 
       static QList<QString> allTourShortcuts() { return shortcutToTour.keys(); }
+
+      void delayWelcomeTour() { delayedWelcomeTour = true; }
+      void showDelayedWelcomeTour();
       };
 
 }


### PR DESCRIPTION
…"Open score" is chosen in Start Center

Welcome tour delayed by opening a score or creating a new score from the start center.