### PR TITLE
partial fix #279259: chord symbol spacing

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1168,6 +1168,8 @@ Shape ChordRest::shape() const
       qreal x2 = -1000000.0;
       bool adjustWidth = false;
       for (Lyrics* l : _lyrics) {
+            if (!l->visible())
+                  continue;
             static const qreal margin = spatium() * .5;
             // for horizontal spacing we only need the lyrics width:
             x1 = qMin(x1, l->bbox().x() - margin + l->pos().x());
@@ -1178,11 +1180,11 @@ Shape ChordRest::shape() const
             }
 
       for (Element* e : segment()->annotations()) {
-            if (e->isHarmony() && e->staffIdx() == staffIdx()) {
+            if (e->isHarmony() && e->staffIdx() == staffIdx() && e->visible()) {
                   e->layout();
-                  qreal hx = e->bbox().x() - e->pos().x();
-                  x1 = qMin(x1, hx);
-                  x2 = qMax(x2, hx + e->bbox().width());
+                  const qreal margin = styleP(Sid::minHarmonyDistance) * 0.5;
+                  x1 = qMin(x1, e->bbox().x() - margin + e->pos().x());
+                  x2 = qMax(x2, e->bbox().x() + e->bbox().width() + margin + e->pos().x());
                   adjustWidth = true;
                   }
             }


### PR DESCRIPTION
I have to confess I didn't work the geometry calculations, I just copied the lyrics layout code just above, which seems to work just fine for both centered and left-aligned lyrics.  Not sure if there was a reason this same calculation wasn't used for chord symbols in the first place, but from my testing it works as expected.

I also made it so invisible chord symbols don't space things, and while I was at it did the same for lyrics.  Since that seems to be coming up a bunch.