### PR TITLE
fix #279202: can't play from selection in part view

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2785,8 +2785,8 @@ void Score::select(Element* e, SelectType type, int staffIdx)
             if (ee->isNote())
                   ee = ee->parent();
             int tick = toChordRest(ee)->segment()->tick();
-            if (playPos() != tick)
-                  setPlayPos(tick);
+            if (masterScore()->playPos() != tick)
+                  masterScore()->setPlayPos(tick);
             }
       if (MScore::debugMode)
             qDebug("select element <%s> type %d(state %d) staff %d",

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4283,12 +4283,23 @@ void MuseScore::play(Element* e, int pitch) const
             return;
       if (preferences.getBool(PREF_SCORE_NOTE_PLAYONCLICK) && e->isNote()) {
             Note* note = static_cast<Note*>(e);
-            int tick = note->chord()->tick();
+
+            Note* masterNote = note;
+            if (note->linkList().size() > 1) {
+                  for (ScoreElement* se : note->linkList()) {
+                        if (se->score() == note->masterScore() && se->isNote()) {
+                              masterNote = toNote(se);
+                              break;
+                              }
+                        }
+                  }
+
+            int tick = masterNote->chord()->tick();
             if (tick < 0)
                   tick = 0;
-            Instrument* instr = note->part()->instrument(tick);
-            const Channel* channel = instr->channel(note->subchannel());
-            seq->startNote(channel->channel(), pitch, 80, MScore::defaultPlayDuration, note->tuning());
+            Instrument* instr = masterNote->part()->instrument(tick);
+            const Channel* channel = instr->channel(masterNote->subchannel());
+            seq->startNote(channel->channel(), pitch, 80, MScore::defaultPlayDuration, masterNote->tuning());
             }
       }
 

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1496,17 +1496,27 @@ void Seq::heartBeatTimeout()
                   const Note* note1 = n.note();
                   if (n.velo()) {
                         while (note1) {
-                              note1->setMark(true);
-                              markedNotes.append(note1);
-                              r |= note1->canvasBoundingRect();
+                              for (ScoreElement* se : note1->linkList()) {
+                                    if (!se->isNote())
+                                          continue;
+                                    Note* currentNote = toNote(se);
+                                    currentNote->setMark(true);
+                                    markedNotes.append(currentNote);
+                                    r |= currentNote->canvasBoundingRect();
+                                    }
                               note1 = note1->tieFor() ? note1->tieFor()->endNote() : 0;
                               }
                         }
                   else {
                         while (note1) {
-                              note1->setMark(false);
-                              r |= note1->canvasBoundingRect();
-                              markedNotes.removeOne(note1);
+                              for (ScoreElement* se : note1->linkList()) {
+                                    if (!se->isNote())
+                                          continue;
+                                    Note* currentNote = toNote(se);
+                                    currentNote->setMark(false);
+                                    r |= currentNote->canvasBoundingRect();
+                                    markedNotes.removeOne(currentNote);
+                                    }
                               note1 = note1->tieFor() ? note1->tieFor()->endNote() : 0;
                               }
                         }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279202

Basically, all selections need to be redirected in one way or another to the master score, and note properties and instruments should be accessed only from master score elements. This is two way - instead of just marking the 'master note' that is being played, the linked notes in the parts should be marked as well.