### PR TITLE
fix #280345: ensure that measure's system is reset on detaching from system

### DIFF
--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -148,7 +148,7 @@ void Clef::layout()
 
             Measure* meas = clefSeg->measure();
             if (meas && meas->system() && !score()->lineMode()) {
-                  auto ml = meas->system()->measures();
+                  const auto& ml = meas->system()->measures();
                   bool found = (std::find(ml.begin(), ml.end(), meas) != ml.end());
                   bool courtesy = (tick == meas->endTick() && (meas == meas->system()->lastMeasure() || !found));
                   if (courtesy && (!showCourtesy() || !score()->styleB(Sid::genCourtesyClef) || meas->isFinalMeasureOfSection()))

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3079,8 +3079,8 @@ System* Score::collectSystem(LayoutContext& lc)
                   if (lc.prevMeasure->noBreak() && system->measures().size() > 2) {
                         // remove last two measures
                         // TODO: check more measures for noBreak()
-                        system->measures().pop_back();
-                        system->measures().pop_back();
+                        system->removeLastMeasure();
+                        system->removeLastMeasure();
                         lc.curMeasure->setSystem(oldSystem);
                         lc.prevMeasure->setSystem(oldSystem);
                         lc.nextMeasure = lc.curMeasure;
@@ -3090,7 +3090,7 @@ System* Score::collectSystem(LayoutContext& lc)
                         }
                   else if (!lc.prevMeasure->noBreak()) {
                         // remove last measure
-                        system->measures().pop_back();
+                        system->removeLastMeasure();
                         lc.curMeasure->setSystem(oldSystem);
                         break;
                         }

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -92,6 +92,10 @@ System::~System()
 
 void System::clear()
       {
+      for (MeasureBase* mb : measures()) {
+            if (mb->system() == this)
+                  mb->setSystem(nullptr);
+            }
       ml.clear();
       for (SpannerSegment* ss : _spannerSegments) {
             if (ss->system() == this)
@@ -109,6 +113,31 @@ void System::appendMeasure(MeasureBase* mb)
       {
       mb->setSystem(this);
       ml.push_back(mb);
+      }
+
+//---------------------------------------------------------
+//   removeMeasure
+//---------------------------------------------------------
+
+void System::removeMeasure(MeasureBase* mb)
+      {
+      ml.erase(std::remove(ml.begin(), ml.end(), mb), ml.end());
+      if (mb->system() == this)
+            mb->setSystem(nullptr);
+      }
+
+//---------------------------------------------------------
+//   removeLastMeasure
+//---------------------------------------------------------
+
+void System::removeLastMeasure()
+      {
+      if (ml.empty())
+            return;
+      MeasureBase* mb = ml.back();
+      ml.pop_back();
+      if (mb->system() == this)
+            mb->setSystem(nullptr);
       }
 
 //---------------------------------------------------------

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -107,6 +107,8 @@ class System final : public Element {
       virtual void scanElements(void* data, void (*func)(void*, Element*), bool all=true) override;
 
       void appendMeasure(MeasureBase*);
+      void removeMeasure(MeasureBase*);
+      void removeLastMeasure();
 
       Page* page() const                    { return (Page*)parent(); }
 
@@ -132,7 +134,6 @@ class System final : public Element {
       int snap(int tick, const QPointF p) const;
       int snapNote(int tick, const QPointF p, int staff) const;
 
-      std::vector<MeasureBase*>& measures()             { return ml; }
       const std::vector<MeasureBase*>& measures() const { return ml; }
 
       MeasureBase* measure(int idx)          { return ml[idx]; }

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1668,11 +1668,7 @@ void InsertRemoveMeasures::removeMeasures()
                   if (!systemList.contains(system)) {
                         systemList.push_back(system);
                         }
-                  auto i = std::find(system->measures().begin(), system->measures().end(), mb);
-                  if (i != system->measures().end()) {
-                        (*i)->setParent(0);
-                        system->measures().erase(i);
-                        }
+                  system->removeMeasure(mb);
                   }
             if (mb == fm)
                   break;


### PR DESCRIPTION
The reason of the issue [280345](https://musescore.org/en/node/280345) is in that those steps created a situation when the system was cleared via a `clear()` call and after that got deleted. Some of the underlying measures still had pointers to that system as their parent so this lead to various bad consequences when such pointers were finally used. The reason of the crash in most cases was `bad_alloc` exception since the usage was in trying to copy a vector containing system's measures, as that copy is not needed, I replaced it with assigning a reference as well.