### PR TITLE
Optimize Bezier curve shape approximation

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -311,17 +311,13 @@ void SlurSegment::computeBezier(QPointF p6o)
       ups(Grip::DRAG).p     = t.map(p5);
       ups(Grip::SHOULDER).p = t.map(p6);
 
-      QPainterPath p;
-      p.moveTo(QPointF());
-      p.cubicTo(p3 + p3o, p4 + p4o, p2);
-      p = t.map(p);
-
       _shape.clear();
       QPointF start = pp1;
       int nbShapes  = 32;  // (pp2.x() - pp1.x()) / _spatium;
       qreal minH    = qAbs(3 * w);
+      const CubicBezier b(pp1, ups(Grip::BEZIER1).pos(), ups(Grip::BEZIER2).pos(), ups(Grip::END).pos());
       for (int i = 1; i <= nbShapes; i++) {
-            QPointF point = p.pointAtPercent(i/float(nbShapes));
+            const QPointF point = b.pointAtPercent(i/float(nbShapes));
             QRectF re     = QRectF(start, point).normalized();
             if (re.height() < minH) {
                   qreal d1 = (minH - re.height()) * .5;

--- a/libmscore/slurtie.h
+++ b/libmscore/slurtie.h
@@ -41,7 +41,34 @@ struct UP {
       QPointF p;            // layout position relative to pos()
       QPointF off;          // user offset in point units
 
+      QPointF pos() const { return p + off; }
       bool operator!=(const UP& up) const { return p != up.p || off != up.off; }
+      };
+
+//---------------------------------------------------------
+//   CubicBezier
+//    Helper class to optimize cubic Bezier curve points
+//    calculation.
+//---------------------------------------------------------
+
+class CubicBezier {
+      QPointF p1;
+      QPointF p2;
+      QPointF p3;
+      QPointF p4;
+
+   public:
+      CubicBezier(QPointF _p1, QPointF _p2, QPointF _p3, QPointF _p4)
+         : p1(_p1), p2(_p2), p3(_p3), p4(_p4) {}
+
+      QPointF pointAtPercent(qreal t) const
+            {
+            Q_ASSERT(t >= 0.0 && t <= 1.0);
+            const qreal r = 1.0 - t;
+            const QPointF B123 = r * (r*p1 + t*p2) + t * (r*p2 + t*p3);
+            const QPointF B234 = r * (r*p2 + t*p3) + t * (r*p3 + t*p4);
+            return r*B123 + t*B234;
+            }
       };
 
 class SlurTie;

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -305,17 +305,15 @@ void TieSegment::computeBezier(QPointF p6o)
 //      path.translate(staffOffset);
 //      shapePath.translate(staffOffset);
 
-      QPainterPath p;
-      p.moveTo(QPointF());
-      p.cubicTo(p3 + p3o, p4 + p4o, p2);
       _shape.clear();
       QPointF start;
       start = t.map(start);
 
       qreal minH = qAbs(3.0 * w);
       int nbShapes = 15;
+      const CubicBezier b(pp1, ups(Grip::BEZIER1).pos(), ups(Grip::BEZIER2).pos(), ups(Grip::END).pos());
       for (int i = 1; i <= nbShapes; i++) {
-            QPointF point = t.map(p.pointAtPercent(i/float(nbShapes)));
+            const QPointF point = b.pointAtPercent(i/float(nbShapes));
             QRectF re = QRectF(start, point).normalized();
             if (re.height() < minH) {
                   d = (minH - re.height()) * .5;


### PR DESCRIPTION
This PR is relevant to the [MuseScore performance problems](https://musescore.org/en/node/280952). The proposed commit replaces `QPainterPath::pointAtPercent` usage with custom implementation for cubic Bezier curves which makes layout faster without any loss of precision of slurs/ties shapes approximation by rectangles. Performance gain in my tests (Debian GNU/Linux 9, Qt 5.10.1, [this benchmark](https://github.com/dmitrio95/MuseScore/blob/1dd6933e3d4c7f7ceb12e9dfc2cc564e53da2777/mtest/libmscore/layout/tst_benchmark.cpp) launched for the [OpenScore edition](https://musescore.com/openscore/scores/4861738) of Mozart Symphony No. 41) is about 15% for score loading and about 27% for both partial and full score layout. This may vary depending on a score and environment but this still should make the situation a bit better.

The idea of this optimization is that [`QPainterPath::pointAtPercent`](https://github.com/qt/qtbase/blob/7d03b9b300741f4559128be52be4907c807ae286/src/gui/painting/qpainterpath.cpp#L3012) implementation is not optimal for our case since it tries to handle cases where several lines can be included to the path so a lot of extra work (like the curve length calculation) is done prior to calculating Bezier curve point itself. Meanwhile slurs and ties are represented by a single cubic Bezier curve so replacing the `QPainterPath` implementation with the implementation suited solely for single Bezier curve saves a lot of computation time on that operation.