### PR TITLE
fix travis ci readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![MuseScore](mscore/data/musescore_logo_full.png)  
  Music notation and composition software
 
-[![Travis CI](https://secure.travis-ci.org/musescore/MuseScore.svg)](https://travis-ci.org/musescore/MuseScore)
+[![Travis CI](https://secure.travis-ci.org/musescore/MuseScore.svg?branch=master)](https://travis-ci.org/musescore/MuseScore)
 [![Appveyor](https://ci.appveyor.com/api/projects/status/bp3ww6v985i64ece/branch/master?svg=true)](https://ci.appveyor.com/project/MuseScore/musescore/branch/master)
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
 


### PR DESCRIPTION
This was just bugging me.
I guess at some point Travis started requiring a branch name 🤷‍♂️ 
