### PR TITLE
fix #281411: Lyrics: select all and reset causes program to freeze

### DIFF
--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -288,6 +288,8 @@ void ScoreElement::undoChangeProperty(Pid id, const QVariant& v)
 
 void ScoreElement::undoChangeProperty(Pid id, const QVariant& v, PropertyFlags ps)
       {
+      if ((getProperty(id) == v) && (propertyFlags(id) == ps))
+            return;
       bool doUpdateInspector = false;
       if (id == Pid::PLACEMENT || id == Pid::HAIRPIN_TYPE) {
             // first set property, then set offset for above/below if styled


### PR DESCRIPTION
See https://musescore.org/en/node/281411.

The idea is that if there is nothing to change, then there is nothing to do. Part of the problem is that changing the placement for a single lyric will change the placement for all lyrics on that line. So by the time we move on to the next selected lyric, we have already called ScoreElement::undoChangeProperty() on that lyric, and all other lyrics on the line, and we are about to do it again. And again. And again, and so on. And updating the Inspector is expensive.
