### PR TITLE
fix #281554: missing space between value and measuring unit

### DIFF
--- a/effects/compressor/compressor_gui.ui
+++ b/effects/compressor/compressor_gui.ui
@@ -530,7 +530,7 @@
       <set>Qt::AlignCenter</set>
      </property>
      <property name="suffix">
-      <string extracomment="milliseconds">ms</string>
+      <string notr="true" extracomment="milliseconds"> ms</string>
      </property>
      <property name="decimals">
       <number>1</number>
@@ -552,7 +552,7 @@
       <set>Qt::AlignCenter</set>
      </property>
      <property name="suffix">
-      <string extracomment="milliseconds">ms</string>
+      <string notr="true" extracomment="milliseconds"> ms</string>
      </property>
      <property name="decimals">
       <number>1</number>
@@ -574,7 +574,7 @@
       <set>Qt::AlignCenter</set>
      </property>
      <property name="suffix">
-      <string extracomment="decibel">dB</string>
+      <string notr="true" extracomment="decibel"> dB</string>
      </property>
      <property name="decimals">
       <number>1</number>
@@ -612,7 +612,7 @@
       <set>Qt::AlignCenter</set>
      </property>
      <property name="suffix">
-      <string extracomment="decibel">dB</string>
+      <string notr="true" extracomment="decibel"> dB</string>
      </property>
      <property name="decimals">
       <number>1</number>
@@ -637,7 +637,7 @@
       <enum>QAbstractSpinBox::UpDownArrows</enum>
      </property>
      <property name="suffix">
-      <string extracomment="decibel">dB</string>
+      <string notr="true" extracomment="decibel"> dB</string>
      </property>
      <property name="decimals">
       <number>1</number>

--- a/mscore/cellproperties.ui
+++ b/mscore/cellproperties.ui
@@ -77,7 +77,7 @@
       <item row="1" column="2">
        <widget class="QDoubleSpinBox" name="xoffset">
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="minimum">
          <double>-99.000000000000000</double>
@@ -87,7 +87,7 @@
       <item row="1" column="4">
        <widget class="QDoubleSpinBox" name="yoffset">
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="minimum">
          <double>-99.000000000000000</double>

--- a/mscore/drumroll.cpp
+++ b/mscore/drumroll.cpp
@@ -330,7 +330,7 @@ void DrumrollEditor::updateVelocity(Note* note)
                         break;
                   case Note::ValueType::OFFSET_VAL:
                         velocity->setReadOnly(false);
-                        velocity->setSuffix("%");
+                        velocity->setSuffix(" %");
                         velocity->setRange(-200, 200);
                         break;
                   }

--- a/mscore/editraster.ui
+++ b/mscore/editraster.ui
@@ -51,7 +51,7 @@
           <item row="0" column="2" rowspan="2">
            <widget class="QSpinBox" name="hraster">
             <property name="suffix">
-             <string>sp</string>
+             <string notr="true"> sp</string>
             </property>
             <property name="minimum">
              <number>1</number>
@@ -74,7 +74,7 @@
           <item row="2" column="2">
            <widget class="QSpinBox" name="vraster">
             <property name="suffix">
-             <string>sp</string>
+             <string notr="true"> sp</string>
             </property>
             <property name="minimum">
              <number>1</number>

--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -192,7 +192,7 @@
              </sizepolicy>
             </property>
             <property name="suffix">
-             <string>sp</string>
+             <string notr="true"> sp</string>
             </property>
             <property name="singleStep">
              <double>0.250000000000000</double>
@@ -212,7 +212,7 @@
           <item row="4" column="1">
            <widget class="QDoubleSpinBox" name="spinExtraDistance">
             <property name="suffix">
-             <string>sp</string>
+             <string notr="true"> sp</string>
             </property>
             <property name="minimum">
              <double>-50.000000000000000</double>
@@ -235,7 +235,7 @@
           <item row="5" column="1">
            <widget class="QDoubleSpinBox" name="mag">
             <property name="suffix">
-             <string>%</string>
+             <string notr="true"> %</string>
             </property>
             <property name="decimals">
              <number>1</number>

--- a/mscore/editstafftype.ui
+++ b/mscore/editstafftype.ui
@@ -153,7 +153,7 @@
           </sizepolicy>
          </property>
          <property name="suffix">
-          <string>sp</string>
+          <string notr="true"> sp</string>
          </property>
          <property name="singleStep">
           <double>0.250000000000000</double>
@@ -466,7 +466,7 @@
                     <item row="0" column="1">
                      <widget class="QDoubleSpinBox" name="fretFontSize">
                       <property name="suffix">
-                       <string>pt</string>
+                       <string notr="true"> pt</string>
                       </property>
                       <property name="decimals">
                        <number>1</number>
@@ -496,7 +496,7 @@
                     <item row="0" column="1">
                      <widget class="QDoubleSpinBox" name="fretY">
                       <property name="suffix">
-                       <string>sp</string>
+                       <string notr="true"> sp</string>
                       </property>
                       <property name="minimum">
                        <double>-99.989999999999995</double>
@@ -751,7 +751,7 @@
                   <item>
                    <widget class="QDoubleSpinBox" name="durFontSize">
                     <property name="suffix">
-                     <string>pt</string>
+                     <string notr="true"> pt</string>
                     </property>
                     <property name="decimals">
                      <number>1</number>
@@ -783,7 +783,7 @@
                   <item>
                    <widget class="QDoubleSpinBox" name="durY">
                     <property name="suffix">
-                     <string>sp</string>
+                     <string notr="true"> sp</string>
                     </property>
                     <property name="minimum">
                      <double>-99.989999999999995</double>

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -442,7 +442,7 @@
                    </sizepolicy>
                   </property>
                   <property name="suffix">
-                   <string>sp</string>
+                   <string notr="true"> sp</string>
                   </property>
                   <property name="minimum">
                    <double>2.000000000000000</double>
@@ -599,7 +599,7 @@
                    </sizepolicy>
                   </property>
                   <property name="suffix">
