### PR TITLE
fix #279782: unlink the removed staves instead of the remaining ones on excerpt removal

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -297,18 +297,16 @@ void MasterScore::deleteExcerpt(Excerpt* excerpt)
 
       // unlink the staves in the excerpt
       for (Staff* st : partScore->staves()) {
-            Staff* staff = nullptr;
-            // find staff in the main score
+            bool hasLinksInMaster = false;
             if (st->links()) {
                   for (auto le : *st->links()) {
-                        Staff* s2 = toStaff(le);
-                        if ((s2->score() == this) && s2->primaryStaff()) {
-                              staff = s2;
+                        if (le->score() == this) {
+                              hasLinksInMaster = true;
                               break;
                               }
                         }
                   }
-            if (staff) {
+            if (hasLinksInMaster) {
                   int staffIdx = st->idx();
                   // unlink the spanners
                   for (auto i = partScore->spanner().begin(); i != partScore->spanner().cend(); ++i) {
@@ -331,7 +329,7 @@ void MasterScore::deleteExcerpt(Excerpt* excerpt)
                               }
                         }
                   // unlink the staff
-                  undo(new Unlink(staff));
+                  undo(new Unlink(st));
                   }
             }
       undo(new RemoveExcerpt(excerpt));


### PR DESCRIPTION
On removing a staff it should be unlinked from the other staves. However, for some reason, on excerpt removal it was the master score staff that was unlinked from others instead of the removed one. This PR corrects this and thus fixes https://musescore.org/en/node/279782.
The only sensible reason for master score staff lookup seems to be checking on whether the unlinking routine needs to happen at all. Thus I changed this lookup to serve entirely this purpose without actually doing something with the staff that is found.