### PR TITLE
doConcurrentLayoutAndUpdate to speedup Score::update() (Not a PR...just sharing for thoughts)

### DIFF
--- a/all.h
+++ b/all.h
@@ -204,6 +204,7 @@
 
 #include <QJsonDocument>
 
+#include <QMutex>
 
 // change Q_ASSERT to NOP if not debugging
 

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1056,11 +1056,13 @@ static void initBeamMetrics()
 
 static Bm beamMetric1(bool up, char l1, char l2)
       {
-      static int initialized = false;
-      if (!initialized) {
+      static bool initialized = false;
+      static QMutex mutexInitBeamMetrics;
+      if (mutexInitBeamMetrics.tryLock()) {
             initBeamMetrics();
             initialized = true;
             }
+      while (!initialized); // spin in rare case that another thread is in initBeamMetrics() while another thread calls beamMetric1
       return bMetrics[Bm::key(up, l1, l2)];
       }
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1465,7 +1465,7 @@ static void checkDivider(bool left, System* s, qreal yOffset)
 static void layoutPage(Page* page, qreal restHeight)
       {
       if (restHeight < 0.0) {
-            qDebug("restHeight < 0.0: %f\n", restHeight);
+            qCDebug(layout, "restHeight < 0.0: %f\n", restHeight);
             restHeight = 0;
             }
 
@@ -4067,7 +4067,7 @@ void Score::doLayoutRange(int stick, int etick)
             }
 //      if (!_systems.isEmpty())
 //            return;
- qDebug("%p %d-%d %s systems %d", this, stick, etick, isMaster() ? "Master" : "Part", int(_systems.size()));
+      qCDebug(layout, "%p %d-%d %s systems %d", this, stick, etick, isMaster() ? "Master" : "Part", int(_systems.size()));
       bool layoutAll = stick <= 0 && (etick < 0 || etick >= last()->endTick());
       if (stick < 0)
             stick = 0;
@@ -4104,7 +4104,7 @@ void Score::doLayoutRange(int stick, int etick)
       // rest which replaces the measure range
 
       if (!m->system() && m->isMeasure() && toMeasure(m)->hasMMRest()) {
-            qDebug("  don’t start with mmrest");
+            qCDebug(layout, " don’t start with mmrest");
             m = toMeasure(m)->mmRest();
             }
 
@@ -4193,6 +4193,8 @@ void Score::doLayoutRange(int stick, int etick)
 
       for (MuseScoreView* v : viewer)
             v->layoutChanged();
+      
+      qCDebug(layout) << "end layout " << hex << this;
       }
 
 //---------------------------------------------------------

--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -13,6 +13,8 @@
 #ifndef __LAYOUT_H__
 #define __LAYOUT_H__
 
