### PR TITLE
278068 newline in new text

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -463,6 +463,7 @@ void SplitJoinText::split(EditData* ed)
 
       CharFormat* charFmt = c.format();         // take current format
       t->textBlockList().insert(line + 1, c.curLine().split(c.column()));
+      c.curLine().setEol(true);
 
       c.setRow(line+1);
       c.curLine().setEol(true);


### PR DESCRIPTION
This pull request fixes the discartion of the first newline in a new text.

In addition to https://github.com/musescore/MuseScore/pull/4359 the EOL marker of the first line is false, if the text has been new inserted and edit mode is still active. In that case also the first line must be set to EOL true.
