### PR TITLE
fix #280817 staff implode delete orphaned spanners

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2608,6 +2608,8 @@ void Score::cmdImplode()
       Segment* endSegment = selection().endSegment();
       Measure* startMeasure = startSegment->measure();
       Measure* endMeasure = endSegment ? endSegment->measure() : lastMeasure();
+      int startTick       = startSegment->tick();
+      int endTick         = endSegment ? endSegment->tick() : lastMeasure()->endTick();
 
       // if single staff selected, combine voices
       // otherwise combine staves
@@ -2678,17 +2680,14 @@ void Score::cmdImplode()
                               }
                         }
                   }
+            // delete orphaned spanners (TODO: figure out solution to reconnect orphaned spanners to their cloned notes)
+            checkSpanner(startTick, endTick);
             }
       else {
             int tracks[VOICES];
             for (int i = 0; i < VOICES; i++)
                   tracks[i] = -1;
             int full = 0;
-            int lTick;
-            if (endSegment)
-                  lTick = endSegment->tick();
-            else
-                  lTick = lastMeasure()->endTick();
 
             // identify tracks to combine, storing the source track numbers in tracks[]
             // first four non-empty tracks to win
@@ -2705,7 +2704,7 @@ void Score::cmdImplode()
             for (int i = dstTrack; i < dstTrack + VOICES; i++) {
                   int strack = tracks[i % VOICES];
                   if (strack != -1 && strack != i) {
-                        undo( new CloneVoice(startSegment, lTick, startSegment, strack, i, i, false));
+                        undo( new CloneVoice(startSegment, endTick, startSegment, strack, i, i, false));
                         }
                   }
             }


### PR DESCRIPTION
Previously, imploding a staff would leave orphaned spanners after the notes they connected to were deleted when moving those notes to the first voice.  These orphaned spanners would cause a crash during layout when the Implode command finished.

This is a simple fix to avoid a crash by deleting these orphaned spanners.

An ideal solution would be to somehow reconnect these orphaned spanners to the new version of their original notes after they move to the first 1st voice.  But that solution would require a lot more thought to get correct, and would also require special consideration for various corner cases, such as what happens with spanners who have one end connected to notes outside the imploded range but the other end connected to a note inside the range...