### PR TITLE
fix #278896: invisible text should not affect mmrests or hide empty staves

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2059,6 +2059,8 @@ static bool breakMultiMeasureRest(Measure* m)
 
       for (Segment* s = m->first(); s; s = s->next()) {
             for (Element* e : s->annotations()) {
+                  if (!e->visible())
+                        continue;
                   if (e->isRehearsalMark() ||
                       e->isTempoText() ||
                       ((e->isHarmony() || e->isStaffText() || e->isSystemText()) && (e->systemFlag() || m->score()->staff(e->staffIdx())->show())))

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2558,7 +2558,7 @@ bool Measure::isMeasureRest(int staffIdx) const
                         return false;
                   }
             for (Element* a : s->annotations()) {
-                  if (!a || a->systemFlag())
+                  if (!a || a->systemFlag() || !a->visible())
                         continue;
                   int atrack = a->track();
                   if (atrack >= strack && atrack < etrack)


### PR DESCRIPTION
Issue https://musescore.org/en/node/278896 is an explicit request for invisible text to not break mmrests, and I agree.  That is the change in layout.cpp

I also am making it not affect hide empty staves.  In 2.x, text was completely ignored in hide empty staves - a staff could be considered empty and hidden even if it contained text.  This was reported as a bug - see https://musescore.org/en/node/44956 - so I fixed it so the presence of text would prevent a staff from being hidden.  However, it is now being observed (see https://musescore.org/en/node/279204) that this breaks one use case where people add staff text to empty measures in parts as a form of cue, and expect the staff to still be hidden in the score.  In one sense this is relying on a bug, but it's a valid thing to want to make happen.  The obvious solution to me is to make it so *visible* text will prevent a staff from being hidden, but *invisible* text won't.  That is the second change in this PR (in measure.cpp).  So now people relying on the old bug can get that behavior by hiding the text in the score.

Overall, both changes seem consistent with the general principle that invisible elements should not affect layout.

BTW, originally I implemented the first change in hopes of taking advantage of invisible text as a way of preventing a staff from being considered empty in a given system, but we can still find some other mechanism for that at some point.