### PR TITLE
Complete reordering of the layout sequence

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2937,6 +2937,27 @@ void layoutTies(Chord* ch, System* system, int stick)
       }
 
 //---------------------------------------------------------
+//   layoutHarmonies
+//---------------------------------------------------------
+
+void layoutHarmonies(const std::vector<Segment*>& sl)
+      {
+      for (const Segment* s : sl) {
+            for (Element* e : s->annotations()) {
+                  if (e->isHarmony()) {
+                        Harmony* h = toHarmony(e);
+                        // Layout of harmony seems to be bound currently
+                        // to ChordRest (see ChordRest::shape). But harmony
+                        // can exist without chord or rest too.
+                        if (h->isLayoutInvalid())
+                              h->layout();
+                        toHarmony(e)->autoplaceSegmentElement(s->score()->styleP(Sid::minHarmonyDistance));
+                        }
+                  }
+            }
+      }
+
+//---------------------------------------------------------
 //   processLines
 //---------------------------------------------------------
 
@@ -3423,13 +3444,15 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             system->staff(si)->skyline().add(d->shape().translated(d->pos() + s->pos() + m->pos()));
             }
 
-      //
-      //    layout SpannerSegments for current system
-      //
+      //-------------------------------------------------------------
+      // layout SpannerSegments for current system
+      // ottavas, pedals, voltas are collected here, but layouted later
+      //-------------------------------------------------------------
 
       spanner.clear();
       std::vector<Spanner*> ottavas;
       std::vector<Spanner*> pedal;
+      std::vector<Spanner*> voltas;
 
       for (auto interval : spanners) {
             Spanner* sp = interval.value;
@@ -3438,30 +3461,35 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                         ottavas.push_back(sp);
                   else if (sp->isPedal())
                         pedal.push_back(sp);
-                  else if (!sp->isSlur() && !sp->isVolta())    // slurs are already, voltas will be later handled
+                  else if (sp->isVolta())
+                        voltas.push_back(sp);
+                  else if (!sp->isSlur() && !sp->isVolta())    // slurs are already
                         spanner.push_back(sp);
                   }
             }
-      processLines(system, ottavas, false);
-      processLines(system, pedal,   true);
       processLines(system, spanner, false);
 
       //-------------------------------------------------------------
-      // TempoText, Fermata, TremoloBar
+      // Fermata, TremoloBar
       //-------------------------------------------------------------
 
       for (const Segment* s : sl) {
             for (Element* e : s->annotations()) {
-                  if (e->isTempoText()) {
-                        TempoText* tt = toTempoText(e);
-                        if (score()->isMaster())
-                              setTempo(tt->segment(), tt->tempo());
-                        tt->layout();
-                        }
-                  else if (e->isFermata() || e->isTremoloBar())
+                  if (e->isFermata() || e->isTremoloBar())
                         e->layout();
                   }
             }
+
+      //-------------------------------------------------------------
+      // Ottava, Pedal
+      //-------------------------------------------------------------
+
+      processLines(system, ottavas, false);
+      processLines(system, pedal,   true);
+
+      //-------------------------------------------------------------
+      // Lyric
+      //-------------------------------------------------------------
 
       layoutLyrics(system);
 
@@ -3472,19 +3500,76 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             sp->layoutSystem(system);
             }
 
+      //
+      // We need to known if we have FretDiagrams in the system to decide when to layout the Harmonies
+      //
+
+      bool hasFretDiagram = false;
+      for (const Segment* s : sl) {
+            for (Element* e : s->annotations()) {
+                  if (e->isFretDiagram()) {
+                        hasFretDiagram = true;
+                        break;
+                        }
+                  }
+
+            if (hasFretDiagram)
+                  break;
+            }
+
+      //-------------------------------------------------------------
+      // Harmony, 1st place
+      // If we have FretDiagrams, we want the Harmony above this and
+      // above the volta, therefore we delay the layout.
+      //-------------------------------------------------------------
+
+      if (!hasFretDiagram) 
+            layoutHarmonies(sl);
+
+      //-------------------------------------------------------------
+      // StaffText, InstrumentChange
+      //-------------------------------------------------------------
+
+      for (const Segment* s : sl) {
+            for (Element* e : s->annotations()) {
+                  if (e->isStaffText() || e->isSystemText() || e->isInstrumentChange())
+                        e->layout();
+                  }
+            }
+
+      //-------------------------------------------------------------
+      // Jump, Marker
+      //-------------------------------------------------------------
+
+      for (MeasureBase* mb : system->measures()) {
+            if (!mb->isMeasure())
+                  continue;
+            Measure* m = toMeasure(mb);
+            for (Element* e : m->el()) {
+                  if (e->isJump() || e->isMarker())
+                        e->layout();
+                  }
+            }
+
+      //-------------------------------------------------------------
+      // TempoText
+      //-------------------------------------------------------------
+
+      for (const Segment* s : sl) {
+            for (Element* e : s->annotations()) {
+                  if (e->isTempoText()) {
+                        TempoText* tt = toTempoText(e);
+                        if (score()->isMaster())
+                              setTempo(tt->segment(), tt->tempo());
+                        tt->layout();
+                        }
+                  }
+            }
+
       //-------------------------------------------------------------
       // layout Voltas for current sytem
       //-------------------------------------------------------------
 
