### PR TITLE
fix #281810:Fix Label Truncation

### DIFF
--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>912</width>
+    <width>1122</width>
     <height>660</height>
    </rect>
   </property>
@@ -32,6 +32,48 @@
    <string>Style</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_39">
+   <item row="1" column="0">
+    <layout class="QHBoxLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QPushButton" name="buttonTogglePagelist">
+       <property name="maximumSize">
+        <size>
+         <width>20</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="0" column="0">
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
@@ -40,7 +82,7 @@
      <widget class="QListWidget" name="pageList">
       <property name="minimumSize">
        <size>
-        <width>180</width>
+        <width>50</width>
         <height>0</height>
        </size>
       </property>
@@ -223,7 +265,7 @@
      </widget>
      <widget class="QStackedWidget" name="pageStack">
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+       <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
@@ -236,12 +278,12 @@
       </property>
       <property name="maximumSize">
        <size>
-        <width>710</width>
+        <width>900</width>
         <height>16777215</height>
        </size>
       </property>
       <property name="currentIndex">
-       <number>33</number>
+       <number>8</number>
       </property>
       <widget class="QWidget" name="PageScore">
        <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -706,7 +748,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_8">
            <property name="verticalSpacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
            <item row="7" column="0" colspan="2">
             <widget class="QCheckBox" name="genClef">
@@ -1346,7 +1388,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_27">
            <property name="horizontalSpacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
            <item row="0" column="0">
             <widget class="QLabel" name="label_38">
@@ -1676,33 +1718,6 @@
              <property name="spacing">
               <number>10</number>
              </property>
-             <item row="1" column="0">
-              <widget class="QLabel" name="labelOddFooter">
-               <property name="text">
-                <string>Odd</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QTextEdit" name="oddFooterL">
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>30</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QLabel" name="labelMiddleFooter">
-               <property name="text">
-                <string>Middle</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
              <item row="1" column="2">
               <widget class="QTextEdit" name="oddFooterC">
                <property name="minimumSize">
@@ -1713,20 +1728,10 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="1">
-              <widget class="QTextEdit" name="evenFooterL">
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>30</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="labelEvenFooter">
+             <item row="1" column="0">
+              <widget class="QLabel" name="labelOddFooter">
                <property name="text">
-                <string>Even</string>
+                <string>Odd</string>
                </property>
               </widget>
              </item>
@@ -1746,6 +1751,16 @@
                </property>
               </widget>
              </item>
+             <item row="1" column="3">
+              <widget class="QTextEdit" name="oddFooterR">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>30</height>
+                </size>
+               </property>
+              </widget>
+             </item>
              <item row="2" column="2">
               <widget class="QTextEdit" name="evenFooterC">
                <property name="minimumSize">
@@ -1756,8 +1771,8 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="3">
-              <widget class="QTextEdit" name="evenFooterR">
+             <item row="2" column="1">
+              <widget class="QTextEdit" name="evenFooterL">
                <property name="minimumSize">
                 <size>
                  <width>0</width>
@@ -1766,8 +1781,28 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="3">
-              <widget class="QTextEdit" name="oddFooterR">
+             <item row="0" column="3">
+              <widget class="QLabel" name="labelRightFooter">
+               <property name="text">
+                <string>Right</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QLabel" name="labelMiddleFooter">
+               <property name="text">
+                <string>Middle</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="3">
+              <widget class="QTextEdit" name="evenFooterR">
                <property name="minimumSize">
                 <size>
                  <width>0</width>
@@ -1783,15 +1818,38 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="3">
-              <widget class="QLabel" name="labelRightFooter">
-               <property name="text">
-                <string>Right</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
+             <item row="1" column="1">
+              <widget class="QTextEdit" name="oddFooterL">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>30</height>
+                </size>
                </property>
               </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="labelEvenFooter">
