### PR TITLE
fix #279585: frame gap not imported correctly 2.x->3.0

### DIFF
--- a/mtest/libmscore/compat206/lidemptytext-ref.mscx
+++ b/mtest/libmscore/compat206/lidemptytext-ref.mscx
@@ -182,7 +182,7 @@
     <Staff id="1">
       <VBox>
         <height>8</height>
-        <bottomGap>6</bottomGap>
+        <bottomGap>13</bottomGap>
         </VBox>
       <Measure>
         <stretch>0.9</stretch>
@@ -352,7 +352,7 @@
       <Staff id="1">
         <VBox>
           <height>8</height>
-          <bottomGap>6</bottomGap>
+          <bottomGap>13</bottomGap>
           <Text>
             <style>Instrument Name (Part)</style>
             <text>Bass</text>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279585

This PR uses the fact that, in 2.x, frames work like this:

- if they precede a measure, they have an automatic (hidden) 7sp bottom gap
- if they follow a measure, they have an automatic (hidden) 7sp top gap

In 3.0, we have no automatic gap. So, all frames _were_ read with the default 7sp bottom gap, which made things go wrong if multiple frames followed each other. This PR fixes this.

When this is merged, I also recommend merging #4528, since this solves layout issues with the same score. I can vouch for that PR having the correct implementation of the fix.

Here is [a 2.x file that shows the changes](https://drive.google.com/file/d/1hK2GIGlmGzZJvgXZRkg01sKgk085o-29/view?usp=sharing).
