### PR TITLE
fix #279950, fix #279804, fix #279666: force chord symbol layout

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1200,7 +1200,9 @@ Shape ChordRest::shape() const
             if (!e || !e->visible() || !e->autoplace())
                   continue;
             if (e->isHarmony() && e->staffIdx() == staffIdx()) {
-                  e->layout();
+                  Harmony* h = toHarmony(e);
+                  if (h->isLayoutInvalid())
+                        h->layout();
                   const qreal margin = styleP(Sid::minHarmonyDistance) * 0.5;
                   x1 = qMin(x1, e->bbox().x() - margin + e->pos().x());
                   x2 = qMax(x2, e->bbox().x() + e->bbox().width() + margin + e->pos().x());

--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -705,8 +705,13 @@ const ChordDescription* Harmony::parseHarmony(const QString& ss, int* root, int*
 
 void Harmony::startEdit(EditData& ed)
       {
-      if (!textList.empty())
+      if (!textList.empty()) {
             setXmlText(harmonyName());
+            // force layout, but restore original position
+            QPointF p = ipos();
+            layout();
+            setPos(p);
+            }
 
       TextBase::startEdit(ed);
       }
@@ -721,12 +726,17 @@ bool Harmony::edit(EditData& ed)
             return true; // Harmony only single line
       bool rv = TextBase::edit(ed);
       setHarmony(plainText());
+
+      // force layout, but restore original position
+      QPointF p = ipos();
+      layout();
+      setPos(p);
+
       int root, base;
       QString str = xmlText();
-      bool badSpell = !str.isEmpty() && !parseHarmony(str, &root, &base, true);
-      setProperty(Pid::COLOR, badSpell ? QColor(Qt::red) : QColor(Qt::black));
+      showSpell = !str.isEmpty() && !parseHarmony(str, &root, &base, true);
 
-      if (badSpell)
+      if (showSpell)
             qDebug("bad spell");
       return rv;
       }
@@ -737,6 +747,7 @@ bool Harmony::edit(EditData& ed)
 
 void Harmony::endEdit(EditData& ed)
       {
+      showSpell = false;
       TextBase::endEdit(ed);
 
       if (links()) {
@@ -1123,10 +1134,19 @@ void Harmony::drawEditMode(QPainter* p, EditData& ed)
       {
       TextBase::drawEditMode(p, ed);
 
+      QColor originalColor = color();
+      if (showSpell) {
+            setColor(QColor(Qt::red));
+            setSelected(false);
+            }
       QPointF pos(canvasPos());
       p->translate(pos);
       TextBase::draw(p);
       p->translate(-pos);
+      if (showSpell) {
+            setColor(originalColor);
+            setSelected(true);
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -73,6 +73,7 @@ class Harmony final : public TextBase {
       QString _userName;                  // name as typed by user if applicable
       QString _textName;                  // name recognized from chord list, read from score file, or constructed from imported source
       ParsedChord* _parsedForm;           // parsed form of chord
+      bool showSpell = false;             // show spell check warning
 
       QList<HDegree> _degreeList;
       QList<QFont> fontList;              // temp values used in render()

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2951,7 +2951,7 @@ void layoutHarmonies(const std::vector<Segment*>& sl)
                         // can exist without chord or rest too.
                         if (h->isLayoutInvalid())
                               h->layout();
-                        toHarmony(e)->autoplaceSegmentElement(s->score()->styleP(Sid::minHarmonyDistance));
+                        h->autoplaceSegmentElement(s->score()->styleP(Sid::minHarmonyDistance));
                         }
                   }
             }

--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -346,8 +346,9 @@ class TextBase : public Element {
       QList<TextBlock>& textBlockList()          { return _layout; }
       int rows() const                           { return _layout.size(); }
 
-      void setTextInvalid()                      { textInvalid = true;   };
+      void setTextInvalid()                      { textInvalid = true;   }
       bool isTextInvalid() const                 { return textInvalid;   }
+      void setLayoutInvalid()                    { layoutInvalid = true; }
       bool isLayoutInvalid() const               { return layoutInvalid; }
 
       // helper functions


### PR DESCRIPTION
Chord symbols are laid out with the chordrest and thus are get laid out separately from when they are autoplaced.  This leads to problems as sometimes we have a layout of the chord symbol *without* the full score layout that leads to the autoplace (or the chord symbol gets laid outa second time after the autoplace).  This PR deals with those cases by only laying out the chord symbol if needed during chordrest layout, and then also forcing the layout to happen during edit operations and preserving the current vertical position since autoplace won't be kicking in.

Since this was hitting the same lines of code that also affect the "spell check", I went ahead and fixed that too so the red color is visible while editing but not permanently.  I'd have made it a separate commit but the code overlapped slightly.

I can see right now I'll need to rebase, but I'm submitting this now and then will force push when I sort that out.