### PR TITLE
fix #269036 InputMethod Cursor rect & enable & update

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -663,6 +663,7 @@ void TextBase::inputTransition(EditData& ed, QInputMethodEvent* ie)
                   editInsertText(_cursor, preEdit);
                   setTextInvalid();
                   layout1();
+                  score()->update();
                   }
             }
       ie->accept();

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1878,8 +1878,18 @@ MuseScore::MuseScore()
       initOsc();
       startAutoSave();
 
+#ifndef NDEBUG
+      // for debugging, but possible may need
       QInputMethod* im = QGuiApplication::inputMethod();
+      connect(im, SIGNAL(anchorRectangleChanged()), SLOT(inputMethodAnchorRectangleChanged()));
+      connect(im, SIGNAL(animatingChanged()), SLOT(inputMethodAnimatingChanged()));
+      connect(im, SIGNAL(cursorRectangleChanged()), SLOT(inputMethodCursorRectangleChanged()));
+      connect(im, SIGNAL(inputDirectionChanged(Qt::LayoutDirection newDirection)), SLOT(inputMethodInputDirectionChanged(Qt::LayoutDirection newDirection)));
+      connect(im, SIGNAL(inputItemClipRectangleChanged()), SLOT(inputMethodInputItemClipRectangleChanged()));
+      connect(im, SIGNAL(keyboardRectangleChanged()), SLOT(inputMethodKeyboardRectangleChanged()));
       connect(im, SIGNAL(localeChanged()), SLOT(inputMethodLocaleChanged()));
+      connect(im, SIGNAL(visibleChanged()), SLOT(inputMethodVisibleChanged()));
+#endif
 
       if (enableExperimental) {
             cornerLabel = new QLabel(this);
@@ -3806,12 +3816,79 @@ void MuseScore::clipboardChanged()
       }
 
 //---------------------------------------------------------
