### PR TITLE
fix #274661: new grace note input

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -547,7 +547,17 @@ Note* Score::setGraceNote(Chord* ch, int pitch, NoteType type, int len)
       chord->setMag(ch->staff()->mag(chord->tick()) * styleD(Sid::graceNoteMag));
 
       undoAddElement(chord);
-      select(note, SelectType::SINGLE, 0);
+
+      if(qApp->keyboardModifiers().testFlag(Qt::ShiftModifier)){
+            Chord* cg = ch->graceNotes().first();
+            if (viewer.count()) {
+                  if (cg->isGraceAfter())
+                        score()->viewer[0]->cmdAddSlur(ch, cg);
+                  else
+                        score()->viewer[0]->cmdAddSlur(cg, ch);
+                  }
+            }
+
       return note;
       }
 

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -340,6 +340,15 @@ void Score::putNote(const Position& p, bool replace)
       ChordRest* cr = _is.cr();
       bool addToChord = false;
 
+      if(_graceInputState != IconType::NONE && selection().elements().count() == 1){
+            if (cr && cr->isChord()) {
+                        if(selection().element()->type() == ElementType::NOTE){
+                        setGraceNote(toChord(cr), nval.pitch, iconTypeToNoteType(_graceInputState), iconTypeToLen(_graceInputState));
+                        score()->addRefresh(cr->canvasBoundingRect());
+                        }
+                  }
+            return;
+            }
       if (cr) {
             // retrieve total duration of current chord
             TDuration d = cr->durationType();

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -260,6 +260,7 @@ Score::Score()
       _pos[int(POS::RIGHT)]   = 0;
       _fileDivision           = MScore::division;
       _style  = MScore::defaultStyle();
+      _graceInputState = IconType::NONE;
 //      accInfo = tr("No selection");     // ??
       accInfo = "No selection";
       }
@@ -4216,6 +4217,126 @@ void Score::changeVoice(int voice)
       setLayoutAll();
       endCmd();
       }
