### PR TITLE
fix #280623: notify importmidi of reloading instrument templates

### DIFF
--- a/mscore/importmidi/importmidi.cpp
+++ b/mscore/importmidi/importmidi.cpp
@@ -1071,7 +1071,7 @@ ReducedFraction findLastChordTick(const std::multimap<int, MTrack> &tracks)
       return lastTick;
       }
 
-void convertMidi(Score *score, const MidiFile *mf)
+QList<MTrack> convertMidi(Score *score, const MidiFile *mf)
       {
       auto *sigmap = score->sigmap();
 
@@ -1161,6 +1161,8 @@ void convertMidi(Score *score, const MidiFile *mf)
       MidiLyrics::setLyricsToScore(trackList);
       MidiTempo::setTempo(tracks, score);
       MidiChordName::setChordNames(trackList);
+
+      return trackList;
       }
 
 void loadMidiData(MidiFile &mf)
@@ -1211,7 +1213,7 @@ Score::FileError importMidi(MasterScore *score, const QString &name)
             opers.setMidiFileData(name, mf);
             }
 
-      convertMidi(score, opers.midiFile(name));
+      opers.data()->tracks = convertMidi(score, opers.midiFile(name));
       ++opers.data()->processingsOfOpenedFile;
 
       return Score::FileError::FILE_NO_ERROR;

--- a/mscore/importmidi/importmidi_inner.h
+++ b/mscore/importmidi/importmidi_inner.h
@@ -1,6 +1,7 @@
 #ifndef IMPORTMIDI_INNER_H
 #define IMPORTMIDI_INNER_H
 
+#include "importmidi_chord.h"
 #include "importmidi_fraction.h"
 #include "importmidi_tuplet.h"
 #include "importmidi_operation.h"

--- a/mscore/importmidi/importmidi_instrument.cpp
+++ b/mscore/importmidi/importmidi_instrument.cpp
@@ -350,12 +350,15 @@ std::vector<const InstrumentTemplate *> findSuitableInstruments(const MTrack &tr
       return templates;
       }
 
-void findInstrumentsForAllTracks(const QList<MTrack> &tracks)
+void findInstrumentsForAllTracks(const QList<MTrack> &tracks, bool forceReload)
       {
       auto& opers = midiImportOperations;
       auto &instrListOption = opers.data()->trackOpers.msInstrList;
 
-      if (opers.data()->processingsOfOpenedFile == 0) {
+      if (forceReload)
+            instrListOption.clear();
+
+      if (opers.data()->processingsOfOpenedFile == 0 || forceReload) {
                         // create instrument list on MIDI file opening
             for (const auto &track: tracks) {
                   instrListOption.setValue(track.indexOfOperation,
@@ -365,6 +368,17 @@ void findInstrumentsForAllTracks(const QList<MTrack> &tracks)
                         opers.data()->trackOpers.msInstrIndex.setDefaultValue(defaultInstrIndex);
                         }
                   }
+            }
+      }
+
+void instrumentTemplatesChanged()
+      {
+      QStringList files(midiImportOperations.allMidiFiles());
+      for (const QString& file : files) {
+            MidiOperations::CurrentMidiFileSetter s(midiImportOperations, file);
+            MidiOperations::FileData* data = midiImportOperations.data();
+            if (data)
+                  findInstrumentsForAllTracks(data->tracks, /* forceReload */ true);
             }
       }
 

--- a/mscore/importmidi/importmidi_instrument.h
+++ b/mscore/importmidi/importmidi_instrument.h
@@ -18,8 +18,10 @@ QString msInstrName(int trackIndex);
 QString concatenateWithComma(const QString &left, const QString &right);
 bool isGrandStaff(const MTrack &t1, const MTrack &t2);
 void setGrandStaffProgram(QList<MTrack> &tracks);
-void findInstrumentsForAllTracks(const QList<MTrack> &tracks);
+void findInstrumentsForAllTracks(const QList<MTrack> &tracks, bool forceReload = false);
 void createInstruments(Score *score, QList<MTrack> &tracks);
+
+extern void instrumentTemplatesChanged();
 
 } // namespace MidiInstr
 } // namespace Ms

--- a/mscore/importmidi/importmidi_operations.h
+++ b/mscore/importmidi/importmidi_operations.h
@@ -1,6 +1,7 @@
 #ifndef IMPORTMIDI_OPERATIONS_H
 #define IMPORTMIDI_OPERATIONS_H
 
+#include "importmidi_inner.h"
 #include "importmidi_operation.h"
 #include "midi/midifile.h"
 
