### PR TITLE
Fix #278970 for Beta: Preferences/Shortcuts not shown (and so not changable)

### DIFF
--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -610,7 +610,7 @@ void PreferenceDialog::updateSCListView()
                             && !s->key().startsWith("debugger")
 #endif
                             && !s->key().startsWith("edit_harmony")
-                            && (MuseScore::unstable() && !s->key().startsWith("file-save-online"))
+                            && !(MuseScore::unstable() && s->key().startsWith("file-save-online"))
                             && !s->key().startsWith("insert-fretframe"))) {
                   shortcutList->addTopLevelItem(newItem);
                   }


### PR DESCRIPTION
This will fix [278970](https://musescore.org/en/node/278970). Problem is that with the change to stable version it never got through ;)
I commented the problematic section out, so we can track it in case we want to make changes to these sections for the really stable builds.