+
+//---------------------------------------------------------
+//   iconTypeToNoteType
+///  IconType is transformed to NoteType
+//---------------------------------------------------------
+
+NoteType Score::iconTypeToNoteType(IconType iType)
+      {
+          switch(iType)  {
+                case IconType::ACCIACCATURA:
+                      return NoteType::ACCIACCATURA;
+                case IconType::APPOGGIATURA:
+                      return NoteType::APPOGGIATURA;
+                case IconType::GRACE4:
+                      return NoteType::GRACE4;
+                case IconType::GRACE16:
+                      return NoteType::GRACE16;
+                case IconType::GRACE32:
+                      return NoteType::GRACE32;
+                case IconType::GRACE8_AFTER:
+                      return NoteType::GRACE8_AFTER;
+                case IconType::GRACE16_AFTER:
+                      return NoteType::GRACE16_AFTER;
+                case IconType::GRACE32_AFTER:
+                      return NoteType::GRACE32_AFTER;
+                default:
+                      return NoteType::NORMAL;
+          }
+
+      }
+
+//---------------------------------------------------------
+//   iconTypeToDuration
+///  IconType is transformed to DurationType
+//---------------------------------------------------------
+
+TDuration Score::iconTypeToDuration(IconType iType)
+      {
+          switch(iType)  {
+                case IconType::ACCIACCATURA:
+                      return TDuration(TDuration::DurationType::V_EIGHTH);
+                case IconType::APPOGGIATURA:
+                      return TDuration(TDuration::DurationType::V_EIGHTH);
+                case IconType::GRACE4:
+                      return TDuration(TDuration::DurationType::V_QUARTER);
+                case IconType::GRACE16:
+                      return TDuration(TDuration::DurationType::V_16TH);
+                case IconType::GRACE32:
+                      return TDuration(TDuration::DurationType::V_32ND);
+                case IconType::GRACE8_AFTER:
+                      return TDuration(TDuration::DurationType::V_EIGHTH);
+                case IconType::GRACE16_AFTER:
+                      return TDuration(TDuration::DurationType::V_16TH);
+                case IconType::GRACE32_AFTER:
+                      return TDuration(TDuration::DurationType::V_32ND);
+                default:
+                      return TDuration(TDuration::DurationType::V_INVALID);
+          }
+
+      }
+
+//---------------------------------------------------------
+//   iconTypeToSymId
+///  IconType is transformed to SymId
+//---------------------------------------------------------
+
+SymId Score::iconTypeToSymId(IconType iType)
+      {
+          switch(iType)  {
+                case IconType::ACCIACCATURA:
+                      return SymId::note8thUp;
+                case IconType::APPOGGIATURA:
+                      return SymId::note8thUp;
+                case IconType::GRACE4:
+                      return SymId::noteQuarterUp;
+                case IconType::GRACE16:
+                      return SymId::note16thUp;
+                case IconType::GRACE32:
+                      return SymId::note32ndUp;
+                case IconType::GRACE8_AFTER:
+                      return SymId::note8thUp;
+                case IconType::GRACE16_AFTER:
+                      return SymId::note16thUp;
+                case IconType::GRACE32_AFTER:
+                      return SymId::note32ndUp;
+                default:
+                      return SymId::noSym;
+          }
+
+      }
+
+//---------------------------------------------------------
+//   iconTypeToLen
+///  Get note lengh from iconType
+//---------------------------------------------------------
+
+int Score::iconTypeToLen(IconType iType)
+      {
+          switch(iType)  {
+            case IconType::ACCIACCATURA:
+                  return MScore::division/2;
+            case IconType::APPOGGIATURA:
+                  return MScore::division/2;
+            case IconType::GRACE4:
+                  return MScore::division;
+            case IconType::GRACE16:
+                  return MScore::division/4;
+            case IconType::GRACE32:
+                  return MScore::division/8;
+            case IconType::GRACE8_AFTER:
+                  return MScore::division/2;
+            case IconType::GRACE16_AFTER:
+                  return MScore::division/4;
+            case IconType::GRACE32_AFTER:
+                  return MScore::division/8;
+            default:
+                  return -1;
+                }
+      }
+
 
 #if 0
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -458,6 +458,7 @@ class Score : public QObject, public ScoreElement {
 
       qreal _noteHeadWidth { 0.0 };       // cached value
       QString accInfo;                    ///< information used by the screen-reader
+      IconType _graceInputState;
 
       //------------------
 
@@ -1188,6 +1189,13 @@ class Score : public QObject, public ScoreElement {
       void createBeams(Measure*);
 
       constexpr static double defaultTempo()  { return _defaultTempo; }
+
+      IconType getGraceInputState() {return _graceInputState;}
+      void setGraceInputState(IconType type) {_graceInputState = type;}
+      NoteType iconTypeToNoteType(IconType);
+      int iconTypeToLen(IconType iType);
+      TDuration iconTypeToDuration(IconType iType);
+      SymId iconTypeToSymId(IconType iType);
 
       friend class ChangeSynthesizerState;
       friend class Chord;

--- a/libmscore/shadownote.cpp
+++ b/libmscore/shadownote.cpp
@@ -93,10 +93,21 @@ SymId ShadowNote::getNoteFlag() const
 
 bool ShadowNote::computeUp() const
       {
+      if (_isGrace)
+            return true;
       if (_voice % VOICES == 0)
             return _line > 4;
       else
             return _voice % VOICES == 2;
+      }
+
+//---------------------------------------------------------
+//   setGrace
+//---------------------------------------------------------
+void ShadowNote::setGrace(bool grace)
+      {
+      _isGrace = grace;
+      setMag(grace ? masterScore()->styleD(Sid::graceNoteMag) : 1);
       }
 
 //---------------------------------------------------------

--- a/libmscore/shadownote.h
+++ b/libmscore/shadownote.h
@@ -33,7 +33,7 @@ class ShadowNote final : public Element {
       TDuration _duration;
       int _voice;
       bool _rest;
-
+      bool _isGrace;
    public:
       ShadowNote(Score*);
       virtual ShadowNote* clone() const  { return new ShadowNote(*this); }
@@ -44,6 +44,7 @@ class ShadowNote final : public Element {
       virtual void draw(QPainter*) const;
 
       void setState(SymId noteSymbol, int voice, TDuration duration, bool rest = false);
+      void setGrace(bool grace);
 
       SymId getNoteFlag() const;
       bool computeUp() const;

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -258,6 +258,7 @@ void ScoreView::mouseReleaseEvent(QMouseEvent*)
                         }
             case ViewState::EDIT:
             case ViewState::NOTE_ENTRY:
+            case ViewState::GRACE_NOTE_ENTRY:
             case ViewState::PLAY:
             case ViewState::ENTRY_PLAY:
             case ViewState::FOTO:
@@ -774,6 +775,7 @@ static const char* stateName(ViewState s)
             case ViewState::DRAG_EDIT:          return "DRAG_EDIT";
             case ViewState::LASSO:              return "LASSO";
             case ViewState::NOTE_ENTRY:         return "NOTE_ENTRY";
+            case ViewState::GRACE_NOTE_ENTRY:   return "GRACE_NOTE_ENTRY";
             case ViewState::PLAY:               return "PLAY";
             case ViewState::ENTRY_PLAY:         return "ENTRY_PLAY";
             case ViewState::FOTO:               return "FOTO";
@@ -873,6 +875,7 @@ void ScoreView::changeState(ViewState s)
                   setCursor(QCursor(Qt::SizeAllCursor));
                   break;
             case ViewState::NOTE_ENTRY:
+            case ViewState::GRACE_NOTE_ENTRY:
                   setCursor(QCursor(Qt::ArrowCursor));
                   startNoteEntry();
                   break;

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -348,6 +348,15 @@ void Palette::mousePressEvent(QMouseEvent* ev)
 */
       if (dragIdx == -1)
             return;
+      if (_name == "Grace Notes" && qApp->keyboardModifiers().testFlag(Qt::ControlModifier)) {
+            // Want one single note to start grace notes input
+            const Selection sel = mscore->currentScoreView()->score()->selection();
+            if (sel.isNone() || ! sel.isSingle() || ! sel.elements().first()->isNote())
+                  return;
+            mscore->currentScoreView()->score()->setGraceInputState(static_cast<Icon*>(cells[dragIdx]->element)->iconType());
+            mscore->currentScoreView()->changeState(ViewState::NOTE_ENTRY);
+            return;
+            }
       if (_selectable) {
             if (dragIdx != selectedIdx) {
                   update(idxRect(dragIdx) | idxRect(selectedIdx));

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -69,6 +69,7 @@ enum class ViewState {
       DRAG_EDIT,
       LASSO,
       NOTE_ENTRY,
+      GRACE_NOTE_ENTRY,
       PLAY,
       ENTRY_PLAY,
 
@@ -240,6 +241,7 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       void startNoteEntry();
       virtual void startNoteEntryMode() override;
+      void graceNoteEntry(IconType graceNoteType);
       void endNoteEntry();
 
       void endLasso();


### PR DESCRIPTION
This implements a grace note entry mode that improves the insert of grace notes. For adding grace notes select the target note, then click on the desired grace note type icon in the palette while pressing the CTRL key. MuseScore changes to GRACE_NOTE_ENTRY, similar NOTE_ENTRY mode. Then work like in NOTE_ENTRY mode by mouse click or pressing the keys A-G. Mouse clicking saves correction of the octave. Pressing Shift key while clicking automatically adds a slur.