### PR TITLE
fix #279367: don't miss layout of page if range stops on its first system

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3611,6 +3611,7 @@ void LayoutContext::collectPage()
             //
             //  check for page break or if next system will fit on page
             //
+            const bool rangeWasDone = rangeDone;
             if (rangeDone) {
                   // take next system unchanged
                   if (systemIdx > 0) {
@@ -3682,6 +3683,9 @@ void LayoutContext::collectPage()
             if (breakPage) {
                   qreal dist = qMax(prevSystem->minBottom(), slb);
                   layoutPage(page, ey - (y + dist));
+                  // We don't accept current system to this page
+                  // so rollback rangeDone variable as well.
+                  rangeDone = rangeWasDone;
                   break;
                   }
             }


### PR DESCRIPTION
Fixes https://musescore.org/en/node/279367.