### PR TITLE
fix #278239 incorrect mapping of voices

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4445,6 +4445,8 @@ void Score::undoAddCR(ChordRest* cr, Measure* measure, int tick)
                   tracks.append(staffIdx * VOICES + (strack % VOICES));
             else if (staff->score()->excerpt() && !staff->score()->excerpt()->tracks().isEmpty())
                   tracks = staff->score()->excerpt()->tracks().values(strack);
+            else if (!staff->score()->excerpt())
+                  tracks.append(staffIdx * VOICES + (strack % VOICES));
             else
                   tracks.append(staffIdx * VOICES + cr->voice());
 


### PR DESCRIPTION
See [279829](https://musescore.org/en/node/279829) for more information. With this fix, the mapping should be correct again. This bug actually was introduced one year ago :laughing: 