### PR TITLE
Fix build without SCRIPT_INTERFACE on Qt 5.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,13 @@ if (MSVC)
    set (MINGW false)
 endif (MSVC)
 
+set(SCRIPT_INTERFACE  TRUE)
 #  Look for Qt5
+if (SCRIPT_INTERFACE)
 SET(QT_MIN_VERSION    "5.8.0")
+else (SCRIPT_INTERFACE)
+SET(QT_MIN_VERSION    "5.7.0")
+endif (SCRIPT_INTERFACE)
 # Include modules
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/build" ${CMAKE_MODULE_PATH})
 include (FindQt5)
@@ -79,7 +84,6 @@ set(MSCORE_RELEASE_CHANNEL "devel")
 #set(MSCORE_RELEASE_CHANNEL "testing")
 #set(MSCORE_RELEASE_CHANNEL "stable")
 set(USE_SSE           TRUE)
-set(SCRIPT_INTERFACE  TRUE)
 
 # Disable components not supported on Windows
 if (MSVC OR MINGW)

--- a/build/config.h.in
+++ b/build/config.h.in
@@ -17,6 +17,9 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
+#ifndef MUSESCORE_CONFIG_H
+#define MUSESCORE_CONFIG_H
+
 #cmakedefine USE_ALSA
 #cmakedefine USE_JACK
 #cmakedefine USE_PORTAUDIO
@@ -58,3 +61,4 @@
 // does not work on windows/mac:
 //#define USE_GLYPHS  true
 
+#endif /* MUSESCORE_CONFIG_H */

--- a/libmscore/fraction.h
+++ b/libmscore/fraction.h
@@ -81,8 +81,6 @@ class Fraction {
 inline Fraction operator*(const Fraction& f, int v) { return Fraction(f) *= v; }
 inline Fraction operator*(int v, const Fraction& f) { return Fraction(f) *= v; }
 
-#ifdef SCRIPT_INTERFACE
-
 //---------------------------------------------------------
 //   FractionWrapper
 //---------------------------------------------------------
@@ -109,16 +107,10 @@ class FractionWrapper : public QObject {
       int ticks() const       { return f.ticks(); }
       };
 
-
-#endif // SCRIPT_INTERFACE
-
 }     // namespace Ms
 
 Q_DECLARE_METATYPE(Ms::Fraction);
 
-#ifdef SCRIPT_INTERFACE
 Q_DECLARE_METATYPE(Ms::FractionWrapper);
-#endif
 
 #endif
-

--- a/libmscore/scorediff.cpp
+++ b/libmscore/scorediff.cpp
@@ -1216,7 +1216,7 @@ static QString addLinePrefix(const QString& str, const QString& prefix)
             lines.pop_back();
       QStringList processedLines;
       for (QStringRef& line : lines)
-            processedLines.push_back(prefix + line);
+            processedLines.push_back(QString(prefix).append(line));
       return processedLines.join('\n');
       }
 

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -13,8 +13,12 @@
 #ifndef __TYPES_H__
 #define __TYPES_H__
 
