### PR TITLE
fix #279774: preserve non-default properties on lyrics layout

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -260,12 +260,12 @@ void Lyrics::layout()
 
       bool styleDidChange = false;
       if ((_no & 1) && !_even) {
-            initTid(Tid::LYRICS_EVEN);
+            initTid(Tid::LYRICS_EVEN, /* preserveDifferent */ true);
             _even             = true;
             styleDidChange    = true;
             }
       if (!(_no & 1) && _even) {
-            initTid(Tid::LYRICS_ODD);
+            initTid(Tid::LYRICS_ODD, /* preserveDifferent */ true);
             _even             = false;
             styleDidChange    = true;
             }


### PR DESCRIPTION
Fixes https://musescore.org/en/node/279774.

On layout `Lyrics` checks the syllable on being even or odd and changes the style correspondingly. However it was a bit too aggressive about it so some user-defined properties also got reset. This commit changes this behavior and preserves user-defined properties values on layout of lyrics..