### PR TITLE
fix #280830 exit edit mode if double-click palette

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -763,6 +763,11 @@ void Palette::mouseDoubleClickEvent(QMouseEvent* ev)
             return;
       if (score->selection().isNone())
             return;
+      
+      // exit edit mode, to allow for palette element to be applied properly
+      ScoreView* viewer = mscore->currentScoreView();
+      if (viewer && viewer->editMode() && !(viewer->mscoreState() & STATE_ALLTEXTUAL_EDIT))
+            viewer->changeState(ViewState::NORMAL);
 
       applyPaletteElement(cellAt(i), ev->modifiers());
       }


### PR DESCRIPTION
Previously, if user was in edit mode (by double-clicking an element in score), then applying palette elements by double-clicking would be problematic.  This would be because Palette::applyPaletteElement() doesn't perform score->startCmd() before applying the element nor a score->endCmd() after applying the element, because it assumes that the score is already in a startCmd.

Exiting edit mode fixes #280830 which was a crash when applying a time signature from palette while in editmode.  And fixes another glitch where applying system text from palette while in edit mode.