### PR TITLE
fix #284235: implement lyricsMinDistance

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1182,10 +1182,14 @@ Shape ChordRest::shape() const
       for (Lyrics* l : _lyrics) {
             if (!l || !l->visible() || !l->autoplace())
                   continue;
-            static const qreal margin = spatium() * .5;
+            qreal lmargin = styleP(Sid::lyricsMinDistance) * .5;
+            qreal rmargin = lmargin;
+            Lyrics::Syllabic syl = l->syllabic();
+            if ((syl == Lyrics::Syllabic::BEGIN || syl == Lyrics::Syllabic::MIDDLE) && score()->styleB(Sid::lyricsDashForce))
+                  rmargin = qMax(rmargin, styleP(Sid::lyricsDashMinLength));
             // for horizontal spacing we only need the lyrics width:
-            x1 = qMin(x1, l->bbox().x() - margin + l->pos().x());
-            x2 = qMax(x2, l->bbox().x() + l->bbox().width() + margin + l->pos().x());
+            x1 = qMin(x1, l->bbox().x() - lmargin + l->pos().x());
+            x2 = qMax(x2, l->bbox().x() + l->bbox().width() + rmargin + l->pos().x());
             if (l->ticks() == Fraction::fromTicks(Lyrics::TEMP_MELISMA_TICKS))
                   x2 += spatium();
             adjustWidth = true;

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -77,7 +77,8 @@ struct StyleVal2 {
       };
 
 static const StyleVal2 style114[] = {
-      { Sid::lyricsMinBottomDistance,      Spatium(2) },
+//      { Sid::lyricsMinBottomDistance,      Spatium(2) },
+      { Sid::lyricsDashForce,              QVariant(false) },
       { Sid::frameSystemDistance,          Spatium(1.0) },
       { Sid::minMeasureWidth,              Spatium(4.0) },
       { Sid::endBarDistance,               Spatium(0.30) },
@@ -2676,6 +2677,11 @@ static void readStyle(MStyle* style, XmlReader& e)
 //                  style->setTextStyle(s);
                   e.skipCurrentElement();
                   }
+            else if (tag == "lyricsMinBottomDistance") {
+                  // no longer meaningful since it is now measured from skyline rather than staff
+                  //style->set(Sid::lyricsMinBottomDistance, QPointF(0.0, y));
+                  e.skipCurrentElement();
+                  }
             else if (tag == "Spatium")
                   style->set(Sid::spatium, e.readDouble() * DPMM);
             else if (tag == "page-layout") {
@@ -3187,8 +3193,6 @@ Score::FileError MasterScore::read114(XmlReader& e)
             }
 
       // adjust some styles
-      Spatium lmbd = styleS(Sid::lyricsMinBottomDistance);
-      style().set(Sid::lyricsMinBottomDistance, Spatium(lmbd.val() + 4.0));
       if (styleB(Sid::hideEmptyStaves))        // http://musescore.org/en/node/16228
             style().set(Sid::dontHideStavesInFirstSystem, false);
       if (styleB(Sid::showPageNumberOne)) {    // http://musescore.org/en/node/21207

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -96,8 +96,9 @@ struct StyleVal2 {
       { Sid::minSystemDistance,           Spatium(8.5)  },
       { Sid::maxSystemDistance,           Spatium(15.0) },
 
-      { Sid::lyricsMinBottomDistance,     Spatium(4.0)  },
+//      { Sid::lyricsMinBottomDistance,     Spatium(4.0)  },      // no longer makes sense
       { Sid::lyricsLineHeight,            QVariant(1.0) },
+      { Sid::lyricsDashForce,             QVariant(false) },
       { Sid::figuredBassFontFamily,       QVariant(QString("MScoreBC")) },
       { Sid::figuredBassFontSize,         QVariant(8.0) },
       { Sid::figuredBassYOffset,          QVariant(6.0) },
@@ -3537,6 +3538,11 @@ static void readStyle(MStyle* style, XmlReader& e)
             else if (tag == "lyricsDistance") {
                   qreal y = e.readDouble();
                   style->set(Sid::lyricsPosBelow, QPointF(0.0, y));
+                  }
+            else if (tag == "lyricsMinBottomDistance") {
+                  // no longer meaningful since it is now measured from skyline rather than staff
+                  //style->set(Sid::lyricsMinBottomDistance, QPointF(0.0, y));
+                  e.skipCurrentElement();
                   }
             else if (tag == "ottavaHook") {
                   qreal y = qAbs(e.readDouble());

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -81,6 +81,7 @@ static const StyleType styleTypes[] {
       { Sid::lyricsPosBelow,          "lyricsPosBelow",          QPointF(.0, 3.0) },
       { Sid::lyricsMinTopDistance,    "lyricsMinTopDistance",    Spatium(1.0)  },
       { Sid::lyricsMinBottomDistance, "lyricsMinBottomDistance", Spatium(2.0)  },
+      { Sid::lyricsMinDistance,       "lyricsMinDistance",       Spatium(0.0)  },
       { Sid::lyricsLineHeight,        "lyricsLineHeight",        1.0 },
       { Sid::lyricsDashMinLength,     "lyricsDashMinLength",     Spatium(0.4) },
       { Sid::lyricsDashMaxLength,     "lyricsDashMaxLegth",      Spatium(0.8) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -57,6 +57,7 @@ enum class Sid {
       lyricsPosBelow,
       lyricsMinTopDistance,
       lyricsMinBottomDistance,
+      lyricsMinDistance,
       lyricsLineHeight,
       lyricsDashMinLength,
       lyricsDashMaxLength,

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -116,6 +116,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { Sid::lyricsPosBelow,          false, lyricsPosBelow,          resetLyricsPosBelow          },
       { Sid::lyricsMinTopDistance,    false, lyricsMinTopDistance,    resetLyricsMinTopDistance    },
       { Sid::lyricsMinBottomDistance, false, lyricsMinBottomDistance, resetLyricsMinBottomDistance },
+      { Sid::lyricsMinDistance,       false, lyricsMinDistance,       resetLyricsMinDistance       },
       { Sid::lyricsLineHeight,        true,  lyricsLineHeight,        resetLyricsLineHeight        },
       { Sid::lyricsDashMinLength,     false, lyricsDashMinLength,     resetLyricsDashMinLength     },
       { Sid::lyricsDashMaxLength,     false, lyricsDashMaxLength,     resetLyricsDashMaxLength     },

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -9285,6 +9285,49 @@
              </property>
             </widget>
            </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="label_minDistance">
+             <property name="text">
+              <string>Min. distance:</string>
+             </property>
+             <property name="buddy">
+              <cstring>lyricsMinDistance</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QDoubleSpinBox" name="lyricsMinDistance">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="decimals">
+              <number>2</number>
+             </property>
+             <property name="minimum">
+              <double>-100.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.050000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="2">
+            <widget class="QToolButton" name="resetLyricsMinDistance">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Min. distance' value</string>
+             </property>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
            <item row="7" column="0" colspan="2">
             <widget class="QCheckBox" name="lyricsAlignVerseNumber">
              <property name="text">
@@ -9405,7 +9448,7 @@
              </property>
             </widget>
            </item>
-           <item row="6" column="0">
+           <item row="8" column="0">
             <spacer name="verticalSpacer_2">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -11337,13 +11380,18 @@
   <tabstop>resetTupletDirection</tabstop>
   <tabstop>lyricsPlacement</tabstop>
   <tabstop>resetLyricsPlacement</tabstop>
+  <tabstop>lyricsPosAbove</tabstop>
   <tabstop>resetLyricsPosAbove</tabstop>
+  <tabstop>lyricsPosBelow</tabstop>
   <tabstop>resetLyricsPosBelow</tabstop>
+  <tabstop>lyricsLineHeight</tabstop>
   <tabstop>resetLyricsLineHeight</tabstop>
   <tabstop>lyricsMinTopDistance</tabstop>
   <tabstop>resetLyricsMinTopDistance</tabstop>
   <tabstop>lyricsMinBottomDistance</tabstop>
   <tabstop>resetLyricsMinBottomDistance</tabstop>
+  <tabstop>lyricsMinDistance</tabstop>
+  <tabstop>resetLyricsMinDistance</tabstop>
   <tabstop>lyricsAlignVerseNumber</tabstop>
   <tabstop>resetLyricsAlignVerseNumber</tabstop>
   <tabstop>lyricsDashMinLength</tabstop>
@@ -11352,13 +11400,22 @@
   <tabstop>resetLyricsDashMaxLength</tabstop>
   <tabstop>lyricsDashMaxDistance</tabstop>
   <tabstop>resetLyricsDashMaxDistance</tabstop>
+  <tabstop>lyricsDashLineThickness</tabstop>
+  <tabstop>resetLyricsDashLineThickness</tabstop>
+  <tabstop>lyricsDashPad</tabstop>
+  <tabstop>resetLyricsDashPad</tabstop>
+  <tabstop>lyricsDashYposRatio</tabstop>
+  <tabstop>resetLyricsDashYposRatio</tabstop>
   <tabstop>lyricsDashForce</tabstop>
   <tabstop>resetLyricsDashForce</tabstop>
   <tabstop>lyricsLineThickness</tabstop>
   <tabstop>resetLyricsLineThickness</tabstop>
+  <tabstop>lyricsMelismaPad</tabstop>
+  <tabstop>resetLyricsMelismaPad</tabstop>
+  <tabstop>lyricsMelismaAlign</tabstop>
+  <tabstop>resetLyricsMelismaAlign</tabstop>
  </tabstops>
  <resources>
-  <include location="musescore.qrc"/>
   <include location="musescore.qrc"/>
  </resources>
  <connections>

--- a/mtest/libmscore/compat114/accidentals-ref.mscx
+++ b/mtest/libmscore/compat114/accidentals-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/articulations-ref.mscx
+++ b/mtest/libmscore/compat114/articulations-ref.mscx
@@ -6,7 +6,7 @@
     <Division>480</Division>
     <Style>
       <minSystemDistance>9.2</minSystemDistance>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/chord_symbol-ref.mscx
+++ b/mtest/libmscore/compat114/chord_symbol-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/clef_missing_first-ref.mscx
+++ b/mtest/libmscore/compat114/clef_missing_first-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/clefs-ref.mscx
+++ b/mtest/libmscore/compat114/clefs-ref.mscx
@@ -6,7 +6,7 @@
     <Division>480</Division>
     <Style>
       <minSystemDistance>9.2</minSystemDistance>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/drumset-ref.mscx
+++ b/mtest/libmscore/compat114/drumset-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/fingering-ref.mscx
+++ b/mtest/libmscore/compat114/fingering-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/hairpin-ref.mscx
+++ b/mtest/libmscore/compat114/hairpin-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
+++ b/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
@@ -6,7 +6,7 @@
     <Division>480</Division>
     <Style>
       <minSystemDistance>9.2</minSystemDistance>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/keysig-ref.mscx
+++ b/mtest/libmscore/compat114/keysig-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/noteheads-ref.mscx
+++ b/mtest/libmscore/compat114/noteheads-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/notes-ref.mscx
+++ b/mtest/libmscore/compat114/notes-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/ottava-ref.mscx
+++ b/mtest/libmscore/compat114/ottava-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/pedal-ref.mscx
+++ b/mtest/libmscore/compat114/pedal-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/slurs-ref.mscx
+++ b/mtest/libmscore/compat114/slurs-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/style-ref.mscx
+++ b/mtest/libmscore/compat114/style-ref.mscx
@@ -10,7 +10,7 @@
       <staffDistance>6</staffDistance>
       <akkoladeDistance>6.4</akkoladeDistance>
       <minSystemDistance>8.2</minSystemDistance>
-      <lyricsMinBottomDistance>5.5</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <systemFrameDistance>6</systemFrameDistance>
       <frameSystemDistance>6</frameSystemDistance>
       <minMeasureWidth>4</minMeasureWidth>

--- a/mtest/libmscore/compat114/tamtam-ref.mscx
+++ b/mtest/libmscore/compat114/tamtam-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/text_scaling-ref.mscx
+++ b/mtest/libmscore/compat114/text_scaling-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/textline-ref.mscx
+++ b/mtest/libmscore/compat114/textline-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/textstyles-ref.mscx
+++ b/mtest/libmscore/compat114/textstyles-ref.mscx
@@ -8,7 +8,7 @@
       <staffUpperBorder>6</staffUpperBorder>
       <staffLowerBorder>2</staffLowerBorder>
       <minSystemDistance>9.5</minSystemDistance>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <systemFrameDistance>1</systemFrameDistance>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>

--- a/mtest/libmscore/compat114/title-ref.mscx
+++ b/mtest/libmscore/compat114/title-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/tremolo2notes-ref.mscx
+++ b/mtest/libmscore/compat114/tremolo2notes-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/tuplets-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/tuplets_1-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_1-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat114/tuplets_2-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_2-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>6</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>

--- a/mtest/libmscore/compat206/accidentals-ref.mscx
+++ b/mtest/libmscore/compat206/accidentals-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/ambitus-ref.mscx
+++ b/mtest/libmscore/compat206/ambitus-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/articulations-double-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-double-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/articulations-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/barlines-ref.mscx
+++ b/mtest/libmscore/compat206/barlines-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/breath-ref.mscx
+++ b/mtest/libmscore/compat206/breath-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/clefs-ref.mscx
+++ b/mtest/libmscore/compat206/clefs-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/drumset-ref.mscx
+++ b/mtest/libmscore/compat206/drumset-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/fermata-ref.mscx
+++ b/mtest/libmscore/compat206/fermata-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/hairpin-ref.mscx
+++ b/mtest/libmscore/compat206/hairpin-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/intrumentNameAlign-ref.mscx
+++ b/mtest/libmscore/compat206/intrumentNameAlign-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/lidemptytext-ref.mscx
+++ b/mtest/libmscore/compat206/lidemptytext-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
@@ -279,7 +279,6 @@
       <currentLayer>0</currentLayer>
       <Division>480</Division>
       <Style>
-        <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
         <clefLeftMargin>0.64</clefLeftMargin>
         <clefKeyRightMargin>1.75</clefKeyRightMargin>
         <barNoteDistance>1.2</barNoteDistance>

--- a/mtest/libmscore/compat206/markers-ref.mscx
+++ b/mtest/libmscore/compat206/markers-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/noteheads-ref.mscx
+++ b/mtest/libmscore/compat206/noteheads-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/compat206/tuplets-ref.mscx
+++ b/mtest/libmscore/compat206/tuplets-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/split/split183846-irregular-hn-hn-qn-qn-hn-hn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-hn-hn-qn-qn-hn-hn-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/split/split183846-irregular-qn-qn-wn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-qn-qn-wn-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/split/split183846-irregular-verylong-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-verylong-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/split/split183846-irregular-wn-wn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wn-wn-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/split/split183846-irregular-wn-wr-wn-hr-qr-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wn-wr-wn-hr-qr-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>

--- a/mtest/libmscore/split/split183846-irregular-wr-wn-wr-hn-qn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wr-wn-wr-hn-qn-ref.mscx
@@ -14,7 +14,7 @@
       <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
       <pageOddTopMargin>0.393701</pageOddTopMargin>
       <pageOddBottomMargin>0.787403</pageOddBottomMargin>
-      <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
+      <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
       <clefLeftMargin>0.64</clefLeftMargin>


### PR DESCRIPTION
In 2.3.2, the "Minimum note distance" style setting was the only thing that determined minimum space between lyrics.  For 3.0, we start there, but then also add an addition 1sp if space between lyrics.  This is way too much and causes scores to take more space than before.

This PR implements a new lyricsMinDistance style setting that is added on top of the minimu  note distance.  I have it default to 0 right now, so default spacing is identical to 2.3.2 (except that 2.3.2 did not force hyphens to display whereas 3.0 does by default, which I think will prevent any complaints we are still too tightly spaced).

I expect there may be test failures due to the new style setting, but perhaps not.

Adding the style setting also gave me the opportunity to fix the tab order on the Lyrics page of the style dialog - it was terrible.  Others need attention as well, but another day.
