### PR TITLE
fix failing Travis builds for PRs by improving on the check

### DIFF
--- a/build/travis/job2_AppImage/osuosl.sh
+++ b/build/travis/job2_AppImage/osuosl.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
 # Do not upload artifacts generated as part of a pull request
-if [ $(env | grep TRAVIS_PULL_REQUEST) == "TRAVIS_PULL_REQUEST" ] ; then
-  if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
+if test x"${TRAVIS_PULL_REQUEST-false}" != x"false"; then
     echo "Not uploading AppImage since this is a pull request."
     exit 0
-  fi
 fi
 
 FILE="$1"


### PR DESCRIPTION
The `env | grep` check failed because multiple variable names now match it.

A slightly different check, after simplification even, does the same as the original did when it worked. This **should** allow all Travis builds to pass for PRs.