### PR TITLE
fix #278943: Can't copy tuplet to last beat of measure

### DIFF
--- a/libmscore/duration.cpp
+++ b/libmscore/duration.cpp
@@ -112,7 +112,7 @@ Fraction DurationElement::afrac() const
             return f.reduced();
             }
       else
-            return Element::afrac();
+            return Fraction::fromTicks(tick());
       }
 
 //---------------------------------------------------------
@@ -125,7 +125,7 @@ Fraction DurationElement::rfrac() const
             if (Measure* m = measure())
                   return afrac() - m->afrac();
             }
-      return Element::rfrac();
+      return Fraction::fromTicks(rtick());
       }
 
 //---------------------------------------------------------

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1718,15 +1718,10 @@ int Element::rtick() const
 
 Fraction Element::rfrac() const
       {
-      const Element* e = this;
-      while (e) {
-            if (e->isSegment())
-                  return toSegment(e)->rfrac();
-            else if (e->isMeasureBase())
-                  return toMeasureBase(e)->rfrac();
-            e = e->parent();
-            }
-      return -1;
+      if (parent())
+            return parent()->rfrac();
+      else
+            return -1;
       }
 
 //---------------------------------------------------------
@@ -1736,15 +1731,10 @@ Fraction Element::rfrac() const
 
 Fraction Element::afrac() const
       {
-      const Element* e = this;
-      while (e) {
-            if (e->isSegment())
-                  return toSegment(e)->afrac();
-            else if (e->isMeasureBase())
-                  return toMeasureBase(e)->afrac();
-            e = e->parent();
-            }
-      return -1;
+      if (parent())
+            return parent()->afrac();
+      else
+            return -1;
       }
 
 //---------------------------------------------------------

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -176,9 +176,7 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                               Measure* measure = tick2measure(tick);
                               tuplet->setParent(measure);
                               tuplet->setTick(tick);
