### PR TITLE
fix #280690: Editing slur in a score with parts leads to crash

### DIFF
--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -181,7 +181,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::TIMESIG_TYPE,            "timesig_type",            true,  "subtype",               P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "subtype")          },
       { Pid::SPANNER_TICK,            "spanner_tick",            true,  "tick",                  P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "tick")             },
       { Pid::SPANNER_TICKS,           "spanner_ticks",           true,  "ticks",                 P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "ticks")            },
-      { Pid::SPANNER_TRACK2,          "spanner_track2",          true,  "track2",                P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "track2")           },
+      { Pid::SPANNER_TRACK2,          "spanner_track2",          false,  "track2",                P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "track2")           },
       { Pid::OFFSET2,                 "user_off2",               false, "userOff2",              P_TYPE::POINT_SP,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "offset2")         },
       { Pid::BREAK_MMR,               "break_mmr",               false, "breakMultiMeasureRest", P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "breaking multimeasure rest")},
       { Pid::REPEAT_COUNT,            "repeat_count",            true,  "endRepeat",             P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "end repeat")       },

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -166,13 +166,22 @@ void SlurSegment::changeAnchor(EditData& ed, Element* element)
             int ticks = spanner()->endElement()->tick() - element->tick();
             spanner()->undoChangeProperty(Pid::SPANNER_TICK, element->tick());
             spanner()->undoChangeProperty(Pid::SPANNER_TICKS, ticks);
-            spanner()->undoChangeProperty(Pid::TRACK, element->track());
+            int diff = element->track() - spanner()->track();
+            for (auto e : spanner()->linkList()) {
+                  Spanner* s = toSpanner(e);
+                  s->undoChangeProperty(Pid::TRACK, s->track() + diff);
+                  }
+
             if (score()->spannerMap().removeSpanner(spanner()))
                   score()->addSpanner(spanner());
             }
       else {
             spanner()->undoChangeProperty(Pid::SPANNER_TICKS,  element->tick() - spanner()->startElement()->tick());
-            spanner()->undoChangeProperty(Pid::SPANNER_TRACK2, element->track());
+            int diff = element->track() - spanner()->track();
+            for (auto e : spanner()->linkList()) {
+                  Spanner* s = toSpanner(e);
+                  s->undoChangeProperty(Pid::SPANNER_TRACK2, s->track() + diff);
+                  }
             }
       const size_t segments  = spanner()->spannerSegments().size();
       ups(ed.curGrip).off = QPointF();

--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -160,7 +160,7 @@ void SlurTieSegment::editDrag(EditData& ed)
                                     if (km != (Qt::ShiftModifier | Qt::ControlModifier)) {
                                           Chord* c = note->chord();
                                           ed.view->setDropTarget(note);
-                                          if (c != spanner->endCR())
+                                          if (c->part() == spanner->part() && c != spanner->endCR())
                                                 changeAnchor(ed, c);
                                           }
                                     }


### PR DESCRIPTION
See https://musescore.org/en/node/280690.