### PR TITLE
Make Above/Below texts in inspector translatable

### DIFF
--- a/awl/utils.cpp
+++ b/awl/utils.cpp
@@ -21,30 +21,30 @@
 
 static const char* vall[] = {
       QT_TRANSLATE_NOOP("awlutils", "c"),
-      QT_TRANSLATE_NOOP("awlutils", "c#"),
+      QT_TRANSLATE_NOOP("awlutils", "c♯"),
       QT_TRANSLATE_NOOP("awlutils", "d"),
-      QT_TRANSLATE_NOOP("awlutils", "d#"),
+      QT_TRANSLATE_NOOP("awlutils", "d♯"),
       QT_TRANSLATE_NOOP("awlutils", "e"),
       QT_TRANSLATE_NOOP("awlutils", "f"),
-      QT_TRANSLATE_NOOP("awlutils", "f#"),
+      QT_TRANSLATE_NOOP("awlutils", "f♯"),
       QT_TRANSLATE_NOOP("awlutils", "g"),
-      QT_TRANSLATE_NOOP("awlutils", "g#"),
+      QT_TRANSLATE_NOOP("awlutils", "g♯"),
       QT_TRANSLATE_NOOP("awlutils", "a"),
       QT_TRANSLATE_NOOP("awlutils", "a#"),
       QT_TRANSLATE_NOOP("awlutils", "b")
       };
 static const char* valu[] = {
       QT_TRANSLATE_NOOP("awlutils", "C"),
-      QT_TRANSLATE_NOOP("awlutils", "C#"),
+      QT_TRANSLATE_NOOP("awlutils", "C♯"),
       QT_TRANSLATE_NOOP("awlutils", "D"),
-      QT_TRANSLATE_NOOP("awlutils", "D#"),
+      QT_TRANSLATE_NOOP("awlutils", "D♯"),
       QT_TRANSLATE_NOOP("awlutils", "E"),
       QT_TRANSLATE_NOOP("awlutils", "F"),
-      QT_TRANSLATE_NOOP("awlutils", "F#"),
+      QT_TRANSLATE_NOOP("awlutils", "F♯"),
       QT_TRANSLATE_NOOP("awlutils", "G"),
-      QT_TRANSLATE_NOOP("awlutils", "G#"),
+      QT_TRANSLATE_NOOP("awlutils", "G♯"),
       QT_TRANSLATE_NOOP("awlutils", "A"),
-      QT_TRANSLATE_NOOP("awlutils", "A#"),
+      QT_TRANSLATE_NOOP("awlutils", "A♯"),
       QT_TRANSLATE_NOOP("awlutils", "B")
       };
 

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -465,30 +465,30 @@ int quantizeLen(int len, int raster)
 
 static const char* vall[] = {
       QT_TRANSLATE_NOOP("utils", "c"),
-      QT_TRANSLATE_NOOP("utils", "c#"),
+      QT_TRANSLATE_NOOP("utils", "c♯"),
       QT_TRANSLATE_NOOP("utils", "d"),
-      QT_TRANSLATE_NOOP("utils", "d#"),
+      QT_TRANSLATE_NOOP("utils", "d♯"),
       QT_TRANSLATE_NOOP("utils", "e"),
       QT_TRANSLATE_NOOP("utils", "f"),
-      QT_TRANSLATE_NOOP("utils", "f#"),
+      QT_TRANSLATE_NOOP("utils", "f♯"),
       QT_TRANSLATE_NOOP("utils", "g"),
-      QT_TRANSLATE_NOOP("utils", "g#"),
+      QT_TRANSLATE_NOOP("utils", "g♯"),
       QT_TRANSLATE_NOOP("utils", "a"),
-      QT_TRANSLATE_NOOP("utils", "a#"),
+      QT_TRANSLATE_NOOP("utils", "a♯"),
       QT_TRANSLATE_NOOP("utils", "b")
       };
 static const char* valu[] = {
       QT_TRANSLATE_NOOP("utils", "C"),
-      QT_TRANSLATE_NOOP("utils", "C#"),
+      QT_TRANSLATE_NOOP("utils", "C♯"),
       QT_TRANSLATE_NOOP("utils", "D"),
-      QT_TRANSLATE_NOOP("utils", "D#"),
+      QT_TRANSLATE_NOOP("utils", "D♯"),
       QT_TRANSLATE_NOOP("utils", "E"),
       QT_TRANSLATE_NOOP("utils", "F"),
-      QT_TRANSLATE_NOOP("utils", "F#"),
+      QT_TRANSLATE_NOOP("utils", "F♯"),
       QT_TRANSLATE_NOOP("utils", "G"),
       QT_TRANSLATE_NOOP("utils", "G#"),
       QT_TRANSLATE_NOOP("utils", "A"),
-      QT_TRANSLATE_NOOP("utils", "A#"),
+      QT_TRANSLATE_NOOP("utils", "A♯"),
       QT_TRANSLATE_NOOP("utils", "B")
       };
 

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -533,16 +533,16 @@ void EditStaff::editStringDataClicked()
 
 static const char* g_cNoteName[] = {
       QT_TRANSLATE_NOOP("editstaff", "C"),
-      QT_TRANSLATE_NOOP("editstaff", "C#"),
+      QT_TRANSLATE_NOOP("editstaff", "C♯"),
       QT_TRANSLATE_NOOP("editstaff", "D"),
-      QT_TRANSLATE_NOOP("editstaff", "Eb"),
+      QT_TRANSLATE_NOOP("editstaff", "E♭"),
       QT_TRANSLATE_NOOP("editstaff", "E"),
       QT_TRANSLATE_NOOP("editstaff", "F"),
-      QT_TRANSLATE_NOOP("editstaff", "F#"),
+      QT_TRANSLATE_NOOP("editstaff", "F♯"),
       QT_TRANSLATE_NOOP("editstaff", "G"),
-      QT_TRANSLATE_NOOP("editstaff", "Ab"),
+      QT_TRANSLATE_NOOP("editstaff", "A♭"),
       QT_TRANSLATE_NOOP("editstaff", "A"),
-      QT_TRANSLATE_NOOP("editstaff", "Bb"),
+      QT_TRANSLATE_NOOP("editstaff", "B♭"),
       QT_TRANSLATE_NOOP("editstaff", "B")
       };
 

