### PR TITLE
fix #280215: reset edited element pointer in ScoreView on element destruction

### DIFF
--- a/libmscore/mscoreview.h
+++ b/libmscore/mscoreview.h
@@ -73,6 +73,8 @@ class MuseScoreView {
       virtual void lyricsMinus()  {}
       virtual void lyricsUnderscore()  {}
 
+      virtual void onElementDestruction(Element*) {}
+
       virtual const QRect geometry() const = 0;
       };
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -372,6 +372,8 @@ void Score::onElementDestruction(Element* e)
             return;
             }
       score->selection().remove(e);
+      for (MuseScoreView* v : score->viewer)
+            v->onElementDestruction(e);
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4406,6 +4406,16 @@ Element* ScoreView::getEditElement()
       }
 
 //---------------------------------------------------------
+//   onElementDestruction
+//---------------------------------------------------------
+
+void ScoreView::onElementDestruction(Element* e)
+      {
+      if (editData.element == e)
+            editData.element = nullptr;
+      }
+
+//---------------------------------------------------------
 //   startNoteEntryMode
 //---------------------------------------------------------
 

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -392,6 +392,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void setOmrView(OmrView* v)     { _omrView = v;    }
       FotoLasso* fotoLasso() const    { return _foto;    }
       Element* getEditElement();
+      void onElementDestruction(Element*) override;
 
       virtual Element* elementNear(QPointF);
 //      void editFretDiagram(FretDiagram*);


### PR DESCRIPTION
This is another quick and lazy fix for another problem with using pointers to destroyed elements. Some more correct management of objects lifetime would be very desirable but this fix at least prevents some more crashes that arise from this problem.

Fixes https://musescore.org/en/node/280215, complements 247802bb9406d734c7e8efb8fb2726fb995e39e5.