### PR TITLE
fix #278499: manage channel listeners properly to avoid invalid pointers

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -428,28 +428,6 @@ Channel::Channel()
 //      qDebug("construct Channel ");
       }
 
-Channel::~Channel()
-      {
-      QList<ChannelListener *> list(listeners);
-
-      for (ChannelListener * l: list) {
-            l->disconnectChannelListener();
-            }
-      }
-
-//---------------------------------------------------------
-//   firePropertyChanged
-//---------------------------------------------------------
-
-void Channel::firePropertyChanged(Channel::Prop prop)
-      {
-      QList<ChannelListener *> list(listeners);
-
-      for (ChannelListener * l: list) {
-            l->propertyChanged(prop);
-            }
-      }
-
 //---------------------------------------------------------
 //   setVolume
 //---------------------------------------------------------
@@ -804,6 +782,24 @@ void Channel::updateInitList() const
       e.setData(ME_CONTROLLER, CTRL_REVERB_SEND, reverb());
       init[int(A::REVERB)] = e;
 
+      }
+
+//---------------------------------------------------------
+//   addListener
+//---------------------------------------------------------
+
+void Channel::addListener(ChannelListener* l)
+      {
+      _notifier.addListener(l);
+      }
+
+//---------------------------------------------------------
+//   removeListener
+//---------------------------------------------------------
+
+void Channel::removeListener(ChannelListener* l)
+      {
+      _notifier.removeListener(l);
       }
 
 //---------------------------------------------------------

--- a/libmscore/notifier.hpp
+++ b/libmscore/notifier.hpp
@@ -1,0 +1,116 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2018 Werner Schweer
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __NOTIFIER_H__
+#define __NOTIFIER_H__
+
+namespace Ms {
+
+template<typename Data> class Notifier;
+
+//---------------------------------------------------------
+//   Listener
+//---------------------------------------------------------
+
+template<typename Data>
+class Listener {
+      Notifier<Data>* _notifier = nullptr;
+
+   public:
+      Listener() = default;
+      Listener(Notifier<Data>* n) : _notifier(n) {}
+      // do not copy notifier attachment
+      Listener(const Listener<Data>&) {}
+      Listener& operator=(const Listener<Data>&) { return *this; }
+      ~Listener();
+
+      void setNotifier(Notifier<Data>* n);
+
+      void detachNotifier(Notifier<Data>* n) { if (_notifier == n) setNotifier(nullptr); }
+
+      Notifier<Data>* notifier() { return _notifier; }
+      const Notifier<Data>* notifier() const { return _notifier; }
+
+      virtual void receive(Data d) = 0;
+      };
+
+//---------------------------------------------------------
+//   Notifier
+//---------------------------------------------------------
+
+template<typename Data>
+class Notifier {
+      std::vector<Listener<Data>*> _listeners;
+      bool _atChange = false;
+
+   public:
+      Notifier() = default;
+      // do not copy listeners list
+      Notifier(const Notifier<Data>&) {}
+      Notifier& operator=(const Notifier<Data>&) { return *this; }
+      ~Notifier()
+            {
+            _atChange = true; // we don't need to update listeners list anymore
+            for (Listener<Data>* l : _listeners)
+                  l->detachNotifier(this);
+            }
+
+      void addListener(Listener<Data>* l)
+            {
+            if (_atChange || !l)
+                  return;
+            _atChange = true;
+            _listeners.push_back(l);
+            l->setNotifier(this);
+            _atChange = false;
+            }
+
+      void removeListener(Listener<Data>* l)
+            {
+            if (_atChange || !l)
+                  return;
+            _atChange = true;
+            _listeners.erase(std::remove(_listeners.begin(), _listeners.end(), l), _listeners.end());
+            l->detachNotifier(this);
+            _atChange = false;
+            }
+
+      void notify(Data d) const
+            {
+            for (Listener<Data>* l : _listeners)
+                  l->receive(d);
+            }
+      };
+
+template<typename Data>
+Listener<Data>::~Listener()
+      {
+      if (_notifier)
+            _notifier->removeListener(this);
+      }
+
+template<typename Data>
+void Listener<Data>::setNotifier(Notifier<Data>* n)
+      {
+      if (n == _notifier)
+            return;
+      Notifier<Data>* oldNotifier = _notifier;
+      _notifier = n;
+      if (oldNotifier)
+            oldNotifier->removeListener(this);
+      if (_notifier)
+            _notifier->addListener(this);
+      }
+
+}     // namespace Ms
+#endif
+

--- a/mscore/mixerdetails.cpp
+++ b/mscore/mixerdetails.cpp
@@ -63,36 +63,13 @@ MixerDetails::MixerDetails(QWidget *parent) :
       }
 
 //---------------------------------------------------------
-//   ~MixerDetails
-//---------------------------------------------------------
-
-MixerDetails::~MixerDetails()
-      {
-      if (_mti) {
-            //Remove old attachment
-            _mti->midiMap()->articulation->removeListener(this);
-            }
-      }
-
-//---------------------------------------------------------
 //   setTrack
 //---------------------------------------------------------
 
 void MixerDetails::setTrack(MixerTrackItemPtr track)
       {
-      if (_mti) {
-            //Remove old attachment
-            Channel* chan = _mti->focusedChan();
-            chan->removeListener(this);
-            }
-
       _mti = track;
-
-      if (_mti) {
-            //Listen to new track
-            Channel* chan = _mti->focusedChan();
-            chan->addListener(this);
-            }
+      setNotifier(_mti ? _mti->focusedChan() : nullptr);
       updateFromTrack();
       }
 