-                   <string>%</string>
+                   <string notr="true"> %</string>
                   </property>
                   <property name="minimum">
                    <number>50</number>
@@ -753,7 +753,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -795,7 +795,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -942,7 +942,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string notr="true"> %</string>
              </property>
              <property name="maximum">
               <number>100</number>
@@ -961,7 +961,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -1097,7 +1097,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -1119,7 +1119,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -1160,7 +1160,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -1202,7 +1202,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -1240,7 +1240,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -1373,7 +1373,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string notr="true"> %</string>
              </property>
              <property name="minimum">
               <number>10</number>
@@ -1441,7 +1441,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string notr="true"> %</string>
              </property>
              <property name="minimum">
               <number>10</number>
@@ -1479,7 +1479,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string notr="true"> %</string>
              </property>
              <property name="minimum">
               <number>10</number>
@@ -1517,7 +1517,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string notr="true">%</string>
+              <string notr="true"> %</string>
              </property>
              <property name="minimum">
               <number>10</number>
@@ -1804,7 +1804,7 @@
               <item row="0" column="4">
                <widget class="QDoubleSpinBox" name="footerFontSize">
                 <property name="suffix">
-                 <string>pt</string>
+                 <string notr="true"> pt</string>
                 </property>
                 <property name="minimum">
                  <double>1.000000000000000</double>
@@ -2211,7 +2211,7 @@
               <item row="0" column="4">
                <widget class="QDoubleSpinBox" name="headerFontSize">
                 <property name="suffix">
-                 <string>pt</string>
+                 <string notr="true"> pt</string>
                 </property>
                 <property name="minimum">
                  <double>1.000000000000000</double>
@@ -2435,7 +2435,7 @@
            <item row="4" column="4">
             <widget class="QDoubleSpinBox" name="measureNumberFontSize">
              <property name="suffix">
-              <string>pt</string>
+              <string notr="true"> pt</string>
              </property>
              <property name="minimum">
               <double>1.000000000000000</double>
@@ -2558,7 +2558,7 @@
                 <item row="0" column="1">
                  <widget class="QDoubleSpinBox" name="bracketWidth">
                   <property name="suffix">
-                   <string extracomment="spatium unit">sp</string>
+                   <string notr="true" extracomment="spatium unit"> sp</string>
                   </property>
                   <property name="decimals">
                    <number>2</number>
@@ -2593,7 +2593,7 @@
                    </sizepolicy>
                   </property>
                   <property name="suffix">
-                   <string>sp</string>
+                   <string notr="true"> sp</string>
                   </property>
                   <property name="decimals">
                    <number>2</number>
@@ -2648,7 +2648,7 @@
                    </size>
                   </property>
                   <property name="suffix">
-                   <string>sp</string>
+                   <string notr="true"> sp</string>
                   </property>
                  </widget>
                 </item>
@@ -2674,7 +2674,7 @@
                    </size>
                   </property>
                   <property name="suffix">
-                   <string>sp</string>
+                   <string notr="true"> sp</string>
                   </property>
                  </widget>
                 </item>
@@ -2749,7 +2749,7 @@
                     </size>
                    </property>
                    <property name="suffix">
-                    <string>sp</string>
+                    <string notr="true"> sp</string>
                    </property>
                    <property name="minimum">
                     <double>-99.000000000000000</double>
@@ -2775,7 +2775,7 @@
                     </size>
                    </property>
                    <property name="suffix">
-                    <string>sp</string>
+                    <string notr="true"> sp</string>
                    </property>
                    <property name="minimum">
                     <double>-99.000000000000000</double>
@@ -2842,7 +2842,7 @@
                     </size>
                    </property>
                    <property name="suffix">
-                    <string>sp</string>
+                    <string notr="true"> sp</string>
                    </property>
                    <property name="minimum">
                     <double>-99.000000000000000</double>
@@ -2868,7 +2868,7 @@
                     </size>
                    </property>
                    <property name="suffix">
-                    <string>sp</string>
+                    <string notr="true"> sp</string>
                    </property>
                    <property name="minimum">
                     <double>-99.000000000000000</double>
@@ -2926,7 +2926,7 @@
               <item row="0" column="4">
                <widget class="QDoubleSpinBox" name="longInstrumentFontSize">
                 <property name="suffix">
-                 <string>pt</string>
+                 <string notr="true"> pt</string>
                 </property>
                 <property name="minimum">
                  <double>1.000000000000000</double>
@@ -3177,7 +3177,7 @@
               <item row="0" column="4">
                <widget class="QDoubleSpinBox" name="shortInstrumentFontSize">
                 <property name="suffix">
-                 <string>pt</string>
+                 <string notr="true"> pt</string>
                 </property>
                 <property name="minimum">
                  <double>1.000000000000000</double>
@@ -3367,7 +3367,7 @@
              <item row="13" column="1">
               <widget class="QDoubleSpinBox" name="keyTimesigDistance">
                <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
+                <string notr="true" extracomment="spatium unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.010000000000000</double>
@@ -3377,7 +3377,7 @@
              <item row="12" column="1">
               <widget class="QDoubleSpinBox" name="clefTimesigDistance">
                <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
+                <string notr="true" extracomment="spatium unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.010000000000000</double>
@@ -3387,7 +3387,7 @@
              <item row="11" column="1">
               <widget class="QDoubleSpinBox" name="clefKeyDistance">
                <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
+                <string notr="true" extracomment="spatium unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.010000000000000</double>
@@ -3570,7 +3570,7 @@
              <item row="14" column="1">
               <widget class="QDoubleSpinBox" name="keyBarlineDistance">
                <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
+                <string notr="true" extracomment="spatium unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.010000000000000</double>
@@ -3651,7 +3651,7 @@
              <item row="15" column="1">
               <widget class="QDoubleSpinBox" name="systemHeaderDistance">
                <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
+                <string notr="true" extracomment="spatium unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -3696,7 +3696,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.050000000000000</double>
@@ -3829,7 +3829,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -3845,7 +3845,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -3888,7 +3888,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -3898,7 +3898,7 @@
              <item row="17" column="1">
               <widget class="QDoubleSpinBox" name="staffLineWidth">
                <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
