### PR TITLE
refactor MusicXML note import

### DIFF
--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -2,7 +2,7 @@
 //  MuseScore
 //  Linux Music Score Editor
 //
-//  Copyright (C) 2015 Werner Schweer and others
+//  Copyright (C) 2015-2019 Werner Schweer and others
 //
 //  This program is free software; you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License version 2.
@@ -776,17 +776,15 @@ static void addLyric(MxmlLogger* logger, const QXmlStreamReader* const xmlreader
 
 static void addLyrics(MxmlLogger* logger, const QXmlStreamReader* const xmlreader,
                       ChordRest* cr,
-                      QMap<int, Lyrics*>& numbrdLyrics,
-                      QSet<Lyrics*>& extLyrics,
+                      const QMap<int, Lyrics*>& numbrdLyrics,
+                      const QSet<Lyrics*>& extLyrics,
                       MusicXmlLyricsExtend& extendedLyrics)
       {
-      int lyricNo = -1;
-      for (QMap<int, Lyrics*>::const_iterator i = numbrdLyrics.constBegin(); i != numbrdLyrics.constEnd(); ++i) {
-            lyricNo = i.key();
-            Lyrics* l = i.value();
-            addLyric(logger, xmlreader, cr, l, lyricNo, extendedLyrics);
-            if (extLyrics.contains(l))
-                  extendedLyrics.addLyric(l);
+      for (const auto lyricNo : numbrdLyrics.keys()) {
+            const auto lyric = numbrdLyrics.value(lyricNo);
+            addLyric(logger, xmlreader, cr, lyric, lyricNo, extendedLyrics);
+            if (extLyrics.contains(lyric))
+                  extendedLyrics.addLyric(lyric);
             }
       }
 
@@ -1177,6 +1175,17 @@ static void addArticulationToChord(ChordRest* cr, SymId articSym, QString dir)
       }
 
 //---------------------------------------------------------
+//   addAllArticulationsToChord
+//---------------------------------------------------------
+
+static void addAllArticulationsToChord(ChordRest* cr, std::vector<SymId> symbols)
+      {
+      for (const auto symbol : symbols) {
+            addArticulationToChord(cr, symbol, "");
+            }
+      }
+
+//---------------------------------------------------------
 //   addFermataToChord
 //---------------------------------------------------------
 
@@ -1237,23 +1246,23 @@ static void addMordentToChord(ChordRest* cr, QString name, QString attrLong, QSt
       }
 
 //---------------------------------------------------------
-//   addMxmlArticulationToChord
+//   convertArticulationToSymId
 //---------------------------------------------------------
 
 /**
- Add a MusicXML articulation to a chord as a "simple" MuseScore articulation.
+ Convert a MusicXML articulation to a chord as a "simple" MuseScore articulation.
  These are the articulations that can be
- - represented by an enum ArticulationType
+ - represented by an enum class SymId
  - added to a ChordRest
- Return true (articulation recognized and handled)
+ Return true (articulation recognized and converted)
  or false (articulation not recognized).
  Note simple implementation: MusicXML syntax is not strictly
  checked, the articulations parent element does not matter.
  */
 
-static bool addMxmlArticulationToChord(ChordRest* cr, QString mxmlName)
+static bool convertArticulationToSymId(const QString& mxmlName, SymId& id)
       {
-      QMap<QString, SymId> map; // map MusicXML articulation name to MuseScore symbol
+      QMap<QString, SymId> map;       // map MusicXML articulation name to MuseScore symbol
       map["accent"]           = SymId::articAccentAbove;
       map["staccatissimo"]    = SymId::articStaccatissimoAbove;
       map["staccato"]         = SymId::articStaccatoAbove;
@@ -1272,11 +1281,13 @@ static bool addMxmlArticulationToChord(ChordRest* cr, QString mxmlName)
       map["thumb-position"]   = SymId::stringsThumbPosition;
 
       if (map.contains(mxmlName)) {
-            addArticulationToChord(cr, map.value(mxmlName), "");
+            id = map.value(mxmlName);
             return true;
             }
-      else
+      else {
+            id = SymId::noSym;
             return false;
+            }
       }
 
 //---------------------------------------------------------
@@ -1347,14 +1358,16 @@ static void addTextToNote(int l, int c, QString txt, Tid style, Score* score, No
  Note: MusicXML common.mod: "The fermata type is upright if not specified."
  */
 
-static void addFermata(ChordRest* cr, const QString type, const SymId articSym)
+static void addFermata(ChordRest* cr, const QString type, const SymId fermataSym)
       {
-      if (type == "upright" || type == "")
-            addFermataToChord(cr, articSym, true);
-      else if (type == "inverted")
-            addFermataToChord(cr, articSym, false);
-      else
-            qDebug("unknown fermata type '%s'", qPrintable(type));
+      if (fermataSym != SymId::noSym) {
+            if (type == "upright" || type == "")
+                  addFermataToChord(cr, fermataSym, true);
+            else if (type == "inverted")
+                  addFermataToChord(cr, fermataSym, false);
+            else
+                  qDebug("unknown fermata type '%s'", qPrintable(type));
+            }
       }
 
 //---------------------------------------------------------
@@ -4070,22 +4083,6 @@ static Chord* createGraceChord(Score* score, const int track,
       }
 
 //---------------------------------------------------------
-//   elementMustBePostponed
-//---------------------------------------------------------
-
-/**
- Check if handling the current element must be postponed
- until after allocating the note.
- */
-
-static bool elementMustBePostponed(const QXmlStreamReader& e)
-      {
-      return e.name() == "notations"
-             || e.name() == "lyric"
-             || e.name() == "play";
-      }
-
-//---------------------------------------------------------
 //   handleDisplayStep
 //---------------------------------------------------------
 
@@ -4165,6 +4162,127 @@ static void addFiguredBassElemens(FiguredBassList& fbl, const Fraction noteStart
       }
 
 //---------------------------------------------------------
+//   addTremolo
+//---------------------------------------------------------
+
+static void addTremolo(ChordRest* cr,
+                       const int tremoloNr, const QString& tremoloType,
+                       Chord*& tremStart,
+                       MxmlLogger* logger, const QXmlStreamReader* const xmlreader)
+      {
+      if (!cr->isChord())
+            return;
+      if (tremoloNr) {
+            //qDebug("tremolo %d type '%s' ticks %d tremStart %p", tremoloNr, qPrintable(tremoloType), ticks, _tremStart);
+            if (tremoloNr == 1 || tremoloNr == 2 || tremoloNr == 3 || tremoloNr == 4) {
+                  if (tremoloType == "" || tremoloType == "single") {
+                        const auto tremolo = new Tremolo(cr->score());
+                        switch (tremoloNr) {
+                              case 1: tremolo->setTremoloType(TremoloType::R8); break;
+                              case 2: tremolo->setTremoloType(TremoloType::R16); break;
+                              case 3: tremolo->setTremoloType(TremoloType::R32); break;
+                              case 4: tremolo->setTremoloType(TremoloType::R64); break;
+                              }
+                        cr->add(tremolo);
+                        }
+                  else if (tremoloType == "start") {
+                        if (tremStart) logger->logError("MusicXML::import: double tremolo start", xmlreader);
+                        tremStart = static_cast<Chord*>(cr);
+                        }
+                  else if (tremoloType == "stop") {
+                        if (tremStart) {
+                              const auto tremolo = new Tremolo(cr->score());
+                              switch (tremoloNr) {
+                                    case 1: tremolo->setTremoloType(TremoloType::C8); break;
+                                    case 2: tremolo->setTremoloType(TremoloType::C16); break;
+                                    case 3: tremolo->setTremoloType(TremoloType::C32); break;
+                                    case 4: tremolo->setTremoloType(TremoloType::C64); break;
+                                    }
+                              tremolo->setChords(tremStart, static_cast<Chord*>(cr));
+                              // fixup chord duration and type
+                              const auto tremDur = cr->duration().ticks() / 2;
+                              tremolo->chord1()->setDurationType(tremDur);
+                              tremolo->chord1()->setDuration(Fraction::fromTicks(tremDur));
+                              tremolo->chord2()->setDurationType(tremDur);
+                              tremolo->chord2()->setDuration(Fraction::fromTicks(tremDur));
+                              // add tremolo to first chord (only)
+                              tremStart->add(tremolo);
+                              }
+                        else logger->logError("MusicXML::import: double tremolo stop w/o start", xmlreader);
+                        tremStart = nullptr;
+                        }
+                  }
+            else
+                  logger->logError(QString("unknown tremolo type %1").arg(tremoloNr), xmlreader);
+            }
+      }
+
+//---------------------------------------------------------
+//   setPitch
+//---------------------------------------------------------
+
+static void setPitch(Note* note, MusicXMLParserPass1& pass1, const QString& partId, const QString& instrumentId, const mxmlNotePitch& mnp, const int octaveShift)
+      {
+      const auto& mxmlDrumset = pass1.getDrumset(partId);
+      if (mnp.unpitched()) {
+            if (hasDrumset(mxmlDrumset)
+                && mxmlDrumset.contains(instrumentId)) {
+                  // step and oct are display-step and ...-oct
+                  // get pitch from instrument definition in drumset instead
+                  int pitch = mxmlDrumset[instrumentId].pitch;
+                  note->setPitch(limit(pitch, 0, 127));
+                  // TODO - does this need to be key-aware?
+                  note->setTpc(pitch2tpc(pitch, Key::C, Prefer::NEAREST));       // TODO: necessary ?
+                  }
+            else {
+                  //qDebug("disp step %d oct %d", displayStep, displayOctave);
+                  xmlSetPitch(note, mnp.displayStep(), 0, mnp.displayOctave(), 0, pass1.getPart(partId)->instrument());
+                  }
+            }
+      else {
+            xmlSetPitch(note, mnp.step(), mnp.alter(), mnp.octave(), octaveShift, pass1.getPart(partId)->instrument());
+            }
+      }
+
+//---------------------------------------------------------
+//   setDrumset
+//---------------------------------------------------------
+
+// set drumset information
+// note that in MuseScore, the drumset contains defaults for notehead,
+// line and stem direction, while a MusicXML file contains actuals.
+// the MusicXML values for each note are simply copied to the defaults
+
+static void setDrumset(Chord* c, MusicXMLParserPass1& pass1, const QString& partId, const QString& instrumentId,
+                       const Fraction noteStartTime, const mxmlNotePitch& mnp, const Direction stemDir, const NoteHead::Group headGroup)
+      {
+      // determine staff line based on display-step / -octave and clef type
+      const auto clef = c->staff()->clef(noteStartTime.ticks());
+      const auto po = ClefInfo::pitchOffset(clef);
+      const auto pitch = MusicXMLStepAltOct2Pitch(mnp.displayStep(), 0, mnp.displayOctave());
+      auto line = po - absStep(pitch);
+
+      // correct for number of staff lines
+      // see ExportMusicXml::unpitch2xml for explanation
+      // TODO handle other # staff lines ?
+      int staffLines = c->staff()->lines(0);
+      if (staffLines == 1) line -= 8;
+      if (staffLines == 3) line -= 2;
+
+      // the drum palette cannot handle stem direction AUTO,
+      // overrule if necessary
+      Direction overruledStemDir = stemDir;
+      if (stemDir == Direction::AUTO) {
+            if (line > 4)
+                  overruledStemDir = Direction::DOWN;
+            else
+                  overruledStemDir = Direction::UP;
+            }
+      // this should be done in pass 1, would make _pass1 const here
+      pass1.setDrumsetDefault(partId, instrumentId, headGroup, line, overruledStemDir);
+      }
+
+//---------------------------------------------------------
 //   note
 //---------------------------------------------------------
 
@@ -4213,11 +4331,13 @@ Note* MusicXMLParserPass2::note(const QString& partId,
       bool printObject = _e.attributes().value("print-object") != "no";
       Beam::Mode bm  = Beam::Mode::AUTO;
       QString instrumentId;
+      MusicXMLParserLyric lyric { _pass1.getMusicXmlPart(partId).lyricNumberHandler(), _e, _score, _logger };
+      MusicXMLParserNotations notations { _e, _score, _logger };
 
-      mxmlNoteDuration mnd(_divs, _logger);
-      mxmlNotePitch mnp(_logger);
+      mxmlNoteDuration mnd { _divs, _logger };
+      mxmlNotePitch mnp { _logger };
 
-      while (_e.readNextStartElement() && !elementMustBePostponed(_e)) {
+      while (_e.readNextStartElement()) {
             if (mnp.readProperties(_e, _score)) {
                   // element handled
                   }
@@ -4242,6 +4362,19 @@ Note* MusicXMLParserPass2::note(const QString& partId,
             else if (_e.name() == "instrument") {
                   instrumentId = _e.attributes().value("id").toString();
                   _e.readNext();
+                  }
+            else if (_e.name() == "lyric") {
+                  // lyrics on grace notes not (yet) supported by MuseScore
+                  if (!grace) {
+                        lyric.parse();
+                        }
+                  else {
+                        _logger->logDebugInfo("ignoring lyrics on grace notes", &_e);
+                        skipLogCurrElem();
+                        }
+                  }
+            else if (_e.name() == "notations") {
+                  notations.parse();
                   }
             else if (_e.name() == "notehead") {
                   noteheadColor.setNamedColor(_e.attributes().value("color").toString());
@@ -4306,68 +4439,28 @@ Note* MusicXMLParserPass2::note(const QString& partId,
 
       if (!_pass1.determineStaffMoveVoice(partId, staff, voice, msMove, msTrack, msVoice)) {
             _logger->logDebugInfo(QString("could not map staff %1 voice '%2'").arg(staff + 1).arg(voice), &_e);
-            // begin experimental fix for postponed <note> children
-            // TODO test /repair
-#if 0
-            while (_e.tokenType() == QXmlStreamReader::StartElement) {
-
-                  //qDebug("in second loop element '%s'", qPrintable(_e.name().toString()));
-                  skipLogCurrElem();
-
-                  // skip to either start of next <note> child or end of <note>
-                  // currently at end of last <note> child handled
-                  //qDebug("::note before skip tokenString '%s' name '%s'", qPrintable(_e.tokenString()), qPrintable(_e.name().toString()));
-                  do
-                        _e.readNext();
-                  while (!(_e.tokenType() == QXmlStreamReader::StartElement)
-                         && !(_e.tokenType() == QXmlStreamReader::EndElement && _e.name() == "note"));
-                  //qDebug("::note after skip tokenString '%s' name '%s'", qPrintable(_e.tokenString()), qPrintable(_e.name().toString()));
-
-
-                  }
-#endif
-            // end experimental fix for testVoiceMapper*
-
             Q_ASSERT(_e.isEndElement() && _e.name() == "note");
             return 0;
-            }
-      else {
             }
 
       TDuration duration = determineDuration(rest, type, mnd.dots(), dura, Fraction::fromTicks(measure->ticks()));
 
-      ChordRest* cr = 0;
-      Note* note = 0;
+      Chord* c { nullptr };
+      ChordRest* cr { nullptr };
+      Note* note { nullptr };
 
       // start time for note:
       // - sTime for non-chord / first chord note
       // - prevTime for others
-      const Fraction noteStartTime = chord ? prevSTime : sTime;
+      const auto noteStartTime = chord ? prevSTime : sTime;
 
+      // begin allocation
       if (rest) {
-            int track = msTrack + msVoice;
+            const auto track = msTrack + msVoice;
             cr = addRest(_score, measure, noteStartTime.ticks(), track, msMove,
                          duration, dura);
-            if (cr) {
-                  if (currBeam) {
-                        if (currBeam->track() == track) {
-                              cr->setBeamMode(Beam::Mode::MID);
-                              currBeam->add(cr);
-                              }
-                        else
-                              removeBeam(currBeam);
-                        }
-                  else
-                        cr->setBeamMode(Beam::Mode::NONE);
-                  cr->setSmall(small);
-                  if (noteColor != QColor::Invalid)
-                        cr->setColor(noteColor);
-                  cr->setVisible(printObject);
-                  handleDisplayStep(cr, mnp.displayStep(), mnp.displayOctave(), noteStartTime.ticks(), _score->spatium());
-                  }
             }
       else {
-            Chord* c;
             if (!grace) {
                   // regular note
                   // if there is already a chord just add to it
@@ -4377,17 +4470,6 @@ Note* MusicXMLParserPass2::note(const QString& partId,
                                         noteStartTime.ticks(),
                                         msTrack + msVoice, msMove,
                                         duration, dura, bm);
-                  // handle beam
-                  if (!chord)
-                        handleBeamAndStemDir(c, bm, stemDir, currBeam);
-
-                  // append any grace chord after chord to the previous chord
-                  Chord* prevChord = measure->findChord(prevSTime.ticks(), msTrack + msVoice);
-                  if (prevChord && prevChord != c)
-                        addGraceChordsAfter(prevChord, gcl, gac);
-
-                  // append any grace chord
-                  addGraceChordsBefore(c, gcl);
                   }
             else {
                   // grace note
@@ -4411,6 +4493,52 @@ Note* MusicXMLParserPass2::note(const QString& partId,
 
                   }
             note = new Note(_score);
+            const int ottavaStaff = (msTrack - _pass1.trackForPart(partId)) / VOICES;
+            const int octaveShift = _pass1.octaveShift(partId, ottavaStaff, noteStartTime);
+            setPitch(note, _pass1, partId, instrumentId, mnp, octaveShift);
+            c->add(note);
+            //c->setStemDirection(stemDir); // already done in handleBeamAndStemDir()
+            //c->setNoStem(noStem);
+            cr = c;
+            }
+      // end allocation
+
+      if (rest) {
+            const auto track = msTrack + msVoice;
+            if (cr) {
+                  if (currBeam) {
+                        if (currBeam->track() == track) {
+                              cr->setBeamMode(Beam::Mode::MID);
+                              currBeam->add(cr);
+                              }
+                        else
+                              removeBeam(currBeam);
+                        }
+                  else
+                        cr->setBeamMode(Beam::Mode::NONE);
+                  cr->setSmall(small);
+                  if (noteColor != QColor::Invalid)
+                        cr->setColor(noteColor);
+                  cr->setVisible(printObject);
+                  handleDisplayStep(cr, mnp.displayStep(), mnp.displayOctave(), noteStartTime.ticks(), _score->spatium());
+                  }
+            }
+      else {
+            if (!grace) {
+                  // regular note
+                  // handle beam
+                  if (!chord)
+                        handleBeamAndStemDir(c, bm, stemDir, currBeam);
+
+                  // append any grace chord after chord to the previous chord
+                  const auto prevChord = measure->findChord(prevSTime.ticks(), msTrack + msVoice);
+                  if (prevChord && prevChord != c)
+                        addGraceChordsAfter(prevChord, gcl, gac);
+
+                  // append any grace chord
+                  addGraceChordsBefore(c, gcl);
+                  }
+
             note->setSmall(small);
             note->setHeadGroup(headGroup);
             if (noteColor != QColor::Invalid)
@@ -4423,67 +4551,8 @@ Note* MusicXMLParserPass2::note(const QString& partId,
                   note->setVeloOffset(velocity);
                   }
 
-            const MusicXMLDrumset& mxmlDrumset = _pass1.getDrumset(partId);
             if (mnp.unpitched()) {
-                  //&& drumsets.contains(partId)
-                  if (_hasDrumset
-                      && mxmlDrumset.contains(instrumentId)) {
-                        // step and oct are display-step and ...-oct
-                        // get pitch from instrument definition in drumset instead
-                        int pitch = mxmlDrumset[instrumentId].pitch;
-                        note->setPitch(limit(pitch, 0, 127));
-                        // TODO - does this need to be key-aware?
-                        note->setTpc(pitch2tpc(pitch, Key::C, Prefer::NEAREST)); // TODO: necessary ?
-                        }
-                  else {
-                        //qDebug("disp step %d oct %d", displayStep, displayOctave);
-                        xmlSetPitch(note, mnp.displayStep(), 0, mnp.displayOctave(), 0, _pass1.getPart(partId)->instrument());
-                        }
-                  }
-            else {
-                  int ottavaStaff = (msTrack - _pass1.trackForPart(partId)) / VOICES;
-                  int octaveShift = _pass1.octaveShift(partId, ottavaStaff, noteStartTime);
-                  xmlSetPitch(note, mnp.step(), mnp.alter(), mnp.octave(), octaveShift, _pass1.getPart(partId)->instrument());
-                  }
-
-            // set drumset information
-            // note that in MuseScore, the drumset contains defaults for notehead,
-            // line and stem direction, while a MusicXML file contains actuals.
-            // the MusicXML values for each note are simply copied to the defaults
-
-            if (mnp.unpitched()) {
-                  // determine staff line based on display-step / -octave and clef type
-                  ClefType clef = c->staff()->clef(noteStartTime.ticks());
-                  int po = ClefInfo::pitchOffset(clef);
-                  int pitch = MusicXMLStepAltOct2Pitch(mnp.displayStep(), 0, mnp.displayOctave());
-                  int line = po - absStep(pitch);
-
-                  // correct for number of staff lines
-                  // see ExportMusicXml::unpitch2xml for explanation
-                  // TODO handle other # staff lines ?
-                  int staffLines = c->staff()->lines(0);
-                  if (staffLines == 1) line -= 8;
-                  if (staffLines == 3) line -= 2;
-
-                  // the drum palette cannot handle stem direction AUTO,
-                  // overrule if necessary
-                  if (stemDir == Direction::AUTO) {
-                        if (line > 4)
-                              stemDir = Direction::DOWN;
-                        else
-                              stemDir = Direction::UP;
-                        }
-
-                  /*
-                  if (drumsets.contains(partId)
-                       && mxmlDrumset.contains(instrId)) {
-                        mxmlDrumset[instrId].notehead = headGroup;
-                        mxmlDrumset[instrId].line = line;
-                        mxmlDrumset[instrId].stemDirection = sd;
-                  }
-                   */
-                  // this should be done in pass 1, would make _pass1 const here
-                  _pass1.setDrumsetDefault(partId, instrumentId, headGroup, line, stemDir);
+                  setDrumset(c, _pass1, partId, instrumentId, noteStartTime, mnp, stemDir, headGroup);
                   }
 
             // accidental handling
@@ -4502,10 +4571,7 @@ Note* MusicXMLParserPass2::note(const QString& partId,
                         alt = mnp.alter();
                   }
 
-            c->add(note);
-            //c->setStemDirection(stemDir); // already done in handleBeamAndStemDir()
             c->setNoStem(noStem);
-            cr = c;
             }
 
       // cr can be 0 here (if a rest cannot be added)
@@ -4515,60 +4581,25 @@ Note* MusicXMLParserPass2::note(const QString& partId,
             if (cue) cr->setSmall(cue);  // only once per chord
             }
 
-      // handle the postponed children of <note>
-      // if one of these was found, the first while loop was terminated
-      // at a StartElement instead of the usual EndElement
-
-      QMap<int, Lyrics*> numberedLyrics; // lyrics with valid number
-      QSet<Lyrics*> extendedLyrics;      // lyrics with the extend flag set
-      MusicXmlTupletDesc tupletDesc;
-      bool lastGraceAFter = false;       // set by notations() if end of grace after sequence found
-
-      while (_e.tokenType() == QXmlStreamReader::StartElement) {
-
-            //qDebug("in second loop element '%s'", qPrintable(_e.name().toString()));
-            if (_e.name() == "lyric") {
-                  // lyrics on grace notes not (yet) supported by MuseScore
-                  if (!grace)
-                        lyric(partId, numberedLyrics, extendedLyrics);  // TODO: move track handling to addlyric
-                  else {
-                        _logger->logDebugInfo("ignoring lyrics on grace notes", &_e);
-                        skipLogCurrElem();
-                        }
-                  }
-            else if (_e.name() == "notations")
-                  notations(note, cr, noteStartTime.ticks(), tupletDesc, lastGraceAFter);
-            else
-                  skipLogCurrElem();
-
-            // skip to either start of next <note> child or end of <note>
-            // currently at end of last <note> child handled
-            //qDebug("::note before skip tokenString '%s' name '%s'", qPrintable(_e.tokenString()), qPrintable(_e.name().toString()));
-            do
-                  _e.readNext();
-            while (!(_e.tokenType() == QXmlStreamReader::StartElement)
-                   && !(_e.tokenType() == QXmlStreamReader::EndElement && _e.name() == "note"));
-            //qDebug("::note after skip tokenString '%s' name '%s'", qPrintable(_e.tokenString()), qPrintable(_e.name().toString()));
-
-            }
-
-      //qDebug("::note after second loop tokenString '%s' name '%s'", qPrintable(_e.tokenString()), qPrintable(_e.name().toString()));
+      // find part-relative track
+      auto part = _pass1.getPart(partId);
+      Q_ASSERT(part);
+      auto scoreRelStaff = _score->staffIdx(part);       // zero-based number of parts first staff in the score
+      auto partRelTrack = msTrack + msVoice - scoreRelStaff * VOICES;
+      // handle notations
+      notations.addToScore(cr, note, noteStartTime.ticks(), partRelTrack, _slurs, _glissandi, _spanners, _trills, _tie);
 
       // handle grace after state: remember current grace list size
-      if (grace && lastGraceAFter)
+      if (grace && notations.mustStopGraceAFter()) {
             gac = gcl.size();
+            }
 
       if (cr) {
             if (!chord && !grace) {
                   // do tuplet if valid time-modification is not 1/1 and is not 1/2 (tremolo)
                   auto timeMod = mnd.timeMod();
-                  // find part-relative track
-                  auto part = _pass1.getPart(partId);
-                  Q_ASSERT(part);
-                  auto scoreRelStaff = _score->staffIdx(part); // zero-based number of parts first staff in the score
-                  auto partRelTrack = msTrack + msVoice - scoreRelStaff * VOICES;
                   if (timeMod.isValid() && timeMod != Fraction(1, 1) && timeMod != Fraction(1, 2)) {
-                        addTupletToChord(cr, _tuplets[partRelTrack], _tuplImpls[partRelTrack], timeMod, tupletDesc, mnd.normalType());
+                        addTupletToChord(cr, _tuplets[partRelTrack], _tuplImpls[partRelTrack], timeMod, notations.tupletDesc(), mnd.normalType());
                         }
                   else if (_tuplets[partRelTrack]) {
                         // stop any still incomplete tuplet
@@ -4580,7 +4611,7 @@ Note* MusicXMLParserPass2::note(const QString& partId,
       // add lyrics found by lyric
       if (cr) {
             // add lyrics and stop corresponding extends
-            addLyrics(_logger, &_e, cr, numberedLyrics, extendedLyrics, _extendedLyrics);
+            addLyrics(_logger, &_e, cr, lyric.numberedLyrics(), lyric.extendedLyrics(), _extendedLyrics);
             if (rest) {
                   // stop all extends
                   _extendedLyrics.setExtend(-1, cr->track(), cr->tick());
@@ -4589,6 +4620,7 @@ Note* MusicXMLParserPass2::note(const QString& partId,
 
       // add figured bass element
       addFiguredBassElemens(fbl, noteStartTime, msTrack, dura, measure);
+      addTremolo(cr, notations.tremoloNr(), notations.tremoloType(), _tremStart, _logger, &_e);
 
       // don't count chord or grace note duration
       // note that this does not check the MusicXML requirement that notes in a chord
@@ -5146,25 +5178,44 @@ void MusicXMLParserPass2::backup(Fraction& dura)
       }
 
 //---------------------------------------------------------
-//   lyric -- parse a MusicXML lyric element
+//   MusicXMLParserLyric
+//---------------------------------------------------------
+
+MusicXMLParserLyric::MusicXMLParserLyric(const LyricNumberHandler lyricNumberHandler,
+                                         QXmlStreamReader& e, Score* score, MxmlLogger* logger)
+      : _lyricNumberHandler(lyricNumberHandler), _e(e), _score(score), _logger(logger)
+      {
+      // nothing
+      }
+
+//---------------------------------------------------------
+//   skipLogCurrElem
 //---------------------------------------------------------
 
 /**
- Parse the /score-partwise/part/measure/note/lyric node.
+ Skip the current element, log debug as info.
  */
 
-void MusicXMLParserPass2::lyric(const QString& partId,
-                                QMap<int, Lyrics*>& numbrdLyrics,
-                                QSet<Lyrics*>& extLyrics)
+void MusicXMLParserLyric::skipLogCurrElem()
+      {
+      //_logger->logDebugInfo(QString("skipping '%1'").arg(_e.name().toString()), &_e);
+      _e.skipCurrentElement();
+      }
+
+//---------------------------------------------------------
+//   parse
+//---------------------------------------------------------
+
+void MusicXMLParserLyric::parse()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "lyric");
 
-      Lyrics* l = new Lyrics(_score);
+      std::unique_ptr<Lyrics> lyric { new Lyrics(_score) };
       // TODO in addlyrics: l->setTrack(trk);
 
       bool hasExtend = false;
-      QString lyricNumber = _e.attributes().value("number").toString();
-      QColor lyricColor = QColor::Invalid;
+      const auto lyricNumber = _e.attributes().value("number").toString();
+      QColor lyricColor { QColor::Invalid };
       lyricColor.setNamedColor(_e.attributes().value("color").toString());
       QString extendType;
       QString formattedText;
@@ -5186,17 +5237,17 @@ void MusicXMLParserPass2::lyric(const QString& partId,
                   _e.readNext();
                   }
             else if (_e.name() == "syllabic") {
-                  QString syll = _e.readElementText();
+                  auto syll = _e.readElementText();
                   if (syll == "single")
-                        l->setSyllabic(Lyrics::Syllabic::SINGLE);
+                        lyric->setSyllabic(Lyrics::Syllabic::SINGLE);
                   else if (syll == "begin")
-                        l->setSyllabic(Lyrics::Syllabic::BEGIN);
+                        lyric->setSyllabic(Lyrics::Syllabic::BEGIN);
                   else if (syll == "end")
-                        l->setSyllabic(Lyrics::Syllabic::END);
+                        lyric->setSyllabic(Lyrics::Syllabic::END);
                   else if (syll == "middle")
-                        l->setSyllabic(Lyrics::Syllabic::MIDDLE);
+                        lyric->setSyllabic(Lyrics::Syllabic::MIDDLE);
                   else
-                        qDebug("unknown syllabic %s", qPrintable(syll));  // TODO
+                        qDebug("unknown syllabic %s", qPrintable(syll));              // TODO
                   }
             else if (_e.name() == "text")
                   formattedText += nextPartOfFormattedString(_e);
@@ -5206,37 +5257,35 @@ void MusicXMLParserPass2::lyric(const QString& partId,
 
       // if no lyric read (e.g. only 'extend "type=stop"'), no further action required
       if (formattedText == "") {
-            delete l;
             return;
             }
 
-      auto mxmlPart = _pass1.getMusicXmlPart(partId);
-      auto lyricNo = mxmlPart.lyricNumberHandler().getLyricNo(lyricNumber);
+      const auto lyricNo = _lyricNumberHandler.getLyricNo(lyricNumber);
       if (lyricNo < 0) {
             _logger->logError("invalid lyrics number (<0)", &_e);
-            delete l;
             return;
             }
       else if (lyricNo > MAX_LYRICS) {
             _logger->logError(QString("too much lyrics (>%1)").arg(MAX_LYRICS), &_e);
-            delete l;
             return;
             }
-      else if (numbrdLyrics.contains(lyricNo)) {
+      else if (_numberedLyrics.contains(lyricNo)) {
             _logger->logError(QString("duplicate lyrics number (%1)").arg(lyricNumber), &_e);
-            delete l;
             return;
             }
-
-      numbrdLyrics[lyricNo] = l;
-
-      if (hasExtend && (extendType == "" || extendType == "start"))
-            extLyrics.insert(l);
 
       //qDebug("formatted lyric '%s'", qPrintable(formattedText));
-      l->setXmlText(formattedText);
+      lyric->setXmlText(formattedText);
       if (lyricColor != QColor::Invalid)
-            l->setColor(lyricColor);
+            lyric->setColor(lyricColor);
+
+      const auto l = lyric.release();
+      _numberedLyrics[lyricNo] = l;
+
+      if (hasExtend && (extendType == "" || extendType == "start"))
+            _extendedLyrics.insert(l);
+
+      Q_ASSERT(_e.isEndElement() && _e.name() == "lyric");
       }
 
 //---------------------------------------------------------
@@ -5247,15 +5296,43 @@ void MusicXMLParserPass2::lyric(const QString& partId,
  Parse the /score-partwise/part/measure/note/notations/slur node.
  */
 
-void MusicXMLParserPass2::slur(ChordRest* cr, const int tick, const int track, bool& lastGraceAFter)
+void MusicXMLParserNotations::slur()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "slur");
 
-      int slurNo   = _e.attributes().value("number").toString().toInt();
+      Notation notation { _e.name().toString() };
+      for (const auto attr : _e.attributes()) {
+            notation.addAttribute(attr.name(), attr.value());
+            }
+      _notations.push_back(notation);
+
+      // any grace note containing a slur stop means
+      // last note of a grace after set has been found
+      // -> remember slur stop
+      if (_e.attributes().value("type") == "stop") {
+            _slurStop = true;
+            }
+
+      _e.readNext();
+
+      Q_ASSERT(_e.isEndElement() && _e.name() == "slur");
+      }
+
+//---------------------------------------------------------
+//   addSlur
+//---------------------------------------------------------
+
+static void addSlur(const Notation& notation, SlurStack& slurs, ChordRest* cr, const int tick,
+                    MxmlLogger* logger, const QXmlStreamReader* const xmlreader)
+      {
+      auto slurNo = notation.attribute("number").toInt();
       if (slurNo > 0) slurNo--;
-      QString slurType = _e.attributes().value("type").toString();
-      QString lineType  = _e.attributes().value("line-type").toString();
+      const auto slurType = notation.attribute("type");
+      auto lineType = notation.attribute("line-type");
       if (lineType == "") lineType = "solid";
+
+      const auto track = cr->track();
+      auto score = cr->score();
 
       // PriMus Music-Notation by Columbussoft (build 10093) generates overlapping
       // slurs that do not have a number attribute to distinguish them.
@@ -5264,19 +5341,19 @@ void MusicXMLParserPass2::slur(ChordRest* cr, const int tick, const int track, b
       // Similar issues happen with Sibelius 7.1.3 (direct export)
 
       if (slurType == "start") {
-            if (_slurs[slurNo].isStart())
+            if (slurs[slurNo].isStart())
                   // slur start when slur already started: report error
-                  _logger->logError(QString("ignoring duplicate slur start"), &_e);
-            else if (_slurs[slurNo].isStop()) {
+                  logger->logError(QString("ignoring duplicate slur start"), xmlreader);
+            else if (slurs[slurNo].isStop()) {
                   // slur start when slur already stopped: wrap up
-                  Slur* newSlur = _slurs[slurNo].slur();
+                  auto newSlur = slurs[slurNo].slur();
                   newSlur->setTick(tick);
                   newSlur->setStartElement(cr);
-                  _slurs[slurNo] = SlurDesc();
+                  slurs[slurNo] = SlurDesc();
                   }
             else {
                   // slur start for new slur: init
-                  Slur* newSlur = new Slur(_score);
+                  auto newSlur = new Slur(score);
                   if (cr->isGrace())
                         newSlur->setAnchor(Spanner::Anchor::CHORD);
                   if (lineType == "dotted")
@@ -5285,102 +5362,72 @@ void MusicXMLParserPass2::slur(ChordRest* cr, const int tick, const int track, b
                         newSlur->setLineType(2);
                   newSlur->setTick(tick);
                   newSlur->setStartElement(cr);
-                  QString pl = _e.attributes().value("placement").toString();
+                  const auto pl = notation.attribute("placement");
                   if (pl == "above")
                         newSlur->setSlurDirection(Direction::UP);
                   else if (pl == "below")
                         newSlur->setSlurDirection(Direction::DOWN);
                   newSlur->setTrack(track);
                   newSlur->setTrack2(track);
-                  _slurs[slurNo].start(newSlur);
-                  _score->addElement(newSlur);
+                  slurs[slurNo].start(newSlur);
+                  score->addElement(newSlur);
                   }
             }
       else if (slurType == "stop") {
-            if (_slurs[slurNo].isStart()) {
+            if (slurs[slurNo].isStart()) {
                   // slur stop when slur already started: wrap up
-                  Slur* newSlur = _slurs[slurNo].slur();
+                  auto newSlur = slurs[slurNo].slur();
                   if (!(cr->isGrace())) {
                         newSlur->setTick2(tick);
                         newSlur->setTrack2(track);
                         }
                   newSlur->setEndElement(cr);
-                  _slurs[slurNo] = SlurDesc();
+                  slurs[slurNo] = SlurDesc();
                   }
-            else if (_slurs[slurNo].isStop())
+            else if (slurs[slurNo].isStop())
                   // slur stop when slur already stopped: report error
-                  _logger->logError(QString("ignoring duplicate slur stop"), &_e);
+                  logger->logError(QString("ignoring duplicate slur stop"), xmlreader);
             else {
                   // slur stop for new slur: init
-                  Slur* newSlur = new Slur(_score);
+                  auto newSlur = new Slur(score);
                   if (!(cr->isGrace())) {
                         newSlur->setTick2(tick);
                         newSlur->setTrack2(track);
                         }
                   newSlur->setEndElement(cr);
-                  _slurs[slurNo].stop(newSlur);
+                  slurs[slurNo].stop(newSlur);
                   }
-            // any grace note containing a slur stop means
-            // last note of a grace after set has been found
-            if (cr->isGrace())
-                  lastGraceAFter = true;
             }
       else if (slurType == "continue")
             ;        // ignore
       else
-            _logger->logError(QString("unknown slur type %1").arg(slurType), &_e);
-
-      _e.readNext();
+            logger->logError(QString("unknown slur type %1").arg(slurType), xmlreader);
       }
 
 //---------------------------------------------------------
 //   tied
 //---------------------------------------------------------
 
+
 /**
  Parse the /score-partwise/part/measure/note/notations/tied node.
  */
 
-void MusicXMLParserPass2::tied(Note* note, const int track)
+void MusicXMLParserNotations::tied()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "tied");
 
-      QString tiedType = _e.attributes().value("type").toString();
-      if (tiedType == "start") {
-            if (_tie) {
-                  _logger->logError(QString("Tie already active"), &_e);
-                  }
-            else if (note) {
-                  _tie = new Tie(_score);
-                  note->setTieFor(_tie);
-                  _tie->setStartNote(note);
-                  _tie->setTrack(track);
-                  QString tiedOrientation = _e.attributes().value("orientation").toString();
-                  if (tiedOrientation == "over")
-                        _tie->setSlurDirection(Direction::UP);
-                  else if (tiedOrientation == "under")
-                        _tie->setSlurDirection(Direction::DOWN);
-                  else if (tiedOrientation == "auto")
-                        ;        // ignore
-                  else if (tiedOrientation == "")
-                        ;        // ignore
-                  else
-                        _logger->logError(QString("unknown tied orientation: %1").arg(tiedOrientation), &_e);
-
-                  QString lineType  = _e.attributes().value("line-type").toString();
-                  if (lineType == "dotted")
-                        _tie->setLineType(1);
-                  else if (lineType == "dashed")
-                        _tie->setLineType(2);
-                  _tie = 0;
-                  }
+      _tiedType = _e.attributes().value("type").toString();
+      _tiedOrientation = _e.attributes().value("orientation").toString();
+      _tiedLineType  = _e.attributes().value("line-type").toString();
+      if (_tiedType != "start" && _tiedType != "stop") {
+            _logger->logError(QString("unknown tied type %").arg(_tiedType), &_e);
             }
-      else if (tiedType == "stop")
-            ;        // ignore
-      else
-            _logger->logError(QString("unknown tied type %").arg(tiedType), &_e);
 
       _e.readNext();
+
+      Q_ASSERT(_e.isEndElement() && _e.name() == "tied");
+
       }
 
 //---------------------------------------------------------
@@ -5391,25 +5438,22 @@ void MusicXMLParserPass2::tied(Note* note, const int track)
  Parse the /score-partwise/part/measure/note/notations/dynamics node.
  */
 
-void MusicXMLParserPass2::dynamics(QString& placement, QStringList& dynamicslist)
+void MusicXMLParserNotations::dynamics()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "dynamics");
 
-      placement = _e.attributes().value("placement").toString();
-      if (preferences.getBool(PREF_IMPORT_MUSICXML_IMPORTLAYOUT)) {
-            // ry        = ee.attribute(QString("relative-y"), "0").toDouble() * -.1;
-            // rx        = ee.attribute(QString("relative-x"), "0").toDouble() * .1;
-            // yoffset   = _e.attributes().value("default-y").toDouble(&hasYoffset) * -0.1;
-            // xoffset   = ee.attribute("default-x", "0.0").toDouble() * 0.1;
-            }
+      _dynamicsPlacement = _e.attributes().value("placement").toString();
+
       while (_e.readNextStartElement()) {
             if (_e.name() == "other-dynamics")
-                  dynamicslist.push_back(_e.readElementText());
+                  _dynamicsList.push_back(_e.readElementText());
             else {
-                  dynamicslist.push_back(_e.name().toString());
+                  _dynamicsList.push_back(_e.name().toString());
                   _e.readNext();
                   }
             }
+
+      Q_ASSERT(_e.isEndElement() && _e.name() == "dynamics");
       }
 
 //---------------------------------------------------------
@@ -5423,45 +5467,62 @@ void MusicXMLParserPass2::dynamics(QString& placement, QStringList& dynamicslist
  as in that case note is 0.
  */
 
-void MusicXMLParserPass2::articulations(ChordRest* cr, SymId& breath, QString& chordLineType)
+void MusicXMLParserNotations::articulations()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "articulations");
 
       while (_e.readNextStartElement()) {
-            if (addMxmlArticulationToChord(cr, _e.name().toString())) {
+            SymId id { SymId::noSym };
+            if (convertArticulationToSymId(_e.name().toString(), id)) {
+                  _articulationSymbols.push_back(id);
                   _e.readNext();
                   continue;
                   }
             else if (_e.name() == "breath-mark") {
-                  breath = SymId::breathMarkComma;
+                  _breath = SymId::breathMarkComma;
                   _e.readElementText();
                   // TODO: handle value read (note: encoding unknown, only "comma" found)
                   }
             else if (_e.name() == "caesura") {
-                  breath = SymId::caesura;
+                  _breath = SymId::caesura;
                   _e.readNext();
                   }
             else if (_e.name() == "doit"
                      || _e.name() == "falloff"
                      || _e.name() == "plop"
                      || _e.name() == "scoop") {
-                  chordLineType = _e.name().toString();
+                  _chordLineType = _e.name().toString();
                   _e.readNext();
                   }
             else if (_e.name() == "strong-accent") {
-                  QString strongAccentType = _e.attributes().value("type").toString();
-                  if (strongAccentType == "up" || strongAccentType == "")
-                        addArticulationToChord(cr, SymId::articMarcatoAbove, "up");
-                  else if (strongAccentType == "down")
-                        addArticulationToChord(cr, SymId::articMarcatoAbove, "down");
-                  else
-                        _logger->logError(QString("unknown mercato type %1").arg(strongAccentType), &_e);
+                  _strongAccentType = _e.attributes().value("type").toString();
+                  if (_strongAccentType == "") {
+                        _strongAccentType = "up";
+                        }
+                  else if (_strongAccentType != "down") {
+                        _logger->logError(QString("unknown mercato type %1").arg(_strongAccentType), &_e);
+                        }
                   _e.readNext();
                   }
-            else
+            else {
                   skipLogCurrElem();
+                  }
             }
       //qDebug("::notations tokenString '%s' name '%s'", qPrintable(_e.tokenString()), qPrintable(_e.name().toString()));
+
+      Q_ASSERT(_e.isEndElement() && _e.name() == "articulations");
+      }
+
+//---------------------------------------------------------
+//   addStrongAccent
+//---------------------------------------------------------
+
+static void addStrongAccent(ChordRest* cr, const QString& upDown)
+      {
+      if (upDown == "up")
+            addArticulationToChord(cr, SymId::articMarcatoAbove, "up");
+      else if (upDown == "down")
+            addArticulationToChord(cr, SymId::articMarcatoAbove, "down");
       }
 
 //---------------------------------------------------------
@@ -5472,18 +5533,16 @@ void MusicXMLParserPass2::articulations(ChordRest* cr, SymId& breath, QString& c
  Parse the /score-partwise/part/measure/note/notations/ornaments node.
  */
 
-void MusicXMLParserPass2::ornaments(ChordRest* cr,
-                                    QString& wavyLineType,
-                                    int& wavyLineNo,
-                                    QString& tremoloType,
-                                    int& tremoloNr, bool& lastGraceAFter)
+void MusicXMLParserNotations::ornaments()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "ornaments");
 
       bool trillMark = false;
       // <trill-mark placement="above"/>
       while (_e.readNextStartElement()) {
-            if (addMxmlArticulationToChord(cr, _e.name().toString())) {
+            SymId id { SymId::noSym };
+            if (convertArticulationToSymId(_e.name().toString(), id)) {
+                  _articulationSymbols.push_back(id);
                   _e.readNext();
                   continue;
                   }
@@ -5492,42 +5551,40 @@ void MusicXMLParserPass2::ornaments(ChordRest* cr,
                   _e.readNext();
                   }
             else if (_e.name() == "wavy-line") {
-                  wavyLineType = _e.attributes().value("type").toString();
-                  wavyLineNo   = _e.attributes().value("number").toString().toInt();
-                  if (wavyLineNo > 0) wavyLineNo--;
+                  _wavyLineType = _e.attributes().value("type").toString();
+                  _wavyLineNo   = _e.attributes().value("number").toString().toInt();
+                  if (_wavyLineNo > 0) _wavyLineNo--;
                   // any grace note containing a wavy-line stop means
                   // last note of a grace after set has been found
-                  if (wavyLineType == "stop" && cr->isGrace())
-                        lastGraceAFter = true;
+                  // remember wavy-line stop
+                  if (_wavyLineType == "stop") {
+                        _wavyLineStop = true;
+                        }
                   _e.readNext();
                   }
             else if (_e.name() == "tremolo") {
-                  tremoloType = _e.attributes().value("type").toString();
-                  tremoloNr = _e.readElementText().toInt();
+                  _tremoloType = _e.attributes().value("type").toString();
+                  _tremoloNr = _e.readElementText().toInt();
                   }
-            else if (_e.name() == "accidental-mark")
-                  skipLogCurrElem();
             else if (_e.name() == "delayed-turn") {
                   // TODO: actually this should be offset a bit to the right
-                  addArticulationToChord(cr, SymId::ornamentTurn, "");
+                  _articulationSymbols.push_back(SymId::ornamentTurn);
                   _e.readNext();
                   }
             else if (_e.name() == "inverted-mordent"
                      || _e.name() == "mordent") {
-                  addMordentToChord(cr, _e.name().toString(),
-                                    _e.attributes().value("long").toString(),
-                                    _e.attributes().value("approach").toString(),
-                                    _e.attributes().value("departure").toString());
+                  mordentNormalOrInverted();
                   _e.readNext();
                   }
-            else
+            else {
                   skipLogCurrElem();
+                  }
             }
-      //qDebug("::notations tokenString '%s' name '%s'", qPrintable(_e.tokenString()), qPrintable(_e.name().toString()));
+
       // note that mscore wavy line already implicitly includes a trillsym
       // so don't add an additional one
-      if (trillMark && wavyLineType != "start")
-            addArticulationToChord(cr, SymId::ornamentTrill, "");
+      if (trillMark && _wavyLineType != "start")
+            _articulationSymbols.push_back(SymId::ornamentTrill);
       }
 
 //---------------------------------------------------------
@@ -5538,54 +5595,98 @@ void MusicXMLParserPass2::ornaments(ChordRest* cr,
  Parse the /score-partwise/part/measure/note/notations/technical node.
  */
 
-void MusicXMLParserPass2::technical(Note* note, ChordRest* cr)
+void MusicXMLParserNotations::technical()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "technical");
 
       while (_e.readNextStartElement()) {
-            if (addMxmlArticulationToChord(cr, _e.name().toString())) {
+            SymId id { SymId::noSym };
+            if (convertArticulationToSymId(_e.name().toString(), id)) {
+                  _articulationSymbols.push_back(id);
                   _e.readNext();
                   continue;
                   }
-            else if (_e.name() == "fingering")
-                  // TODO: distinguish between keyboards (style Tid::FINGERING)
-                  // and (plucked) strings (style Tid::LH_GUITAR_FINGERING)
-                  addTextToNote(_e.lineNumber(), _e.columnNumber(), _e.readElementText(),
-                                  Tid::FINGERING, _score, note);
+            else if (_e.name() == "fingering") {
+                  _technicalFingering = _e.readElementText();
+                  }
             else if (_e.name() == "fret") {
-                  int fret = _e.readElementText().toInt();
-                  if (note) {
-                        if (note->staff()->isTabStaff(0))
-                              note->setFret(fret);
-                        }
-                  else
-                        _logger->logError("no note for fret", &_e);
+                  _technicalFret = _e.readElementText();
                   }
-            else if (_e.name() == "pluck")
-                  addTextToNote(_e.lineNumber(), _e.columnNumber(), _e.readElementText(),
-                                Tid::RH_GUITAR_FINGERING, _score, note);
+            else if (_e.name() == "pluck") {
+                  _technicalPluck = _e.readElementText();
+                  }
             else if (_e.name() == "string") {
-                  QString txt = _e.readElementText();
-                  if (note) {
-                        if (note->staff()->isTabStaff(0))
-                              note->setString(txt.toInt() - 1);
-                        else
-                              addTextToNote(_e.lineNumber(), _e.columnNumber(), txt,
-                                            Tid::STRING_NUMBER, _score, note);
-                        }
-                  else
-                        _logger->logError("no note for string", &_e);
+                  _technicalString = _e.readElementText();
                   }
-            else if (_e.name() == "pull-off")
+            else {
                   skipLogCurrElem();
-            else
-                  skipLogCurrElem();
+                  }
             }
-      //qDebug("::notations tokenString '%s' name '%s'", qPrintable(_e.tokenString()), qPrintable(_e.name().toString()));
       }
 
 //---------------------------------------------------------
-//   glissando
+//   addTechnical
+//---------------------------------------------------------
+
+void MusicXMLParserNotations::addTechnical(Note* note)
+      {
+      if (_technicalFingering != "") {
+            // TODO: distinguish between keyboards (style Tid::FINGERING)
+            // and (plucked) strings (style Tid::LH_GUITAR_FINGERING)
+            addTextToNote(_e.lineNumber(), _e.columnNumber(), _technicalFingering,
+                          Tid::FINGERING, _score, note);
+            }
+      else if (_technicalFret != "") {
+            auto fret = _technicalFret.toInt();
+            if (note) {
+                  if (note->staff()->isTabStaff(0))
+                        note->setFret(fret);
+                  }
+            else
+                  _logger->logError("no note for fret", &_e);
+            }
+      else if (_technicalPluck != "") {
+            addTextToNote(_e.lineNumber(), _e.columnNumber(), _technicalPluck,
+                          Tid::RH_GUITAR_FINGERING, _score, note);
+            }
+      else if (_technicalString != "") {
+            if (note) {
+                  if (note->staff()->isTabStaff(0))
+                        note->setString(_technicalString.toInt() - 1);
+                  else
+                        addTextToNote(_e.lineNumber(), _e.columnNumber(), _technicalString,
+                                      Tid::STRING_NUMBER, _score, note);
+                  }
+            else
+                  _logger->logError("no note for string", &_e);
+            }
+      }
+
+//---------------------------------------------------------
+//   mordentNormalOrInverted
+//---------------------------------------------------------
+
+/**
+ Parse the /score-partwise/part/measure/note/notations/ornaments/mordent
+ and /score-partwise/part/measure/note/notations/ornaments/inverted-mordent nodes.
+ */
+
+void MusicXMLParserNotations::mordentNormalOrInverted()
+      {
+      Q_ASSERT(_e.isStartElement() && (_e.name() == "mordent" || _e.name() == "inverted-mordent"));
+
+      Notation notation { _e.name().toString() };
+      for (const auto attr : _e.attributes()) {
+            notation.addAttribute(attr.name(), attr.value());
+            }
+      notation.setText(_e.readElementText());
+      _notations.push_back(notation);
+
+      Q_ASSERT(_e.isEndElement() && (_e.name() == "mordent" || _e.name() == "inverted-mordent"));
+      }
+
+//---------------------------------------------------------
+//   glissandoSlide
 //---------------------------------------------------------
 
 /**
@@ -5593,59 +5694,81 @@ void MusicXMLParserPass2::technical(Note* note, ChordRest* cr)
  and /score-partwise/part/measure/note/notations/slide nodes.
  */
 
-void MusicXMLParserPass2::glissando(Note* note, const int tick, const int ticks, const int track)
+void MusicXMLParserNotations::glissandoSlide()
       {
       Q_ASSERT(_e.isStartElement() && (_e.name() == "glissando" || _e.name() == "slide"));
 
-      int n                   = _e.attributes().value("number").toString().toInt();
-      if (n > 0) n--;
-      QString spannerType     = _e.attributes().value("type").toString();
-      int tag                 = _e.name() == "slide" ? 0 : 1;
+      Notation notation { _e.name().toString() };
+      for (const auto attr : _e.attributes()) {
+            notation.addAttribute(attr.name(), attr.value());
+            }
+      notation.setText(_e.readElementText());
+      _notations.push_back(notation);
+
+      Q_ASSERT(_e.isEndElement() && (_e.name() == "glissando" || _e.name() == "slide"));
+      }
+
+//---------------------------------------------------------
+//   addGlissandoSlide
+//---------------------------------------------------------
+
+static void addGlissandoSlide(const Notation& notation, Note* note,
+                              Glissando* glissandi[MAX_NUMBER_LEVEL][2], MusicXmlSpannerMap& spanners,
+                              MxmlLogger* logger, const QXmlStreamReader* const xmlreader)
+      {
+      auto glissandoNumber = notation.attribute("number").toInt();
+      if (glissandoNumber > 0) glissandoNumber--;
+      const auto glissandoType = notation.attribute("type");
+      int glissandoTag = notation.name() == "slide" ? 0 : 1;
       //                  QString lineType  = ee.attribute(QString("line-type"), "solid");
-      Glissando*& gliss = _glissandi[n][tag];
-      if (spannerType == "start") {
-            QColor color(_e.attributes().value("color").toString());
-            QString glissText = _e.readElementText();
+      Glissando*& gliss = glissandi[glissandoNumber][glissandoTag];
+
+      const auto tick = note->tick();
+      const auto track = note->track();
+      auto score = note->score();
+
+      if (glissandoType == "start") {
+            const QColor glissandoColor { notation.attribute("color") };
+            const auto glissandoText = notation.text();
             if (gliss) {
-                  _logger->logError(QString("overlapping glissando/slide number %1").arg(n+1), &_e);
+                  logger->logError(QString("overlapping glissando/slide number %1").arg(glissandoNumber+1), xmlreader);
                   }
             else if (!note) {
-                  _logger->logError(QString("no note for glissando/slide number %1 start").arg(n+1), &_e);
+                  logger->logError(QString("no note for glissando/slide number %1 start").arg(glissandoNumber+1), xmlreader);
                   }
             else {
-                  gliss = new Glissando(_score);
+                  gliss = new Glissando(score);
                   gliss->setAnchor(Spanner::Anchor::NOTE);
                   gliss->setStartElement(note);
                   gliss->setTick(tick);
                   gliss->setTrack(track);
                   gliss->setParent(note);
-                  if (color.isValid())
-                        gliss->setColor(color);
-                  gliss->setText(glissText);
-                  gliss->setGlissandoType(tag == 0 ? GlissandoType::STRAIGHT : GlissandoType::WAVY);
-                  _spanners[gliss] = QPair<int, int>(tick, -1);
+                  if (glissandoColor.isValid())
+                        gliss->setColor(glissandoColor);
+                  gliss->setText(glissandoText);
+                  gliss->setGlissandoType(glissandoTag == 0 ? GlissandoType::STRAIGHT : GlissandoType::WAVY);
+                  spanners[gliss] = QPair<int, int>(tick, -1);
                   // qDebug("glissando/slide=%p inserted at first tick %d", gliss, tick);
                   }
             }
-      else if (spannerType == "stop") {
+      else if (glissandoType == "stop") {
             if (!gliss) {
-                  _logger->logError(QString("glissando/slide number %1 stop without start").arg(n+1), &_e);
+                  logger->logError(QString("glissando/slide number %1 stop without start").arg(glissandoNumber+1), xmlreader);
                   }
             else if (!note) {
-                  _logger->logError(QString("no note for glissando/slide number %1 stop").arg(n+1), &_e);
+                  logger->logError(QString("no note for glissando/slide number %1 stop").arg(glissandoNumber+1), xmlreader);
                   }
             else {
-                  _spanners[gliss].second = tick + ticks;
+                  spanners[gliss].second = tick + note->chord()->duration().ticks();;
                   gliss->setEndElement(note);
                   gliss->setTick2(tick);
                   gliss->setTrack2(track);
                   // qDebug("glissando/slide=%p second tick %d", gliss, tick);
-                  gliss = 0;
+                  gliss = nullptr;
                   }
             }
       else
-            _logger->logError(QString("unknown glissando/slide type %1").arg(spannerType), &_e);
-      _e.readNext();
+            logger->logError(QString("unknown glissando/slide type %1").arg(glissandoType), xmlreader);
       }
 
 //---------------------------------------------------------
@@ -5657,84 +5780,64 @@ static void addArpeggio(ChordRest* cr, const QString& arpeggioType,
       {
       // no support for arpeggio on rest
       if (!arpeggioType.isEmpty() && cr->type() == ElementType::CHORD) {
-            Arpeggio* a = new Arpeggio(cr->score());
-            if (arpeggioType == "none")
-                  a->setArpeggioType(ArpeggioType::NORMAL);
-            else if (arpeggioType == "up")
-                  a->setArpeggioType(ArpeggioType::UP);
+            std::unique_ptr<Arpeggio> arpeggio { new Arpeggio(cr->score()) };
+            arpeggio->setArpeggioType(ArpeggioType::NORMAL);
+            if (arpeggioType == "up")
+                  arpeggio->setArpeggioType(ArpeggioType::UP);
             else if (arpeggioType == "down")
-                  a->setArpeggioType(ArpeggioType::DOWN);
+                  arpeggio->setArpeggioType(ArpeggioType::DOWN);
             else if (arpeggioType == "non-arpeggiate")
-                  a->setArpeggioType(ArpeggioType::BRACKET);
+                  arpeggio->setArpeggioType(ArpeggioType::BRACKET);
             else {
                   logger->logError(QString("unknown arpeggio type %1").arg(arpeggioType), xmlreader);
-                  delete a;
-                  a = 0;
                   }
-            if ((static_cast<Chord*>(cr))->arpeggio()) {
-                  // there can be only one
-                  delete a;
-                  a = 0;
+            // there can be only one
+            if (!(static_cast<Chord*>(cr))->arpeggio()) {
+                  cr->add(arpeggio.release());
                   }
-            else
-                  cr->add(a);
             }
       }
 
 //---------------------------------------------------------
-//   addTremolo
+//   addTie
 //---------------------------------------------------------
 
-static void addTremolo(ChordRest* cr,
-                       const int tremoloNr, const QString& tremoloType, const int ticks,
-                       Chord*& tremStart,
-                       MxmlLogger* logger, const QXmlStreamReader* const xmlreader)
+static void addTie(Score* score, Note* note, const int track,
+                   const QString& type, const QString& orientation, const QString& lineType,
+                   Tie*& tie, MxmlLogger* logger, const QXmlStreamReader* const xmlreader)
       {
-      if (!cr->isChord())
-            return;
-      if (tremoloNr) {
-            //qDebug("tremolo %d type '%s' ticks %d tremStart %p", tremoloNr, qPrintable(tremoloType), ticks, _tremStart);
-            if (tremoloNr == 1 || tremoloNr == 2 || tremoloNr == 3 || tremoloNr == 4) {
-                  if (tremoloType == "" || tremoloType == "single") {
-                        Tremolo* t = new Tremolo(cr->score());
-                        switch (tremoloNr) {
-                              case 1: t->setTremoloType(TremoloType::R8); break;
-                              case 2: t->setTremoloType(TremoloType::R16); break;
-                              case 3: t->setTremoloType(TremoloType::R32); break;
-                              case 4: t->setTremoloType(TremoloType::R64); break;
-                              }
-                        cr->add(t);
-                        }
-                  else if (tremoloType == "start") {
-                        if (tremStart) logger->logError("MusicXML::import: double tremolo start", xmlreader);
-                        tremStart = static_cast<Chord*>(cr);
-                        }
-                  else if (tremoloType == "stop") {
-                        if (tremStart) {
-                              Tremolo* t = new Tremolo(cr->score());
-                              switch (tremoloNr) {
-                                    case 1: t->setTremoloType(TremoloType::C8); break;
-                                    case 2: t->setTremoloType(TremoloType::C16); break;
-                                    case 3: t->setTremoloType(TremoloType::C32); break;
-                                    case 4: t->setTremoloType(TremoloType::C64); break;
-                                    }
-                              t->setChords(tremStart, static_cast<Chord*>(cr));
-                              // fixup chord duration and type
-                              const int tremDur = ticks / 2;
-                              t->chord1()->setDurationType(tremDur);
-                              t->chord1()->setDuration(Fraction::fromTicks(tremDur));
-                              t->chord2()->setDurationType(tremDur);
-                              t->chord2()->setDuration(Fraction::fromTicks(tremDur));
-                              // add tremolo to first chord (only)
-                              tremStart->add(t);
-                              }
-                        else logger->logError("MusicXML::import: double tremolo stop w/o start", xmlreader);
-                        tremStart = 0;
-                        }
+      Q_ASSERT(note);
+
+      if (type == "start") {
+            if (tie) {
+                  logger->logError(QString("Tie already active"), xmlreader);
                   }
+            tie = new Tie(score);
+            note->setTieFor(tie);
+            tie->setStartNote(note);
+            tie->setTrack(track);
+
+            if (orientation == "over")
+                  tie->setSlurDirection(Direction::UP);
+            else if (orientation == "under")
+                  tie->setSlurDirection(Direction::DOWN);
+            else if (orientation == "auto")
+                  ;                    // ignore
+            else if (orientation == "")
+                  ;                    // ignore
             else
-                  logger->logError(QString("unknown tremolo type %1").arg(tremoloNr), xmlreader);
+                  logger->logError(QString("unknown tied orientation: %1").arg(orientation), xmlreader);
+
+            if (lineType == "dotted")
+                  tie->setLineType(1);
+            else if (lineType == "dashed")
+                  tie->setLineType(2);
+            tie = nullptr;
             }
+      else if (type == "stop")
+            ;              // ignore
+      else
+            logger->logError(QString("unknown tied type %").arg(type), xmlreader);
       }
 
 //---------------------------------------------------------
@@ -5750,26 +5853,26 @@ static void addWavyLine(ChordRest* cr, const int tick,
             const auto ticks = cr->duration().ticks();
             const auto track = cr->track();
             const auto trk = (track / VOICES) * VOICES;       // first track of staff
-            Trill*& t = trills[wavyLineNo];
+            Trill*& trill = trills[wavyLineNo];
             if (wavyLineType == "start") {
-                  if (t) {
+                  if (trill) {
                         logger->logError(QString("overlapping wavy-line number %1").arg(wavyLineNo+1), xmlreader);
                         }
                   else {
-                        t = new Trill(cr->score());
-                        t->setTrack(trk);
-                        spanners[t] = QPair<int, int>(tick, -1);
+                        trill = new Trill(cr->score());
+                        trill->setTrack(trk);
+                        spanners[trill] = QPair<int, int>(tick, -1);
                         // qDebug("wedge trill=%p inserted at first tick %d", trill, tick);
                         }
                   }
             else if (wavyLineType == "stop") {
-                  if (!t) {
+                  if (!trill) {
                         logger->logError(QString("wavy-line number %1 stop without start").arg(wavyLineNo+1), xmlreader);
                         }
                   else {
-                        spanners[t].second = tick + ticks;
+                        spanners[trill].second = tick + ticks;
                         // qDebug("wedge trill=%p second tick %d", trill, tick);
-                        t = 0;
+                        trill = nullptr;
                         }
                   }
             else
@@ -5784,12 +5887,12 @@ static void addWavyLine(ChordRest* cr, const int tick,
 static void addBreath(ChordRest* cr, const int tick, SymId breath)
       {
       if (breath != SymId::noSym && !cr->isGrace()) {
-            Breath* b = new Breath(cr->score());
+            const auto b = new Breath(cr->score());
             // b->setTrack(trk + voice); TODO check next line
             b->setTrack(cr->track());
             b->setSymId(breath);
             const auto ticks = cr->duration().ticks();
-            auto seg = cr->measure()->getSegment(SegmentType::Breath, tick + ticks);
+            const auto seg = cr->measure()->getSegment(SegmentType::Breath, tick + ticks);
             seg->add(b);
             }
       }
@@ -5803,16 +5906,16 @@ static void addChordLine(Note* note, const QString& chordLineType,
       {
       if (chordLineType != "") {
             if (note) {
-                  ChordLine* cl = new ChordLine(note->score());
+                  const auto chordline = new ChordLine(note->score());
                   if (chordLineType == "falloff")
-                        cl->setChordLineType(ChordLineType::FALL);
+                        chordline->setChordLineType(ChordLineType::FALL);
                   if (chordLineType == "doit")
-                        cl->setChordLineType(ChordLineType::DOIT);
+                        chordline->setChordLineType(ChordLineType::DOIT);
                   if (chordLineType == "plop")
-                        cl->setChordLineType(ChordLineType::PLOP);
+                        chordline->setChordLineType(ChordLineType::PLOP);
                   if (chordLineType == "scoop")
-                        cl->setChordLineType(ChordLineType::SCOOP);
-                  note->chord()->add(cl);
+                        chordline->setChordLineType(ChordLineType::SCOOP);
+                  note->chord()->add(chordline);
                   }
             else
                   logger->logError(QString("no note for %1").arg(chordLineType), xmlreader);
@@ -5820,112 +5923,185 @@ static void addChordLine(Note* note, const QString& chordLineType,
       }
 
 //---------------------------------------------------------
-//   notations
+//   addAttribute
+//---------------------------------------------------------
+
+void Notation::addAttribute(const QStringRef name, const QStringRef value)
+      {
+      _attributes.insert(std::pair<QString, QString>(name.toString(), value.toString()));
+      }
+
+//---------------------------------------------------------
+//   attribute
+//---------------------------------------------------------
+
+QString Notation::attribute(const QString& name) const
+      {
+      const auto it = _attributes.find(name);
+      return (it != _attributes.end()) ? it->second : "";
+      }
+
+//---------------------------------------------------------
+//   print
+//---------------------------------------------------------
+
+QString Notation::print() const
+      {
+      QString res { _name };
+
+      for (auto const& pair : _attributes) {
+            res += " ";
+            res += pair.first;
+            res += " ";
+            res += pair.second;
+            }
+
+      if (_text != "") {
+            res += " ";
+            res += _text;
+            }
+      return res;
+      }
+
+//---------------------------------------------------------
+//   MusicXMLParserNotations
+//---------------------------------------------------------
+
+MusicXMLParserNotations::MusicXMLParserNotations(QXmlStreamReader& e, Score* score, MxmlLogger* logger)
+      : _e(e), _score(score), _logger(logger)
+      {
+      // nothing
+      }
+
+//---------------------------------------------------------
+//   skipLogCurrElem
 //---------------------------------------------------------
 
 /**
- Parse the /score-partwise/part/measure/note/notations node.
+ Skip the current element, log debug as info.
+ */
+
+void MusicXMLParserNotations::skipLogCurrElem()
+      {
+      //_logger->logDebugInfo(QString("skipping '%1'").arg(_e.name().toString()), &_e);
+      _e.skipCurrentElement();
+      }
+
+//---------------------------------------------------------
+//   parse
+//---------------------------------------------------------
+
+void MusicXMLParserNotations::parse()
+      {
+      Q_ASSERT(_e.isStartElement() && _e.name() == "notations");
+
+      while (_e.readNextStartElement()) {
+            if (_e.name() == "arpeggiate") {
+                  _arpeggioType = _e.attributes().value("direction").toString();
+                  if (_arpeggioType == "") _arpeggioType = "none";
+                  _e.readNext();
+                  }
+            else if (_e.name() == "articulations") {
+                  articulations();
+                  }
+            else if (_e.name() == "dynamics") {
+                  dynamics();
+                  }
+            else if (_e.name() == "fermata") {
+                  fermata();
+                  }
+            else if (_e.name() == "glissando") {
+                  glissandoSlide();
+                  }
+            else if (_e.name() == "non-arpeggiate") {
+                  _arpeggioType = "non-arpeggiate";
+                  _e.readNext();
+                  }
+            else if (_e.name() == "ornaments") {
+                  ornaments();
+                  }
+            else if (_e.name() == "slur") {
+                  slur();
+                  }
+            else if (_e.name() == "slide") {
+                  glissandoSlide();
+                  }
+            else if (_e.name() == "technical") {
+                  technical();
+                  }
+            else if (_e.name() == "tied") {
+                  tied();
+                  }
+            else if (_e.name() == "tuplet") {
+                  tuplet();
+                  }
+            else {
+                  skipLogCurrElem();
+                  }
+            }
+
+      for (const auto& notation : _notations) {
+            qDebug("%s", qPrintable(notation.print()));
+            }
+
+      Q_ASSERT(_e.isEndElement() && _e.name() == "notations");
+      }
+
+//---------------------------------------------------------
+//   addToScore
+//---------------------------------------------------------
+
+/**
+ Add the notations found to the score.
  Note that some notations attach to notes only in MuseScore,
  which means trying to attach them to a rest will crash,
  as in that case note is a nullptr.
  */
 
-void MusicXMLParserPass2::notations(Note* note, ChordRest* cr, const int tick,
-                                    MusicXmlTupletDesc& tupletDesc, bool& lastGraceAFter)
+void MusicXMLParserNotations::addToScore(ChordRest* const cr, Note* const note, const int tick, const int track, SlurStack& slurs,
+                                         Glissando* glissandi[MAX_NUMBER_LEVEL][2], MusicXmlSpannerMap& spanners,
+                                         TrillStack& trills, Tie*& tie)
       {
-      Q_ASSERT(_e.isStartElement() && _e.name() == "notations");
+      addArpeggio(cr, _arpeggioType, _logger, &_e);
+      addAllArticulationsToChord(cr, _articulationSymbols);
+      addBreath(cr, cr->tick(), _breath);
+      addFermata(cr, _fermataType, _fermataSymbol);
+      addStrongAccent(cr, _strongAccentType);
+      addWavyLine(cr, tick, _wavyLineNo, _wavyLineType, spanners, trills, _logger, &_e);
 
-      if (cr) {
-            lastGraceAFter = false; // ensure default
-
-            Measure* measure = cr->measure();
-            int ticks = cr->duration().ticks();
-            int track = cr->track();
-
-            QString wavyLineType;
-            int wavyLineNo = 0;
-            QString arpeggioType;
-            SymId breath = SymId::noSym;
-            int tremoloNr = 0;
-            QString tremoloType;
-            QString placement;
-            QStringList dynamicslist;
-            // qreal rx = 0.0;
-            // qreal ry = 0.0;
-            // qreal yoffset = 0.0; // actually this is default-y
-            // qreal xoffset = 0.0; // not used
-            // bool hasYoffset = false;
-            QString chordLineType;
-
-            while (_e.readNextStartElement()) {
-                  if (_e.name() == "slur") {
-                        slur(cr, tick, track, lastGraceAFter);
-                        }
-                  else if (_e.name() == "tied") {
-                        tied(note, track);
-                        }
-                  else if (_e.name() == "tuplet") {
-                        tuplet(tupletDesc);
-                        }
-                  else if (_e.name() == "dynamics") {
-                        placement = _e.attributes().value("placement").toString();
-                        if (preferences.getBool(PREF_IMPORT_MUSICXML_IMPORTLAYOUT)) {
-                              // ry        = ee.attribute(QString("relative-y"), "0").toDouble() * -.1;
-                              // rx        = ee.attribute(QString("relative-x"), "0").toDouble() * .1;
-                              // yoffset   = _e.attributes().value("default-y").toDouble(&hasYoffset) * -0.1;
-                              // xoffset   = ee.attribute("default-x", "0.0").toDouble() * 0.1;
-                              }
-                        dynamics(placement, dynamicslist);
-                        }
-                  else if (_e.name() == "articulations") {
-                        articulations(cr, breath, chordLineType);
-                        }
-                  else if (_e.name() == "fermata")
-                        fermata(cr);
-                  else if (_e.name() == "ornaments") {
-                        ornaments(cr, wavyLineType, wavyLineNo, tremoloType, tremoloNr, lastGraceAFter);
-                        }
-                  else if (_e.name() == "technical") {
-                        technical(note, cr);
-                        }
-                  else if (_e.name() == "arpeggiate") {
-                        arpeggioType = _e.attributes().value("direction").toString();
-                        if (arpeggioType == "") arpeggioType = "none";
-                        _e.readNext();
-                        }
-                  else if (_e.name() == "non-arpeggiate") {
-                        arpeggioType = "non-arpeggiate";
-                        _e.readNext();
-                        }
-                  else if (_e.name() == "glissando" || _e.name() == "slide") {
-                        glissando(note, tick, ticks, track);
-                        }
-                  else
-                        skipLogCurrElem();
+      for (const auto& notation : _notations) {
+            if (notation.name() == "slur") {
+                  addSlur(notation, slurs, cr, tick, _logger, &_e);
                   }
+            else if (notation.name() == "glissando" || notation.name() == "slide") {
+                  if (note) {
+                        addGlissandoSlide(notation, note, glissandi, spanners, _logger, &_e);
+                        }
+                  }
+            else if (notation.name() == "mordent" || notation.name() == "inverted-mordent") {
+                  addMordentToChord(cr, notation.name(),
+                                    notation.attribute("long"),
+                                    notation.attribute("approach"),
+                                    notation.attribute("departure"));
+                  }
+            }
 
-            addArpeggio(cr, arpeggioType, _logger, &_e);
-            addWavyLine(cr, tick, wavyLineNo, wavyLineType, _spanners, _trills, _logger, &_e);
-            addBreath(cr, tick, breath);
-            addTremolo(cr, tremoloNr, tremoloType, ticks, _tremStart, _logger, &_e);
-            addChordLine(note, chordLineType, _logger, &_e);
 
-            // more than one dynamic ???
-            // LVIFIX: check import/export of <other-dynamics>unknown_text</...>
-            // TODO remove duplicate code (see MusicXml::direction)
-            for (QStringList::Iterator it = dynamicslist.begin(); it != dynamicslist.end(); ++it ) {
-                  Dynamic* dyn = new Dynamic(_score);
-                  dyn->setDynamicType(*it);
+      // more than one dynamic ???
+      // LVIFIX: check import/export of <other-dynamics>unknown_text</...>
+      // TODO remove duplicate code (see MusicXml::direction)
+      for (const auto& d : _dynamicsList) {
+            auto dynamic = new Dynamic(_score);
+            dynamic->setDynamicType(d);
 //TODO:ws            if (hasYoffset) dyn->textStyle().setYoff(yoffset);
-                  addElemOffset(dyn, track, placement, measure, tick);
-                  }
-            }
-      else {
-            _logger->logDebugInfo("no note to attach to, skipping notations", &_e);
-            _e.skipCurrentElement();
+            addElemOffset(dynamic, cr->track(), _dynamicsPlacement, cr->measure(), tick);
             }
 
-      Q_ASSERT(_e.isEndElement() && _e.name() == "notations");
+      if (note) {
+            addChordLine(note, _chordLineType, _logger, &_e);
+            addTechnical(note);
+            addTie(_score, note, track, _tiedType, _tiedOrientation, _tiedLineType, tie, _logger, &_e);
+            }
       }
 
 //---------------------------------------------------------
@@ -5967,21 +6143,23 @@ void MusicXMLParserPass2::stem(Direction& sd, bool& nost)
  Note: MusicXML common.mod: "An empty fermata element represents a normal fermata."
  */
 
-void MusicXMLParserPass2::fermata(ChordRest* cr)
+void MusicXMLParserNotations::fermata()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "fermata");
 
-      QString fermataType = _e.attributes().value("type").toString();
-      QString fermata     = _e.readElementText();
+      _fermataType = _e.attributes().value("type").toString();
+      const auto fermataText = _e.readElementText();
 
-      if (fermata == "normal" || fermata == "")
-            addFermata(cr, fermataType, SymId::fermataAbove);
-      else if (fermata == "angled")
-            addFermata(cr, fermataType, SymId::fermataShortAbove);
-      else if (fermata == "square")
-            addFermata(cr, fermataType, SymId::fermataLongAbove);
+      if (fermataText == "normal" || fermataText == "")
+            _fermataSymbol = SymId::fermataAbove;
+      else if (fermataText == "angled")
+            _fermataSymbol = SymId::fermataShortAbove;
+      else if (fermataText == "square")
+            _fermataSymbol = SymId::fermataLongAbove;
       else
-            _logger->logError(QString("unknown fermata '%1'").arg(fermata), &_e);
+            _logger->logError(QString("unknown fermata '%1'").arg(fermataText), &_e);
+
+      Q_ASSERT(_e.isEndElement() && _e.name() == "fermata");
       }
 
 //---------------------------------------------------------
@@ -5992,7 +6170,7 @@ void MusicXMLParserPass2::fermata(ChordRest* cr)
  Parse the /score-partwise/part/measure/note/notations/tuplet node.
  */
 
-void MusicXMLParserPass2::tuplet(MusicXmlTupletDesc& tupletDesc)
+void MusicXMLParserNotations::tuplet()
       {
       Q_ASSERT(_e.isStartElement() && _e.name() == "tuplet");
 
@@ -6005,26 +6183,28 @@ void MusicXMLParserPass2::tuplet(MusicXmlTupletDesc& tupletDesc)
       _e.skipCurrentElement();
 
       if (tupletType == "start")
-            tupletDesc.type = MxmlStartStop::START;
+            _tupletDesc.type = MxmlStartStop::START;
       else if (tupletType == "stop")
-            tupletDesc.type = MxmlStartStop::STOP;
+            _tupletDesc.type = MxmlStartStop::STOP;
       else if (tupletType != "" && tupletType != "start" && tupletType != "stop") {
             _logger->logError(QString("unknown tuplet type '%1'").arg(tupletType), &_e);
             }
 
       // set bracket, leave at default if unspecified
       if (tupletBracket == "yes")
-            tupletDesc.bracket = TupletBracketType::SHOW_BRACKET;
+            _tupletDesc.bracket = TupletBracketType::SHOW_BRACKET;
       else if (tupletBracket == "no")
-            tupletDesc.bracket = TupletBracketType::SHOW_NO_BRACKET;
+            _tupletDesc.bracket = TupletBracketType::SHOW_NO_BRACKET;
 
       // set number, default is "actual" (=NumberType::SHOW_NUMBER)
       if (tupletShowNumber == "both")
-            tupletDesc.shownumber = TupletNumberType::SHOW_RELATION;
+            _tupletDesc.shownumber = TupletNumberType::SHOW_RELATION;
       else if (tupletShowNumber == "none")
-            tupletDesc.shownumber = TupletNumberType::NO_TEXT;
+            _tupletDesc.shownumber = TupletNumberType::NO_TEXT;
       else
-            tupletDesc.shownumber = TupletNumberType::SHOW_NUMBER;
+            _tupletDesc.shownumber = TupletNumberType::SHOW_NUMBER;
+
+      Q_ASSERT(_e.isEndElement() && _e.name() == "tuplet");
       }
 
 //---------------------------------------------------------

--- a/mscore/importxmlfirstpass.h
+++ b/mscore/importxmlfirstpass.h
@@ -68,6 +68,7 @@ public:
       void setPrintAbbr(bool b) { printAbbr = b; }
       bool getPrintAbbr() const { return printAbbr; }
       LyricNumberHandler& lyricNumberHandler() { return _lyricNumberHandler; }
+      const LyricNumberHandler& lyricNumberHandler() const { return _lyricNumberHandler; }
       void setMaxStaff(const int staff);
       int maxStaff() const { return _maxStaff; }
 private:

--- a/mtest/musicxml/io/iotest.single
+++ b/mtest/musicxml/io/iotest.single
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# simple standalone iotest for MusicXML import
+# run in mtest/musicxml/io directory as "./iotest"
+
+# Linux
+#MSCORE=../../../build.debug/mscore/mscore
+# OS X terminal build
+#MSCORE=../../../applebuild/mscore.app/Contents/MacOS/mscore
+# OS X Xcode build
+MSCORE=../../../build.xcode/mscore/Debug/mscore.app/Contents/MacOS/mscore
+
+echo "----------------------------------------------"
+echo "Regression Tests for MuseScore MusicXML import"
+echo "----------------------------------------------"
+echo
+$MSCORE -v
+echo
+
+
+testcount=0
+failures=0
+
+rwtestXml() {
+      echo -n "testing load/save $1";
+      $MSCORE $1 -d -o mops.xml &> /dev/null
+      if diff -q $1 mops.xml &> /dev/null; then
+            echo -e "\r\t\t\t\t\t\t...OK";
+      else
+            echo -e "\r\t\t\t\t\t\t...FAILED";
+            failures=$(($failures+1));
+            #echo "+++++++++DIFF++++++++++++++"
+            diff $1 mops.xml
+            #echo "+++++++++++++++++++++++++++"
+      fi
+      rm mops.xml
+      testcount=$(($testcount+1))
+      }
+
+rwtestXmlRef() {
+      echo -n "testing load/save $1";
+      REF=`basename $1 .xml`_ref.xml
+      $MSCORE $1 -d -o mops.xml &> /dev/null
+      if diff -q $REF mops.xml &> /dev/null; then
+            echo -e "\r\t\t\t\t\t\t...OK";
+      else
+            echo -e "\r\t\t\t\t\t\t...FAILED";
+            failures=$(($failures+1));
+            #echo "+++++++++DIFF++++++++++++++"
+            #diff $REF mops.xml
+            #echo "+++++++++++++++++++++++++++"
+      fi
+      rm mops.xml
+      testcount=$(($testcount+1))
+      }
+
+usage() {
+      echo "usage: $0 <testfile.xml>"
+      echo
+      exit 1
+      }
+
+if [ $# -eq 1 ]; then
+      rwtestXml $1
+else
+      usage
+fi
+
+echo
+echo "$testcount test(s), $failures failure(s)"


### PR DESCRIPTION
This PR contains a significant refactoring of the MusicXML note import code. It untangles note reading from note allocating, enabling better error handling. Next step will be a similar refactoring of the tuplet handling (mostly done, but blocked until this PR is merged). When the tuplet refactoring is done I can finally make the tuplet error handling fail-safe. As especially mscore/importmxmlpass2.cpp is significantly changed, I would appreciate a quick merge into master, to prevent conflicts with other changes.

Notes:
- no functional changes whatsoever
- this contains about three months of work
- all squashed into one commit, see https://github.com/lvinken/MuseScore/tree/musicxml-import-refactoring-001 for the original version