### PR TITLE
fix #279215: Time wise delete causes corruption in measures with measure rest

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3013,7 +3013,7 @@ void Score::timeDelete(Measure* m, Segment* startSegment, const Fraction& f)
                                     }
 
                               if (cr->isFullMeasureRest()) {
-                                    // do nothing
+                                    cr->setDuration(cr->duration() - f);
                                     }
                               // inside deleted area
                               else if (s->rtick() >= tick && cetick <= etick) {


### PR DESCRIPTION
See https://musescore.org/en/node/279215.