### PR TITLE
fix #279062: re-implement instrument option for hide when empty

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1254,10 +1254,14 @@ void Score::hideEmptyStaves(System* system, bool isFirstSystem)
                         for (int i = 0; i < part->nstaves(); ++i) {
                               int st = idx + i;
 
-                              foreach (MeasureBase* mb, system->measures()) {
+                              for (MeasureBase* mb : system->measures()) {
                                     if (!mb->isMeasure())
                                           continue;
                                     Measure* m = toMeasure(mb);
+                                    if (staff->hideWhenEmpty() == Staff::HideMode::INSTRUMENT && !m->isMeasureRest(st)) {
+                                          hideStaff = false;
+                                          break;
+                                          }
                                     for (Segment* s = m->first(SegmentType::ChordRest); s; s = s->next(SegmentType::ChordRest)) {
                                           for (int voice = 0; voice < VOICES; ++voice) {
                                                 ChordRest* cr = s->cr(st * VOICES + voice);


### PR DESCRIPTION
Looks like the few lines of code it took to implement this accidentally got clobbered by other changes a few weeks later (https://github.com/musescore/MuseScore/commit/9f933d8503b3060e4f9a3880805ed18fc3fac642#diff-fd94ca9d9d96db30c9eecee54314437bL2407) and it wasn't noticed until the beta.  Better late than never.  Added the missing code back, tested, still works :-)