### PR TITLE
Q_ASSERT undoRemoveMeasures non-null

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4790,6 +4790,7 @@ void Score::undoInsertTime(int tick, int len)
 
 void Score::undoRemoveMeasures(Measure* m1, Measure* m2)
       {
+      Q_ASSERT(m1 && m2);
       //
       //  handle ties which start before m1 and end in (m1-m2)
       //


### PR DESCRIPTION
This is *not a fix* for #117701 (which appears to me to be the result of a corrupted score, possibly from some other bug), but rather is simply to provide *some* console output incase some other user runs into the same issue.