### PR TITLE
fix #280383: bad edit handles for ties

### DIFF
--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -30,7 +30,7 @@ Note* Tie::editEndNote;
 void TieSegment::updateGrips(EditData& ed) const
       {
       QPointF p(pagePos());
-      p -= QPointF(0.0, system()->staff(staffIdx())->y());   // ??
+      //p -= QPointF(0.0, system()->staff(staffIdx())->y());   // ??
       for (int i = 0; i < int(Grip::GRIPS); ++i)
             ed.grip[i].translate(_ups[i].p + _ups[i].off + p);
       }


### PR DESCRIPTION
Commenting out this one line fixes the issue, I tested top staff, non-top staff, page, continuous, and single page views.

FWIW, the original comment "??" on the line suggests there was some known question about it to begin with - see https://github.com/musescore/MuseScore/commit/6ef95da0d6caf2fea0070ff57cc874da64af7245#diff-bb6215350928561e7f460c401dced0edR34