+               <property name="text">
+                <string>Even</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_17">
+               <property name="text">
+                <string>Alignment</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="2">
+              <widget class="QDoubleSpinBox" name="footerCAlignment"/>
+             </item>
+             <item row="3" column="1">
+              <widget class="QDoubleSpinBox" name="footerLAlignment"/>
+             </item>
+             <item row="3" column="3">
+              <widget class="QDoubleSpinBox" name="footerRAlignment"/>
              </item>
             </layout>
            </item>
@@ -2271,7 +2329,7 @@
           </property>
           <layout class="QGridLayout" name="_2">
            <property name="spacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
            <item row="8" column="1">
             <widget class="Ms::OffsetSelect" name="measureNumberOffset" native="true"/>
@@ -2715,7 +2773,7 @@
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_13">
                  <property name="spacing">
-                  <number>-1</number>
+                  <number>6</number>
                  </property>
                  <item>
                   <widget class="QLabel" name="label_7">
@@ -2901,7 +2959,7 @@
              </property>
              <layout class="QGridLayout" name="_3">
               <property name="horizontalSpacing">
-               <number>-1</number>
+               <number>6</number>
               </property>
               <property name="verticalSpacing">
                <number>0</number>
@@ -3054,7 +3112,7 @@
              </property>
              <layout class="QGridLayout" name="_4">
               <property name="horizontalSpacing">
-               <number>-1</number>
+               <number>6</number>
               </property>
               <property name="verticalSpacing">
                <number>0</number>
@@ -3358,420 +3416,20 @@
         </property>
         <item>
          <widget class="QGroupBox" name="groupBox_3">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="title">
            <string>Measure</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_9">
            <item row="0" column="0">
             <layout class="QGridLayout" name="gridLayout_99">
-             <item row="13" column="1">
-              <widget class="QDoubleSpinBox" name="keyTimesigDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="12" column="1">
-              <widget class="QDoubleSpinBox" name="clefTimesigDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="11" column="1">
-              <widget class="QDoubleSpinBox" name="clefKeyDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="11" column="0">
-              <widget class="QLabel" name="label_94">
-               <property name="text">
-                <string>Clef to key distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>clefKeyDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="17" column="2">
-              <widget class="QToolButton" name="resetStaffLineWidth">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Staff line thickness' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="16" column="2">
-              <widget class="QToolButton" name="resetMultiMeasureRestMargin">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Multimeasure rest margin' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="9" column="2">
-              <widget class="QToolButton" name="resetClefKeyRightMargin">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Clef/Key right margin' valua</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="13" column="0">
-              <widget class="QLabel" name="label_109">
-               <property name="text">
-                <string>Key to time signature distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>keyTimesigDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="2">
-              <widget class="QToolButton" name="resetTimesigLeftMargin">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Time signature left margin' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="2">
-              <widget class="QToolButton" name="resetClefLeftMargin">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Clef left margin' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="2">
-              <widget class="QToolButton" name="resetMinNoteDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Minimum note distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="2">
-              <widget class="QToolButton" name="resetNoteBarDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Note to barline distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="14" column="2">
-              <widget class="QToolButton" name="resetKeyBarlineDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Key to barline distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="12" column="2">
-              <widget class="QToolButton" name="resetClefTimesigDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Clef to time signature distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="14" column="1">
-              <widget class="QDoubleSpinBox" name="keyBarlineDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="11" column="2">
-              <widget class="QToolButton" name="resetClefKeyDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Clef to key distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="13" column="2">
-              <widget class="QToolButton" name="resetKeyTimesigDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Key to time signature distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="0">
-              <widget class="QLabel" name="label_111">
-               <property name="text">
-                <string>System header distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>systemHeaderDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="14" column="0">
-              <widget class="QLabel" name="label_110">
-               <property name="text">
-                <string>Key to barline distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>keyBarlineDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="2">
-              <widget class="QToolButton" name="resetSystemHeaderDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'System header distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="1">
-              <widget class="QDoubleSpinBox" name="systemHeaderDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="5">
-              <widget class="QDoubleSpinBox" name="measureSpacing">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="decimals">
-                <number>3</number>
-               </property>
-               <property name="minimum">
-                <double>1.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="12" column="0">
-              <widget class="QLabel" name="label_108">
-               <property name="text">
-                <string>Clef to time signature distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>clefTimesigDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="9" column="1">
-              <widget class="QDoubleSpinBox" name="clefKeyRightMargin">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.050000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_89">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Minimum measure width:</string>
-               </property>
-               <property name="buddy">
-                <cstring>minMeasureWidth_2</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="2">
-              <widget class="QToolButton" name="resetBarAccidentalDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Barline to accidental distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="10" column="2">
-              <widget class="QToolButton" name="resetClefBarlineDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Clef to barline distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="2">
-              <widget class="QToolButton" name="resetKeysigLeftMargin">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Key signature left margin' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_61">
+             <item row="6" column="0">
+              <widget class="QLabel" name="label_18">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                  <horstretch>0</horstretch>
@@ -3779,60 +3437,10 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Barline to grace note distance:</string>
+                <string>Clef left margin:</string>
                </property>
                <property name="buddy">
