### PR TITLE
fix typo in courtesy clef test

### DIFF
--- a/mtest/libmscore/clef_courtesy/tst_clef_courtesy.cpp
+++ b/mtest/libmscore/clef_courtesy/tst_clef_courtesy.cpp
@@ -137,7 +137,7 @@ void TestClefCourtesy::clef_courtesy02()
       clef = new Clef(score); // create a new element, as Measure::drop() will eventually delete it
       clef->setClefType(ClefType::G);
       dropData.pos = m2->pagePos();
-      dropData.element = clef;
+      dropData.dropElement = clef;
       m2->drop(dropData);
       score->doLayout();
 


### PR DESCRIPTION
In order to fix a memory access bug found with AddressSanitizer, see https://github.com/musescore/MuseScore/pull/4262#issuecomment-444885036