### PR TITLE
fix #279178: commands for flip/mirror hairpin

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2303,8 +2303,8 @@ Element* Score::selectMove(const QString& cmd)
 void Score::cmdMirrorNoteHead()
       {
       const QList<Element*>& el = selection().elements();
-      foreach(Element* e, el) {
-            if (e->type() == ElementType::NOTE) {
+      for (Element* e : el) {
+            if (e->isNote()) {
                   Note* note = toNote(e);
                   if (note->staff() && note->staff()->isTabStaff(note->chord()->tick()))
                         e->undoChangeProperty(Pid::GHOST, !note->ghost());
@@ -2316,6 +2316,27 @@ void Score::cmdMirrorNoteHead()
                               d = d == MScore::DirectionH::LEFT ? MScore::DirectionH::RIGHT : MScore::DirectionH::LEFT;
                         undoChangeUserMirror(note, d);
                         }
+                  }
+            else if (e->isHairpinSegment()) {
+                  Hairpin* h = toHairpinSegment(e)->hairpin();
+                  HairpinType st = h->hairpinType();
+                  switch (st)  {
+                        case HairpinType::CRESC_HAIRPIN:
+                              st = HairpinType::DECRESC_HAIRPIN;
+                              break;
+                        case HairpinType::DECRESC_HAIRPIN:
+                              st = HairpinType::CRESC_HAIRPIN;
+                              break;
+                        case HairpinType::CRESC_LINE:
+                              st = HairpinType::DECRESC_LINE;
+                              break;
+                        case HairpinType::DECRESC_LINE:
+                              st = HairpinType::CRESC_LINE;
+                              break;
+                        case HairpinType::INVALID:
+                              break;
+                        }
+                  h->undoChangeProperty(Pid::HAIRPIN_TYPE, int(st));
                   }
             }
       }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1387,27 +1387,6 @@ void Score::cmdFlip()
                         slurTieSegment->undoChangeProperty(Pid::SLUR_DIRECTION, QVariant::fromValue<Direction>(dir));
                         });
                   }
-            else if (e->isHairpinSegment()) {
-                  Hairpin* h = toHairpinSegment(e)->hairpin();
-                  HairpinType st = h->hairpinType();
-                  switch (st)  {
-                        case HairpinType::CRESC_HAIRPIN:
-                              st = HairpinType::DECRESC_HAIRPIN;
-                              break;
-                        case HairpinType::DECRESC_HAIRPIN:
-                              st = HairpinType::CRESC_HAIRPIN;
-                              break;
-                        case HairpinType::CRESC_LINE:
-                              st = HairpinType::DECRESC_LINE;
-                              break;
-                        case HairpinType::DECRESC_LINE:
-                              st = HairpinType::CRESC_LINE;
-                              break;
-                        case HairpinType::INVALID:
-                              break;
-                        }
-                  h->undoChangeProperty(Pid::HAIRPIN_TYPE, int(st));
-                  }
             else if (e->isArticulation()) {
                   auto articulation = toArticulation(e);
                   flipOnce(articulation, [articulation](){
@@ -1448,6 +1427,7 @@ void Score::cmdFlip()
                || e->isStaffText()
                || e->isDynamic()
                || e->isHairpin()
+               || e->isHairpinSegment()
                || e->isOttavaSegment()
                || e->isTextLineSegment()
                || e->isPedalSegment()


### PR DESCRIPTION
"X" works to flip placement between above & below for just about everything but hairpins, where it reverses the direction of the hairpin instead (crescendo to diminuendo or vice versa).  This PR makes "X" do the usual flip, and uses Shift+X (same as mirror note between sides of a stem) to change direction.