### PR TITLE
fix #268123: Wrong vertical position of breath mark

### DIFF
--- a/libmscore/breath.cpp
+++ b/libmscore/breath.cpp
@@ -61,10 +61,15 @@ bool Breath::isCaesura() const
 
 void Breath::layout()
       {
-      if (isCaesura())
-            setPos(x(), spatium());
-      else
-            setPos(x(), 0.5 * spatium());
+      bool palette = (track() == -1);
+      if (!palette) {
+            if (isCaesura())
+                  setPos(x(), spatium());
+            else if ((score()->styleSt(Sid::MusicalSymbolFont) == "Emmentaler") && (symId() == SymId::breathMarkComma))
+                  setPos(x(), 0.5 * spatium());
+            else
+                  setPos(x(), -0.5 * spatium());
+            }
       setbbox(symBbox(_symId));
       }
 


### PR DESCRIPTION
See https://musescore.org/en/node/268123.

The symbol for the breath mark in Emmentaler has a unique appearance, and it is intended to be positioned such that it intersects the top staff line. Other fonts have a symbol that more closely resembles the comma in the palette, and this symbol is intended to be positioned above the staff.

Commit [f09f554](https://github.com/musescore/MuseScore/commit/f09f554) was meant to fix the issue linked above, but it repositioned all of the non-caesura breath marks for all of the fonts, rather than just the one breath mark in the MScore font.

This PR also fixes the problem of the symbols not being centered vertically in the palette.

I thought about adjusting the symbol's position in the MScore font itself, but we are already repositioning all of the breath marks anyway during layout. After giving the matter much thought, I have decided that the solution presented in this PR makes more sense.