### PR TITLE
fix #280829 spanner-drop-apply.tour

### DIFF
--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -28,6 +28,7 @@
 #include "musescore.h"
 #include "scoreview.h"
 #include "continuouspanel.h"
+#include "tourhandler.h"
 
 namespace Ms {
 
@@ -412,6 +413,7 @@ void ScoreView::dropEvent(QDropEvent* event)
 
       if (editData.dropElement) {
             bool applyUserOffset = false;
+            bool triggerSpannerDropApplyTour = editData.dropElement->isSpanner();
             editData.dropElement->styleChanged();
             _score->startCmd();
             Q_ASSERT(editData.dropElement->score() == score());
@@ -554,6 +556,8 @@ void ScoreView::dropEvent(QDropEvent* event)
             // update input cursor position (must be done after layout)
             if (noteEntryMode())
                   moveCursor();
+            if (triggerSpannerDropApplyTour)
+                  TourHandler::startTour("spanner-drop-apply");
             return;
             }
 

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -45,6 +45,7 @@
 #include "paletteBoxButton.h"
 #include "palettebox.h"
 #include "shortcut.h"
+#include "tourhandler.h"
 
 namespace Ms {
 
@@ -467,6 +468,9 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
             element = cell->element;
       if (element == 0)
             return;
+      
+      if (element->isSpanner())
+            TourHandler::startTour("spanner-drop-apply");
 
       ScoreView* viewer = mscore->currentScoreView();
       if (viewer->mscoreState() != STATE_EDIT

--- a/share/tours/CMakeLists.txt
+++ b/share/tours/CMakeLists.txt
@@ -25,6 +25,7 @@ install(FILES
       noteinput.tour
       palette.tour
       select.tour
+      spanner-drop-apply.tour
       timeline.tour
       welcome.tour
       DESTINATION ${Mscore_SHARE_NAME}${Mscore_INSTALL_NAME}tours

--- a/share/tours/spanner-drop-apply.tour
+++ b/share/tours/spanner-drop-apply.tour
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Tour name="spanner-drop-apply">
+  <Message>
+    <Text>Most elements on the lines palette span a range from a start element to an end element.\n
+    To edit its range, double-click the line (which automatically selects its end handle) and:\n
+    - Press Shift-Right to move that handle forward.\n
+    - Press Shift-Left to move that handle backward.</Text>
+    </Message>
+  <Message>    
+    <Text>Alternatively, first selecting a range of elements in the score and then double-clicking a line element in the palette will add that new element across the selected range.</Text>
+    </Message>
+  </Tour>


### PR DESCRIPTION
Added new tour message triggered when either dropping or double-clicking spanners from the palette.

Explains how to extend a spanner's range with Shift-Right/Left.
Explains how to add a new spanner across a pre-selected range.