### PR TITLE
fix #280775: fix inserting text elements on MM rest via shortcut

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1297,5 +1297,21 @@ bool ChordRest::isBefore(ChordRest* o)
       return t < otick;
       }
 
+//---------------------------------------------------------
+//   undoAddAnnotation
+//---------------------------------------------------------
+
+void ChordRest::undoAddAnnotation(Element* a)
+      {
+      Segment* seg = segment();
+      Measure* m = measure();
+      if (m && m->isMMRest())
+            seg = m->mmRestFirst()->findSegmentR(SegmentType::ChordRest, 0);
+
+      a->setTrack(a->systemFlag() ? 0 : track());
+      a->setParent(seg);
+      score()->undoAddElement(a);
+      }
+
 }
 

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -181,6 +181,8 @@ class ChordRest : public DurationElement {
       virtual void removeMarkings(bool keepTremolo = false);
 
       bool isBefore(ChordRest*);
+
+      void undoAddAnnotation(Element*);
       };
 
 

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1257,10 +1257,10 @@ bool Element::isPrintable() const
 //   findMeasure
 //---------------------------------------------------------
 
-Element* Element::findMeasure()
+Measure* Element::findMeasure()
       {
       if (isMeasure())
-            return this;
+            return toMeasure(this);
       else if (_parent)
             return _parent->findMeasure();
       else
@@ -1271,7 +1271,7 @@ Element* Element::findMeasure()
 //   findMeasure
 //---------------------------------------------------------
 
-const Element* Element::findMeasure() const
+const Measure* Element::findMeasure() const
       {
       Element* e = const_cast<Element*>(this);
       return e->findMeasure();

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -175,8 +175,8 @@ class Element : public ScoreElement {
 
       Element* parent() const                 { return _parent;     }
       void setParent(Element* e)              { _parent = e;        }
-      Element* findMeasure();
-      const Element* findMeasure() const;
+      Measure* findMeasure();
+      const Measure* findMeasure() const;
       MeasureBase* findMeasureBase();
       const MeasureBase* findMeasureBase() const;
 


### PR DESCRIPTION
Fixes https://musescore.org/en/node/280775.

A similar issue (https://musescore.org/en/node/251451) took place already for adding `StaffText` and was fixed by 72950fca7a87ceeb45e9484b99157781adb49dc5. However the same issue applies to some other text-based elements. This PR tries to resolve the issue for all such elements.