### PR TITLE
fix #280208: hairpin should not normally cross barline to meet note

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -112,9 +112,8 @@ void HairpinSegment::layout()
                         const qreal edLeft  = ed->bbox().left() + ed->pos().x()
                                               + ed->segment()->pos().x() + ed->measure()->pos().x();
                         const qreal dist    = edLeft - pos2().x() - pos().x() - score()->styleP(Sid::autoplaceHairpinDynamicsDistance);
-                        rxpos2() += dist;
-                        // TODO - don't extend hairpin across barline to reach dynamic in next measure?
-                        // or only if there is also a key signature? see Gould
+                        if (dist < 0.0 || dist >= 3.0 * spatium())
+                              rxpos2() += dist;
                         }
                   }
             }


### PR DESCRIPTION
As mentioned in the issue, probably there should be a style setting for this, but the same can be said about a lot of numbers we determine empirically.  Can always be added later.  For now, this does the job nicely, it keeps the hairpin on its own side of the barline most of the time, but it crosses if there is much more than a single accidental between the barline and first note.