### PR TITLE
fix #283152: crash involving section breaks on mutimeasure rests

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1819,6 +1819,7 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
 
       mmr->setRepeatStart(m->repeatStart() || lm->repeatStart());
       mmr->setRepeatEnd(m->repeatEnd() || lm->repeatEnd());
+      mmr->setSectionBreak(lm->sectionBreak());
 
       ElementList oldList = mmr->takeElements();
       ElementList newList = lm->el();


### PR DESCRIPTION
Fixes https://musescore.org/en/node/283152.