### PR TITLE
fix #281020: Slurs settings and saving added instruments lead to crash

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2528,6 +2528,7 @@ void Score::cmdRemoveStaff(int staffIdx)
 
 void Score::sortStaves(QList<int>& dst)
       {
+      qDeleteAll(systems());
       systems().clear();  //??
       _parts.clear();
       Part* curPart = 0;


### PR DESCRIPTION
See https://musescore.org/en/node/281020.
Not sure why that systems cleaning is needed (`??` comment suggests that it is not clear not only for me) but if doing so we need at least to destroy these removed systems in order for things to go properly. This patch does exactly that.