### PR TITLE
fix #280900 Implode Single Measure

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2606,6 +2606,7 @@ void Score::cmdImplode()
       Measure* endMeasure = endSegment ? endSegment->measure() : lastMeasure();
       int startTick       = startSegment->tick();
       int endTick         = endSegment ? endSegment->tick() : lastMeasure()->endTick();
+      Q_ASSERT(startMeasure && endMeasure);
 
       // if single staff selected, combine voices
       // otherwise combine staves
@@ -2688,12 +2689,13 @@ void Score::cmdImplode()
             // identify tracks to combine, storing the source track numbers in tracks[]
             // first four non-empty tracks to win
             for (int track = startTrack; track < endTrack && full < VOICES; ++track) {
-                  for (Measure* m = startMeasure; m && m != endMeasure; m = m->nextMeasure()) {
+                  Measure* m = startMeasure;
+                  do {
                         if (m->hasVoice(track) && !m->isOnlyRests(track)) {
                               tracks[full++] = track;
                               break;
                               }
-                        }
+                        } while ((m != endMeasure) && (m = m->nextMeasure()));
                   }
 
             // clone source tracks into destination


### PR DESCRIPTION
Fixes a bug where if single measure (or smaller) range was selected, then multi-staff implode wouldn't do anything.  Also fixs case where endMeasure is the only measure which in selection which contains voices.  Code from commit 961782a likely caused this regression.

The fix is to change structure of the loop iterating over measures from a for loop to a do while loop, to ensure that the loop body always runs for startMeasure.  And also makes sure to run the body of the loop for endMeasure.