-      std::vector<Spanner*> voltas;
-
-      for (auto interval : spanners) {
-            Spanner* sp = interval.value;
-            if (sp->tick() < etick && sp->tick2() > stick) {
-                  if (sp->isVolta())
-                        voltas.push_back(sp);
-                  }
-            }
       processLines(system, voltas, false);
 
       //
@@ -3512,23 +3597,14 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                         ++idx;
                         prevVolta = volta;
                         }
-                  for (int i = 0; i < idx; ++i)
-                        voltaSegments[i]->rypos() = y;
+
+                  for (int i = 0; i < idx; ++i) {
+                        SpannerSegment* ss = voltaSegments[i];
+                        ss->rypos() = y;
+                        system->staff(staffIdx)->skyline().add(ss->shape().translated(ss->pos()));
+                        }
+
                   voltaSegments.erase(voltaSegments.begin(), voltaSegments.begin() + idx);
-                  }
-            }
-
-      //-------------------------------------------------------------
-      // Jump, Marker
-      //-------------------------------------------------------------
-
-      for (MeasureBase* mb : system->measures()) {
-            if (!mb->isMeasure())
-                  continue;
-            Measure* m = toMeasure(mb);
-            for (Element* e : m->el()) {
-                  if (e->isJump() || e->isMarker())
-                        e->layout();
                   }
             }
 
@@ -3536,31 +3612,21 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
       // FretDiagram
       //-------------------------------------------------------------
 
-      for (const Segment* s : sl) {
-            for (Element* e : s->annotations()) {
-                  if (e->isFretDiagram())
-                        e->layout();
-                  }
-            }
-
-      //-------------------------------------------------------------
-      // StaffText, Harmony, InstrumentChange
-      //-------------------------------------------------------------
-
-      for (const Segment* s : sl) {
-            for (Element* e : s->annotations()) {
-                  if (e->isStaffText() || e->isSystemText() || e->isInstrumentChange())
-                        e->layout();
-                  if (e->isHarmony()) {
-                        Harmony* h = toHarmony(e);
-                        // Layout of harmony seems to be bound currently
-                        // to ChordRest (see ChordRest::shape). But harmony
-                        // can exist without chord or rest too.
-                        if (h->isLayoutInvalid())
-                              h->layout();
-                        toHarmony(e)->autoplaceSegmentElement(styleP(Sid::minHarmonyDistance));
+      if (hasFretDiagram) {
+            for (const Segment* s : sl) {
+                  for (Element* e : s->annotations()) {
+                        if (e->isFretDiagram())
+                              e->layout();
                         }
                   }
+
+            //-------------------------------------------------------------
+            // Harmony, 2nd place
+            // We have FretDiagrams, we want the Harmony above this and
+            // above the volta.
+            //-------------------------------------------------------------
+
+            layoutHarmonies(sl);
             }
 
       //-------------------------------------------------------------

--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -420,6 +420,41 @@ void LayoutContext::layoutLinear()
                   }
             }
 
+      //
+      // Volta
+      //
+
+      if (etick > stick) {    // ignore vbox
+            auto spanners = score->spannerMap().findOverlapping(stick, etick);
+
+            std::vector<Spanner*> voltas;
+
+            for (auto interval : spanners) {
+                  Spanner* sp = interval.value;
+                  if (sp->tick() < etick && sp->tick2() > stick) {
+                        if (sp->isVolta())
+                              voltas.push_back(sp);
+                        }
+                  }
+            processLines(system, voltas, false);
+
+            //
+            // vertical align volta segments
+            //
+            std::vector<SpannerSegment*> voltaSegments;
+            for (SpannerSegment* ss : system->spannerSegments()) {
+                  if (ss->isVoltaSegment())
+                       voltaSegments.push_back(ss);
+                 }
+            if (voltaSegments.size() > 1) {
+                  qreal y = 0;
+                  for (SpannerSegment* ss : voltaSegments)
+                        y = qMin(y, ss->offset().y());
+                  for (SpannerSegment* ss : voltaSegments)
+                        ss->ryoffset() = y;
+                  }
+            }
+
       score->layoutLyrics(system);
 
       for (Spanner* sp : score->unmanagedSpanners()) {


### PR DESCRIPTION
In this PR we try to resolve some of the flaws in automatic layout by reordering the layout sequence. The new layout sequence is:

* ...
* Tuplet
* Slur
* Dynamic
* Spanner w/o slur, ottava, pedal, volta
* Fermata, Tremolobar
* Ottava
* Pedal
* Lyric
* Harmony **if no Fret Diagram in system** 
* StaffText, InstrumentChange
* Jump, Marker
* TempoText
* Volta
* Fret Diagram
* Harmony **if Fret Diagram in system**
* RehearsalMark
