### PR TITLE
fix #280422: align hairpin and dynamics

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3639,6 +3639,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
       //-------------------------------------------------------------
 
       spanner.clear();
+      std::vector<Spanner*> hairpins;
       std::vector<Spanner*> ottavas;
       std::vector<Spanner*> pedal;
       std::vector<Spanner*> voltas;
@@ -3652,10 +3653,13 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                         pedal.push_back(sp);
                   else if (sp->isVolta())
                         voltas.push_back(sp);
+                  else if (sp->isHairpin())
+                        hairpins.push_back(sp);
                   else if (!sp->isSlur() && !sp->isVolta())    // slurs are already
                         spanner.push_back(sp);
                   }
             }
+      processLines(system, hairpins, false);
       processLines(system, spanner, false);
 
       //-------------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/280422

Assuming people are OK with my analysis of the desired result (autoplace aligns hairpins vertically with start and end dynamic if present), this PR should do the job.  Here are the results:

![image](https://user-images.githubusercontent.com/1799936/50503163-f7da7b00-0a21-11e9-90dd-764fcdddbe29.png)
