### PR TITLE
fix #280714: copy excerpts list before removing excerpts in a loop

### DIFF
--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -496,7 +496,8 @@ void MuseScore::editInstrList()
       if (masterScore->measures()->size() == 0)
             masterScore->insertMeasure(ElementType::MEASURE, 0, false);
 
-      for (Excerpt* excerpt : masterScore->excerpts()) {
+      const QList<Excerpt*> excerpts(masterScore->excerpts()); // excerpts list may change in the loop below
+      for (Excerpt* excerpt : excerpts) {
             QList<Staff*> sl       = excerpt->partScore()->staves();
             QMultiMap<int, int> tr = excerpt->tracks();
             if (sl.size() == 0)


### PR DESCRIPTION
Fixes https://musescore.org/en/node/280714.

A small related side note: in `mscore3.txt` there is a related note on iterating over Qt and STL containers:
https://github.com/musescore/MuseScore/blob/master/mscore3.txt#L148-L152
Still that note seems to be not correct as it is the `foreach` loop that does copy the container but not the container itself. So I guess that note should be edited, or am I wrong somewhere here?