### PR TITLE
Disabled keys

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4570,8 +4570,11 @@ void Score::undoRemoveElement(Element* element)
             }
       for (Segment* s : segments) {
             if (s->empty()) {
-                  if (s->header() || s->trailer())    // probably more segment types (system header)
+                  if (s->header() || s->trailer()) {  // probably more segment types (system header)
+                        // TODO
                         s->setEnabled(false);
+                        //undo(new RemoveElement(s));
+                        }
                   else
                         undo(new RemoveElement(s));
                   }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3455,6 +3455,8 @@ void Score::undoChangeKeySig(Staff* ostaff, int tick, KeySigEvent key)
                   continue;
                   }
             Segment* s   = measure->undoGetSegment(SegmentType::KeySig, tick);
+            if (s && !s->enabled())
+                s->setEnabled(true);
 
             int staffIdx = staff->idx();
             int track    = staffIdx * VOICES;

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2678,7 +2678,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
                               Measure* pm = mi->prevMeasure();
                               if (pm) {
                                     Segment* ps = pm->findSegment(SegmentType::Clef, tick);
-                                    if (ps) {
+                                    if (ps && ps->enabled()) {
                                           Element* pc = ps->element(staffIdx * VOICES);
                                           if (pc) {
                                                 pcl.push_back(toClef(pc));
@@ -2689,7 +2689,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
                                           }
                                     }
                               for (Segment* s = mi->first(); s && s->rtick() == 0; s = s->next()) {
-                                    if (s->isHeaderClefType())
+                                    if (s->isHeaderClefType() || !s->enabled())
                                           continue;
                                     Element* e = s->element(staffIdx * VOICES);
                                     if (!e)
@@ -3455,6 +3455,7 @@ void Score::undoChangeKeySig(Staff* ostaff, int tick, KeySigEvent key)
                   continue;
                   }
             Segment* s   = measure->undoGetSegment(SegmentType::KeySig, tick);
+
             int staffIdx = staff->idx();
             int track    = staffIdx * VOICES;
             KeySig* ks   = toKeySig(s->element(track));

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3456,7 +3456,7 @@ void Score::undoChangeKeySig(Staff* ostaff, int tick, KeySigEvent key)
                   }
             Segment* s   = measure->undoGetSegment(SegmentType::KeySig, tick);
             if (s && !s->enabled())
-                s->setEnabled(true);
+                s->undoChangeProperty(Pid::VISIBLE, true);
 
             int staffIdx = staff->idx();
             int track    = staffIdx * VOICES;

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3634,10 +3634,8 @@ void Measure::addSystemHeader(bool isFirstSystem)
 
                         if (disable) {
                               // TODO
-                              // disabling key signatures requires a lot of care making sure we ignore them everywhere else
-                              // for now, just remove them
-                              //kSegment->setEnabled(false);
-                              score()->undo(new RemoveElement(kSegment));
+                              kSegment->setEnabled(false);
+                              //score()->undo(new RemoveElement(kSegment));
                               }
                         else {
                               Element* e = kSegment->element(track);
@@ -3686,8 +3684,8 @@ void Measure::addSystemHeader(bool isFirstSystem)
             else {
                   if (cSegment) {
                         // TODO
-                        //cSegment->setEnabled(false);
-                        score()->undo(new RemoveElement(cSegment));
+                        cSegment->setEnabled(false);
+                        //score()->undo(new RemoveElement(cSegment));
                         }
                   }
             ++staffIdx;
@@ -3722,8 +3720,8 @@ void Measure::addSystemHeader(bool isFirstSystem)
             }
       else if (s) {
             // TODO
-            //s->setEnabled(false);
-            score()->undo(new RemoveElement(s));
+            s->setEnabled(false);
+            //score()->undo(new RemoveElement(s));
             }
       checkHeader();
       }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3632,8 +3632,13 @@ void Measure::addSystemHeader(bool isFirstSystem)
                                     }
                               }
 
