### PR TITLE
fix #278894 Hide mixer details when button toggled

### DIFF
--- a/mscore/data/icons/triangleDown.svg
+++ b/mscore/data/icons/triangleDown.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="10"
+   height="10"
+   viewBox="0 0 2.6458333 2.6458334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="triangleDown.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.8"
+     inkscape:cx="3.5709816"
+     inkscape:cy="4.4705924"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4747" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-294.35415)">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 0.52916673,295.41248 H 2.1166667 l -0.79375,0.79375 z"
+       id="path8452"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/mscore/data/icons/triangleUp.svg
+++ b/mscore/data/icons/triangleUp.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="10"
+   height="10"
+   viewBox="0 0 2.6458333 2.6458334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="triangleUp.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.8"
+     inkscape:cx="3.5709816"
+     inkscape:cy="4.4705924"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4747" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-294.35415)">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 0.52916673,295.94165 H 2.1166667 l -0.79375,-0.79375 z"
+       id="path8452"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -72,8 +72,8 @@ char userRangeToReverb(double v) { return (char)qBound(0, (int)(v / 100.0 * 128.
 
 Mixer::Mixer(QWidget* parent)
    : QWidget(parent, Qt::Dialog),
-      showExpanded(false),
-      trackHolder(0)
+      showDetails(true),
+      trackHolder(nullptr)
       {
       setupUi(this);
 
@@ -87,7 +87,7 @@ Mixer::Mixer(QWidget* parent)
       trackArea->setLayout(trackAreaLayout);
 
       mixerDetails = new MixerDetails(this);
-      QGridLayout* detailsLayout = new QGridLayout(this);
+      detailsLayout = new QGridLayout(this);
 
       detailsLayout->addWidget(mixerDetails);
       detailsLayout->setContentsMargins(0, 0, 0, 0);
@@ -113,6 +113,7 @@ Mixer::Mixer(QWidget* parent)
       iconSliderHead.addFile(QStringLiteral(":/data/icons/mixer-slider-handle-vertical.svg"), QSize(), QIcon::Normal, QIcon::Off);
       masterSlider->setSliderHeadIcon(iconSliderHead);
 
+      connect(toggleDetailsButton, &QPushButton::toggled, this, &Mixer::showDetailsToggled);
       connect(masterSlider, SIGNAL(valueChanged(double)), SLOT(masterVolumeChanged(double)));
       connect(masterSpin, SIGNAL(valueChanged(double)), SLOT(masterVolumeChanged(double)));
       connect(synti, SIGNAL(gainChanged(float)), SLOT(synthGainChanged(float)));
@@ -122,6 +123,19 @@ Mixer::Mixer(QWidget* parent)
       enablePlay = new EnablePlayForWidget(this);
       readSettings();
       retranslate(true);
+      }
+
+//---------------------------------------------------------
+//   showDetailsToggled
+//---------------------------------------------------------
+
+void Mixer::showDetailsToggled(bool shown)
+      {
+      showDetails = shown;
+      if (showDetails)
+            detailsLayout->addWidget(mixerDetails);
+      else
+            detailsLayout->removeWidget(mixerDetails);
       }
 
 //---------------------------------------------------------

--- a/mscore/mixer.h
+++ b/mscore/mixer.h
@@ -67,8 +67,9 @@ class Mixer : public QWidget, public Ui::Mixer, public MixerTrackGroup
       EnablePlayForWidget* enablePlay;
 
       MixerDetails* mixerDetails;
+      QGridLayout* detailsLayout;
 
-      bool showExpanded;
+      bool showDetails;
       QSet<Part*> expandedParts;
       QWidget* trackHolder;
       QList<MixerTrack*> trackList;
@@ -105,6 +106,7 @@ class Mixer : public QWidget, public Ui::Mixer, public MixerTrackGroup
       void writeSettings();
       void expandToggled(Part* part, bool expanded) override;
       void notifyTrackSelected(MixerTrack* track) override;
+      void showDetailsToggled(bool shown);
       };
 
 

--- a/mscore/mixer.ui
+++ b/mscore/mixer.ui
@@ -10,20 +10,8 @@
     <x>0</x>
     <y>0</y>
     <width>648</width>
-    <height>620</height>
+    <height>431</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>0</width>
-    <height>620</height>
-   </size>
   </property>
   <property name="focusPolicy">
    <enum>Qt::ClickFocus</enum>
@@ -39,6 +27,36 @@
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="toggleDetailsButton">
+     <property name="toolTip">
+      <string>Show/hide details</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 2px</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="musescore.qrc">
+       <normaloff>:/data/icons/triangleDown.svg</normaloff>
+       <normalon>:/data/icons/triangleUp.svg</normalon>:/data/icons/triangleDown.svg</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>10</width>
+       <height>10</height>
+      </size>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -90,6 +108,18 @@
      </item>
      <item>
       <widget class="QScrollArea" name="tracks_scrollArea">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>370</height>
+        </size>
+       </property>
        <property name="widgetResizable">
         <bool>true</bool>
        </property>
@@ -99,7 +129,7 @@
           <x>0</x>
           <y>0</y>
           <width>554</width>
-          <height>582</height>
+          <height>371</height>
          </rect>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -144,6 +174,9 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="musescore.qrc"/>
+  <include location="musescore.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/mscore/musescore.qrc
+++ b/mscore/musescore.qrc
@@ -172,5 +172,7 @@
         <file>data/icons/mixer-solo-on.svg</file>
         <file>data/icons/mixer-dial.svg</file>
         <file>data/icons/mixer-slider-handle-vertical.svg</file>
+        <file>data/icons/triangleDown.svg</file>
+        <file>data/icons/triangleUp.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Adding a button to hide the details menu to allow for easier use of the mixer on small monitors.