### PR TITLE
partial fix #88861: show current staff name after instrument change

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2970,7 +2970,8 @@ System* Score::collectSystem(LayoutContext& lc)
             lc.startWithLongNames = lc.firstSystem && measure->sectionBreakElement()->startWithLongNames();
             }
       System* system = getNextSystem(lc);
-      system->setInstrumentNames(lc.startWithLongNames);
+      int lcmTick = lc.curMeasure ? lc.curMeasure->tick() : 0;
+      system->setInstrumentNames(lc.startWithLongNames, lcmTick);
 
       qreal minWidth    = 0;
       bool firstMeasure = true;

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -595,7 +595,7 @@ void System::layout2()
 //   setInstrumentNames
 //---------------------------------------------------------
 
-void System::setInstrumentNames(bool longName)
+void System::setInstrumentNames(bool longName, int tick)
       {
       //
       // remark: add/remove instrument names is not undo/redoable
@@ -612,10 +612,6 @@ void System::setInstrumentNames(bool longName)
             return;
             }
 
-      // TODO: ml is normally empty here, so we are unable to retrieve tick
-      // thus, staff name does not reflect current instrument
-
-      int tick = ml.empty() ? 0 : ml.front()->tick();
       int staffIdx = 0;
       for (SysStaff* staff : _staves) {
             Staff* s = score()->staff(staffIdx);

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -128,7 +128,7 @@ class System final : public Element {
       void removeStaff(int);
 
       int y2staff(qreal y) const;
-      void setInstrumentNames(bool longName);
+      void setInstrumentNames(bool longName, int tick = 0);
       int snap(int tick, const QPointF p) const;
       int snapNote(int tick, const QPointF p, int staff) const;
 

--- a/mscore/continuouspanel.cpp
+++ b/mscore/continuouspanel.cpp
@@ -159,10 +159,10 @@ void ContinuousPanel::paint(const QRect&, QPainter& painter)
                   Segment* parent = _score->tick2segment(tick);
 
                   // Find maximum width for the staff name
-                  QList<StaffName>& staffNamesLong = currentStaff->part()->instrument()->longNames();
+                  QList<StaffName>& staffNamesLong = currentStaff->part()->instrument(tick)->longNames();
                   QString staffName = staffNamesLong.isEmpty() ? " " : staffNamesLong[0].name();
                   if (staffName == "") {
-                        QList<StaffName>& staffNamesShort = currentStaff->part()->instrument()->shortNames();
+                        QList<StaffName>& staffNamesShort = currentStaff->part()->instrument(tick)->shortNames();
                         staffName = staffNamesShort.isEmpty() ? "" : staffNamesShort[0].name();
                         }
                   Text* newName = new Text(_score);
@@ -345,10 +345,10 @@ void ContinuousPanel::paint(const QRect&, QPainter& painter)
                   barLine.draw(&painter);
 
                   // Draw the current staff name
-                  QList<StaffName>& staffNamesLong = currentStaff->part()->instrument()->longNames();
+                  QList<StaffName>& staffNamesLong = currentStaff->part()->instrument(tick)->longNames();
                   QString staffName = staffNamesLong.isEmpty() ? " " : staffNamesLong[0].name();
                   if (staffName == "") {
-                        QList<StaffName>& staffNamesShort = currentStaff->part()->instrument()->shortNames();
+                        QList<StaffName>& staffNamesShort = currentStaff->part()->instrument(tick)->shortNames();
                         staffName = staffNamesShort.isEmpty() ? "" : staffNamesShort[0].name();
                         }
 


### PR DESCRIPTION
It's often requested that after a mid-score instrument change, the staff names reflect the new name.  This PR implements that.  The issue referenced actually requests a UI to edit the staff name, and that's not unreasonable, but a task for another day.