### PR TITLE
fix #282862: Moving an image can't be undone

### DIFF
--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -366,7 +366,7 @@ class ImageEditData : public ElementEditData {
 //   startDrag
 //---------------------------------------------------------
 
-void Image::startDrag(EditData& data)
+void Image::startEditDrag(EditData& data)
       {
       ImageEditData* ed = new ImageEditData();
       ed->e    = this;

--- a/libmscore/image.h
+++ b/libmscore/image.h
@@ -49,7 +49,7 @@ class Image final : public BSymbol {
 
       virtual bool isEditable() const override { return true; }
       virtual void startEdit(EditData&) override;
-      virtual void startDrag(EditData&) override;
+      virtual void startEditDrag(EditData&) override;
       virtual void editDrag(EditData& ed) override;
       virtual void endEditDrag(EditData&) override;
       virtual void updateGrips(EditData&) const override;


### PR DESCRIPTION
In commit ac41fa396e62419, startEditDrag was renamed to startDrag. However, this function sets up the data structure for image resizing, not for element dragging; that name also overloaded Element::startDrag() which would have set up the correct state for Element::endDrag to properly set the undo action.

Renaming this function back reenables Element::startDrag for images, and instead invokes this function when the user starts resizing an image.

This fix is a necessary step towards solving issue #282945 but is not sufficient.