### PR TITLE
fix #279172: skip <timeStretch> correctly if not handled on 2.X import

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2482,6 +2482,10 @@ Element* readArticulation(ChordRest* cr, XmlReader& e)
             else if (tag == "timeStretch") {
                   if (el && el->isFermata())
                         el->setProperty(Pid::TIME_STRETCH ,e.readDouble());
+                  else {
+                        qDebug("line %lld: read206: skipping <timeStretch>", e.lineNumber());
+                        e.skipCurrentElement();
+                        }
                   }
             else {
                   if (!el) {


### PR DESCRIPTION
See https://musescore.org/en/node/279172.
The issue is in not skipping `<timeStretch>` tag if it remains unhandled (probably because only fermata has a time stretch property now). That causes an overall incorrect reading of the rest of the file. As always, the fact that MuseScore crashes on some reading problems is bad but it goes beyond the considered issue.