### PR TITLE
fix #279099: Dotted tuplet has incorrect duration after save/reload

### DIFF
--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -718,6 +718,8 @@ void Tuplet::write(XmlWriter& xml) const
       writeProperty(xml, Pid::P2);
 
       xml.tag("baseNote", _baseLen.name());
+      if (int dots = _baseLen.dots())
+            xml.tag("baseDots", dots);
 
       if (_number) {
             xml.stag("Number", _number);
@@ -740,7 +742,7 @@ void Tuplet::read(XmlReader& e)
             else
                   e.unknown();
             }
-      Fraction f(_ratio.denominator(), _baseLen.fraction().denominator());
+      Fraction f = _baseLen.fraction() * _ratio.denominator();
       setDuration(f.reduced());
       }
 
@@ -764,6 +766,8 @@ bool Tuplet::readProperties(XmlReader& e)
             _p2 = e.readPoint() * score()->spatium();
       else if (tag == "baseNote")
             _baseLen = TDuration(e.readElementText());
+      else if (tag == "baseDots")
+            _baseLen.setDots(e.readInt());
       else if (tag == "Number") {
             _number = new Text(score(), Tid::TUPLET);
             _number->setComposition(true);

--- a/mscore/tupletdialog.cpp
+++ b/mscore/tupletdialog.cpp
@@ -115,9 +115,8 @@ Tuplet* MuseScore::tupletDialog()
          qPrintable(tuplet->ratio().print()),
          qPrintable(f.print()));
 
-      Fraction fbl(1, f.denominator());
-      if (TDuration::isValid(fbl))
-            tuplet->setBaseLen(fbl);
+      if (TDuration::isValid(f))
+            tuplet->setBaseLen(f);
       else
             tuplet->setBaseLen(TDuration::DurationType::V_INVALID);
 

--- a/mtest/guitarpro/dotted-tuplets.gp5-ref.mscx
+++ b/mtest/guitarpro/dotted-tuplets.gp5-ref.mscx
@@ -90,6 +90,7 @@
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
+            <baseDots>1</baseDots>
             <Number>
               <style>Tuplet</style>
               <text>3</text>
@@ -282,6 +283,7 @@
               <normalNotes>2</normalNotes>
               <actualNotes>3</actualNotes>
               <baseNote>eighth</baseNote>
+              <baseDots>1</baseDots>
               <Number>
                 <style>Tuplet</style>
                 <text>3</text>
@@ -394,6 +396,7 @@
               <normalNotes>2</normalNotes>
               <actualNotes>3</actualNotes>
               <baseNote>eighth</baseNote>
+              <baseDots>1</baseDots>
               <Number>
                 <style>Tuplet</style>
                 <text>3</text>


### PR DESCRIPTION
See https://musescore.org/en/node/279099.