### PR TITLE
MSVC pch allow switch configuration

### DIFF
--- a/build/CreatePrecompiledHeader.cmake
+++ b/build/CreatePrecompiledHeader.cmake
@@ -98,7 +98,7 @@ macro( vstudio_pch target_name )
     if( MSVC )
         # Prepare paths and filenames
         message(STATUS "Preparing pre-compiled headers for ${target_name}")
-        set(_pch_path "${CMAKE_CURRENT_BINARY_DIR}/${target_name}_pch")
+        set(_pch_path "${CMAKE_CURRENT_BINARY_DIR}/$(Configuration)")
         make_directory("${_pch_path}")
         set(_pch_file "${_pch_path}/${PCH_HEADERNAME}.pch")
         set(_pch_force_use "/Fp${_pch_file} /Yu${PCH_HEADER}")


### PR DESCRIPTION
Previously, changing build configuration in MSVC would result in a failed compilation.  That's because CreatePrecompiledHeader.cmake told MSVC to use the same pre-compiled header file for all configurations, causing the compiler to complain that the pch was generated with different incompatible compiler options.

This commit fixes that by using the MSVC string for configuration as part of the directory for the pre-compiled header location, so each configuration (Release, Debug, RelWithDebInfo, or any other) will have its own precompiled header which works properly during compile.  That allows programmer to easily switch between configurations.