### PR TITLE
fix #280504 edit surrogate pairs atomically

### DIFF
--- a/libmscore/textbase.h
+++ b/libmscore/textbase.h
@@ -126,7 +126,8 @@ class TextCursor {
       bool movePosition(QTextCursor::MoveOperation op, QTextCursor::MoveMode mode = QTextCursor::MoveAnchor, int count = 1);
       void moveCursorToEnd()   { movePosition(QTextCursor::End);   }
       void moveCursorToStart() { movePosition(QTextCursor::Start); }
-      QChar currentCharacter() const;
+      QString currentVariableLengthUnicodeCharacter() const;
+      QChar currentQChar() const;
       bool set(const QPointF& p, QTextCursor::MoveMode mode = QTextCursor::MoveAnchor);
       QString selectedText() const;
       void updateCursorFormat();


### PR DESCRIPTION
I haven't finished this for sure, and I might want to add some test cases...but it solves a lot of problems with cutting, pasting, editing, deleting Unicode belonging to the Supplemental Planes.  Previous code wasn't always aware or properly handling surrogate paired unicode.  Issue description: https://musescore.org/en/node/280504

I'm also working on fixing related issue (https://musescore.org/en/node/280522) which I'll submit together in this PR.  But just putting this up so people can see.