### PR TITLE
Specify desktop icon for Wayland sessions

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6880,6 +6880,9 @@ int main(int argc, char* av[])
 #endif
 
       QApplication::setDesktopSettingsAware(true);
+#ifdef Q_OS_LINUX
+      QGuiApplication::setDesktopFileName("mscore");
+#endif
       QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
       QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #if defined(QT_DEBUG) && defined(Q_OS_WIN)


### PR DESCRIPTION
Otherwise, a generic Wayland icon is shown in the title bar.