### PR TITLE
fix #279662: fixup for aeb4919e775f26be52b438ac3a636c64527a49e2

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1254,7 +1254,7 @@ void Score::cmdAddTie(bool addToChord)
 
 void Score::cmdAddOttava(OttavaType type)
       {
-      const Selection& sel = selection();
+      const Selection sel = selection(); // copy selection state before the operation.
       // add on each staff if possible
       if (sel.isRange() && sel.staffStart() != sel.staffEnd() - 1) {
             for (int staffIdx = sel.staffStart() ; staffIdx < sel.staffEnd(); ++staffIdx) {

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -456,7 +456,7 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
       Score* score = mscore->currentScore();
       if (score == 0)
             return;
-      const Selection& sel = score->selection();       // make a copy of the list
+      const Selection sel = score->selection(); // make a copy of selection state before applying the operation.
       if (sel.isNone())
             return;
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3330,8 +3330,7 @@ void ScoreView::cmdAddNoteLine()
 void ScoreView::cmdChangeEnharmonic(bool both)
       {
       _score->startCmd();
-      Selection& selection = _score->selection();
-      QList<Note*> notes = selection.uniqueNotes();
+      QList<Note*> notes = _score->selection().uniqueNotes();
       for (Note* n : notes) {
             Staff* staff = n->staff();
             if (staff->part()->instrument()->useDrumset())
@@ -3392,6 +3391,7 @@ void ScoreView::cmdChangeEnharmonic(bool both)
                   }
             }
 
+      Selection& selection = _score->selection();
       selection.clear();
       for (Note* n : notes)
             selection.add(n);


### PR DESCRIPTION
This PR fixes my older commit aeb4919e775f26be52b438ac3a636c64527a49e2 according to [this discussion](https://github.com/musescore/MuseScore/commit/aeb4919e775f26be52b438ac3a636c64527a49e2#r31608742).

The reason for it is that copying of some selection information is still needed when selection state can be modified. This commit reverts back to copying Selection object in such cases.