### PR TITLE
Fix some Windows nightly builds failing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 clone_folder: C:\MuseScore
 
 # set clone depth
-clone_depth: 3                      # clone entire repository history if not defined
+clone_depth: 50                      # clone entire repository history if not defined
 
 image: Visual Studio 2017
 


### PR DESCRIPTION
The merged PR build job can start after more than 2 other commits are pushed, and thus failing due to the desired build commit not being present.

I chose the value 50 because it's reasonable and because it's the same value Travis CI build jobs use.

An example of such failed build that is available for linux but not Windows would be 11d7b247. You can see it's present in the [linux](http://ftp.osuosl.org/pub/musescore-nightlies/linux/x86_64/) and [macOS](http://prereleases.musescore.org/macosx/nightly/) nightly pages but not in the [Windows builds](https://ftp.osuosl.org/pub/musescore-nightlies/windows/) page.