### PR TITLE
fix #282186: importing tremolo from 1.3 causes crash

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2478,8 +2478,10 @@ static void connectTremolo(Measure* m)
 
                         for (Segment* ls = s->next(st); ls; ls = ls->next(st)) {
                               if (Element* element = ls->element(i)) {
-                                    if (!element->isChord())
+                                    if (!element->isChord()) {
                                           qDebug("cannot connect tremolo");
+                                          continue;
+                                          }
                                     Chord* nc = toChord(element);
                                     tremolo->setChords(c, nc);
                                     nc->setTremolo(tremolo);

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -904,8 +904,20 @@ void renderTremolo(Chord* chord, QList<NoteEventList>& ell)
             int track = chord->track();
             while (seg2 && !seg2->element(track))
                   seg2 = seg2->next(st);
-            Chord* c2 = seg2 ? toChord(seg2->element(track)) : 0;
-            if (c2 && c2->type() == ElementType::CHORD) {
+
+            if (!seg2)
+                  return;
+
+            Element* s2El = seg2->element(track);
+            if (s2El) {
+                  if (!s2El->isChord())
+                        return;
+                  }
+            else
+                  return;
+
+            Chord* c2 = toChord(s2El);
+            if (c2->type() == ElementType::CHORD) {
                   int notes2 = int(c2->notes().size());
                   int tnotes = qMax(notes, notes2);
                   int tticks = chord->actualTicks() * 2; // use twice the size


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/282186

Adds a couple of checks that were missing.