@@ -283,16 +260,6 @@ void MixerDetails::trackColorChanged(QColor col)
             }
 
       _mti->setColor(col.rgb());
-      }
-
-//---------------------------------------------------------
-//   disconnectChannelListener
-//---------------------------------------------------------
-
-void MixerDetails::disconnectChannelListener()
-      {
-      //Channel has been destroyed.  Don't remove listener when invoking destructor.
-      _mti = nullptr;
       }
 
 //---------------------------------------------------------

--- a/mscore/mixerdetails.h
+++ b/mscore/mixerdetails.h
@@ -56,13 +56,10 @@ public slots:
 
 public:
       explicit MixerDetails(QWidget *parent);
-      ~MixerDetails() override;
 
       MixerTrackItemPtr track() { return _mti; }
       void setTrack(MixerTrackItemPtr track);
       void propertyChanged(Channel::Prop property) override;
-      void disconnectChannelListener() override;
-
       };
 
 }

--- a/mscore/mixertrackchannel.cpp
+++ b/mscore/mixertrackchannel.cpp
@@ -119,18 +119,6 @@ MixerTrackChannel::MixerTrackChannel(QWidget *parent, MixerTrackItemPtr mti) :
       }
 
 //---------------------------------------------------------
-//   ~MixerTrack
-//---------------------------------------------------------
-
-MixerTrackChannel::~MixerTrackChannel()
-      {
-      if (_mti) {
-            Channel* chan = _mti->chan();
-            chan->removeListener(this);
-            }
-      }
-
-//---------------------------------------------------------
 //   expandToggled
 //---------------------------------------------------------
 
@@ -231,17 +219,6 @@ void MixerTrackChannel::updateNameLabel()
 void MixerTrackChannel::paintEvent(QPaintEvent*)
       {
       applyStyle();
-      }
-
-
-//---------------------------------------------------------
-//   disconnectChannelListener
-//---------------------------------------------------------
-
-void MixerTrackChannel::disconnectChannelListener()
-      {
-      //Channel has been destroyed.  Don't remove listener when invoking destructor.
-      _mti = nullptr;
       }
 
 //---------------------------------------------------------

--- a/mscore/mixertrackchannel.h
+++ b/mscore/mixertrackchannel.h
@@ -68,11 +68,9 @@ public slots:
 protected:
       void mouseReleaseEvent(QMouseEvent * event) override;
       void propertyChanged(Channel::Prop property) override;
-      void disconnectChannelListener() override;
 
 public:
       explicit MixerTrackChannel(QWidget *parent, MixerTrackItemPtr trackItem);
-      ~MixerTrackChannel() override;
 
       bool selected() override { return _selected; }
       QWidget* getWidget() override { return this; }

--- a/mscore/mixertrackpart.cpp
+++ b/mscore/mixertrackpart.cpp
@@ -136,18 +136,6 @@ MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItemPtr mti, bool expa
       }
 
 //---------------------------------------------------------
-//   ~MixerTrack
-//---------------------------------------------------------
-
-MixerTrackPart::~MixerTrackPart()
-      {
-      if (_mti) {
-            Channel* chan = _mti->focusedChan();
-            chan->removeListener(this);
-            }
-      }
-
-//---------------------------------------------------------
 //   expandToggled
 //---------------------------------------------------------
 
@@ -229,17 +217,6 @@ void MixerTrackPart::updateNameLabel()
 void MixerTrackPart::paintEvent(QPaintEvent*)
       {
       applyStyle();
-      }
-
-
-//---------------------------------------------------------
-//   disconnectChannelListener
-//---------------------------------------------------------
-
-void MixerTrackPart::disconnectChannelListener()
-      {
-      //Channel has been destroyed.  Don't remove listener when invoking destructor.
-      _mti = nullptr;
       }
 
 //---------------------------------------------------------

--- a/mscore/mixertrackpart.h
+++ b/mscore/mixertrackpart.h
@@ -69,11 +69,9 @@ public slots:
 protected:
       void mouseReleaseEvent(QMouseEvent * event) override;
       void propertyChanged(Channel::Prop property) override;
-      void disconnectChannelListener() override;
 
 public:
       explicit MixerTrackPart(QWidget *parent, MixerTrackItemPtr trackItem, bool expanded);
-      ~MixerTrackPart() override;
 
       bool selected() override { return _selected; }
       QWidget* getWidget() override { return this; }


### PR DESCRIPTION
This pull request is another option to fix https://musescore.org/en/node/278499.
The proposed solution is to move listeners/notifiers management logic to the separate set of classes. We could use `QObject` for that purpose but it seems to be unwanted to use `QObject` inside `libmscore`. For that purpose I implemented a simple set of template classes following Observer pattern, which are then used to remove all the related logic from `Channel`/`ChannelListener` classes and their descendants. The added `Listener` and `Notifier` classes have no-op copy constructor and assignment operators in order to not interfere with copying classes that use it (like `Channel`) though it could possibly be better to disable copying or allow only move-construction and move-assignment of such objects. Still they make it simpler to provide a reliable management of listeners list in notifier object which helps to avoid using invalid pointers and, thus, crashes.

The alternative #4198 PR has also some changes related to replacing `MixerTrackItemPtr` (which is a `shared_ptr` with `QPointer`s and raw pointers. I am not sure whether this change is necessary but the current implementation of using `MixerTrackItemPtr` does not seem to cause any visible issues so I didn't change anything in it.