### PR TITLE
Fix #280048: Applying changed preferences restores default UI

### DIFF
--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -922,6 +922,11 @@ void Workspace::readGlobalGUIState()
 
 void Workspace::save()
       {
+      if (!saveComponents)
+            writeGlobalGUIState();
+      if (!saveToolbars)
+            writeGlobalToolBar();
+
       if (_readOnly)
             return;
       PaletteBox* pb = mscore->getPaletteBox();


### PR DESCRIPTION
Before a switch is made, save the global values if used.