### PR TITLE
fix #279533: trigger layout on end dragging slur or tie

### DIFF
--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -129,6 +129,7 @@ void SlurTieSegment::startEditDrag(EditData& ed)
 void SlurTieSegment::endEditDrag(EditData& ed)
       {
       Element::endEditDrag(ed);
+      triggerLayout();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR finishes fixing the issue https://musescore.org/en/node/279533.
The other part of it was fixed by 2435d84cd270ff10f8c02bb417d2358e89165514.