### PR TITLE
fix #280503: disable generating play events before layout

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4081,8 +4081,10 @@ void Score::doLayoutRange(int stick, int etick)
 
       if (cmdState().layoutFlags & LayoutFlag::FIX_PITCH_VELO)
             updateVelo();
+#if 0 // TODO: needed? It was introduced in ab9774ec4098512068b8ef708167d9aa6e702c50
       if (cmdState().layoutFlags & LayoutFlag::PLAY_EVENTS)
             createPlayEvents();
+#endif
 
       //---------------------------------------------------
       //    initialize layout context lc


### PR DESCRIPTION
The disabled code was introduced in ab9774ec4098512068b8ef708167d9aa6e702c50 and is actually used only when slurs are added or removed. It is not clear whether slurs playback actually needs this code as playback itself does not seem to alter with this change, and other slurs-related code from the mentioned commit is probably not present now.

This is a temporary change to fix https://musescore.org/en/node/280503, overall we will need to decide whether we need this code and `PLAY_EVENTS` layout flags in general.