### PR TITLE
fix #279141: layout score on undoing staves reordering

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2560,6 +2560,7 @@ void Score::sortStaves(QList<int>& dst)
                         sp->setTrack2(idx * VOICES +(sp->track2() % VOICES)); // at least keep the voice...
                   }
             }
+      setLayoutAll();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fixes https://musescore.org/en/node/279141.
Full layout of score was done when reordering staves via instruments dialog but was missed when undoing this operation. Meanwhile this should be done regardless of the reason that caused that reordering happen.