### PR TITLE
fix #279377: unify PNG export and image copying to clipboard

### DIFF
--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -410,6 +410,31 @@ void ScoreView::fotoContextPopup(QContextMenuEvent* ev)
       }
 
 //---------------------------------------------------------
+//   getRectImage
+//---------------------------------------------------------
+
+QImage ScoreView::getRectImage(const QRectF& rect, double dpi, bool transparent, bool printMode)
+      {
+      const double mag = dpi / DPI;
+      const int w = lrint(rect.width()  * mag);
+      const int h = lrint(rect.height() * mag);
+
+      QImage::Format f = QImage::Format_ARGB32_Premultiplied;
+      QImage img(w, h, f);
+      img.setDotsPerMeterX(lrint((dpi * 1000) / INCH));
+      img.setDotsPerMeterY(lrint((dpi * 1000) / INCH));
+      img.fill(transparent ? 0 : 0xffffffff);
+
+      const auto pr = MScore::pixelRatio;
+      MScore::pixelRatio = 1.0 / mag;
+      QPainter p(&img);
+      paintRect(printMode, p, rect, mag);
+      MScore::pixelRatio = pr;
+
+      return img;
+      }
+
+//---------------------------------------------------------
 //   fotoModeCopy
 //---------------------------------------------------------
 
@@ -424,21 +449,9 @@ void ScoreView::fotoModeCopy()
       bool transparent = preferences.getBool(PREF_EXPORT_PNG_USETRANSPARENCY);
 #endif
       double convDpi   = preferences.getDouble(PREF_EXPORT_PNG_RESOLUTION);
-      double mag       = convDpi / DPI;
-
       QRectF r(_foto->canvasBoundingRect());
 
-      int w = lrint(r.width()  * mag);
-      int h = lrint(r.height() * mag);
-
-      QImage::Format f;
-      f = QImage::Format_ARGB32_Premultiplied;
-      QImage printer(w, h, f);
-      printer.setDotsPerMeterX(lrint(DPMM * 1000.0));
-      printer.setDotsPerMeterY(lrint(DPMM * 1000.0));
-      printer.fill(transparent ? 0 : 0xffffffff);
-      QPainter p(&printer);
-      paintRect(true, p, r, mag);
+      QImage printer(getRectImage(r, convDpi, transparent, /* printMode */ true));
       QApplication::clipboard()->setImage(printer);
       }
 
@@ -546,14 +559,7 @@ bool ScoreView::saveFotoAs(bool printMode, const QRectF& r)
             MScore::pdfPrinting = false;
             }
       else if (ext == "png") {
-            QImage::Format f = QImage::Format_ARGB32_Premultiplied;
-            QImage printer(w, h, f);
-            printer.setDotsPerMeterX(lrint((convDpi * 1000) / INCH));
-            printer.setDotsPerMeterY(lrint((convDpi * 1000) / INCH));
-            printer.fill(transparent ? 0 : 0xffffffff);
-            MScore::pixelRatio = 1.0 / mag;
-            QPainter p(&printer);
-            paintRect(printMode, p, r, mag);
+            QImage printer(getRectImage(r, convDpi, transparent, printMode));
             printer.save(fn, "png");
             }
       else

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -228,6 +228,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void startFotoDrag();
       void endFotoDrag();
       void endFotoDragEdit();
+      QImage getRectImage(const QRectF& rect, double dpi, bool transparent, bool printMode);
 
       virtual void startEdit();
       void endEdit();


### PR DESCRIPTION
This PR should fix the issue https://musescore.org/en/node/279377.

The problem is in inconsistency between the DPI value assigned to the created `QImage` and the value assigned to `MScore::pixelRatio`. Drawing some element relies on the properties returned by `QPainter` and the underlying device while other elements (including text elements) draw themselves relying on `MScore::pixelRatio` value to calculate dimensions. Moreover magnitude parameter is used by `paintRect` to scale a canvas on drawing. So it is important to maintain consistency between all these values to get correct scaling of all elements. This was so for PNG export but not for image copying to clipboard.

The proposed solution is to use a common function in both cases which maintains this consistency between the mentioned values. It is unclear which DPI was intended to be used in case of image copying since different DPIs were mixed in that case. For now I chose to use the same DPI used for PNG export (that is, the DPI value chosen by user in foto mode dialog). Still this choice can be easily altered to use any other DPI for this operation.