### PR TITLE
Fix #279503 (expanded): UI font is changing without notice

### DIFF
--- a/mscore/prefsdialog.cpp
+++ b/mscore/prefsdialog.cpp
@@ -332,14 +332,15 @@ void PreferenceDialog::updateValues(bool useDefaultValues)
 
       iconWidth->setValue(preferences.getInt(PREF_UI_THEME_ICONWIDTH));
       iconHeight->setValue(preferences.getInt(PREF_UI_THEME_ICONHEIGHT));
-      
-      //macOS default fonts are not in QFontCombobox because they are "private":
-      //https://code.woboq.org/qt5/qtbase/src/widgets/widgets/qfontcombobox.cpp.html#329
-      auto currFontFamily = preferences.getString(PREF_UI_THEME_FONTFAMILY);
-      if (-1 == fontFamily->findText(currFontFamily))
-            fontFamily->addItem(currFontFamily);
-      fontFamily->setCurrentIndex(fontFamily->findText(currFontFamily));
-      
+
+      QFontDatabase qfd;
+      int curr = 0;
+      for (QString family : qfd.families()) {
+            fontFamily->addItem(family);
+            if (preferences.getString(PREF_UI_THEME_FONTFAMILY) == family)
+                  fontFamily->setCurrentIndex(curr);
+            curr++;
+      }
       fontSize->setValue(preferences.getInt(PREF_UI_THEME_FONTSIZE));
 
       enableMidiInput->setChecked(preferences.getBool(PREF_IO_MIDI_ENABLEINPUT));
@@ -956,7 +957,7 @@ void PreferenceDialog::apply()
       preferences.setPreference(PREF_UI_CANVAS_SCROLL_LIMITSCROLLAREA, limitScrollArea->isChecked());
       preferences.setPreference(PREF_UI_THEME_ICONWIDTH, iconWidth->value());
       preferences.setPreference(PREF_UI_THEME_ICONHEIGHT, iconHeight->value());
-      preferences.setPreference(PREF_UI_THEME_FONTFAMILY, fontFamily->currentFont().family());
+      preferences.setPreference(PREF_UI_THEME_FONTFAMILY, QFont(fontFamily->currentText()));
       preferences.setPreference(PREF_UI_THEME_FONTSIZE, fontSize->value());
 
       bool wasJack = (preferences.getBool(PREF_IO_JACK_USEJACKMIDI) || preferences.getBool(PREF_IO_JACK_USEJACKAUDIO));

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>834</width>
-    <height>569</height>
+    <width>879</width>
+    <height>572</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -740,9 +740,6 @@
           <item row="2" column="3">
            <widget class="QSpinBox" name="fontSize"/>
           </item>
-          <item row="2" column="1">
-           <widget class="QFontComboBox" name="fontFamily"/>
-          </item>
           <item row="2" column="0">
            <widget class="QLabel" name="fontFamilyLabel">
             <property name="text">
@@ -756,6 +753,9 @@
              <string>Font size:</string>
             </property>
            </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="fontFamily"/>
           </item>
          </layout>
         </widget>
@@ -4214,7 +4214,6 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>styleName</tabstop>
   <tabstop>iconWidth</tabstop>
   <tabstop>iconHeight</tabstop>
-  <tabstop>fontFamily</tabstop>
   <tabstop>fontSize</tabstop>
   <tabstop>autoSave</tabstop>
   <tabstop>autoSaveTime</tabstop>


### PR DESCRIPTION
Use QFontDatabase directly instead of QFontComboBox. Displays private ones too.