### PR TITLE
fix #277500: adjust offsets/placements for text on 2.x import

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1452,6 +1452,15 @@ static bool readTextProperties206(XmlReader& e, TextBase* t, Element* be)
             t->readProperty(e, Pid::OFFSET);
             if ((char(t->align()) & char(Align::VMASK)) == char(Align::TOP))
                   t->ryoffset() += .5 * t->score()->spatium();     // HACK: bbox is different in 2.x
+            if (t->staff()) {
+                  qreal staffHeight = t->staff()->height();
+                  if (t->offset().y() >= staffHeight) {
+                        t->setProperty(Pid::PLACEMENT, int(Placement::BELOW));
+                        t->ryoffset() -= staffHeight;
+                        }
+                  else
+                        t->setProperty(Pid::PLACEMENT, int(Placement::ABOVE));
+                  }
             }
       else if (!t->readProperties(e))
             return false;
@@ -3034,6 +3043,16 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   // for symbols attached to anything but a measure
                   el->setTrack(e.track());
                   el->read(e);
+                  if (el->staff() && (el->isHarmony() || el->isFretDiagram() || el->isInstrumentChange())) {
+                        qreal staffHeight = el->staff()->height();
+                        if (el->offset().y() >= staffHeight) {
+                              el->setProperty(Pid::PLACEMENT, int(Placement::BELOW));
+                              el->ryoffset() -= staffHeight;
+                              }
+                        else
+                              el->setProperty(Pid::PLACEMENT, int(Placement::ABOVE));
+                        }
+
                   segment = m->getSegment(SegmentType::ChordRest, e.tick());
                   segment->add(el);
                   }


### PR DESCRIPTION
This is basically the same code from Werner's fix for spanners (https://github.com/musescore/MuseScore/commit/7416874dcda68cdf575901cdd861508bef04bd06), adapted for text.  So now 2.x scores wih dynamics moved above the staff, or staff text moved below, will display miore properly if you don't choose the reset option.