-                <cstring>barGraceDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QToolButton" name="resetMinMeasureWidth">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Minimum measure width' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="2">
-              <widget class="QToolButton" name="resetBarGraceDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Barline to grace note distance' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QDoubleSpinBox" name="barGraceDistance">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
+                <cstring>clefLeftMargin</cstring>
                </property>
               </widget>
              </item>
@@ -3852,157 +3460,8 @@
                </property>
               </widget>
              </item>
-             <item row="16" column="0">
-              <widget class="QLabel" name="label_103">
-               <property name="text">
-                <string>Multimeasure rest margin:</string>
-               </property>
-               <property name="buddy">
-                <cstring>multiMeasureRestMargin</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="2">
-              <widget class="QToolButton" name="resetBarNoteDistance">
-               <property name="toolTip">
-                <string>Reset to default</string>
-               </property>
-               <property name="accessibleName">
-                <string>Reset 'Note left margin' value</string>
-               </property>
-               <property name="text">
-                <string notr="true"/>
-               </property>
-               <property name="icon">
-                <iconset resource="musescore.qrc">
-                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
-               </property>
-              </widget>
-             </item>
              <item row="3" column="1">
               <widget class="QDoubleSpinBox" name="barAccidentalDistance">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="17" column="1">
-              <widget class="QDoubleSpinBox" name="staffLineWidth">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="label_102">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Barline to accidental distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>barAccidentalDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="17" column="0">
-              <widget class="QLabel" name="label">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Staff line thickness:</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <property name="buddy">
-                <cstring>staffLineWidth</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="10" column="1">
-              <widget class="QDoubleSpinBox" name="clefBarlineDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="10" column="0">
-              <widget class="QLabel" name="label_53">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Clef to barline distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>clefBarlineDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="9" column="0">
-              <widget class="QLabel" name="label_21">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Clef/Key right margin:</string>
-               </property>
-               <property name="textFormat">
-                <enum>Qt::PlainText</enum>
-               </property>
-               <property name="buddy">
-                <cstring>clefKeyRightMargin</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="1">
-              <widget class="QDoubleSpinBox" name="timesigLeftMargin">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QDoubleSpinBox" name="barNoteDistance">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                  <horstretch>0</horstretch>
@@ -4033,6 +3492,23 @@
                </property>
               </widget>
              </item>
+             <item row="11" column="2">
+              <widget class="QToolButton" name="resetClefKeyDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Clef to key distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
              <item row="8" column="0">
               <widget class="QLabel" name="label_20">
                <property name="sizePolicy">
@@ -4049,35 +3525,20 @@
                </property>
               </widget>
              </item>
-             <item row="7" column="0">
-              <widget class="QLabel" name="label_19">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+             <item row="8" column="2">
+              <widget class="QToolButton" name="resetTimesigLeftMargin">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Time signature left margin' value</string>
                </property>
                <property name="text">
-                <string>Key signature left margin:</string>
+                <string notr="true"/>
                </property>
