### PR TITLE
fix #279203 PortMidi Win device names unicode

### DIFF
--- a/thirdparty/portmidi/pm_win/pmwinmm.c
+++ b/thirdparty/portmidi/pm_win/pmwinmm.c
@@ -11,6 +11,11 @@
     #define _WIN32_WINNT 0x0500
 #endif
 
+// Undefine UNICODE to get the char-based library functions
+#ifdef UNICODE
+#undef UNICODE
+#endif
+
 #include "windows.h"
 #include "mmsystem.h"
 #include "portmidi.h"


### PR DESCRIPTION
I don't know history about why an earlier commit 3acc363 "Solved all compilation errors on MSVC" had to remove this #undef UNICODE.  I'm on MSVC 2017 right now and I'm able to compile just fine.  That commit's removal of those lines caused all the Midi device names to be identical and undescriptive as 'MMSystem,M' although the devices were perfectly valid.

Note: the previous commit that removed these lines was: https://github.com/musescore/MuseScore/commit/3acc363498531bb97dc1a9c5a64764a78d906e23#diff-91e83d30d208dc7c39b292678a93fff8R10

The problem that the removal of those lines is described here: https://musescore.org/en/node/279203