### PR TITLE
fix #279859 reallow drop break elements on vbox

### DIFF
--- a/libmscore/box.cpp
+++ b/libmscore/box.cpp
@@ -702,7 +702,6 @@ VBox::VBox(Score* score)
       {
       initElementStyle(&boxStyle);
       setBoxHeight(Spatium(10.0));
-      setLineBreak(true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
MuseScore 2.3.2 behavior allowed dropping break elements onto a VBox.  But some 3.0 code must have broke this functionality.  Turns out the breaks were not being alowed to be dropped because VBox::Vbox() sets the line break flag to true, which the Box::drop() code deliberatly checks for with if (pageBreak() || lineBreak()) in order to handle dropping breaks specially when there was already a break element.  That drop code does seem to be correct as far as I can tell.

So it seems to me the line break flag should not actually be set if there is not actual line break *element*, so this PR changes Vbox::Vbox() to not set the line break flag.  It seems that line break flag should only be set if there is an actual line break element on the VBox (not simply the implicit line break that always occurs after a VBox).  I'm not completely conviced this is correct, though because werner made the commit ab1723fc6f46feb05af737e5eab5039172d9613a two years ago which added that setLineBreak(true) statement...so maybe he should review this PR in case that line is actually intended.