### PR TITLE
fix #281573: New Score Wizard crashes if "Done" is pressed when "Choose Instruments" is selected.

### DIFF
--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -346,6 +346,7 @@ void NewWizardTemplatePage::fileAccepted(const QString& s)
 
 void NewWizardTemplatePage::templateChanged(const QString& s)
       {
+      setFinalPage(QFileInfo(s).completeBaseName() != "00-Blank");
       path = s;
       emit completeChanged();
       }


### PR DESCRIPTION
See https://musescore.org/en/node/281573.