### PR TITLE
fix #279721: fix delayed update of pianoroll editor

### DIFF
--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -723,7 +723,21 @@ Element* PianorollEditor::elementNear(QPointF)
 
 void PianorollEditor::updateAll()
       {
-      startTimer(0);    // delayed update
+      if (updateScheduled)
+            return;
+
+      QTimer::singleShot(0, this, &PianorollEditor::doUpdate);
+      updateScheduled = true;
+      }
+
+//---------------------------------------------------------
+//   doUpdate
+//---------------------------------------------------------
+
+void PianorollEditor::doUpdate()
+      {
+      updateScheduled = false;
+
       if (staff && staff->idx() == -1) { // staff removed
             removeScore();
             return;

--- a/mscore/pianoroll.h
+++ b/mscore/pianoroll.h
@@ -67,9 +67,12 @@ class PianorollEditor : public QMainWindow, public MuseScoreView {
       QSplitter* split;
       QList<QAction*> actions;
 
+      bool updateScheduled = false;
+
       void updateVelocity(Note* note);
       void updateSelection();
       void readSettings();
+      void doUpdate();
 
    private slots:
       void selectionChanged();


### PR DESCRIPTION
Fixes https://musescore.org/en/node/279721.

This PR fixes delayed update of pianoroll editor which was anyway working wrong since no `timerEvent()` function was implemented to handle the started timer timeout.

The reason of high CPU usage was a permanent sequence of timer events which was caused by that `startTimer()` call. According to [Qt documentation](https://doc.qt.io/qt-5/qobject.html#startTimer),
```
A timer event will occur every interval milliseconds until killTimer() is called.
```
But `killTimer()` was apparently never called so events just continued to fire.