### PR TITLE
Key signatures problems

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2684,7 +2684,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
                               Measure* pm = mi->prevMeasure();
                               if (pm) {
                                     Segment* ps = pm->findSegment(SegmentType::Clef, tick);
-                                    if (ps) {
+                                    if (ps && ps->enabled()) {
                                           Element* pc = ps->element(staffIdx * VOICES);
                                           if (pc) {
                                                 pcl.push_back(toClef(pc));
@@ -2695,7 +2695,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
                                           }
                                     }
                               for (Segment* s = mi->first(); s && s->rtick() == 0; s = s->next()) {
-                                    if (s->isHeaderClefType())
+                                    if (s->isHeaderClefType() || !s->enabled())
                                           continue;
                                     Element* e = s->element(staffIdx * VOICES);
                                     if (!e)
@@ -3461,6 +3461,7 @@ void Score::undoChangeKeySig(Staff* ostaff, int tick, KeySigEvent key)
                   continue;
                   }
             Segment* s   = measure->undoGetSegment(SegmentType::KeySig, tick);
+
             int staffIdx = staff->idx();
             int track    = staffIdx * VOICES;
             KeySig* ks   = toKeySig(s->element(track));

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -261,6 +261,14 @@ Segment* Segment::next1MM(SegmentType types) const
       return 0;
       }
 
+Segment* Segment::next1MMenabled() const
+      {
+      Segment* s = next1MM();
+      while (s && !s->enabled())
+            s = s->next1MM();
+      return s;
+      }
+
 //---------------------------------------------------------
 //   next
 //    got to next segment which has subtype in types
@@ -303,12 +311,28 @@ Segment* Segment::prev1() const
       return m ? m->last() : 0;
       }
 
+Segment* Segment::prev1enabled() const
+      {
+      Segment* s = prev1();
+      while (s && !s->enabled())
+            s = s->prev1();
+      return s;
+      }
+
 Segment* Segment::prev1MM() const
       {
       if (prev())
             return prev();
       Measure* m = measure()->prevMeasureMM();
       return m ? m->last() : 0;
+      }
+
+Segment* Segment::prev1MMenabled() const
+      {
+      Segment* s = prev1MM();
+      while (s && !s->enabled())
+            s = s->prev1MM();
+      return s;
       }
 
 Segment* Segment::prev1(SegmentType types) const

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1249,7 +1249,7 @@ Element* Segment::firstInNextSegments(int activeStaff)
       Element* re = 0;
       Segment* seg = this;
       while (!re) {
-            seg = seg->next1MM(SegmentType::All);
+            seg = seg->next1MMenabled();
             if (!seg) //end of staff, or score
                   break;
 
@@ -1517,12 +1517,12 @@ Element* Segment::nextElement(int activeStaff)
                         if (s)
                               return s->spannerSegments().front();
                         }
-                  Segment* nextSegment = this->next1();
+                  Segment* nextSegment = this->next1enabled();
                   while (nextSegment) {
                         Element* nextEl = nextSegment->firstElementOfSegment(nextSegment, activeStaff);
                         if (nextEl)
                               return nextEl;
-                        nextSegment = nextSegment->next1();
+                        nextSegment = nextSegment->next1enabled();
                         }
                   break;
                   }
@@ -1536,12 +1536,12 @@ Element* Segment::nextElement(int activeStaff)
                   if (sp)
                         return sp->spannerSegments().front();
 
-                  Segment* nextSegment = this->next1();
+                  Segment* nextSegment = this->next1enabled();
                   while (nextSegment) {
                         Element* nextEl = nextSegment->firstElementOfSegment(nextSegment, activeStaff);
                         if (nextEl)
                               return nextEl;
-                        nextSegment = nextSegment->next1();
+                        nextSegment = nextSegment->next1enabled();
                         }
                   break;
                   }
@@ -1576,12 +1576,12 @@ Element* Segment::nextElement(int activeStaff)
                   Spanner* s = firstSpanner(activeStaff);
                   if (s)
                         return s->spannerSegments().front();
-                  Segment* nextSegment =  seg->next1();
+                  Segment* nextSegment =  seg->next1enabled();
                   while (nextSegment) {
                         nextEl = nextSegment->firstElementOfSegment(nextSegment, activeStaff);
                         if (nextEl)
                               return nextEl;
-                        nextSegment = nextSegment->next1();
+                        nextSegment = nextSegment->next1enabled();
                         }
                   }
                   break;
