### PR TITLE
fix #224031: record adding measure elements to undo stack on creating MM rests

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1787,8 +1787,11 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                         break;
                         }
                   }
-            if (!found)
-                  mmr->add(e->clone());
+            if (!found) {
+                  Element* e1 = e->clone();
+                  e1->setParent(mmr);
+                  undo(new AddElement(e1));
+                  }
             }
       for (Element* e : oldList)
             delete e;


### PR DESCRIPTION
See https://musescore.org/en/node/224031.

Records elements added to measure rest to undo stack which makes it possible to undo removing operation on that element properly. There is nothing to undo though from the user point of view: it seems that such elements are removed from MM rest only but not from the underlying measures. This should be handled separately though, and the proposed patch at least fixes the related crash. 