### PR TITLE
fix #281269: barlines in the middle of bars don't appear 2.x->3.0

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2780,6 +2780,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                         st = SegmentType::EndBarLine;
                   segment = m->getSegment(st, e.tick());
                   segment->add(bl);
+                  bl->layout();
                   }
             else if (tag == "Chord") {
                   Chord* chord = new Chord(score);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/281269