### PR TITLE
fix #278031: refresh note input cursor position on view mode switch

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6170,6 +6170,8 @@ void MuseScore::switchLayoutMode(LayoutMode mode)
       cv->pageTop();
       if (m && m != cs->firstMeasureMM())
             cv->adjustCanvasPosition(m, false);
+      if (cv->noteEntryMode())
+            cv->moveCursor();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fixes this issue: https://musescore.org/en/node/278031.