### PR TITLE
InstrumentsWidget: Replace TreeWidget with FilterableTreeWidget

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -418,8 +418,8 @@ InstrumentsWidget::InstrumentsWidget(QWidget* parent)
       removeButton->setEnabled(false);
       upButton->setEnabled(false);
       downButton->setEnabled(false);
-      belowButton->setEnabled(false);
-      linkedButton->setEnabled(false);
+      addStaffButton->setEnabled(false);
+      addLinkedStaffButton->setEnabled(false);
 
       connect(instrumentList, SIGNAL(clicked(const QModelIndex &)), SLOT(expandOrCollapse(const QModelIndex &)));
       }
@@ -467,7 +467,7 @@ void populateInstrumentList(QTreeWidget* instrumentList)
 void InstrumentsWidget::buildTemplateList()
       {
       // clear search if instrument list is updated
-      search->clear();
+      instrumentSearch->clear();
 
       populateInstrumentList(instrumentList);
       populateGenreCombo(instrumentGenreFilter);
@@ -545,8 +545,8 @@ void InstrumentsWidget::on_partiturList_itemSelectionChanged()
             removeButton->setEnabled(false);
             upButton->setEnabled(false);
             downButton->setEnabled(false);
-            linkedButton->setEnabled(false);
-            belowButton->setEnabled(false);
+            addLinkedStaffButton->setEnabled(false);
+            addStaffButton->setEnabled(false);
             return;
             }
       QTreeWidgetItem* item = wi.front();
@@ -579,8 +579,8 @@ void InstrumentsWidget::on_partiturList_itemSelectionChanged()
       removeButton->setEnabled(flag && !onlyOne);
       upButton->setEnabled(flag && !onlyOne && !first);
       downButton->setEnabled(flag && !onlyOne && !last);
-      linkedButton->setEnabled(item && item->type() == STAFF_LIST_ITEM);
-      belowButton->setEnabled(item && item->type() == STAFF_LIST_ITEM);
+      addLinkedStaffButton->setEnabled(item && item->type() == STAFF_LIST_ITEM);
+      addStaffButton->setEnabled(item && item->type() == STAFF_LIST_ITEM);
       }
 
 //---------------------------------------------------------
@@ -876,11 +876,10 @@ void InstrumentsWidget::on_downButton_clicked()
       }
 
 //---------------------------------------------------------
-//   on_belowButton_clicked
-//    (actually "Add Staff" button)
+//   on_addStaffButton_clicked
 //---------------------------------------------------------
 
-StaffListItem* InstrumentsWidget::on_belowButton_clicked()
+StaffListItem* InstrumentsWidget::on_addStaffButton_clicked()
       {
       QList<QTreeWidgetItem*> wi = partiturList->selectedItems();
       if (wi.isEmpty())
@@ -917,21 +916,21 @@ StaffListItem* InstrumentsWidget::on_belowButton_clicked()
       }
 
 //---------------------------------------------------------
-//   on_linkedButton_clicked
+//   on_addLinkedStaffButton_clicked
 //---------------------------------------------------------
 
-void InstrumentsWidget::on_linkedButton_clicked()
+void InstrumentsWidget::on_addLinkedStaffButton_clicked()
       {
-      StaffListItem* nsli = on_belowButton_clicked();
+      StaffListItem* nsli = on_addStaffButton_clicked();
       if (nsli)
             nsli->setLinked(true);
       }
 
 //---------------------------------------------------------
-//   on_search_textChanged
+//   on_instrumentSearch_textChanged
 //---------------------------------------------------------
 
-void InstrumentsWidget::on_search_textChanged(const QString &searchPhrase)
+void InstrumentsWidget::on_instrumentSearch_textChanged(const QString &searchPhrase)
       {
       instrumentGenreFilter->blockSignals(true);
       instrumentGenreFilter->setCurrentIndex(0);
@@ -1076,8 +1075,8 @@ void InstrumentsWidget::init()
       removeButton->setEnabled(false);
       upButton->setEnabled(false);
       downButton->setEnabled(false);
-      linkedButton->setEnabled(false);
-      belowButton->setEnabled(false);
+      addLinkedStaffButton->setEnabled(false);
+      addStaffButton->setEnabled(false);
       emit completeChanged(false);
       }
 

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -135,9 +135,8 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
       void on_downButton_clicked();
       StaffListItem* on_addStaffButton_clicked();
       void on_addLinkedStaffButton_clicked();
-      void expandOrCollapse(const QModelIndex &);
 
-      void on_instrumentSearch_textChanged(const QString &searchPhrase);
+      void on_instrumentSearch_textChanged(const QString &);
 
       void on_instrumentGenreFilter_currentIndexChanged(int);
       void filterInstrumentsByGenre(QTreeWidget *, QString);

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -133,11 +133,11 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
       void on_removeButton_clicked();
       void on_upButton_clicked();
       void on_downButton_clicked();
