### PR TITLE
fix #279622: fix styled properties values for palette elements

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -527,6 +527,7 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
                   ElementType type = Element::readType(e, &dragOffset, &duration);
                   Spanner* spanner = static_cast<Spanner*>(Element::create(type, score));
                   spanner->read(e);
+                  spanner->styleChanged();
                   score->cmdAddSpanner(spanner, idx, startSegment, endSegment);
                   }
             else {
@@ -1517,6 +1518,7 @@ void Palette::read(XmlReader& e)
                                     }
                               else {
                                     cell->element->read(e);
+                                    cell->element->styleChanged();
                                     if (cell->element->type() == ElementType::ICON) {
                                           Icon* icon = static_cast<Icon*>(cell->element);
                                           QAction* ac = getAction(icon->action());


### PR DESCRIPTION
This PR tries to resolve the issue [#279622](https://musescore.org/en/node/279622) by resetting styled values for elements after initialization in two cases:
- Initial reading the palette from file.
- Applying some palette elements to score by double-click (drag-and-drop seems to work correctly regarding this issue).