### PR TITLE
fix #280917: fix tie pasting to a score with linked parts

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1460,6 +1460,12 @@ void Note::readAddConnector(ConnectorInfoReader* info, bool pasteMode)
                                     toChord(parent())->setEndsGlissando(true);
                               addSpannerBack(sp);
                               }
+
+                        // As spanners get added after being fully read, they
+                        // do not get cloned with the note when pasting to
+                        // linked staves. So add this spanner explicilty.
+                        if (pasteMode)
+                              score()->undoAddElement(sp);
                         }
                   }
             default:


### PR DESCRIPTION
Probably was broken with 40dc553a758211e84e3e0972c7802023d4c39f4e. See https://musescore.org/en/node/280917 for the issue description. 