--- a/mscore/editstringdata.cpp
+++ b/mscore/editstringdata.cpp
@@ -211,16 +211,16 @@ void EditStringData::accept()
 
 static const char* g_cNoteName[] = {
       QT_TRANSLATE_NOOP("editstringdata", "C"),
-      QT_TRANSLATE_NOOP("editstringdata", "C#"),
+      QT_TRANSLATE_NOOP("editstringdata", "C♯"),
       QT_TRANSLATE_NOOP("editstringdata", "D"),
-      QT_TRANSLATE_NOOP("editstringdata", "Eb"),
+      QT_TRANSLATE_NOOP("editstringdata", "E♭"),
       QT_TRANSLATE_NOOP("editstringdata", "E"),
       QT_TRANSLATE_NOOP("editstringdata", "F"),
-      QT_TRANSLATE_NOOP("editstringdata", "F#"),
+      QT_TRANSLATE_NOOP("editstringdata", "F♯"),
       QT_TRANSLATE_NOOP("editstringdata", "G"),
-      QT_TRANSLATE_NOOP("editstringdata", "Ab"),
+      QT_TRANSLATE_NOOP("editstringdata", "A♭"),
       QT_TRANSLATE_NOOP("editstringdata", "A"),
-      QT_TRANSLATE_NOOP("editstringdata", "Bb"),
+      QT_TRANSLATE_NOOP("editstringdata", "B♭"),
       QT_TRANSLATE_NOOP("editstringdata", "B")
       };
 

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -3438,7 +3438,7 @@
                 <string>Reset to default</string>
                </property>
                <property name="accessibleName">
-                <string>Reset 'Clef/Key right margin' valua</string>
+                <string>Reset 'Clef/Key right margin' value</string>
                </property>
                <property name="text">
                 <string notr="true"/>

--- a/mscore/inspector/inspector_fret.ui
+++ b/mscore/inspector/inspector_fret.ui
@@ -137,12 +137,12 @@
         </property>
         <item>
          <property name="text">
-          <string notr="true">Above</string>
+          <string>Above</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string notr="true">Below</string>
+          <string>Below</string>
          </property>
         </item>
        </widget>
@@ -241,22 +241,22 @@
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="Ms::ResetButton" name="resetMag"/>
+       <widget class="Ms::ResetButton" name="resetMag" native="true"/>
       </item>
       <item row="1" column="2">
-       <widget class="Ms::ResetButton" name="resetPlacement"/>
+       <widget class="Ms::ResetButton" name="resetPlacement" native="true"/>
       </item>
       <item row="2" column="2">
-       <widget class="Ms::ResetButton" name="resetStrings"/>
+       <widget class="Ms::ResetButton" name="resetStrings" native="true"/>
       </item>
       <item row="3" column="2">
-       <widget class="Ms::ResetButton" name="resetFrets"/>
+       <widget class="Ms::ResetButton" name="resetFrets" native="true"/>
       </item>
       <item row="5" column="2">
-       <widget class="Ms::ResetButton" name="resetBarre"/>
+       <widget class="Ms::ResetButton" name="resetBarre" native="true"/>
       </item>
       <item row="6" column="2">
-       <widget class="Ms::ResetButton" name="resetOffset"/>
+       <widget class="Ms::ResetButton" name="resetOffset" native="true"/>
       </item>
      </layout>
     </widget>
@@ -286,8 +286,6 @@
   <tabstop>barre</tabstop>
   <tabstop>offset</tabstop>
  </tabstops>
- <resources>
-  <include location="../musescore.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/mscore/inspector/inspector_harmony.ui
+++ b/mscore/inspector/inspector_harmony.ui
@@ -113,21 +113,21 @@
         </property>
         <item>
          <property name="text">
-          <string notr="true">Above</string>
+          <string>Above</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string notr="true">Below</string>
+          <string>Below</string>
          </property>
         </item>
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="Ms::ResetButton" name="resetStyle"/>
+       <widget class="Ms::ResetButton" name="resetStyle" native="true"/>
       </item>
       <item row="1" column="2">
-       <widget class="Ms::ResetButton" name="resetPlacement"/>
+       <widget class="Ms::ResetButton" name="resetPlacement" native="true"/>
       </item>
      </layout>
     </widget>
@@ -145,8 +145,6 @@
  <tabstops>
   <tabstop>title</tabstop>
  </tabstops>
- <resources>
-  <include location="../musescore.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
* Above/Below for Chord symbols (see https://musescore.org/en/node/284320)
* Above/Below for Fretboard diagrams

* ♭ and ♯ vs. b and #
* fixing a typo