### PR TITLE
fix #280522 undo text edit keep TextBase selected

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -406,7 +406,7 @@ Element* UndoMacro::selectedElement(const Selection& sel)
       if (sel.isSingle()) {
             Element* e = sel.element();
             Q_ASSERT(e); // otherwise it shouldn't be "single" selection
-            if (e->isNote() || e->isChordRest())
+            if (e->isNote() || e->isChordRest() || e->isTextBase())
                   return e;
             }
       return nullptr;


### PR DESCRIPTION
Previously when undid an edit in a TextBase element, that TextBase element would be unintentionally deselected, resulting in subsequent inputs with Ctrl-> to produced undesired unicode values instead of performing their typical commands of cut, copy, etc.

This commit tries to make sure TextBase elements aren't deselected if undid an undo that was simply for text in that textedit box.  There may be a better way to do that than this commit.

This fixes https://musescore.org/en/node/280522