### PR TITLE
fix #279814: right-click instrument name

### DIFF
--- a/libmscore/iname.cpp
+++ b/libmscore/iname.cpp
@@ -37,8 +37,9 @@ static const ElementStyle shortInstrumentStyle {
 //---------------------------------------------------------
 
 InstrumentName::InstrumentName(Score* s)
-   : TextBase(s, Tid::INSTRUMENT_LONG, ElementFlag::NOTHING | ElementFlag::NOT_SELECTABLE)
+   : TextBase(s, Tid::INSTRUMENT_LONG, ElementFlag::NOTHING)
       {
+      setFlag(ElementFlag::MOVABLE, false);
       setInstrumentNameType(InstrumentNameType::LONG);
       }
 
@@ -106,6 +107,10 @@ bool InstrumentName::setProperty(Pid id, const QVariant& v)
       switch (id) {
             case Pid::INAME_LAYOUT_POSITION:
                   _layoutPos = v.toInt();
+                  break;
+            case Pid::VISIBLE:
+            case Pid::COLOR:
+                  // not supported
                   break;
             default:
                   rv = TextBase::setProperty(id, v);

--- a/libmscore/iname.h
+++ b/libmscore/iname.h
@@ -42,6 +42,7 @@ class InstrumentName final : public TextBase  {
       void setInstrumentNameType(InstrumentNameType v);
       void setInstrumentNameType(const QString& s);
 
+      virtual bool isEditable() const override { return false; }
       virtual QVariant getProperty(Pid propertyId) const override;
       virtual bool setProperty(Pid propertyId, const QVariant&) override;
       virtual QVariant propertyDefault(Pid) const override;

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -333,7 +333,7 @@ void Inspector::update(Score* s)
                               ie = new InspectorBracket(this);
                               break;
                         case ElementType::INSTRUMENT_NAME:
-                              ie = new InspectorIname(this);
+                              //ie = new InspectorIname(this);
                               break;
                         case ElementType::FINGERING:
                               ie = new InspectorFingering(this);


### PR DESCRIPTION
This PR restores the ability to right-click an instrument name to access the staff properties.  Kind of by accident, it also restores the ability to delete instrument name by pressing Delete - the code that mapped this operation to cleaning the appropriate staff property (long/short instrument name) was still in place and still works (and the results survive save/reload).  I've also made sure the Inspector is disabled as is drag, double-click to edit, and the "toggle visibility" command - setting properties on the generated names themselves works but currently doesn't survive save/reload.

Previously this all *did* work, but it was disabled in https://github.com/musescore/MuseScore/commit/14324a6f5b72e00db29ee873c598facf15b02c24.  As per the comments, the perception was that editing properties for the generated instrument names was problematic, so I tried to be careful to only re-enable the things that would be safe: changes to *staff* properties.  In principle we could also make it so double-click brought up the staff properties dialog, but I wasn't sure we wanted to establish that precedent.

Eventually it would be nice to re-enable the ability to make individual generated instrument names invisible etc - it's a clear regression vs MuseScore 2.  But my PR here at least solves the confusion many people experience when they discover right-click no longer works.