### PR TITLE
fix #280234: fix progress bar values for audio export

### DIFF
--- a/mscore/exportaudio.cpp
+++ b/mscore/exportaudio.cpp
@@ -163,7 +163,7 @@ bool MuseScore::saveAudio(Score* score, QIODevice *device, std::function<bool(fl
                 playTime = endTime;
                 if (updateProgress) {
                     // normalize to [0, 1] range
-                    if (!updateProgress((pass * et + playTime) / passes / et)) {
+                    if (!updateProgress(float(pass * et + playTime) / passes / et)) {
                         cancelled = true;
                         break;
                     }


### PR DESCRIPTION
Does not apply to mp3 export as it is handled separately.

Fixes https://musescore.org/en/node/280234.