### PR TITLE
Remove unused function

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -114,15 +114,6 @@ bool Excerpt::operator==(const Excerpt& e) const
       }
 
 //---------------------------------------------------------
-//   localSetScore
-//---------------------------------------------------------
-
-static void localSetScore(void* score, Element* element)
-      {
-      element->setScore((Score*)score);
-      }
-
-//---------------------------------------------------------
 //   createExcerpt
 //---------------------------------------------------------
 


### PR DESCRIPTION
This function is unused accord the whole MuseScore scope and produce a warning at build time.