### PR TITLE
fix #279119: frame radius and border width don't scale with spatium

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -2563,7 +2563,9 @@ void TextBase::draw(QPainter* p) const
       if (hasFrame()) {
             if (frameWidth().val() != 0.0) {
                   QColor fColor = curColor(visible(), frameColor());
-                  QPen pen(fColor, frameWidth().val() * spatium(), Qt::SolidLine,
+                  qreal frameWidthVal = frameWidth().val() * (sizeIsSpatiumDependent() ? spatium() : 1);
+
+                  QPen pen(fColor, frameWidthVal, Qt::SolidLine,
                      Qt::SquareCap, Qt::MiterJoin);
                   p->setPen(pen);
                   }
@@ -2574,10 +2576,13 @@ void TextBase::draw(QPainter* p) const
             if (circle())
                   p->drawEllipse(frame);
             else {
-                  int r2 = frameRound();
+                  qreal baseSpatium = MScore::baseStyle().value(Sid::spatium).toDouble();
+                  qreal frameRoundFactor = (sizeIsSpatiumDependent() ? (spatium()/baseSpatium) / 2 : 0.5f);
+
+                  int r2 = frameRound() * frameRoundFactor;
                   if (r2 > 99)
                         r2 = 99;
-                  p->drawRoundedRect(frame, frameRound(), r2);
+                  p->drawRoundedRect(frame, frameRound() * frameRoundFactor, r2);
                   }
             }
       p->setBrush(Qt::NoBrush);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279119

Because frame round is a percentage, and so has no unit, we can't just multiply it by `spatium()`. So, this fix multiplies it by the percentage that `spatium()` is of the default value, divided by a constant (2). The constant exists to provide a more similar look to 2.0 frames, although it hasn't been completely replicated (because that would be impossible due to the new way we handle frames in MS3).

For example, if the default spatium is 25, and the styled spatium is 50, then the border radius will be multiplied by (50/25)/2 = 1.
If the default is 25, and the styled is 100, then (100/25)/2 = 2.

Comparisons for 25 border radius and 50 border radius respectively:

MuseScore 2.3.2:
![1544266454](https://user-images.githubusercontent.com/8274049/49685284-00056180-fad9-11e8-8371-9c934c3685f5.png)

MuseScore 3.0-dev (this fix):
![1544266444](https://user-images.githubusercontent.com/8274049/49685283-00056180-fad9-11e8-9517-a102d46c066f.png)

This fix also makes both the frame round and border width properties obey the `SIZE_SPATIUM_DEPENDENT` property.