### PR TITLE
fix #279610: do not account offset twice for symbols

### DIFF
--- a/libmscore/symbol.cpp
+++ b/libmscore/symbol.cpp
@@ -72,7 +72,7 @@ void Symbol::layout()
             p.setX(-w);
       else if (align() & Align::HCENTER)
             p.setX(-(w * .5));
-      setPos(p + o);
+      setPos(p);
       BSymbol::layout();
       }
 


### PR DESCRIPTION
Fixes https://musescore.org/en/node/279610.