+                <string notr="true" extracomment="spatium unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -3943,7 +3943,7 @@
              <item row="10" column="1">
               <widget class="QDoubleSpinBox" name="clefBarlineDistance">
                <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
+                <string notr="true" extracomment="spatium unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.010000000000000</double>
@@ -3994,7 +3994,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -4010,7 +4010,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -4026,7 +4026,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -4106,7 +4106,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -4122,7 +4122,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -4138,7 +4138,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -4164,7 +4164,7 @@
              <item row="0" column="1">
               <widget class="QDoubleSpinBox" name="minMeasureWidth_2">
                <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
+                <string notr="true" extracomment="spatium unit"> sp</string>
                </property>
                <property name="minimum">
                 <double>2.000000000000000</double>
@@ -4282,7 +4282,7 @@
              <item row="15" column="5">
               <widget class="QDoubleSpinBox" name="systemHeaderTimeSigDistance">
                <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
+                <string notr="true" extracomment="spatium unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -4315,7 +4315,7 @@
                 </sizepolicy>
                </property>
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -4408,7 +4408,7 @@
            <item row="10" column="1">
             <widget class="QDoubleSpinBox" name="repeatBarlineDotSeparation">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -4418,7 +4418,7 @@
            <item row="8" column="1">
             <widget class="QDoubleSpinBox" name="doubleBarWidth">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -4598,7 +4598,7 @@
            <item row="7" column="1">
             <widget class="QDoubleSpinBox" name="endBarDistance">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -4615,7 +4615,7 @@
            <item row="5" column="1">
             <widget class="QDoubleSpinBox" name="barWidth">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -4683,7 +4683,7 @@
            <item row="6" column="1">
             <widget class="QDoubleSpinBox" name="endBarWidth">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -4710,7 +4710,7 @@
            <item row="9" column="1">
             <widget class="QDoubleSpinBox" name="doubleBarDistance">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -4745,7 +4745,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -4764,7 +4764,7 @@
               <item row="2" column="1">
                <widget class="QDoubleSpinBox" name="shortestStem">
                 <property name="suffix">
-                 <string extracomment="space unit">sp</string>
+                 <string notr="true" extracomment="space unit"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>1.000000000000000</double>
@@ -4787,7 +4787,7 @@
               <item row="0" column="1">
                <widget class="QDoubleSpinBox" name="shortStemProgression">
                 <property name="suffix">
-                 <string extracomment="space unit">sp</string>
+                 <string notr="true" extracomment="space unit"> sp</string>
                 </property>
                 <property name="singleStep">
                  <double>0.050000000000000</double>
@@ -4826,7 +4826,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -4879,7 +4879,7 @@
            <item row="3" column="1">
             <widget class="QSpinBox" name="dotMag">
              <property name="suffix">
-              <string notr="true">%</string>
+              <string notr="true"> %</string>
              </property>
              <property name="minimum">
               <number>50</number>
@@ -4904,7 +4904,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -4920,7 +4920,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -4936,7 +4936,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -5005,7 +5005,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -5021,7 +5021,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -5060,7 +5060,7 @@
            <item row="0" column="1">
             <widget class="QDoubleSpinBox" name="beamWidth">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -5077,7 +5077,7 @@
            <item row="2" column="1">
             <widget class="QDoubleSpinBox" name="beamMinLen">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.050000000000000</double>
@@ -5130,7 +5130,7 @@
            <item row="1" column="1">
             <widget class="QDoubleSpinBox" name="beamDistance">
              <property name="suffix">
-              <string>%</string>
+              <string notr="true"> %</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -5175,7 +5175,7 @@
               <item row="1" column="1">
                <widget class="QDoubleSpinBox" name="tupletVStemDistance">
                 <property name="suffix">
-                 <string>sp</string>
+                 <string notr="true"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>-5.000000000000000</double>
@@ -5194,7 +5194,7 @@
               <item row="0" column="1">
                <widget class="QDoubleSpinBox" name="tupletMaxSlope">
                 <property name="suffix">
-                 <string extracomment="spatium unit">sp</string>
+                 <string notr="true" extracomment="spatium unit"> sp</string>
                 </property>
                 <property name="maximum">
                  <double>1.000000000000000</double>
@@ -5230,7 +5230,7 @@
               <item row="2" column="1">
                <widget class="QDoubleSpinBox" name="tupletVHeadDistance">
                 <property name="suffix">
-                 <string>sp</string>
+                 <string notr="true"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>-5.000000000000000</double>
@@ -5360,7 +5360,7 @@
               <item row="0" column="1">
                <widget class="QDoubleSpinBox" name="tupletStemLeftDistance">
                 <property name="suffix">
-                 <string>sp</string>
+                 <string notr="true"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>-5.000000000000000</double>
@@ -5389,7 +5389,7 @@
               <item row="1" column="1">
                <widget class="QDoubleSpinBox" name="tupletNoteLeftDistance">
                 <property name="suffix">
-                 <string>sp</string>
+                 <string notr="true"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>-5.000000000000000</double>
@@ -5415,7 +5415,7 @@
               <item row="2" column="1">
                <widget class="QDoubleSpinBox" name="tupletStemRightDistance">
                 <property name="suffix">
-                 <string>sp</string>
+                 <string notr="true"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>-5.000000000000000</double>
@@ -5444,7 +5444,7 @@
               <item row="3" column="1">
                <widget class="QDoubleSpinBox" name="tupletNoteRightDistance">
                 <property name="suffix">
-                 <string>sp</string>
+                 <string notr="true"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>-5.000000000000000</double>
@@ -5627,7 +5627,7 @@
               <item row="0" column="1">
                <widget class="QDoubleSpinBox" name="tupletBracketWidth">
                 <property name="suffix">
-                 <string>sp</string>
+                 <string notr="true"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>0.050000000000000</double>
@@ -5646,7 +5646,7 @@
               <item row="1" column="1">
                <widget class="QDoubleSpinBox" name="tupletBracketHookHeight">
                 <property name="suffix">
