### PR TITLE
fix #278940: restore chords spacing for glissando

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3103,6 +3103,8 @@ Shape Chord::shape() const
       shape.add(ChordRest::shape());      // add lyrics
       for (LedgerLine* l = _ledgerLines; l; l = l->next())
             shape.add(l->shape().translated(l->pos()));
+      if (_spaceLw || _spaceRw)
+            shape.addHorizontalSpacing(Shape::SPACING_GENERAL, -_spaceLw, _spaceRw);
       return shape;
       }
 

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1164,6 +1164,7 @@ QString ChordRest::accessibleExtraInfo() const
 Shape ChordRest::shape() const
       {
       Shape shape;
+      {
       qreal x1 = 1000000.0;
       qreal x2 = -1000000.0;
       bool adjustWidth = false;
@@ -1178,7 +1179,14 @@ Shape ChordRest::shape() const
                   x2 += spatium();
             adjustWidth = true;
             }
+      if (adjustWidth)
+            shape.addHorizontalSpacing(Shape::SPACING_LYRICS, x1, x2);
+      }
 
+      {
+      qreal x1 = 1000000.0;
+      qreal x2 = -1000000.0;
+      bool adjustWidth = false;
       for (Element* e : segment()->annotations()) {
             if (e->isHarmony() && e->staffIdx() == staffIdx() && e->visible()) {
                   e->layout();
@@ -1189,7 +1197,8 @@ Shape ChordRest::shape() const
                   }
             }
       if (adjustWidth)
-            shape.add(QRectF(x1, 0.0, x2-x1, 0.0));
+            shape.addHorizontalSpacing(Shape::SPACING_HARMONY, x1, x2);
+      }
 
       return shape;
       }

--- a/libmscore/shape.cpp
+++ b/libmscore/shape.cpp
@@ -16,6 +16,20 @@
 namespace Ms {
 
 //---------------------------------------------------------
+//   addHorizontalSpacing
+//    Currently implemented by adding rectangles of zero
+//    height to the Y position corresponding to the type.
+//    This is a simple solution but has its drawbacks too.
+//---------------------------------------------------------
+
+void Shape::addHorizontalSpacing(HorizontalSpacingType type, qreal leftEdge, qreal rightEdge)
+      {
+      constexpr qreal eps = 100 * std::numeric_limits<qreal>::epsilon();
+      const qreal y = eps * int(type);
+      add(QRectF(leftEdge, y, rightEdge - leftEdge, 0));
+      }
+
+//---------------------------------------------------------
 //   translate
 //---------------------------------------------------------
 

--- a/libmscore/shape.h
+++ b/libmscore/shape.h
@@ -42,6 +42,12 @@ struct ShapeElement : public QRectF {
 class Shape : public std::vector<ShapeElement> {
 // class Shape : std::vector<ShapeElement> {
    public:
+      enum HorizontalSpacingType {
+            SPACING_GENERAL = 0,
+            SPACING_LYRICS,
+            SPACING_HARMONY,
+            };
+
       Shape() {}
 #ifndef NDEBUG
       Shape(const QRectF& r, const char* s = 0) { add(r, s); }
@@ -56,6 +62,8 @@ class Shape : public std::vector<ShapeElement> {
 #endif
       void remove(const QRectF&);
       void remove(const Shape&);
+
+      void addHorizontalSpacing(HorizontalSpacingType type, qreal left, qreal right);
 
       void translate(const QPointF&);
       void translateX(qreal);


### PR DESCRIPTION
See https://musescore.org/en/node/278940.

Spacing for glissandi (and some other cases) got calculated in `Chord::layoutPitched` and `Chord::layoutTablature` but were never applied. This PR does apply these spacing values using shapes mechanism. This adds also a way to differentiate types of horizontal spacing. The underlying implementation (zero-height shape elements) still remains the same.