### PR TITLE
fix #278907: extend time signature shape vertically

### DIFF
--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -347,6 +347,26 @@ void TimeSig::layout()
       }
 
 //---------------------------------------------------------
+//   shape
+//---------------------------------------------------------
+
+Shape TimeSig::shape() const
+      {
+      QRectF box(bbox());
+      const Staff* st = staff();
+      if (st && autoplace()) {
+            // Extend time signature shape up and down to
+            // the first ledger line height to ensure that
+            // no notes will be too close to the timesig.
+            const qreal sp = spatium();
+            const qreal y = pos().y();
+            box.setTop(std::min(-sp - y, box.top()));
+            box.setBottom(std::max(st->height() - y + sp, box.bottom()));
+            }
+      return Shape(box);
+      }
+
+//---------------------------------------------------------
 //   draw
 //---------------------------------------------------------
 

--- a/libmscore/timesig.h
+++ b/libmscore/timesig.h
@@ -76,6 +76,7 @@ class TimeSig final : public Element {
       virtual void write(XmlWriter& xml) const override;
       virtual void read(XmlReader&) override;
       virtual void layout() override;
+      virtual Shape shape() const override;
 
       Fraction sig() const               { return _sig; }
       void setSig(const Fraction& f, TimeSigType st = TimeSigType::NORMAL);


### PR DESCRIPTION
This PR tries to fix [this issue](https://musescore.org/en/node/278907) by slightly extending (by 1 line height) time signature shape in vertical direction. This should prevent placing notes too close to time signature. This shape extension can be disabled with disabling time signature autoplacement.