### PR TITLE
fix #280900 Implode Single Measure

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2608,6 +2608,7 @@ void Score::cmdImplode()
       Segment* endSegment = selection().endSegment();
       Measure* startMeasure = startSegment->measure();
       Measure* endMeasure = endSegment ? endSegment->measure() : lastMeasure();
+      Q_ASSERT(startMeasure && endMeasure);
 
       // if single staff selected, combine voices
       // otherwise combine staves
@@ -2693,12 +2694,14 @@ void Score::cmdImplode()
             // identify tracks to combine, storing the source track numbers in tracks[]
             // first four non-empty tracks to win
             for (int track = startTrack; track < endTrack && full < VOICES; ++track) {
-                  for (Measure* m = startMeasure; m && m != endMeasure; m = m->nextMeasure()) {
+                  Measure* m = startMeasure;
+                  do {
                         if (m->hasVoice(track) && !m->isOnlyRests(track)) {
                               tracks[full++] = track;
                               break;
                               }
-                        }
+                        m = m->nextMeasure();
+                        } while (m && m != endMeasure);
                   }
 
             // clone source tracks into destination


### PR DESCRIPTION
Fixes a bug where if single measure (or smaller) range was selected, then multi-staff implode wouldn't do anything.  Code from commit 961782a likely caused this regression.

The fix is to change structure of the loop iterating over measures from a for loop to a do while loop, to ensure that the loop body always runs for startMeasure.