### PR TITLE
fix #278939: reinstate shift/ctrl for drag

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -474,7 +474,7 @@ void ScoreView::mouseMoveEvent(QMouseEvent* me)
                         return;
                   if (!editData.element && (me->modifiers() & Qt::ShiftModifier))
                         changeState(ViewState::LASSO);
-                  else if (editData.element && !(me->modifiers()) && editData.element->isMovable())
+                  else if (editData.element && editData.element->isMovable())
                         changeState(ViewState::DRAG_OBJECT);
                   else
                         changeState(ViewState::DRAG);


### PR DESCRIPTION
In 2.3.2 you could start your drag with Shift or Ctrl and it would start constraining the drag immediately.  For 3.0, you currently have to start dragging first.  This kind of defeats the purpose and I don't see any reason for it.  My change here allows Shift & Ctrl to take effect immediately, or at least, as immediately as any other drag (we don't engage until the mouse is moved a few pixels).

One remaining glitch / regression over 2.3.2 is that if an element is already selected and you use Ctrl+Drag, it deselects the elements (normal behavior of Ctrl+click) rather than allow drag.  In 2.3.2 Ctrl+click didn't engage until mouse *release*, so this wasn't an issue.  Not a big deal I think, and fixing it by going back to using mouse release would probably risk messing up something else.