### PR TITLE
Use Qt 5.12.1 on AppVeyor and fix #281539 32-bit build for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,7 @@ branches:
 # build cache to preserve files/folders between builds
 cache:
   - dependencies.7z
+  # - qt-5.12.1-msvc.7z # if not using AppVeyor's built-in Qt in before_build.bat
   - C:\Qt\Tools\mingw530_32\lib
   - C:\Qt\Tools\mingw530_32\i686-w64-mingw32
   - C:\Program Files (x86)\Jack
@@ -22,6 +23,7 @@ cache:
 # build platform, i.e. x86, x64, Any CPU. This setting is optional.
 platform:
   - x86
+  - x64
 
 #environment:
 
@@ -30,6 +32,10 @@ configuration: Release
 
 # Stop Appveyor from "Discovering Tests"
 test: off
+
+matrix:
+  fast_finish: true # stop all jobs if any job fails
+  #allow_failures: # list jobs allowed to fail without stopping the rest
 
 install:
   - IF DEFINED ENCRYPT_SECRET_SSH (
@@ -81,4 +87,3 @@ deploy:
 #    region: us-east-1
 #    set_public: true
 #    artifact: appcast.xml
-

--- a/build/appveyor/after_build.bat
+++ b/build/appveyor/after_build.bat
@@ -21,7 +21,7 @@ IF "%NIGHTLY_BUILD%" == "" (
 echo "Stable: Build MSI package"
 :: sign dlls and exe files
 CD C:\MuseScore
-SET dSource=msvc.install_x64
+SET dSource=msvc.install_%PLATFORM%
 for /f "delims=" %%f in ('dir /a-d /b /s "%dSource%\*.dll" "%dSource%\*.exe"') do (
     echo "Signing %%f"
     "C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool.exe" sign /f "C:\MuseScore\build\appveyor\resources\musescore.p12" /t http://timestamp.verisign.com/scripts/timstamp.dll /p "%CERTIFICATE_PASSWORD%" "%%f"
@@ -37,19 +37,25 @@ echo %PACKAGE_UUID%
 echo off
 bash -c "sed -i 's/00000000-0000-0000-0000-000000000000/%PACKAGE_UUID%/' C:/MuseScore/build/Packaging.cmake"
 
-call C:\MuseScore\msvc_build.bat package 64 %APPVEYOR_BUILD_NUMBER%
+call C:\MuseScore\msvc_build.bat package %TARGET_PROCESSOR_BITS% %APPVEYOR_BUILD_NUMBER%
 
 CD C:\MuseScore
 
 :: find the MSI file without the hardcoded version
-for /r %%i in (msvc.build_x64\*.msi) do ( SET FILEPATH=%%i )
-echo on
-echo %FILEPATH%
-echo off
-for /F %%f in ("%FILEPATH%") do (SET FILENAME=%%~nxf)
-echo on
-echo %FILENAME%
-echo off
+for /r %%i in (msvc.build_%PLATFORM%\*.msi) do (
+  SET "FILEPATH=%%i"
+  SET "FILEBASE=%%~ni"
+  SET "FILEEXT=%%~xi"
+  SET "FILEDIR=%%~dpi"
+  )
+echo "Package: %FILEPATH%"
+SET "FILEBASE=%FILEBASE%-%TARGET_PROCESSOR_ARCH%"
+SET "FILENAME=%FILEBASE%%FILEEXT%"
+RENAME "%FILEPATH%" "%FILENAME%"
+SET "FILEPATH=%FILEDIR%%FILENAME%"
+echo "Renamed: %FILENAME%"
+echo "Location: %FILEPATH%"
+@echo off
 "C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool.exe" sign /debug /f "C:\MuseScore\build\appveyor\resources\musescore.p12" /t http://timestamp.verisign.com/scripts/timstamp.dll /p "%CERTIFICATE_PASSWORD%" /d %FILENAME% %FILEPATH%
 :: verify signature
 "C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool.exe" verify /pa %FILEPATH%
@@ -73,8 +79,8 @@ goto :UPLOAD
 :UNSTABLE_LABEL
 echo "Unstable: build 7z package"
 CD C:\MuseScore
-RENAME C:\MuseScore\msvc.install_x64\bin\MuseScore3.exe nightly.exe
-RENAME C:\MuseScore\msvc.install_x64 MuseScoreNightly
+RENAME C:\MuseScore\msvc.install_%PLATFORM%\bin\MuseScore3.exe nightly.exe
+RENAME C:\MuseScore\msvc.install_%PLATFORM% MuseScoreNightly
 XCOPY C:\MuseScore\build\appveyor\special C:\MuseScore\MuseScoreNightly\special /I /E /Y /Q
 COPY C:\MuseScore\build\appveyor\support\README.txt C:\MuseScore\MuseScoreNightly\README.txt /Y
 COPY C:\MuseScore\build\appveyor\support\nightly.bat C:\MuseScore\MuseScoreNightly\nightly.bat /Y
@@ -84,7 +90,7 @@ SET hh0=%time:~0,2%
 SET /a hh1=%hh0%+100
 SET hh=%hh1:~1,2%
 SET BUILD_DATE=%Date:~10,4%-%Date:~4,2%-%Date:~7,2%-%hh%%time:~3,2%
-SET ARTIFACT_NAME=MuseScoreNightly-%BUILD_DATE%-%APPVEYOR_REPO_BRANCH%-%MSREVISION%.7z
+SET ARTIFACT_NAME=MuseScoreNightly-%BUILD_DATE%-%APPVEYOR_REPO_BRANCH%-%MSREVISION%-%TARGET_PROCESSOR_ARCH%.7z
 7z a C:\MuseScore\%ARTIFACT_NAME% C:\MuseScore\MuseScoreNightly
 
 :: create update file for S3

--- a/build/appveyor/before_build.bat
+++ b/build/appveyor/before_build.bat
@@ -1,3 +1,23 @@
+:: SET "QTCACHE=qt-5.12.1-msvc.7z" & :: bump version here and .appveyor.yml to trigger cache rebuild when upgrading Qt
+:: set platform-dependent variables
+IF "%PLATFORM%" == "x64" (
+  :: SET "QTURL=https://utils.musescore.org.s3.amazonaws.com/qt5120_msvc2017_64.7z"
+  :: SET "QTDIR=%cd%\qt\msvc2017_64" & :: uncomment to use our Qt
+  SET "QTDIR=C:\Qt\5.12\msvc2017_64" & :: uncomment to use AppVeyor's Qt
+  SET "TARGET_PROCESSOR_BITS=64"
+  SET "TARGET_PROCESSOR_ARCH=x86_64"
+) ELSE (
+  :: SET "QTURL=https://utils.musescore.org.s3.amazonaws.com/qt5120_msvc2017_32.7z"
+  :: SET "QTDIR=%cd%\qt\msvc2017" & :: uncomment to use our Qt
+  SET "QTDIR=C:\Qt\5.12\msvc2017" & :: uncomment to use AppVeyor's Qt
+  SET "TARGET_PROCESSOR_BITS=32"
+  SET "TARGET_PROCESSOR_ARCH=x86"
+)
+
+:: Download Qt if necessary
+:: IF NOT EXIST "%QTCACHE%" ( START " " /wait "C:\cygwin64\bin\wget.exe" --no-check-certificate "%QTURL%" -O "%QTCACHE%" )
+:: START " " /wait "7z" x -y "%QTCACHE%" "-oqt" & :: extract into `qt` directory
+
 :: keep full PATH for later
 SET OLD_PATH=%PATH%
 mkdir archive
@@ -27,7 +47,8 @@ for /f "delims=" %%i in ('grep "^[[:blank:]]*set( *MSCORE_UNSTABLE \+TRUE *)" C:
 ::)
 
 :: get revision number
-SET PATH=C:\Qt\5.9\msvc2017_64\bin;%PATH%
+SET "PATH=%QTDIR%\bin;%PATH%"
+qmake --version & :: check qt is in %PATH%
 call C:\MuseScore\msvc_build.bat revision
 git rev-parse --short=7 HEAD > mscore/revision.h
 SET /p MSREVISION=<mscore\revision.h

--- a/build/appveyor/build_script.bat
+++ b/build/appveyor/build_script.bat
@@ -1,3 +1,2 @@
-call C:\MuseScore\msvc_build.bat release 64 %APPVEYOR_BUILD_NUMBER%
-call C:\MuseScore\msvc_build.bat install 64 %APPVEYOR_BUILD_NUMBER%
- 
+call C:\MuseScore\msvc_build.bat release %TARGET_PROCESSOR_BITS% %APPVEYOR_BUILD_NUMBER%
+call C:\MuseScore\msvc_build.bat install %TARGET_PROCESSOR_BITS% %APPVEYOR_BUILD_NUMBER%


### PR DESCRIPTION
It errored with this message when I tried to build it on my fork:

```
MSBUILD : error MSB1009: Project file does not exist.
```

Not sure if that is my fault.

Build log is here: https://ci.appveyor.com/project/shoogle/musescore/builds/21611397

__EDIT:__ The problem with that `7z`'s `-o` option to set the output directory for files to be extracted to must be used like `-o<dir>` but I was using it like `-o <dir>` (i.e. the space is not allowed).