### PR TITLE
fix #282184 dont layout invisible slurs

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3123,17 +3123,20 @@ void Score::layoutLyrics(System* system)
 
 void layoutTies(Chord* ch, System* system, int stick)
       {
+      SysStaff* staff = system->staff(ch->staffIdx());
+      if (!staff->show())
+            return;
       for (Note* note : ch->notes()) {
             Tie* t = note->tieFor();
             if (t) {
                   TieSegment* ts = t->layoutFor(system);
-                  system->staff(ch->staffIdx())->skyline().add(ts->shape().translated(ts->pos()));
+                  staff->skyline().add(ts->shape().translated(ts->pos()));
                   }
             t = note->tieBack();
             if (t) {
                   if (t->startNote()->tick() < stick) {
                         TieSegment* ts = t->layoutBack(system);
-                        system->staff(ch->staffIdx())->skyline().add(ts->shape().translated(ts->pos()));
+                        staff->skyline().add(ts->shape().translated(ts->pos()));
                         }
                   }
             }

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -481,7 +481,7 @@ void Tie::slurPos(SlurPos* sp)
             }
       Chord* ec = endNote()->chord();
       sp->p2    = ec->pos() + ec->segment()->pos() + ec->measure()->pos();
-      if ((sc->measure() == sp->system1->lastMeasure()) && (ec->measure() != sc->measure()))
+      if (sp->system1 && (sc->measure() == sp->system1->lastMeasure()) && (ec->measure() != sc->measure()))
             sp->system2 = nullptr;
       else
             sp->system2 = ec->measure()->system();


### PR DESCRIPTION
fix #282184

critical patch is in layout.cpp , Though I think the check should be hoisted to Score::layoutSystemElements().

The second patch in tie.cpp is for safety, when sp->system1 can be nil (perhaps a return is missing in the earlier check).