### PR TITLE
fix #280814 add timesig to meas w/some clefs

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1585,7 +1585,7 @@ std::vector<Clef*> InsertRemoveMeasures::getCourtesyClefs(Measure* m)
             if (clefSeg) {
                   for (int st = 0; st < score->nstaves(); ++st) {
                         Element* clef = clefSeg->element(staff2track(st));
-                        if (clef->isClef())
+                        if (clef && clef->isClef())
                               startClefs.push_back(toClef(clef));
                         }
                   }


### PR DESCRIPTION
Fixes a crash when adding a timesig to a measure that has at least one clef but where not all staves have clef for that measure.  Crash was result of a NULL defreference on the first staff that didn't have a clef in that clef segment.

Fix is simple to make sure to test that clef is non-NULL before dereferencing it.