### PR TITLE
fix #281321: Create irregular measures from second measure and following results in corruption

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3032,7 +3032,7 @@ void Score::timeDelete(Measure* m, Segment* startSegment, const Fraction& f)
                                           undoRemoveElement(cr);
                                           ChordRest* newCR = toChordRest(cr->clone());
                                           newCR->setDuration(cr->duration() - f);
-                                          undoAddCR(newCR, m, etick);
+                                          undoAddCR(newCR, m, m->tick() + etick);
                                           }
                                     else
                                           cr->undoChangeProperty(Pid::DURATION, cr->duration() - f);


### PR DESCRIPTION
See https://musescore.org/en/node/281321.

_etick_ is relative to the start of the measure. undoAddCR() takes an absolute tick as the third parameter.