### PR TITLE
fix #279080: update beam info for rests, tweak rest beams parameters

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -410,13 +410,11 @@ void Beam::layout1()
             // otherwise, assume beam direction is stem direction
 
             for (ChordRest* cr : _elements) {
-                  if (!cr->isChord())
-                        continue;
-                  Chord* chord = toChord(cr);
-                  if (!(_cross || chord->staffMove())) {
-                        if (chord->up() != _up) {
-                              chord->setUp(_up);
-                              chord->layoutStem1();
+                  const bool staffMove = cr->isChord() ? toChord(cr)->staffMove() : false;
+                  if (!(_cross || staffMove)) {
+                        if (cr->up() != _up) {
+                              cr->setUp(_up);
+                              cr->layoutStem1();
                               }
                         }
                   }

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -729,9 +729,9 @@ QPointF Rest::stemPosBeam() const
       {
       QPointF p(pagePos());
       if (_up)
-            p.ry() += bbox().top() + spatium() * 2;
+            p.ry() += bbox().top() + spatium() * 1.5;
       else
-            p.ry() += bbox().bottom() - spatium() * 2;
+            p.ry() += bbox().bottom() - spatium() * 1.5;
       return p;
       }
 

--- a/mtest/libmscore/rhythmicGrouping/groupConflicts-ref.mscx
+++ b/mtest/libmscore/rhythmicGrouping/groupConflicts-ref.mscx
@@ -993,8 +993,8 @@
             <text>Alternative: beam over rests</text>
             </StaffText>
           <Beam>
-            <l1>27</l1>
-            <l2>27</l2>
+            <l1>20</l1>
+            <l2>20</l2>
             </Beam>
           <Chord>
             <durationType>16th</durationType>


### PR DESCRIPTION
Should fix — or at least make the situation better — for https://musescore.org/en/node/279080.