### PR TITLE
fix #281761: Adding interval to note in parts leads to crash

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -449,6 +449,7 @@ void Score::cmdAddInterval(int val, const std::vector<Note*>& nl)
             Note* note = new Note(this);
             Chord* chord = on->chord();
             note->setParent(chord);
+            note->setTrack(chord->track());
             int valTmp = val < 0 ? val+1 : val-1;
 
             int npitch;


### PR DESCRIPTION
See https://musescore.org/en/node/281761.

The track for the new note was never set. Therefore staff() would return NULL, and dereferencing the result is what caused the crash.