### PR TITLE
fix #280937: Lyrics with hyphen on two systems crashes the program when changing the instruments order

### DIFF
--- a/libmscore/lyricsline.cpp
+++ b/libmscore/lyricsline.cpp
@@ -358,7 +358,7 @@ void LyricsLineSegment::layout()
             endOfSystem = (sys != system());
             // if next lyrics is on a different system, this line segment is at the end of its system:
             // do not adjust for next lyrics position
-            if (!endOfSystem) {
+            if (sys && !endOfSystem) {
                   qreal lyrX        = lyr->bbox().x();
                   qreal lyrXp       = lyr->pagePos().x();
                   qreal sysXp       = sys->pagePos().x();


### PR DESCRIPTION
See https://musescore.org/en/node/280937.

The crash happens when dereferencing `sys` if `sys` happens to be `NULL`, and it only happens if `system()` is also `NULL`. I am not sure whether or not we should be concerned that we are trying to layout a LyricsLineSegment that does not have a system, but I like this fix because the same test is made in line 374.