-                        if (disable)
-                              kSegment->setEnabled(false);
+                        if (disable) {
+                              // TODO
+                              // disabling key signatures requires a lot of care making sure we ignore them everywhere else
+                              // for now, just remove them
+                              //kSegment->setEnabled(false);
+                              score()->undo(new RemoveElement(kSegment));
+                              }
                         else {
                               Element* e = kSegment->element(track);
                               if (e && e->isKeySig()) {
@@ -3679,8 +3684,11 @@ void Measure::addSystemHeader(bool isFirstSystem)
                   cSegment->setEnabled(true);
                   }
             else {
-                  if (cSegment)
-                        cSegment->setEnabled(false);
+                  if (cSegment) {
+                        // TODO
+                        //cSegment->setEnabled(false);
+                        score()->undo(new RemoveElement(cSegment));
+                        }
                   }
             ++staffIdx;
             }
@@ -3712,8 +3720,11 @@ void Measure::addSystemHeader(bool isFirstSystem)
             s->setHeader(true);
             setHeader(true);
             }
-      else if (s)
-            s->setEnabled(false);
+      else if (s) {
+            // TODO
+            //s->setEnabled(false);
+            score()->undo(new RemoveElement(s));
+            }
       checkHeader();
       }
 
@@ -3766,7 +3777,9 @@ void Measure::addSystemTrailer(Measure* nm)
             }
       if (!showCourtesySig && s) {
             // remove any existing time signatures
+            // TODO
             s->setEnabled(false);
+            //score()->undo(new RemoveElement(s));
             }
 
       // courtesy key signatures
@@ -3807,8 +3820,11 @@ void Measure::addSystemTrailer(Measure* nm)
                   }
             else {
                   // remove any existent courtesy key signature
-                  if (s)
+                  if (s) {
+                        // TODO
                         s->setEnabled(false);
+                        //score()->undo(new RemoveElement(s));
+                        }
                   }
             if (clefSegment) {
                   Clef* clef = toClef(clefSegment->element(track));
@@ -3833,7 +3849,9 @@ void Measure::removeSystemHeader()
       for (Segment* seg = first(); seg; seg = seg->next()) {
             if (!seg->header())
                   break;
-            seg->setEnabled(false);
+            // TODO
+            //seg->setEnabled(false);
+            score()->undo(new RemoveElement(seg));
             }
       setHeader(false);
       }
@@ -3848,8 +3866,11 @@ void Measure::removeSystemTrailer()
       for (Segment* seg = last(); seg != first(); seg = seg->prev()) {
             if (!seg->trailer())
                   break;
-            if (seg->enabled())
+            if (seg->enabled()) {
+                  // TODO
                   seg->setEnabled(false);
+                  //score()->undo(new RemoveElement(seg));
+                  }
             changed = true;
             }
       setTrailer(false);

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -844,6 +844,8 @@ QVariant Segment::getProperty(Pid propertyId) const
                   return _tick;
             case Pid::LEADING_SPACE:
                   return extraLeadingSpace();
+            case Pid::VISIBLE:
+                  return enabled();
             default:
                   return Element::getProperty(propertyId);
             }
@@ -875,6 +877,9 @@ bool Segment::setProperty(Pid propertyId, const QVariant& v)
                   break;
             case Pid::LEADING_SPACE:
                   setExtraLeadingSpace(v.value<Spatium>());
+                  break;
+            case Pid::VISIBLE:
+                  setEnabled(v.toBool());
                   break;
             default:
                   return Element::setProperty(propertyId, v);

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1225,7 +1225,7 @@ Element* Segment::firstInNextSegments(int activeStaff)
       Element* re = 0;
       Segment* seg = this;
       while (!re) {
-            seg = seg->next1MM(SegmentType::All);
+            seg = seg->next1enabled();
             if (!seg) //end of staff, or score
                   break;
 
@@ -1493,12 +1493,12 @@ Element* Segment::nextElement(int activeStaff)
                         if (s)
                               return s->spannerSegments().front();
                         }
-                  Segment* nextSegment = this->next1();
+                  Segment* nextSegment = this->next1enabled();
                   while (nextSegment) {
                         Element* nextEl = nextSegment->firstElementOfSegment(nextSegment, activeStaff);
                         if (nextEl)
                               return nextEl;
-                        nextSegment = nextSegment->next1();
+                        nextSegment = nextSegment->next1enabled();
                         }
                   break;
                   }
@@ -1512,12 +1512,12 @@ Element* Segment::nextElement(int activeStaff)
                   if (sp)
                         return sp->spannerSegments().front();
 