-      StaffListItem* on_belowButton_clicked();
-      void on_linkedButton_clicked();
+      StaffListItem* on_addStaffButton_clicked();
+      void on_addLinkedStaffButton_clicked();
       void expandOrCollapse(const QModelIndex &);
 
-      void on_search_textChanged(const QString &searchPhrase);
+      void on_instrumentSearch_textChanged(const QString &searchPhrase);
 
       void on_instrumentGenreFilter_currentIndexChanged(int);
       void filterInstrumentsByGenre(QTreeWidget *, QString);

--- a/mscore/instrwidget.ui
+++ b/mscore/instrwidget.ui
@@ -44,7 +44,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QTreeWidget" name="instrumentList">
+        <widget class="Ms::FilterableTreeWidget" name="instrumentList">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
@@ -83,7 +83,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="instrumentSearch">
+        <widget class="Ms::SearchBox" name="instrumentSearch">
          <property name="focusPolicy">
           <enum>Qt::StrongFocus</enum>
          </property>
@@ -348,6 +348,18 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Ms::FilterableTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>widgets/filterabletreeview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Ms::SearchBox</class>
+   <extends>QLineEdit</extends>
+   <header>widgets/searchbox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>instrumentGenreFilter</tabstop>
   <tabstop>instrumentList</tabstop>

--- a/mscore/instrwidget.ui
+++ b/mscore/instrwidget.ui
@@ -83,30 +83,23 @@
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <property name="bottomMargin">
-          <number>0</number>
+        <widget class="QLineEdit" name="instrumentSearch">
+         <property name="focusPolicy">
+          <enum>Qt::StrongFocus</enum>
          </property>
-         <item>
-          <widget class="QLineEdit" name="search">
-           <property name="focusPolicy">
-            <enum>Qt::StrongFocus</enum>
-           </property>
-           <property name="accessibleName">
-            <string>Search</string>
-           </property>
-           <property name="inputMask">
-            <string notr="true"/>
-           </property>
-           <property name="placeholderText">
-            <string>Search</string>
-           </property>
-           <property name="clearButtonEnabled">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
+         <property name="accessibleName">
+          <string>Search</string>
+         </property>
+         <property name="inputMask">
+          <string notr="true"/>
+         </property>
+         <property name="placeholderText">
+          <string>Search</string>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -254,7 +247,7 @@
         </spacer>
        </item>
        <item>
-        <widget class="QPushButton" name="belowButton">
+        <widget class="QPushButton" name="addStaffButton">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -270,7 +263,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="linkedButton">
+        <widget class="QPushButton" name="addLinkedStaffButton">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -358,13 +351,13 @@
  <tabstops>
   <tabstop>instrumentGenreFilter</tabstop>
   <tabstop>instrumentList</tabstop>
-  <tabstop>search</tabstop>
+  <tabstop>instrumentSearch</tabstop>
   <tabstop>addButton</tabstop>
   <tabstop>removeButton</tabstop>
   <tabstop>upButton</tabstop>
   <tabstop>downButton</tabstop>
-  <tabstop>belowButton</tabstop>
-  <tabstop>linkedButton</tabstop>
+  <tabstop>addStaffButton</tabstop>
+  <tabstop>addLinkedStaffButton</tabstop>
   <tabstop>partiturList</tabstop>
  </tabstops>
  <resources>

--- a/mscore/selectinstr.ui
+++ b/mscore/selectinstr.ui
@@ -42,7 +42,13 @@
     <widget class="QComboBox" name="instrumentGenreFilter"/>
    </item>
    <item>
-    <widget class="QTreeWidget" name="instrumentList">
+    <widget class="Ms::FilterableTreeWidget" name="instrumentList">
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="uniformRowHeights">
+      <bool>true</bool>
+     </property>
      <property name="expandsOnDoubleClick">
       <bool>false</bool>
      </property>
@@ -57,18 +63,14 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLineEdit" name="search">
-       <property name="placeholderText">
-        <string>Search</string>
-       </property>
-       <property name="clearButtonEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="Ms::SearchBox" name="instrumentSearch">
+     <property name="placeholderText">
+      <string>Search</string>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -82,11 +84,23 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Ms::FilterableTreeWidget</class>
+   <extends>QTreeWidget</extends>
+   <header>widgets/filterabletreeview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Ms::SearchBox</class>
+   <extends>QLineEdit</extends>
+   <header>widgets/searchbox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>currentInstrument</tabstop>
   <tabstop>instrumentGenreFilter</tabstop>
   <tabstop>instrumentList</tabstop>
-  <tabstop>search</tabstop>
+  <tabstop>instrumentSearch</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/mscore/selinstrument.cpp
+++ b/mscore/selinstrument.cpp
@@ -41,7 +41,7 @@ SelectInstrument::SelectInstrument(const Instrument* instrument, QWidget* parent
       currentInstrument->setText(instrument->trackName());
       buildTemplateList();
       buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
-      connect(instrumentList, SIGNAL(clicked(const QModelIndex &)), SLOT(expandOrCollapse(const QModelIndex &)));
+      instrumentSearch->setFilterableView(instrumentList);
       MuseScore::restoreGeometry(this);
       }
 
