### PR TITLE
partial fix #279415: no bottom wing shown in part with barline span in score

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -371,7 +371,11 @@ bool BarLine::isTop() const
 
 bool BarLine::isBottom() const
       {
-      return !_spanStaff;      // TODO
+      int nstaves = score()->nstaves();
+      if (!_spanStaff || staffIdx() == nstaves - 1)
+            return true;
+      // TODO: check if spanned-to staves are visible on this system
+      return false;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
We aren't displaying the bottom wing of a repeat is it has a barline span, even if that span isn't relevant because this is a part instead of the score (so it's the only staff), or if there are invisible staves involved.

A full fix means going through the staves, checking staff visiblity and barline spans to see if this is the last visible staff of the span on this system, and this may or may not even work given the other limitations in barline functionality.  But just checking to see if this is the last staff of the score will fix the case at hand, which will be quite common in ensemble scores / parts, especially for jazz where winged repeats are the norm.