### PR TITLE
fix #278175: add fingering mode (also works for staff text)

### DIFF
--- a/libmscore/mscoreview.h
+++ b/libmscore/mscoreview.h
@@ -66,6 +66,7 @@ class MuseScoreView {
       virtual void drawBackground(QPainter*, const QRectF&) const = 0;
       virtual void setDropTarget(const Element*) {}
 
+      virtual void textTab(bool /*back*/) {}
       virtual void lyricsTab(bool /*back*/, bool /*end*/, bool /*moveOnly*/) {}
       virtual void lyricsReturn() {}
       virtual void lyricsEndEdit() {}

--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -301,10 +301,17 @@ bool TextBase::edit(EditData& ed)
                         break;
 
                   case Qt::Key_Space:
-                        if (ed.modifiers & CONTROL_MODIFIER)
+                        if (ed.modifiers & CONTROL_MODIFIER) {
                               s = QString(QChar(0xa0)); // non-breaking space
-                        else
+                              }
+                        else {
+                              if (isFingering() && ed.view) {
+                                    score()->endCmd();
+                                    ed.view->textTab(ed.modifiers & Qt::ShiftModifier);
+                                    return true;
+                                    }
                               s = " ";
+                              }
                         ed.modifiers = 0;
                         break;
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2037,6 +2037,10 @@ void ScoreView::cmd(const char* s)
                   cmdGotoElement(score()->lastElement());
             }
       else if (cmd == "next-element") {
+            if (editMode()) {
+                  textTab(false);
+                  return;
+                  }
             Element* el = score()->selection().element();
             if (!el && !score()->selection().elements().isEmpty() )
                 el = score()->selection().elements().first();
@@ -2047,6 +2051,10 @@ void ScoreView::cmd(const char* s)
                   cmdGotoElement(score()->firstElement());
             }
       else if (cmd == "prev-element") {
+            if (editMode()) {
+                  textTab(true);
+                  return;
+                  }
             Element* el = score()->selection().element();
             if (!el && !score()->selection().elements().isEmpty())
                 el = score()->selection().elements().last();
@@ -2313,6 +2321,108 @@ void ScoreView::cmd(const char* s)
             }
       if (_score->processMidiInput())
             mscore->endCmd();
+      }
+
+//---------------------------------------------------------
+//   textTab
+//---------------------------------------------------------
+
+void ScoreView::textTab(bool back)
+      {
+      if (!editMode())
+            return;
+      Element* oe = editData.element;
+      if (!oe || !oe->isTextBase())
+            return;
+
+      if (oe->isHarmony()) {
+            harmonyBeatsTab(true, back);
+            return;
+            }
+      else if (oe->isFiguredBass()) {
+            figuredBassTab(false, back);
+            return;
+            }
+      else if (oe->isLyrics()) {
+            // not actually hit, left/right handled elsewhere
+            lyricsTab(back, false, true);
+            return;
+            }
+
+      Element* op = oe->parent();
+      if (!(op->isSegment() || op->isNote()))
+            return;
+
+      TextBase* ot = toTextBase(oe);
+      Tid tid = ot->tid();
+      ElementType type = ot->type();
+
+      // get prev/next element, as current element may be deleted if empty
+      Element* el = back ? score()->prevElement() : score()->nextElement();
+      // end edit mode
+      changeState(ViewState::NORMAL);
+
+      // find new note to add text to
+      while (el) {
+            if (el->isNote()) {
+                  Note* n = toNote(el);
+                  if (op->isNote() && n != op)
+                        break;
+                  else if (op->isSegment() && n->chord()->segment() != op)
+                        break;
+                  }
+            // get prev/next note
+            score()->select(el);
+            el = back ? score()->prevElement() : score()->nextElement();
+            }
+      if (!el || !el->isNote())
+            return;
+      Note* nn = toNote(el);
+
+      // go to note
+      cmdGotoElement(nn);
+
+      // get existing text to edit
+      el = nullptr;
+      if (op->isNote()) {
+            // check element list of new note
+            for (Element* e : nn->el()) {
+                  if (e->type() != type)
+                        continue;
+                  TextBase* nt = toTextBase(e);
+                  if (nt->tid() == tid) {
+                        el = e;
+                        break;
+                        }
+                  }
+            }
+      else if (op->isSegment()) {
+            // check annotation list of new segment
+            Segment* ns = nn->chord()->segment();
+            for (Element* e : ns->annotations()) {
+                  if (e->type() != type)
+                        continue;
+                  TextBase* nt = toTextBase(e);
+                  if (nt->tid() == tid) {
+                        el = e;
+                        break;
+                        }
+                  }
+            }
+
+      if (el) {
+            // edit existing text
+            score()->select(el);
+            startEditMode(el);
+            }
+      else {
+            // add new text if no existing element to edit
+            // TODO: for tempo text, mscore->addTempo() could be called
+            // but it pre-fills the text
+            // would be better to create empty tempo element
+            if (type != ElementType::TEMPO_TEXT)
+                  cmdAddText(tid);
+            }
       }
 
 //---------------------------------------------------------
