### PR TITLE
fix #278847: two decimal places for tempo in inspector

### DIFF
--- a/mscore/inspector/inspector_tempotext.ui
+++ b/mscore/inspector/inspector_tempotext.ui
@@ -98,7 +98,7 @@
          <string>BPM</string>
         </property>
         <property name="decimals">
-         <number>1</number>
+         <number>2</number>
         </property>
         <property name="minimum">
          <double>5.000000000000000</double>


### PR DESCRIPTION
fix #278847: Changes tempo text inspector decimal precision from 1 to 2 decimal places. This gives it precision of 1/100th of a bpm.
I notice in the text file version of the .ui file that it added native="true" in four places. I edited this file in Qt Creator, not via a text editor. I am running on Windows. Let me know of those 4 additions are a problem, and we'll figure out a way to eliminate them.