### PR TITLE
Fix issues with articulation placement

### DIFF
--- a/mtest/musicxml/io/testNoteAttributes1.xml
+++ b/mtest/musicxml/io/testNoteAttributes1.xml
@@ -285,8 +285,8 @@
         <notations>
           <slur type="stop" number="2"/>
           <articulations>
-            <accent/>
             <staccato/>
+            <accent/>
             </articulations>
           </notations>
         </note>


### PR DESCRIPTION
This fixes https://musescore.org/en/node/279607 and https://musescore.org/en/node/279672.

Stem-side articulations should not move closer to the note than the end of the stem (See Gould, 118). Staff-anchored articulations already account for the stem when determining their y-position. This PR makes chord-anchored articulations do the same.