### PR TITLE
fix #280468: choosing Style... from note property menu opens with wrong tab

### DIFF
--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -84,7 +84,7 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       void resetUserStyleName();
 
 public:
-      static const int PAGE_NOTE = 6;
+      static const int PAGE_NOTE = 10;
       EditStyle(Score*, QWidget*);
       void setPage(int no);
       };


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/280468