### PR TITLE
fix #276295: put signatures in <voice> tag when saving selection

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1248,6 +1248,8 @@ void Score::writeSegments(XmlWriter& xml, int strack, int etrack,
                   if (e->generated())
                         continue;
                   if (forceTimeSig && track2voice(track) == 0 && segment->segmentType() == SegmentType::ChordRest && !timeSigWritten && !crWritten) {
+                        // Ensure that <voice> tag is open
+                        voiceTagWritten |= writeVoiceMove(xml, segment, startTick, track, &lastTrackWritten);
                         // we will miss a key sig!
                         if (!keySigWritten) {
                               Key k = score()->staff(track2staff(track))->key(segment->tick());


### PR DESCRIPTION
This PR fixes the issue [276295](https://musescore.org/en/node/276295) which is an unintentional side effect of my summer's #3870. Not forgetting to include the written key and time signatures to `<voice>` tags fixes this issue.