### PR TITLE
fix #279874: Copy paste tuplet across barlines causes corruption

### DIFF
--- a/libmscore/tuplet.h
+++ b/libmscore/tuplet.h
@@ -121,6 +121,7 @@ class Tuplet final : public DurationElement {
       Direction direction() const          { return _direction; }
       bool isUp() const                    { return _isUp; }
       virtual int tick() const override    { return _tick; }
+      virtual int rtick() const override   { return _tick - parent()->tick(); }
       void setTick(int val)                { _tick = val; }
       Fraction elementsDuration();
       void sortElements();


### PR DESCRIPTION
See https://musescore.org/en/node/279874.

Tuplet::rtick() needs to override Element::rtick() because there is no Segment in the parent() chain.