### PR TITLE
fix #280347: reset inspector if property change leads to selection change

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -358,6 +358,7 @@ void Inspector::update(Score* s)
                               break;
                         }
                   }
+            connect(ie, &InspectorBase::elementChanged, this, QOverload<>::of(&Inspector::update), Qt::QueuedConnection);
             sa->setWidget(ie);      // will destroy previous set widget
 
             //focus policies were set by hand in each inspector_*.ui. this code just helps keeping them like they are

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -384,7 +384,8 @@ void InspectorBase::valueChanged(int idx, bool reset)
       const InspectorItem& ii = iList[idx];
       Pid id       = ii.t;
       QVariant val2 = getValue(ii);                   // get new value from UI
-      Score* score  = inspector->element()->score();
+      Element* iElement = inspector->element();
+      Score* score  = iElement->score();
 
       score->startCmd();
       for (Element* e : *inspector->el()) {
@@ -413,6 +414,14 @@ void InspectorBase::valueChanged(int idx, bool reset)
       checkDifferentValues(ii);
       score->endCmd();
       inspector->setInspectorEdit(false);
+
+      if (iElement != inspector->element()) {
+            // Something changed in selection as a result of value change.
+            recursion = false;
+            emit elementChanged();
+            return;
+            }
+
       postInit();
 
       // a subStyle change may change several other values:

--- a/mscore/inspector/inspectorBase.h
+++ b/mscore/inspector/inspectorBase.h
@@ -54,6 +54,9 @@ class InspectorBase : public QWidget {
       bool compareValues(const InspectorItem& ii, QVariant a, QVariant b);
       Element* effectiveElement(const InspectorItem&) const;
 
+   signals:
+      void elementChanged();
+
    private slots:
       void resetToStyle();
 


### PR DESCRIPTION
Fixes https://musescore.org/en/node/280347.

On changing bracket column the bracket itself gets destroyed on next layout. We can do nothing about that without changing brackets implementation. However we definitely should make inspector be aware of such possible changes.

Previously inspector did not get updated on re-layout because of `_inspectorEdit` flag denoting that current change originated from inspector itself. This flag is necessary to avoid extra updates of inspector, updating inspector in this particular case would lead also to destruction of `InspectorBase` object in the middle of its member function being executed. However the problem can be resolved, for example, via Qt signal-slot system by establishing a queued connection between `InspectorBase` (element-related controls) and `Inspector` (the whole Inspector widget) for the case when selection changes as a result of some inspector-originated changes. This is exactly what is done in this PR.

It could be also good to select new bracket instead of the destroyed one so that inspector doesn't get just reset on each column change but this is probably another issue.