### PR TITLE
fix #278383: images can't be moved with mouse

### DIFF
--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -32,7 +32,7 @@ static bool defaultSizeIsSpatium    = true;
 //---------------------------------------------------------
 
 Image::Image(Score* s)
-   : BSymbol(s, ElementFlag::NOTHING)
+   : BSymbol(s, ElementFlag::MOVABLE)
       {
       imageType        = ImageType::NONE;
       rasterDoc        = 0;

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -468,7 +468,7 @@ void ScoreView::mouseMoveEvent(QMouseEvent* me)
 
       switch (state) {
             case ViewState::NORMAL:
-                   if (!drag)
+                  if (!drag)
                         return;
                   if (!editData.element && (me->modifiers() & Qt::ShiftModifier))
                         changeState(ViewState::LASSO);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/278383

The element just wasn't movable :)