### PR TITLE
fix #278039: layout symbols attached to segments

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2491,7 +2491,13 @@ void Score::getNextMeasure(LayoutContext& lc)
                               staff(staffIdx)->addTimeSig(ts);
                         }
                   }
-            else if (isMaster() && segment.isChordRestType()) {
+            else if (segment.isChordRestType()) {
+                  for (Element* e : segment.annotations()) {
+                        if (e->isSymbol())
+                              e->layout();
+                        }
+                  if (!isMaster())
+                        continue;
 #if 0 // ws
                   for (Element* e : segment.annotations()) {
                         if (!(e->isTempoText()

--- a/mtest/libmscore/layout_elements/layout_elements.mscx
+++ b/mtest/libmscore/layout_elements/layout_elements.mscx
@@ -505,6 +505,11 @@
               <subtype>0</subtype>
               </Arpeggio>
             </Chord>
+          <Symbol>
+            <name>accdnRH3RanksAccordion</name>
+            <font>Bravura</font>
+            <offset x="0" y="-2"/>
+            </Symbol>
           <Chord>
             <durationType>quarter</durationType>
             <Note>


### PR DESCRIPTION
This PR fixes [this issue](https://musescore.org/en/node/278039) with layout of symbols attached to segments. I put a `layout()` call for them to the place where it was likely done before and where it seems to be reasonable to do that. However I believe it doesn't make sense to restrict layout of such elements to master score only so I changed slightly the code in that place to avoid such a restriction.

A test case for this issue is also added.