### PR TITLE
fix #281827 update textTools when reclick text

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -435,6 +435,8 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                         else {
                               editData.element->mousePress(editData);
                               score()->update();
+                              if (editData.element->isTextBase() && mscore->textTools())
+                                    mscore->textTools()->updateTools(editData);
                               }
                         }
                   }


### PR DESCRIPTION
Previously the text toolbar would be updated when double-clicking a new text element, but wouldn't be updated when click in a different position inside the same text element currently being edited.  This commit will now update the text toolbar upon such a reclick.