### PR TITLE
New Score Wizard: Double clicking on template goes to next page

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -544,7 +544,7 @@ void InstrumentsWidget::on_partiturList_itemSelectionChanged()
 //   on_instrumentList
 //---------------------------------------------------------
 
-void InstrumentsWidget::on_instrumentList_itemDoubleClicked(QTreeWidgetItem* item, int)
+void InstrumentsWidget::on_instrumentList_itemActivated(QTreeWidgetItem* item, int)
       {
       if (item->flags() & Qt::ItemIsSelectable)
             on_addButton_clicked();

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -16,6 +16,8 @@
 #include "ui_instrwidget.h"
 #include "libmscore/clef.h"
 
+class QTreeWidgetItem;
+
 namespace Ms {
 
 //class EditInstrument;
@@ -127,7 +129,7 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
 
    private slots:
       void on_instrumentList_itemSelectionChanged();
-      void on_instrumentList_itemDoubleClicked(QTreeWidgetItem* item, int);
+      void on_instrumentList_itemActivated(QTreeWidgetItem* item, int);
       void on_partiturList_itemSelectionChanged();
       void on_addButton_clicked();
       void on_removeButton_clicked();

--- a/mscore/newwizard.cpp
+++ b/mscore/newwizard.cpp
@@ -282,6 +282,7 @@ NewWizardTemplatePage::NewWizardTemplatePage(QWidget* parent)
       setLayout(layout);
 
       connect(templateFileBrowser, SIGNAL(scoreSelected(const QString&)), SLOT(templateChanged(const QString&)));
+      connect(templateFileBrowser, SIGNAL(scoreActivated(const QString&)), SLOT(fileAccepted(const QString&)));
       buildTemplatesList();
       }
 

--- a/mscore/templateBrowser.cpp
+++ b/mscore/templateBrowser.cpp
@@ -74,6 +74,7 @@ TemplateBrowser::TemplateBrowser(QWidget* parent)
       else
             preview->setVisible(false);
       connect(templateTree, &QTreeWidget::itemSelectionChanged, this, &TemplateBrowser::scoreClicked);
+      connect(templateTree, &QTreeWidget::itemActivated, this, &TemplateBrowser::handleItemActivated);
       templateSearch->setFilterableView(templateTree);
       }
 
@@ -212,4 +213,13 @@ void TemplateBrowser::scoreClicked()
       emit scoreSelected(""); // no score selected
       }
 
+//---------------------------------------------------------
+//   handleItemActivated
+//---------------------------------------------------------
+
+void TemplateBrowser::handleItemActivated(QTreeWidgetItem* item)
+      {
+      if (item->flags() & Qt::ItemIsSelectable)
+            emit scoreActivated(static_cast<TemplateItem*>(item)->info().filePath());
+      }
 }

--- a/mscore/templateBrowser.h
+++ b/mscore/templateBrowser.h
@@ -16,6 +16,8 @@
 #include "ui_templateBrowser.h"
 #include "scoreInfo.h"
 
+class QTreeWidgetItem;
+
 namespace Ms {
 
 class TemplateItem;
@@ -37,10 +39,12 @@ class TemplateBrowser : public QWidget, public Ui::TemplateBrowser
 
    private slots:
       void scoreClicked();
+      void handleItemActivated(QTreeWidgetItem* item);
 
    signals:
       void leave();
       void scoreSelected(QString);
+      void scoreActivated(QString path);
 
    public:
       TemplateBrowser(QWidget* parent = 0);

--- a/mscore/widgets/filterabletreeview.cpp
+++ b/mscore/widgets/filterabletreeview.cpp
@@ -23,7 +23,7 @@ FilterableTreeViewTemplate<T>::FilterableTreeViewTemplate(QWidget* parent)
       {
       // expand branches when clicked unless the branch is selectable, in which case it will just be selected as usual
       FilterableTreeViewTemplate<T>::connect(this, &FilterableTreeViewTemplate<T>::clicked, this, &FilterableTreeViewTemplate<T>::toggleExpandedForUnselectable);
-      // expand current branch when activated (usally when Enter key is pressed)
+      // expand current branch when activated (usually when double-clicked, or when selected and Enter key is pressed)
       FilterableTreeViewTemplate<T>::connect(this, &FilterableTreeViewTemplate<T>::activated, this, &FilterableTreeViewTemplate<T>::toggleExpanded);
       }
 


### PR DESCRIPTION
Fixes regression where double-clicking on a template does not take you to the next page.