### PR TITLE
fix #281910 ottava import 2.x

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2360,6 +2360,7 @@ static void readOttava(XmlReader& e, Ottava* ottava)
             else if (!readTextLineProperties(e, ottava))
                   e.unknown();
             }
+      ottava->styleChanged();
       adjustPlacement(ottava);
       }
 


### PR DESCRIPTION
While all the properties of ottavas saved in 2.x files were actually imported into 3.0, however the properties which are affected by the style defaults weren't actually applied, so it seemed as if ottavas with subtype property other than 8va weren't properly imported.  Indeed performing any operation which triggered applying the style defaults would reveal that yes the ottavas subtype property was indeed imported, but not apparent.

This fixes the problem by calling styleChanged() at the end of read206.cpp's readOttava() to now trigger these properties to be set according to the style defaults for the particular ottava subtype.  So now the different types of ottavas actually get their style applied during import.