-                 <string>sp</string>
+                 <string notr="true"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>0.050000000000000</double>
@@ -5916,7 +5916,7 @@
              <item row="0" column="1">
               <widget class="QDoubleSpinBox" name="arpeggioNoteDistance">
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="maximum">
                 <double>99999.000000000000000</double>
@@ -5939,7 +5939,7 @@
              <item row="1" column="1">
               <widget class="QDoubleSpinBox" name="arpeggioLineWidth">
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="maximum">
                 <double>99999.000000000000000</double>
@@ -5962,7 +5962,7 @@
              <item row="2" column="1">
               <widget class="QDoubleSpinBox" name="arpeggioHookLen">
                <property name="suffix">
-                <string>sp</string>
+                <string notr="true"> sp</string>
                </property>
                <property name="maximum">
                 <double>99999.000000000000000</double>
@@ -6022,7 +6022,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.050000000000000</double>
@@ -6048,7 +6048,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.050000000000000</double>
@@ -6075,7 +6075,7 @@
            <item row="3" column="1">
             <widget class="QDoubleSpinBox" name="minTieLength">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -6104,7 +6104,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.050000000000000</double>
@@ -6140,7 +6140,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>2</number>
@@ -6283,7 +6283,7 @@
            <item row="5" column="1">
             <widget class="QDoubleSpinBox" name="hairpinHeight">
              <property name="suffix">
-              <string extracomment="spatium unit">sp</string>
+              <string notr="true" extracomment="spatium unit"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -6402,7 +6402,7 @@
            <item row="6" column="1">
             <widget class="QDoubleSpinBox" name="hairpinContinueHeight">
              <property name="suffix">
-              <string extracomment="spatium unit">sp</string>
+              <string notr="true" extracomment="spatium unit"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -6412,7 +6412,7 @@
            <item row="7" column="1">
             <widget class="QDoubleSpinBox" name="autoplaceHairpinDynamicsDistance">
              <property name="suffix">
-              <string extracomment="spatium unit">sp</string>
+              <string notr="true" extracomment="spatium unit"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -6558,7 +6558,7 @@
            <item row="8" column="1">
             <widget class="QDoubleSpinBox" name="hairpinLineWidth">
              <property name="suffix">
-              <string extracomment="spatium unit">sp</string>
+              <string notr="true" extracomment="spatium unit"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.010000000000000</double>
@@ -6672,7 +6672,7 @@
            <item row="3" column="1">
             <widget class="QDoubleSpinBox" name="voltaLineWidth">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
             </widget>
            </item>
@@ -6692,7 +6692,7 @@
            <item row="2" column="1">
             <widget class="QDoubleSpinBox" name="voltaHook">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
             </widget>
            </item>
@@ -6870,7 +6870,7 @@
            <item row="2" column="4">
             <widget class="QDoubleSpinBox" name="ottavaHookAbove">
              <property name="suffix">
-              <string extracomment="spatium unit">sp</string>
+              <string notr="true" extracomment="spatium unit"> sp</string>
              </property>
             </widget>
            </item>
@@ -6992,7 +6992,7 @@
            <item row="6" column="1">
             <widget class="QDoubleSpinBox" name="ottavaLineWidth">
              <property name="suffix">
-              <string extracomment="spatium unit">sp</string>
+              <string notr="true" extracomment="spatium unit"> sp</string>
              </property>
             </widget>
            </item>
@@ -7111,7 +7111,7 @@
            <item row="3" column="4">
             <widget class="QDoubleSpinBox" name="ottavaHookBelow">
              <property name="suffix">
-              <string extracomment="spatium unit">sp</string>
+              <string notr="true" extracomment="spatium unit"> sp</string>
              </property>
             </widget>
            </item>
@@ -7358,7 +7358,7 @@
            <item row="4" column="1">
             <widget class="QDoubleSpinBox" name="pedalLineWidth">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="singleStep">
               <double>0.100000000000000</double>
@@ -7686,7 +7686,7 @@
            <item row="0" column="1">
             <widget class="QDoubleSpinBox" name="bendLineWidth">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="minimum">
               <double>0.000000000000000</double>
@@ -7722,7 +7722,7 @@
            <item row="3" column="1">
             <widget class="QDoubleSpinBox" name="bendFontSize">
              <property name="suffix">
-              <string>pt</string>
+              <string notr="true"> pt</string>
              </property>
              <property name="minimum">
               <double>1.000000000000000</double>
@@ -7732,7 +7732,7 @@
            <item row="1" column="1">
             <widget class="QDoubleSpinBox" name="bendArrowWidth">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="minimum">
               <double>0.000000000000000</double>
@@ -8066,7 +8066,7 @@
              <item row="0" column="1">
               <widget class="QDoubleSpinBox" name="propertyDistanceHead">
                <property name="suffix">
-                <string comment="space unit">sp</string>
+                <string notr="true" comment="space unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -8096,7 +8096,7 @@
              <item row="3" column="1">
               <widget class="QSpinBox" name="articulationMag">
                <property name="suffix">
-                <string notr="true">%</string>
+                <string notr="true"> %</string>
                </property>
                <property name="maximum">
                 <number>300</number>
@@ -8122,7 +8122,7 @@
              <item row="2" column="1">
               <widget class="QDoubleSpinBox" name="propertyDistance">
                <property name="suffix">
-                <string comment="space unit">sp</string>
+                <string notr="true" comment="space unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -8142,7 +8142,7 @@
              <item row="1" column="1">
               <widget class="QDoubleSpinBox" name="propertyDistanceStem">
                <property name="suffix">
-                <string comment="space unit">sp</string>
+                <string notr="true" comment="space unit"> sp</string>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -8303,7 +8303,7 @@
              <item row="2" column="1">
               <widget class="QDoubleSpinBox" name="fermataMinDistance">
                <property name="suffix">
-                <string extracomment="spatium unit">sp</string>
+                <string notr="true" extracomment="spatium unit"> sp</string>
                </property>
                <property name="minimum">
                 <double>0.000000000000000</double>
