### PR TITLE
fix #279827: maintain selection state in UndoMacro instead of using SaveState entries

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -132,13 +132,11 @@ void Score::startCmd()
 
       // Start collecting low-level undo operations for a
       // user-visible undo action.
-
       if (undoStack()->active()) {
             qDebug("Score::startCmd(): cmd already active");
             return;
             }
-      undoStack()->beginMacro();
-      undo(new SaveState(this));
+      undoStack()->beginMacro(this);
       }
 
 //---------------------------------------------------------
@@ -181,7 +179,7 @@ void Score::endCmd(bool rollback)
 
       if (MScore::debugMode)
             qDebug("===endCmd() %d", undoStack()->current()->childCount());
-      bool noUndo = undoStack()->current()->childCount() <= 1;       // nothing to undo?
+      const bool noUndo = undoStack()->current()->empty();       // nothing to undo?
       undoStack()->endMacro(noUndo);
 
       if (dirty()) {

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -113,12 +113,35 @@ class UndoCommand {
       };
 
 //---------------------------------------------------------
+//   UndoMacro
+//    A root element for undo macro which is stored
+//    directly in UndoStack
+//---------------------------------------------------------
+
+class UndoMacro : public UndoCommand {
+      InputState undoInputState;
+      InputState redoInputState;
+      Element* undoSelectedElement = nullptr;
+      Element* redoSelectedElement = nullptr;
+      Score* score;
+
+      static Element* selectedElement(const Selection&);
+
+   public:
+      UndoMacro(Score* s);
+      virtual void undo(EditData*) override;
+      virtual void redo(EditData*) override;
+      bool empty() const { return childCount() == 0; }
+      UNDO_NAME("UndoMacro");
+      };
+
+//---------------------------------------------------------
 //   UndoStack
 //---------------------------------------------------------
 
 class UndoStack {
-      UndoCommand* curCmd;
-      QList<UndoCommand*> list;
+      UndoMacro* curCmd;
+      QList<UndoMacro*> list;
       std::vector<int> stateList;
       int nextState;
       int cleanState;
@@ -129,7 +152,7 @@ class UndoStack {
       ~UndoStack();
 
       bool active() const           { return curCmd != 0; }
-      void beginMacro();
+      void beginMacro(Score*);
       void endMacro(bool rollback);
       void push(UndoCommand*, EditData*);      // push & execute
       void push1(UndoCommand*);
@@ -142,35 +165,12 @@ class UndoStack {
       int getCurIdx() const         { return curIdx; }
       void remove(int idx);
       bool empty() const            { return !canUndo() && !canRedo();  }
-      UndoCommand* current() const  { return curCmd;               }
-      UndoCommand* last() const     { return curIdx > 0 ? list[curIdx-1] : 0; }
+      UndoMacro* current() const    { return curCmd;               }
+      UndoMacro* last() const       { return curIdx > 0 ? list[curIdx-1] : 0; }
       void undo(EditData*);
       void redo(EditData*);
       void rollback();
       void reopen();
-      };
-
-//---------------------------------------------------------
-//   SaveState
-//---------------------------------------------------------
-
-class SaveState : public UndoCommand {
-      InputState undoInputState;
-      InputState redoInputState;
-      Element* undoSelectedElement = nullptr;
-      Element* redoSelectedElement = nullptr;
-//       Selection  undoSelection;
-//       Selection  redoSelection;
-      Score* score;
-      bool first = true; // first redo operation.
-
-      static Element* selectedElement(const Selection&);
-
-   public:
-      SaveState(Score*);
-      virtual void undo(EditData*) override;
-      virtual void redo(EditData*) override;
-      UNDO_NAME("SaveState")
       };
 
 //---------------------------------------------------------

--- a/mscore/drumroll.cpp
+++ b/mscore/drumroll.cpp
@@ -307,9 +307,9 @@ void DrumrollEditor::veloTypeChanged(int val)
       if ((note == 0) || (Note::ValueType(val) == note->veloType()))
             return;
 
-      _score->undoStack()->beginMacro();
+      _score->startCmd();
       _score->undo(new ChangeVelocity(note, Note::ValueType(val), note->veloOffset()));
-      _score->undoStack()->endMacro(_score->undoStack()->current()->childCount() == 0);
+      _score->endCmd();
       updateVelocity(note);
       }
 
@@ -356,9 +356,9 @@ void DrumrollEditor::velocityChanged(int val)
       if (vt == Note::ValueType::OFFSET_VAL)
             return;
 
-      _score->undoStack()->beginMacro();
+      _score->startCmd();
       _score->undo(new ChangeVelocity(note, vt, val));
-      _score->undoStack()->endMacro(_score->undoStack()->current()->childCount() == 0);
+      _score->endCmd();
       }
 
 //---------------------------------------------------------

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -513,9 +513,9 @@ void PianorollEditor::veloTypeChanged(int val)
                   break;
             }
 
-      _score->undoStack()->beginMacro();
+      _score->startCmd();
       _score->undo(new ChangeVelocity(note, Note::ValueType(val), newVelocity));
-      _score->undoStack()->endMacro(_score->undoStack()->current()->childCount() == 0);
+      _score->endCmd();
       updateVelocity(note);
       }
 
@@ -566,9 +566,9 @@ void PianorollEditor::velocityChanged(int val)
       if (val == note->veloOffset())
             return;
 
-      _score->undoStack()->beginMacro();
+      _score->startCmd();
       _score->undo(new ChangeVelocity(note, vt, val));
-      _score->undoStack()->endMacro(_score->undoStack()->current()->childCount() == 0);
+      _score->endCmd();
 
       pianoLevels->update();
       }


### PR DESCRIPTION
This PR fixes https://musescore.org/en/node/279827. The proposed changes are described in the commit message:
```
As undo/redo may change score state and lead to elements destruction
selection must be reset prior to undo/redo operation. In order to be
able to restore (single) selection correctly we have to save info on
selection before it gets reset - and before committing any undo/redo
operation which may change it. Restoring selection makes sense only
after the operation ends.
The same, generally, applies to InputState with the exception that
it is not strictly necessary to reset it.

In order to do that at least two options are available:
1) Use two SaveState entries instead of one in each command stored
   directly in undo stack: start and end entries.
2) Make undo commands stored directly in undo stack maintain state
   themselves.

This commit implements the second option by introducing UndoMacro
class which replaces previously used single SaveState entries and
helps to resolve the issues mentioned above.
```

EDIT: forgot to mention. The issue in its current state was introduced by #4222 so this fix tries not to break note selection undoing that was re-implemented in #4222 and still not return to the 2.X approach with selection copying which was disabled in ac41fa396e6241912031d89669070457c6493984 for reasons similar to those described here: https://github.com/musescore/MuseScore/pull/4268#issuecomment-443441901. This all is mentioned briefly in the commit message which I cited above but maybe this paragraph will provide some more context to these changes.