### PR TITLE
Add a possibility to write comments to test scripts

### DIFF
--- a/mscore/script/scriptentry.cpp
+++ b/mscore/script/scriptentry.cpp
@@ -26,12 +26,10 @@ namespace Ms {
 
 std::unique_ptr<ScriptEntry> ScriptEntry::deserialize(const QString& line)
       {
+      if (line.isEmpty() || line.startsWith('#')) // comment or empty line
+            return nullptr;
       QStringList tokens = line.split(' ');
       const QString& type = tokens[0];
-      if (tokens.empty()) {
-            qWarning("Script line is empty");
-            return nullptr;
-            }
       if (type == SCRIPT_CMD) {
             if (tokens.size() != 2) {
                   qWarning("Unexpected number of tokens in command: %d", tokens.size());


### PR DESCRIPTION
This change is present in some flavor in #4155 but since it probably will not be merged in the nearest time I'll make it a separate PR. This adds comments support to test scripts which will make reading and writing them more convenient.