### PR TITLE
fix #279995: second (unneeded) layout of voltas in linear view removed.

### DIFF
--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -420,41 +420,6 @@ void LayoutContext::layoutLinear()
                   }
             }
 
-      //
-      // Volta
-      //
-
-      if (etick > stick) {    // ignore vbox
-            auto spanners = score->spannerMap().findOverlapping(stick, etick);
-
-            std::vector<Spanner*> voltas;
-
-            for (auto interval : spanners) {
-                  Spanner* sp = interval.value;
-                  if (sp->tick() < etick && sp->tick2() > stick) {
-                        if (sp->isVolta())
-                              voltas.push_back(sp);
-                        }
-                  }
-            processLines(system, voltas, false);
-
-            //
-            // vertical align volta segments
-            //
-            std::vector<SpannerSegment*> voltaSegments;
-            for (SpannerSegment* ss : system->spannerSegments()) {
-                  if (ss->isVoltaSegment())
-                       voltaSegments.push_back(ss);
-                 }
-            if (voltaSegments.size() > 1) {
-                  qreal y = 0;
-                  for (SpannerSegment* ss : voltaSegments)
-                        y = qMin(y, ss->offset().y());
-                  for (SpannerSegment* ss : voltaSegments)
-                        ss->ryoffset() = y;
-                  }
-            }
-
       score->layoutLyrics(system);
 
       for (Spanner* sp : score->unmanagedSpanners()) {


### PR DESCRIPTION
Due to a rebase error in https://github.com/musescore/MuseScore/pull/4386 a change for https://github.com/musescore/MuseScore/pull/4342 was put in again. This results in the problem. that the layout of the volta is done twice.

This is fixed by this PR.