### PR TITLE
fix #280651: unbreak building without QtWebEngine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,19 @@ if (MSVC)
    set (MINGW false)
 endif (MSVC)
 
+# We need this early, before FindQt5
+option(BUILD_WEBENGINE "Built in webengine support" ON)
+
+if (BUILD_WEBENGINE)
+   if (MINGW)
+      SET (USE_WEBENGINE 0)
+   else (MINGW)
+      SET (USE_WEBENGINE 1)
+   endif(MINGW)
+else (BUILD_WEBENGINE)
+   SET (USE_WEBENGINE 0)
+endif (BUILD_WEBENGINE)
+
 set(SCRIPT_INTERFACE  TRUE)
 #  Look for Qt5
 if (SCRIPT_INTERFACE)
@@ -130,7 +143,6 @@ option(BUILD_PULSEAUDIO "Build with support for PulseAudio audio backend." ON)
 option(BUILD_ALSA "Build with support for ALSA audio backend." ON)
 option(BUILD_PORTAUDIO "Build with support for PortAudio audio backend." ON)
 option(BUILD_PORTMIDI "Build with support for PortAudio's MIDI features." ${BUILD_PORTAUDIO}) # PortAudio required
-option(BUILD_WEBENGINE "Built in webengine support" ON)
 option(BUILD_PCH "Build using precompiled headers." ON)
 option(BUILD_FOR_WINSTORE "Build for the Windows Store." OFF)
 option(COVERAGE "Build with instrumentation to record code coverage." OFF)
@@ -270,16 +282,6 @@ SET(MUSESCORE_NAME_VERSION "${MUSESCORE_NAME} ${MUSESCORE_VERSION_MAJOR}")
 # Version schema x.x.x is hardcoded in source
 #
 SET(MUSESCORE_VERSION_FULL  "${MUSESCORE_VERSION}.${MUSESCORE_VERSION_PATCH}")
-
-if (BUILD_WEBENGINE)
-   if (MINGW)
-      SET (USE_WEBENGINE 0)
-   else (MINGW)
-      SET (USE_WEBENGINE 1)
-   endif(MINGW)
-else (BUILD_WEBENGINE)
-   SET (USE_WEBENGINE 0)
-endif (BUILD_WEBENGINE)
 
 if (MUSESCORE_LABEL)
   SET (MUSESCORE_NAME_VERSION "${MUSESCORE_NAME_VERSION} ${MUSESCORE_LABEL}")

--- a/build/FindQt5.cmake
+++ b/build/FindQt5.cmake
@@ -18,14 +18,14 @@ set(_components
     LinguistTools
     Help
   )
-if (NOT MINGW)
+if (USE_WEBENGINE)
   set(_components
     ${_components}
     WebEngine
     WebEngineCore
     WebEngineWidgets
 	)
-endif(NOT MINGW)
+endif(USE_WEBENGINE)
 foreach(_component ${_components})
   find_package(Qt5${_component})
   list(APPEND QT_LIBRARIES ${Qt5${_component}_LIBRARIES})


### PR DESCRIPTION
Shuffle a few things around so we can use the simplified definition of `USE_WEBENGINE` everywhere, instead of duplicating the MinGW check.