### PR TITLE
fix #280771 midi entry on empty voice

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2001,7 +2001,7 @@ bool Score::processMidiInput()
                         ev.chord = true;
 
                   Element* cr = _is.lastSegment()->element(_is.track());
-                  if (cr->isChord()) {
+                  if (cr && cr->isChord()) {
                         Note* n = toChord(cr)->findNote(ev.pitch);
                         if (n) {
                               deleteItem(n->tieBack());


### PR DESCRIPTION
Previous code would crash because cr would (correctly) be set to NULL when there are no elements in a particular track of input state's last segment.  Once case this situtation occurs is when inputting midi for with a voice that hasn't been used before.  This commit prevents this crash by making sure cr is non-NULL before testing if it is a chord.