### PR TITLE
fix #281068: Regression - All accidentals in Edit mode crash the program

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1958,6 +1958,11 @@ bool Element::edit(EditData& ed)
 void Element::startEditDrag(EditData& ed)
       {
       ElementEditData* eed = ed.getData(this);
+      if (!eed) {
+            eed = new ElementEditData();
+            eed->e = this;
+            ed.addData(eed);
+            }
       eed->pushProperty(Pid::OFFSET);
       }
 


### PR DESCRIPTION
See https://musescore.org/en/node/281068.