@@ -8513,7 +8513,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -8705,7 +8705,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -8777,7 +8777,7 @@
            <item row="0" column="1">
             <widget class="QDoubleSpinBox" name="lyricsDashMinLength">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="maximum">
               <double>9.990000000000000</double>
@@ -8803,7 +8803,7 @@
            <item row="1" column="1">
             <widget class="QDoubleSpinBox" name="lyricsDashMaxLength">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="minimum">
               <double>0.050000000000000</double>
@@ -8832,7 +8832,7 @@
            <item row="2" column="1">
             <widget class="QDoubleSpinBox" name="lyricsDashMaxDistance">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>0</number>
@@ -8943,7 +8943,7 @@
            <item row="4" column="1">
             <widget class="QDoubleSpinBox" name="lyricsDashPad">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="maximum">
               <double>1.000000000000000</double>
@@ -8966,7 +8966,7 @@
            <item row="3" column="1">
             <widget class="QDoubleSpinBox" name="lyricsDashLineThickness">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="maximum">
               <double>1.000000000000000</double>
@@ -9086,7 +9086,7 @@
            <item row="0" column="1">
             <widget class="QDoubleSpinBox" name="lyricsLineThickness">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="maximum">
               <double>1.000000000000000</double>
@@ -9119,7 +9119,7 @@
            <item row="1" column="1">
             <widget class="QDoubleSpinBox" name="lyricsMelismaPad">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="maximum">
               <double>1.000000000000000</double>
@@ -9188,7 +9188,7 @@
            <item row="3" column="1">
             <widget class="QDoubleSpinBox" name="lyricsLineHeight">
              <property name="suffix">
-              <string>%</string>
+              <string notr="true"> %</string>
              </property>
              <property name="minimum">
               <double>50.000000000000000</double>
@@ -9261,7 +9261,7 @@
            <item row="5" column="1">
             <widget class="QDoubleSpinBox" name="lyricsMinBottomDistance">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -9304,7 +9304,7 @@
            <item row="6" column="1">
             <widget class="QDoubleSpinBox" name="lyricsMinDistance">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>2</number>
@@ -9397,7 +9397,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -9512,7 +9512,7 @@
            <item row="3" column="1">
             <widget class="QDoubleSpinBox" name="dynamicsMinDistance">
              <property name="suffix">
-              <string extracomment="spatium unit">sp</string>
+              <string notr="true" extracomment="spatium unit"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -9825,7 +9825,7 @@
               </sizepolicy>
              </property>
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>1</number>
@@ -9881,7 +9881,7 @@
                <item row="3" column="1">
                 <widget class="QSpinBox" name="spinFBLineHeight">
                  <property name="suffix">
-                  <string notr="true">%</string>
+                  <string notr="true"> %</string>
                  </property>
                  <property name="minimum">
                   <number>1</number>
@@ -9913,7 +9913,7 @@
                <item row="2" column="1">
                 <widget class="QDoubleSpinBox" name="doubleSpinFBVertPos">
                  <property name="suffix">
-                  <string>sp</string>
+                  <string notr="true"> sp</string>
                  </property>
                  <property name="minimum">
                   <double>-25.000000000000000</double>
@@ -9945,7 +9945,7 @@
                <item row="1" column="1">
                 <widget class="QDoubleSpinBox" name="doubleSpinFBSize">
                  <property name="suffix">
-                  <string>pt</string>
+                  <string notr="true"> pt</string>
                  </property>
                  <property name="decimals">
                   <number>1</number>
@@ -10341,7 +10341,7 @@
               <item row="1" column="1">
                <widget class="QDoubleSpinBox" name="minHarmonyDistance">
                 <property name="suffix">
-                 <string>sp</string>
+                 <string notr="true"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>-50.000000000000000</double>
@@ -10373,7 +10373,7 @@
                  <bool>true</bool>
                 </property>
                 <property name="suffix">
-                 <string extracomment="spatium unit">sp</string>
+                 <string notr="true" extracomment="spatium unit"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>-10000.000000000000000</double>
@@ -10425,7 +10425,7 @@
               <item row="2" column="1">
                <widget class="QDoubleSpinBox" name="maxHarmonyBarDistance">
                 <property name="suffix">
-                 <string>sp</string>
+                 <string notr="true"> sp</string>
                 </property>
                 <property name="minimum">
                  <double>-50.000000000000000</double>
@@ -10525,7 +10525,7 @@
            <item row="0" column="1">
             <widget class="QDoubleSpinBox" name="fretY">
              <property name="suffix">
-              <string>sp</string>
+              <string notr="true"> sp</string>
              </property>
              <property name="decimals">
               <number>2</number>
@@ -10601,7 +10601,7 @@
            <item row="2" column="1">
             <widget class="QSpinBox" name="fretNumMag">
              <property name="suffix">
-              <string notr="true">%</string>
+              <string notr="true"> %</string>
              </property>
              <property name="maximum">
               <number>500</number>
@@ -10715,7 +10715,7 @@
            <item row="2" column="1">
             <widget class="QDoubleSpinBox" name="textStyleFontSize">
              <property name="suffix">
-              <string>pt</string>
+              <string notr="true"> pt</string>
              </property>
              <property name="minimum">
               <double>1.000000000000000</double>

--- a/mscore/inspector/inspectorElementBase.cpp
+++ b/mscore/inspector/inspectorElementBase.cpp
@@ -43,9 +43,9 @@ void InspectorElementBase::setElement()
       {
       InspectorBase::setElement();
       if (inspector->element()->sizeIsSpatiumDependent())
-            e.offset->setSuffix("sp");
+            e.offset->setSuffix(" sp");
       else
-            e.offset->setSuffix("mm");
+            e.offset->setSuffix(" mm");
       }
 
 } // namespace Ms

--- a/mscore/inspector/inspectorImage.cpp
+++ b/mscore/inspector/inspectorImage.cpp
@@ -73,7 +73,7 @@ void InspectorImage::postInit()
       b.size->setEnabled(v);
       b.sizeIsSpatium->setEnabled(v);
 