-                  Segment* nextSegment = this->next1();
+                  Segment* nextSegment = this->next1enabled();
                   while (nextSegment) {
                         Element* nextEl = nextSegment->firstElementOfSegment(nextSegment, activeStaff);
                         if (nextEl)
                               return nextEl;
-                        nextSegment = nextSegment->next1();
+                        nextSegment = nextSegment->next1enabled();
                         }
                   break;
                   }
@@ -1552,12 +1552,12 @@ Element* Segment::nextElement(int activeStaff)
                   Spanner* s = firstSpanner(activeStaff);
                   if (s)
                         return s->spannerSegments().front();
-                  Segment* nextSegment =  seg->next1();
+                  Segment* nextSegment =  seg->next1enabled();
                   while (nextSegment) {
                         nextEl = nextSegment->firstElementOfSegment(nextSegment, activeStaff);
                         if (nextEl)
                               return nextEl;
-                        nextSegment = nextSegment->next1();
+                        nextSegment = nextSegment->next1enabled();
                         }
                   }
                   break;
@@ -1607,6 +1607,8 @@ Element* Segment::prevElement(int activeStaff)
                          if (track == 0) {
                                track = score()->nstaves() * VOICES - 1;
                                s = s->prev1();
+                               while (s && !s->enabled())
+                                     s = s->prev1();
                                }
                          }
                    if (el->staffIdx() != activeStaff)
@@ -1677,12 +1679,16 @@ Element* Segment::prevElement(int activeStaff)
                               }
                         }
                    Segment* prevSeg = seg->prev1();
+                   while (prevSeg && !prevSeg->enabled())
+                         prevSeg = prevSeg->prev1();
                    if (!prevSeg)
                          return score()->lastElement();
 
                    prev = lastElementOfSegment(prevSeg, activeStaff);
                    while (!prev && prevSeg) {
                          prevSeg = prevSeg->prev1();
+                         while (prevSeg && !prevSeg->enabled())
+                               prevSeg = prevSeg->prev1();
                          prev = lastElementOfSegment(prevSeg, activeStaff);
                          }
                    if (!prevSeg)
@@ -1742,6 +1748,8 @@ Element* Segment::lastInPrevSegments(int activeStaff)
 
       while (!re) {
             seg = seg->prev1MM(SegmentType::All);
+            while (seg && !seg->enabled())
+                  seg = seg->prev1MM(SegmentType::All);
             if (!seg) //end of staff, or score
                   break;
 
@@ -1765,6 +1773,9 @@ Element* Segment::lastInPrevSegments(int activeStaff)
                         return re;
 
                   seg = seg->prev1(SegmentType::All);
+                  while (seg && !seg->enabled())
+                        seg = seg->prev1(SegmentType::All);
+
                   }
             }
 

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1565,7 +1565,7 @@ void InsertRemoveMeasures::insertMeasures()
             fs = toMeasure(fm)->first();
             ls = toMeasure(lm)->last();
             for (Segment* s = fs; s && s != ls; s = s->next1()) {
-                  if (!(s->segmentType() & (SegmentType::Clef | SegmentType::KeySig)))
+                  if (!s->enabled() || !(s->segmentType() & (SegmentType::Clef | SegmentType::KeySig)))
                         continue;
                   for (int track = 0; track < score->ntracks(); track += VOICES) {
                         Element* e = s->element(track);


### PR DESCRIPTION
At some point the implementation of system headers/trailers was changed so that as layout changes and measures no longer need them, instead of deleting them, we leave them in place but mark the segments as disabled.  This is OK in principle, but it means any code that looks for key signature segments needs to be aware to ignore disabled ones (in principle, same for clefs and time signatures).  So far I've found several places where this isn't happening:

- inserting measures in front of a measure with a disabled key signature will copy that key signature to the front of the inserted measures, completely inappropriately (it might not even be the right key signature at that point)

- deleting measures and undoing will treat that disabled key signature as if it really applies, leading to incorrect spelling of accidentals (although this only happens if the disabled key signature was also marked as non-generated, like if you hid it while it was present)

- adding a key signature to a measure with a disabled key signature takes effect in terms of note spelling but does not appear in the score

- the navigation commands next-element, next-segment-element, prev-element, and prev-segment-element are reporting the contents of these disabled segments

This PR fixes all those issues.  Only the navigation change involving more than a couple of lines of code; the more critical issues are solved with just the first two commits.  I do have these as separate commits because they *are* independent and could conceivably be merged or reverted independently if problems are found with my approach, also because the first two address different issues in the tracker.