### PR TITLE
fix #279471 Set note cutoff length

### DIFF
--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -31,6 +31,7 @@
 #include "ottava.h"
 #include "harmony.h"
 #include "bracketItem.h"
+#include "chord.h"
 
 // #define DEBUG_CLEFS
 
@@ -863,6 +864,44 @@ int Staff::capo(int tick) const
             return 0;
       --i;
       return i.value();
+      }
+
+//---------------------------------------------------------
+//   getNotes
+//---------------------------------------------------------
+
+QList<Note*> Staff::getNotes()
+      {
+      QList<Note*> list;
+
+      int staffIdx = idx();
+
+      SegmentType st = SegmentType::ChordRest;
+      for (Segment* s = score()->firstSegment(st); s; s = s->next1(st)) {
+            for (int voice = 0; voice < VOICES; ++voice) {
+                  int track = voice + staffIdx * VOICES;
+                  Element* e = s->element(track);
+                  if (e && e->isChord())
+                        addChord(list, toChord(e), voice);
+                  }
+            }
+
+      return list;
+      }
+
+//---------------------------------------------------------
+//   addChord
+//---------------------------------------------------------
+
+void Staff::addChord(QList<Note*>& list, Chord* chord, int voice)
+      {
+      for (Chord* c : chord->graceNotes())
+            addChord(list, c, voice);
+      for (Note* note : chord->notes()) {
+            if (note->tieBack())
+                  continue;
+            list.append(note);
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/staff.h
+++ b/libmscore/staff.h
@@ -59,6 +59,8 @@ struct SwingParameters {
 ///    Global staff data not directly related to drawing.
 //---------------------------------------------------------
 
+class Note;
+
 class Staff final : public ScoreElement {
    public:
       enum class HideMode { AUTO, ALWAYS, NEVER, INSTRUMENT };
@@ -181,6 +183,9 @@ class Staff final : public ScoreElement {
       void setBarLineFrom(int val)   { _barLineFrom = val;  }
       void setBarLineTo(int val)     { _barLineTo = val;    }
       qreal height() const;
+
+      QList<Note*> getNotes();
+      void addChord(QList<Note*>& list, Chord* chord, int voice);
 
       int channel(int tick, int voice) const;
       void clearChannelList(int voice)                               { _channelList[voice].clear(); }

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -71,7 +71,7 @@ endif (SCRIPT_INTERFACE)
 QT5_WRAP_UI (ui_headers
       insertmeasuresdialog.ui editinstrument.ui editstyle.ui instrdialog.ui instrwidget.ui
       measuresdialog.ui pagesettings.ui mixer.ui mixertrackchannel.ui mixertrackpart.ui mixerdetails.ui parteditbase.ui
-      playpanel.ui prefsdialog.ui measureproperties.ui
+      playpanel.ui prefsdialog.ui measureproperties.ui pianolevelschooser.ui
       textpalette.ui  timedialog.ui symboldialog.ui  shortcutcapturedialog.ui  editdrumset.ui
       editstaff.ui timesigproperties.ui
       instrwizard.ui timesigwizard.ui newwizard.ui aboutbox.ui aboutmusicxmlbox.ui
@@ -84,7 +84,7 @@ QT5_WRAP_UI (ui_headers
       note_groups.ui resourceManager.ui stafftypetemplates.ui
       startcenter.ui scorePreview.ui scoreBrowser.ui templateBrowser.ui
       logindialog.ui uploadscoredialog.ui breaksdialog.ui
-      toolbarEditor.ui workspacedialog.ui
+      toolbarEditor.ui workspacedialog.ui notetweakerdialog.ui
 
       importmidi/importmidi_panel.ui
 
@@ -323,7 +323,7 @@ add_executable ( ${ExecutableName}
       magbox.h masterpalette.h
       measureproperties.h mediadialog.h metaedit.h miconengine.h mididriver.h
       mixer.h mixertrack.h mixertrackchannel.h mixertrackgroup.h mixertrackitem.h mixertrackpart.h mixerdetails.h musedata.h
-      musescore.h musicxml.h musicxmlfonthandler.h musicxmlsupport.h navigator.h newwizard.h noteGroups.h
+      musescore.h musicxml.h musicxmlfonthandler.h musicxmlsupport.h navigator.h newwizard.h noteGroups.h notetweakerdialog.h
       omrpanel.h ove.h pa.h pagesettings.h palette.h palettebox.h paletteBoxButton.h partedit.h parteditbase.h
       pathlistdialog.h piano.h pianolevels.h pianolevelschooser.h  pianolevelsfilter.h
       pianokeyboard.h pianoroll.h pianoruler.h pianotools.h pianoview.h
@@ -361,6 +361,7 @@ add_executable ( ${ExecutableName}
       synthcontrol.cpp drumroll.cpp pianoroll.cpp piano.cpp
       pianokeyboard.cpp pianolevels.cpp pianolevelschooser.cpp pianolevelsfilter.cpp
       pianoruler.cpp pianoview.cpp drumview.cpp scoretab.cpp keyedit.cpp harmonyedit.cpp
+      notetweakerdialog.cpp
       updatechecker.cpp
       importove.cpp
       ove.cpp

--- a/mscore/notetweakerdialog.cpp
+++ b/mscore/notetweakerdialog.cpp
@@ -1,0 +1,139 @@
+#include "notetweakerdialog.h"
+#include "ui_notetweakerdialog.h"
+
+#include "libmscore/segment.h"
+#include "libmscore/score.h"
+#include "libmscore/staff.h"
+#include "libmscore/chord.h"
+#include "libmscore/rest.h"
+#include "libmscore/note.h"
+#include "libmscore/slur.h"
+#include "libmscore/tie.h"
+#include "libmscore/tuplet.h"
+#include "libmscore/noteevent.h"
+#include "libmscore/undo.h"
+
+namespace Ms{
+
+
+NoteTweakerDialog::NoteTweakerDialog(QWidget *parent) :
+      QDialog(parent),
+      _staff(nullptr),
+      ui(new Ui::NoteTweakerDialog)
+      {
+      ui->setupUi(this);
+
+      connect(ui->bnClose, &QPushButton::clicked, this, &QDialog::close);
+      connect(ui->bnSetNoteOffTime, &QPushButton::clicked, this, &NoteTweakerDialog::setNoteOffTime);
+      }
+
+NoteTweakerDialog::~NoteTweakerDialog()
+      {
+      delete ui;
+      }
+
+void NoteTweakerDialog::setNoteOffTime()
+      {
+      if (!_staff)
+            return;
+
+      QString s = ui->comboOffTimeFrac->currentText();
+      QStringList parts = s.split("/");
+      int num = parts[0].toInt();
+      double denom = parts[1].toInt();
+      double gapTicks = MScore::division * num / denom;
+
+      Score* score = _staff->score();
+
+      score->startCmd();
+
+      for(Note* note: noteList) {
+            if (!note->selected())
+                  continue;
+
+            Chord* chord = note->chord();
+            int ticks = chord->duration().ticks();
+
+            int scalar = 1000 * (ticks - gapTicks) / ticks;
+            if (scalar <= 0)
+                  scalar = 1;
+
+            for (NoteEvent& e : note->playEvents()) {
+                  NoteEvent ne = e;
+                  ne.setLen(scalar);
+                  score->undo(new ChangeNoteEvent(note, &e, ne));
+                  }
+            }
+
+      score->endCmd();
+
+      emit notesChanged();
+      }
+
+//---------------------------------------------------------
+//   setStaff
+//---------------------------------------------------------
+
+void NoteTweakerDialog::setStaff(Staff* s)
+      {
+      if (_staff == s)
+            return;
+
+      _staff    = s;
+      updateNotes();
+      }
+
+//---------------------------------------------------------
+//   addChord
+//---------------------------------------------------------
+
+void NoteTweakerDialog::addChord(Chord* chord, int voice)
+      {
+      for (Chord* c : chord->graceNotes())
+            addChord(c, voice);
+      for (Note* note : chord->notes()) {
+            if (note->tieBack())
+                  continue;
+            noteList.append(note);
+            }
+      }
+
+//---------------------------------------------------------
+//   updateNotes
+//---------------------------------------------------------
+
+void NoteTweakerDialog::updateNotes()
+      {
+      clearNoteData();
+
+      if (!_staff) {
+            return;
+            }
+
+      int staffIdx = _staff->idx();
+      if (staffIdx == -1)
+            return;
+
+      SegmentType st = SegmentType::ChordRest;
+      for (Segment* s = _staff->score()->firstSegment(st); s; s = s->next1(st)) {
+            for (int voice = 0; voice < VOICES; ++voice) {
+                  int track = voice + staffIdx * VOICES;
+                  Element* e = s->element(track);
+                  if (e && e->isChord())
+                        addChord(toChord(e), voice);
+                  }
+            }
+
+      update();
+      }
+
+//---------------------------------------------------------
+//   clearNoteData
+//---------------------------------------------------------
+
+void NoteTweakerDialog::clearNoteData()
+      {
+      noteList.clear();
+      }
+
+}

--- a/mscore/notetweakerdialog.h
+++ b/mscore/notetweakerdialog.h
@@ -1,0 +1,46 @@
+#ifndef NOTETWEAKERDIALOG_H
+#define NOTETWEAKERDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class NoteTweakerDialog;
+}
+
+namespace Ms {
+
+class Staff;
+class Note;
+class Chord;
+
+class NoteTweakerDialog : public QDialog
+      {
+      Q_OBJECT
+
+      Staff* _staff;
+      QList<Note*> noteList;
+
+public:
+      explicit NoteTweakerDialog(QWidget *parent = nullptr);
+      ~NoteTweakerDialog();
+
+      void setStaff(Staff* s);
+
+signals:
+      void notesChanged();
+
+public slots:
+      void setNoteOffTime();
+
+private:
+      void addChord(Chord* chord, int voice);
+      void updateNotes();
+      void clearNoteData();
+
+
+      Ui::NoteTweakerDialog *ui;
+      };
+
+}
+
+#endif // NOTETWEAKERDIALOG_H

--- a/mscore/notetweakerdialog.ui
+++ b/mscore/notetweakerdialog.ui
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>NoteTweakerDialog</class>
+ <widget class="QDialog" name="NoteTweakerDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>206</width>
+    <height>137</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Note Tweaker</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Note Off Time</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Fraction of beat:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="comboOffTimeFrac">
+        <item>
+         <property name="text">
+          <string>1/2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1/4</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1/8</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1/16</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1/32</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1/64</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="bnSetNoteOffTime">
+        <property name="text">
+         <string>Set</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="bnClose">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mscore/pianolevelschooser.cpp
+++ b/mscore/pianolevelschooser.cpp
@@ -1,8 +1,9 @@
 #include "pianolevelschooser.h"
 #include "pianolevelsfilter.h"
 
-namespace Ms {
+#include "libmscore/score.h"
 
+namespace Ms {
 
 //---------------------------------------------------------
 //   PianoLevelsChooser
@@ -11,22 +12,27 @@ namespace Ms {
 PianoLevelsChooser::PianoLevelsChooser(QWidget *parent)
       : QWidget(parent)
 {
+      setupUi(this);
+
       _levelsIndex = 0;
 
-      QGridLayout* layout = new QGridLayout;
-
-      levelsCombo = new QComboBox;
       for (int i = 0; PianoLevelsFilter::FILTER_LIST[i]; ++i) {
             QString name = PianoLevelsFilter::FILTER_LIST[i]->name();
             levelsCombo->addItem(name, i);
             }
 
-      layout->addWidget(levelsCombo, 0, 0, 1, 1);
-
-      setLayout(layout);
-
       connect(levelsCombo, SIGNAL(activated(int)), SLOT(setLevelsIndex(int)));
+      connect(setEventsBn, SIGNAL(clicked(bool)), SLOT(setEventDataPressed()));
 }
+
+//---------------------------------------------------------
+//   setStaff
+//---------------------------------------------------------
+
+void PianoLevelsChooser::setStaff(Staff* staff)
+      {
+      _staff = staff;
+      }
 
 
 //---------------------------------------------------------
@@ -40,5 +46,55 @@ void PianoLevelsChooser::setLevelsIndex(int index)
             emit levelsIndexChanged(index);
             }
 }
+
+
+//---------------------------------------------------------
+//   PianoLevelsChooser
+//---------------------------------------------------------
+
+void PianoLevelsChooser::setEventDataPressed()
+      {
+      PianoLevelsFilter* filter = PianoLevelsFilter::FILTER_LIST[_levelsIndex];
+
+      int val = eventValSpinBox->value();
+      QList<Note*> noteList = _staff->getNotes();
+
+      Score* score = _staff->score();
+
+      score->startCmd();
+
+      for(Note* note: noteList) {
+            if (!note->selected())
+                  continue;
+
+            if (filter->isPerEvent()) {
+                  for (NoteEvent& e : note->playEvents()) {
+                        filter->setValue(_staff, note, &e, val);
+                        }
+                  }
+                  else
+                        filter->setValue(_staff, note, nullptr, val);
+
+            }
+
+      score->endCmd();
+
+      emit notesChanged();
+      }
+
+//---------------------------------------------------------
+//   addChord
+//---------------------------------------------------------
+
+//void PianoLevelsChooser::addChord(Chord* chord, int voice)
+//      {
+//      for (Chord* c : chord->graceNotes())
+//            addChord(c, voice);
+//      for (Note* note : chord->notes()) {
+//            if (note->tieBack())
+//                  continue;
+//            noteList.append(note);
+//            }
+//      }
 
 }

--- a/mscore/pianolevelschooser.h
+++ b/mscore/pianolevelschooser.h
@@ -20,8 +20,11 @@
 #ifndef __PIANOLEVELSCHOOSER_H__
 #define __PIANOLEVELSCHOOSER_H__
 
+#include "ui_pianolevelschooser.h"
+
 #include <QObject>
 #include <QWidget>
+#include "libmscore/staff.h"
 
 namespace Ms {
 
@@ -30,17 +33,24 @@ namespace Ms {
 //   PianoLevelsChooser
 //---------------------------------------------------------
 
-class PianoLevelsChooser : public QWidget
+class PianoLevelsChooser : public QWidget, public Ui::PianoLevelsChooser
 {
-    Q_OBJECT
+      Q_OBJECT
 
-      QComboBox* levelsCombo;
       int _levelsIndex;
+      Staff* _staff;
+
+public:
+      Staff* staff() { return _staff; }
+      void setStaff(Staff*);
+
 signals:
       void levelsIndexChanged(int);
+      void notesChanged();
 
 public slots:
       void setLevelsIndex(int index);
+      void setEventDataPressed();
 
 public:
     explicit PianoLevelsChooser(QWidget *parent = 0);

--- a/mscore/pianolevelschooser.ui
+++ b/mscore/pianolevelschooser.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PianoLevelsChooser</class>
+ <widget class="QWidget" name="PianoLevelsChooser">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>369</width>
+    <height>288</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QComboBox" name="levelsCombo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Note Event Data Type</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Set Values</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="2" column="1">
+       <widget class="QPushButton" name="setEventsBn">
+        <property name="toolTip">
+         <string>Set Selected Note Event Data</string>
+        </property>
+        <property name="text">
+         <string>Set</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QSpinBox" name="eventValSpinBox">
+        <property name="minimum">
+         <number>-100000</number>
+        </property>
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/mscore/pianolevelsfilter.h
+++ b/mscore/pianolevelsfilter.h
@@ -21,6 +21,7 @@
 #define __PIANOLEVELSFILTER_H__
 
 #include <QString>
+#include <QCoreApplication>
 
 namespace Ms {
 
@@ -55,8 +56,10 @@ public:
 
 class PianoLevelFilterOnTime : public PianoLevelsFilter
 {
+      Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterOnTime)
+
 public:
-      QString name() override { return "On Time"; }
+      QString name() override { return tr("On Time"); }
       int maxRange() override { return 1000; }
       int minRange() override { return -1000; }
       int divisionGap() override { return 250; }
@@ -73,11 +76,33 @@ public:
 
 class PianoLevelFilterLen : public PianoLevelsFilter
 {
+      Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterLen)
+
 public:
-      QString name() override { return "Length"; }
+      QString name() override { return tr("Length As Note Multiplier"); }
       int maxRange() override { return 1000; }
       int minRange() override { return 0; }
       int divisionGap() override { return 250; }
+      bool isPerEvent() override { return true; }
+      int value(Staff* staff, Note* note, NoteEvent* evt) override;
+      void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
+};
+
+
+//---------------------------------------------------------
+//   PianoLevelFilterLenOff
+//---------------------------------------------------------
+
+
+class PianoLevelFilterLenOfftime : public PianoLevelsFilter
+{
+      Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterLenOfftime)
+
+public:
+      QString name() override { return tr("Length As Note Offtime"); }
+      int maxRange() override;
+      int minRange() override { return 0; }
+      int divisionGap() override;
       bool isPerEvent() override { return true; }
       int value(Staff* staff, Note* note, NoteEvent* evt) override;
       void setValue(Staff* staff, Note* note, NoteEvent* evt, int value) override;
@@ -91,8 +116,10 @@ public:
 
 class PianoLevelFilterVeloOffset : public PianoLevelsFilter
 {
+      Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterVeloOffset)
+
 public:
-      QString name() override { return "Velocity Offset"; }
+      QString name() override { return tr("Velocity Relative to Dynamic"); }
       int maxRange() override { return 200; }
       int minRange() override { return -200; }
       int divisionGap() override { return 100; }
@@ -109,8 +136,10 @@ public:
 
 class PianoLevelFilterVeloUser : public PianoLevelsFilter
 {
+      Q_DECLARE_TR_FUNCTIONS(PianoLevelFilterVeloUser)
+
 public:
-      QString name() override { return "Velocity Absolute"; }
+      QString name() override { return tr("Velocity As MIDI Volume"); }
       int maxRange() override { return 128; }
       int minRange() override { return 0; }
       int divisionGap() override { return 32; }

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -21,6 +21,7 @@
 #include "seq.h"
 #include "preferences.h"
 #include "waveview.h"
+#include "notetweakerdialog.h"
 #include "libmscore/staff.h"
 #include "libmscore/measure.h"
 #include "libmscore/note.h"
@@ -48,6 +49,8 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       waveView = 0;
       _score   = 0;
       staff    = 0;
+
+      noteTweakerDlg = new NoteTweakerDialog(this);
 
       QWidget* mainWidget = new QWidget;
       QToolBar* tb = addToolBar("Toolbar 1");
@@ -262,16 +265,19 @@ PianorollEditor::PianorollEditor(QWidget* parent)
       connect(hsb,         SIGNAL(valueChanged(int)),                 SLOT(setXpos(int)));
       connect(pianoView->horizontalScrollBar(), SIGNAL(valueChanged(int)),   SLOT(setXpos(int)));
 
-      connect(ruler,       SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
-      connect(pianoLevels, SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
-      connect(veloType,    SIGNAL(activated(int)),                SLOT(veloTypeChanged(int)));
-      connect(velocity,    SIGNAL(valueChanged(int)),             SLOT(velocityChanged(int)));
-      connect(onTime,      SIGNAL(valueChanged(int)),             SLOT(onTimeChanged(int)));
-      connect(tickLen,     SIGNAL(valueChanged(int)),             SLOT(tickLenChanged(int)));
-      connect(pianoView,   SIGNAL(selectionChanged()),            SLOT(selectionChanged()));
-      connect(pianoKbd,    SIGNAL(keyPressed(int)),               SLOT(keyPressed(int)));
-      connect(pianoKbd,    SIGNAL(keyReleased(int)),              SLOT(keyReleased(int)));
-      connect(pianoLevels, SIGNAL(noteLevelsChanged()),           SLOT(selectionChanged()));
+      connect(ruler,              SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
+      connect(pianoLevels,        SIGNAL(locatorMoved(int, const Pos&)), SLOT(moveLocator(int, const Pos&)));
+      connect(veloType,           SIGNAL(activated(int)),                SLOT(veloTypeChanged(int)));
+      connect(velocity,           SIGNAL(valueChanged(int)),             SLOT(velocityChanged(int)));
+      connect(onTime,             SIGNAL(valueChanged(int)),             SLOT(onTimeChanged(int)));
+      connect(tickLen,            SIGNAL(valueChanged(int)),             SLOT(tickLenChanged(int)));
+      connect(pianoView,          SIGNAL(selectionChanged()),            SLOT(selectionChanged()));
+      connect(pianoView,          SIGNAL(showNoteTweakerRequest()),      SLOT(showNoteTweaker()));
+      connect(pianoKbd,           SIGNAL(keyPressed(int)),               SLOT(keyPressed(int)));
+      connect(pianoKbd,           SIGNAL(keyReleased(int)),              SLOT(keyReleased(int)));
+      connect(pianoLevels,        SIGNAL(noteLevelsChanged()),           SLOT(selectionChanged()));
+      connect(noteTweakerDlg,     SIGNAL(notesChanged()),                SLOT(selectionChanged()));
+      connect(pianoLevelsChooser, SIGNAL(notesChanged()),                SLOT(selectionChanged()));
 
       readSettings();
 
@@ -311,8 +317,18 @@ PianorollEditor::~PianorollEditor()
             action->disconnect(this);
       }
 
+
 //---------------------------------------------------------
-//   focucOnElement
+//   showNoteTweaker
+//---------------------------------------------------------
+
+void PianorollEditor::showNoteTweaker()
+      {
+      noteTweakerDlg->show();
+      }
+
+//---------------------------------------------------------
+//   focusOnPosition
 //---------------------------------------------------------
 
 void PianorollEditor::focusOnPosition(Position* p)
@@ -368,7 +384,9 @@ void PianorollEditor::setStaff(Staff* st)
       pianoView->setStaff(staff, locator);
       pianoLevels->setScore(_score, locator);
       pianoLevels->setStaff(staff, locator);
+      pianoLevelsChooser->setStaff(staff);
       pianoKbd->setStaff(staff);
+      noteTweakerDlg->setStaff(staff);
 
       updateSelection();
       setEnabled(st != nullptr);
@@ -626,6 +644,7 @@ void PianorollEditor::cmd(QAction* /*a*/)
       //score()->startCmd();
       pianoView->setStaff(staff, locator);
       pianoLevels->setStaff(staff, locator);
+      pianoLevelsChooser->setStaff(staff);
       pianoKbd->setStaff(staff);
       //score()->endCmd();
       }

--- a/mscore/pianoroll.h
+++ b/mscore/pianoroll.h
@@ -31,6 +31,7 @@ class PianoView;
 class PianoKeyboard;
 class PianoLevels;
 class PianoLevelsChooser;
+class NoteTweakerDialog;
 class Note;
 class PianoRuler;
 class Seq;
@@ -68,6 +69,7 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       QList<QAction*> actions;
 
       bool updateScheduled = false;
+      NoteTweakerDialog* noteTweakerDlg;
 
       void updateVelocity(Note* note);
       void updateSelection();
@@ -92,6 +94,7 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
 
    public slots:
       void changeSelection(SelState);
+      void showNoteTweaker();
 
    public:
       PianorollEditor(QWidget* parent = 0);

--- a/mscore/pianoview.cpp
+++ b/mscore/pianoview.cpp
@@ -556,7 +556,6 @@ void PianoView::wheelEvent(QWheelEvent* event)
             }
       }
 
-
 //---------------------------------------------------------
 //   showPopupMenu
 //---------------------------------------------------------
@@ -564,6 +563,12 @@ void PianoView::wheelEvent(QWheelEvent* event)
 void PianoView::showPopupMenu(const QPoint& pos)
       {
       QMenu popup(this);
+
+      {
+            QAction* act = new QAction(tr("Note Tweaker"));
+            connect(act, SIGNAL(triggered(bool)), this, SLOT(showNoteTweaker()));
+            popup.addAction(act);
+      }
 //      popup.addAction(getAction("cut"));
 //      popup.addAction(getAction("copy"));
       popup.addAction(getAction("paste"));
@@ -1186,6 +1191,15 @@ QAction* PianoView::getAction(const char* id)
       {
       Shortcut* s = Shortcut::getShortcut(id);
       return s ? s->action() : 0;
+      }
+
+//---------------------------------------------------------
+//   showNoteTweaker
+//---------------------------------------------------------
+
+void PianoView::showNoteTweaker()
+      {
+      emit showNoteTweakerRequest();
       }
 
 //---------------------------------------------------------

--- a/mscore/pianoview.h
+++ b/mscore/pianoview.h
@@ -24,6 +24,7 @@ class ChordRest;
 class Note;
 class NoteEvent;
 class PianoView;
+class NoteTweakerDialog;
 
 enum class NoteSelectType {
       REPLACE = 0,
@@ -132,6 +133,7 @@ private:
       void pitchChanged(int);
       void trackingPosChanged(const Pos&);
       void selectionChanged();
+      void showNoteTweakerRequest();
 
    public slots:
       void moveLocator(int);
@@ -140,6 +142,7 @@ private:
       void setTuplet(int);
       void setSubdiv(int);
       void setBarPattern(int);
+      void showNoteTweaker();
 
    public:
       PianoView();


### PR DESCRIPTION
Adding dialog to allow user to specify a fraction of a beat that notes should be cutoff at.  Right click in the paino note area and select 'Note Tweaker' to activate dialog.