### PR TITLE
fix #279925: double sigs on switch from page to continuous view

### DIFF
--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -162,6 +162,8 @@ void Score::resetSystems(bool /*layoutAll*/, LayoutContext& lc)
                         }
                   else if (m->header())
                         m->removeSystemHeader();
+                  if (m->trailer())
+                        m->removeSystemTrailer();
                   m->createEndBarLines(true);
                   m->computeMinWidth();
                   ww = m->width();


### PR DESCRIPTION
My investigation shows the extra signatures are courtesies that were generated while in page view (so the bug does not appear on initial load from continuous view) and while never laid out again in continuous view, they are also never removed.  So, my change here simply removes them in collectLinearSystem(), right after the place we also remove headers.  Seems to work for the basic test cases.  There may be other things that cause problems not addressed by this - I saw reports also of problems in page view while viewing parts.  Probably not related.