### PR TITLE
fix #283600: range and step value for offset fields

### DIFF
--- a/mscore/inspector/offset_select.ui
+++ b/mscore/inspector/offset_select.ui
@@ -47,10 +47,13 @@
           <string>sp</string>
          </property>
          <property name="minimum">
-          <double>-99.000000000000000</double>
+          <double>-999.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>999.990000000000009</double>
          </property>
          <property name="singleStep">
-          <double>0.200000000000000</double>
+          <double>0.500000000000000</double>
          </property>
         </widget>
        </item>
@@ -97,10 +100,13 @@
           <string>sp</string>
          </property>
          <property name="minimum">
-          <double>-99.000000000000000</double>
+          <double>-999.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>999.990000000000009</double>
          </property>
          <property name="singleStep">
-          <double>0.200000000000000</double>
+          <double>0.500000000000000</double>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
As per https://musescore.org/en/node/283600, the current min/max are not enough for some real world use cases.  While at it, I changed the step value based on discussions on IRC and elsewhere.