### PR TITLE
Initialize enumeration wrappers only once per MuseScore session

### DIFF
--- a/mscore/plugin/api/cursor.cpp
+++ b/mscore/plugin/api/cursor.cpp
@@ -157,8 +157,6 @@ void Cursor::add(Element* wrapped)
       if (!_segment || !s)
             return;
 
-      if (s->isStaffText())
-            qDebug() << toStaffText(s)->plainText();
       wrapped->setOwnership(Ownership::SCORE);
       s->setTrack(_track);
       s->setParent(_segment);

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -27,6 +27,24 @@
 namespace Ms {
 namespace PluginAPI {
 
+Enum* const PluginAPI::elementTypeEnum = wrapEnum<Ms::ElementType>();
+Enum* const PluginAPI::accidentalTypeEnum = wrapEnum<Ms::AccidentalType>();
+Enum* const PluginAPI::beamModeEnum = wrapEnum<Ms::Beam::Mode>();
+Enum* const PluginAPI::placementEnum = wrapEnum<Ms::Placement>();
+Enum* const PluginAPI::glissandoTypeEnum = wrapEnum<Ms::GlissandoType>();
+Enum* const PluginAPI::layoutBreakTypeEnum = wrapEnum<Ms::LayoutBreak::Type>();
+Enum* const PluginAPI::lyricsSyllabicEnum = wrapEnum<Ms::Lyrics::Syllabic>();
+Enum* const PluginAPI::directionEnum = wrapEnum<Ms::Direction>();
+Enum* const PluginAPI::directionHEnum = wrapEnum<Ms::MScore::DirectionH>();
+Enum* const PluginAPI::ornamentStyleEnum = wrapEnum<Ms::MScore::OrnamentStyle>();
+Enum* const PluginAPI::glissandoStyleEnum = wrapEnum<Ms::GlissandoStyle>();
+Enum* const PluginAPI::tidEnum = wrapEnum<Ms::Tid>();
+Enum* const PluginAPI::noteHeadTypeEnum = wrapEnum<Ms::NoteHead::Type>();
+Enum* const PluginAPI::noteHeadGroupEnum = wrapEnum<Ms::NoteHead::Group>();
+Enum* const PluginAPI::noteValueTypeEnum = wrapEnum<Ms::Note::ValueType>();
+Enum* const PluginAPI::segmentTypeEnum = wrapEnum<Ms::SegmentType>();
+Enum* const PluginAPI::spannerAnchorEnum = wrapEnum<Ms::Spanner::Anchor>();
+
 //---------------------------------------------------------
 //   PluginAPI
 //---------------------------------------------------------
@@ -35,23 +53,6 @@ PluginAPI::PluginAPI(QQuickItem* parent)
    : Ms::QmlPlugin(parent)
       {
       setRequiresScore(true);              // by default plugins require a score to work
-      // Expose enumerations to QML
-      elementTypeEnum = wrapEnum<Ms::ElementType>(this);
-      accidentalTypeEnum = wrapEnum<Ms::AccidentalType>(this);
-      beamModeEnum = wrapEnum<Ms::Beam::Mode>(this);
-      glissandoTypeEnum = wrapEnum<Ms::GlissandoType>(this);
-      layoutBreakTypeEnum = wrapEnum<Ms::LayoutBreak::Type>(this);
-      lyricsSyllabicEnum = wrapEnum<Ms::Lyrics::Syllabic>(this);
-      directionEnum = wrapEnum<Ms::Direction>(this);
-      directionHEnum = wrapEnum<Ms::MScore::DirectionH>(this);
-      ornamentStyleEnum = wrapEnum<Ms::MScore::OrnamentStyle>(this);
-      glissandoStyleEnum = wrapEnum<Ms::GlissandoStyle>(this);
-      tidEnum = wrapEnum<Ms::Tid>(this); // TODO: check that it is exposed
-      noteHeadTypeEnum = wrapEnum<Ms::NoteHead::Type>(this);
-      noteHeadGroupEnum = wrapEnum<Ms::NoteHead::Group>(this);
-      noteValueTypeEnum = wrapEnum<Ms::Note::ValueType>(this);
-      segmentTypeEnum = wrapEnum<Ms::SegmentType>(this);
-      spannerAnchorEnum = wrapEnum<Ms::Spanner::Anchor>(this);
       }
 
 //---------------------------------------------------------

--- a/mscore/plugin/api/qmlpluginapi.h
+++ b/mscore/plugin/api/qmlpluginapi.h
@@ -32,6 +32,11 @@ class Element;
 class FractionWrapper;
 class Score;
 
+#define DECLARE_API_ENUM(qmlName, cppName) \
+      static Enum* const cppName; \
+      static Enum* get_##cppName() { return cppName; } \
+      Q_PROPERTY(Ms::PluginAPI::Enum* qmlName READ get_##cppName CONSTANT)
+
 //---------------------------------------------------------
 //   QmlPlugin
 //   @@ MuseScore
@@ -63,48 +68,32 @@ class PluginAPI : public Ms::QmlPlugin {
       Q_PROPERTY(QString dockArea        READ dockArea WRITE setDockArea)
       Q_PROPERTY(bool requiresScore      READ requiresScore WRITE setRequiresScore)
       Q_PROPERTY(int division            READ division)
-      Q_PROPERTY(int mscoreVersion       READ mscoreVersion)
-      Q_PROPERTY(int mscoreMajorVersion  READ mscoreMajorVersion)
-      Q_PROPERTY(int mscoreMinorVersion  READ mscoreMinorVersion)
-      Q_PROPERTY(int mscoreUpdateVersion READ mscoreUpdateVersion)
+      Q_PROPERTY(int mscoreVersion       READ mscoreVersion       CONSTANT)
+      Q_PROPERTY(int mscoreMajorVersion  READ mscoreMajorVersion  CONSTANT)
+      Q_PROPERTY(int mscoreMinorVersion  READ mscoreMinorVersion  CONSTANT)
+      Q_PROPERTY(int mscoreUpdateVersion READ mscoreUpdateVersion CONSTANT)
       Q_PROPERTY(qreal mscoreDPI         READ mscoreDPI)
       Q_PROPERTY(Ms::PluginAPI::Score* curScore     READ curScore)
 //TODO-ws      Q_PROPERTY(QQmlListProperty<Ms::Score> scores READ scores)
 
-      Enum* elementTypeEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* Element MEMBER elementTypeEnum)
-      Enum* accidentalTypeEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* Accidental MEMBER accidentalTypeEnum)
-      Enum* beamModeEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* Beam MEMBER beamModeEnum)
-      Enum* placementEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* Placement MEMBER placementEnum) // was Element.ABOVE and Element.BELOW in 2.X
-      Enum* glissandoTypeEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* Glissando MEMBER glissandoTypeEnum) // was probably absent in 2.X
-      Enum* layoutBreakTypeEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* LayoutBreak MEMBER layoutBreakTypeEnum)
-      Enum* lyricsSyllabicEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* Lyrics MEMBER lyricsSyllabicEnum)
-      Enum* directionEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* Direction MEMBER directionEnum) // was in MScore class in 2.X
-      Enum* directionHEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* DirectionH MEMBER directionHEnum) // was in MScore class in 2.X
-      Enum* ornamentStyleEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* OrnamentStyle MEMBER ornamentStyleEnum) // was in MScore class in 2.X
-      Enum* glissandoStyleEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* GlissandoStyle MEMBER glissandoStyleEnum) // was in MScore class in 2.X
-      Enum* tidEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* Tid MEMBER tidEnum) // was TextStyleType in 2.X
-      Enum* noteHeadTypeEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* NoteHeadType MEMBER noteHeadTypeEnum) // was in NoteHead class in 2.X
-      Enum* noteHeadGroupEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* NoteHeadGroup MEMBER noteHeadGroupEnum) // was in NoteHead class in 2.X
-      Enum* noteValueTypeEnum; // or velo type?
-      Q_PROPERTY(Ms::PluginAPI::Enum* NoteValueType MEMBER noteValueTypeEnum) // was in Note class in 2.X
-      Enum* segmentTypeEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* Segment MEMBER segmentTypeEnum);
-      Enum* spannerAnchorEnum;
-      Q_PROPERTY(Ms::PluginAPI::Enum* Spanner MEMBER spannerAnchorEnum); // probably unavailable in 2.X
+      // Should be initialized in qmlpluginapi.cpp
+      DECLARE_API_ENUM( Element,          elementTypeEnum         )
+      DECLARE_API_ENUM( Accidental,       accidentalTypeEnum      )
+      DECLARE_API_ENUM( Beam,             beamModeEnum            )
+      DECLARE_API_ENUM( Placement,        placementEnum           ) // was Element.ABOVE and Element.BELOW in 2.X
+      DECLARE_API_ENUM( Glissando,        glissandoTypeEnum       ) // was probably absent in 2.X
+      DECLARE_API_ENUM( LayoutBreak,      layoutBreakTypeEnum     )
+      DECLARE_API_ENUM( Lyrics,           lyricsSyllabicEnum      )
+      DECLARE_API_ENUM( Direction,        directionEnum           ) // was in MScore class in 2.X
+      DECLARE_API_ENUM( DirectionH,       directionHEnum          ) // was in MScore class in 2.X
+      DECLARE_API_ENUM( OrnamentStyle,    ornamentStyleEnum       ) // was in MScore class in 2.X
+      DECLARE_API_ENUM( GlissandoStyle,   glissandoStyleEnum      ) // was in MScore class in 2.X
+      DECLARE_API_ENUM( Tid,              tidEnum                 ) // was TextStyleType in 2.X
+      DECLARE_API_ENUM( NoteHeadType,     noteHeadTypeEnum        ) // was in NoteHead class in 2.X
+      DECLARE_API_ENUM( NoteHeadGroup,    noteHeadGroupEnum       ) // was in NoteHead class in 2.X
+      DECLARE_API_ENUM( NoteValueType,    noteValueTypeEnum       ) // was in Note class in 2.X
+      DECLARE_API_ENUM( Segment,          segmentTypeEnum         )
+      DECLARE_API_ENUM( Spanner,          spannerAnchorEnum       ) // probably unavailable in 2.X
 
       QFile logFile;
 
@@ -139,6 +128,7 @@ class PluginAPI : public Ms::QmlPlugin {
       Q_INVOKABLE Ms::PluginAPI::FractionWrapper* fraction(int numerator, int denominator) const;
       };
 
+#undef DECLARE_API_ENUM
 } // namespace PluginAPI
 } // namespace Ms
 #endif


### PR DESCRIPTION
A fixup for #4610 to avoid redundant work on creating plugins wrappers. Also contains a little number of other minor changes.