### PR TITLE
fix #278485: fix a crash on inserting measures before boxes

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2660,7 +2660,13 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
             if (type == ElementType::MEASURE) {
                   Measure* m  = toMeasure(mb);  // new measure
                   ticks       = m->ticks();
-                  Measure* mi = toMeasure(im);  // insert before
+                  Measure* mi = nullptr;        // insert before
+                  if (im) {
+                        if (im->isMeasure())
+                              mi = toMeasure(im);
+                        else
+                              mi = score->tick2measure(im->tick());
+                        }
 
                   if (score->isMaster())
                         om = m;


### PR DESCRIPTION
Fixes https://musescore.org/en/node/278485.

The corresponding code was changed in d9ff5a26f6ac15a662ffca72f38e93008d9d5d28 and introduced an unchecked conversion of `MeasureBase` to `Measure`. This commit adds a check prior to performing the conversion and restores a measure search that was performed before that commit in case the type check does not pass.