### PR TITLE
fix #280186: forbid setting font size below 1pt in Inspector

### DIFF
--- a/mscore/inspector/inspector_bend.ui
+++ b/mscore/inspector/inspector_bend.ui
@@ -165,6 +165,9 @@
         <property name="suffix">
          <string>pt</string>
         </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
        </widget>
       </item>
       <item row="3" column="0">

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -223,6 +223,9 @@
         <property name="suffix">
          <string>pt</string>
         </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
        </widget>
       </item>
       <item row="7" column="0">

--- a/mscore/inspector/inspector_text.ui
+++ b/mscore/inspector/inspector_text.ui
@@ -138,6 +138,9 @@
            <property name="suffix">
             <string>pt</string>
            </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
           </widget>
          </item>
          <item row="0" column="1">

--- a/mscore/inspector/inspector_textlinebase.ui
+++ b/mscore/inspector/inspector_textlinebase.ui
@@ -261,6 +261,9 @@
            <property name="suffix">
             <string>pt</string>
            </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
           </widget>
          </item>
          <item row="5" column="0">
@@ -506,6 +509,9 @@
            </property>
            <property name="suffix">
             <string>pt</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
            </property>
           </widget>
          </item>
@@ -776,6 +782,9 @@
            </property>
            <property name="suffix">
             <string>pt</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
            </property>
           </widget>
          </item>

--- a/mscore/inspector/inspector_tuplet.ui
+++ b/mscore/inspector/inspector_tuplet.ui
@@ -108,6 +108,9 @@
         <property name="suffix">
          <string>pt</string>
         </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
        </widget>
       </item>
       <item row="0" column="0" colspan="2">


### PR DESCRIPTION
This PR sets lower bound for font size combo boxes in Inspector to 1pt. Setting font size below that value does not make sense and [leads to crashes](https://musescore.org/en/node/280186).