### PR TITLE
fix #280330: Headings of Stem, Bracket and Instrument Name Inspectors

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -968,7 +968,8 @@ InspectorStem::InspectorStem(QWidget* parent)
             { Pid::LINE_WIDTH, 0, s.lineWidth,  s.resetLineWidth  },
             { Pid::USER_LEN,   0, s.userLength, s.resetUserLength },
             };
-      mapSignals(iiList);
+      const std::vector<InspectorPanel> ppList = { { s.title, s.panel } };
+      mapSignals(iiList, ppList);
       }
 
 //---------------------------------------------------------
@@ -1159,7 +1160,8 @@ InspectorBracket::InspectorBracket(QWidget* parent) : InspectorBase(parent)
       const std::vector<InspectorItem> il = {
             { Pid::BRACKET_COLUMN, 0, b.column, b.resetColumn }
             };
-      mapSignals(il);
+      const std::vector<InspectorPanel> ppList = { { b.title, b.panel } };
+      mapSignals(il, ppList);
       }
 
 //---------------------------------------------------------
@@ -1173,7 +1175,8 @@ InspectorIname::InspectorIname(QWidget* parent) : InspectorTextBase(parent)
       const std::vector<InspectorItem> il = {
             { Pid::INAME_LAYOUT_POSITION, 0, i.layoutPosition, i.resetLayoutPosition }
             };
-      mapSignals(il);
+      const std::vector<InspectorPanel> ppList = { { i.title, i.panel } };
+      mapSignals(il, ppList);
       }
 
 }


### PR DESCRIPTION
should be bold, left aligned, and collapsable