### PR TITLE
fix #280364 allow insert @start of measure

### DIFF
--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -155,6 +155,7 @@ std::vector<MScoreError> MScore::errorList {
       { NO_MIME,                         "p6", TR("Nothing to paste")                                                      },
       { DEST_NO_CR,                      "p7", TR("Destination is not a chord or rest")                                    },
       { CANNOT_CHANGE_LOCAL_TIMESIG,     "l1", TR("Cannot change local time signature:\nMeasure is not empty")             },
+      { CANNOT_INSERT_START_OF_MMREST,   "m3", TR("Cannot do timewise insert into a multi-measure rest:\nPlease untoggle multi-measure rests and retry") },
       };
 #undef TR
 

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -275,6 +275,7 @@ enum MsError {
       NO_MIME,
       DEST_NO_CR,
       CANNOT_CHANGE_LOCAL_TIMESIG,
+      CANNOT_INSERT_START_OF_MMREST,
       };
 
 struct MScoreError {

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -530,6 +530,14 @@ void Score::insertChord(const Position& pos)
       if (!el || !(el->isNote() || el->isRest()))
             return;
       Segment* seg = pos.segment;
+
+      // Don't insert if in a multi-measure rest.  TODO: actually allow this case
+      Measure* m = seg->measure();
+      if (m->isMMRest()) {
+            MScore::setError(CANNOT_INSERT_START_OF_MMREST);
+            return;
+            }
+
       if (seg->splitsTuplet()) {
             MScore::setError(CANNOT_INSERT_TUPLET);
             return;
@@ -576,7 +584,7 @@ void Score::localInsertChord(const Position& pos)
 
       for (int track = 0; track < msTracks; ++track) {
             // Insert rest only if there is no full-measure rest here.
-            Element* maybeRest = msMeasure->findFirst(SegmentType::ChordRest, /* rel. tick */ 0)->element(track);
+            Element* maybeRest = msMeasure->first(SegmentType::ChordRest)->element(track);
             if (maybeRest && maybeRest->isRest() && toRest(maybeRest)->durationType().isMeasure())
                   toRest(maybeRest)->undoChangeProperty(Pid::DURATION, targetMeasureLen);
             else if (msMeasure->hasVoice(track))


### PR DESCRIPTION
Previous code crashed when doing a timewise insert at the beginning of a measure.  This was because the call to msMeasure->findFirst searches for a segment at tick 0, but segment ticks had already been shifted forward in time with the earlier call to InsertTime.  Using msMeasure->first(SegmentType::ChordRest) avoids that problem.

There is also the case of inserting at the begining of a multi-measure rest, which I couldn't quite figure out how to easily solve.  So I've disabled that ability as a stopgap.  If someone else wants to and knows how best to allow that ability, please feel free to do so.