### PR TITLE
fix #279240: systems overlap rather than separate by minVerticalDistance

### DIFF
--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1109,7 +1109,7 @@ qreal System::minDistance(System* s2) const
                         }
                   }
             qreal sld = staff(lastStaff)->skyline().minDistance(s2->staff(firstStaff)->skyline());
-            sld -=  staff(lastStaff)->bbox().height() + minVerticalDistance;
+            sld -=  staff(lastStaff)->bbox().height() - minVerticalDistance;
             dist = qMax(dist, sld);
 //            dist = dist - staff(lastStaff)->bbox().height() + minVerticalDistance;
             }


### PR DESCRIPTION
Seems straightforward, the calculation was accounting for minVerticalDistance the wrong way in System::minDistance().

BTW, this is a style parameter, but no UI to set it that I can see.  Is that a deliberate decision not to expose it?