### PR TITLE
fix #279296: apply tempo text before fermata time stretch

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2599,6 +2599,12 @@ void Score::getNextMeasure(LayoutContext& lc)
                   for (Element* e : segment.annotations()) {
                         if (e->isFermata())
                               stretch = qMax(stretch, toFermata(e)->timeStretch());
+                        else if (e->isTempoText()) {
+                              if (score()->isMaster()) {
+                                    TempoText* tt = toTempoText(e);
+                                    setTempo(tt->segment(), tt->tempo());
+                                    }
+                              }
                         }
                   if (stretch != 0.0 && stretch != 1.0) {
                         qreal otempo = tempomap()->tempo(segment.tick());
@@ -3630,12 +3636,8 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
 
       for (const Segment* s : sl) {
             for (Element* e : s->annotations()) {
-                  if (e->isTempoText()) {
-                        TempoText* tt = toTempoText(e);
-                        if (score()->isMaster())
-                              setTempo(tt->segment(), tt->tempo());
-                        tt->layout();
-                        }
+                  if (e->isTempoText())
+                        e->layout();
                   }
             }
 


### PR DESCRIPTION
This PR is an attempt to fix https://musescore.org/en/node/279296.
The solution is to apply tempo from tempo text markings not after applying fermata time stretch. On file loading fermata markings may not know about tempo set by tempo text just because it has not been applied yet. I don't know though what was the reason for applying tempo text on system layout stage rather than measure layout so it would be good to test and review the proposed changes.