### PR TITLE
fix #277721: fix layout of lyrics lines in continuous view

### DIFF
--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -334,11 +334,6 @@ void LayoutContext::layoutLinear()
                   for (SpannerSegment* ss : voltaSegments)
                         ss->ryoffset() = y;
                   }
-            for (Spanner* sp : score->unmanagedSpanners()) {
-                  if (sp->tick() >= etick || sp->tick2() < stick)
-                        continue;
-                  sp->layout();
-                  }
             }
 
       //
@@ -405,6 +400,12 @@ void LayoutContext::layoutLinear()
             }
 
       score->layoutLyrics(system);
+
+      for (Spanner* sp : score->unmanagedSpanners()) {
+            if (sp->tick() >= etick || sp->tick2() <= stick)
+                  continue;
+            sp->layoutSystem(system);
+            }
 
       system->layout2();   // compute staff distances
 


### PR DESCRIPTION
See https://musescore.org/en/node/277721.
This fix just makes lyrics line layout code in continuous view match that for a page view.