### PR TITLE
fix #57056: content of status bar doesn't get deleted if last score gets closed

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -17,6 +17,7 @@
 #include "texttools.h"
 #include "fotomode.h"
 #include "tourhandler.h"
+#include "scoreaccessibility.h"
 #include "libmscore/score.h"
 #include "libmscore/keysig.h"
 #include "libmscore/segment.h"
@@ -255,6 +256,7 @@ void ScoreView::mouseReleaseEvent(QMouseEvent*)
                         _score->deselectAll();
                         _score->update();
                         mscore->updateInspector();
+                        ScoreAccessibility::instance()->updateAccessibilityInfo();
                         }
             case ViewState::EDIT:
             case ViewState::NOTE_ENTRY:

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -170,20 +170,19 @@ void Inspector::update(Score* s)
             return;
       _score = s;
       bool sameTypes = true;
-      if (!el())
-            return;
-
-      for (Element* ee : *el()) {
-            if (((element()->type() != ee->type()) && // different and
-                (!element()->isSystemText()     || !ee->isStaffText())  && // neither system text nor
-                (!element()->isStaffText()      || !ee->isSystemText()) && // staff text either side and
-                (!element()->isPedalSegment()   || !ee->isTextLineSegment()) && // neither pedal nor
-                (!element()->isTextLineSegment()|| !ee->isPedalSegment())    && // text line either side and
-                (!element()->isSlurTieSegment() || !ee->isSlurTieSegment())) || // neither Slur nor Tie either side, or
-                (ee->isNote() && toNote(ee)->chord()->isGrace() != toNote(element())->chord()->isGrace())) // HACK
-                  {
-                  sameTypes = false;
-                  break;
+      if (el()) {
+            for (Element* ee : *el()) {
+                  if (((element()->type() != ee->type()) && // different and
+                      (!element()->isSystemText()     || !ee->isStaffText())  && // neither system text nor
+                      (!element()->isStaffText()      || !ee->isSystemText()) && // staff text either side and
+                      (!element()->isPedalSegment()   || !ee->isTextLineSegment()) && // neither pedal nor
+                      (!element()->isTextLineSegment()|| !ee->isPedalSegment())    && // text line either side and
+                      (!element()->isSlurTieSegment() || !ee->isSlurTieSegment())) || // neither Slur nor Tie either side, or
+                      (ee->isNote() && toNote(ee)->chord()->isGrace() != toNote(element())->chord()->isGrace())) // HACK
+                        {
+                        sameTypes = false;
+                        break;
+                        }
                   }
             }
       if (oe != element() || oSameTypes != sameTypes) {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2433,6 +2433,7 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
             if (_drumTools)
                   _drumTools->hide();
             changeState(STATE_DISABLED);
+            ScoreAccessibility::instance()->clearAccessibilityInfo();
             return;
             }
 

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -104,7 +104,9 @@ ScoreAccessibility::~ScoreAccessibility()
 void ScoreAccessibility::clearAccessibilityInfo()
       {
       statusBarLabel->setText("");
-      static_cast<MuseScore*>(mainWindow)->currentScoreView()->score()->setAccessibleInfo(tr("No selection"));
+      MuseScoreView* view = static_cast<MuseScore*>(mainWindow)->currentScoreView();
+      if (view)
+            view->score()->setAccessibleInfo(tr("No selection"));
       }
 
 void ScoreAccessibility::currentInfoChanged()


### PR DESCRIPTION
See https://musescore.org/en/node/57056.

This also fixes two related bugs:
1. Contents of status bar doesn't get deleted if selection is cleared, and
2. Inspector does not finish updating if last score gets closed.