### PR TITLE
Implode fixes

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2654,19 +2654,17 @@ void Score::cmdImplode()
                                     undoRemoveElement(src);
                               }
                         }
-#if 1
                   // TODO - use first voice that actually has a note and implode remaining voices on it?
                   // see https://musescore.org/en/node/174111
                   else if (dst) {
                         // destination track has something, but it isn't a chord
-                        // remove everything from other voices if in "voice mode"
+                        // remove rests from other voices if in "voice mode"
                         for (int i = 1; i < VOICES; ++i) {
                               Element* e = s->element(dstTrack + i);
-                              if (e)
+                              if (e && e->isRest())
                                     undoRemoveElement(e);
                               }
                         }
-#endif
                   }
             }
       else {

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2654,6 +2654,9 @@ void Score::cmdImplode()
                                     undoRemoveElement(src);
                               }
                         }
+#if 1
+                  // TODO - use first voice that actually has a note and implode remaining voices on it?
+                  // see https://musescore.org/en/node/174111
                   else if (dst) {
                         // destination track has something, but it isn't a chord
                         // remove everything from other voices if in "voice mode"
@@ -2663,6 +2666,7 @@ void Score::cmdImplode()
                                     undoRemoveElement(e);
                               }
                         }
+#endif
                   }
             }
       else {
@@ -2675,23 +2679,19 @@ void Score::cmdImplode()
                   lTick = endSegment->tick();
             else
                   lTick = lastMeasure()->endTick();
-            for (Segment* seg = startSegment; seg && seg->tick() < lTick; seg = seg->next1()) {
-                  for (int i = startTrack; i < endTrack && full != VOICES; i++) {
-                        bool t = true;
-                        for (int j = 0; j < VOICES; j++) {
-                              if (i == tracks[j]) {
-                                    t = false;
-                                    break;
-                                    }
-                              }
 
-                        if (!seg->measure()->hasVoice(i) || seg->measure()->isOnlyRests(i) || !t)
-                              continue;
-                        tracks[full] = i;
-                        full++;
+            // identify tracks to combine, storing the source track numbers in tracks[]
+            // first four non-empty tracks to win
+            for (int track = startTrack; track < endTrack && full < VOICES; ++track) {
+                  for (Measure* m = startMeasure; m && m != endMeasure; m = m->nextMeasure()) {
+                        if (m->hasVoice(track) && !m->isOnlyRests(track)) {
+                              tracks[full++] = track;
+                              break;
+                              }
                         }
                   }
 
+            // clone source tracks into destination
             for (int i = dstTrack; i < dstTrack + VOICES; i++) {
                   int strack = tracks[i % VOICES];
                   if (strack != -1 && strack != i) {

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3154,7 +3154,9 @@ void Score::cloneVoice(int strack, int dtrack, Segment* sf, int lTick, bool link
                               for (size_t i = 0; i < n; ++i) {
                                     Note* on = och->notes().at(i);
                                     Note* nn = nch->notes().at(i);
-                                    Interval v = staff(dtrack) ? staff(dtrack)->part()->instrument(dtrack)->transpose() : Interval();
+                                    int idx = track2staff(dtrack);
+                                    int tick = oseg->tick();
+                                    Interval v = staff(idx) ? staff(idx)->part()->instrument(tick)->transpose() : Interval();
                                     nn->setTpc1(on->tpc1());
                                     if (v.isZero())
                                           nn->setTpc2(on->tpc1());

--- a/mtest/libmscore/implode_explode/implode1-ref.mscx
+++ b/mtest/libmscore/implode_explode/implode1-ref.mscx
@@ -316,7 +316,6 @@
             <Note>
               <pitch>64</pitch>
               <tpc>18</tpc>
-              <tpc2>20</tpc2>
               </Note>
             </Chord>
           <Chord>
@@ -324,7 +323,6 @@
             <Note>
               <pitch>69</pitch>
               <tpc>17</tpc>
-              <tpc2>19</tpc2>
               </Note>
             </Chord>
           <Chord>
@@ -332,7 +330,6 @@
             <Note>
               <pitch>67</pitch>
               <tpc>15</tpc>
-              <tpc2>17</tpc2>
               </Note>
             </Chord>
           <Chord>
@@ -340,7 +337,6 @@
             <Note>
               <pitch>64</pitch>
               <tpc>18</tpc>
-              <tpc2>20</tpc2>
               </Note>
             </Chord>
           </voice>
@@ -446,7 +442,6 @@
             <Note>
               <pitch>65</pitch>
               <tpc>13</tpc>
-              <tpc2>15</tpc2>
               </Note>
             </Chord>
           <Chord>
@@ -454,7 +449,6 @@
             <Note>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <tpc2>16</tpc2>
               </Note>
             </Chord>
           <Chord>
@@ -462,7 +456,6 @@
             <Note>
               <pitch>62</pitch>
               <tpc>16</tpc>
-              <tpc2>18</tpc2>
               </Note>
             </Chord>
           <Chord>
@@ -470,7 +463,6 @@
             <Note>
               <pitch>59</pitch>
               <tpc>19</tpc>
-              <tpc2>21</tpc2>
               </Note>
             </Chord>
           </voice>
@@ -618,7 +610,6 @@
             <Note>
               <pitch>60</pitch>
               <tpc>14</tpc>
-              <tpc2>16</tpc2>
               </Note>
             </Chord>
           <Chord>
@@ -629,7 +620,6 @@
             <Note>
               <pitch>65</pitch>
               <tpc>13</tpc>
-              <tpc2>15</tpc2>
               </Note>
             </Chord>
           <Rest>
@@ -698,7 +688,6 @@
             <Note>
               <pitch>64</pitch>
               <tpc>18</tpc>
-              <tpc2>20</tpc2>
               </Note>
             </Chord>
           </voice>


### PR DESCRIPTION
Fixes three separate issues in the "new" implode tool, two critical and one merely serious :-).  They are in separate commits for ease of tracking.

- First commit fixes a critical issue where transposition is not handled correctly leading to "tpc corruption" - bad notes with concert pitch off.  See https://musescore.org/en/node/279351.  The affected code is shared by the "parts from voices" facility, which presumably could be induced to show the same flaw.

- Second commit fixes a critical issue where empty measures lead to wrong results on implode and then loss of data on undo.

- Third commit is at least a partial fix (I consider it enough for now) to an issue where merging voices would delete notes in voices 2 - 4 that occurred simultaneously with rests in voice 1, thus leaving you a result that did not match the original.  Ideally, we actually try to combine voices 2-4, but merely leaving them alone is already a big improvement, and in any case, some of the most common use cases here only use two voices.