### PR TITLE
fix #280865: lyric attached to rest too low

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -336,11 +336,11 @@ void Lyrics::layout2(int nAbove)
 
       if (placeBelow()) {
             qreal yo = segment()->measure()->system()->staff(staffIdx())->bbox().height();
-            rypos()  = lh * (_no - nAbove) + yo;
+            rypos()  = lh * (_no - nAbove) + yo - chordRest()->y();
             rpos()  += styleValue(Pid::OFFSET, Sid::lyricsPosBelow).toPointF();
             }
       else {
-            rypos() = -lh * (nAbove - _no - 1);
+            rypos() = -lh * (nAbove - _no - 1) - chordRest()->y();
             rpos() += styleValue(Pid::OFFSET, Sid::lyricsPosAbove).toPointF();
             }
       }


### PR DESCRIPTION
We weren't accounting for the position of the parent when setting the position of the lyric.  For chords the Y position is normally 0, so no issue there, but for rests it is not.  I elected to account for the parent position always, not just for rests, in case there do end up being cases where chord Y position is not 0 - like grace notes, should we wish to support lyrics on those.