### PR TITLE
fix tuning offset for Sori and Koron

### DIFF
--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -126,8 +126,8 @@ static Acc accList[] = {
       Acc(AccidentalVal::NATURAL,    0,    SymId::accidentalQuarterSharpEqualTempered),
 
       // Persian
-      Acc(AccidentalVal::NATURAL, 50,   SymId::accidentalSori),                          // SORI
-      Acc(AccidentalVal::NATURAL, -50,  SymId::accidentalKoron),                         // KORON
+      Acc(AccidentalVal::NATURAL, 33,   SymId::accidentalSori),                          // SORI
+      Acc(AccidentalVal::NATURAL, -67,  SymId::accidentalKoron),                         // KORON
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
These settings are currently completly ignored by musescore, but should
get set correctly anyhow, just in case playback for those ever gets
implemented.
Sori is not a quarter tone up, but 1/3 semitone up
Koron is not a quarter tone down, but 2/3 semitones down.