### PR TITLE
fix #279572: can't disable 'size changes with spatium' from inspector

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -2165,7 +2165,7 @@ QString TextBase::subtypeName() const
 //   fragmentList
 //---------------------------------------------------------
 
-/**
+/*
  Return the text as a single list of TextFragment
  Used by the MusicXML formatted export to avoid parsing the xml text format
  */

--- a/mscore/inspector/inspectorTextBase.cpp
+++ b/mscore/inspector/inspectorTextBase.cpp
@@ -29,6 +29,7 @@ InspectorTextBase::InspectorTextBase(QWidget* parent)
       const std::vector<InspectorItem> iiList = {
             { Pid::FONT_FACE,         0, t.fontFace,     t.resetFontFace     },
             { Pid::FONT_SIZE,         0, t.fontSize,     t.resetFontSize     },
+            { Pid::SIZE_SPATIUM_DEPENDENT,        0,  t.spatiumDependent,    t.resetSpatiumDependent    },
             { Pid::FONT_STYLE,        0, t.fontStyle,    t.resetFontStyle    },
             { Pid::FRAME_TYPE,        0, t.frameType,    t.resetFrameType    },
             { Pid::FRAME_FG_COLOR,    0, t.frameColor,   t.resetFrameColor   },

--- a/mscore/inspector/inspector_text.ui
+++ b/mscore/inspector/inspector_text.ui
@@ -107,23 +107,36 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <item row="5" column="1">
-          <widget class="QComboBox" name="frameType">
-           <property name="accessibleName">
-            <string>Frame</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_8">
+         <item row="6" column="0">
+          <widget class="QLabel" name="label">
            <property name="text">
-            <string>Font size:</string>
+            <string>Frame:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
            <property name="buddy">
-            <cstring>fontSize</cstring>
+            <cstring>frameType</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <item>
+            <widget class="Ms::FontStyleSelect" name="fontStyle" native="true"/>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="fontSize">
+           <property name="toolTip">
+            <string>Font size</string>
+           </property>
+           <property name="accessibleName">
+            <string>Font size</string>
+           </property>
+           <property name="suffix">
+            <string>pt</string>
            </property>
           </widget>
          </item>
@@ -149,6 +162,32 @@
            </property>
           </widget>
          </item>
+         <item row="1" column="2">
+          <widget class="Ms::ResetButton" name="resetFontSize" native="true"/>
+         </item>
+         <item row="6" column="1">
+          <widget class="QComboBox" name="frameType">
+           <property name="accessibleName">
+            <string>Frame</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>Font size:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="buddy">
+            <cstring>fontSize</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="Ms::ResetButton" name="resetFontStyle" native="true"/>
+         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="label_9">
            <property name="text">
@@ -162,40 +201,13 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Frame:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="buddy">
-            <cstring>frameType</cstring>
-           </property>
-          </widget>
+         <item row="5" column="2">
+          <widget class="Ms::ResetButton" name="resetAlign" native="true"/>
          </item>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="fontSize">
-           <property name="toolTip">
-            <string>Font size</string>
-           </property>
-           <property name="accessibleName">
-            <string>Font size</string>
-           </property>
-           <property name="suffix">
-            <string>pt</string>
-           </property>
-          </widget>
+         <item row="2" column="2">
+          <widget class="Ms::ResetButton" name="resetSpatiumDependent" native="true"/>
          </item>
-         <item row="3" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="Ms::FontStyleSelect" name="fontStyle"/>
-           </item>
-          </layout>
-         </item>
-         <item row="3" column="0">
+         <item row="4" column="0">
           <widget class="QLabel" name="label_4">
            <property name="text">
             <string>Font style:</string>
@@ -206,19 +218,9 @@
           </widget>
          </item>
          <item row="0" column="2">
-          <widget class="Ms::ResetButton" name="resetFontFace"/>
+          <widget class="Ms::ResetButton" name="resetFontFace" native="true"/>
          </item>
-         <item row="1" column="2">
-          <widget class="Ms::ResetButton" name="resetFontSize"/>
-         </item>
-         <item row="4" column="0" colspan="2">
-          <widget class="Ms::AlignSelect" name="align" native="true">
-           <property name="toolTip">
-            <string>Text alignment</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0" colspan="3">
+         <item row="7" column="0" colspan="3">
           <widget class="QFrame" name="frameWidget">
            <layout class="QGridLayout" name="gridLayout_3">
             <property name="leftMargin">
@@ -236,6 +238,103 @@
             <property name="spacing">
              <number>0</number>
             </property>
+            <item row="3" column="2">
+             <widget class="Ms::ResetButton" name="resetBgColor" native="true"/>
+            </item>
+            <item row="6" column="2">
+             <widget class="Ms::ResetButton" name="resetFrameRound" native="true"/>
+            </item>
+            <item row="5" column="2">
+             <widget class="Ms::ResetButton" name="resetPaddingWidth" native="true"/>
+            </item>
+            <item row="6" column="0">
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Border radius:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="buddy">
+               <cstring>frameRound</cstring>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_7">
+              <property name="text">
+               <string>Background:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="buddy">
+               <cstring>bgColor</cstring>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_5">
+              <property name="text">
+               <string>Text margin:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="buddy">
+               <cstring>paddingWidth</cstring>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="Awl::ColorLabel" name="frameColor">
+              <property name="accessibleName">
+               <string>Foreground color</string>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::Box</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QDoubleSpinBox" name="paddingWidth">
+              <property name="accessibleName">
+               <string>Text margin</string>
+              </property>
+              <property name="suffix">
+               <string>sp</string>
+              </property>
+              <property name="singleStep">
+               <double>0.200000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="Awl::ColorLabel" name="bgColor">
+              <property name="accessibleName">
+               <string>Background color</string>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::Box</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>Border:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="buddy">
+               <cstring>frameWidth</cstring>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="2">
+             <widget class="Ms::ResetButton" name="resetFrameWidth" native="true"/>
+            </item>
             <item row="0" column="0">
              <widget class="QLabel" name="label_6">
               <property name="sizePolicy">
@@ -255,53 +354,10 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="Awl::ColorLabel" name="frameColor">
-              <property name="accessibleName">
-               <string>Foreground color</string>
-              </property>
-              <property name="frameShape">
-               <enum>QFrame::Box</enum>
-              </property>
-             </widget>
+            <item row="0" column="2">
+             <widget class="Ms::ResetButton" name="resetFrameColor" native="true"/>
             </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_7">
-              <property name="text">
-               <string>Background:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="buddy">
-               <cstring>bgColor</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="Awl::ColorLabel" name="bgColor">
-              <property name="accessibleName">
-               <string>Background color</string>
-              </property>
-              <property name="frameShape">
-               <enum>QFrame::Box</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="label_3">
-              <property name="text">
-               <string>Border:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="buddy">
-               <cstring>frameWidth</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
+            <item row="4" column="1">
              <widget class="QDoubleSpinBox" name="frameWidth">
               <property name="accessibleName">
                <string>Border</string>
@@ -320,78 +376,38 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
-             <widget class="QLabel" name="label_5">
-              <property name="text">
-               <string>Text margin:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="buddy">
-               <cstring>paddingWidth</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QDoubleSpinBox" name="paddingWidth">
-              <property name="accessibleName">
-               <string>Text margin</string>
-              </property>
-              <property name="suffix">
-               <string>sp</string>
-              </property>
-              <property name="singleStep">
-               <double>0.200000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>Border radius:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="buddy">
-               <cstring>frameRound</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="1">
+            <item row="6" column="1">
              <widget class="QSpinBox" name="frameRound">
               <property name="accessibleName">
                <string>Border radius</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="2">
-             <widget class="Ms::ResetButton" name="resetBgColor"/>
-            </item>
-            <item row="3" column="2">
-             <widget class="Ms::ResetButton" name="resetFrameWidth"/>
-            </item>
-            <item row="4" column="2">
-             <widget class="Ms::ResetButton" name="resetPaddingWidth"/>
-            </item>
-            <item row="5" column="2">
-             <widget class="Ms::ResetButton" name="resetFrameRound"/>
-            </item>
-            <item row="0" column="2">
-             <widget class="Ms::ResetButton" name="resetFrameColor"/>
-            </item>
            </layout>
           </widget>
          </item>
-         <item row="3" column="2">
-          <widget class="Ms::ResetButton" name="resetFontStyle"/>
+         <item row="5" column="0" colspan="2">
+          <widget class="Ms::AlignSelect" name="align" native="true">
+           <property name="toolTip">
+            <string>Text alignment</string>
+           </property>
+          </widget>
          </item>
-         <item row="4" column="2">
-          <widget class="Ms::ResetButton" name="resetAlign"/>
+         <item row="6" column="2">
+          <widget class="Ms::ResetButton" name="resetFrameType" native="true"/>
          </item>
-         <item row="5" column="2">
-          <widget class="Ms::ResetButton" name="resetFrameType"/>
+         <item row="2" column="1">
+          <widget class="QCheckBox" name="spatiumDependent">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::TabFocus</enum>
+           </property>
+           <property name="text">
+            <string>Size follows 'Staff space' setting</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279572

Since the code exists to handle the `Pid::SIZE_SPATIUM_DEPENDENT` in the `TextBase` class, it seems like the removal of the option to change this for text was an accident. So, this adds a checkbox in the text base inspector for this property.