### PR TITLE
fix #280885: Re-instate persistence of "First page number" setting

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3435,6 +3435,15 @@ void Score::undoChangeStyleVal(Sid idx, const QVariant& v)
       }
 
 //---------------------------------------------------------
+//   undoChangePageNumberOffset
+//---------------------------------------------------------
+
+void Score::undoChangePageNumberOffset(int po)
+      {
+      undo(new ChangePageNumberOffset(this, po));
+      }
+
+//---------------------------------------------------------
 //   undoChangeElement
 //---------------------------------------------------------
 

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3599,6 +3599,8 @@ static bool readScore(Score* score, XmlReader& e)
                   score->setCurrentLayer(e.readInt());
             else if (tag == "Synthesizer")
                   score->synthesizerState().read(e);
+            else if (tag == "page-offset")
+                  score->setPageNumberOffset(e.readInt());
             else if (tag == "Division")
                   score->setFileDivision(e.readInt());
             else if (tag == "showInvisible")

--- a/libmscore/read301.cpp
+++ b/libmscore/read301.cpp
@@ -79,6 +79,8 @@ bool Score::read(XmlReader& e)
                   _currentLayer = e.readInt();
             else if (tag == "Synthesizer")
                   _synthesizerState.read(e);
+            else if (tag == "page-offset")
+                  _pageNumberOffset = e.readInt();
             else if (tag == "Division")
                   _fileDivision = e.readInt();
             else if (tag == "showInvisible")

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -629,6 +629,7 @@ class Score : public QObject, public ScoreElement {
       void undoRemoveBracket(Bracket*);
       void undoInsertTime(int tick, int len);
       void undoChangeStyleVal(Sid idx, const QVariant& v);
+      void undoChangePageNumberOffset(int po);
 
       Note* setGraceNote(Chord*,  int pitch, NoteType type, int len);
 

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1509,6 +1509,20 @@ void ChangeStyleVal::flip(EditData*)
       }
 
 //---------------------------------------------------------
+//   ChangePageNumberOffset::flip
+//---------------------------------------------------------
+
+void ChangePageNumberOffset::flip(EditData*)
+      {
+      int po = score->pageNumberOffset();
+
+      score->setPageNumberOffset(pageOffset);
+      score->setLayoutAll();
+
+      pageOffset = po;
+      }
+
+//---------------------------------------------------------
 //   ChangeChordStaffMove
 //---------------------------------------------------------
 

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -653,6 +653,21 @@ class ChangeStyleVal : public UndoCommand {
       };
 
 //---------------------------------------------------------
+//   ChangePageNumberOffset
+//---------------------------------------------------------
+
+class ChangePageNumberOffset : public UndoCommand {
+      Score* score;
+      int pageOffset;
+
+      void flip(EditData*) override;
+
+   public:
+      ChangePageNumberOffset(Score* s, int po) : score(s), pageOffset(po) {}
+      UNDO_NAME("ChangePageNumberOffset")
+      };
+
+//---------------------------------------------------------
 //   ChangeChordStaffMove
 //---------------------------------------------------------
 

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -305,6 +305,7 @@ void PageSettings::applyToScore(Score* s)
       s->undoChangeStyleVal(Sid::pageOddLeftMargin, oddPageLeftMargin->value() * f);
       s->undoChangeStyleVal(Sid::pageTwosided, twosided->isChecked());
       s->undoChangeStyleVal(Sid::spatium, spatiumEntry->value() * f1);
+      s->undoChangePageNumberOffset(pageOffsetEntry->value() - 1);
 
       s->endCmd();
       }


### PR DESCRIPTION
I believe this is the correct fix - I think the bug was introduced when PageFormat was removed and replaced with new styles, and some of the pageNumberOffset code was deleted. Maybe the original plan was to change pageNumberOffset into a style as well; but at the moment it is still a separate Score property and needs handling on its own. This commit also allows the property to be read from v2 files. I don't see an easy way to read it from v1 files though.