### PR TITLE
do not use any non-constant format strings

### DIFF
--- a/mscore/network/loginmanager.cpp
+++ b/mscore/network/loginmanager.cpp
@@ -578,7 +578,7 @@ void LoginManager::onGetMediaUrlReply(QNetworkReply* reply, int code, const QJso
                   }
             }
       else // TODO: handle request error properly
-            qWarning(getErrorString(reply, response).toUtf8().constData());
+            qWarning("%s", getErrorString(reply, response).toUtf8().constData());
 #if 0
       disconnect(_oauthManager, SIGNAL(requestReady(QByteArray)),
             this, SLOT(onGetMediaUrlRequestReady(QByteArray)));


### PR DESCRIPTION
fixes compilation abort with `-Werror=format-security` (mandated in Debian)

The idea here is:

    printf(some_function());

… cannot be checked for potentially insecure (such as, containing `%n`) format strings because they are the result of a function, so they are forbidden in order to prevent exploitable buffer overflows.