### PR TITLE
fix #280950: Text style style changes not applied to existing chord symbols

### DIFF
--- a/libmscore/harmony.h
+++ b/libmscore/harmony.h
@@ -92,7 +92,6 @@ class Harmony final : public TextBase {
       virtual void drawEditMode(QPainter* p, EditData& ed) override;
       void render(const QString&, qreal&, qreal&);
       void render(const QList<RenderAction>& renderList, qreal&, qreal&, int tpc, NoteSpellingType noteSpelling = NoteSpellingType::STANDARD, NoteCaseType noteCase = NoteCaseType::AUTO);
-      virtual void styleChanged() override     { render(); }
       virtual Sid getPropertyStyle(Pid) const override;
 
    public:


### PR DESCRIPTION
Fixes https://musescore.org/en/node/280950.

There is no need for Harmony to override TextBase::styleChanged, since TextBase::styleChanged calls setProperty for all the styled properties, and Harmony::setProperty calls render().

Overriding this function without calling TextBase::styleChanged() was the cause of the problem.