### PR TITLE
fix #282864: Dropping "Image" on note attaches it to segment instead.

### DIFF
--- a/libmscore/mscoreview.cpp
+++ b/libmscore/mscoreview.cpp
@@ -24,6 +24,8 @@ static bool elementLower(const Element* e1, const Element* e2)
       {
       if (!e1->selectable())
             return false;
+      if (!e2->selectable())
+            return true;
       return e1->z() < e2->z();
       }
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4179,6 +4179,8 @@ static bool elementLower(const Element* e1, const Element* e2)
       {
       if (!e1->selectable())
             return false;
+      if (!e2->selectable())
+            return true;
       if (e1->z() == e2->z()) {
             if (e1->type() == e2->type()) {
                   if (e1->type() == ElementType::NOTEDOT) {


### PR DESCRIPTION
See https://musescore.org/en/node/282864.

Selectable elements should be ordered before non-selectable elements. Previously, if e2 was non-selectable, it would not necessarily get ordered after e1 like it should.