### PR TITLE
fix #281146: Add "User" text styles to Inspector dropdown for fingering

### DIFF
--- a/mscore/inspector/inspectorFingering.cpp
+++ b/mscore/inspector/inspectorFingering.cpp
@@ -33,11 +33,31 @@ InspectorFingering::InspectorFingering(QWidget* parent)
             { f.title, f.panel }
             };
 
-      f.style->clear();
-      for (auto ss : { Tid::FINGERING, Tid::LH_GUITAR_FINGERING, Tid::RH_GUITAR_FINGERING, Tid::STRING_NUMBER } )
-            f.style->addItem(textStyleUserName(ss), int(ss));
+      populateStyle(f.style);
 
       mapSignals(iiList, ppList);
+      }
+
+//---------------------------------------------------------
+//   allowedTextStyles
+//---------------------------------------------------------
+
+const std::vector<Tid>& InspectorFingering::allowedTextStyles()
+      {
+      static const std::vector<Tid> _fingeringTextStyles = {
+            Tid::FINGERING,
+            Tid::LH_GUITAR_FINGERING,
+            Tid::RH_GUITAR_FINGERING,
+            Tid::STRING_NUMBER,
+            Tid::USER1,
+            Tid::USER2,
+            Tid::USER3,
+            Tid::USER4,
+            Tid::USER5,
+            Tid::USER6
+            };
+
+      return _fingeringTextStyles;
       }
 }
 

--- a/mscore/inspector/inspectorFingering.h
+++ b/mscore/inspector/inspectorFingering.h
@@ -29,6 +29,7 @@ class InspectorFingering : public InspectorTextBase {
 
    public:
       InspectorFingering(QWidget* parent);
+      virtual const std::vector<Tid>& allowedTextStyles() override;
       };
 
 

--- a/mscore/inspector/inspectorTextBase.cpp
+++ b/mscore/inspector/inspectorTextBase.cpp
@@ -95,6 +95,15 @@ void InspectorTextBase::setElement()
       }
 
 //---------------------------------------------------------
+//   allowedTextStyles
+//---------------------------------------------------------
+
+const std::vector<Tid>& InspectorTextBase::allowedTextStyles()
+      {
+      return primaryTextStyles();
+      }
+
+//---------------------------------------------------------
 //   populateStyle
 //---------------------------------------------------------
 
@@ -106,7 +115,7 @@ void InspectorTextBase::populateStyle(QComboBox* style)
             style->blockSignals(true);
             int idx = style->currentIndex();
             style->clear();
-            for (auto ss : primaryTextStyles())
+            for (auto ss : allowedTextStyles())
                   style->addItem(score->getTextStyleUserName(ss), int(ss));
             style->setCurrentIndex(idx);
             style->blockSignals(false);

--- a/mscore/inspector/inspectorTextBase.h
+++ b/mscore/inspector/inspectorTextBase.h
@@ -35,6 +35,7 @@ class InspectorTextBase : public InspectorElementBase {
    public:
       InspectorTextBase(QWidget* parent);
       virtual void setElement() override;
+      virtual const std::vector<Tid>& allowedTextStyles();
       void populateStyle(QComboBox* style);
       };
 


### PR DESCRIPTION
See https://musescore.org/en/node/281146.