### PR TITLE
Custom chords

### DIFF
--- a/libmscore/chordlist.cpp
+++ b/libmscore/chordlist.cpp
@@ -1571,6 +1571,8 @@ void ChordList::read(XmlReader& e)
             if (tag == "font") {
                   ChordFont f;
                   f.family = e.attribute("family", "default");
+                  if (f.family == "MuseJazz")
+                        f.family = "MuseJazz Text";
                   f.mag    = 1.0;
                   while (e.readNextStartElement()) {
                         if (e.name() == "sym") {

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1483,6 +1483,8 @@ void ChangeStyleVal::flip(EditData*)
             score->style().set(idx, value);
             if (idx == Sid::chordDescriptionFile) {
                   score->style().chordList()->unload();
+                  if (score->styleB(Sid::chordsXmlFile))
+                      score->style().chordList()->read("chords.xml");
                   score->style().chordList()->read(value.toString());
                   }
             score->styleChanged();

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -504,6 +504,9 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       connect(chordsStandard,      SIGNAL(toggled(bool)),             SLOT(setChordStyle(bool)));
       connect(chordsJazz,          SIGNAL(toggled(bool)),             SLOT(setChordStyle(bool)));
       connect(chordsCustom,        SIGNAL(toggled(bool)),             SLOT(setChordStyle(bool)));
+      connect(chordsXmlFile,       SIGNAL(toggled(bool)),             SLOT(setChordStyle(bool)));
+      connect(chordDescriptionFile,&QLineEdit::editingFinished,       [=]() { setChordStyle(true); });
+      //chordDescriptionFile->setEnabled(false);
 
       connect(SwingOff,            SIGNAL(toggled(bool)),             SLOT(setSwingParams(bool)));
       connect(swingEighth,         SIGNAL(toggled(bool)),             SLOT(setSwingParams(bool)));
@@ -1019,6 +1022,7 @@ void EditStyle::selectChordDescriptionFile()
       if (fn.isEmpty())
             return;
       chordDescriptionFile->setText(fn);
+      setChordStyle(true);
       }
 
 //---------------------------------------------------------
@@ -1056,24 +1060,31 @@ void EditStyle::setChordStyle(bool checked)
             return;
       QVariant val;
       QString file;
+      bool chordsXml;
       if (chordsStandard->isChecked()) {
             val  = QString("std");
             file = "chords_std.xml";
+            chordsXml = false;
             }
       else if (chordsJazz->isChecked()) {
             val  = QString("jazz");
             file = "chords_jazz.xml";
+            chordsXml = false;
             }
       else {
             val = QString("custom");
             chordDescriptionGroup->setEnabled(true);
+            file = chordDescriptionFile->text();
+            chordsXml = chordsXmlFile->isChecked();
             }
-      cs->undo(new ChangeStyleVal(cs, Sid::chordStyle, val));
-      if (!file.isEmpty()) {
-            cs->undo(new ChangeStyleVal(cs, Sid::chordsXmlFile, false));
-            chordsXmlFile->setChecked(false);
+      if (val != "custom") {
+            chordsXmlFile->setChecked(chordsXml);
             chordDescriptionGroup->setEnabled(false);
             chordDescriptionFile->setText(file);
+            }
+      cs->undo(new ChangeStyleVal(cs, Sid::chordsXmlFile, chordsXml));
+      cs->undo(new ChangeStyleVal(cs, Sid::chordStyle, val));
+      if (!file.isEmpty()) {
             cs->undo(new ChangeStyleVal(cs, Sid::chordDescriptionFile, file));
             cs->update();
             }

--- a/mtest/libmscore/compat114/textstyles-ref.mscx
+++ b/mtest/libmscore/compat114/textstyles-ref.mscx
@@ -37,7 +37,7 @@
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
       <ChordList>
-        <font id="0" family="MuseJazz">
+        <font id="0" family="MuseJazz Text">
           <mag>1</mag>
           <sym name="#" code="0xe10c"/>
           <sym name="(" code="0x28"/>
@@ -80,7 +80,7 @@
           <sym name="sus4" code="0xe18d"/>
           <sym name="triangle" code="0xe18a"/>
           </font>
-        <font id="1" family="MuseJazz">
+        <font id="1" family="MuseJazz Text">
           <mag>1.25</mag>
           <sym name="0" code="0xe190"/>
           <sym name="1" code="0xe191"/>
@@ -97,7 +97,7 @@
           <sym name="add" code="0xe18b"/>
           <sym name="add11" code="0xe18c"/>
           </font>
-        <font id="2" family="MuseJazz">
+        <font id="2" family="MuseJazz Text">
           <mag>0.8</mag>
           <sym name="a" code="0x61"/>
           <sym name="c" code="0x63"/>
@@ -130,7 +130,7 @@
           <sym name="y" code="0x79"/>
           <sym name="z" code="0x7a"/>
           </font>
-        <font id="3" family="MuseJazz">
+        <font id="3" family="MuseJazz Text">
           <mag>0.55</mag>
           </font>
         <renderRoot>:n :a</renderRoot>

--- a/share/styles/cchords_muse.xml
+++ b/share/styles/cchords_muse.xml
@@ -202,7 +202,7 @@
       configured text style font family is used.
 -->
 
-  <font id="0" family="MuseJazz">
+  <font id="0" family="MuseJazz Text">
 
     <sym code="0x28" name="("/>
     <sym code="0x29" name=")"/>
@@ -264,7 +264,7 @@
 
     </font>
 
-  <font id="2" family="MuseJazz">
+  <font id="2" family="MuseJazz Text">
     <mag>1.25</mag>
 
     <sym code="0xe190" name="0"/>
@@ -286,7 +286,7 @@
 
     </font>
 
-  <font id="108" family="MuseJazz">
+  <font id="108" family="MuseJazz Text">
     <mag>0.8</mag>
 
     <sym code="0x28" name="s("/>
@@ -326,7 +326,7 @@
 
     </font>
 
-  <font id="106" family="MuseJazz">
+  <font id="106" family="MuseJazz Text">
     <mag>0.55</mag>
 
 <!-- small caps letters

--- a/share/styles/cchords_nrb.xml
+++ b/share/styles/cchords_nrb.xml
@@ -202,7 +202,7 @@
       configured text style font family is used.
 -->
 
-  <font id="0" family="MuseJazz">
+  <font id="0" family="MuseJazz Text">
 
     <sym code="0x28" name="("/>
     <sym code="0x29" name=")"/>
@@ -264,7 +264,7 @@
 
     </font>
 
-  <font id="2" family="MuseJazz">
+  <font id="2" family="MuseJazz Text">
     <mag>1.25</mag>
 
     <sym code="0xe190" name="0"/>
@@ -286,7 +286,7 @@
 
     </font>
 
-  <font id="108" family="MuseJazz">
+  <font id="108" family="MuseJazz Text">
     <mag>0.8</mag>
 
     <sym code="0x28" name="s("/>
@@ -326,7 +326,7 @@
 
     </font>
 
-  <font id="106" family="MuseJazz">
+  <font id="106" family="MuseJazz Text">
     <mag>0.55</mag>
 
 <!-- small caps letters

--- a/share/styles/cchords_rb.xml
+++ b/share/styles/cchords_rb.xml
@@ -202,7 +202,7 @@
       configured text style font family is used.
 -->
 
-  <font id="0" family="MuseJazz">
+  <font id="0" family="MuseJazz Text">
 
     <sym code="0x28" name="("/>
     <sym code="0x29" name=")"/>
@@ -264,7 +264,7 @@
 
     </font>
 
-  <font id="2" family="MuseJazz">
+  <font id="2" family="MuseJazz Text">
     <mag>1.25</mag>
 
     <sym code="0xe190" name="0"/>
@@ -286,7 +286,7 @@
 
     </font>
 
-  <font id="108" family="MuseJazz">
+  <font id="108" family="MuseJazz Text">
     <mag>0.8</mag>
 
     <sym code="0x28" name="s("/>
@@ -326,7 +326,7 @@
 
     </font>
 
-  <font id="106" family="MuseJazz">
+  <font id="106" family="MuseJazz Text">
     <mag>0.55</mag>
 
 <!-- small caps letters

--- a/share/styles/cchords_sym.xml
+++ b/share/styles/cchords_sym.xml
@@ -202,7 +202,7 @@
       configured text style font family is used.
 -->
 
-  <font id="0" family="MuseJazz">
+  <font id="0" family="MuseJazz Text">
 
     <sym code="0x28" name="("/>
     <sym code="0x29" name=")"/>
@@ -264,7 +264,7 @@
 
     </font>
 
-  <font id="2" family="MuseJazz">
+  <font id="2" family="MuseJazz Text">
     <mag>1.25</mag>
 
     <sym code="0xe190" name="0"/>
@@ -286,7 +286,7 @@
 
     </font>
 
-  <font id="108" family="MuseJazz">
+  <font id="108" family="MuseJazz Text">
     <mag>0.8</mag>
 
     <sym code="0x28" name="s("/>
@@ -326,7 +326,7 @@
 
     </font>
 
-  <font id="106" family="MuseJazz">
+  <font id="106" family="MuseJazz Text">
     <mag>0.55</mag>
 
 <!-- small caps letters


### PR DESCRIPTION
Two separate problems involving custom chord symbols (chord description files)

- MuseJazz was renamed to MuseJazz Text so we need to map that font family when we see it in these files
- Format / Style dialog was not acting on attempts to set/change the chord description file

Both fixed here (in separate commits).  The demo scores still look bad because they were originally created in 1.3 (or earlier); I still intend to update those.  But these changes at least fix the bugs so they don't look so completely ridiculous.