### PR TITLE
fix #283316: Hang on pressing space after entering fingering on only note of score

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2366,9 +2366,7 @@ void ScoreView::textTab(bool back)
       while (el) {
             if (el->isNote()) {
                   Note* n = toNote(el);
-                  if (op->isNote() && n != op)
-                        break;
-                  else if (op->isSegment() && n->chord()->segment() != op)
+                  if (op->isNote() || op->isSegment())
                         break;
                   }
             // get prev/next note


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/283316

A check for if the note is the same shouldn't be needed, since nextElement() will only return the same element when there are no other options. This means that, without the check, the fingering will just wrap around to the start of the score after reaching the last note. I believe this should be the expected behaviour.