### PR TITLE
fix #278979: don't change input state on restoring selection on undo

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -426,7 +426,9 @@ void SaveState::undo(EditData*)
       redoSelectedElement = selectedElement(score->selection());
       score->setInputState(undoInputState);
 //      score->setSelection(undoSelection);
-      score->select(undoSelectedElement);
+      score->deselectAll();
+      if (undoSelectedElement)
+            score->selection().add(undoSelectedElement);
       }
 
 void SaveState::redo(EditData*)
@@ -438,8 +440,11 @@ void SaveState::redo(EditData*)
 //      score->setSelection(redoSelection);
       if (first)
             first = false;
-      else
-            score->select(redoSelectedElement);
+      else {
+            score->deselectAll();
+            if (redoSelectedElement)
+                  score->selection().add(redoSelectedElement);
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/278979 and #4222.
Restoring selection via direct calls to `Selection` object (like it was done in 2.X) helps to prevent modifying input state in unwanted way.