### PR TITLE
fix #279880: place articulations under slurs except at endpoints

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -569,7 +569,7 @@ QString Articulation::accessibleInfo() const
 void Articulation::doAutoplace()
       {
       qreal minDistance = score()->styleP(Sid::dynamicsMinDistance);
-      if (autoplace() && parent()) {
+      if (autoplace() && visible() && parent()) {
             Segment* s = segment();
             Measure* m = measure();
             int si     = staffIdx();

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -198,6 +198,7 @@ class Chord final : public ChordRest {
 
       void layoutArticulations();
       void layoutArticulations2();
+      void layoutArticulations3(Slur* s);
 
       QVector<Articulation*>& articulations()             { return _articulations; }
       const QVector<Articulation*>& articulations() const { return _articulations; }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3364,7 +3364,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             }
 
       //-------------------------------------------------------------
-      // layout tuplet
+      // layout articulations, tuplet
       //-------------------------------------------------------------
 
       for (Segment* s : sl) {
@@ -3372,6 +3372,10 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                   if (!e || !e->isChordRest() || !score()->staff(e->staffIdx())->show())
                         continue;
                   ChordRest* cr = toChordRest(e);
+                  // articulations
+                  if (cr->isChord())
+                        toChord(cr)->layoutArticulations2();
+                  // tuplets
                   // sanity check
                   if (cr->beam() && !isTopBeam(cr))
                         continue;
@@ -3407,6 +3411,15 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                   }
             }
       processLines(system, spanner, false);
+      for (auto s : spanner) {
+            Slur* slur = toSlur(s);
+            ChordRest* scr = s->startCR();
+            ChordRest* ecr = s->endCR();
+            if (scr->isChord())
+                  toChord(scr)->layoutArticulations3(slur);
+            if (ecr->isChord())
+                  toChord(ecr)->layoutArticulations3(slur);
+            }
 
       std::vector<Dynamic*> dynamics;
       for (Segment* s : sl) {
@@ -3418,7 +3431,6 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                         for (Chord* ch : c->graceNotes())
                               layoutTies(ch, system, stick);
                         layoutTies(c, system, stick);
-                        c->layoutArticulations2();
                         }
                   }
             for (Element* e : s->annotations()) {
@@ -3524,7 +3536,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
       // above the volta, therefore we delay the layout.
       //-------------------------------------------------------------
 
-      if (!hasFretDiagram) 
+      if (!hasFretDiagram)
             layoutHarmonies(sl);
 
       //-------------------------------------------------------------


### PR DESCRIPTION
After the big reordering of layout in #4386, the final (?!) thing that is still needed to be revamped to bring things in line with Gould is the relationship between articulations and slurs.  This PR addresses that.

The rule stated by Gould (and, I think, supported by the literature) is that staccato and tenuto go inside slurs always, other articulations go inside except at the slur endpoints where they go over.  Previously we were placing other articulations outside the slur always, which often placed the articulations quite far from the notes they are attached to.  This was actually a regression of sorts compared to 2.3.2, which put articulations closer to the notes (of course, the slurs were not guaranteed to avoid these articulations).

This PR implements the Gould rule primarily by adding a new articulation layout function Chord::layoutArticulations3 that is called after slur layout, and moving the layoutArticulations2 call to before slur layout.  layoutArticulations continues to do the initial layout of staccato and tenuto to keep them closest to the notes, then we call layoutArticulations2 just before slur layout to lay out the remaining articulations, then we lay out slurs, and then finally we call the new layoutArticulations2 function *just* for the notes on slur endpoints to re-adjust the articulations originally placed by layoutArticulations2.

In addition to this change in layout.cpp and chord.cpp, there are some further tweaks to the slur layout in slur.cpp to make sure we get the endpoints right in the presence of all the various combinations of articulations and stem directions (only certain combinations worked correctly before).  A side benefit is that we actually do manage to tuck articulations inside the slur at the endpoints where there is room (see fourth measure in example below), which is also recommended by Gould.

There are no doubt other quibbles with the specifics of the layout of particular elements, but again, I believe this is the last necessary change to the basic layout order itself.  The effect is not necessarily dramatic but there are definitely cases where it makes a big difference, as in the second measure below.

Here is the before:

![image](https://user-images.githubusercontent.com/1799936/50050934-5bc97f00-00c5-11e9-99dd-a8166fe3c1dd.png)

And there is the after:

![image](https://user-images.githubusercontent.com/1799936/50050937-65eb7d80-00c5-11e9-88ff-f1ae1f1cb5c7.png)

Although I know timing is tight, I would love for this PR to be reviewed and merged for the initial release of 3.0.  That way we don't end up with people making inappropriate manual adjustments that need to be corrected later.
