### PR TITLE
fix #278767: Always position dragged item to the top left of the cursor

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -389,10 +389,9 @@ void Palette::mouseMoveEvent(QMouseEvent* ev)
                   drag->setMimeData(mimeData);
 
                   drag->setPixmap(pixmap(currentIdx));
-                  QRect r = idxRect(currentIdx);
 
-                  QPoint o(dragStartPosition - r.topLeft());
-                  drag->setHotSpot(o);
+                  QPoint hotsp(drag->pixmap().rect().bottomRight());
+                  drag->setHotSpot(hotsp);
 
                   Qt::DropActions da;
                   if (!(_readOnly || filterActive) && (ev->modifiers() & Qt::ShiftModifier)) {


### PR DESCRIPTION
Fixes the "detached drag item" bug discussed [here](https://musescore.org/en/node/278767) by always positioning the drag item to the top left of the cursor. Also fixed two MSVC compiler warnings about masking local variables in the same file.