### PR TITLE
fix #283546: removing text frame causes second corrupt one to appear

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1468,7 +1468,7 @@ void Score::removeElement(Element* element)
             measures()->remove(mb);
             System* system = mb->system();
             Page* page = system->page();
-            if (element->isVBox() && system->measures().size() == 1) {
+            if (element->isVBoxBase() && system->measures().size() == 1) {
                   auto i = std::find(page->systems().begin(), page->systems().end(), system);
                   page->systems().erase(i);
                   mb->setSystem(0);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/283546