### PR TITLE
fix #21243: Allow selection of multiple parts in Instruments dialog

### DIFF
--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -31,6 +31,7 @@ class InstrumentGenre;
 
 enum class ListItemOp : char { KEEP, I_DELETE, ADD, UPDATE };
 enum { PART_LIST_ITEM = QTreeWidgetItem::UserType, STAFF_LIST_ITEM };
+enum class PartiturSelectionType : char { PARENTS_SELECTED, CHILDREN_SELECTED, NONE_SELECTED };
 
 //---------------------------------------------------------
 //   PartListItem
@@ -126,7 +127,9 @@ class InstrumentTemplateListItem : public QTreeWidgetItem {
 
 class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
       Q_OBJECT
-
+      PartiturSelectionType _partiturSelectionType;
+      QList<QTreeWidgetItem*> _partiturSelectedItems;
+      
    private slots:
       void on_instrumentList_itemSelectionChanged();
       void on_instrumentList_itemActivated(QTreeWidgetItem* item, int);
@@ -142,6 +145,9 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
 
       void on_instrumentGenreFilter_currentIndexChanged(int);
       void filterInstrumentsByGenre(QTreeWidget *, QString);
+      
+      void sanitizePartiturListSelection();
+      void movePartiturListItems(bool moveUp);
 
    public slots:
       void buildTemplateList();


### PR DESCRIPTION
Fix to allow selection of multiple parts/staves in the Instruments to move or remove multiple parts or staves at once. Apart from the possibility to select multiple parts it will automatically select the parts/staves that are involved (selecting children from multiple parts will select all parts and staves, selecting a part will select all staves, as moving and removing already applies to all children).
Methods for moving a part/staff could be optimized but I have touched them only where necessary.

Open for all feedback, as this is the first contribution. Commits will probably need to be squashed in a single commit?