@@ -3816,6 +3926,9 @@ void ScoreView::cmdAddText(Tid tid)
                   }
                   break;
             case Tid::FINGERING:
+            case Tid::LH_GUITAR_FINGERING:
+            case Tid::RH_GUITAR_FINGERING:
+            case Tid::STRING_NUMBER:
                   {
                   Element* e = _score->getSelectedElement();
                   if (!e || !e->isNote())
@@ -3824,7 +3937,7 @@ void ScoreView::cmdAddText(Tid tid)
                   bool tabFingering = e->staff()->staffType(e->tick())->showTabFingering();
                   if (isTablature && !tabFingering)
                         break;
-                  s = new Fingering(_score);
+                  s = new Fingering(_score, tid);
                   s->setTrack(e->track());
                   s->setParent(e);
                   _score->undoAddElement(s);

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -186,6 +186,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       virtual void lyricsUpDown(bool up, bool end) override;
       virtual void lyricsMinus() override;
       virtual void lyricsUnderscore() override;
+      virtual void textTab(bool back = false) override;
       void harmonyEndEdit();
       void harmonyTab(bool back);
       void harmonyBeatsTab(bool noterest, bool back);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -867,7 +867,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NORMAL,
+         STATE_NORMAL | STATE_TEXT_EDIT | STATE_HARMONY_FIGBASS_EDIT,
          "next-element",
          QT_TRANSLATE_NOOP("action","Next Element"),
          QT_TRANSLATE_NOOP("action","Accessibility: Next element"),
@@ -878,7 +878,7 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
-         STATE_NORMAL,
+         STATE_NORMAL | STATE_TEXT_EDIT | STATE_HARMONY_FIGBASS_EDIT,
          "prev-element",
          QT_TRANSLATE_NOOP("action","Previous Element"),
          QT_TRANSLATE_NOOP("action","Accessibility: Previous element"),


### PR DESCRIPTION
See https://musescore.org/en/node/278175 for some discussion.  Adding an easy way to add quickly move through the score adding fingerings - like we have for lyrics - is a common request.  It always seemed like it would be a lot of work to introduce a whole new mode and the necessary semantics for it, but recently it occurred to me there is a much simpler approach that leverages the existing next/previous element commands (alt+left/right).

The basic gist of my change is to tweak the behavior of alt+left/right so that if you are in text edit mode, we not only move to the next note, but also terminate edit mode on the original text and then invoke it on a text attached to the next note.

Bottom line is that entering fingerings now can work almost exactly like lyrics.  Staff text too.  Selection moves to next/previous note; if there is a text of the same type there, you can edit it, if not, one is added.

One might wish it were Space/Shift+Space that invokes this, but we can't do that without introducing a whole new state and all the state transitions and handling of cases that means throughout the code.  After all, we can hardly reserve Space for a command during regular text edit.

If someone wants to do the work of adding a whole new mode just for fingering edit, we could still use the same textTab() function I introduced as the handler, and still keep the alt+left/right behavior in addition.