### PR TITLE
fix #279988: in preventing empty system, pick a visible staff to show

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1293,6 +1293,7 @@ void Score::hideEmptyStaves(System* system, bool isFirstSystem)
 
             ++staffIdx;
             }
+      Staff* firstVisible = nullptr;
       if (systemIsEmpty) {
             for (Staff* staff : _staves) {
                   SysStaff* ss  = system->staff(staff->idx());
@@ -1300,11 +1301,14 @@ void Score::hideEmptyStaves(System* system, bool isFirstSystem)
                         ss->setShow(true);
                         systemIsEmpty = false;
                         }
+                  else if (!firstVisible && staff->show()) {
+                        firstVisible = staff;
+                        }
                   }
             }
       // don’t allow a complete empty system
       if (systemIsEmpty) {
-            Staff* staff = _staves.front();
+            Staff* staff = firstVisible ? firstVisible : _staves.front();
             SysStaff* ss = system->staff(staff->idx());
             ss->setShow(true);
             }


### PR DESCRIPTION
We make an effort to avoid empty systems in hideEmptyStaves, but if everything is empty, instead of picking first staff to show, show the first staff *not set to invisible*, otherwise it still ends up being empty, and this can lead to problems.