### PR TITLE
fix #281426: Excluding measure from measure count causes bad count; fixes on relayout

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2930,10 +2930,6 @@ QVariant Measure::getProperty(Pid propertyId) const
                   return repeatCount();
             case Pid::USER_STRETCH:
                   return userStretch();
-            case Pid::NO_OFFSET:
-                  return noOffset();
-            case Pid::IRREGULAR:
-                  return irregular();
             default:
                   return MeasureBase::getProperty(propertyId);
             }
@@ -2963,12 +2959,6 @@ bool Measure::setProperty(Pid propertyId, const QVariant& value)
                   break;
             case Pid::USER_STRETCH:
                   setUserStretch(value.toDouble());
-                  break;
-            case Pid::NO_OFFSET:
-                  setNoOffset(value.toInt());
-                  break;
-            case Pid::IRREGULAR:
-                  setIrregular(value.toBool());
                   break;
             default:
                   return MeasureBase::setProperty(propertyId, value);

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -332,6 +332,10 @@ QVariant MeasureBase::getProperty(Pid id) const
                   return repeatStart();
             case Pid::REPEAT_JUMP:
                   return repeatJump();
+            case Pid::NO_OFFSET:
+                  return noOffset();
+            case Pid::IRREGULAR:
+                  return irregular();
             default:
                   return Element::getProperty(id);
             }
@@ -352,6 +356,12 @@ bool MeasureBase::setProperty(Pid id, const QVariant& value)
                   break;
             case Pid::REPEAT_JUMP:
                   setRepeatJump(value.toBool());
+                  break;
+            case Pid::NO_OFFSET:
+                  setNoOffset(value.toInt());
+                  break;
+            case Pid::IRREGULAR:
+                  setIrregular(value.toBool());
                   break;
             default:
                   if (!Element::setProperty(id, value))


### PR DESCRIPTION
See https://musescore.org/en/node/281426.

`setNoOffset()` and `setIrregular()` are members of `class MeasureBase`, so it makes sense to handle the cases for `Pid::NO_OFFSET` and `Pid::IRREGULAR` in `MeasureBase::setProperty()` rather than in `Measure::setProperty()`. The reason this makes a difference is because `MeasureBase::setProperty()` calls `score()->setLayoutAll();`, but `Measure::setProperty()` calls `score()->setLayout(tick());`.