### PR TITLE
fix #280497 fit default window size inside primary screen

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4252,7 +4252,7 @@ void MuseScore::readSettings()
       int w = 1024;
       int h = 768;
       QScreen* screen      = QGuiApplication::primaryScreen();
-      const QSize screenSize = screen->availableVirtualSize();
+      const QSize screenSize = screen->availableSize();
       if (screenSize.width() - margin > w)
             w = screenSize.width() - margin;
       else


### PR DESCRIPTION
MuseScore factory reset on a multi-monitor setup produced default window size that was way too big, spanning the height and width of the entire available 'virtual' size, crossing over monitor boundaries.  That is not standard default behavior for most any other program I'm aware of.

This PR instead uses only screen->availableSize(), which according to Qt doc is simply referring to primary monitor size and seems much more sane default, rather than screen->availableVirtualSize(), which according to Qt doc refers to the entire area of all monitors.