### PR TITLE
fix #278057, fix #277666: hide empty staves reusing space for instrument names

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2973,6 +2973,7 @@ System* Score::collectSystem(LayoutContext& lc)
       system->setInstrumentNames(lc.startWithLongNames);
 
       qreal minWidth    = 0;
+      qreal layoutSystemMinWidth = 0;
       bool firstMeasure = true;
       bool createHeader = false;
       qreal systemWidth = styleD(Sid::pagePrintableWidth) * DPI;
@@ -2987,7 +2988,7 @@ System* Score::collectSystem(LayoutContext& lc)
             if (lc.curMeasure->isMeasure()) {
                   Measure* m = toMeasure(lc.curMeasure);
                   if (firstMeasure) {
-                        hideEmptyStaves(system, lc.firstSystem);
+                        layoutSystemMinWidth = minWidth;
                         system->layoutSystem(minWidth);
                         minWidth += system->leftMargin();
                         if (m->repeatStart()) {
@@ -3122,6 +3123,22 @@ System* Score::collectSystem(LayoutContext& lc)
       if (lc.prevMeasure && lc.prevMeasure->isMeasure()) {
             qreal w = toMeasure(lc.prevMeasure)->createEndBarLines(true);
             minWidth += w;
+            }
+
+      hideEmptyStaves(system, lc.firstSystem);
+      bool allShown = true;
+      for (const SysStaff* ss : *system->staves()) {
+            if (!ss->show()) {
+                  allShown = false;
+                  break;
+                  }
+            }
+      if (!allShown) {
+            // Relayout system decorations to reuse space properly for
+            // hidden staves' instrument names or other hidden elements.
+            minWidth -= system->leftMargin();
+            system->layoutSystem(layoutSystemMinWidth);
+            minWidth += system->leftMargin();
             }
 
       //-------------------------------------------------------


### PR DESCRIPTION
This PR implements a fix for [#277666](https://musescore.org/en/node/277666) avoiding the negative side effects described [here](https://musescore.org/en/node/278057).

The previous fix 9c8ca0fdb488074313fa2112b02ee37edd05497c caused hiding non-empty staves if their first measure was empty.