### PR TITLE
fix #278919 : uninitialised memory when creating hairpins

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -414,6 +414,7 @@ Hairpin::Hairpin(Score* s)
       initElementStyle(&hairpinStyle);
 
       resetProperty(Pid::BEGIN_TEXT_PLACE);
+      resetProperty(Pid::CONTINUE_TEXT_PLACE);
       resetProperty(Pid::HAIRPIN_TYPE);
       resetProperty(Pid::LINE_VISIBLE);
 
@@ -621,6 +622,7 @@ QVariant Hairpin::propertyDefault(Pid id) const
                   return QString("");
 
             case Pid::BEGIN_TEXT_PLACE:
+            case Pid::CONTINUE_TEXT_PLACE:
                   return int(PlaceText::LEFT);
 
             case Pid::LINE_VISIBLE:


### PR DESCRIPTION
This fixes the horizontal position of continue text in hairpins spanning over multiple lines when reading a file