+#include "config.h"
+
 namespace Ms {
+#ifdef SCRIPT_INTERFACE
 Q_NAMESPACE
+#endif
 
 //-------------------------------------------------------------------
 //    The value of this enum determines the "stacking order"
@@ -225,9 +229,10 @@ constexpr bool operator& (FontStyle a1, FontStyle a2) {
 enum class TupletNumberType  : char { SHOW_NUMBER, SHOW_RELATION, NO_TEXT         };
 enum class TupletBracketType : char { AUTO_BRACKET, SHOW_BRACKET, SHOW_NO_BRACKET };
 
-
+#ifdef SCRIPT_INTERFACE
 Q_ENUM_NS(ElementType)
 Q_ENUM_NS(Direction)
+#endif
 
 //hack: to force the build system to run moc on this file
 class Mops : public QObject {
@@ -243,5 +248,6 @@ extern void fillComboBoxDirection(QComboBox*);
 
 Q_DECLARE_METATYPE(Ms::Align)
 
+Q_DECLARE_METATYPE(Ms::Direction);
 
 #endif

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -49,7 +49,7 @@ include_directories(
       )
 
 if (SCRIPT_INTERFACE)
-      set (SCRIPT_FILES mscorePlugins pluginCreator.cpp qmledit.cpp pluginManager.cpp)
+      set (SCRIPT_FILES mscorePlugins pluginCreator.cpp pluginCreator.h pluginManager.cpp pluginManager.h qmledit.cpp qmledit.h)
       set (SCRIPT_UI   pluginCreator.ui pluginManager.ui)
 endif (SCRIPT_INTERFACE)
 
@@ -310,8 +310,7 @@ add_executable ( ${ExecutableName}
       omrpanel.h ove.h pa.h pagesettings.h palette.h palettebox.h paletteBoxButton.h partedit.h parteditbase.h
       pathlistdialog.h piano.h pianolevels.h pianolevelschooser.h  pianolevelsfilter.h
       pianokeyboard.h pianoroll.h pianoruler.h pianotools.h pianoview.h
-      playpanel.h pluginCreator.h
-      pluginManager.h pm.h preferences.h preferenceslistwidget.h prefsdialog.h qmledit.h
+      playpanel.h pm.h preferences.h preferenceslistwidget.h prefsdialog.h
       qmlplugin.h recordbutton.h resourceManager.h revision.h ruler.h scoreaccessibility.h
       scoreBrowser.h scoreInfo.h scorePreview.h scoretab.h scoreview.h searchComboBox.h
       sectionbreakprop.h selectdialog.h selectionwindow.h selectnotedialog.h selinstrument.h

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7426,8 +7426,10 @@ int main(int argc, char* av[])
             }
 
       errorMessage = new QErrorMessage(mscore);
+#ifdef SCRIPT_INTERFACE
       mscore->getPluginManager()->readPluginList();
       mscore->loadPlugins();
+#endif
       mscore->writeSessionFile(false);
 
 #ifdef Q_OS_MAC

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -90,7 +90,9 @@ class TDockWidget;
 class Sym;
 class MasterPalette;
 class PluginCreator;
+#ifdef SCRIPT_INTERFACE
 class PluginManager;
+#endif
 class MasterSynthesizer;
 class SynthesizerState;
 class Driver;
@@ -283,7 +285,9 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       InsertMeasuresDialog* insertMeasuresDialog { 0 };
       MasterPalette* masterPalette         { 0 };
       PluginCreator* _pluginCreator        { 0 };
+#ifdef SCRIPT_INTERFACE
       PluginManager* pluginManager         { 0 };
+#endif
       SelectionWindow* selectionWindow     { 0 };
 
       QMenu* menuFile;
@@ -629,7 +633,9 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       PianorollEditor* getPianorollEditor() const { return pianorollEditor; }
       DrumrollEditor* getDrumrollEditor() const   { return drumrollEditor; }
       PianoTools* pianoTools() const              { return _pianoTools; }
+#ifdef SCRIPT_INTERFACE
       PluginManager* getPluginManager() const     { return pluginManager; }
+#endif
       void writeSessionFile(bool);
       bool restoreSession(bool);
       bool splitScreen() const { return _splitScreen; }

--- a/mscore/preferenceslistwidget.cpp
+++ b/mscore/preferenceslistwidget.cpp
@@ -18,6 +18,7 @@
 //=============================================================================
 
 #include "preferenceslistwidget.h"
+#include <cfloat>
 
 namespace Ms {
 

--- a/mtest/config.h
+++ b/mtest/config.h
@@ -17,6 +17,9 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
+#ifndef MUSESCORE_CONFIG_H
+#define MUSESCORE_CONFIG_H
+
 #define USE_ALSA
 #define USE_JACK
 /* #undef USE_PORTAUDIO */
@@ -46,4 +49,4 @@
 #define USE_BSP         true
 #define SCRIPT_INTERFACE true
 
-
+#endif /* MUSESCORE_CONFIG_H */


### PR DESCRIPTION
 * without SCRIPT_INTERFACE, Qt 5.7 is enough
 * cursor.cpp depends on FractionWrapper
 * backwards-compatible QString + QStringRef construction
 * let Q_NAMESPACE and Q_ENUM_NS depend on SCRIPT_INTERFACE
 * Ms::Direction must be Q_DECLARE_METATYPE
 * elide plugin-related headers from the build without SCRIPT_INTERFACE
 * supply matching ifdefs for pluginManager calls in main code

This is based on changes by @AntonioBL  and I merely made it rely on the SCRIPT_INTERFACE compilation option more (so it does not break anything when SCRIPT_INTERFACE is on — that is, by default), to make backporting this easier.

Add header defining DBL_MIN and DBL_MAX, too.

Tested to compile fine on Debian stable (9 “stretch”), Qt 5.7.