### PR TITLE
fix #278918, fix #279284: a quick fix for crash on parts export to various formats

### DIFF
--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -59,6 +59,64 @@ Staff* Part::staff(int idx) const
       }
 
 //---------------------------------------------------------
+//   Part::masterPart
+//---------------------------------------------------------
+
+const Part* Part::masterPart() const
+      {
+      if (score()->isMaster())
+            return this;
+      if (_staves.empty())
+            return this;
+
+      Staff* st = _staves[0];
+      LinkedElements* links = st->links();
+      if (!links)
+            return this;
+
+      for (ScoreElement* le : *links) {
+            if (le->isStaff() && toStaff(le)->score()->isMaster()) {
+                  if (Part* p = toStaff(le)->part())
+                        return p;
+                  }
+            }
+      return this;
+      }
+
+//---------------------------------------------------------
+//   Part::masterPart
+//---------------------------------------------------------
+
+Part* Part::masterPart()
+      {
+      return const_cast<Part*>(const_cast<const Part*>(this)->masterPart());
+      }
+
+//---------------------------------------------------------
+//   Part::redirectPart
+//---------------------------------------------------------
+
+const Part* Part::redirectPart() const
+      {
+      const Part* p = masterPart();
+      if (p != this)
+            return p;
+      return nullptr;
+      }
+
+//---------------------------------------------------------
+//   Part::redirectPart
+//---------------------------------------------------------
+
+Part* Part::redirectPart()
+      {
+      Part* p = masterPart();
+      if (p != this)
+            return p;
+      return nullptr;
+      }
+
+//---------------------------------------------------------
 //   readProperties
 //---------------------------------------------------------
 
@@ -399,6 +457,8 @@ void Part::removeInstrument(int tick)
 
 Instrument* Part::instrument(int tick)
       {
+      if (Part* p = redirectPart())
+            return p->instrument(tick);
       return _instruments.instrument(tick);
       }
 
@@ -408,7 +468,20 @@ Instrument* Part::instrument(int tick)
 
 const Instrument* Part::instrument(int tick) const
       {
+      if (const Part* p = redirectPart())
+            return p->instrument(tick);
       return _instruments.instrument(tick);
+      }
+
+//---------------------------------------------------------
+//   instruments
+//---------------------------------------------------------
+
+const InstrumentList* Part::instruments() const
+      {
+      if (const Part* p = redirectPart())
+            return p->instruments();
+      return &_instruments;
       }
 
 //---------------------------------------------------------

--- a/libmscore/part.h
+++ b/libmscore/part.h
@@ -54,6 +54,11 @@ class Part final : public ScoreElement {
       static const int DEFAULT_COLOR = 0x3399ff;
       int _color;                   ///User specified color for helping to label parts
 
+      const Part* masterPart() const;
+      Part* masterPart();
+      const Part* redirectPart() const;
+      Part* redirectPart();
+
    public:
       Part(Score* = 0);
       void initFromInstrTemplate(const InstrumentTemplate*);
@@ -121,7 +126,7 @@ class Part final : public ScoreElement {
       void setInstrument(const Instrument&&, int tick = -1);
       void setInstrument(const Instrument&, int tick = -1);
       void removeInstrument(int tick);
-      const InstrumentList* instruments() const   { return &_instruments;       }
+      const InstrumentList* instruments() const;
 
       void insertTime(int tick, int len);
 
@@ -138,6 +143,10 @@ class Part final : public ScoreElement {
       bool hasPitchedStaff();
       bool hasTabStaff();
       bool hasDrumStaff();
+
+      // Allows not reading the same instrument twice on importing 2.X scores.
+      // TODO: do we need instruments info in parts at all?
+      friend void readPart206(Part*, XmlReader&);
       };
 
 }     // namespace Ms

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1043,12 +1043,12 @@ static void readStaff(Staff* staff, XmlReader& e)
 //   readPart
 //---------------------------------------------------------
 
-static void readPart(Part* part, XmlReader& e)
+void readPart206(Part* part, XmlReader& e)
       {
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "Instrument") {
-                  Instrument* i = part->instrument();
+                  Instrument* i = part->_instruments.instrument(/* tick */ -1);
                   readInstrument(i, part, e);
                   Drumset* ds = i->drumset();
                   Staff*   s = part->staff(0);
@@ -3540,7 +3540,7 @@ static bool readScore(Score* score, XmlReader& e)
                   }
             else if (tag == "Part") {
                   Part* part = new Part(score);
-                  readPart(part, e);
+                  readPart206(part, e);
                   score->parts().push_back(part);
                   }
             else if ((tag == "HairPin")   // TODO: do this elements exist here?


### PR DESCRIPTION
This is a quick and dirty option to fix these issues:
https://musescore.org/en/node/278918
https://musescore.org/en/node/279284

Maybe it can be useful for some time.