### PR TITLE
fix #279176: "Line visible" property not honored when printing or after save/close/open

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -495,6 +495,7 @@ void Hairpin::write(XmlWriter& xml) const
       writeProperty(xml, Pid::BEGIN_TEXT);
       writeProperty(xml, Pid::END_TEXT);
       writeProperty(xml, Pid::CONTINUE_TEXT);
+      writeProperty(xml, Pid::LINE_VISIBLE);
 
       for (const StyledProperty& spp : *styledProperties()) {
             if (!isStyled(spp.pid))

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -88,7 +88,7 @@ void TextLineBaseSegment::draw(QPainter* painter) const
             painter->translate(-_endText->pos());
             }
 
-      if (npoints == 0)
+      if ((npoints == 0) || (score() && score()->printing() && !tl->lineVisible()))
             return;
 
       // color for line (text color comes from the text properties)


### PR DESCRIPTION
See https://musescore.org/en/node/279176#comment-873905.