### PR TITLE
More issues with disabled header segments

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -628,12 +628,12 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                   const Measure* m;
                   if (grip == Grip::START) {
                         m = startMeasure();
-                        // start after clef/key
+                        // start after clef/keysig/timesig/barline
                         qreal offset = 0.0;
                         Segment* s = m->first(SegmentType::ChordRest);
                         if (s) {
                               s = s->prev();
-                              if (s) {
+                              if (s && s->enabled()) {
                                     offset = s->x();
                                     Element* e = s->element(staffIdx() * VOICES);
                                     if (e)

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -390,6 +390,8 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
             s1 = s1->measure()->first();
       Segment* s2 = _selection.endSegment();
       for (Segment* segment = s1; segment && segment != s2; segment = segment->next1()) {
+            if (!segment->enabled())
+                  continue;
             for (int track : tracks) {
                   if (staff(track/VOICES)->staffType(s1->tick())->group() == StaffGroup::PERCUSSION)
                         continue;

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -503,7 +503,7 @@ void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickE
 
             bool createKey = tickStart == 0;
             for (Segment* s = firstSegment(SegmentType::KeySig); s; s = s->next1(SegmentType::KeySig)) {
-                  if (s->tick() < tickStart)
+                  if (!s->enabled() || s->tick() < tickStart)
                         continue;
                   if (tickEnd != -1 && s->tick() >= tickEnd)
                         break;
@@ -513,7 +513,7 @@ void Score::transposeKeys(int staffStart, int staffEnd, int tickStart, int tickE
                               segmentInterval.flip();
                         }
                   KeySig* ks = toKeySig(s->element(staffIdx * VOICES));
-                  if (!ks || (ks->generated() && ks->segment()->rtick() > 0))
+                  if (!ks || ks->generated())
                         continue;
                   if (s->tick() == 0)
                         createKey = false;


### PR DESCRIPTION
See https://musescore.org/en/node/280366.  I figure we'll be fixing cases like this for a while.  BTW, it's much worse if there was also a key signature:

![image](https://user-images.githubusercontent.com/1799936/50311244-b49c6d00-0461-11e9-8734-0ee610c3af34.png)

But this PR fixes all such cases (for voltas anyhow).