### PR TITLE
instantly update mixer track background greyness upon select

### DIFF
--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -420,7 +420,8 @@ void Mixer::notifyTrackSelected(MixerTrack* track)
       {
       for (MixerTrack *mt: trackList) {
             if (!(mt->mti()->part() == track->mti()->part() &&
-                mt->mti()->chan() == track->mti()->chan())) {
+                  mt->mti()->chan() == track->mti()->chan() &&
+                  mt->mti()->trackType() == track->mti()->trackType())) {
                   mt->setSelected(false);
                   }
             }

--- a/mscore/mixertrackchannel.cpp
+++ b/mscore/mixertrackchannel.cpp
@@ -336,6 +336,8 @@ void MixerTrackChannel::setSelected(bool sel)
 
       if (_selected && _group)
             _group->notifyTrackSelected(this);
+
+      applyStyle();
       }
 
 }

--- a/mscore/mixertrackpart.cpp
+++ b/mscore/mixertrackpart.cpp
@@ -333,6 +333,8 @@ void MixerTrackPart::setSelected(bool sel)
 
       if (_selected && _group)
             _group->notifyTrackSelected(this);
+
+      applyStyle();
       }
 
 }


### PR DESCRIPTION
Clicking each individual track should immediately update the greyness such that the selected track is light grey while all non-selected tracks are dark-grey.  Apparently some past change must have broke this functionality.

Credit to Mark McKay for walking me through debugging, and ultimately identifying the correct fix.