### PR TITLE
build only x64 AppVeyor configuration for master

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,8 @@ cache:
 
 # build platform, i.e. x86, x64, Any CPU. This setting is optional.
 platform:
-  - x86
+#use for releases only
+#  - x86
   - x64
 
 #environment:


### PR DESCRIPTION
To keep available space and optimize CI time