### PR TITLE
fix #280666 disable mouse drag for measure rests

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -148,6 +148,10 @@ void Rest::setOffset(const QPointF& o)
 
 QRectF Rest::drag(EditData& ed)
       {
+      // don't allow drag for Measure Rests, because they can't be easily laid out in correct position while dragging
+      if (measure() && durationType().type() == TDuration::DurationType::V_MEASURE)
+            return QRectF();
+
       QPointF s(ed.delta);
       QRectF r(abbox());
 


### PR DESCRIPTION
A very minor but noticeable slightly annoying glitch would occur while dragging Measure Rests: their x position would be relative to the initial tick even though their position is relative to their parent measure center.

This occurs because Measure Rests are supposed to be laid out in the center of their measure...but unfortunately it is not easy to lay them out because their x position is dependent on layout of their parent measure. So to make things simple, to avoid this glitch I'm disabling this ability. I doubt anyone will complain. Users may still adjust position of measure rests by using inspector x/y offset or pressing up/down on keyboard.

see https://musescore.org/en/node/280666 for gifs illustrating problem.