### PR TITLE
fix #283157, fix #283180, fix #283323: fingering layout glitches

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1895,11 +1895,14 @@ void Chord::layoutPitched()
                         }
                   }
 
-            // clear fingering layout
+            // clear layout for note-based fingerings
             for (Element* e : note->el()) {
                   if (e->isFingering()) {
-                        e->setPos(QPointF());
-                        e->setbbox(QRectF());
+                        Fingering* f = toFingering(e);
+                        if (f->layoutType() == ElementType::NOTE) {
+                              f->setPos(QPointF());
+                              f->setbbox(QRectF());
+                              }
                         }
                   }
 
@@ -1996,7 +1999,7 @@ void Chord::layoutPitched()
       for (Note* note : _notes)
             note->layout2();
 
-      // align fingering
+      // align note-based fingerings
       std::vector<Fingering*> alignNote;
       qreal xNote = 10000.0;
       for (Note* note : _notes) {


### PR DESCRIPTION
These three issues are all related and have do with exactly *when* I clear the old layout and create the new one.  These were cases where it was being cleared but not then re-established.  Probably there would have been other cases where similar things (fingerings either disappearing or else moving on each relayout) could have happened, but my fix here should be good.

I added this to my original branch as it was simpler to do it that way.  Soon enough I expect I'll be building from master again and could resubmit this if needed.  Looks like no merge conflicts as is though.