### PR TITLE
It is not nedded to copy libeay32.dll or libsslay32.dll from QT_INSTALL_BINS

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -850,7 +850,6 @@ else (MINGW)
                   "${QT_INSTALL_BINS}/Qt5WebChannel.dll"
                   "${QT_INSTALL_BINS}/Qt5QuickWidgets.dll" "${QT_INSTALL_BINS}/Qt5Positioning.dll"
                   "${QT_INSTALL_BINS}/libEGL.dll" "${QT_INSTALL_BINS}/libGLESv2.dll"
-                  "${QT_INSTALL_BINS}/libeay32.dll" "${QT_INSTALL_BINS}/libsslay32.dll"
                   )
       if (USE_WEBENGINE)
          list(APPEND dlls_to_copy "${QT_INSTALL_BINS}/Qt5WebEngineWidgets.dll" "${QT_INSTALL_BINS}/Qt5WebEngineCore.dll")


### PR DESCRIPTION
Those two libraries don't actually belong to the Qt install.  Trying to copy them from Qt produces an Error message.  Turns out that error message can be safely ignored anyway.  That is because those dlls will already get copied later from DEPENDENCIES_DIR where they are actually located.