### PR TITLE
fix #278874: fix regressions caused by transition to the new text style format

### DIFF
--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1070,6 +1070,7 @@ class MStyle {
       void save(XmlWriter& xml, bool optimize);
       bool readProperties(XmlReader&);
       bool readStyleValCompat(XmlReader&);
+      bool readTextStyleValCompat(XmlReader&);
 
       void reset(Score*);
 

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -557,6 +557,8 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
                   connect(qobject_cast<AlignSelect*>(sw.widget), SIGNAL(alignChanged(Align)), mapper2, SLOT(map()));
             else if (qobject_cast<OffsetSelect*>(sw.widget))
                   connect(qobject_cast<OffsetSelect*>(sw.widget), SIGNAL(offsetChanged(const QPointF&)), mapper2, SLOT(map()));
+            else if (FontStyleSelect* fontStyle = qobject_cast<FontStyleSelect*>(sw.widget))
+                  connect(fontStyle, &FontStyleSelect::fontStyleChanged, mapper2, QOverload<>::of(&QSignalMapper::map));
             else {
                   qFatal("unhandled gui widget type %s valueType %s",
                      sw.widget->metaObject()->className(),
@@ -796,6 +798,8 @@ QVariant EditStyle::getValue(Sid idx)
                   QButtonGroup* bg = qobject_cast<QButtonGroup*>(sw.widget);
                   return bg->checkedId();
                   }
+            else if (FontStyleSelect* fontStyle = qobject_cast<FontStyleSelect*>(sw.widget))
+                  return int(fontStyle->fontStyle());
             else
                   qFatal("unhandled int");
             }
@@ -888,6 +892,8 @@ void EditStyle::setValues()
                                     }
                               }
                         }
+                  else if (FontStyleSelect* fontStyle = qobject_cast<FontStyleSelect*>(sw.widget))
+                        fontStyle->setFontStyle(FontStyle(val.toInt()));
                   else
                         unhandledType(&sw);
                   }

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -1985,7 +1985,7 @@
                </widget>
               </item>
               <item row="0" column="7">
-               <widget class="QWidget" name="headerFontStyle" native="true"/>
+               <widget class="Ms::FontStyleSelect" name="headerFontStyle" native="true"/>
               </item>
               <item row="0" column="8">
                <widget class="QToolButton" name="resetHeaderFontStyle">
@@ -8718,7 +8718,7 @@
             </widget>
            </item>
            <item row="2" column="9">
-            <widget class="QWidget" name="bendFontStyle" native="true"/>
+            <widget class="Ms::FontStyleSelect" name="bendFontStyle" native="true"/>
            </item>
            <item row="2" column="10">
             <widget class="QToolButton" name="resetBendFontStyle">

--- a/mtest/libmscore/compat206/lidemptytext-ref.mscx
+++ b/mtest/libmscore/compat206/lidemptytext-ref.mscx
@@ -284,6 +284,7 @@
         <barNoteDistance>1.2</barNoteDistance>
         <pedalPosBelow x="0" y="0"/>
         <trillPosAbove x="0" y="0"/>
+        <dynamicsFontStyle>0</dynamicsFontStyle>
         <Spatium>1.76389</Spatium>
         </Style>
       <showInvisible>1</showInvisible>

--- a/mtest/libmscore/split/split184061-keep-tie-before-break-voice-4-ref.mscx
+++ b/mtest/libmscore/split/split184061-keep-tie-before-break-voice-4-ref.mscx
@@ -21,6 +21,7 @@
       <pedalPosBelow x="0" y="0"/>
       <trillPosAbove x="0" y="0"/>
       <minMMRestWidth>0</minMMRestWidth>
+      <dynamicsFontStyle>0</dynamicsFontStyle>
       <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/mtest/libmscore/split/split184061-keep-tie-ref.mscx
+++ b/mtest/libmscore/split/split184061-keep-tie-ref.mscx
@@ -30,6 +30,7 @@
       <longInstrumentFontSize>10</longInstrumentFontSize>
       <shortInstrumentFontSize>10</shortInstrumentFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
+      <dynamicsFontStyle>0</dynamicsFontStyle>
       <tempoFontSize>10</tempoFontSize>
       <metronomeFontSize>10</metronomeFontSize>
       <translatorFontSize>10</translatorFontSize>

--- a/mtest/libmscore/split/split184061-no-tie-ref.mscx
+++ b/mtest/libmscore/split/split184061-no-tie-ref.mscx
@@ -30,6 +30,7 @@
       <longInstrumentFontSize>10</longInstrumentFontSize>
       <shortInstrumentFontSize>10</shortInstrumentFontSize>
       <partInstrumentFontSize>10</partInstrumentFontSize>
+      <dynamicsFontStyle>0</dynamicsFontStyle>
       <tempoFontSize>10</tempoFontSize>
       <metronomeFontSize>10</metronomeFontSize>
       <translatorFontSize>10</translatorFontSize>

--- a/mtest/libmscore/split/split184061-other-inst-only-one-tie-ref.mscx
+++ b/mtest/libmscore/split/split184061-other-inst-only-one-tie-ref.mscx
@@ -21,6 +21,7 @@
       <pedalPosBelow x="0" y="0"/>
       <trillPosAbove x="0" y="0"/>
       <minMMRestWidth>0</minMMRestWidth>
+      <dynamicsFontStyle>0</dynamicsFontStyle>
       <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>


### PR DESCRIPTION
This PR fixes the noticed regressions caused by the recent ffdab67a9d9b8a237a5dd905684a170610c4745c commit.
The fixed regressions have been reported here:
https://musescore.org/en/node/278874 