### PR TITLE
fix #248891: chord symbols transposed incorrectly when score concert, parts not

### DIFF
--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -436,25 +436,27 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
                   foreach (Element* e, segment->annotations()) {
                         if ((e->type() != ElementType::HARMONY) || (!tracks.contains(e->track())))
                               continue;
-                        Harmony* h  = toHarmony(e);
+                        Harmony* hh  = toHarmony(e);
                         int rootTpc, baseTpc;
-                        if (mode == TransposeMode::DIATONICALLY) {
-                              int tick = segment->tick();
-                              Key key = !h->staff() ? Key::C : h->staff()->key(tick);
-                              rootTpc = transposeTpcDiatonicByKey(h->rootTpc(),
-                                          transposeInterval, key, trKeys, useDoubleSharpsFlats);
-                              baseTpc = transposeTpcDiatonicByKey(h->baseTpc(),
-                                          transposeInterval, key, trKeys, useDoubleSharpsFlats);
-                              }
-                        else {
-                              rootTpc = transposeTpc(h->rootTpc(), interval, useDoubleSharpsFlats);
-                              baseTpc = transposeTpc(h->baseTpc(), interval, useDoubleSharpsFlats);
-                              }
                         // undoTransposeHarmony does not do links
                         // because it is also used to handle transposing instruments
                         // and score / parts could be in different concert pitch states
-                        for (ScoreElement* scoreElement : h->linkList())
-                              undoTransposeHarmony(toHarmony(scoreElement), rootTpc, baseTpc);
+                        for (ScoreElement* se : hh->linkList()) {
+                              Harmony* h = toHarmony(se);
+                              if (mode == TransposeMode::DIATONICALLY) {
+                                    int tick = segment->tick();
+                                    Key key = !h->staff() ? Key::C : h->staff()->key(tick);
+                                    rootTpc = transposeTpcDiatonicByKey(h->rootTpc(),
+                                                transposeInterval, key, trKeys, useDoubleSharpsFlats);
+                                    baseTpc = transposeTpcDiatonicByKey(h->baseTpc(),
+                                                transposeInterval, key, trKeys, useDoubleSharpsFlats);
+                                    }
+                              else {
+                                    rootTpc = transposeTpc(h->rootTpc(), interval, useDoubleSharpsFlats);
+                                    baseTpc = transposeTpc(h->baseTpc(), interval, useDoubleSharpsFlats);
+                                    }
+                              undoTransposeHarmony(h, rootTpc, baseTpc);
+                              }
                         }
                   }
             }


### PR DESCRIPTION
It's a pretty common scenario at least while a score is in development, so having this fixed will be good.  Two separate problems fixed, actually, one involving chords not being transposed correctly at the moment the part is generated (if the chord is on a measure that becomes part of a multimeasure rest) and one involving chords not being transposed correctly when using Notes / Transpose.

As noted in the issue report, there is still a bug with an initial C major key signature not being transposed correctly in the latter case.  Looks to be a thornier problem, and luckily, fairly easy for the user to notce and correct (by adding the correct key signature).  I wouldn't recommend attempting the sort of architectural changes I suspect would be necessary to fix that problem, not right before release.