### PR TITLE
fix #278968: improve mixer sliders mouse dragging

### DIFF
--- a/awl/styledslider.cpp
+++ b/awl/styledslider.cpp
@@ -75,7 +75,7 @@ void StyledSlider::mousePressEvent(QMouseEvent* e)
       {
       draggingMouse = true;
       mouseDownPos = e->pos();
-      lastMousePos = mouseDownPos;
+      mouseDownVal = _value;
       emit(sliderPressed());
       }
 
@@ -97,13 +97,12 @@ void StyledSlider::mouseMoveEvent(QMouseEvent* e)
       {
       if (draggingMouse) {
             QPoint p = e->pos();
-            double dPixY = p.y() - lastMousePos.y();
+            double dPixY = p.y() - mouseDownPos.y();
             double barLength = height() - (_margin * 2);
             double dy = dPixY * (_maxValue - _minValue) / barLength;
 
-            double val = qBound(_minValue, _value - dy + 0.5, _maxValue);
+            double val = qBound(_minValue, mouseDownVal - dy, _maxValue);
 
-            lastMousePos = p;
             setValue(val);
             update();
             }

--- a/awl/styledslider.h
+++ b/awl/styledslider.h
@@ -48,7 +48,7 @@ class StyledSlider : public QWidget
 
       bool draggingMouse;
       QPoint mouseDownPos;
-      QPoint lastMousePos;
+      double mouseDownVal;
 
       QIcon _sliderHeadIcon;
 


### PR DESCRIPTION
See this issue: https://musescore.org/en/node/278968.
The cause of the issue is in adding `0.5` to the delta added to slider value in this commit: 2411b5694017336ef9e7c8e77932a4c9faf48f2f. This change tried to address another issue with sliders which was caused by rounding errors on each mouse move step (since volume/gain or whichever these sliders are used for can take a discrete number of values rounding errors are inevitable). I tried to eliminate these accumulating rounding errors by calculating the value directly from the difference to the initial slider value rather than by incrementing the value separately on each mouse drag event. These sliders' UI can probably be improved further though.