-               <property name="buddy">
-                <cstring>keysigLeftMargin</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_12">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Note left margin:</string>
-               </property>
-               <property name="buddy">
-                <cstring>barNoteDistance</cstring>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                </property>
               </widget>
              </item>
@@ -4097,56 +3558,35 @@
                </property>
               </widget>
              </item>
-             <item row="7" column="1">
-              <widget class="QDoubleSpinBox" name="keysigLeftMargin">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+             <item row="14" column="0">
+              <widget class="QLabel" name="label_110">
+               <property name="text">
+                <string>Key to barline distance:</string>
                </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
+               <property name="buddy">
+                <cstring>keyBarlineDistance</cstring>
                </property>
               </widget>
              </item>
-             <item row="5" column="1">
-              <widget class="QDoubleSpinBox" name="minNoteDistance">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+             <item row="7" column="2">
+              <widget class="QToolButton" name="resetKeysigLeftMargin">
+               <property name="toolTip">
+                <string>Reset to default</string>
                </property>
-               <property name="suffix">
-                <string>sp</string>
+               <property name="accessibleName">
+                <string>Reset 'Key signature left margin' value</string>
                </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
+               <property name="text">
+                <string notr="true"/>
                </property>
-              </widget>
-             </item>
-             <item row="6" column="1">
-              <widget class="QDoubleSpinBox" name="clefLeftMargin">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="suffix">
-                <string>sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                </property>
               </widget>
              </item>
-             <item row="5" column="0">
-              <widget class="QLabel" name="label_14">
+             <item row="7" column="0">
+              <widget class="QLabel" name="label_19">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                  <horstretch>0</horstretch>
@@ -4154,36 +3594,47 @@
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Minimum note distance:</string>
+                <string>Key signature left margin:</string>
                </property>
                <property name="buddy">
-                <cstring>minNoteDistance</cstring>
+                <cstring>keysigLeftMargin</cstring>
                </property>
               </widget>
              </item>
-             <item row="0" column="1">
-              <widget class="QDoubleSpinBox" name="minMeasureWidth_2">
+             <item row="3" column="2">
+              <widget class="QToolButton" name="resetBarAccidentalDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Barline to accidental distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="14" column="1">
+              <widget class="QDoubleSpinBox" name="keyBarlineDistance">
                <property name="suffix">
                 <string extracomment="spatium unit">sp</string>
                </property>
-               <property name="minimum">
-                <double>2.000000000000000</double>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
                </property>
               </widget>
              </item>
-             <item row="6" column="0">
-              <widget class="QLabel" name="label_18">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
+             <item row="15" column="0">
+              <widget class="QLabel" name="label_111">
                <property name="text">
-                <string>Clef left margin:</string>
+                <string>System header distance:</string>
                </property>
                <property name="buddy">
-                <cstring>clefLeftMargin</cstring>
+                <cstring>systemHeaderDistance</cstring>
                </property>
               </widget>
              </item>
@@ -4203,13 +3654,13 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="6">
-              <widget class="QToolButton" name="resetMeasureSpacing">
+             <item row="12" column="2">
+              <widget class="QToolButton" name="resetClefTimesigDistance">
                <property name="toolTip">
                 <string>Reset to default</string>
                </property>
                <property name="accessibleName">
-                <string>Reset 'Spacing' value</string>
+                <string>Reset 'Clef to time signature distance' value</string>
                </property>
                <property name="text">
                 <string notr="true"/>
@@ -4220,16 +3671,229 @@
                </property>
               </widget>
              </item>
-             <item row="15" column="4">
-              <widget class="QLabel" name="label_112">
-               <property name="text">
-                <string>System header with time signature distance:</string>
+             <item row="15" column="2">
+              <widget class="QToolButton" name="resetSystemHeaderDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
                </property>
-               <property name="indent">
-                <number>-1</number>
+               <property name="accessibleName">
+                <string>Reset 'System header distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="minMeasureWidth_2">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="minimum">
+                <double>2.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_12">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Note left margin:</string>
                </property>
                <property name="buddy">
