### PR TITLE
fix shape of key signatures

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -262,6 +262,26 @@ void KeySig::layout()
       }
 
 //---------------------------------------------------------
+//   shape
+//---------------------------------------------------------
+
+Shape KeySig::shape() const
+      {
+      QRectF box(bbox());
+      const Staff* st = staff();
+      if (st && autoplace() && visible()) {
+            // Extend key signature shape up and down to
+            // the first ledger line height to ensure that
+            // no notes will be too close to the keysig.
+            const qreal sp = spatium();
+            const qreal y = pos().y();
+            box.setTop(std::min(-sp - y, box.top()));
+            box.setBottom(std::max(st->height() - y + sp, box.bottom()));
+            }
+      return Shape(box);
+      }
+
+//---------------------------------------------------------
 //   set
 //---------------------------------------------------------
 

--- a/libmscore/keysig.h
+++ b/libmscore/keysig.h
@@ -43,6 +43,7 @@ class KeySig final : public Element {
       virtual bool acceptDrop(EditData&) const override;
       virtual Element* drop(EditData&) override;
       virtual void layout() override;
+      virtual Shape shape() const override;
       virtual qreal mag() const override;
 
       //@ sets the key of the key signature

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -354,7 +354,7 @@ Shape TimeSig::shape() const
       {
       QRectF box(bbox());
       const Staff* st = staff();
-      if (st && autoplace()) {
+      if (st && autoplace() && visible()) {
             // Extend time signature shape up and down to
             // the first ledger line height to ensure that
             // no notes will be too close to the timesig.


### PR DESCRIPTION
The original issue was about notes overlapping start repeats, but for whatever reason, my first attempt at extending the barline shape the same way Dmitriy did for time signatures didn't work (see Barline::shape() isn't called normally?)

But, I also realized key signatures have the same problem, so here is the time sig fix copied over to keysigs.