### PR TITLE
fix #281652: cloneMeasure breaks tuplets

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2821,6 +2821,8 @@ Measure* Measure::cloneMeasure(Score* sc, TieMap* tieMap)
                                     nt->clear();
                                     nt->setTrack(track);
                                     nt->setScore(sc);
+                                    nt->setParent(m);
+                                    nt->setTick(m->tick() + ot->rtick());
                                     tupletMap.add(ot, nt);
                                     }
                               ncr->setTuplet(nt);


### PR DESCRIPTION
Definitly needs a review, as I have no idea what I'm doing here, I just took the issues's author's word for it and turned it into a PR

see https://musescore.org/en/node/281652