### PR TITLE
fix #280710: correct tracks mapping for parts in undoAddElement

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3928,10 +3928,9 @@ void Score::undoAddElement(Element* element)
       Staff* ostaff = element->staff();
       int strack = -1;
       if (ostaff) {
-            if (ostaff->score()->excerpt() && strack > -1)
+            strack = ostaff->idx() * VOICES + element->track() % VOICES;
+            if (ostaff->score()->excerpt() && !ostaff->score()->excerpt()->tracks().isEmpty() && strack > -1)
                   strack = ostaff->score()->excerpt()->tracks().key(strack, -1);
-            else
-                  strack = ostaff->idx() * VOICES + element->track() % VOICES;
             }
 
       ElementType et = element->type();


### PR DESCRIPTION
Fixes https://musescore.org/en/node/280710.

The reason of the bug was in that tracks mapping for excerpts in `undoAddElement` was never actually done properly because such mapping was under the condition that was never true. I corrected the code to what was probably meant by its author and what is closer to the implementation of [`undoAddCR`](https://github.com/dmitrio95/MuseScore/blob/d8a77b4d3e7eb84ad48299c0c80a91457ad6fb2b/libmscore/edit.cpp#L4450-L4453). That fixed the issue.