### PR TITLE
fix #279484: fix incorrect segment ticks on time delete

### DIFF
--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -940,6 +940,21 @@ bool Segment::operator>(const Segment& s) const
       }
 
 //---------------------------------------------------------
+//   hasElements
+///  Returns true if the segment has at least one element.
+///  Annotations are not considered.
+//---------------------------------------------------------
+
+bool Segment::hasElements() const
+      {
+      for (const Element* e : _elist) {
+            if (e)
+                  return true;
+            }
+      return false;
+      }
+
+//---------------------------------------------------------
 //   hasAnnotationOrElement
 ///  return true if an annotation of type type or and element is found in the track range
 //---------------------------------------------------------

--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -201,6 +201,7 @@ class Segment final : public Element {
       bool hasAnnotationOrElement(ElementType type, int minTrack, int maxTrack) const;
       Element* findAnnotation(ElementType type, int minTrack, int maxTrack);
       std::vector<Element*> findAnnotations(ElementType type, int minTrack, int maxTrack);
+      bool hasElements() const;
 
 
       qreal dotPosX(int staffIdx) const          { return _dotPosX[staffIdx];  }

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1147,18 +1147,13 @@ void ChangeMeasureLen::flip(EditData*)
       // to end of measure:
       //
 
-      Segment* s = measure->first();
       std::list<Segment*> sl;
-      for (; s;) {
-            Segment* ns = s->next();
-            if (!s->isEndBarLineType() && !s->isTimeSigAnnounceType()) {
-                  s = ns;
+      for (Segment* s = measure->first(); s; s = s->next()) {
+            if (!s->isEndBarLineType() && !s->isTimeSigAnnounceType())
                   continue;
-                  }
             s->setRtick(len.ticks());
             sl.push_back(s);
             measure->remove(s);
-            s = ns;
             }
       measure->setLen(len);
       measure->score()->fixTicks();


### PR DESCRIPTION
This PR fixes the issue [#279484](https://musescore.org/en/node/279484). Time delete algorithm seemed to assign invalid ticks to some segments ending up with negative tick values for some segments on time-delete in the beginning of the score. This PR slightly changes the logic of fixing ticks for segments avoiding unnecessary tick changes. This fixes that issue.

This PR also makes all segment annotations that are left after time delete operation be moved to other segments. Not sure that these annotations should be preserved at all but in the current way of working this causes strange behavior and crashes on note input and undo/redo operations.