@@ -52,7 +52,7 @@ SelectInstrument::SelectInstrument(const Instrument* instrument, QWidget* parent
 void SelectInstrument::buildTemplateList()
       {
       // clear search if instrument list is updated
-      search->clear();
+      instrumentSearch->clear();
 
       populateInstrumentList(instrumentList);
       populateGenreCombo(instrumentGenreFilter);
@@ -109,12 +109,16 @@ const InstrumentTemplate* SelectInstrument::instrTemplate() const
 //   on_search_textChanged
 //---------------------------------------------------------
 
-void SelectInstrument::on_search_textChanged(const QString &searchPhrase)
+void SelectInstrument::on_search_textChanged(const QString&)
       {
-      instrumentGenreFilter->blockSignals(true);
-      instrumentGenreFilter->setCurrentIndex(0);
-      instrumentGenreFilter->blockSignals(false);
-      filterInstruments(instrumentList, searchPhrase);
+      // searching is done in Ms::SearchBox so here we just reset the
+      // genre dropdown to ensure that the search includes all genres
+      const int idxAllGenres = 0;
+      if (instrumentGenreFilter->currentIndex() != idxAllGenres) {
+            instrumentGenreFilter->blockSignals(true);
+            instrumentGenreFilter->setCurrentIndex(idxAllGenres);
+            instrumentGenreFilter->blockSignals(false);
+            }
       }
 
 

--- a/mscore/selinstrument.h
+++ b/mscore/selinstrument.h
@@ -41,7 +41,7 @@ class SelectInstrument : public QDialog, private Ui::SelectInstrument {
       void on_instrumentList_itemSelectionChanged();
       void on_instrumentList_itemDoubleClicked(QTreeWidgetItem* item, int);
 
-      void on_search_textChanged(const QString &searchPhrase);
+      void on_search_textChanged(const QString&);
 
       void on_instrumentGenreFilter_currentIndexChanged(int);
       void filterInstrumentsByGenre(QTreeWidget *, QString);

--- a/mscore/widgets/CMakeLists.txt
+++ b/mscore/widgets/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(WIDGETS_SOURCE_FILES
+    filterableview.cpp
     filterabletreeview.cpp
     searchbox.cpp
     )

--- a/mscore/widgets/filterabletreeview.h
+++ b/mscore/widgets/filterabletreeview.h
@@ -30,6 +30,7 @@ class FilterableTreeViewTemplate : public T, public FilterableView
 
    private:
       void toggleExpanded(const QModelIndex& node);
+      void toggleExpandedForUnselectable(const QModelIndex& node);
       template <typename F> inline QModelIndex recurse(const F& func, const bool backwards = false) {
             return recurseUnder(func, FilterableTreeViewTemplate<T>::rootIndex(), backwards);
             }

--- a/mscore/widgets/filterableview.cpp
+++ b/mscore/widgets/filterableview.cpp
@@ -1,0 +1,41 @@
+//=============================================================================
+//  FilterableView
+//
+//  Copyright (C) 2018 Peter Jonas
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "filterableview.h"
+#include "../stringutils.h"
+
+namespace Ms {
+
+//---------------------------------------------------------
+//   FilterableView (pure virtual class has no constructor)
+//---------------------------------------------------------
+
+//---------------------------------------------------------
+//   matches
+// Does the node text contain the search string?
+//---------------------------------------------------------
+
+bool FilterableView::matches(const QModelIndex& node, const QString& searchString)
+      {
+      // replace the unicode b (accidental) so a search phrase of "bb" would match "Bb Trumpet", etc
+      QString text = node.data().toString().replace(QChar(0x266d), QChar('b'));
+
+      if (text.contains(searchString, Qt::CaseInsensitive))
+            return true;
+
+      // replace special characters
+      text = stringutils::removeLigatures(text);
+      text = stringutils::removeDiacritics(text);
+
+      return text.contains(searchString, Qt::CaseInsensitive);
+      }
+
+}

--- a/mscore/widgets/filterableview.h
+++ b/mscore/widgets/filterableview.h
@@ -31,6 +31,7 @@ class FilterableView
       virtual void toInitialState() = 0;
       virtual void toInitialState(const QModelIndex& node) = 0;
       virtual bool filter(const QString& searchString) = 0;
+      virtual bool matches(const QModelIndex& node, const QString& searchString);
       };
 
 }


### PR DESCRIPTION
- Also fixes bugs that allowed user to create scores with no instruments:
  - Double-clicking on instrument group no longer enables Next button
  - Removing instruments from the top no longer lets you remove them all
- Replace SelectInstrument's TreeWidget too