### PR TITLE
Fix #279024: double click on mixer's dial and sliders should reset th…

### DIFF
--- a/mscore/mixertrackpart.cpp
+++ b/mscore/mixertrackpart.cpp
@@ -124,6 +124,7 @@ MixerTrackPart::MixerTrackPart(QWidget *parent, MixerTrackItemPtr mti, bool expa
       panSlider->setToolTip(tr("Pan: %1").arg(QString::number(chan->pan())));
       panSlider->setMaxValue(127);
       panSlider->setMinValue(0);
+      panSlider->setDclickValue1(64);
 
       connect(volumeSlider, SIGNAL(valueChanged(double)),      SLOT(volumeChanged(double)));
       connect(panSlider,    SIGNAL(valueChanged(double, int)), SLOT(panChanged(double)));


### PR DESCRIPTION
…em to their defaults

Any other defaults that should be set in the mixer?