### PR TITLE
fix #277956: do not reset positions for generated elements

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1907,6 +1907,8 @@ void Score::cmdResetNoteAndRestGroupings()
 
 static void resetElementPosition(void*, Element* e)
       {
+      if (e->generated())
+            return;
       e->undoResetProperty(Pid::AUTOPLACE);
       e->undoResetProperty(Pid::OFFSET);
       if (e->isSpanner())


### PR DESCRIPTION
Resetting positions for generated elements may cause extra elements to appear, see https://musescore.org/en/node/277956 for example.