### PR TITLE
fix #282130: invisible lyricsline

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -314,6 +314,7 @@ void Lyrics::layout()
             _separator->setTicks(1);
             _separator->setTrack(track());
             _separator->setTrack2(track());
+            _separator->setVisible(visible());
             // bbox().setWidth(bbox().width());  // ??
             }
       else {


### PR DESCRIPTION
The lyricsline itself was never actually set to invisible, draw() just depended on getting color info from the parent lyric, so it grayed out as expected but wasn't *really* invisible.