### PR TITLE
fix #85876: Breath marks for voices > 1

### DIFF
--- a/libmscore/breath.cpp
+++ b/libmscore/breath.cpp
@@ -65,12 +65,13 @@ void Breath::layout()
       {
       bool palette = (track() == -1);
       if (!palette) {
+            int voiceOffset = placeBelow() * (staff()->lines(tick()) - 1) * spatium();
             if (isCaesura())
-                  setPos(rxpos(), spatium());
+                  setPos(rxpos(), spatium() + voiceOffset);
             else if ((score()->styleSt(Sid::MusicalSymbolFont) == "Emmentaler") && (symId() == SymId::breathMarkComma))
-                  setPos(rxpos(), 0.5 * spatium());
+                  setPos(rxpos(), 0.5 * spatium() + voiceOffset);
             else
-                  setPos(rxpos(), -0.5 * spatium());
+                  setPos(rxpos(), -0.5 * spatium() + voiceOffset);
             }
       setbbox(symBbox(_symId));
       }
@@ -181,7 +182,6 @@ bool Breath::setProperty(Pid propertyId, const QVariant& v)
             case Pid::SYMBOL:
                   setSymId(v.value<SymId>());
                   break;
-
             case Pid::PAUSE:
                   setPause(v.toDouble());
                   break;
@@ -204,6 +204,8 @@ QVariant Breath::propertyDefault(Pid id) const
       switch(id) {
             case Pid::PAUSE:
                   return 0.0;
+            case Pid::PLACEMENT:
+                  return track() & 1 ? int(Placement::BELOW) : int(Placement::ABOVE);
             default:
                   return Element::propertyDefault(id);
             }

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -414,17 +414,12 @@ Element* ChordRest::drop(EditData& data)
                   {
                   Breath* b = toBreath(e);
                   b->setPos(QPointF());
-                  int track = staffIdx() * VOICES;
-                  b->setTrack(track);
+                  // allow breath marks in voice > 1
+                  b->setTrack(this->track());
+                  b->setPlacement(b->track() & 1 ? Placement::BELOW : Placement::ABOVE);
+                  Fraction bt = tick() + actualTicks();    
 
-                  // find start tick of next note in staff
-#if 0
-                  int bt = tick() + actualTicks();    // this could make sense if we allowed breath marks in voice > 1
-#else
-                  Segment* next = segment()->nextCR(track);
-                  Fraction bt = next ? next->tick() : score()->lastSegment()->tick();
-#endif
-
+                  bt = tick() + actualTicks();
                   // TODO: insert automatically in all staves?
 
                   Segment* seg = m->undoGetSegment(SegmentType::Breath, bt);

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2169,6 +2169,7 @@ void Measure::readVoice(XmlReader& e, int staffIdx, bool irregular)
             else if (tag == "Breath") {
                   Breath* breath = new Breath(score());
                   breath->setTrack(e.track());
+                  breath->setPlacement(breath->track() & 1 ? Placement::BELOW : Placement::ABOVE);
                   breath->read(e);
                   segment = getSegment(SegmentType::Breath, e.tick());
                   segment->add(breath);

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1699,6 +1699,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   Breath* breath = new Breath(m->score());
                   breath->setTrack(e.track());
                   Fraction tick = e.tick();
+                  breath->setPlacement(breath->track() & 1 ? Placement::BELOW : Placement::ABOVE);
                   breath->read(e);
                   // older scores placed the breath segment right after the chord to which it applies
                   // rather than before the next chordrest segment with an element for the staff

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2991,6 +2991,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             else if (tag == "Breath") {
                   Breath* breath = new Breath(score);
                   breath->setTrack(e.track());
+                  breath->setPlacement(Placement::ABOVE);
                   Fraction tick = e.tick();
                   breath->read(e);
                   // older scores placed the breath segment right after the chord to which it applies

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -1321,9 +1321,11 @@ InspectorCaesura::InspectorCaesura(QWidget* parent)
             c.title->setText(b->isCaesura() ? tr("Caesura") : tr("Breath"));
 
       const std::vector<InspectorItem> iiList = {
-            { Pid::PAUSE,  0, c.pause, c.resetPause         }
+            { Pid::PAUSE    ,  0, c.pause,         c.resetPause         },
+            { Pid::PLACEMENT,  0, c.placement,     c.resetPlacement     }
             };
       const std::vector<InspectorPanel> ppList = { {c.title, c.panel} };
+      populatePlacement(c.placement);
       mapSignals(iiList, ppList);
       }
 

--- a/mscore/inspector/inspector_caesura.ui
+++ b/mscore/inspector/inspector_caesura.ui
@@ -127,7 +127,59 @@
         </property>
        </widget>
       </item>
-     </layout>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelPlacement">
+        <property name="text">
+         <string>Placement:</string>
+        </property>
+        <property name="buddy">
+         <cstring>placement</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="placement">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>1</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="accessibleName">
+         <string>Placement</string>
+        </property>
+        <item>
+         <property name="text">
+          <string notr="true">Above</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">Below</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="Ms::ResetButton" name="resetPlacement" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Placement' value</string>
+        </property>
+       </widget>
+      </item>
+   </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
With this pull request breath marks can be assigned to voices > 1. 

When a breath mark is dropped on a note the breath mark gets assigned to the voice of the note. The horizontal position is set to the end of this note. 

Layouting a breath mark adapts it's vertical position according to it's voice. Breath mark of voices 1 and 3 are set to top staff line as before. Breath marks for voices 2 and 4 are moved down to the bottom line of the staff.