### PR TITLE
fix #34426: Paste chords with lyrics to linked staves correctly

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4396,6 +4396,16 @@ void Score::undoAddElement(Element* element)
 void Score::undoAddCR(ChordRest* cr, Measure* measure, int tick)
       {
       Q_ASSERT(!cr->isChord() || !(toChord(cr)->notes()).empty());
+      if (!cr->lyrics().empty()) {
+            // Add chordrest and lyrics separately for correct
+            // handling of adding lyrics to linked staves.
+            std::vector<Lyrics*> lyrics;
+            std::swap(lyrics, cr->lyrics());
+            undoAddCR(cr, measure, tick);
+            for (Lyrics* l : lyrics)
+                  undoAddElement(l);
+            return;
+            }
 
       Staff* ostaff = cr->staff();
       int strack    = ostaff->idx() * VOICES + cr->voice();


### PR DESCRIPTION
This PR adds some sort of hack to resolve the issue [#34426]. This hack just lets all the rules applied to adding lyrics in normal way be also applied on chords paste operations. This resolves the mentioned issue without breaking pasting lyrics to linked staves in general.