### PR TITLE
Fixes for channel texts' styles and caesuras' pauses

### DIFF
--- a/libmscore/breath.cpp
+++ b/libmscore/breath.cpp
@@ -25,10 +25,10 @@ const std::vector<BreathType> Breath::breathList {
       { SymId::breathMarkTick,       false, 0.0 },
       { SymId::breathMarkSalzedo,    false, 0.0 },
       { SymId::breathMarkUpbow,      false, 0.0 },
-      { SymId::caesuraCurved,        true,  0.0 },
-      { SymId::caesura,              true,  0.0 },
-      { SymId::caesuraShort,         true,  0.0 },
-      { SymId::caesuraThick,         true,  0.0 },
+      { SymId::caesuraCurved,        true,  2.0 },
+      { SymId::caesura,              true,  2.0 },
+      { SymId::caesuraShort,         true,  2.0 },
+      { SymId::caesuraThick,         true,  2.0 },
       };
 
 //---------------------------------------------------------

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1302,14 +1302,14 @@ Palette* MuseScore::newTextPalette(bool defaultPalette)
       sp->append(stxt, tr("System text"));
 
       if (!defaultPalette) {
-            StaffText* pz = new StaffText(gscore, Tid::EXPRESSION);
+            StaffText* pz = new StaffText(gscore);
             pz->setXmlText(tr("pizz."));
             pz->setChannelName(0, "pizzicato");
             sp->append(pz, tr("pizz."));
 
-            StaffText* ar = new StaffText(gscore, Tid::EXPRESSION);
+            StaffText* ar = new StaffText(gscore);
             ar->setXmlText(tr("arco"));
-            ar->setChannelName(0, "arco"); // needs updated instruments.xml to work with strings too, not just acoustic bass
+            ar->setChannelName(0, "arco");
             sp->append(ar, tr("arco"));
 
             StaffText* tm = new StaffText(gscore, Tid::EXPRESSION);
@@ -1317,12 +1317,12 @@ Palette* MuseScore::newTextPalette(bool defaultPalette)
             tm->setChannelName(0, "tremolo");
             sp->append(tm, tr("tremolo"));
 
-            StaffText* mu = new StaffText(gscore, Tid::EXPRESSION);
+            StaffText* mu = new StaffText(gscore);
             mu->setXmlText(tr("mute"));
             mu->setChannelName(0, "mute");
             sp->append(mu, tr("mute"));
 
-            StaffText* no = new StaffText(gscore, Tid::EXPRESSION);
+            StaffText* no = new StaffText(gscore);
             no->setXmlText(tr("open"));
             no->setChannelName(0, "open");
             sp->append(no, tr("open"));

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -775,21 +775,25 @@
         <Cell name="Curved caesura">
           <Breath>
             <symbol>caesuraCurved</symbol>
+            <pause>2</pause>
             </Breath>
           </Cell>
         <Cell name="Caesura">
           <Breath>
             <symbol>caesura</symbol>
+            <pause>2</pause>
             </Breath>
           </Cell>
         <Cell name="Short caesura">
           <Breath>
             <symbol>caesuraShort</symbol>
+            <pause>2</pause>
             </Breath>
           </Cell>
         <Cell name="Thick caesura">
           <Breath>
             <symbol>caesuraThick</symbol>
+            <pause>2</pause>
             </Breath>
           </Cell>
         </Palette>
@@ -1525,7 +1529,6 @@
           <StaffText>
             <channelSwitch voice="0" name="pizzicato"/>
             <track>0</track>
-            <style>Expression</style>
             <text>pizz.</text>
             </StaffText>
           </Cell>
@@ -1533,7 +1536,6 @@
           <StaffText>
             <channelSwitch voice="0" name="arco"/>
             <track>0</track>
-            <style>Expression</style>
             <text>arco</text>
             </StaffText>
           </Cell>
@@ -1549,7 +1551,6 @@
           <StaffText>
             <channelSwitch voice="0" name="mute"/>
             <track>0</track>
-            <style>Expression</style>
             <text>mute</text>
             </StaffText>
           </Cell>
@@ -1557,7 +1558,6 @@
           <StaffText>
             <channelSwitch voice="0" name="open"/>
             <track>0</track>
-            <style>Expression</style>
             <text>open</text>
             </StaffText>
           </Cell>

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -541,7 +541,6 @@
           <StaffText>
             <channelSwitch voice="0" name="pizzicato"/>
             <track>0</track>
-            <style>Expression</style>
             <text>pizz.</text>
             </StaffText>
           </Cell>
@@ -549,7 +548,6 @@
           <StaffText>
             <channelSwitch voice="0" name="arco"/>
             <track>0</track>
-            <style>Expression</style>
             <text>arco</text>
             </StaffText>
           </Cell>
@@ -557,7 +555,6 @@
           <StaffText>
             <channelSwitch voice="0" name="mute"/>
             <track>0</track>
-            <style>Expression</style>
             <text>mute</text>
             </StaffText>
           </Cell>
@@ -565,7 +562,6 @@
           <StaffText>
             <channelSwitch voice="0" name="open"/>
             <track>0</track>
-            <style>Expression</style>
             <text>open</text>
             </StaffText>
           </Cell>


### PR DESCRIPTION
* [fix #281980](https://musescore.org/en/node/281980): Arco and pizz. text should be non-italic
* [fix #281909](https://musescore.org/en/node/281909): Set Caesuras' Pauses to 2 sec by default
