### PR TITLE
Fix opening scores by drag-and-drop if some score is already open

### DIFF
--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -231,8 +231,14 @@ void ScoreView::dragEnterEvent(QDragEnterEvent* event)
 
       if (dta->hasUrls()) {
             QList<QUrl>ul = dta->urls();
-
             QUrl u = ul.front();
+
+            QMimeDatabase db;
+            if (!QImageReader::supportedMimeTypes().contains(db.mimeTypeForUrl(u).name().toLatin1())) {
+                  event->ignore();
+                  return;
+                  }
+
             Image* image = 0;
             if (u.scheme() == "file") {
                   QFileInfo fi(u.path());


### PR DESCRIPTION
This is a minor fixup for https://github.com/musescore/MuseScore/commit/a216ffba2eb9f41f9d68115222631813c7aa8936. This returns the ability to open scores by dropping them to MuseScore window in case some score is already open by adding a missing check on whether the dragged object is an image or not.