### PR TITLE
fix #280338: Changed fullscreen state to ~STATE_TEXT_EDIT

### DIFF
--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2689,7 +2689,7 @@ Shortcut Shortcut::_sc[] = {
 #endif
       {
          MsWidget::MAIN_WINDOW,
-         STATE_NORMAL & (~STATE_TEXT_EDIT),
+         ~STATE_TEXT_EDIT,
          "fullscreen",
          QT_TRANSLATE_NOOP("action","Full Screen"),
          QT_TRANSLATE_NOOP("action","Full screen")


### PR DESCRIPTION
Fixes https://musescore.org/en/node/280338

I don't know if allowing entering and exiting full screen has undesirable side effects, but I didn't notice anything other than the conflict with underlining while editing text. It wasn't previously possible to enter full screen while playing something, for example, but I tested it and it seemed to work fine.