### PR TITLE
follow up pr #4535: display patches in mixer in order of preset numbe…

### DIFF
--- a/aeolus/aeolus.cpp
+++ b/aeolus/aeolus.cpp
@@ -55,7 +55,7 @@ Synthesizer* createAeolus()
 Aeolus::Aeolus()
       {
       model = 0;
-      patchList.append(new MidiPatch { false, "Aeolus", 0, 0, "Aeolus" });
+      patchList.append(new MidiPatch { false, "Aeolus", 0, 0, 0, "Aeolus" });
 
       _sc_cmode = 0;
       _sc_group = 0;

--- a/fluid/fluid.cpp
+++ b/fluid/fluid.cpp
@@ -571,9 +571,8 @@ void Fluid::updatePatchList()
       qDeleteAll(patches);
       patches.clear();
 
-      QMap<int, QList<MidiPatch*>> patchNums;
-
       int bankOffset = 0;
+      int sfid = 0;
       for (SFont* sf : sfonts) {
             sf->setBankOffset(bankOffset);
             int banks = 0;
@@ -586,15 +585,11 @@ void Fluid::updatePatchList()
                   patch->bank = p->get_banknum() + bankOffset;
                   patch->prog = p->get_num();
                   patch->name = p->get_name();
-                  patchNums[patch->prog].append(patch);
+                  patch->sfid = sfid;
+                  patches.append(patch);
                   }
+            sfid++;
             bankOffset += (banks + 1);
-            }
-
-      // Order by patch number first instead of by bank first
-      for (QList<MidiPatch*> num : patchNums) {
-            for (MidiPatch* p : num)
-                  patches.append(p);
             }
 
       /* try to set the correct presets */

--- a/synthesizer/midipatch.h
+++ b/synthesizer/midipatch.h
@@ -29,7 +29,7 @@ namespace Ms {
 struct MidiPatch {
       bool drum;
       QString synti;
-      int bank, prog;
+      int bank, prog, sfid;
       QString name;
       };
 

--- a/zerberus/zerberus.cpp
+++ b/zerberus/zerberus.cpp
@@ -257,7 +257,7 @@ void Zerberus::updatePatchList()
       patches.clear();
       int idx = 0;
       for (ZInstrument* i : instruments) {
-            Ms::MidiPatch* p = new Ms::MidiPatch { false, name(), 0, idx, i->name() };
+            Ms::MidiPatch* p = new Ms::MidiPatch { false, name(), 0, idx, 0, i->name() };
             patches.append(p);
             ++idx;
             }


### PR DESCRIPTION
This is a follow up to #4535 . I decided that it would be better to make the significant changes in the mixer code, rather than in the fluid code.

This changes the way patches are ordered in the mixer GUI, without changing the actual way bank numbers and program numbers are handled. This has the effect that all scores will still be imported correctly.

The difference is, that patches are ordered by these three things, from most to least significant:
- Which soundfont they belong to, as the soundfont's position in the synthesizer soundfont list
- What program number each patch has. Since similar patches are placed on the same program number on different banks as per the MIDI specification, this puts similar instruments closer together.
- Finally, by bank number.

An additional change is the addition of '(n)' to the end of patch names that are the same as the names of patches from other soundfonts, to distinguish them, where n is the index of the soundfont in the synth list. The first occurrence of a name will never have this '(n)' appended.