### PR TITLE
fix #279386 Crash when pasting measures if number > to last mm rest

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -414,10 +414,10 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                   endStaff = nstaves();
             //check and add truly invisible rests insted of gaps
             //TODO: look if this could be done different
-            Measure* dstM = tick2measureMM(dstTick);
-            Measure* endM = tick2measureMM(dstTick + tickLen);
+            Measure* dstM = tick2measure(dstTick);
+            Measure* endM = tick2measure(dstTick + tickLen);
             for (int i = dstStaff; i < endStaff; i++) {
-                  for (Measure* m = dstM; m && m != endM->nextMeasureMM(); m = m->nextMeasureMM())
+                  for (Measure* m = dstM; m && m != endM->nextMeasure(); m = m->nextMeasure())
                         m->checkMeasure(i);
                   }
             _selection.setRangeTicks(dstTick, dstTick + tickLen, dstStaff, endStaff);


### PR DESCRIPTION
This is a first attempt to fix [279386](https://musescore.org/en/node/279386). 