### PR TITLE
fix #280092, fix #279183, fix #279676: clefs-related issues

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2702,7 +2702,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
                                           }
                                     }
                               for (Segment* s = mi->first(); s && s->rtick() == 0; s = s->next()) {
-                                    if (s->isHeaderClefType() || !s->enabled())
+                                    if (!s->enabled())
                                           continue;
                                     Element* e = s->element(staffIdx * VOICES);
                                     if (!e)
@@ -2750,7 +2750,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
                         }
                   for (Clef* clef : cl) {
                         Clef* nClef = new Clef(*clef);
-                        Segment* s  = m->undoGetSegmentR(SegmentType::Clef, 0);
+                        Segment* s  = m->undoGetSegmentR(SegmentType::HeaderClef, 0);
                         nClef->setParent(s);
                         undoAddElement(nClef);
                         }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1791,6 +1791,27 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                   }
             }
 
+      Segment* clefSeg = lm->findSegmentR(SegmentType::Clef | SegmentType::HeaderClef, lm->ticks());
+      if (clefSeg) {
+            Segment* mmrClefSeg = mmr->undoGetSegment(clefSeg->segmentType(), lm->endTick());
+            for (int staffIdx = 0; staffIdx < nstaves(); ++staffIdx) {
+                  const int track = staff2track(staffIdx);
+                  Element* e = clefSeg->element(track);
+                  if (e && e->isClef()) {
+                        Clef* clef = toClef(e);
+                        if (!mmrClefSeg->element(track)) {
+                              Clef* mmrClef = clef->clone();
+                              mmrClef->setParent(mmrClefSeg);
+                              undoAddElement(mmrClef);
+                              }
+                        else {
+                              Clef* mmrClef = toClef(mmrClefSeg->element(track));
+                              mmrClef->setClefType(clef->clefType());
+                              }
+                        }
+                  }
+            }
+
       mmr->setRepeatStart(m->repeatStart() || lm->repeatStart());
       mmr->setRepeatEnd(m->repeatEnd() || lm->repeatEnd());
 

--- a/libmscore/range.cpp
+++ b/libmscore/range.cpp
@@ -557,12 +557,12 @@ bool TrackList::write(Score* score, int tick) const
                   Segment* seg;
                   if (remains == m->len() && m->tick() > 0) {
                         Measure* pm = m->prevMeasure();
-                        seg = pm->undoGetSegment(SegmentType::Clef, pm->len());
+                        seg = pm->getSegment(SegmentType::Clef, pm->len());
                         }
                   else if (remains != m->len())
-                        seg = m->undoGetSegment(SegmentType::Clef, m->len() - remains);
+                        seg = m->getSegment(SegmentType::Clef, m->len() - remains);
                   else
-                        seg = m->undoGetSegmentR(SegmentType::HeaderClef, 0);
+                        seg = m->getSegmentR(SegmentType::HeaderClef, 0);
                   Element* ne = e->clone();
                   ne->setScore(score);
                   ne->setTrack(_track);
@@ -574,7 +574,7 @@ bool TrackList::write(Score* score, int tick) const
                   // add the element in its own segment;
                   // but KeySig has to be at start of (current) measure
 
