### PR TITLE
fix #278752: Add tied note by keyboard fails when notes are already present

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1134,7 +1134,7 @@ void Score::regroupNotesAndRests(int startTick, int endTick, int track)
 //   cmdAddTie
 //---------------------------------------------------------
 
-void Score::cmdAddTie()
+void Score::cmdAddTie(bool addToChord)
       {
       std::vector<Note*> noteList;
       Element* el = selection().element();
@@ -1189,7 +1189,7 @@ void Score::cmdAddTie()
 
                   // try to re-use existing note or chord
                   Note* n = nullptr;
-                  if (cr->isChord()) {
+                  if (addToChord && cr->isChord()) {
                         Chord* chord = toChord(cr);
                         Note* nn = chord->findNote(note->pitch());
                         if (nn && nn->tpc() == note->tpc())

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -583,7 +583,7 @@ class Score : public QObject, public ScoreElement {
       void getNextMeasure(LayoutContext&);      // get next measure for layout
 
       void cmdRemovePart(Part*);
-      void cmdAddTie();
+      void cmdAddTie(bool addToChord = false);
       void cmdAddOttava(OttavaType);
       void cmdAddStretch(qreal);
       void cmdResetNoteAndRestGroupings();

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -161,6 +161,10 @@
     <seq>Shift+G</seq>
     </SC>
   <SC>
+    <key>chord-tie</key>
+    <seq>Alt++</seq>
+    </SC>
+  <SC>
     <key>insert-a</key>
     <seq>Ctrl+Shift+A</seq>
     </SC>

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2066,6 +2066,10 @@ void ScoreView::cmd(const char* s)
             _score->cmdAddTie();
             moveCursor();
             }
+      else if (cmd == "chord-tie") {
+            _score->cmdAddTie(true);
+            moveCursor();
+            }
       else if (cmd == "duplet")
             cmdTuplet(2);
       else if (cmd == "triplet")

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -538,6 +538,13 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY_STAFF_PITCHED | STATE_NOTE_ENTRY_STAFF_DRUM,
+         "chord-tie",
+         QT_TRANSLATE_NOOP("action","Add Tied Note to Chord"),
+         QT_TRANSLATE_NOOP("action","Add tied note to chord")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY_STAFF_PITCHED | STATE_NOTE_ENTRY_STAFF_DRUM,
          "insert-a",
          QT_TRANSLATE_NOOP("action","Insert A"),
          QT_TRANSLATE_NOOP("action","Insert note A")


### PR DESCRIPTION
See https://musescore.org/en/node/278752.

This makes a new action for "Add tied note to chord", rather than have it be performed by the regular "tie" command. As a result, the regular "tie" command will now overwrite any existing chord.