### PR TITLE
fix #278471: hide fingerings depending on staff settings

### DIFF
--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -52,6 +52,16 @@ Fingering::Fingering(Score* s, ElementFlags ef)
 
 void Fingering::layout()
       {
+      if (parent()) {
+            const int tick = parent()->tick();
+            const Staff* st = staff();
+            if (st && st->isTabStaff(tick)
+               && !st->staffType(tick)->showTabFingering()) {
+                  setbbox(QRectF());
+                  return;
+                  }
+            }
+
       TextBase::layout();
 
       if (autoplace() && note()) {


### PR DESCRIPTION
See https://musescore.org/ru/node/278471.
Not hiding fingerings depending on staff settings was apparently caused by e8621b8e2a5d63c5ca50130e3f0b554fb1e1aaf6. The code that implemented that behavior was put there again and updated to work correctly with the current state of MuseScore code.