### PR TITLE
fix #279280: changes to font style for text that is bold by default are not saved

### DIFF
--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -379,16 +379,16 @@ void ScoreElement::writeProperty(XmlWriter& xml, Pid pid) const
             return;
             }
       PropertyFlags f = propertyFlags(pid);
-      QVariant d = (f == PropertyFlags::NOSTYLE) ? propertyDefault(pid) : QVariant();
+      QVariant d = (f != PropertyFlags::STYLED) ? propertyDefault(pid) : QVariant();
 
       if (pid == Pid::FONT_STYLE) {
             FontStyle ds = FontStyle(d.isValid() ? d.toInt() : 0);
             FontStyle fs = FontStyle(p.toInt());
-            if ((fs & FontStyle::Bold) !=  (ds & FontStyle::Bold))
+            if ((fs & FontStyle::Bold) != (ds & FontStyle::Bold))
                   xml.tag("bold", fs & FontStyle::Bold);
-            if ((fs & FontStyle::Italic) && (ds & FontStyle::Italic))
-                  xml.tag("italic", fs & FontStyle::Bold);
-            if ((fs & FontStyle::Underline) && (ds & FontStyle::Underline))
+            if ((fs & FontStyle::Italic) != (ds & FontStyle::Italic))
+                  xml.tag("italic", fs & FontStyle::Italic);
+            if ((fs & FontStyle::Underline) != (ds & FontStyle::Underline))
                   xml.tag("underline", fs & FontStyle::Underline);
             return;
             }

--- a/mtest/libmscore/compat114/chord_symbol-ref.mscx
+++ b/mtest/libmscore/compat114/chord_symbol-ref.mscx
@@ -180,7 +180,6 @@
             <root>19</root>
             <extension>33</extension>
             <name>dim</name>
-            <family>FreeSerif</family>
             </Harmony>
           <Rest>
             <durationType>measure</durationType>
@@ -195,7 +194,6 @@
           <Harmony>
             <root>14</root>
             <name>7</name>
-            <family>FreeSerif</family>
             </Harmony>
           <Rest>
             <durationType>measure</durationType>

--- a/mtest/libmscore/compat114/clefs-ref.mscx
+++ b/mtest/libmscore/compat114/clefs-ref.mscx
@@ -91,7 +91,6 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>Clefs</text>
           </Text>
         </VBox>

--- a/mtest/libmscore/compat114/fingering-ref.mscx
+++ b/mtest/libmscore/compat114/fingering-ref.mscx
@@ -100,7 +100,6 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>fing</text>
           </Text>
         </VBox>

--- a/mtest/libmscore/compat114/hairpin-ref.mscx
+++ b/mtest/libmscore/compat114/hairpin-ref.mscx
@@ -96,7 +96,6 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>Hairpin</text>
           </Text>
         </VBox>

--- a/mtest/libmscore/compat114/keysig-ref.mscx
+++ b/mtest/libmscore/compat114/keysig-ref.mscx
@@ -91,7 +91,6 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>keysig</text>
           </Text>
         </VBox>

--- a/mtest/libmscore/compat114/notes-ref.mscx
+++ b/mtest/libmscore/compat114/notes-ref.mscx
@@ -91,7 +91,6 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>notes</text>
           </Text>
         </VBox>

--- a/mtest/libmscore/compat114/text_scaling-ref.mscx
+++ b/mtest/libmscore/compat114/text_scaling-ref.mscx
@@ -91,7 +91,6 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>Title</text>
           </Text>
         </VBox>
@@ -106,14 +105,12 @@
             <sigD>4</sigD>
             </TimeSig>
           <StaffText>
-            <family>FreeSerif</family>
             <text><font face="Times New Roman"/>staff text</text>
             </StaffText>
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>begin</syllabic>
-              <family>FreeSerif</family>
               <text><font face="Times New Roman"/>ly</text>
               </Lyrics>
             <Note>
@@ -125,7 +122,6 @@
             <durationType>quarter</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <family>FreeSerif</family>
               <text><font face="Times New Roman"/>rics</text>
               </Lyrics>
             <Note>

--- a/mtest/libmscore/compat114/textstyles-ref.mscx
+++ b/mtest/libmscore/compat114/textstyles-ref.mscx
@@ -1675,23 +1675,18 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
-          <size>24</size>
           <text><font size="28"/><font face="MuseJazz"/><b>Title</b></text>
           </Text>
         <Text>
           <style>Subtitle</style>
-          <family>FreeSerif</family>
           <text><font face="MuseJazz"/>Subtitle</text>
           </Text>
         <Text>
           <style>Composer</style>
-          <family>FreeSerif</family>
           <text><font face="MuseJazz"/>Composer</text>
           </Text>
         <Text>
           <style>Lyricist</style>
-          <family>FreeSerif</family>
           <text><font face="MuseJazz"/>Lyricist</text>
           </Text>
         </VBox>

--- a/mtest/libmscore/compat114/title-ref.mscx
+++ b/mtest/libmscore/compat114/title-ref.mscx
@@ -96,22 +96,18 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>title</text>
           </Text>
         <Text>
           <style>Subtitle</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>subtitle</text>
           </Text>
         <Text>
           <style>Composer</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>Composer</text>
           </Text>
         <Text>
           <style>Lyricist</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>Lyrics</text>
           </Text>
         </VBox>

--- a/mtest/libmscore/compat114/tuplets-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets-ref.mscx
@@ -89,7 +89,6 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>Tuplets</text>
           </Text>
         </VBox>

--- a/mtest/libmscore/compat114/tuplets_1-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_1-ref.mscx
@@ -89,7 +89,6 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>Tuplet 1.3 file</text>
           </Text>
         </VBox>

--- a/mtest/libmscore/compat114/tuplets_2-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_2-ref.mscx
@@ -89,7 +89,6 @@
         <bottomMargin>5</bottomMargin>
         <Text>
           <style>Title</style>
-          <family>FreeSerif</family>
           <text><font face="Times New Roman"/>Tuplet 1.3 file</text>
           </Text>
         </VBox>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279280

Just some incorrect code - we should write the tag only if it isn't flagged as being styled, and we look for differences between the default style and the current style - not for them to be the same (old lines 389 & 391).

The refs seem like they can be updated fine - there seems to be redundancy in the way text is described, e. g. in the size tag and in the size attribute for text. I've also checked for any visible differences, and they appear exactly the same.