### PR TITLE
fix #87241, fix #279064: Remove invalid pointers to elements from selection and avoid complete data loss in case of crash on saving .mscz file

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2479,16 +2479,14 @@ void Score::cmdExplode()
                   lastStaff = qMin(nstaves(), srcStaff + n);
                   }
 
-            // make our own copy of selection, since pasting modifies actual selection
-            Selection srcSelection(selection());
-
+            const QByteArray mimeData(selection().mimeData());
             // copy to all destination staves
             Segment* firstCRSegment = startMeasure->tick2segment(startMeasure->tick());
             for (int i = 1; srcStaff + i < lastStaff; ++i) {
                   int track = (srcStaff + i) * VOICES;
                   ChordRest* cr = toChordRest(firstCRSegment->element(track));
                   if (cr) {
-                        XmlReader e(srcSelection.mimeData());
+                        XmlReader e(mimeData);
                         e.setPasteMode(true);
                         pasteStaff(e, cr->segment(), cr->staffIdx());
                         }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1254,7 +1254,7 @@ void Score::cmdAddTie()
 
 void Score::cmdAddOttava(OttavaType type)
       {
-      Selection sel = selection();
+      const Selection& sel = selection();
       // add on each staff if possible
       if (sel.isRange() && sel.staffStart() != sel.staffEnd() - 1) {
             for (int staffIdx = sel.staffStart() ; staffIdx < sel.staffEnd(); ++staffIdx) {

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -186,14 +186,7 @@ Element::Element(const Element& e)
 
 Element::~Element()
       {
-#if 0
-      if (score() &&  flag(ElementFlag::SELECTED)) {
-            if (score()->selection().elements().removeOne(this))
-                  printf("remove element from selection\n");
-            else
-                  printf("element not in selection\n");
-            }
-#endif
+      Score::onElementDestruction(this);
       }
 
 //---------------------------------------------------------

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3825,8 +3825,7 @@ void Score::doLayoutRange(int stick, int etick)
             for (System* s : _systems) {
                   for (Bracket* b : s->brackets()) {
                         if (b->selected()) {
-                              _selection.elements().removeOne(b);
-                              _selection.updateState();
+                              _selection.remove(b);
                               setSelectionChanged(true);
                               }
                         }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -387,6 +387,7 @@ class Score : public QObject, public ScoreElement {
             };
 
    private:
+      static std::set<Score*> validScores;
       int _linkId { 0 };
       MasterScore* _masterScore { 0 };
       QList<MuseScoreView*> viewer;
@@ -559,6 +560,8 @@ class Score : public QObject, public ScoreElement {
 
       virtual bool isMaster() const  { return false;        }
       virtual bool readOnly() const;
+
+      static void onElementDestruction(Element* se);
 
       virtual inline QList<Excerpt*>& excerpts();
       virtual inline const QList<Excerpt*>& excerpts() const;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -758,7 +758,7 @@ class Score : public QObject, public ScoreElement {
       bool saveFile(QFileInfo& info);
       bool saveFile(QIODevice* f, bool msczFormat, bool onlySelection = false);
       bool saveCompressedFile(QFileInfo&, bool onlySelection);
-      bool saveCompressedFile(QIODevice*, QFileInfo&, bool onlySelection, bool createThumbnail = true);
+      bool saveCompressedFile(QFileDevice*, QFileInfo&, bool onlySelection, bool createThumbnail = true);
       bool exportFile();
 
       void print(QPainter* printer, int page);

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -546,7 +546,7 @@ QImage Score::createThumbnail()
 //    file is already opened
 //---------------------------------------------------------
 
-bool Score::saveCompressedFile(QIODevice* f, QFileInfo& info, bool onlySelection, bool doCreateThumbnail)
+bool Score::saveCompressedFile(QFileDevice* f, QFileInfo& info, bool onlySelection, bool doCreateThumbnail)
       {
       MQZipWriter uz(f);
 
@@ -571,6 +571,14 @@ bool Score::saveCompressedFile(QIODevice* f, QFileInfo& info, bool onlySelection
       cbuf.seek(0);
       //uz.addDirectory("META-INF");
       uz.addFile("META-INF/container.xml", cbuf.data());
+
+      QBuffer dbuf;
+      dbuf.open(QIODevice::ReadWrite);
+      saveFile(&dbuf, true, onlySelection);
+      dbuf.seek(0);
+      uz.addFile(fn, dbuf.data());
+      f->flush(); // flush to preserve score data in case of
+                  // any failures on the further operations.
 
       // save images
       //uz.addDirectory("Pictures");
@@ -620,11 +628,6 @@ bool Score::saveCompressedFile(QIODevice* f, QFileInfo& info, bool onlySelection
       if (_audio)
             uz.addFile("audio.ogg", _audio->data());
 
-      QBuffer dbuf;
-      dbuf.open(QIODevice::ReadWrite);
-      saveFile(&dbuf, true, onlySelection);
-      dbuf.seek(0);
-      uz.addFile(fn, dbuf.data());
       uz.close();
       return true;
       }

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -319,9 +319,10 @@ void Selection::clear()
 
 void Selection::remove(Element* el)
       {
-      _el.removeOne(el);
+      const bool removed = _el.removeOne(el);
       el->setSelected(false);
-      updateState();
+      if (removed)
+            updateState();
       }
 
 //---------------------------------------------------------

--- a/libmscore/select.h
+++ b/libmscore/select.h
@@ -157,7 +157,6 @@ class Selection {
       void setState(SelState s);
 
       const QList<Element*>& elements() const { return _el; }
-      QList<Element*>& elements()             { return _el; }
       std::vector<Note*> noteList(int track = -1) const;
 
       const QList<Element*> uniqueElements() const;

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -451,7 +451,7 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
       Score* score = mscore->currentScore();
       if (score == 0)
             return;
-      Selection sel = score->selection();       // make a copy of the list
+      const Selection& sel = score->selection();       // make a copy of the list
       if (sel.isNone())
             return;
 
@@ -753,8 +753,7 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
       Score* score = mscore->currentScore();
       if (score == 0)
             return;
-      Selection sel = score->selection();       // make a copy of the list
-      if (sel.isNone())
+      if (score->selection().isNone())
             return;
 
       applyPaletteElement(cellAt(i), ev->modifiers());

--- a/mscore/pianotools.cpp
+++ b/mscore/pianotools.cpp
@@ -184,7 +184,7 @@ void HPiano::releasePitch(int pitch)
 //   changeSelection
 //---------------------------------------------------------
 
-void HPiano::changeSelection(Selection selection)
+void HPiano::changeSelection(const Selection& selection)
       {
       for (PianoKeyItem* key : keys) {
             key->setHighlighted(false);
@@ -533,7 +533,7 @@ bool HPiano::gestureEvent(QGestureEvent *event)
 //   changeSelection
 //---------------------------------------------------------
 
-void PianoTools::changeSelection(Selection selection)
+void PianoTools::changeSelection(const Selection& selection)
       {
       _piano->changeSelection(selection);
       }

--- a/mscore/pianotools.h
+++ b/mscore/pianotools.h
@@ -79,7 +79,7 @@ class HPiano : public QGraphicsView {
       void pressPitch(int pitch);
       void releasePitch(int pitch);
       void clearSelection();
-      void changeSelection(Selection selection);
+      void changeSelection(const Selection& selection);
       void updateAllKeys();
       virtual QSize sizeHint() const;
 
@@ -110,7 +110,7 @@ class PianoTools : public QDockWidget {
       void releasePitch(int pitch)  { _piano->releasePitch(pitch); }
       void heartBeat(QList<const Note*> notes);
       void clearSelection();
-      void changeSelection(Selection selection);
+      void changeSelection(const Selection& selection);
       };
 
 

--- a/mscore/pianoview.cpp
+++ b/mscore/pianoview.cpp
@@ -937,7 +937,8 @@ void PianoView::selectNotes(int startTick, int endTick, int lowPitch, int highPi
       //score->masterScore()->cmdState().reset();      // DEBUG: should not be necessary
       score->startCmd();
 
-      Selection selection(score);
+      Selection& selection = score->selection();
+      selection.deselectAll();
 
       for (int i = 0; i < noteList.size(); ++i) {
             PianoItem* pi = noteList[i];
@@ -967,7 +968,6 @@ void PianoView::selectNotes(int startTick, int endTick, int lowPitch, int highPi
                   selection.add(pi->note());
             }
 
-      score->setSelection(selection);
       for (MuseScoreView* view : score->getViewer())
             view->updateAll();
       

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3308,7 +3308,7 @@ void ScoreView::cmdAddNoteLine()
 void ScoreView::cmdChangeEnharmonic(bool both)
       {
       _score->startCmd();
-      Selection selection = _score->selection();
+      Selection& selection = _score->selection();
       QList<Note*> notes = selection.uniqueNotes();
       for (Note* n : notes) {
             Staff* staff = n->staff();

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1726,8 +1726,8 @@ void Timeline::drawSelection()
 
       std::set<std::tuple<Measure*, int, ElementType>> meta_labels_set;
 
-      const Selection selection = _score->selection();
-      QList<Element*> el = selection.elements();
+      const Selection& selection = _score->selection();
+      const QList<Element*>& el = selection.elements();
       for (Element* element : el) {
             if (element->tick() == -1)
                   continue;


### PR DESCRIPTION
This pull request is intended to try to mitigate the [issue #87241](https://musescore.org/en/node/87241). It contains three commits:
- The first is optional one, it avoids unnecessary copying of Selection objects. This will probably assist during the latter development of the complete solution for the issue but is largely optional now.
- The second one tries to mitigate consequences of failures of such sort and reorganizes the process of writing .mscz file so that in case of MuseScore crash on writing thumbnails or pictures the saved file still contains the full score saved, and although the file is still corrupted in this case it is possible to restore the information from it using external unzip programs. Such a reparation could be also built into MuseScore but this would probably require changing the library used for ZIP format handling.
- The third one fixes the particular case which I could reproduce and which leads to the same kind of failure on writing .mscz files ending up with an empty/corrupted file. This particular issue was in not removing brackets from selection on deleting them in some cases.

See 
https://github.com/musescore/MuseScore/pull/4268#issuecomment-443441901 as well.