### PR TITLE
fix #279369: fix a crash on undoing of cutting a multiline text

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1571,8 +1571,10 @@ void ScoreView::editCopy()
 
 void ScoreView::editCut()
       {
+      _score->startCmd();
       if (editData.element)
             editData.element->editCut(editData);
+      _score->endCmd();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR fixes https://musescore.org/en/node/279369.
To be properly done cutting should process inside command context. This condition is fulfilled for cut operation in normal mode but not in edit mode. This PR fixes that.