-      b.size->setSuffix(image->sizeIsSpatium() ? "sp" : "mm");
+      b.size->setSuffix(image->sizeIsSpatium() ? " sp" : " mm");
       }
 }
 

--- a/mscore/inspector/inspectorLasso.cpp
+++ b/mscore/inspector/inspectorLasso.cpp
@@ -30,8 +30,8 @@ InspectorLasso::InspectorLasso(QWidget* parent)
             { Pid::LASSO_SIZE,   0, b.size,  0 },
             };
 
-      b.pos->setSuffix(tr("mm"));
-      b.size->setSuffix(tr("mm"));
+      b.pos->setSuffix(" mm");
+      b.size->setSuffix(" mm");
 
       mapSignals();
       }

--- a/mscore/inspector/inspector_ambitus.ui
+++ b/mscore/inspector/inspector_ambitus.ui
@@ -175,7 +175,7 @@
          <string>Line thickness</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="maximum">
          <double>10.000000000000000</double>

--- a/mscore/inspector/inspector_bend.ui
+++ b/mscore/inspector/inspector_bend.ui
@@ -163,7 +163,7 @@
          <string>Font size</string>
         </property>
         <property name="suffix">
-         <string>pt</string>
+         <string notr="true"> pt</string>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -199,7 +199,7 @@
          <string>Line thickness</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
        </widget>
       </item>

--- a/mscore/inspector/inspector_caesura.ui
+++ b/mscore/inspector/inspector_caesura.ui
@@ -82,7 +82,7 @@
          <string>Pause</string>
         </property>
         <property name="suffix">
-         <string extracomment="seconds">s</string>
+         <string notr="true" extracomment="seconds"> s</string>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -221,7 +221,7 @@
          <string>Font size</string>
         </property>
         <property name="suffix">
-         <string>pt</string>
+         <string notr="true"> pt</string>
         </property>
         <property name="minimum">
          <number>1</number>

--- a/mscore/inspector/inspector_hairpin.ui
+++ b/mscore/inspector/inspector_hairpin.ui
@@ -107,7 +107,7 @@
          <string>Continue height</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="singleStep">
          <double>0.100000000000000</double>
@@ -208,7 +208,7 @@
          <string>Height</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="singleStep">
          <double>0.100000000000000</double>

--- a/mscore/inspector/inspector_hbox.ui
+++ b/mscore/inspector/inspector_hbox.ui
@@ -82,7 +82,7 @@
          <string>Right gap</string>
         </property>
         <property name="suffix">
-         <string extracomment="spatium unit">sp</string>
+         <string notr="true" extracomment="spatium unit"> sp</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -114,7 +114,7 @@
          <string>Width</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -130,7 +130,7 @@
          <string>Left gap</string>
         </property>
         <property name="suffix">
-         <string extracomment="spatium unit">sp</string>
+         <string notr="true" extracomment="spatium unit"> sp</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>

--- a/mscore/inspector/inspector_line.ui
+++ b/mscore/inspector/inspector_line.ui
@@ -232,7 +232,7 @@
          <string>Line thickness</string>
         </property>
         <property name="suffix">
-         <string extracomment="Staff space unit">sp</string>
+         <string notr="true" extracomment="Staff space unit"> sp</string>
         </property>
         <property name="singleStep">
          <double>0.100000000000000</double>

--- a/mscore/inspector/inspector_segment.ui
+++ b/mscore/inspector/inspector_segment.ui
@@ -82,7 +82,7 @@
          <string>Leading space</string>
         </property>
         <property name="suffix">
-         <string extracomment="spatium unit">sp</string>
+         <string notr="true" extracomment="spatium unit"> sp</string>
         </property>
         <property name="minimum">
          <double>-10.000000000000000</double>

--- a/mscore/inspector/inspector_spacer.ui
+++ b/mscore/inspector/inspector_spacer.ui
@@ -87,7 +87,7 @@
          <string>Height</string>
         </property>
         <property name="suffix">
-         <string extracomment="spatium unit">sp</string>
+         <string notr="true" extracomment="spatium unit"> sp</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>

--- a/mscore/inspector/inspector_stafftypechange.ui
+++ b/mscore/inspector/inspector_stafftypechange.ui
@@ -149,7 +149,7 @@
         <string>Line distance</string>
        </property>
        <property name="suffix">
-        <string>sp</string>
+        <string notr="true"> sp</string>
        </property>
        <property name="decimals">
         <number>1</number>
@@ -291,7 +291,7 @@
         <string>Offset Y</string>
        </property>
        <property name="suffix">
-        <string>sp</string>
+        <string notr="true"> sp</string>
        </property>
        <property name="decimals">
         <number>1</number>

--- a/mscore/inspector/inspector_stem.ui
+++ b/mscore/inspector/inspector_stem.ui
@@ -82,7 +82,7 @@
          <string>Line thickness</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="singleStep">
          <double>0.010000000000000</double>
@@ -121,7 +121,7 @@
          <string>Length offset</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="minimum">
          <double>-99.000000000000000</double>

--- a/mscore/inspector/inspector_tbox.ui
+++ b/mscore/inspector/inspector_tbox.ui
@@ -108,7 +108,7 @@
          <string>Left margin</string>
         </property>
         <property name="suffix">
-         <string>mm</string>
+         <string notr="true"> mm</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -150,7 +150,7 @@
          <string>Right margin</string>
         </property>
         <property name="suffix">
-         <string>mm</string>
+         <string notr="true"> mm</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -166,7 +166,7 @@
          <string>Bottom margin</string>
         </property>
         <property name="suffix">
-         <string>mm</string>
+         <string notr="true"> mm</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -192,7 +192,7 @@
          <string>Top gap</string>
         </property>
         <property name="suffix">
-         <string extracomment="spatium unit">sp</string>
+         <string notr="true" extracomment="spatium unit"> sp</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -224,7 +224,7 @@
          <string>Bottom gap</string>
         </property>
         <property name="suffix">