@@ -1630,7 +1630,7 @@ Element* Segment::prevElement(int activeStaff)
                          el = s->element(--track);
                          if (track == 0) {
                                track = score()->nstaves() * VOICES - 1;
-                               s = s->prev1();
+                               s = s->prev1enabled();
                                }
                          }
                    if (el->staffIdx() != activeStaff)
@@ -1700,13 +1700,13 @@ Element* Segment::prevElement(int activeStaff)
                               return prev;
                               }
                         }
-                   Segment* prevSeg = seg->prev1();
+                   Segment* prevSeg = seg->prev1enabled();
                    if (!prevSeg)
                          return score()->lastElement();
 
                    prev = lastElementOfSegment(prevSeg, activeStaff);
                    while (!prev && prevSeg) {
-                         prevSeg = prevSeg->prev1();
+                         prevSeg = prevSeg->prev1enabled();
                          prev = lastElementOfSegment(prevSeg, activeStaff);
                          }
                    if (!prevSeg)
@@ -1765,7 +1765,7 @@ Element* Segment::lastInPrevSegments(int activeStaff)
       Segment* seg = this;
 
       while (!re) {
-            seg = seg->prev1MM(SegmentType::All);
+            seg = seg->prev1MMenabled();
             if (!seg) //end of staff, or score
                   break;
 
@@ -1788,7 +1788,7 @@ Element* Segment::lastInPrevSegments(int activeStaff)
                   if ((re = seg->lastElement(activeStaff -1)) != 0)
                         return re;
 
-                  seg = seg->prev1(SegmentType::All);
+                  seg = seg->prev1enabled();
                   }
             }
 

--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -130,11 +130,14 @@ class Segment final : public Element {
       Segment* next1() const;
       Segment* next1enabled() const;
       Segment* next1MM() const;
+      Segment* next1MMenabled() const;
       Segment* next1(SegmentType) const;
       Segment* next1MM(SegmentType) const;
 
       Segment* prev1() const;
+      Segment* prev1enabled() const;
       Segment* prev1MM() const;
+      Segment* prev1MMenabled() const;
       Segment* prev1(SegmentType) const;
       Segment* prev1MM(SegmentType) const;
 

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1586,7 +1586,7 @@ void InsertRemoveMeasures::insertMeasures()
             fs = toMeasure(fm)->first();
             ls = toMeasure(lm)->last();
             for (Segment* s = fs; s && s != ls; s = s->next1()) {
-                  if (!(s->segmentType() & (SegmentType::Clef | SegmentType::KeySig)))
+                  if (!s->enabled() || !(s->segmentType() & (SegmentType::Clef | SegmentType::KeySig)))
                         continue;
                   for (int track = 0; track < score->ntracks(); track += VOICES) {
                         Element* e = s->element(track);

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -355,11 +355,12 @@ class ChangeKeySig : public UndoCommand {
       KeySig* keysig;
       KeySigEvent ks;
       bool showCourtesy;
+      bool evtInStaff;
 
       void flip(EditData*) override;
 
    public:
-      ChangeKeySig(KeySig* k, KeySigEvent newKeySig, bool sc) : keysig(k), ks(newKeySig), showCourtesy(sc) {}
+      ChangeKeySig(KeySig* k, KeySigEvent newKeySig, bool sc, bool addEvtToStaff = true);
       UNDO_NAME("ChangeKeySig")
       };
 


### PR DESCRIPTION
This pull request is an attempt to address a number of issues related to key signatures. The [issue #279096](https://musescore.org/en/node/279096) is handled by altering the code for `ChangeKeySig` undo command which allows to address both the original issue and the related issues on undoing key signature changes. For other issues @MarcSabatella's commits from #4353 are taken. The commit on accessibility navigation was slightly edited to replace the remaining explicit loops skipping disabled segments to single function calls.

I tried some other options to resolve these issues including removing disabled segments at all but this leads to a number of other issues so such changes should be even larger than I initially thought. While I still assume it may be good to do such change as it can potentially allow to do all handling of system headers/trailers in a very limited number of places, this change seems to need some more consideration and more testing. So I came to this PR which seems to resolve the known key signatures issues.