### PR TITLE
fix #276135: do not show context menu in note input mode

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -695,6 +695,10 @@ void ScoreView::keyReleaseEvent(QKeyEvent* ev)
 
 void ScoreView::contextMenuEvent(QContextMenuEvent* ev)
       {
+      if (state == ViewState::NOTE_ENTRY) {
+            // Do not show context menu in note input mode.
+            return;
+            }
       if (state == ViewState::FOTO) {
             fotoContextPopup(ev);
             return;


### PR DESCRIPTION
This PR just implements this request: https://musescore.org/en/node/276135.