-                <cstring>systemHeaderTimeSigDistance</cstring>
+                <cstring>barNoteDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="2">
+              <widget class="QToolButton" name="resetClefBarlineDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Clef to barline distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="0">
+              <widget class="QLabel" name="label_21">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Clef/Key right margin:</string>
+               </property>
+               <property name="textFormat">
+                <enum>Qt::PlainText</enum>
+               </property>
+               <property name="buddy">
+                <cstring>clefKeyRightMargin</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="12" column="1">
+              <widget class="QDoubleSpinBox" name="clefTimesigDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="label_102">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Barline to accidental distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>barAccidentalDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="1">
+              <widget class="QDoubleSpinBox" name="keysigLeftMargin">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="17" column="2">
+              <widget class="QToolButton" name="resetStaffLineWidth">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Staff line thickness' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="17" column="1">
+              <widget class="QDoubleSpinBox" name="staffLineWidth">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_89">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Minimum measure width:</string>
+               </property>
+               <property name="buddy">
+                <cstring>minMeasureWidth_2</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="2">
+              <widget class="QToolButton" name="resetBarGraceDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Barline to grace note distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="1">
+              <widget class="QDoubleSpinBox" name="clefBarlineDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="5">
+              <widget class="QDoubleSpinBox" name="measureSpacing">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="decimals">
+                <number>3</number>
+               </property>
+               <property name="minimum">
+                <double>1.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QDoubleSpinBox" name="barNoteDistance">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
                </property>
               </widget>
              </item>
@@ -4263,32 +3927,6 @@
                </property>
               </widget>
              </item>
-             <item row="8" column="4">
-              <widget class="QLabel" name="label_113">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Time signature to barline distance:</string>
-               </property>
-               <property name="buddy">
-                <cstring>timesigBarlineDistance</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="15" column="5">
-              <widget class="QDoubleSpinBox" name="systemHeaderTimeSigDistance">
-               <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
              <item row="8" column="6">
               <widget class="QToolButton" name="resetTimesigBarlineDistance">
                <property name="toolTip">
@@ -4303,6 +3941,102 @@
                <property name="icon">
                 <iconset resource="musescore.qrc">
                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="2">
+              <widget class="QToolButton" name="resetClefKeyRightMargin">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Clef/Key right margin' valua</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QDoubleSpinBox" name="minNoteDistance">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="11" column="0">
+              <widget class="QLabel" name="label_94">
+               <property name="text">
+                <string>Clef to key distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>clefKeyDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="14" column="2">
+              <widget class="QToolButton" name="resetKeyBarlineDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Key to barline distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QDoubleSpinBox" name="clefLeftMargin">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="12" column="0">
+              <widget class="QLabel" name="label_108">
+               <property name="text">
+                <string>Clef to time signature distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>clefTimesigDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="15" column="1">
+              <widget class="QDoubleSpinBox" name="systemHeaderDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
                </property>
               </widget>
              </item>
@@ -4322,6 +4056,336 @@
                </property>
               </widget>
              </item>
