### PR TITLE
fix #278975: rewrite the condition for showing naturals on keysig change

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -134,9 +134,12 @@ void KeySig::layout()
       Measure* prevMeasure = measure() ? measure()->prevMeasure() : 0;
 
       // If we're not force hiding naturals (Continuous panel), use score style settings
-      if (!_hideNaturals)
-            naturalsOn = (prevMeasure && !prevMeasure->sectionBreak()
-               && (score()->styleI(Sid::keySigNaturals) != int(KeySigNatural::NONE))) || (t1 == 0);
+      if (!_hideNaturals) {
+            const bool newSection = (!segment()
+               || (segment()->rtick() == 0 && (!prevMeasure || prevMeasure->sectionBreak()))
+               );
+            naturalsOn = !newSection && (score()->styleI(Sid::keySigNaturals) != int(KeySigNatural::NONE) || (t1 == 0));
+            }
 
 
       // Don't repeat naturals if shown in courtesy


### PR DESCRIPTION
This PR rewrites the condition for showing naturals in key signature to avoid showing them in any case when the key signature is situated at the beginning of new section. That way it fixes https://musescore.org/en/node/278975.