### PR TITLE
Make Start Center child of MuseScore's Main Window

### DIFF
--- a/mscore/startcenter.cpp
+++ b/mscore/startcenter.cpp
@@ -27,7 +27,7 @@ void MuseScore::showStartcenter(bool show)
       {
       QAction* a = getAction("startcenter");
       if (show && startcenter == nullptr) {
-            startcenter = new Startcenter;
+            startcenter = new Startcenter(this);
             startcenter->addAction(a);
             startcenter->readSettings();
             connect(startcenter, SIGNAL(closed(bool)), a, SLOT(setChecked(bool)));
@@ -45,8 +45,8 @@ void MuseScore::showStartcenter(bool show)
 //   Startcenter
 //---------------------------------------------------------
 
-Startcenter::Startcenter()
- : AbstractDialog(0)
+Startcenter::Startcenter(QWidget* parent)
+ : AbstractDialog(parent)
       {
       setObjectName("Startcenter");
       setupUi(this);

--- a/mscore/startcenter.h
+++ b/mscore/startcenter.h
@@ -89,7 +89,7 @@ class Startcenter : public AbstractDialog, public Ui::Startcenter {
       void closed(bool);
 
     public:
-      Startcenter();
+      Startcenter(QWidget* parent);
       ~Startcenter();
       void updateRecentScores();
       void writeSettings();


### PR DESCRIPTION
- Start Center no longer a separate tab in taskbar and Alt+Tab window list
- Closes with Esc automatically, no need for keyPressEvent hacks