### PR TITLE
FIX278847

### DIFF
--- a/mscore/inspector/inspector_tempotext.ui
+++ b/mscore/inspector/inspector_tempotext.ui
@@ -98,7 +98,7 @@
          <string>BPM</string>
         </property>
         <property name="decimals">
-         <number>1</number>
+         <number>2</number>
         </property>
         <property name="minimum">
          <double>5.000000000000000</double>
@@ -172,16 +172,16 @@
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="Ms::ResetButton" name="resetFollowText"/>
+       <widget class="Ms::ResetButton" name="resetFollowText" native="true"/>
       </item>
       <item row="1" column="2">
-       <widget class="Ms::ResetButton" name="resetTempo"/>
+       <widget class="Ms::ResetButton" name="resetTempo" native="true"/>
       </item>
       <item row="2" column="2">
-       <widget class="Ms::ResetButton" name="resetStyle"/>
+       <widget class="Ms::ResetButton" name="resetStyle" native="true"/>
       </item>
       <item row="3" column="2">
-       <widget class="Ms::ResetButton" name="resetPlacement"/>
+       <widget class="Ms::ResetButton" name="resetPlacement" native="true"/>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
fix #278847: Changes tempo text inspector decimal precision from 1 to 2 decimal places.  This gives it precision of 1/100th of a bpm.
I notice in the text file version of the .ui file that it added native="true" in four places.  I edited this file in Qt Creator, not via a text editor.  I am running on Windows.  Let me know of those 4 additions are a problem, and we'll figure out a way to eliminate them.