### PR TITLE
restore set as style menu

### DIFF
--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -525,7 +525,9 @@ void InspectorBase::mapSignals(const std::vector<InspectorItem>& il, const std::
                               QMenu* menu = new QMenu(this);
                               resetButton->setMenu(menu);
                               resetButton->setPopupMode(QToolButton::MenuButtonPopup);
-                              QAction* a = menu->addAction(tr("Set as style"));
+                              QAction* a = menu->addAction(tr("Reset to default"));
+                              connect(a, &QAction::triggered, [=] { resetClicked(i); });
+                              a = menu->addAction(tr("Set as style"));
                               connect(a, &QAction::triggered, [=] { setStyleClicked(i); });
                               }
                         }

--- a/mscore/inspector/inspector_text.ui
+++ b/mscore/inspector/inspector_text.ui
@@ -247,12 +247,6 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
-          <widget class="Ms::ResetButton" name="resetFontFace" native="true"/>
-         </item>
-         <item row="1" column="2">
-          <widget class="Ms::ResetButton" name="resetFontSize" native="true"/>
-         </item>
          <item row="4" column="0" colspan="2">
           <widget class="Ms::AlignSelect" name="align" native="true">
            <property name="toolTip">
@@ -475,6 +469,34 @@
            </layout>
           </widget>
          </item>
+         <item row="0" column="2">
+          <widget class="QToolButton" name="resetFontFace">
+           <property name="toolTip">
+            <string>Reset to default</string>
+           </property>
+           <property name="accessibleName">
+            <string>Reset 'Font face' value</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../musescore.qrc">
+             <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QToolButton" name="resetFontSize">
+           <property name="toolTip">
+            <string>Reset to default</string>
+           </property>
+           <property name="accessibleName">
+            <string>Reset 'Font size' value</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../musescore.qrc">
+             <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -497,12 +519,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>Ms::ResetButton</class>
-   <extends>QWidget</extends>
-   <header>inspector/resetButton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>Ms::FontStyleSelect</class>
    <extends>QWidget</extends>
    <header>inspector/fontStyleSelect.h</header>
@@ -514,6 +530,7 @@
   <tabstop>resetFontFace</tabstop>
   <tabstop>fontSize</tabstop>
   <tabstop>resetFontSize</tabstop>
+  <tabstop>fontStyle</tabstop>
   <tabstop>resetFontStyle</tabstop>
   <tabstop>align</tabstop>
   <tabstop>resetAlign</tabstop>


### PR DESCRIPTION
I don't know if @wschweer has other plans, but if not, I'd like to see us do something with the "set as style" action for beta, even if we want to revisit it later.  I like the idea of the custom widgets that were introduced for font face and size as an experiment a few weeks ago, but I also like consistency, and I like saving space.

So in this PR, I have restored the popup menu, but to make it seem less awkward having only "Set as style", I went and added "Reset to default" as well, as the first item in the menu.  Might seem odd to repeat it since it is also the action for the button itself, but actually, that's consistent with the "N" note input button (pressing it invokes step-time, and step-time is also the first element on the menu).  It's also what the "Back" button on some browsers so - button goes back to previous page, arrow brings up menu with previous page at top of list.