### PR TITLE
fix #280906: Dont slash-fill MMRest measures.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2745,6 +2745,8 @@ void Score::cmdSlashFill()
             for (Segment* s = startSegment; s && s->tick() < endTick; s = s->next1()) {
                   if (s->segmentType() != SegmentType::ChordRest)
                         continue;
+                  if (s->measure()->isMMRest())
+                        continue;
                   // determine beat type based on time signature
                   int d = s->measure()->timesig().denominator();
                   int n = (d > 4 && s->measure()->timesig().numerator() % 3 == 0) ? 3 : 1;

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2743,9 +2743,7 @@ void Score::cmdSlashFill()
             int voice = -1;
             // loop through segments adding slashes on each beat
             for (Segment* s = startSegment; s && s->tick() < endTick; s = s->next1()) {
-                  if (s->segmentType() != SegmentType::ChordRest)
-                        continue;
-                  if (s->measure()->isMMRest())
+                  if (s->segmentType() != SegmentType::ChordRest || s->measure()->isMMRest())
                         continue;
                   // determine beat type based on time signature
                   int d = s->measure()->timesig().denominator();


### PR DESCRIPTION
fix #280906