### PR TITLE
fix #282629, fix #281411: flip only selected lyrics

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -588,6 +588,8 @@ void Lyrics::undoChangeProperty(Pid id, const QVariant& v, PropertyFlags ps)
             TextBase::undoChangeProperty(id, v, ps);
             return;
             }
+#if 0
+      // TODO: create new command to do this
       if (id == Pid::PLACEMENT) {
             if (Placement(v.toInt()) == Placement::ABOVE) {
                   // change placment of all verse for the same voice upto this one to ABOVE
@@ -605,6 +607,7 @@ void Lyrics::undoChangeProperty(Pid id, const QVariant& v, PropertyFlags ps)
                   }
             return;
             }
+#endif
 
       TextBase::undoChangeProperty(id, v, ps);
       }


### PR DESCRIPTION
Right now "X" flips all lyrics of the selected verse/voice, actually others verses too.  This is often counter to what the user wants, and there is no way to override it, plus it leads to a hang if you select multiple lyrics yourself and then flip.

So, I simply ifdef'd out the code to do this.  If you want to flip a while verse, just select it using Select / More / Same verse.  If the automatic feature is still deemed useful, we can add a new command to do it - but I recommend the loop be done somewhere outside of undoChangeProperty().