### PR TITLE
Fix #279622: All ottavas in the palettes are 8va

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1044,33 +1044,39 @@ Palette* MuseScore::newLinesPalette()
       Ottava* ottava = new Ottava(gscore);
       ottava->setOttavaType(OttavaType::OTTAVA_8VA);
       ottava->setLen(w);
+      ottava->styleChanged();
       sp->append(ottava, QT_TRANSLATE_NOOP("Palette", "8va"));
 
       ottava = new Ottava(gscore);
       ottava->setOttavaType(OttavaType::OTTAVA_8VB);
       ottava->setLen(w);
       ottava->setPlacement(Placement::BELOW);
+      ottava->styleChanged();
       sp->append(ottava, QT_TRANSLATE_NOOP("Palette", "8vb"));
 
       ottava = new Ottava(gscore);
       ottava->setOttavaType(OttavaType::OTTAVA_15MA);
       ottava->setLen(w);
+      ottava->styleChanged();
       sp->append(ottava, QT_TRANSLATE_NOOP("Palette", "15ma"));
 
       ottava = new Ottava(gscore);
       ottava->setOttavaType(OttavaType::OTTAVA_15MB);
       ottava->setLen(w);
       ottava->setPlacement(Placement::BELOW);
+      ottava->styleChanged();
       sp->append(ottava, QT_TRANSLATE_NOOP("Palette", "15mb"));
 
       ottava = new Ottava(gscore);
       ottava->setOttavaType(OttavaType::OTTAVA_22MA);
       ottava->setLen(w);
+      ottava->styleChanged();
       sp->append(ottava, QT_TRANSLATE_NOOP("Palette", "22ma"));
 
       ottava = new Ottava(gscore);
       ottava->setOttavaType(OttavaType::OTTAVA_22MB);
       ottava->setLen(w);
+      ottava->styleChanged();
       sp->append(ottava, QT_TRANSLATE_NOOP("Palette", "22mb"));
 
       Pedal* pedal;


### PR DESCRIPTION
Not sure whether that obsoletes the earlier fix in 59f1a34c20, from PR #4354