@@ -67,6 +68,13 @@ class TrackOp
                   return;
             _operation[-1] = value;
             _canRedefineDefaultLater = canRedefineDefaultLater;
+            }
+
+      void clear()
+            {
+            T defaultVal = defaultValue();
+            _operation.clear();
+            _operation[-1] = defaultVal;
             }
    private:
                   // <track index, operation value>
@@ -184,6 +192,7 @@ struct HumanBeatData
 struct FileData
       {
       MidiFile midiFile;
+      QList<MTrack> tracks;
       int processingsOfOpenedFile = 0;
       bool hasTempoText = false;
       QByteArray HHeaderData;

--- a/mscore/importmidi/importmidi_panel.cpp
+++ b/mscore/importmidi/importmidi_panel.cpp
@@ -215,9 +215,12 @@ void ImportMidiPanel::applyMidiImport()
 
 void ImportMidiPanel::cancelChanges()
       {
-      if (!canTryCancelChanges())
-            return;
+      if (canTryCancelChanges())
+            doCancelChanges();
+      }
 
+void ImportMidiPanel::doCancelChanges()
+      {
       auto &opers = midiImportOperations;
       MidiOperations::CurrentMidiFileSetter setCurrentMidiFile(opers, _midiFile);
 
@@ -234,6 +237,12 @@ void ImportMidiPanel::cancelChanges()
                   // tracks view has multiple headers (need for frozen rows/columns)
                   // so to set all headers special methods there have been implemented
       _ui->tracksView->setHHeaderResizeMode(QHeaderView::ResizeToContents);
+      }
+
+void ImportMidiPanel::instrumentTemplatesChanged()
+      {
+      if (fileDataAvailable(_midiFile))
+            doCancelChanges();
       }
 
 bool ImportMidiPanel::canImportMidi() const
@@ -256,6 +265,13 @@ bool ImportMidiPanel::canTryCancelChanges() const
 
       const QByteArray vData = _ui->tracksView->verticalHeader()->saveState();
       return opers.data()->VHeaderData != vData;
+      }
+
+bool ImportMidiPanel::fileDataAvailable(const QString& midiFile)
+      {
+      auto &opers = midiImportOperations;
+      MidiOperations::CurrentMidiFileSetter setCurrentMidiFile(opers, midiFile);
+      return bool(opers.data());
       }
 
 bool ImportMidiPanel::canMoveTrackUp(int visualIndex) const

--- a/mscore/importmidi/importmidi_panel.h
+++ b/mscore/importmidi/importmidi_panel.h
@@ -28,6 +28,8 @@ class ImportMidiPanel : public QWidget
 
       static bool isMidiFile(const QString &fileName);
 
+      void instrumentTemplatesChanged();
+
    signals:
       void closeClicked();
 
@@ -51,6 +53,9 @@ class ImportMidiPanel : public QWidget
       void restoreTableViewState();
       void resetTableViewState();
       void fillCharsetList();
+
+      void doCancelChanges();
+      static bool fileDataAvailable(const QString& midiFile);
 
       Ui::ImportMidiPanel *_ui;
       QTimer *_updateUiTimer;

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -57,6 +57,7 @@
 #include "navigator.h"
 #include "timeline.h"
 #include "importmidi/importmidi_panel.h"
+#include "importmidi/importmidi_instrument.h"
 #include "importmidi/importmidi_operations.h"
 #include "scorecmp/scorecmp.h"
 #include "script/recorderwidget.h"
@@ -2307,6 +2308,10 @@ void MuseScore::reloadInstrumentTemplates()
             for (auto instFile : instFiles)
                   loadInstrumentTemplates(instFile.absoluteFilePath());
             }
+
+      MidiInstr::instrumentTemplatesChanged();
+      if (importmidiPanel)
+            importmidiPanel->instrumentTemplatesChanged();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This PR is intended to fix this issue: https://musescore.org/en/node/280623.

As cadiz1 mentioned in the issue, the bug was introduced with [this commit](https://github.com/musescore/MuseScore/pull/3741/commits/f71c3390949cf2b47637aa7901beaf3d2a1a75ec#diff-3056168911c88e142262cb695efd9fdaR558) which made instrument templates be reloaded on each preferences change (probably because it is possible to change instruments lists in preferences now). Old instrument templates were deleted while pointers to them were still used inside `importmidi` classes. This PR makes them reload instrument templates too on reloading instrument templates by MuseScore thus preventing the reported crash.