### PR TITLE
fix #283834: Setting pedal and (de)crescendo lines to invisible doesn't work in PDF export and uploading

### DIFF
--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -1124,6 +1124,7 @@ SpannerSegment* Spanner::getNextLayoutSystemSegment(System* system, std::functio
       seg->setSystem(system);
       seg->setSpanner(this);
       seg->setTrack(track());
+      seg->setVisible(visible());
       return seg;
       }
 


### PR DESCRIPTION
Fixes https://musescore.org/en/node/283834.