### PR TITLE
fix #280668: correct unmanaged spanners handling on time delete

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4776,12 +4776,7 @@ void Score::undoInsertTime(int tick, int len)
                   }
             }
 
-      for (auto i = _unmanagedSpanner.begin(); i != _unmanagedSpanner.end();) {
-            auto ni = i;
-            ++ni;
-            (*i)->undoInsertTimeUnmanaged(tick, len); // may remove spanner from list
-            i = ni;
-            }
+      undo(new InsertTimeUnmanagedSpanner(this, tick, len));
       }
 
 //---------------------------------------------------------

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -363,10 +363,10 @@ void Spanner::removeUnmanaged()
       }
 
 //---------------------------------------------------------
-//   undoInserTimeUnmanaged
+//   insertTimeUnmanaged
 //---------------------------------------------------------
 
-void Spanner::undoInsertTimeUnmanaged(int fromTick, int len)
+void Spanner::insertTimeUnmanaged(int fromTick, int len)
       {
       int   newTick1    = tick();
       int   newTick2    = tick2();

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -216,7 +216,7 @@ class Spanner : public Element {
       virtual void scanElements(void* data, void (*func)(void*, Element*), bool all=true) override;
       bool removeSpannerBack();
       virtual void removeUnmanaged();
-      virtual void undoInsertTimeUnmanaged(int tick, int len);
+      virtual void insertTimeUnmanaged(int tick, int len);
 
       QVariant getProperty(Pid propertyId) const;
       bool setProperty(Pid propertyId, const QVariant& v);

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2200,6 +2200,20 @@ void InsertTime::undo(EditData*)
       }
 
 //---------------------------------------------------------
+//   InsertTimeUnmanagedSpanner::flip
+//---------------------------------------------------------
+
+void InsertTimeUnmanagedSpanner::flip(EditData*)
+      {
+      for (Score* s : score->scoreList()) {
+            const auto unmanagedSpanners(s->unmanagedSpanners());
+            for (Spanner* sp : unmanagedSpanners)
+                  sp->insertTimeUnmanaged(tick, len);
+            }
+      len = -len;
+      }
+
+//---------------------------------------------------------
 //   ChangeNoteEvent::flip
 //---------------------------------------------------------
 

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -1133,6 +1133,23 @@ class InsertTime : public UndoCommand {
       };
 
 //---------------------------------------------------------
+//   InsertTimeUnmanagedSpanner
+//---------------------------------------------------------
+
+class InsertTimeUnmanagedSpanner : public UndoCommand {
+      Score* score;
+      int tick;
+      int len;
+
+      void flip(EditData*) override;
+
+   public:
+      InsertTimeUnmanagedSpanner(Score* s, int _tick, int _len)
+         : score(s), tick(_tick), len(_len) {}
+      UNDO_NAME("InsertTimeUnmanagedSpanner")
+      };
+
+//---------------------------------------------------------
 //   ChangeNoteEvent
 //---------------------------------------------------------
 

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -317,7 +317,6 @@ void MuseScore::editInstrList()
                   for (int cidx = 0; pli->child(cidx); ++cidx) {
                         StaffListItem* sli = static_cast<StaffListItem*>(pli->child(cidx));
                         if (sli->op() == ListItemOp::I_DELETE) {
-                              masterScore->systems().clear();
                               Staff* staff = sli->staff();
                               int sidx = staff->idx();
                               masterScore->cmdRemoveStaff(sidx);


### PR DESCRIPTION
Also don't manually clear systems list from instrument dialog, this
produces crashes too.

Fixes two crashes described here: https://musescore.org/en/node/280668.