### PR TITLE
fix #279377: bad text size in image capture

### DIFF
--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -431,15 +431,18 @@ void ScoreView::fotoModeCopy()
       int w = lrint(r.width()  * mag);
       int h = lrint(r.height() * mag);
 
+      double pr = MScore::pixelRatio;
       QImage::Format f;
       f = QImage::Format_ARGB32_Premultiplied;
       QImage printer(w, h, f);
       printer.setDotsPerMeterX(lrint(DPMM * 1000.0));
       printer.setDotsPerMeterY(lrint(DPMM * 1000.0));
       printer.fill(transparent ? 0 : 0xffffffff);
+      MScore::pixelRatio = 1.0;
       QPainter p(&printer);
       paintRect(true, p, r, mag);
       QApplication::clipboard()->setImage(printer);
+      MScore::pixelRatio = pr;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
The problem definitely has to do with pixel scaling, and I think it probably is only seen on systems that have screen resolutions very different from 96 DPI.  Probably not on *all* such systems, because between the OS and Qt, we can get all sorts of different values reported to us and different ways Qt handles things.

I say all that to emphasize I have no idea if the value I am using for MScore::pixelRatio is "right".  I have little doubt that the basic approach of temporarily setting pixelRatio to another value here is good - it's also what is used for Save As, which works fine.  But maybe it needs to be calculated form something. 
 I just know that empircally, 1.0 works for me, on my Surface Pro 5 running Windows which has an actual physical DPI of 266 but is reported by Qt as 133.  I'd love it if others could test.  It's an easy change to make in your own builds, and easy to test - just do an image capture involving text, hit Ctrl+C, and try pasting back into the score to see if it looks right.