-                  Segment* seg = m->undoGetSegment(Segment::segmentType(e->type()), e->isKeySig() ? Fraction() : m->len() - remains);
+                  Segment* seg = m->getSegment(Segment::segmentType(e->type()), e->isKeySig() ? Fraction() : m->len() - remains);
                   Element* ne = e->clone();
                   ne->setScore(score);
                   ne->setTrack(_track);

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -705,6 +705,8 @@ class InsertRemoveMeasures : public UndoCommand {
       MeasureBase* fm;
       MeasureBase* lm;
 
+      static std::vector<Clef*> getCourtesyClefs(Measure* m);
+
    protected:
       void removeMeasures();
       void insertMeasures();

--- a/mtest/libmscore/measure/measure-2-ref.mscx
+++ b/mtest/libmscore/measure/measure-2-ref.mscx
@@ -113,6 +113,10 @@
         </VBox>
       <Measure>
         <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            </Clef>
           <TimeSig>
             <sigN>2</sigN>
             <sigD>4</sigD>
@@ -126,10 +130,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Tempo>
             <tempo>1.66667</tempo>
             <text>𝅘𝅥 = 100</text>
@@ -211,6 +211,10 @@
     <Staff id="2">
       <Measure>
         <voice>
+          <Clef>
+            <concertClefType>F</concertClefType>
+            <transposingClefType>F</transposingClefType>
+            </Clef>
           <TimeSig>
             <sigN>2</sigN>
             <sigD>4</sigD>
@@ -224,10 +228,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>F</concertClefType>
-            <transposingClefType>F</transposingClefType>
-            </Clef>
           <Rest>
             <linkedMain/>
             <durationType>measure</durationType>
@@ -266,6 +266,10 @@
     <Staff id="3">
       <Measure>
         <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            </Clef>
           <TimeSig>
             <sigN>2</sigN>
             <sigD>4</sigD>
@@ -279,10 +283,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Rest>
             <linkedMain/>
             <durationType>measure</durationType>
@@ -398,6 +398,10 @@
           </VBox>
         <Measure>
           <voice>
+            <Clef>
+              <concertClefType>G</concertClefType>
+              <transposingClefType>G</transposingClefType>
+              </Clef>
             <TimeSig>
               <sigN>2</sigN>
               <sigD>4</sigD>
@@ -413,10 +417,6 @@
         <Measure>
           <breakMultiMeasureRest>1</breakMultiMeasureRest>
           <voice>
-            <Clef>
-              <concertClefType>G</concertClefType>
-              <transposingClefType>G</transposingClefType>
-              </Clef>
             <Tempo>
               <tempo>1.66667</tempo>
               <text>𝅘𝅥 = 100</text>
@@ -511,6 +511,10 @@
       <Staff id="2">
         <Measure>
           <voice>
+            <Clef>
+              <concertClefType>G</concertClefType>
+              <transposingClefType>G</transposingClefType>
+              </Clef>
             <TimeSig>
               <sigN>2</sigN>
               <sigD>4</sigD>
@@ -525,10 +529,6 @@
           </Measure>
         <Measure>
           <voice>
-            <Clef>
-              <concertClefType>G</concertClefType>
-              <transposingClefType>G</transposingClefType>
-              </Clef>
             <Rest>
               <linked>
                 </linked>
@@ -642,6 +642,10 @@
           </VBox>
         <Measure>
           <voice>
+            <Clef>
+              <concertClefType>G</concertClefType>
+              <transposingClefType>G</transposingClefType>
+              </Clef>
             <TimeSig>
               <sigN>2</sigN>
               <sigD>4</sigD>
@@ -657,10 +661,6 @@
         <Measure>
           <breakMultiMeasureRest>1</breakMultiMeasureRest>
           <voice>
-            <Clef>
-              <concertClefType>G</concertClefType>
-              <transposingClefType>G</transposingClefType>
-              </Clef>
             <Tempo>
               <tempo>1.66667</tempo>
               <linkedMain/>

--- a/mtest/libmscore/measure/measure-5-ref.mscx
+++ b/mtest/libmscore/measure/measure-5-ref.mscx
@@ -57,6 +57,10 @@
     <Staff id="1">
       <Measure>
         <voice>
+          <Clef>
+            <concertClefType>G</concertClefType>
+            <transposingClefType>G</transposingClefType>
+            </Clef>
           <TimeSig>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -69,10 +73,6 @@
         </Measure>
       <Measure>
         <voice>
-          <Clef>
-            <concertClefType>G</concertClefType>
-            <transposingClefType>G</transposingClefType>
-            </Clef>
           <Chord>
             <durationType>quarter</durationType>
             <Note>


### PR DESCRIPTION
Should fix https://musescore.org/en/node/280092 but actually nothing more than that. This makes clefs be properly moved to proper segments when inserting measure to the beginning of the score.