+             <item row="10" column="0">
+              <widget class="QLabel" name="label_53">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Clef to barline distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>clefBarlineDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QToolButton" name="resetMinMeasureWidth">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Minimum measure width' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="2">
+              <widget class="QToolButton" name="resetClefLeftMargin">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Clef left margin' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QDoubleSpinBox" name="barGraceDistance">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="2">
+              <widget class="QToolButton" name="resetNoteBarDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Note to barline distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="17" column="0">
+              <widget class="QLabel" name="label">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Staff line thickness:</string>
+               </property>
+               <property name="wordWrap">
+                <bool>false</bool>
+               </property>
+               <property name="buddy">
+                <cstring>staffLineWidth</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="1">
+              <widget class="QDoubleSpinBox" name="clefKeyRightMargin">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.050000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0">
+              <widget class="QLabel" name="label_14">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Minimum note distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>minNoteDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="15" column="4">
+              <widget class="QLabel" name="label_112">
+               <property name="text">
+                <string>System header with time signature distance:</string>
+               </property>
+               <property name="indent">
+                <number>-1</number>
+               </property>
+               <property name="buddy">
+                <cstring>systemHeaderTimeSigDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="13" column="2">
+              <widget class="QToolButton" name="resetKeyTimesigDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Key to time signature distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="11" column="1">
+              <widget class="QDoubleSpinBox" name="clefKeyDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="label_61">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Barline to grace note distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>barGraceDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="16" column="0">
+              <widget class="QLabel" name="label_103">
+               <property name="text">
+                <string>Multimeasure rest margin:</string>
+               </property>
+               <property name="buddy">
+                <cstring>multiMeasureRestMargin</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QToolButton" name="resetBarNoteDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Note left margin' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="6">
+              <widget class="QToolButton" name="resetMeasureSpacing">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Spacing' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="13" column="0">
+              <widget class="QLabel" name="label_109">
+               <property name="text">
+                <string>Key to time signature distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>keyTimesigDistance</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="15" column="5">
+              <widget class="QDoubleSpinBox" name="systemHeaderTimeSigDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="13" column="1">
+              <widget class="QDoubleSpinBox" name="keyTimesigDistance">
+               <property name="suffix">
+                <string extracomment="spatium unit">sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.010000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="2">
+              <widget class="QToolButton" name="resetMinNoteDistance">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Minimum note distance' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="16" column="2">
+              <widget class="QToolButton" name="resetMultiMeasureRestMargin">
+               <property name="toolTip">
+                <string>Reset to default</string>
+               </property>
+               <property name="accessibleName">
+                <string>Reset 'Multimeasure rest margin' value</string>
+               </property>
+               <property name="text">
+                <string notr="true"/>
+               </property>
+               <property name="icon">
+                <iconset resource="musescore.qrc">
+                 <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="8" column="1">
+              <widget class="QDoubleSpinBox" name="timesigLeftMargin">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="suffix">
+                <string>sp</string>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="8" column="4">
+              <widget class="QLabel" name="label_113">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Time signature to barline distance:</string>
+               </property>
+               <property name="buddy">
+                <cstring>timesigBarlineDistance</cstring>
+               </property>
+              </widget>
+             </item>
             </layout>
            </item>
            <item row="0" column="1">
@@ -4330,11 +4394,11 @@
               <enum>Qt::Horizontal</enum>
              </property>
              <property name="sizeType">
-              <enum>QSizePolicy::Expanding</enum>
+              <enum>QSizePolicy::Fixed</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>40</width>
+               <width>10</width>
                <height>20</height>
               </size>
              </property>
@@ -6268,7 +6332,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_7">
            <property name="verticalSpacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
            <item row="5" column="0">
             <widget class="QLabel" name="label_9">
@@ -6602,7 +6666,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout0">
            <property name="verticalSpacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
            <item row="3" column="2">
             <widget class="QToolButton" name="resetVoltaLineWidth">
@@ -6832,7 +6896,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_12">
            <property name="verticalSpacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
            <item row="3" column="2">
             <widget class="QToolButton" name="resetOttavaPosBelow">
@@ -8755,7 +8819,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_24">
            <property name="spacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
            <item row="3" column="0">
             <widget class="QLabel" name="label_189">
@@ -9149,7 +9213,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_23">
            <property name="spacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
            <item row="0" column="0">
             <widget class="QLabel" name="label_71">
@@ -10467,7 +10531,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_131">
            <property name="verticalSpacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
            <item row="2" column="0">
             <widget class="QLabel" name="label_601">
@@ -10650,7 +10714,7 @@
           </property>
           <layout class="QGridLayout" name="_12">
            <property name="spacing">
-            <number>-1</number>
+            <number>6</number>
            </property>
            <item row="0" column="0">
             <widget class="QLabel" name="labelStyleName">
@@ -11054,48 +11118,6 @@
       </widget>
      </widget>
     </widget>
