### PR TITLE
New Score Wizard: Make template previews work for any page size

### DIFF
--- a/mscore/scorePreview.ui
+++ b/mscore/scorePreview.ui
@@ -2,49 +2,14 @@
 <ui version="4.0">
  <class>ScorePreview</class>
  <widget class="QWidget" name="ScorePreview">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>256</width>
-    <height>299</height>
-   </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>256</width>
-    <height>0</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>256</width>
-    <height>16777215</height>
-   </size>
-  </property>
-  <property name="windowTitle">
-   <string notr="true"/>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout">
    <item>
     <widget class="QLabel" name="icon">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::PlainText</enum>
-     </property>
-     <property name="scaledContents">
-      <bool>false</bool>
+     <property name="minimumSize">
+      <size>
+       <width>256</width>
+       <height>256</height>
+      </size>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>

--- a/mscore/templateBrowser.ui
+++ b/mscore/templateBrowser.ui
@@ -59,14 +59,7 @@
     </layout>
    </item>
    <item>
-    <widget class="Ms::ScorePreview" name="preview" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
+    <widget class="Ms::ScorePreview" name="preview" native="true"/>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
As discovered in https://musescore.org/en/node/281482, score previews were only being rendered correctly for A4 and not for other sizes like Letter (some of the preview would get cut off). In addition, the preview area was only wide enough for scores in portrait orientation, but now it will work for scores in landscape too.

Before you can test this, you will first need to create some templates at different page sizes:

1. Start MuseScore with My_First_Score.
2. Save it as "A4_Portrait.mscx" inside your personal templates folder (probably `~/Documents/MuseScore3Development/Templates`).
3. Go to Format > Page size, change the size to Letter and save the score as "Letter_Portrait.mscx" in the templates folder.
4. Do the same for "A3_Landscape" and any other required sizes.
5. Restart MuseScore to ensure that the thumbnails are generated for the new templates.

To test, open the New Score Wizard and go to the templates page. The new templates will be displayed under the "Custom Templates" category.