### PR TITLE
fix #278128: move text with cursor keys again

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1018,8 +1018,8 @@ void Harmony::layout()
             setOffset(0.0, 0.0);
             return;
             }
-      if (isStyled(Pid::OFFSET))
-            setOffset(propertyDefault(Pid::OFFSET).toPointF());
+      //if (isStyled(Pid::OFFSET))
+      //      setOffset(propertyDefault(Pid::OFFSET).toPointF());
 
       qreal yy = 0.0;
       qreal xx = 0.0;

--- a/libmscore/measurenumber.cpp
+++ b/libmscore/measurenumber.cpp
@@ -60,8 +60,8 @@ void MeasureNumber::layout()
       setPos(QPointF());
       if (!parent())
             setOffset(0.0, 0.0);
-      else if (isStyled(Pid::OFFSET))
-            setOffset(propertyDefault(Pid::OFFSET).toPointF());
+      //else if (isStyled(Pid::OFFSET))
+      //      setOffset(propertyDefault(Pid::OFFSET).toPointF());
 
       const StaffType* st = staff()->constStaffType(measure()->tick());
       if (st->lines() == 1 && staff())

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1928,7 +1928,7 @@ void ScoreView::cmd(const char* s)
          || cmd == "next-measure"
          || cmd == "prev-measure") {
             Element* el = score()->selection().element();
-            if (el && (el->isText())) {
+            if (el && (el->isTextBase())) {
                   score()->startCmd();
                   if (cmd == "prev-chord")
                         el->undoChangeProperty(Pid::OFFSET, el->offset() - QPointF (MScore::nudgeStep * el->spatium(), 0.0));


### PR DESCRIPTION
Silly typo prevented this from working for text not of actual "Text" type.  With that fixed, all is good except chord symbols for whatever reaosn don't work - the change property of offset just keeps getting ignored (and I tried turning autoplace off, no difference).  Actually, I might guess it's because of changes I made recently to keep them from jumping up and down all the time.  Probably fixable, but getting *other* text* working is too important to hold up on account of chord symbols.