### PR TITLE
fix #281821: Mid-measure barline from the palette isn't deletable

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1684,7 +1684,7 @@ void Score::deleteItem(Element* el)
                   BarLine* bl = toBarLine(el);
                   Segment* s = bl->segment();
                   Measure* m = s->measure();
-                  if (s->isBeginBarLineType()) {
+                  if (s->isBeginBarLineType() || s->isBarLineType()) {
                         undoRemoveElement(el);
                         }
                   else {


### PR DESCRIPTION
See https://musescore.org/en/node/281821.

There are four segment types for bar lines. They are

SegmentType::BeginBarLine (for bar lines at the beginning of a system), 
SegmentType::StartRepeatBarLine (for start repeat bar lines),
SegmentType::EndBarLine (for bar lines at the end of a measure), and
SegmentType::BarLine (for bar lines in the middle of a measure).

Segment::isBarLineType() is only true for SegmentType::BarLine. The right thing to do when the user tries to delete a bar line in this type of segment is to pass that bar line to Score::undoRemoveElement().