### PR TITLE
fix #280631: fix writing offset and length for pedal lines

### DIFF
--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -122,8 +122,6 @@ void Pedal::write(XmlWriter& xml) const
          Pid::END_HOOK_TYPE,
          Pid::BEGIN_TEXT,
          Pid::END_TEXT,
-         Pid::LINE_WIDTH,
-         Pid::LINE_STYLE,
          Pid::LINE_VISIBLE,
          Pid::BEGIN_HOOK_TYPE
          }) {
@@ -132,7 +130,7 @@ void Pedal::write(XmlWriter& xml) const
       for (const StyledProperty& spp : *styledProperties())
             writeProperty(xml, spp.pid);
 
-      Element::writeProperties(xml);
+      SLine::writeProperties(xml);
       xml.etag();
       }
 

--- a/mtest/libmscore/compat114/pedal-ref.mscx
+++ b/mtest/libmscore/compat114/pedal-ref.mscx
@@ -101,8 +101,8 @@
           <Spanner type="Pedal">
             <Pedal>
               <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
-              <lineWidth>0.006</lineWidth>
               <endHookHeight>-1.5</endHookHeight>
+              <lineWidth>0.006</lineWidth>
               </Pedal>
             <next>
               <location>


### PR DESCRIPTION
`Pedal::write` skips all `writeProperties` overrides  and directly calls `Element::writeProperties`. There may be a reason to skip `TextLineBase::writeProperties` as some properties written by it may be not relevant to `Pedal` or be already handled by `Pedal::write` but skipping `SLine::writeProperties` leads to a loss of information on offset and length of the pedal line being written. This PR fixes that.