### PR TITLE
Windows: fix nightly build executable name

### DIFF
--- a/build/appveyor/after_build.bat
+++ b/build/appveyor/after_build.bat
@@ -73,7 +73,7 @@ goto :UPLOAD
 :UNSTABLE_LABEL
 echo "Unstable: build 7z package"
 CD C:\MuseScore
-RENAME C:\MuseScore\msvc.install_x64\bin\musescore.exe nightly.exe
+RENAME C:\MuseScore\msvc.install_x64\bin\MuseScore3.exe nightly.exe
 RENAME C:\MuseScore\msvc.install_x64 MuseScoreNightly
 XCOPY C:\MuseScore\build\appveyor\special C:\MuseScore\MuseScoreNightly\special /I /E /Y /Q
 COPY C:\MuseScore\build\appveyor\support\README.txt C:\MuseScore\MuseScoreNightly\README.txt /Y


### PR DESCRIPTION
As pointed out by @ericfont in #4324 

> extremely minor. I just downloaded a nightly .7z archive, and double-clicked the nightly.bat in the extracted base directory, and saw that it didn't work. Because apparently "MuseScore3.exe" is the name of the built exe, not "nightly.exe".

This PR should fix it.