### PR TITLE
fix #279063: check systems when aligning hairpins with dynamics

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -86,9 +86,12 @@ void HairpinSegment::layout()
       const int _track = track();
       if (autoplace() && !score()->isPalette()) {
             // Try to fit between adjacent dynamics
+            const System* sys = system();
             if (isSingleType() || isBeginType()) {
                   Segment* start = hairpin()->startSegment();
-                  Dynamic* sd = start ? toDynamic(start->findAnnotation(ElementType::DYNAMIC, _track, _track)) : nullptr;
+                  Dynamic* sd = nullptr;
+                  if (start && start->system() == sys)
+                        sd = toDynamic(start->findAnnotation(ElementType::DYNAMIC, _track, _track));
                   if (sd) {
                         const qreal sdRight = sd->bbox().right() + sd->pos().x()
                                               + sd->segment()->pos().x() + sd->measure()->pos().x();
@@ -99,7 +102,12 @@ void HairpinSegment::layout()
                   }
             if (isSingleType() || isEndType()) {
                   Segment* end = hairpin()->endSegment();
-                  Dynamic* ed = end ? toDynamic(end->findAnnotation(ElementType::DYNAMIC, _track, _track)) : nullptr;
+                  Dynamic* ed = nullptr;
+                  if (end && end->tick() < sys->endTick()) {
+                        // checking ticks rather than systems since latter
+                        // systems may be unknown at layout stage.
+                        ed = toDynamic(end->findAnnotation(ElementType::DYNAMIC, _track, _track));
+                        }
                   if (ed) {
                         const qreal edLeft  = ed->bbox().left() + ed->pos().x()
                                               + ed->segment()->pos().x() + ed->measure()->pos().x();


### PR DESCRIPTION
See https://musescore.org/en/node/279063.
This issue seems to be introduced by my PR #4203. This PR modifies the code added by that one to check systems of the hairpin segment and the adjacent dynamics marking prior to making any position and length adjustments.