### PR TITLE
fix #278897: fix high CPU load in Mixer

### DIFF
--- a/awl/styledslider.cpp
+++ b/awl/styledslider.cpp
@@ -47,7 +47,7 @@ void StyledSlider::wheelEvent(QWheelEvent* e)
       auto value = _value + ad.y() / 120;
       value = qBound(_minValue, value, _maxValue);
       setValue(value);
-      repaint();
+      update();
       }
 
 //---------------------------------------------------------
@@ -105,7 +105,7 @@ void StyledSlider::mouseMoveEvent(QMouseEvent* e)
 
             lastMousePos = p;
             setValue(val);
-            repaint();
+            update();
             }
       }
 
@@ -210,7 +210,7 @@ void StyledSlider::setValue(double v)
             return;
 
       _value = v;
-      repaint();
+      update();
       emit(valueChanged(v));
       }
 
@@ -223,7 +223,7 @@ void StyledSlider::setMinValue(double v)
       if (v == _minValue)
             return;
       _minValue = v;
-      repaint();
+      update();
       emit(minValueChanged(v));
       }
 
@@ -236,7 +236,7 @@ void StyledSlider::setMaxValue(double v)
       if (v == _maxValue)
             return;
       _maxValue = v;
-      repaint();
+      update();
       emit(maxValueChanged(v));
       }
 
@@ -247,7 +247,7 @@ void StyledSlider::setMaxValue(double v)
 void StyledSlider::setBackgroundColor(QColor v)
       {
       _backgroundColor = v;
-      repaint();
+      update();
       }
 
 //---------------------------------------------------------
@@ -257,7 +257,7 @@ void StyledSlider::setBackgroundColor(QColor v)
 void StyledSlider::setHilightColor(QColor v)
       {
       _hilightColor = v;
-      repaint();
+      update();
       }
 
 //---------------------------------------------------------
@@ -267,7 +267,7 @@ void StyledSlider::setHilightColor(QColor v)
 void StyledSlider::setTickColor(QColor v)
       {
       _tickColor = v;
-      repaint();
+      update();
       }
 
 //---------------------------------------------------------
@@ -277,7 +277,7 @@ void StyledSlider::setTickColor(QColor v)
 void StyledSlider::setBarThickness(double v)
       {
       _barThickness = v;
-      repaint();
+      update();
       }
 
 //---------------------------------------------------------
@@ -287,7 +287,7 @@ void StyledSlider::setBarThickness(double v)
 void StyledSlider::setMargin(double v)
       {
       _margin = v;
-      repaint();
+      update();
       }
 
 //---------------------------------------------------------
@@ -297,7 +297,7 @@ void StyledSlider::setMargin(double v)
 void StyledSlider::setNumMajorTicks(int v)
       {
       _numMajorTicks = v;
-      repaint();
+      update();
       }
 
 //---------------------------------------------------------
@@ -307,7 +307,7 @@ void StyledSlider::setNumMajorTicks(int v)
 void StyledSlider::setNumMinorTicks(int v)
       {
       _numMinorTicks = v;
-      repaint();
+      update();
       }
 
 //---------------------------------------------------------
@@ -317,7 +317,7 @@ void StyledSlider::setNumMinorTicks(int v)
 void StyledSlider::setMajorTickWidth(double v)
       {
       _majorTickWidth = v;
-      repaint();
+      update();
       }
 
 //---------------------------------------------------------
@@ -327,7 +327,7 @@ void StyledSlider::setMajorTickWidth(double v)
 void StyledSlider::setMinorTickWidth(double v)
       {
       _minorTickWidth = v;
-      repaint();
+      update();
       }
 
 //---------------------------------------------------------
@@ -337,7 +337,7 @@ void StyledSlider::setMinorTickWidth(double v)
 void StyledSlider::setSliderHeadIcon(QIcon v)
       {
       _sliderHeadIcon = v;
-      repaint();
+      update();
       }
 
 }

--- a/mscore/mixertrackpart.cpp
+++ b/mscore/mixertrackpart.cpp
@@ -130,8 +130,6 @@ MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItemPtr mti, bool expa
 
       connect(volumeSlider, SIGNAL(sliderPressed()),    SLOT(controlSelected()));
       connect(panSlider,    SIGNAL(sliderPressed(int)), SLOT(controlSelected()));
-
-      applyStyle();
       }
 
 //---------------------------------------------------------
@@ -213,9 +211,11 @@ void MixerTrackPart::updateNameLabel()
 //   paintEvent
 //---------------------------------------------------------
 
-void MixerTrackPart::paintEvent(QPaintEvent*)
+void MixerTrackPart::showEvent(QShowEvent* event)
       {
-      applyStyle();
+      if (!event->spontaneous())
+            applyStyle();
+      QWidget::showEvent(event);
       }
 
 //---------------------------------------------------------
@@ -328,7 +328,6 @@ void MixerTrackPart::setSelected(bool sel)
             return;
 
       _selected = sel;
-      applyStyle();
 
       emit(selectedChanged(sel));
 

--- a/mscore/mixertrackpart.h
+++ b/mscore/mixertrackpart.h
@@ -77,7 +77,7 @@ public:
       MixerTrackGroup* group() override { return _group; }
       MixerTrackItemPtr mti() override { return _mti; }
       void setGroup(MixerTrackGroup* group) { _group = group; }
-      void paintEvent(QPaintEvent* evt) override;
+      void showEvent(QShowEvent*) override;
       };
 
 }


### PR DESCRIPTION
This commit fixes high CPU load when Mixer window is shown, as reported here: https://musescore.org/en/node/278897.
In particular, the proposed commit replaces `repaint()` calls with `update()` which are more safe regarding that they do not perform immediate repaint but schedule it for Qt to perform later. It also removes `updateStyle()` call from paint event handler in `MixerTrackPart` which was probably the primary cause for this high CPU load. As an alternative, `updateStyle()` is now called inside `showEvent()` handler though I am not sure whether even this is necessary to perform. Anyway, that way it does not cause infinite number of paint events be scheduled thus freeing CPU from constant redrawing mixer widgets.