### PR TITLE
Noteline

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -327,6 +327,8 @@ void Score::cmdAddSpanner(Spanner* spanner, int staffIdx, Segment* startSegment,
       int track = staffIdx * VOICES;
       spanner->setTrack(track);
       spanner->setTrack2(track);
+      for (auto ss : spanner->spannerSegments())
+            ss->setTrack(track);
       spanner->setTick(startSegment->tick());
       int tick2;
       if (!endSegment)

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -1288,6 +1288,9 @@ void SpannerSegment::autoplaceSpannerSegment(qreal minDistance)
       if (isStyled(Pid::OFFSET))
             setOffset(spanner()->propertyDefault(Pid::OFFSET).toPointF());
 
+      if (spanner()->anchor() == Spanner::Anchor::NOTE)
+            return;
+
       if (visible() && autoplace()) {
             SkylineLine sl(!spanner()->placeAbove());
             sl.add(shape().translated(pos()));


### PR DESCRIPTION
The original fix in https://github.com/musescore/MuseScore/commit/c489ea507aca07923f57c1ac258872609980fe90 had the right idea and probably fixed some cases, but for lines added by double-click on a single selection, the track was not actually set yet for the spanner, so copying it to the segments didn't help.  In this case, we "read' the spanner from the palette item, and in this case, generate a segment right away, then add the spanner, rather than adding the spanner first then generating segments later.  So all this fix does

There is a problem with "note anchored lines" (found in Add / Lines only) that appears related - added line is displayed above top staff no matter what - but in fact it is not.  In this case, the line is actually attached and laid out correctly, but autoplace is moving it to the top of the system.  There is no good reason to autoplace these - they need to connect the notes directly.  So the second commit in this PR simply skips these lines during autoplace.