### PR TITLE
fix 284282: layout rest on change of offset

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -955,8 +955,7 @@ bool Rest::setProperty(Pid propertyId, const QVariant& v)
                   setOffset(v.toPointF());
                   layout();
                   score()->addRefresh(canvasBoundingRect());
-                  if (beam())
-                        score()->setLayout(tick());
+                  score()->setLayout(tick());
                   break;
             default:
                   return ChordRest::setProperty(propertyId, v);


### PR DESCRIPTION
I think maybe we didn't bother triggering a layout when moving rests unless a beam was present because before autoplace, nothing else would be normally be affected by a change in position of the rest.  But now you can get collisions you shouldn't get, so we really do need to trigger this always.