### PR TITLE
fix #283405: "Ped.  *" has line visible in advanced workspace

### DIFF
--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -1105,13 +1105,16 @@
           <Pedal id="18">
             <endHookType>1</endHookType>
             <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
+            <continueText>(&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;)</continueText>
             <track>0</track>
             </Pedal>
           </Cell>
         <Cell name="Pedal">
           <Pedal id="19">
             <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
+            <continueText>(&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;)</continueText>
             <endText>&lt;sym&gt;keyboardPedalUp&lt;/sym&gt;</endText>
+            <lineVisible>0</lineVisible>
             <track>0</track>
             </Pedal>
           </Cell>


### PR DESCRIPTION
but not in master palette. Also for both "Ped." lines continueText is set in master palette but missing in the palette.

Not sure about the track info in the palette, seems superfluous? At least it doesn't show in the scores. Same for all lines in the workspaces' lines palette.

Also there's another bug lurking: continueText is not taken when applying those lines, not via master palette nor, after this fix, via the advanced workspace. Still having them in the workspace is the right thing, to match the master palette.