### PR TITLE
fix #280055: chord symbol stays high

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1201,6 +1201,10 @@ Shape ChordRest::shape() const
                   continue;
             if (e->isHarmony() && e->staffIdx() == staffIdx()) {
                   Harmony* h = toHarmony(e);
+                  // this layout is needed just to calculate the correct bbox
+                  // so only do it if necessary, as it will reset position to default
+                  // and there might not be an autoplace after this
+                  // since ChordRest::shape() can be called at several points
                   if (h->isLayoutInvalid())
                         h->layout();
                   const qreal margin = styleP(Sid::minHarmonyDistance) * 0.5;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2946,11 +2946,12 @@ void layoutHarmonies(const std::vector<Segment*>& sl)
             for (Element* e : s->annotations()) {
                   if (e->isHarmony()) {
                         Harmony* h = toHarmony(e);
-                        // Layout of harmony seems to be bound currently
-                        // to ChordRest (see ChordRest::shape). But harmony
-                        // can exist without chord or rest too.
-                        if (h->isLayoutInvalid())
-                              h->layout();
+                        // For chord symbols that coincide with a chord or rest,
+                        // a partial layout can also happen (if needed) during ChordRest layout
+                        // in order to calculate a bbox and allocate its shape to the ChordRest.
+                        // But that layout (if it happens at all) does not do autoplace,
+                        // so we need the full layout here.
+                        h->layout();
                         h->autoplaceSegmentElement(s->score()->styleP(Sid::minHarmonyDistance));
                         }
                   }


### PR DESCRIPTION
Harmony layout can happen during ChordRest layout (because we need to assign the harmony shape to the chordrest for spacing purposes), but it also happens during the "normal" layout of segment elements later, which handles harmony not attached to a chordrest, and it is also when autoplace happens.

It can be dangerous to layout the harmony unless you know for sure an autoplace will follow, since the layout resets the harmony to default position.  That's why just the yesterday I added a check to not layout the harmony it unnecessarily in ChordRest::shape, since there are times when this gets called without a subsequent autoplace (and this isn't the right time to do the autoplace).  Yet, it's important that when we finally *do* the autoplace, theharmony has to have been laid out during this layout operation - otherwise a previously-autoplaced chord can get stuck up high, which is the bug here.  We were sometimes skipping the layout before autoplace on the assumption it would was already done in ChordRest::shape, but with my (needed) change yesterday, that's no longer reliably true.

It's harmless to layout twice as long as you know an autoplace follows.  So, the fix is to always do the layout before the autoplace, while still being careful not to layout unnecessarily during ChordRest::shape().

@dmitrio95 I wouldn't mind a look from you