### PR TITLE
.bat files should point to MuseScore3 not nightly

### DIFF
--- a/build/appveyor/special/debugMode.bat
+++ b/build/appveyor/special/debugMode.bat
@@ -1,3 +1,3 @@
 @echo off
-start ../bin/nightly.exe -d
+start ../bin/MuseScore3.exe -d
 exit

--- a/build/appveyor/special/revertToFactorySettings.bat
+++ b/build/appveyor/special/revertToFactorySettings.bat
@@ -1,3 +1,3 @@
 @echo off
-start ../bin/nightly.exe -F
+start ../bin/MuseScore3.exe -F
 exit

--- a/build/appveyor/support/nightly.bat
+++ b/build/appveyor/support/nightly.bat
@@ -1,3 +1,3 @@
 @echo off
-start bin/nightly.exe
+start bin/MuseScore3.exe
 exit


### PR DESCRIPTION
extremely minor.  I just downloaded a nightly .7z archive, and double-clicked the nightly.bat in the extracted base directory, and saw that it didn't work.  Because apparently "MuseScore3.exe" is the name of the built exe, not "nightly.exe".