### PR TITLE
fix #280390: spurious keychange on each system on transpose

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -507,6 +507,18 @@ bool KeySig::operator==(const KeySig& k) const
       }
 
 //---------------------------------------------------------
+//   isChange
+//---------------------------------------------------------
+
+bool KeySig::isChange() const
+      {
+      if (!staff())
+            return false;
+      int keyTick = tick();
+      return staff()->currentKeyTick(keyTick) == keyTick;
+      }
+
+//---------------------------------------------------------
 //   changeKeySigEvent
 //---------------------------------------------------------
 

--- a/libmscore/keysig.h
+++ b/libmscore/keysig.h
@@ -57,6 +57,7 @@ class KeySig final : public Element {
       Q_INVOKABLE Key key() const         { return _sig.key(); }
       bool isCustom() const               { return _sig.custom(); }
       bool isAtonal() const               { return _sig.isAtonal(); }
+      bool isChange() const;
       KeySigEvent keySigEvent() const     { return _sig; }
       bool operator==(const KeySig&) const;
       void changeKeySigEvent(const KeySigEvent&);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1959,7 +1959,8 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                               }
                         else {
                               if (!(nts->keySigEvent() == ts->keySigEvent())) {
-                                    undo(new ChangeKeySig(nts, ts->keySigEvent(), nts->showCourtesy()));
+                                    bool addKey = ts->isChange();
+                                    undo(new ChangeKeySig(nts, ts->keySigEvent(), nts->showCourtesy(), addKey));
                                     }
                               }
                         }

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -422,14 +422,16 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
                               }
                         }
                   else if (e->isKeySig() && trKeys && mode != TransposeMode::DIATONICALLY) {
+                        bool startKey = segment->tick() == s1->tick();
                         QList<ScoreElement*> ll = e->linkList();
                         for (ScoreElement* scoreElement : ll) {
                               KeySig* ks = toKeySig(scoreElement);
+                              bool addKey = ks->isChange();
                               if (!ks->isCustom() && !ks->isAtonal()) {
                                     Key nKey = transposeKey(ks->key(), interval);
                                     KeySigEvent ke = ks->keySigEvent();
                                     ke.setKey(nKey);
-                                    undo(new ChangeKeySig(ks, ke, ks->showCourtesy()));
+                                    undo(new ChangeKeySig(ks, ke, ks->showCourtesy(), startKey || addKey));
                                     }
                               }
                         }


### PR DESCRIPTION
See https://musescore.org/en/node/280390#comment-895040 for analysis.  One way or another, we need to avoid adding these generated and them transposed keysigs to the map.  My solution here simply skips them entirely, same as we do on toggling concert pitch, on the assumption they will get regenerated on layout anyhow.

Another possible solution would be to perform the same test here, but instead of continuing, set a flag "addEvent" to false (true otherwise), and then add that flag as the fourth parameter to the undo(new ChangeKeySig()) call to follow.  But this seems a little wasteful, we may end up transposing keysigs that will actually go away on the layout if they aren't at the beginning of a system any more.