### PR TITLE
fix #280012: Crash fix for reading old MuseScore 206 files with tremo…

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3697,7 +3697,7 @@ static bool readScore(Score* score, XmlReader& e)
                   ms->setShowOmr(false);
             ms->rebuildMidiMapping();
             ms->updateChannel();
-            ms->createPlayEvents();
+ //           ms->createPlayEvents();
             }
       return true;
       }


### PR DESCRIPTION
…los.

Don't call createPlayEvents() at the end at of readScore() in read206.cpp anymore. This call tries to access tremolo objects without proper settings of their members.

I have done this in parallel to commit fedb04b66e6f1825b45c91b750eec84790a36867.

Please review thoroughly, I am not sure, that I understood what I did :-)