-                              int ticks = tuplet->actualTicks();
-                              int rticks = measure->endTick() - tick;
-                              if (rticks < ticks) {
+                              if (tuplet->rfrac() + tuplet->duration() > measure->len()) {
                                     delete tuplet;
                                     if (oldTuplet && oldTuplet->elements().empty())
                                           delete oldTuplet;

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -952,27 +952,6 @@ void Tuplet::sortElements()
       }
 
 //---------------------------------------------------------
-//   afrac
-//---------------------------------------------------------
-
-Fraction Tuplet::afrac() const
-      {
-      return Fraction::fromTicks(tick());
-      }
-
-//---------------------------------------------------------
-//   rfrac
-//---------------------------------------------------------
-
-Fraction Tuplet::rfrac() const
-      {
-      const Measure* m = measure();
-      if (m)
-            return Fraction::fromTicks(tick() - m->tick());
-      return afrac();
-      }
-
-//---------------------------------------------------------
 //   elementsDuration
 ///  Get the sum of the element fraction in the tuplet,
 ///  even if the tuplet is not complete yet

--- a/libmscore/tuplet.h
+++ b/libmscore/tuplet.h
@@ -119,8 +119,6 @@ class Tuplet final : public DurationElement {
       Direction direction() const          { return _direction; }
       bool isUp() const                    { return _isUp; }
       virtual int tick() const override    { return _tick; }
-      virtual Fraction afrac() const override;
-      virtual Fraction rfrac() const override;
       void setTick(int val)                { _tick = val; }
       Fraction elementsDuration();
       void sortElements();

--- a/mscore/importgtp-gp4.cpp
+++ b/mscore/importgtp-gp4.cpp
@@ -915,6 +915,7 @@ bool GuitarPro4::read(QFile* fp)
                               Tuplet* tuplet = tuplets[staffIdx];
                               if ((tuplet == 0) || (tuplet->elementsDuration() == tuplet->baseLen().fraction() * tuplet->ratio().numerator())) {
                                     tuplet = new Tuplet(score);
+                                    tuplet->setTick(tick);
                                     tuplet->setTrack(cr->track());
                                     tuplets[staffIdx] = tuplet;
                                     setTuplet(tuplet, tuple);

--- a/mscore/importgtp-gp5.cpp
+++ b/mscore/importgtp-gp5.cpp
@@ -296,6 +296,7 @@ int GuitarPro5::readBeat(int tick, int voice, Measure* measure, int staffIdx, Tu
                   Tuplet* tuplet = tuplets[staffIdx * 2 + voice];
                   if ((tuplet == 0) || (tuplet->elementsDuration() == tuplet->baseLen().fraction() * tuplet->ratio().numerator())) {
                         tuplet = new Tuplet(score);
+                        tuplet->setTick(tick);
                         // int track = staffIdx * 2 + voice;
                         tuplets[staffIdx * 2 + voice] = tuplet;
                         tuplet->setTrack(cr->track());

--- a/mscore/importgtp-gp6.cpp
+++ b/mscore/importgtp-gp6.cpp
@@ -1653,6 +1653,7 @@ int GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* measure,
                                     cr->setTrack(track);
                                     if ((tuplet == 0) || (tuplet->elementsDuration() == tuplet->baseLen().fraction() * tuplet->ratio().numerator())) {
                                           tuplet                           = new Tuplet(score);
+                                          tuplet->setTick(currentTick);
                                           tuplets[staffIdx * VOICES + voiceNum] = tuplet;
                                           tuplet->setParent(measure);
                                           }

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -1210,6 +1210,7 @@ bool GuitarPro1::read(QFile* fp)
                               Tuplet* tuplet = tuplets[staffIdx];
                               if ((tuplet == 0) || (tuplet->elementsDuration() == tuplet->baseLen().fraction() * tuplet->ratio().numerator())) {
                                     tuplet = new Tuplet(score);
+                                    tuplet->setTick(tick);
                                     tuplet->setTrack(cr->track());
                                     tuplets[staffIdx] = tuplet;
                                     setTuplet(tuplet, tuple);
@@ -1698,6 +1699,7 @@ bool GuitarPro2::read(QFile* fp)
                               Tuplet* tuplet = tuplets[staffIdx];
                               if ((tuplet == 0) || (tuplet->elementsDuration() == tuplet->baseLen().fraction() * tuplet->ratio().numerator())) {
                                     tuplet = new Tuplet(score);
+                                    tuplet->setTick(tick);
                                     tuplet->setTrack(cr->track());
                                     tuplets[staffIdx] = tuplet;
                                     setTuplet(tuplet, tuple);
@@ -2413,6 +2415,7 @@ bool GuitarPro3::read(QFile* fp)
                               Tuplet* tuplet = tuplets[staffIdx];
                               if ((tuplet == 0) || (tuplet->elementsDuration() == tuplet->baseLen().fraction() * tuplet->ratio().numerator())) {
                                     tuplet = new Tuplet(score);
+                                    tuplet->setTick(tick);
                                     tuplet->setTrack(cr->track());
                                     tuplets[staffIdx] = tuplet;
                                     setTuplet(tuplet, tuple);

--- a/mtest/guitarpro/dotted-tuplets.gp5-ref.mscx
+++ b/mtest/guitarpro/dotted-tuplets.gp5-ref.mscx
@@ -390,6 +390,7 @@
               </Rest>
             <Tuplet>
               <linked>
+                <indexDiff>1</indexDiff>
                 </linked>
               <normalNotes>2</normalNotes>
               <actualNotes>3</actualNotes>
@@ -405,11 +406,13 @@
               </Beam>
             <Chord>
               <linked>
+                <indexDiff>1</indexDiff>
                 </linked>
               <dots>1</dots>
               <durationType>eighth</durationType>
               <Note>
                 <linked>
+                  <indexDiff>1</indexDiff>
                   </linked>
                 <pitch>71</pitch>
                 <tpc>19</tpc>

--- a/mtest/guitarpro/testIrrTuplet.gp4-ref.mscx
+++ b/mtest/guitarpro/testIrrTuplet.gp4-ref.mscx
@@ -447,10 +447,12 @@
               </Beam>
             <Chord>
               <linked>
+                <indexDiff>1</indexDiff>
                 </linked>
               <durationType>16th</durationType>
               <Note>
                 <linked>
+                  <indexDiff>1</indexDiff>
                   </linked>
                 <Spanner type="Tie">
                   <Tie>

--- a/mtest/guitarpro/tuplets2.gpx-ref.mscx
+++ b/mtest/guitarpro/tuplets2.gpx-ref.mscx
@@ -273,7 +273,7 @@ solo concert</text>
                 </Slur>
               <next>
                 <location>
-                  <fractions>-1/1</fractions>
+                  <fractions>1/4</fractions>
                   </location>
                 </next>
               </Spanner>
@@ -313,7 +313,7 @@ solo concert</text>
             <Spanner type="Slur">
               <prev>
                 <location>
-                  <fractions>1/1</fractions>
+                  <fractions>-1/4</fractions>
                   </location>
                 </prev>
               </Spanner>
@@ -1036,7 +1036,7 @@ solo concert</text>
                   </Slur>
                 <next>
                   <location>
-                    <fractions>-1/1</fractions>
+                    <fractions>1/4</fractions>
                     </location>
                   </next>
                 </Spanner>
@@ -1079,7 +1079,7 @@ solo concert</text>
               <Spanner type="Slur">
                 <prev>
                   <location>
-                    <fractions>1/1</fractions>
+                    <fractions>-1/4</fractions>
                     </location>
                   </prev>
                 </Spanner>
@@ -1710,7 +1710,7 @@ solo concert</text>
                   </Slur>
                 <next>
                   <location>
-                    <fractions>-1/1</fractions>
+                    <fractions>1/4</fractions>
                     </location>
                   </next>
                 </Spanner>
@@ -1753,7 +1753,7 @@ solo concert</text>
               <Spanner type="Slur">
                 <prev>
                   <location>
-                    <fractions>1/1</fractions>
+                    <fractions>-1/4</fractions>
                     </location>
                   </prev>
                 </Spanner>

--- a/mtest/libmscore/tuplet/split1-ref.mscx
+++ b/mtest/libmscore/tuplet/split1-ref.mscx
@@ -155,7 +155,7 @@
                 <next>
                   <location>
                     <measures>1</measures>
-                    <fractions>-1387/1920</fractions>
+                    <fractions>-35/36</fractions>
                     </location>
                   </next>
                 </Spanner>
@@ -198,7 +198,7 @@
                 <prev>
                   <location>
                     <measures>-1</measures>
-                    <fractions>1387/1920</fractions>
+                    <fractions>35/36</fractions>
                     </location>
                   </prev>
                 </Spanner>

--- a/mtest/libmscore/tuplet/split2-ref.mscx
+++ b/mtest/libmscore/tuplet/split2-ref.mscx
@@ -166,7 +166,7 @@
                 <next>
                   <location>
                     <measures>1</measures>
-                    <fractions>-2/3</fractions>
+                    <fractions>-11/12</fractions>
                     </location>
                   </next>
                 </Spanner>
@@ -195,7 +195,7 @@
                 <prev>
                   <location>
                     <measures>-1</measures>
-                    <fractions>2/3</fractions>
+                    <fractions>11/12</fractions>
                     </location>
                   </prev>
                 </Spanner>

--- a/mtest/libmscore/tuplet/split3-ref.mscx
+++ b/mtest/libmscore/tuplet/split3-ref.mscx
@@ -135,7 +135,7 @@
                 <next>
                   <location>
                     <measures>1</measures>
-                    <fractions>-2/3</fractions>
+                    <fractions>-11/12</fractions>
                     </location>
                   </next>
                 </Spanner>
@@ -168,7 +168,7 @@
                 <prev>
                   <location>
                     <measures>-1</measures>
-                    <fractions>2/3</fractions>
+                    <fractions>11/12</fractions>
                     </location>
                   </prev>
                 </Spanner>

--- a/mtest/libmscore/tuplet/split4-ref.mscx
+++ b/mtest/libmscore/tuplet/split4-ref.mscx
@@ -174,7 +174,7 @@
                 <next>
                   <location>
                     <measures>1</measures>
-                    <fractions>-237/320</fractions>
+                    <fractions>-107/108</fractions>
                     </location>
                   </next>
                 </Spanner>
@@ -227,7 +227,7 @@
                 <prev>
                   <location>
                     <measures>-1</measures>
-                    <fractions>237/320</fractions>
+                    <fractions>107/108</fractions>
                     </location>
                   </prev>
                 </Spanner>


### PR DESCRIPTION
See https://musescore.org/en/node/278943.

Tuplet::rfrac() and Tuplet::afrac() are unnecessary, as well as incorrect. DurationElement provides the correct implementation of these two methods.