### PR TITLE
fix #281720: image read with incorrect size 2.x->3

### DIFF
--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -247,7 +247,12 @@ void Image::read(XmlReader& e)
             else if (tag == "lockAspectRatio")
                   readProperty(e, Pid::LOCK_ASPECT_RATIO);
             else if (tag == "sizeIsSpatium")
-                  readProperty(e, Pid::SIZE_IS_SPATIUM);
+                  // setting this using the property Pid::SIZE_IS_SPATIUM breaks, because the
+                  // property setter attempts to maintain a constant size. If we're reading, we
+                  // don't want to do that, because the stored size will be in:
+                  //    mm if size isn't spatium
+                  //    sp if size is spatium
+                  _sizeIsSpatium = e.readBool();
             else if (tag == "path")
                   _storePath = e.readElementText();
             else if (tag == "linkPath")


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/281720

This, along with #4572 and another linked in that PR, is one of three PRs that fix, in particular, OpenScore layout. Merging all 3 together would be what I recommend :)  