### PR TITLE
fix #281441 unset selected flag in clones

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -174,6 +174,7 @@ Element::Element(const Element& e)
       _offset     = e._offset;
       _track      = e._track;
       _flags      = e._flags;
+      setFlag(ElementFlag::SELECTED, false);
       _tag        = e._tag;
       _z          = e._z;
       _color      = e._color;


### PR DESCRIPTION
Previously, if had elements selected prior to creating a part, they would maintain their SELECTED flag in the generated score, even though the new part scores won't actually have anything acutally selected.  They would thus appear blue as if they were part of a selection even though they weren't.

It seems to me that the SELECTED flag shouldn't be kept when cloning elements, because cloned elements aren't added to a selection.  So I'm unsetting the SELECTED flag whenever cloning an element, incase the original element was selected.