### PR TITLE
followup for #279814: don't crash on undo of delete instrument name

### DIFF
--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -406,7 +406,7 @@ Element* UndoMacro::selectedElement(const Selection& sel)
       if (sel.isSingle()) {
             Element* e = sel.element();
             Q_ASSERT(e); // otherwise it shouldn't be "single" selection
-            if (e->isNote() || e->isChordRest() || e->isTextBase())
+            if (e->isNote() || e->isChordRest() || (e->isTextBase() && !e->isInstrumentName()))
                   return e;
             }
       return nullptr;


### PR DESCRIPTION
My recently-merged PR to reinstate ability to right-click and delete instrument names introduced a problem where undo of delete would crash on trying to reinstate the selection.  On the advice of @dmitrio95, I have fixed this here by excluding instrument names from the list of elements that can be re-selected.