+Q_DECLARE_LOGGING_CATEGORY(layout)
+
 namespace Ms {
 
 class Segment;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -388,6 +388,7 @@ class Score : public QObject, public ScoreElement {
 
    private:
       static std::set<Score*> validScores;
+      static Score* scoreOfUpdate; // set by Score::update() and needed in doConcurrentLayoutAndUpdate to know which score called update when CmdState is only doing updateRange
       int _linkId { 0 };
       MasterScore* _masterScore { 0 };
       QList<MuseScoreView*> viewer;
@@ -526,6 +527,8 @@ class Score : public QObject, public ScoreElement {
       void renderSpanners(EventMap* events);
       void renderMetronome(EventMap* events, Measure* m, int tickOffset);
       void updateVelo();
+
+      void doConcurrentLayoutAndUpdate();
 
    protected:
       int _fileDivision; ///< division of current loading *.msc file
@@ -997,7 +1000,7 @@ class Score : public QObject, public ScoreElement {
       void removeAudio();
 
       void doLayout();
-      void doLayoutRange(int, int);
+      void doLayoutRange(int stick, int etick);
       void layoutLinear(bool layoutAll, LayoutContext& lc);
 
       void layoutSystemsUndoRedo();

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -18,6 +18,7 @@
  Definition of undo-releated classes and structs.
 */
 
+#include "all.h"
 #include "spatium.h"
 #include "mscore.h"
 #include "sig.h"
@@ -146,6 +147,7 @@ class UndoStack {
       int nextState;
       int cleanState;
       int curIdx;
+      QMutex mutexPushPop;
 
    public:
       UndoStack();

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -143,8 +143,10 @@ extern Ms::Synthesizer* createZerberus();
 
 #ifdef QT_NO_DEBUG
       Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtCriticalMsg)
+      Q_LOGGING_CATEGORY(layout,   "layout",   QtCriticalMsg)
 #else
       Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtCriticalMsg)
+      Q_LOGGING_CATEGORY(layout,   "layout",   QtCriticalMsg)
 //      Q_LOGGING_CATEGORY(undoRedo, "undoRedo")
 #endif
 

--- a/mtest/testutils.cpp
+++ b/mtest/testutils.cpp
@@ -41,6 +41,7 @@ inline void initMyResources() {
 extern Ms::Score::FileError importOve(Ms::MasterScore*, const QString& name);
 
 Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtCriticalMsg)
+Q_LOGGING_CATEGORY(layout, "layout", QtCriticalMsg)
 // Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtDebugMsg)
 
 namespace Ms {


### PR DESCRIPTION
I was pondering how much potential there was to speed up very large scores (see "Score Editing Slow" issue https://musescore.org/en/node/280952).  While familiarizing myself with the update code, I found that the big scores with lots of parts get bogged down even when just changing pitch of one note because they have to regenerate layout and update of the affected system for every single part that has been created.  That is in addition to the very large main score.

I notice that the layout and update of each individual part is independent* of eachother and the main score.  And turns out that QtConcurrent has nice high-level functions for map-reduce.  So basically what I've done is rearrange Score::update() code to be able to deal with each score independently, and spun off each individual score's independent processing into `Score::doConcurrentLayoutAndUpdate()`, and then in the main Score::update used `QtConcurrent::blockingMap(scores, [](Score* s){ s->doConcurrentLayoutAndUpdate(); } );` to concurrently execute the layout & update for every score in the MasterScore's scoreList().  QtConcurrent seems to know my CPU count (I'm on a 12-core machine) and automatically create that many threads without me having to specify that, which is nice. 

Anyway, here are some speed measurements on MSVC release build (using the Thunderbolt_March.mscz attached to that "Score Editing Slow" issue mentioned earlier) by putting timers at start and end of Score::update():

- first update (entire range) upon initial load of score: 3701 ms single threaded becomes 1360 ms with concurrent update, almost 3 times faster
- an incremental update of just changing first pitch of 2nd staff 4th meas in main score: 1114 ms becomes 870 ms, only ~28% faster.

So it seems the biggest improvement comes from updating the entire score.  That is because every part score has to relayout it's entire score.  But not much speedup when just change single note.  And that is because the main score has a lot (34) staves.  So even though the system that is being updated is only 8 measures long, there are so many staves that it takes much longer.  Compared to every individual part score where the system to be regenerated has only one staff (or 2 in case of grand-staff instruments).  But still it is nice to have all these part scores do update concurrently, so user doesn't have to wait for all of the easier part scores to finish, (even though they're easier, there are so many that their time does add up).

Here's a screen shot of the CPU usage...100% means that all 12 cores are being utilized, and you can see that does indeed happen with that biggest spike where, which occurs when doing relayout of entire score (which is the case upon initial load of a score or doing any operation which mandates full relayout).  The subsequent smaller spikes are when I change a single pitch...and unfortunately only has a much smaller peak...but at least it is some speedup:

![concurrent_release-mode](https://user-images.githubusercontent.com/6502474/50631375-09d08800-0f12-11e9-8359-b7220856d026.PNG)

Anyway, I think the takeaway point is that layout speed for main scores with very large systems still needs to be significantly improved...there is probably a lot of redundant computations...as I'm sure most people are aware of.  Also as I mentioned in pictures in the original issue report, the hottest line is calculating bezier rectangles...which surely could be simplified...

* Note: layout isn't quite completely indpendent...there are some exceptions which can be fixed...such as initBeamMetrics which causes sporadic crash on first concurrent update, I think because two threads might try to do that init at the same time...obviously that initBeamMetrics should be moved out of the parallel section.  If there are any other non-independent parts in layout, I think they can also be made independent.