### PR TITLE
fix #279509: always set correct track for spanner segments

### DIFF
--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -1123,6 +1123,7 @@ SpannerSegment* Spanner::getNextLayoutSystemSegment(System* system, std::functio
             }
       seg->setSystem(system);
       seg->setSpanner(this);
+      seg->setTrack(track());
       return seg;
       }
 


### PR DESCRIPTION
Fixes https://musescore.org/en/node/279509.