### PR TITLE
fix #280715 input midi identical pitches

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2005,9 +2005,15 @@ bool Score::processMidiInput()
                         Note* n = toChord(cr)->findNote(ev.pitch);
                         if (n) {
                               deleteItem(n->tieBack());
-                              deleteItem(n);
+
+                              // to prevent two notes of same pitch in same chord, remove the existing one
+                              if (qApp->keyboardModifiers() & Qt::ShiftModifier)
+                                    deleteItem(n);
                               }
-                        if (qApp->keyboardModifiers() & Qt::ShiftModifier)
+
+                        // check if there are any remaining notes
+                        cr = _is.lastSegment()->element(_is.track());
+                        if (cr && cr->isChord() && (qApp->keyboardModifiers() & Qt::ShiftModifier))
                               ev.chord = true;
                         }
 


### PR DESCRIPTION
A prior PR #4473 (holding shift and entering notes with piano doesn't form chord) broke the ability to input identical midi pitches sequentially.  That was because that PR did handling to ensure that identical pitches weren't inputted into the same chord by deleting the currently-existing note that had the same pitch.  That deleting makes sense if user is holding Shift while inputting in the virtual midi piano keyboard, but that deleting doesn't make sense if user wasn't holding Shift.

My commit only deletes the note if the Shift key is held.  There is also an addition step to check if there are any remaining notes in the last segment of the input state, because if that deleted note was the only note in the chord, then it's deletion would have meant there is no longer a chord.