-         <string extracomment="spatium unit">sp</string>
+         <string notr="true" extracomment="spatium unit"> sp</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -256,7 +256,7 @@
          <string>Top margin</string>
         </property>
         <property name="suffix">
-         <string>mm</string>
+         <string notr="true"> mm</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>

--- a/mscore/inspector/inspector_tempotext.ui
+++ b/mscore/inspector/inspector_tempotext.ui
@@ -95,7 +95,7 @@
          <string>Tempo</string>
         </property>
         <property name="suffix">
-         <string>BPM</string>
+         <string notr="true"> BPM</string>
         </property>
         <property name="decimals">
          <number>1</number>

--- a/mscore/inspector/inspector_text.ui
+++ b/mscore/inspector/inspector_text.ui
@@ -136,7 +136,7 @@
             <string>Font size</string>
            </property>
            <property name="suffix">
-            <string>pt</string>
+            <string notr="true"> pt</string>
            </property>
            <property name="minimum">
             <number>1</number>
@@ -305,7 +305,7 @@
                <string>Text margin</string>
               </property>
               <property name="suffix">
-               <string>sp</string>
+               <string notr="true"> sp</string>
               </property>
               <property name="singleStep">
                <double>0.200000000000000</double>
@@ -369,7 +369,7 @@
                <string/>
               </property>
               <property name="suffix">
-               <string>sp</string>
+               <string notr="true"> sp</string>
               </property>
               <property name="singleStep">
                <double>0.100000000000000</double>

--- a/mscore/inspector/inspector_textlinebase.ui
+++ b/mscore/inspector/inspector_textlinebase.ui
@@ -88,7 +88,7 @@
          <string>Height</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="minimum">
          <double>-99.989999999999995</double>
@@ -172,7 +172,7 @@
          <string>Begin hook height</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="minimum">
          <double>-99.989999999999995</double>
@@ -259,7 +259,7 @@
             <string>Font size</string>
            </property>
            <property name="suffix">
-            <string>pt</string>
+            <string notr="true"> pt</string>
            </property>
            <property name="minimum">
             <number>1</number>
@@ -508,7 +508,7 @@
             <string>Font size</string>
            </property>
            <property name="suffix">
-            <string>pt</string>
+            <string notr="true"> pt</string>
            </property>
            <property name="minimum">
             <number>1</number>
@@ -781,7 +781,7 @@
             <string>Font size</string>
            </property>
            <property name="suffix">
-            <string>pt</string>
+            <string notr="true"> pt</string>
            </property>
            <property name="minimum">
             <number>1</number>

--- a/mscore/inspector/inspector_tremolo.ui
+++ b/mscore/inspector/inspector_tremolo.ui
@@ -85,7 +85,7 @@
          <string>Line thickness</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>

--- a/mscore/inspector/inspector_tuplet.ui
+++ b/mscore/inspector/inspector_tuplet.ui
@@ -106,7 +106,7 @@
          <string>Font size</string>
         </property>
         <property name="suffix">
-         <string>pt</string>
+         <string notr="true"> pt</string>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -315,7 +315,7 @@
          <string>Line thickness</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="singleStep">
          <double>0.100000000000000</double>

--- a/mscore/inspector/inspector_vbox.ui
+++ b/mscore/inspector/inspector_vbox.ui
@@ -108,7 +108,7 @@
          <string>Left margin</string>
         </property>
         <property name="suffix">
-         <string>mm</string>
+         <string notr="true"> mm</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -127,7 +127,7 @@
          <string>Top gap</string>
         </property>
         <property name="suffix">
-         <string extracomment="spatium unit">sp</string>
+         <string notr="true" extracomment="spatium unit"> sp</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -159,7 +159,7 @@
          <string>Height</string>
         </property>
         <property name="suffix">
-         <string>sp</string>
+         <string notr="true"> sp</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -188,7 +188,7 @@
          <string>Bottom gap</string>
         </property>
         <property name="suffix">
-         <string extracomment="spatium unit">sp</string>
+         <string notr="true" extracomment="spatium unit"> sp</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -246,7 +246,7 @@
          <string>Top margin</string>
         </property>
         <property name="suffix">
-         <string>mm</string>
+         <string notr="true"> mm</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -262,7 +262,7 @@
          <string>Right margin</string>
         </property>
         <property name="suffix">
-         <string>mm</string>
+         <string notr="true"> mm</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>
@@ -278,7 +278,7 @@
          <string>Bottom margin</string>
         </property>
         <property name="suffix">
-         <string>mm</string>
+         <string notr="true"> mm</string>
         </property>
         <property name="minimum">
          <double>-10000.000000000000000</double>

--- a/mscore/inspector/offset_select.ui
+++ b/mscore/inspector/offset_select.ui
@@ -44,7 +44,7 @@
           <string>Horizontal offset</string>
          </property>
          <property name="suffix">
-          <string>sp</string>
+          <string notr="true"> sp</string>
          </property>
          <property name="minimum">
           <double>-999.000000000000000</double>
@@ -97,7 +97,7 @@
           <string>Vertical offset</string>
          </property>
          <property name="suffix">
-          <string>sp</string>
+          <string notr="true"> sp</string>
          </property>
          <property name="minimum">
           <double>-999.000000000000000</double>

--- a/mscore/omrpanel.ui
+++ b/mscore/omrpanel.ui
@@ -17,7 +17,7 @@
    <item row="4" column="1">
     <widget class="QDoubleSpinBox" name="spatium">
      <property name="suffix">
-      <string>mm</string>
+      <string notr="true"> mm</string>
      </property>
     </widget>
    </item>

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -157,12 +157,12 @@ void PageSettings::updateValues()
       double singleStepSize;
       double singleStepScale;
       if (mm) {
-            suffix = "mm";
+            suffix = " mm";
             singleStepSize = 1.0;
             singleStepScale = 0.2;
             }
       else {
-            suffix = "in";
+            suffix = " in";
             singleStepSize = 0.05;
             singleStepScale = 0.005;
             }

