### PR TITLE
fix #277723: score jump on various operations if system does not fit on screen

### DIFF
--- a/libmscore/mscoreview.h
+++ b/libmscore/mscoreview.h
@@ -47,7 +47,7 @@ class MuseScoreView {
       virtual void moveCursor()          {}
       virtual void showLoopCursors(bool) {}
 
-      virtual void adjustCanvasPosition(const Element*, bool /*playBack*/, int /*staffIdx*/ = 0) {};
+      virtual void adjustCanvasPosition(const Element*, bool /*playBack*/, int /*staffIdx*/ = -1) {};
       virtual void setScore(Score* s) { _score = s; }
       Score* score() const            { return _score; }
       virtual void removeScore() {};


### PR DESCRIPTION
I was gearing up to deal with all the hairy calculations in adjustCanvasPosition() when I realize, the problem was simpler - the "staff" parameter was 0, not -1, so we were actually *trying* to view the top staff.  ScoreView::adjustCanvasPosition was setting the default to 0, but the code is using variables of type MuseScoreView (the parent class), which sets the default to 0.  That's not right; there is no situation I know of where that's what we want.

This also fixes both https://musescore.org/en/node/277723 and https://musescore.org/en/node/277781