### PR TITLE
fix #280657 trig layout when set meas rest offset

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -951,6 +951,8 @@ bool Rest::setProperty(Pid propertyId, const QVariant& v)
                   setOffset(v.toPointF());
                   layout();
                   score()->addRefresh(canvasBoundingRect());
+                  if (measure() && durationType().type() == TDuration::DurationType::V_MEASURE)
+                        measure()->triggerLayout();
                   if (beam())
                         score()->setLayout(tick());
                   break;


### PR DESCRIPTION
Previously, measure rests wouldn't be laid out properly around the center of their measure after their x or y position was adjusted, such that they would instead be laid out relative to the initial tick at the left side of the measure.

This fix ensures than changing the offset property of measure rests will trigger layout of their parent measure, thus ensuring that they will be laid out around the center of their measure.