### PR TITLE
fix #279570: fix incorrect merging of tied notes on timesig change

### DIFF
--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -174,8 +174,7 @@ void TrackList::append(Element* e)
                                    }
                               if (akkumulateChord && back()->isChord()) {
                                     Chord* bc   = toChord(back());
-                                    Fraction du = bc->duration();
-                                    du += bc->duration();
+                                    const Fraction du = bc->duration() + chord->duration();
                                     bc->setDuration(du);
 
                                     // forward ties


### PR DESCRIPTION
Fixes https://musescore.org/en/node/279570 by correcting the code for calculating duration of the note being merged from several tied notes on time signature change.