### PR TITLE
fix #279009: fix text pasting

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1638,8 +1638,8 @@ void ScoreView::editPaste()
       if (editData.element) {
             if (editData.element->isLyrics())
                   toLyrics(editData.element)->paste(editData);
-            else if (editData.element->isText())
-                  toText(editData.element)->paste(editData);
+            else if (editData.element->isTextBase())
+                  toTextBase(editData.element)->paste(editData);
             }
       }
 


### PR DESCRIPTION
See https://musescore.org/en/node/279009.
In MuseScore 2, `Text` was the base class for various text-related entities. Now `TextBase` is such a class, but at least this check was not corrected according to this change.