### PR TITLE
fix #278865, fix #279521: reuse system elements layout code in linear mode

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3239,10 +3239,24 @@ System* Score::collectSystem(LayoutContext& lc)
             }
       system->setWidth(pos.x());
 
-      //#############################################################
-      //    layout system elements
-      //#############################################################
+      layoutSystemElements(system, lc);
+      system->layout2();   // compute staff distances
 
+      lm  = system->lastMeasure();
+      if (lm) {
+            lc.firstSystem        = lm->sectionBreak() && _layoutMode != LayoutMode::FLOAT;
+            lc.startWithLongNames = lc.firstSystem && lm->sectionBreakElement()->startWithLongNames();
+            }
+
+      return system;
+      }
+
+//---------------------------------------------------------
+//   layoutSystemElements
+//---------------------------------------------------------
+
+void Score::layoutSystemElements(System* system, LayoutContext& lc)
+      {
       //-------------------------------------------------------------
       //    create cr segment list to speed up computations
       //-------------------------------------------------------------
@@ -3541,16 +3555,6 @@ System* Score::collectSystem(LayoutContext& lc)
                         e->layout();
                   }
             }
-
-      system->layout2();   // compute staff distances
-
-      lm  = system->lastMeasure();
-      if (lm) {
-            lc.firstSystem        = lm->sectionBreak() && _layoutMode != LayoutMode::FLOAT;
-            lc.startWithLongNames = lc.firstSystem && lm->sectionBreakElement()->startWithLongNames();
-            }
-
-      return system;
       }
 
 //---------------------------------------------------------

--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -204,6 +204,7 @@ void LayoutContext::layoutLinear()
       {
       System* system = score->systems().front();
 
+#if 0 // replaced by layoutSystemElements()
       //
       // layout
       //    - beams
@@ -407,6 +408,9 @@ void LayoutContext::layoutLinear()
                   continue;
             sp->layoutSystem(system);
             }
+#endif
+
+      score->layoutSystemElements(system, *this);
 
       system->layout2();   // compute staff distances
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -583,6 +583,7 @@ class Score : public QObject, public ScoreElement {
       void setExcerpt(Excerpt* e)   { _excerpt = e;     }
 
       System* collectSystem(LayoutContext&);
+      void layoutSystemElements(System* system, LayoutContext& lc);
       void getNextMeasure(LayoutContext&);      // get next measure for layout
 
       void cmdRemovePart(Part*);


### PR DESCRIPTION
This PR tries to address a number of issues with continuous view layout by reusing the code for layout of elements belonging to the whole system in page mode. This should help to reduce number of issues that originate from desynchronizing of code for page layout and linear layout. Still this does not resolve all the issues with continuous view, for example, [tempo issues with voltas](https://musescore.org/en/node/278153) are still remaining.
Still at least these two issues seem to be resolved by this PR:
https://musescore.org/en/node/279521
https://musescore.org/en/node/278865

There may be some concerns regarding performance of this solution but my tests with release builds did not show any noticeable difference. Though optimization issues regarding linear layout still should be addressed at some point later.

P.S. Yes, the branch name slightly mismatch the actual result.