-   </item>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="leftMargin">
-      <number>0</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QPushButton" name="buttonTogglePagelist">
-       <property name="maximumSize">
-        <size>
-         <width>20</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="flat">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -35,7 +35,7 @@
    <item row="1" column="0">
     <layout class="QHBoxLayout">
      <property name="spacing">
-      <number>6</number>
+      <number>-1</number>
      </property>
      <property name="leftMargin">
       <number>0</number>
@@ -1388,7 +1388,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_27">
            <property name="horizontalSpacing">
-            <number>6</number>
+            <number>-1</number>
            </property>
            <item row="0" column="0">
             <widget class="QLabel" name="label_38">
@@ -2329,7 +2329,7 @@
           </property>
           <layout class="QGridLayout" name="_2">
            <property name="spacing">
-            <number>6</number>
+            <number>-1</number>
            </property>
            <item row="8" column="1">
             <widget class="Ms::OffsetSelect" name="measureNumberOffset" native="true"/>
@@ -2773,7 +2773,7 @@
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_13">
                  <property name="spacing">
-                  <number>6</number>
+                  <number>-1</number>
                  </property>
                  <item>
                   <widget class="QLabel" name="label_7">
@@ -2959,7 +2959,7 @@
              </property>
              <layout class="QGridLayout" name="_3">
               <property name="horizontalSpacing">
-               <number>6</number>
+               <number>-1</number>
               </property>
               <property name="verticalSpacing">
                <number>0</number>
@@ -3112,7 +3112,7 @@
              </property>
              <layout class="QGridLayout" name="_4">
               <property name="horizontalSpacing">
-               <number>6</number>
+               <number>-1</number>
               </property>
               <property name="verticalSpacing">
                <number>0</number>
@@ -6332,7 +6332,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_7">
            <property name="verticalSpacing">
-            <number>6</number>
+            <number>-1</number>
            </property>
            <item row="5" column="0">
             <widget class="QLabel" name="label_9">
@@ -6666,7 +6666,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout0">
            <property name="verticalSpacing">
-            <number>6</number>
+            <number>-1</number>
            </property>
            <item row="3" column="2">
             <widget class="QToolButton" name="resetVoltaLineWidth">
@@ -6896,7 +6896,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_12">
            <property name="verticalSpacing">
-            <number>6</number>
+            <number>-1</number>
            </property>
            <item row="3" column="2">
             <widget class="QToolButton" name="resetOttavaPosBelow">
@@ -8819,7 +8819,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_24">
            <property name="spacing">
-            <number>6</number>
+            <number>-1</number>
            </property>
            <item row="3" column="0">
             <widget class="QLabel" name="label_189">
@@ -9213,7 +9213,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_23">
            <property name="spacing">
-            <number>6</number>
+            <number>-1</number>
            </property>
            <item row="0" column="0">
             <widget class="QLabel" name="label_71">
@@ -10531,7 +10531,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_131">
            <property name="verticalSpacing">
-            <number>6</number>
+            <number>-1</number>
            </property>
            <item row="2" column="0">
             <widget class="QLabel" name="label_601">
@@ -10714,7 +10714,7 @@
           </property>
           <layout class="QGridLayout" name="_12">
            <property name="spacing">
-            <number>6</number>
+            <number>-1</number>
            </property>
            <item row="0" column="0">
             <widget class="QLabel" name="labelStyleName">

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -748,7 +748,7 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_8">
            <property name="verticalSpacing">
-            <number>6</number>
+            <number>-1</number>
            </property>
            <item row="7" column="0" colspan="2">
             <widget class="QCheckBox" name="genClef">


### PR DESCRIPTION
Fixed the Label Truncation

Before:

In dialog box Style, some second column labels are truncated and cannot be seen even by expanding the window. One example is the Measure styles in the Format->Style Dialog.

![image](https://user-images.githubusercontent.com/41850468/51914701-751d5500-23ff-11e9-9482-5eae8126c85f.png)

After:

![image](https://user-images.githubusercontent.com/41850468/51914811-aa29a780-23ff-11e9-923f-cdc13c387a06.png)
