### PR TITLE
fix #281327: Measure Numbers and Section Break

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4146,8 +4146,11 @@ void Score::doLayoutRange(int stick, int etick)
                   lc.tick      = 0;
                   }
             else {
-                  lc.measureNo = lc.nextMeasure->prevMeasure()->no() + 1; // will be adjusted later with respect
-                                                                          // to the user-defined offset.
+                  if (lc.nextMeasure->prevMeasure()->sectionBreak())
+                        lc.measureNo = 0;
+                  else
+                        lc.measureNo = lc.nextMeasure->prevMeasure()->no() + 1; // will be adjusted later with respect
+                                                                                // to the user-defined offset.
                   lc.tick      = lc.nextMeasure->tick();
                   }
             }


### PR DESCRIPTION
See https://musescore.org/en/node/281327.