### PR TITLE
fix #282810: Wrong measure number when starting with a multimeasure rest

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2518,13 +2518,12 @@ void Score::getNextMeasure(LayoutContext& lc)
                   int n       = 0;
                   Fraction len;
 
-                  lc.measureNo = m->no();
-
                   while (validMMRestMeasure(nm)) {
                         MeasureBase* mb = _showVBox ? nm->next() : nm->nextMeasure();
                         if (breakMultiMeasureRest(nm) && n)
                               break;
-                        lc.adjustMeasureNo(nm);
+                        if (nm != m)
+                              lc.adjustMeasureNo(nm);
                         ++n;
                         len += nm->len();
                         lm = nm;


### PR DESCRIPTION
Fixes https://musescore.org/en/node/282810.

`lc.adjustMeasureNo()` has already been called on `m`, so it is a mistake to do it again.

Also, `lc.measureNo` is already correctly set to `m->no() + 1` by the previous call to `lc.adjustMeasureNo()`, so it is a mistake to set it to `m->no()`.

These two "mistakes" cancel each other out in the usual case, but not if there is a measure number offset applied to the first measure of the multimeasure rest.