### PR TITLE
fixed saving courtesy for time signature change

### DIFF
--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -50,7 +50,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::VISIBLE,                 "visible",                 false, "visible",               P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "visible")          },
       { Pid::Z,                       "z",                       false, "z",                     P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "z")                },
       { Pid::SMALL,                   "small",                   false, "small",                 P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "small")            },
-      { Pid::SHOW_COURTESY,           "show_courtesy",           false, "showCourtesy",          P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "show courtesy")    },
+      { Pid::SHOW_COURTESY,           "show_courtesy",           false, "showCourtesySig",       P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "show courtesy")    },
       { Pid::LINE_TYPE,               "line_type",               false, "lineType",              P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "line type")        },
       { Pid::PITCH,                   "pitch",                   true,  "pitch",                 P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "pitch")            },
 


### PR DESCRIPTION
I noticed that hiding the change announcement for the time signature in MS 3.0.0 and 3.0.1 is not saved (or loaded) correctly.
When analyzing the file content (XML), I noticed that there are two types of tags associated with the change announcement of signature changes, "showCourtesy" in the time sig change and "showCourtesySig" for key sig change. I wondered why they were different, so I decided to make my first attempt for code contribution.

I think I identified the root cause when writing the XML. Here "showCourtesy" is used while loading is checking for "showCourtesySig".
I'm not quite sure which is the desired tag name, I've noticed that the mentioned change of this PR solves the problem: "Hiding the change of time signature is saved and restored after loading".