### PR TITLE
fix #273302: Fermata loses assignment to voice and direction

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -472,6 +472,7 @@ Element* ChordRest::drop(EditData& data)
                         }
 
             case ElementType::FERMATA:
+                  e->setPlacement(track() & 1 ? Placement::BELOW : Placement::ABOVE);
                   for (Element* el: segment()->annotations())
                         if (el->isFermata() && (el->track() == track())) {
                               if (el->subtype() == e->subtype()) {
@@ -479,8 +480,7 @@ Element* ChordRest::drop(EditData& data)
                                     return el;
                                     }
                               else {
-                                    if (el->placeBelow())
-                                          e->setPlacement(Placement::BELOW);
+                                    e->setPlacement(el->placement());
                                     e->setTrack(track());
                                     e->setParent(segment());
                                     score()->undoChangeElement(el, e);

--- a/libmscore/fermata.cpp
+++ b/libmscore/fermata.cpp
@@ -309,7 +309,7 @@ QVariant Fermata::propertyDefault(Pid propertyId) const
       {
       switch (propertyId) {
             case Pid::PLACEMENT:
-                  return int(Placement::ABOVE);
+                  return int(track() & 1 ? Placement::BELOW : Placement::ABOVE);
             case Pid::TIME_STRETCH:
                   return 1.0; // articulationList[int(articulationType())].timeStretch;
             case Pid::PLAY:

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2260,6 +2260,8 @@ void Measure::readVoice(XmlReader& e, int staffIdx, bool irregular)
                   // hack - needed because tick tags are unreliable in 1.3 scores
                   // for symbols attached to anything but a measure
                   el->setTrack(e.track());
+                  if (el->isFermata())
+                        el->setPlacement(el->track() & 1 ? Placement::BELOW : Placement::ABOVE);
                   el->read(e);
                   segment = getSegment(SegmentType::ChordRest, e.tick());
                   segment->add(el);

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -334,6 +334,8 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                            ) {
                               Element* el = Element::name2Element(tag, this);
                               el->setTrack(e.track());      // a valid track might be necessary for el->read() to work
+                              if (el->isFermata())
+                                    el->setPlacement(el->track() & 1 ? Placement::BELOW : Placement::ABOVE);
                               el->read(e);
 
                               Measure* m = tick2measure(e.tick());

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2457,6 +2457,8 @@ Element* readArticulation(ChordRest* cr, XmlReader& e)
       SymId sym = SymId::fermataAbove;          // default -- backward compatibility (no type = ufermata in 1.2)
       ArticulationAnchor anchor  = ArticulationAnchor::TOP_STAFF;
       Direction direction = Direction::AUTO;
+      double timeStretch = 0.0;
+      bool useDefaultPlacement = true;
 
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
@@ -2506,6 +2508,8 @@ Element* readArticulation(ChordRest* cr, XmlReader& e)
                                           sym       = al[i].id;
                                           bool up   = al[i].up;
                                           direction = up ? Direction::UP : Direction::DOWN;
+                                          if ((direction == Direction::DOWN) != (cr->track() & 1))
+                                                useDefaultPlacement = false;
                                           break;
                                           }
                                     }
@@ -2526,7 +2530,6 @@ Element* readArticulation(ChordRest* cr, XmlReader& e)
                         case SymId::fermataVeryLongAbove:
                         case SymId::fermataVeryLongBelow:
                               el = new Fermata(sym, cr->score());
-                              setFermataPlacement(el, anchor, direction);
                               break;
                         default:
                               el = new Articulation(sym, cr->score());
@@ -2535,32 +2538,21 @@ Element* readArticulation(ChordRest* cr, XmlReader& e)
                         };
                   }
             else if (tag == "anchor") {
-                  if (!el)
+                  useDefaultPlacement = false;
+                  if (!el || el->isFermata())
                         anchor = ArticulationAnchor(e.readInt());
-                  else {
-                        if (el->isFermata()) {
-                              anchor = ArticulationAnchor(e.readInt());
-                              setFermataPlacement(el, anchor, direction);
-                              }
-                        else
-                              el->readProperties(e);
-                        }
+                  else
+                        el->readProperties(e);
                   }
             else  if (tag == "direction") {
-                  if (!el)
+                  useDefaultPlacement = false;
+                  if (!el || el->isFermata())
                         direction = toDirection(e.readElementText());
-                  else {
-                        if (!el->isFermata())
-                              el->readProperties(e);
-                        }
+                  else
+                        el->readProperties(e);
                   }
             else if (tag == "timeStretch") {
-                  if (el && el->isFermata())
-                        el->setProperty(Pid::TIME_STRETCH ,e.readDouble());
-                  else {
-                        qDebug("line %lld: read206: skipping <timeStretch>", e.lineNumber());
-                        e.skipCurrentElement();
-                        }
+                  timeStretch = e.readDouble();
                   }
             else {
                   if (!el) {
@@ -2571,9 +2563,15 @@ Element* readArticulation(ChordRest* cr, XmlReader& e)
                   }
             }
       // Special case for "no type" = ufermata, with missing subtype tag
-      if (!el) {
+      if (!el)
             el = new Fermata(sym, cr->score());
-            setFermataPlacement(el, anchor, direction);
+      if (el->isFermata()) {
+            if (timeStretch != 0.0)
+                  el->setProperty(Pid::TIME_STRETCH, timeStretch);
+            if (useDefaultPlacement)
+                  el->setPlacement(cr->track() & 1 ? Placement::BELOW : Placement::ABOVE);
+            else
+                  setFermataPlacement(el, anchor, direction);
             }
       el->setTrack(cr->track());
       return el;


### PR DESCRIPTION
See https://musescore.org/en/node/273302.

This will set the placement for fermatas added to voice 2 or voice 4 to Placement::BELOW by default. But if there is already a fermata in the segment for that track, the new fermata will take on the placement of the old fermata before replacing it. setPlacement() is called after setTrack() and before Fermata::read(), so that the default placement can be set based on the track, but a manual adjustment to the placement will be honored.