### PR TITLE
fix compiler error in importpdf

### DIFF
--- a/omr/importpdf.cpp
+++ b/omr/importpdf.cpp
@@ -70,7 +70,7 @@ void OmrState::importPdfMeasure(OmrMeasure* m, const OmrSystem* omrSystem)
             score->sigmap()->add(tick.ticks(), SigEvent(timesig));
             }
       measure->setTimesig(timesig);
-      measure->setLen(timesig);
+      measure->setTicks(timesig);
       TDuration d(TDuration::DurationType::V_MEASURE);
       Rest* rest;
       Segment* s = measure->getSegment(SegmentType::ChordRest, tick);


### PR DESCRIPTION
Measure::setLen() was recently changed to Measure::setTicks(). The change in this PR is necessary for the build to succeed if OMR is enabled.