### PR TITLE
fix #279175, fix #279252: Update chord symbol on updating its text

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1609,6 +1609,8 @@ QVariant Harmony::getProperty(Pid pid) const
 bool Harmony::setProperty(Pid pid, const QVariant& v)
       {
       if (TextBase::setProperty(pid, v)) {
+            if (pid == Pid::TEXT)
+                  setHarmony(v.toString());
             render();
             return true;
             }


### PR DESCRIPTION
This PR fixes some issues with chord symbols editing regarding its updating in parts. There are some other issues left regarding, for example, red highlighting of invalid chords, but they will probably anyway require a separate treatment.
For the issues description see:
https://musescore.org/en/node/279175
https://musescore.org/en/node/279252