### PR TITLE
Fix #278230: Looking at staff properties changes clef of instruments …

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -912,13 +912,20 @@ bool Instrument::operator==(const Instrument& i) const
             if (!(i._shortNames[k] == _shortNames[k].name()))
                   return false;
             }
+      n = _channel.size();
+      if (i._channel.size() != n)
+            return false;
+      for (int k = 0; k < n; ++k) {
+            if (!(*i._channel[k] == *_channel[k]))
+                  return false;
+            }
+
       return i._minPitchA == _minPitchA
          &&  i._maxPitchA == _maxPitchA
          &&  i._minPitchP == _minPitchP
          &&  i._maxPitchP == _maxPitchP
          &&  i._useDrumset == _useDrumset
          &&  i._midiActions == _midiActions
-         &&  i._channel == _channel
          &&  i._articulation == _articulation
          &&  i._transpose.diatonic == _transpose.diatonic
          &&  i._transpose.chromatic == _transpose.chromatic

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -335,7 +335,7 @@ void EditStaff::apply()
       instrument.setLongName(ln);
 
       bool inv       = invisible->isChecked();
-      ClefTypeList clefType = instrument.clefType(orgStaff->rstaff());
+      ClefTypeList clefType = orgStaff->defaultClefType();
       qreal userDist = spinExtraDistance->value();
       bool ifEmpty   = showIfEmpty->isChecked();
       bool hideSystemBL = hideSystemBarLine->isChecked();
@@ -353,6 +353,8 @@ void EditStaff::apply()
 
             if (v1 != v2)
                   score->transpositionChanged(part, v2, _tickStart, _tickEnd);
+
+            clefType = instrument.clefType(orgStaff->rstaff());
             }
       orgStaff->undoChangeProperty(Pid::MAG, mag->value() / 100.0);
       orgStaff->undoChangeProperty(Pid::COLOR, color->color());


### PR DESCRIPTION
…with multiple staves

Only check clef change if instrument changes. For some reason, the comparison of channels was not properly working, so I expanded it and did it manually. I'd rather not do it this way, but I don't know what is wrong with the operator.