### PR TITLE
fix #278068 Second line feed was discarded

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -463,9 +463,9 @@ void SplitJoinText::split(EditData* ed)
 
       CharFormat* charFmt = c.format();         // take current format
       t->textBlockList().insert(line + 1, c.curLine().split(c.column()));
-      c.curLine().setEol(true);
 
       c.setRow(line+1);
+      c.curLine().setEol(true);
       c.setColumn(0);
       c.setFormat(*charFmt);             // restore orig. format at new line
       c.clearSelection();


### PR DESCRIPTION
This pull request fixes the discartion of the second inserted newline in a string.

Without the fix the EOL marker is applied to the first (already existing) line of text which already has the EOL marker. Now the second (new) line will get the EOL marker and thereafter both lines are set as EOL. 