### PR TITLE
fix #281831 text cursor init w/special symbols

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -107,10 +107,10 @@ void TextCursor::updateCursorFormat()
       TextBlock* block = &_text->_layout[_row];
       int col = hasSelection() ? selectColumn() : column();
       const CharFormat* format = block->formatAt(col);
-      if (format)
-            setFormat(*format);
-      else
+      if (!format || format->fontFamily() == "ScoreText")
             init();
+      else
+            setFormat(*format);
       }
 
 //---------------------------------------------------------
@@ -358,8 +358,8 @@ bool TextCursor::set(const QPointF& p, QTextCursor::MoveMode mode)
                   clearSelection();
             if (hasSelection())
                   QApplication::clipboard()->setText(selectedText(), QClipboard::Selection);
-            updateCursorFormat();
             }
+      updateCursorFormat();
       return true;
       }
 


### PR DESCRIPTION
Previously double-clicking text cursor next to a special text such as piano or forte dynamics or the notehead of tempo text would cause musescore to set the cursor to use a special font family ScoreText.  This caused problems when typing more text because this special ScoreText font doesn't actually exist in the list of fonts, and so musescore would default to an undesired one (on my arch linux computer would be Bitstream Vera Sans) instead of the text element style's default.  This is fixed by having TextCursor::updateCursorFormat() initialize the cursor (to use the default) if the fontFamily was the special 'ScoreText'.

Another problem occured when setting the cursor to be before the initial character when text started with one of these special characters, whereby the fontFamily would be an empty string.  This was because TextCursor::set() wouldn't call updateCursorFormat() if the cursor was first placed at row and column 0, due to what looks like a problematic attempt at an optimization.  Seems like the optimization was to not perform updates if the text cursor and row indexes (edit: didn't) change from last click...but this optimization failed to consider the case that the TextCursor has row and column initilized to 0, so the updateCursorFormat() wouldn't happen.  This is fixed by moving updateCursorFormat() line to be after the if (oldRow != _row || oldColumn != _column) block, so that it always gets called even when first double-clicking the initial character of a text element.