### PR TITLE
fix #278964: rework duration types handling with tremolo

### DIFF
--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -138,7 +138,7 @@ class Chord final : public ChordRest {
       Stem* stem() const                     { return _stem; }
       Arpeggio* arpeggio() const             { return _arpeggio;  }
       Tremolo* tremolo() const               { return _tremolo;   }
-      void setTremolo(Tremolo* t)            { _tremolo = t;      }
+      void setTremolo(Tremolo* t);
       bool endsGlissando() const             { return _endsGlissando; }
       void setEndsGlissando (bool val)       { _endsGlissando = val; }
       void updateEndsGlissando();

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2334,6 +2334,50 @@ void layoutDrumsetChord(Chord* c, const Drumset* drumset, const StaffType* st, q
       }
 
 //---------------------------------------------------------
+//   connectTremolo
+//    Connect two-notes tremolo and update duration types
+//    for the involved chords.
+//---------------------------------------------------------
+
+static void connectTremolo(Measure* m)
+      {
+      const int ntracks = m->score()->ntracks();
+      constexpr SegmentType st = SegmentType::ChordRest;
+      for (Segment* s = m->first(st); s; s = s->next(st)) {
+            for (int i = 0; i < ntracks; ++i) {
+                  Element* e = s->element(i);
+                  if (!e || !e->isChord())
+                        continue;
+
+                  Chord* c = toChord(e);
+                  Tremolo* tremolo = c->tremolo();
+                  if (tremolo && tremolo->twoNotes()) {
+                        // Ensure correct duration type for chord
+                        c->setDurationType(tremolo->durationType());
+
+                        // If it is the first tremolo's chord, find the second
+                        // chord for tremolo, if needed.
+                        if (!tremolo->chord1())
+                              tremolo->setChords(c, tremolo->chord2());
+                        else if (tremolo->chord1() != c || tremolo->chord2())
+                              continue;
+
+                        for (Segment* ls = s->next(st); ls; ls = ls->next(st)) {
+                              if (Element* element = ls->element(i)) {
+                                    if (!element->isChord())
+                                          qDebug("cannot connect tremolo");
+                                    Chord* nc = toChord(element);
+                                    tremolo->setChords(c, nc);
+                                    nc->setTremolo(tremolo);
+                                    break;
+                                    }
+                              }
+                        }
+                  }
+            }
+      }
+
+//---------------------------------------------------------
 //   getNextMeasure
 //---------------------------------------------------------
 
@@ -2406,6 +2450,8 @@ void Score::getNextMeasure(LayoutContext& lc)
       //
       if (measure->sectionBreak() && measure->pause() != 0.0)
             setPause(measure->endTick(), measure->pause());
+
+      connectTremolo(measure);
 
       //
       // calculate accidentals and note lines,

--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -13,6 +13,7 @@
 #include "score.h"
 #include "page.h"
 #include "system.h"
+#include "tremolo.h"
 #include "measure.h"
 #include "layout.h"
 #include "bracket.h"

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -23,7 +23,6 @@
 #include "noteevent.h"
 #include "pitchspelling.h"
 #include "shape.h"
-#include "tremolo.h"
 #include "key.h"
 
 namespace Ms {

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1065,6 +1065,7 @@ static void readChord(Measure* m, Chord* chord, XmlReader& e)
                   }
             else if (tag == "Tremolo") {
                   Tremolo* tremolo = new Tremolo(chord->score());
+                  tremolo->setDurationType(chord->durationType());
                   chord->setTremolo(tremolo);
                   tremolo->setTrack(chord->track());
                   readTremolo(tremolo, e);

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1991,6 +1991,7 @@ bool readChordProperties206(XmlReader& e, Chord* ch)
             tremolo->setTrack(ch->track());
             tremolo->read(e);
             tremolo->setParent(ch);
+            tremolo->setDurationType(ch->durationType());
             ch->setTremolo(tremolo);
             }
       else if (tag == "tickOffset")       // obsolete

--- a/libmscore/tremolo.cpp
+++ b/libmscore/tremolo.cpp
@@ -53,6 +53,7 @@ Tremolo::Tremolo(const Tremolo& t)
       setTremoloType(t.tremoloType());
       _chord1  = t.chord1();
       _chord2  = t.chord2();
+      _durationType = t._durationType;
       }
 
 //---------------------------------------------------------
@@ -243,6 +244,8 @@ void Tremolo::layout()
       //
       // two chord tremolo
       //
+
+#if 0 // Needs to be done earlier, see connectTremolo in layout.cpp
       Segment* s = _chord1->segment()->next();
       while (s) {
             if (s->element(track()) && (s->element(track())->isChord()))
@@ -256,6 +259,7 @@ void Tremolo::layout()
 
       _chord2 = toChord(s->element(track()));
       _chord2->setTremolo(this);
+#endif
 
       Stem* stem1 = _chord1->stem();
       Stem* stem2 = _chord2->stem();

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -13,6 +13,7 @@
 #ifndef __TREMOLO_H__
 #define __TREMOLO_H__
 
+#include "durationtype.h"
 #include "symbol.h"
 
 namespace Ms {
@@ -34,6 +35,7 @@ class Tremolo final : public Element {
       TremoloType _tremoloType;
       Chord* _chord1;
       Chord* _chord2;
+      TDuration _durationType;
       QPainterPath path;
 
       int _lines;       // derived from _subtype
@@ -66,6 +68,9 @@ class Tremolo final : public Element {
 
       Chord* chord1() const { return _chord1; }
       Chord* chord2() const { return _chord2; }
+
+      TDuration durationType() const { return _durationType; }
+      void setDurationType(TDuration d) { _durationType = d; }
 
       void setChords(Chord* c1, Chord* c2) {
             _chord1 = c1;


### PR DESCRIPTION
This PR is intended to fix the issue [280095](https://musescore.org/en/node/280095) but the way of fixing this (setting some chords for tremolo on chord cloning) required some changes in handling duration types for chords with tremolos to get meaningful results on cloning parts. Such changes allowed also to resolve the issue [278964](https://musescore.org/en/node/278964).

The proposed changes make `Tremolo` store duration type for its chords. This allows more easy way to maintain consistent state of the tremoloed chords' duration types regardless of the order of assignments (chords to tremolo or tremolo to chords etc.) and other operations with duration types happening, for example, in copy-paste operations.