### PR TITLE
fix #276235: make it possible to enable readahead for XmlReader

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2949,26 +2949,24 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   // MuseScore 3 has different types for system text and
                   // staff text while MuseScore 2 didn't.
                   // We need to decide first which one we should create.
-                  QIODevice* dev = e.device();
                   QString styleName;
-                  if (dev && !dev->isSequential()) { // we want to be able to seek a position
-                        const auto pos = dev->pos();
-                        dev->seek(e.characterOffset());
-                        const QString closeTag = QString("</").append(tag).append(">");
-                        QByteArray arrLine = dev->readLine();
-                        while (!arrLine.isEmpty()) {
-                              QString line(arrLine);
-                              if (line.contains("<style>")) {
-                                    QRegExp re("<style>([A-z0-9]+)</style>");
-                                    if (re.indexIn(line) > -1)
-                                          styleName = re.cap(1);
-                                    break;
+                  if (e.readAheadAvailable()) {
+                        e.performReadAhead([&styleName, tag](QIODevice& dev) {
+                              const QString closeTag = QString("</").append(tag).append(">");
+                              QByteArray arrLine = dev.readLine();
+                              while (!arrLine.isEmpty()) {
+                                    QString line(arrLine);
+                                    if (line.contains("<style>")) {
+                                          QRegExp re("<style>([A-z0-9]+)</style>");
+                                          if (re.indexIn(line) > -1)
+                                                styleName = re.cap(1);
+                                          return;
+                                          }
+                                    if (line.contains(closeTag))
+                                          return;
+                                    arrLine = dev.readLine();
                                     }
-                              if (line.contains(closeTag))
-                                    break;
-                              arrLine = dev->readLine();
-                              }
-                        dev->seek(pos);
+                              });
                         }
                   StaffTextBase* t;
                   if (styleName == "System"   || styleName == "Tempo"

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -816,6 +816,8 @@ Score::FileError MasterScore::loadCompressedMsc(QIODevice* io, bool ignoreVersio
                   }
             }
       XmlReader e(dbuf);
+      QBuffer readAheadBuf(&dbuf);
+      e.setReadAheadDevice(&readAheadBuf);
       e.setDocName(masterScore()->fileInfo()->completeBaseName());
 
       FileError retval = read1(e, ignoreVersionError);
@@ -873,6 +875,7 @@ Score::FileError MasterScore::loadMsc(QString name, QIODevice* io, bool ignoreVe
             return loadCompressedMsc(io, ignoreVersionError);
       else {
             XmlReader r(io);
+            r.setReadAheadDevice(io);
             return read1(r, ignoreVersionError);
             }
       }

--- a/libmscore/xml.h
+++ b/libmscore/xml.h
@@ -67,6 +67,10 @@ class LinksIndexer {
 class XmlReader : public QXmlStreamReader {
       QString docName;  // used for error reporting
 
+      // For readahead possibility.
+      // If needed, must be explicitly set by setReadAheadDevice.
+      QIODevice* _readAheadDevice = nullptr;
+
       // Score read context (for read optimizations):
       int _tick             { 0       };
       int _tickOffset       { 0       };
@@ -105,6 +109,7 @@ class XmlReader : public QXmlStreamReader {
       XmlReader(QIODevice* d, const QString& st = QString()) : QXmlStreamReader(d), docName(st) {}
       XmlReader(const QString& d, const QString& st = QString()) : QXmlStreamReader(d), docName(st) {}
       XmlReader(const XmlReader&) = delete;
+      XmlReader& operator=(const XmlReader&) = delete;
       ~XmlReader();
 
       bool hasAccidental;                     // used for userAccidental backward compatibility
@@ -194,6 +199,11 @@ class XmlReader : public QXmlStreamReader {
       void checkTuplets();
       Tid addUserTextStyle(const QString& name);
       Tid lookupUserTextStyle(const QString& name);
+
+      // Ownership on read ahead device is NOT transfered to XmlReader.
+      void setReadAheadDevice(QIODevice* dev) { if (!dev->isSequential()) _readAheadDevice = dev; }
+      bool readAheadAvailable() const { return bool(_readAheadDevice); }
+      void performReadAhead(std::function<void(QIODevice&)> readAheadRoutine);
 
       QList<std::pair<Element*, QPointF>>& fixOffsets() { return  _fixOffsets; }
       };

--- a/libmscore/xmlreader.cpp
+++ b/libmscore/xmlreader.cpp
@@ -565,6 +565,27 @@ Tid XmlReader::lookupUserTextStyle(const QString& name)
       }
 
 //---------------------------------------------------------
+//   performReadAhead
+//    If f is called, the device will be non-sequential and
+//    open. Reading position equals to the current value of
+//    characterOffset(), but it is possible to seek for any
+//    other position inside f.
+//---------------------------------------------------------
+
+void XmlReader::performReadAhead(std::function<void(QIODevice&)> f)
+      {
+      if (!_readAheadDevice || _readAheadDevice->isSequential())
+            return;
+      if (!_readAheadDevice->isOpen())
+            _readAheadDevice->open(QIODevice::ReadOnly);
+
+      const auto pos = _readAheadDevice->pos();
+      _readAheadDevice->seek(characterOffset());
+      f(*_readAheadDevice);
+      _readAheadDevice->seek(pos);
+      }
+
+//---------------------------------------------------------
 //   addConnectorInfo
 //---------------------------------------------------------
 


### PR DESCRIPTION
In order to fix https://musescore.org/en/node/276235 this PR makes it possible sometimes to perform a readahead operation on XmlReader. This possibility is used then for correct importing of 2.X
system/staff text for both compressed and uncompressed files. Part of that functionality was already implemented in #4171 but it worked only for uncompressed .mscx files.

The other possible approach would be to turn `readText206` function into a factory function which takes a decision on an actual type of the returned text object based on the read properties. Implementing this approach is a non-trivial task since we have to re-implement reading of both large number of text-specific tags and, possibly, some tags that are common to all elements like those tags describing links between elements. Therefore the more simple (but not necessarily more correct) approach with implementing a minimal readahead functionality was chosen.