+//   inputMethodAnchorRectangleChanged
+//---------------------------------------------------------
+
+void MuseScore::inputMethodAnchorRectangleChanged()
+      {
+      QRectF r =  QGuiApplication::inputMethod()->anchorRectangle();
+      qDebug("inputMethod AnchorRectangle Changed: (%f, %f) + (%f, %f)", r.x(), r.y(), r.width(), r.height());
+      }
+
+//---------------------------------------------------------
+//   inputMethodAnimatingChanged
+//---------------------------------------------------------
+
+void MuseScore::inputMethodAnimatingChanged()
+      {
+      qDebug("inputMethod Animating Changed: %d", QGuiApplication::inputMethod()->isAnimating());
+      }
+
+//---------------------------------------------------------
+//   inputMethodCursorRectangleChanged
+//---------------------------------------------------------
+
+void MuseScore::inputMethodCursorRectangleChanged()
+      {
+      QRectF r =  QGuiApplication::inputMethod()->cursorRectangle();
+      qDebug("inputMethod CursorRectangle Changed: (%f, %f) + (%f, %f)", r.x(), r.y(), r.width(), r.height());
+      }
+
+//---------------------------------------------------------
+//   inputMethodInputDirectionChanged
+//---------------------------------------------------------
+
+void MuseScore::inputMethodInputDirectionChanged(Qt::LayoutDirection newDirection)
+      {
+      qDebug("inputMethod InputDirection Changed: (QLocale::LayoutDirection enum) #%d", newDirection);
+      }
+
+//---------------------------------------------------------
+//   inputMethodInputItemClipRectangleChanged
+//---------------------------------------------------------
+
+void MuseScore::inputMethodInputItemClipRectangleChanged()
+      {
+      QRectF r =  QGuiApplication::inputMethod()->inputItemClipRectangle();
+      qDebug("inputMethod InputItemClipRectangle Changed: (%f, %f) + (%f, %f)", r.x(), r.y(), r.width(), r.height());
+      }
+
+//---------------------------------------------------------
+//   inputMethodKeyboardRectangleChanged
+//---------------------------------------------------------
+
+void MuseScore::inputMethodKeyboardRectangleChanged()
+      {
+      QRectF r =  QGuiApplication::inputMethod()->keyboardRectangle();
+      qDebug("inputMethod KeyboardRectangle Changed: (%f, %f) + (%f, %f)", r.x(), r.y(), r.width(), r.height());
+      }
+
+//---------------------------------------------------------
 //   inputMethodLocaleChanged
 //---------------------------------------------------------
 
 void MuseScore::inputMethodLocaleChanged()
       {
-      qDebug("Input method QLocale::Script enum now #%d.", QGuiApplication::inputMethod()->locale().script());
+      qDebug("inputMethod Locale Changed: (QLocale::Script enum) #%d.", QGuiApplication::inputMethod()->locale().script());
+      }
+
+//---------------------------------------------------------
+//   inputMethodVisibleChanged
+//---------------------------------------------------------
+
+void MuseScore::inputMethodVisibleChanged()
+      {
+      qDebug("inputMethodVisibleChanged: %d", QGuiApplication::inputMethod()->isVisible());
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -514,7 +514,14 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void removeTab(int);
       void removeTab();
       void clipboardChanged();
+      void inputMethodAnchorRectangleChanged();
+      void inputMethodAnimatingChanged();
+      void inputMethodCursorRectangleChanged();
+      void inputMethodInputDirectionChanged(Qt::LayoutDirection newDirection);
+      void inputMethodInputItemClipRectangleChanged();
+      void inputMethodKeyboardRectangleChanged();
       void inputMethodLocaleChanged();
+      void inputMethodVisibleChanged();
       void endSearch();
       void saveScoreDialogFilterSelected(const QString&);
 #ifdef OSC

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2581,9 +2581,8 @@ void ScoreView::deselectAll()
 QVariant ScoreView::inputMethodQuery(Qt::InputMethodQuery query) const
       {
 //      qDebug("0x%x  %s", int(query), editData.element ? editData.element->name() : "-no element-");
-      // if editing a text object, place the InputMethod popup window just below the text
-      if (editData.dropElement && editData.dropElement->isTextBase()) {
-            TextBase* text = toTextBase(editData.dropElement);
+      if (editData.element && editData.element->isTextBase()) {
+            TextBase* text = toTextBase(editData.element);
             switch (query) {
                   case Qt::ImCursorRectangle: {
                         QRectF r;
@@ -2595,11 +2594,14 @@ QVariant ScoreView::inputMethodQuery(Qt::InputMethodQuery query) const
                         else
                               r = toPhysical(text->canvasBoundingRect());
                         r.setHeight(r.height() + 10); // add a little margin under the cursor
-                        qDebug("   cursorRect: [%3f,%3f,%3f,%3f]", r.x(), r.y(), r.width(), r.height());
-                        return QVariant(r);
+                        qDebug("ScoreView::inputMethodQuery() updating cursorRect to: (%3f, %3f) + (%3f, %3f)", r.x(), r.y(), r.width(), r.height());
+                        return QVariant(r);     
                         }
                   case Qt::ImEnabled:
-                        return editMode();
+                        return true; // TextBase will always accept input method input
+                  case Qt::ImHints:
+                        return Qt::ImhNone; // No hints for now, but maybe in future will give hints
+                  case Qt::ImInputItemClipRectangle: // maybe give clip rect hint in future, but for now use default parent clipping rect
                   default:
                         return QWidget::inputMethodQuery(query); // fall back to QWidget's version as default
                   }


### PR DESCRIPTION
Previously the InputMethod would appear at the bottom center of ScoreView. This is because someone's previous commit broke the main if statement in ScoreView::inputMethodQuery such that it would always fail. That resulting in undesired default fallback behavior which caused the cursor to appear below the bottom of the ScoreView, rather than immediately below the TextBase element that user wants to input to. Fixing that if statement allows my original code to work again.

Additionally I noticed sometimes input editor would fail to work after unselecting the text element. Turns out that was because the query for Im::Enabled was set to isEditing(). I found by always returning true for that case for TextBase objects, that resulted in the InputMethod to always work on subsequent edits.

Also added dummy slot functions for all signals that InputMethod can produce...right now just outputting debug messages. In the future might end up responding to those signals, although for now leaving as empty skeleton functions.