### PR TITLE
fix #279292: honor slurMinDistance

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -552,11 +552,12 @@ void SlurSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
                         }
                   }
             if (intersection && gdist > 0.0) {
+                  qreal min = score()->styleP(Sid::SlurMinDistance);
                   if (up) {
-                        ryoffset() -= (gdist + spatium() * .5);
+                        ryoffset() -= (gdist + min);
                         }
                   else
-                        ryoffset() += (gdist + spatium() * .5);
+                        ryoffset() += (gdist + min);
                   }
             }
       setbbox(path.boundingRect());


### PR DESCRIPTION
Admittedly not a hugely important fix, but an easy and harmless one, and I don't like style settings that do nothing.  Imagine someone cranking this up trying to see what it does, seeing no effect, then a few months later we fix this and suddenly his score looks crazy.  Best to get it now.