### PR TITLE
fix #278943: Can't copy nested tuplets to last beat of measure

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -177,7 +177,8 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff)
                               Measure* measure = tick2measure(tick);
                               tuplet->setParent(measure);
                               tuplet->setTick(tick);
-                              if (tuplet->rfrac() + tuplet->duration() > measure->len()) {
+                              tuplet->setTuplet(oldTuplet);
+                              if (tuplet->rfrac() + tuplet->actualFraction() > measure->len()) {
                                     delete tuplet;
                                     if (oldTuplet && oldTuplet->elements().empty())
                                           delete oldTuplet;


### PR DESCRIPTION
See https://musescore.org/en/node/278943.