### PR TITLE
fix #151256: fix lyrics intersection inside measure, disallow lyrics to cross barlines

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3955,7 +3955,7 @@ static void dumpMeasure(Measure* m)
 
 void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
       {
-      Segment* fs = s;
+      Segment* fs = firstEnabled();
       bool first  = system()->firstMeasure() == this;
       const Shape ls(first ? QRectF(0.0, -1000000.0, 0.0, 2000000.0) : QRectF(0.0, 0.0, 0.0, spatium() * 4));
 
@@ -3996,10 +3996,17 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
                   // look back for collisions with previous segments
                   // this is time consuming (ca. +5%) and probably requires more optimization
 
+                  if (s == fs) // don't let the second segment cross measure start (not covered by the loop below)
+                        w = std::max(w, ns->minLeft(ls) - s->x());
+
                   int n = 1;
                   for (Segment* ps = s; ps != fs;) {
                         qreal ww;
                         ps = ps->prevEnabled();
+
+                        Q_ASSERT(ps); // ps should never be nullptr but better be safe.
+                        if (!ps)
+                              break;
 
                         if (ps->isChordRestType())
                               ++n;

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -4000,13 +4000,14 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
                   for (Segment* ps = s; ps != fs;) {
                         qreal ww;
                         ps = ps->prevEnabled();
+
+                        if (ps->isChordRestType())
+                              ++n;
+                        ww = ps->minHorizontalCollidingDistance(ns) - (s->x() - ps->x());
+
                         if (ps == fs)
-                              ww = ns->minLeft(ls) - s->x();
-                        else {
-                              if (ps->isChordRestType())
-                                    ++n;
-                              ww = ps->minHorizontalCollidingDistance(ns) - (s->x() - ps->x());
-                              }
+                              ww = std::max(ww, ns->minLeft(ls) - s->x());
+
                         if (ww > w) {
                               // overlap !
                               // distribute extra space between segments ps - ss;

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -146,6 +146,7 @@ class Measure final : public MeasureBase {
       int size() const                          { return _segments.size();        }
       Ms::Segment* first() const                { return _segments.first();       }
       Segment* first(SegmentType t) const     { return _segments.first(t);      }
+      Segment* firstEnabled() const             { return _segments.first(ElementFlag::ENABLED); }
 
       Ms::Segment* last() const                 { return _segments.last(); }
       SegmentList& segments()                   { return _segments; }

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1866,6 +1866,7 @@ void Segment::createShape(int staffIdx)
 #endif
                   }
             s.addHorizontalSpacing(Shape::SPACING_GENERAL, 0, 0);
+            s.addHorizontalSpacing(Shape::SPACING_LYRICS, 0, 0);
             return;
             }
 #if 0

--- a/libmscore/segmentlist.cpp
+++ b/libmscore/segmentlist.cpp
@@ -210,5 +210,17 @@ Segment* SegmentList::first(SegmentType types) const
       return 0;
       }
 
+//---------------------------------------------------------
+//   first
+//---------------------------------------------------------
+
+Segment* SegmentList::first(ElementFlag flags) const
+      {
+      for (Segment* s = _first; s; s = s->next()) {
+            if (s->flag(flags))
+                  return s;
+            }
+      return nullptr;
+      }
 }
 

--- a/libmscore/segmentlist.h
+++ b/libmscore/segmentlist.h
@@ -41,6 +41,7 @@ class SegmentList {
 
       Segment* first() const               { return _first;       }
       Segment* first(SegmentType) const;
+      Segment* first(ElementFlag) const;
 
       Segment* last() const                { return _last;        }
       Segment* firstCRSegment() const;

--- a/libmscore/shape.cpp
+++ b/libmscore/shape.cpp
@@ -26,6 +26,8 @@ void Shape::addHorizontalSpacing(HorizontalSpacingType type, qreal leftEdge, qre
       {
       constexpr qreal eps = 100 * std::numeric_limits<qreal>::epsilon();
       const qreal y = eps * int(type);
+      if (leftEdge == rightEdge) // HACK zero-width shapes collide with everything currently.
+            rightEdge += eps;
       add(QRectF(leftEdge, y, rightEdge - leftEdge, 0));
       }
 


### PR DESCRIPTION
A partial fix for the issue [151256](https://musescore.org/en/node/151256). This fixes the case of overlapping lyrics syllables if the first syllable happens to be in the first segment of a measure.