### PR TITLE
log vtest comparison in machine-parsable format

### DIFF
--- a/vtest/gen
+++ b/vtest/gen
@@ -108,9 +108,9 @@ echo "Compare PNG files and references"
 for src in $SRC; do
       if test -f $src-1.png; then
             cp ../$src-ref.png .
-            compare $src-1.png $src-ref.png $src-diff.png
+            compare -verbose -metric AE $src-1.png $src-ref.png $src-diff.png
             fi
-      done
+      done 2>&1 | tee /dev/stderr | fgrep -e Image: -e all: >LOG-compare
 
 echo "Generate report"
 F=vtest.html


### PR DESCRIPTION
This shows the number of different pixels in the output and stores them into a file, so the build could be made to fail if there is difference. (vtests are highly dependent on the font rendering engine though, so I’d not recommend doing so by default.)