### PR TITLE
fix #279340: crash and incorrect middle segment length of slurs

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -951,7 +951,7 @@ SpannerSegment* Slur::layoutSystem(System* system)
                   }
             sst = tick2() < etick ? SpannerSegmentType::SINGLE : SpannerSegmentType::BEGIN;
             }
-      else if (tick() < stick && tick2() > etick)
+      else if (tick() < stick && tick2() >= etick)
             sst = SpannerSegmentType::MIDDLE;
       else
             sst = SpannerSegmentType::END;

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -71,8 +71,10 @@ System::System(Score* s)
 
 System::~System()
       {
-      for (SpannerSegment* ss : spannerSegments())
-            ss->setParent(0);
+      for (SpannerSegment* ss : spannerSegments()) {
+            if (ss->system() == this)
+                  ss->setParent(nullptr);
+            }
       for (MeasureBase* mb : measures()) {
             if (mb->system() == this)
                   mb->setSystem(nullptr);

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -106,8 +106,14 @@ void ScoreView::startEdit(Element* element, Grip startGrip)
             qDebug("The element cannot be edited");
             return;
             }
+
+      const bool forceStartEdit = (state == ViewState::EDIT && element != editData.element);
       editData.element = element;
-      changeState(ViewState::EDIT);
+      if (forceStartEdit) // call startEdit() forcibly to reinitialize edit mode.
+            startEdit();
+      else
+            changeState(ViewState::EDIT);
+
       if (startGrip != Grip::NO_GRIP)
             editData.curGrip = startGrip;
       }


### PR DESCRIPTION
The issue: https://musescore.org/en/node/279340.

Changes:
1) Reinitialize edit mode when changing the edited element.
   Fixes a crash on dragging slur after increasing its size to more
   than one system.
2) Correct segment type determination for slur segments.
   For slurs tick2 is at the beginning of the end point unlike as
   for most of other spanners.
3) Be more cautious on resetting spanner segment parent on system
   destruction. No known issues related to this.