--- a/mscore/palette.ui
+++ b/mscore/palette.ui
@@ -94,7 +94,7 @@
      <item row="1" column="2">
       <widget class="QDoubleSpinBox" name="elementOffset">
        <property name="suffix">
-        <string>sp</string>
+        <string notr="true"> sp</string>
        </property>
        <property name="minimum">
         <double>-99.000000000000000</double>

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -534,7 +534,7 @@ void PianorollEditor::updateVelocity(Note* note)
                   break;
             case Note::ValueType::OFFSET_VAL:
                   velocity->setReadOnly(false);
-                  velocity->setSuffix("%");
+                  velocity->setSuffix(" %");
                   break;
             }
 

--- a/mscore/playpanel.ui
+++ b/mscore/playpanel.ui
@@ -354,7 +354,7 @@
          <string/>
         </property>
         <property name="suffix">
-         <string notr="true">%</string>
+         <string notr="true"> %</string>
         </property>
         <property name="decimals">
          <number>0</number>

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -306,7 +306,7 @@
              <string>Select delay (in minutes) between auto saves</string>
             </property>
             <property name="suffix">
-             <string extracomment="minutes">min</string>
+             <string notr="true" extracomment="minutes"> min</string>
             </property>
             <property name="minimum">
              <number>1</number>
@@ -680,7 +680,7 @@
              <string>Icon Width</string>
             </property>
             <property name="suffix">
-             <string extracomment="pixel">px</string>
+             <string notr="true" extracomment="pixel"> px</string>
             </property>
             <property name="minimum">
              <number>5</number>
@@ -710,7 +710,7 @@
              <string>Icon Height</string>
             </property>
             <property name="suffix">
-             <string extracomment="pixel">px</string>
+             <string notr="true" extracomment="pixel"> px</string>
             </property>
             <property name="minimum">
              <number>5</number>
@@ -1131,7 +1131,7 @@
              <string>Proximity for selecting elements</string>
             </property>
             <property name="suffix">
-             <string extracomment="pixel">px</string>
+             <string notr="true" extracomment="pixel"> px</string>
             </property>
             <property name="minimum">
              <number>1</number>
@@ -1220,7 +1220,7 @@
           <item row="2" column="1">
            <widget class="QSpinBox" name="realtimeDelay">
             <property name="suffix">
-             <string extracomment="milliseconds">ms</string>
+             <string notr="true" extracomment="milliseconds"> ms</string>
             </property>
             <property name="minimum">
              <number>300</number>
@@ -1280,7 +1280,7 @@
              <string>Default duration</string>
             </property>
             <property name="suffix">
-             <string extracomment="milliseconds">ms</string>
+             <string notr="true" extracomment="milliseconds"> ms</string>
             </property>
             <property name="minimum">
              <number>20</number>
@@ -2399,7 +2399,7 @@
              <string>Default scale for new score views</string>
             </property>
             <property name="suffix">
-             <string notr="true">%</string>
+             <string notr="true"> %</string>
             </property>
             <property name="decimals">
              <number>0</number>
@@ -2851,7 +2851,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
                <string>Choose MIDI Output Latency</string>
               </property>
               <property name="suffix">
-               <string extracomment="milliseconds">ms</string>
+               <string notr="true" extracomment="milliseconds"> ms</string>
               </property>
               <property name="maximum">
                <number>999</number>
@@ -3062,7 +3062,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
           <item row="1" column="2">
            <widget class="QLabel" name="alsaSampleRateHzLabel">
             <property name="text">
-             <string extracomment="Hertz">Hz</string>
+             <string extracomment="Hertz" notr="true">Hz</string>
             </property>
            </widget>
           </item>
@@ -3523,7 +3523,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
              <string>Choose resolution DPI</string>
             </property>
             <property name="suffix">
-             <string extracomment="dots per inch">DPI</string>
+             <string notr="true" extracomment="dots per inch"> DPI</string>
             </property>
             <property name="minimum">
              <number>32</number>
@@ -3647,7 +3647,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
              <string>Choose resolution DPI</string>
             </property>
             <property name="suffix">
-             <string extracomment="dots per inch">DPI</string>
+             <string notr="true" extracomment="dots per inch"> DPI</string>
             </property>
             <property name="minimum">
              <number>75</number>
@@ -3803,7 +3803,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
           <item row="1" column="3">
            <widget class="QLabel" name="label_8">
             <property name="text">
-             <string extracomment="Hertz">Hz</string>
+             <string extracomment="Hertz" notr="true">Hz</string>
             </property>
            </widget>
           </item>

--- a/mscore/sectionbreak.ui
+++ b/mscore/sectionbreak.ui
@@ -35,7 +35,7 @@
         </sizepolicy>
        </property>
        <property name="suffix">
-        <string>s</string>
+        <string notr="true"> s</string>
        </property>
       </widget>
      </item>

--- a/mscore/stafftext.ui
+++ b/mscore/stafftext.ui
@@ -4137,7 +4137,7 @@ VI</string>
               <bool>true</bool>
              </property>
              <property name="suffix">
-              <string>%</string>
+              <string notr="true"> %</string>
              </property>
              <property name="minimum">
               <number>50</number>

--- a/mscore/synthcontrol.ui
+++ b/mscore/synthcontrol.ui
@@ -246,7 +246,7 @@
           <string>Hertz</string>
          </property>
          <property name="suffix">
-          <string extracomment="Frequency Herz">Hz</string>
+          <string notr="true" extracomment="Frequency Hertz"> Hz</string>
          </property>
          <property name="decimals">
           <number>1</number>


### PR DESCRIPTION
As the reporter correctly observed, SI requires the space, see https://www.bipm.org/en/publications/si-brochure/section5-3.html §5.3.3 for units and §5.3.7 for the percent sign.

The commentary in the thread hinted at this being done “because Qt”, however, the Qt5 documentation is *explicit* in requiring the explicit space: https://doc.qt.io/qt-5/qdoublespinbox.html#suffix-prop

    spinbox->setSuffix(" km");

Also, do not translate “mm”, it’s an SI unit and constant text.