### PR TITLE
Fix build without USE_WEBENGINE and SCRIPT_INTERFACE

### DIFF
--- a/mscore/logindialog.h
+++ b/mscore/logindialog.h
@@ -21,6 +21,8 @@ class LoginManager;
 
 //---------------------------------------------------------
 //   LoginDialog
+//    Old-style login dialog in case QtWebEngine is
+//    unavailable.
 //---------------------------------------------------------
 
 class LoginDialog : public QDialog, public Ui::LoginDialog

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7572,12 +7572,14 @@ bool MuseScore::exportPartsPdfsToJSON(const QString& inFilePath, const QString& 
       }
 
 //---------------------------------------------------------
-//   getQmlEngine
+//   getPluginEngine
 //---------------------------------------------------------
 
+#ifdef SCRIPT_INTERFACE
 QmlPluginEngine* MuseScore::getPluginEngine()
       {
       if (!_qmlEngine)
             _qmlEngine = new QmlPluginEngine(this);
       return _qmlEngine;
       }
+#endif

--- a/mscore/network/loginmanager.cpp
+++ b/mscore/network/loginmanager.cpp
@@ -18,7 +18,9 @@
 #include "kQOAuth/kqoauthrequest.h"
 #include "kQOAuth/kqoauthrequest_xauth.h"
 
+#ifdef USE_WEBENGINE
 #include <QWebEngineCookieStore>
+#endif
 
 namespace Ms {
 
@@ -286,8 +288,11 @@ void LoginManager::onTryLoginError(const QString& error)
       disconnect(this, SIGNAL(getUserError(QString)), this, SLOT(onTryLoginError(QString)));
       connect(this, SIGNAL(loginSuccess()), this, SLOT(tryLogin()));
       logout();
+#ifdef USE_WEBENGINE
       loginInteractive();
-//       mscore->showLoginDialog(); // TODO: switch depending on USE_WEBENGINE
+#else
+      mscore->showLoginDialog();
+#endif
       }
 /*------- END - TRY LOGIN ROUTINES ----------------------------*/
 
@@ -295,6 +300,7 @@ void LoginManager::onTryLoginError(const QString& error)
 //   loginInteractive
 //---------------------------------------------------------
 
+#ifdef USE_WEBENGINE
 void LoginManager::loginInteractive()
       {
       QWebEngineView* webView = new QWebEngineView;
@@ -326,6 +332,7 @@ void LoginManager::loginInteractive()
       webView->load(ApiInfo::loginUrl);
       webView->show();
       }
+#endif
 
 //---------------------------------------------------------
 //   login
@@ -346,7 +353,7 @@ void LoginManager::login(QString login, QString password)
       connect(reply, &QNetworkReply::finished, this, [this, reply] {
             onReplyFinished(reply, RequestType::LOGIN);
             });
-     }
+      }
 
 //---------------------------------------------------------
 //   onLoginSuccessReply
@@ -874,6 +881,7 @@ ApiRequest ApiRequestBuilder::build() const
 //    musescore.com
 //---------------------------------------------------------
 
+#ifdef USE_WEBENGINE
 void ApiWebEngineRequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo& request)
       {
       const ApiInfo& apiInfo = ApiInfo::instance();
@@ -881,4 +889,5 @@ void ApiWebEngineRequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo& 
       request.setHttpHeader(apiInfo.clientIdHeader, apiInfo.clientId);
       request.setHttpHeader(apiInfo.apiKeyHeader, apiInfo.apiKey);
       }
+#endif
 }

--- a/mscore/network/loginmanager.h
+++ b/mscore/network/loginmanager.h
@@ -13,6 +13,8 @@
 #ifndef __LOGINMANAGER_H__
 #define __LOGINMANAGER_H__
 
+#include "config.h"
+
 namespace Ms {
 
 //---------------------------------------------------------
@@ -83,7 +85,9 @@ class LoginManager : public QObject
    public:
       LoginManager(QAction* uploadAudioMenuAction, QObject* parent = 0);
       void login(QString login, QString password);
+#ifdef USE_WEBENGINE
       void loginInteractive();
+#endif
       void upload(const QString& path, int nid, const QString& title, const QString& description, const QString& priv, const QString& license, const QString& tags, const QString& changes);
       bool hasAccessToken();
       void getUser();

--- a/mscore/network/loginmanager_p.h
+++ b/mscore/network/loginmanager_p.h
@@ -20,6 +20,8 @@
 #ifndef __LOGINMANAGER_P_H__
 #define __LOGINMANAGER_P_H__
 
+#include "config.h"
+
 namespace Ms {
 
 //---------------------------------------------------------
@@ -102,6 +104,7 @@ class ApiRequestBuilder
 //   ApiWebEngineRequestInterceptor
 //---------------------------------------------------------
 
+#ifdef USE_WEBENGINE
 class ApiWebEngineRequestInterceptor : public QWebEngineUrlRequestInterceptor
       {
       Q_OBJECT
@@ -109,6 +112,7 @@ class ApiWebEngineRequestInterceptor : public QWebEngineUrlRequestInterceptor
       ApiWebEngineRequestInterceptor(QObject* parent) : QWebEngineUrlRequestInterceptor(parent) {}
       void interceptRequest(QWebEngineUrlRequestInfo& info) override;
       };
+#endif
 
 //---------------------------------------------------------
 //   HttpStatus


### PR DESCRIPTION
Needed to build it for pure Debian 9, maybe MinGW builds will be closer to be working with this too.

Old-style login dialog is used if USE_WEBENGINE is turned off.