### PR TITLE
fix #278814: remove references to the system being destroyed

### DIFF
--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -73,6 +73,10 @@ System::~System()
       {
       for (SpannerSegment* ss : spannerSegments())
             ss->setParent(0);
+      for (MeasureBase* mb : measures()) {
+            if (mb->system() == this)
+                  mb->setSystem(nullptr);
+            }
       qDeleteAll(_staves);
       qDeleteAll(_brackets);
       delete _systemDividerLeft;


### PR DESCRIPTION
Fixes https://musescore.org/en/node/278814.
Adds a code to the `System` class destructor that removes references to the deleted system in its measures list. This helps to avoid dereferencing such invalid pointers to the deleted system.