### PR TITLE
fix #280220: slurs should not adjust just to avoid barlines

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -368,17 +368,20 @@ void SlurSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
             for (Segment* s = fs; s && s != ls; s = s->next1()) {
                   if (!s->enabled())
                         continue;
+                  // skip start and end segments on assumption start and end points were placed well already
+                  // this avoids overcorrection on collision with own ledger lines and accidentals
+                  // it also avoids issues where slur appears to be attached to a note in a different voice
+                  if (s == ss || s == es)
+                        continue;
+                  // allow slurs to cross barlines
+                  if (s->segmentType() & SegmentType::BarLineType)
+                        continue;
                   qreal x1 = s->x() + s->measure()->x();
                   qreal x2 = x1 + s->width();
                   if (pp1.x() > x2)
                         continue;
                   if (pp2.x() < x1)
                         break;
-                  // skip start and end segments on assumption start and end points were placed well already
-                  // this avoids overcorrection on collision with own ledger lines and accidentals
-                  // it also avoids issues where slur appears to be attached to a note in a different voice
-                  if (s == ss || s == es)
-                        continue;
                   const Shape& segShape = s->staffShape(staffIdx()).translated(s->pos() + s->measure()->pos());
                   if (!intersection)
                         intersection = segShape.intersects(_shape);


### PR DESCRIPTION
Ideally, we would be able to reshape slurs in autoplace rather than just move them up, then we could at least consider avoiding barlines.  But given there seems to be no rule against it and the results are definitely very bad when we adjust a slur for no other reason, this PR skips barline segments when checking for intersections, thus allowing slur layout in https://musescore.org/en/node/280220 to look like the second picture by default rather than requiring you to turn off autoplacement.

It's still the case that if there is an intersection anywhere else, we're going to end up moving the whole slur above the staff.  That's something we will need to fix soon too, but I don't see an easy / safe way and I'm willing to live with that for now.