### PR TITLE
fix #282433: numbers only not saved

### DIFF
--- a/libmscore/ottava.cpp
+++ b/libmscore/ottava.cpp
@@ -258,6 +258,7 @@ void Ottava::write(XmlWriter& xml) const
       xml.stag(this);
       xml.tag("subtype", ottavaDefault[int(ottavaType())].name);
       writeProperty(xml, Pid::PLACEMENT);
+      writeProperty(xml, Pid::NUMBERS_ONLY);
 //      for (const StyledProperty& spp : *styledProperties())
 //            writeProperty(xml, spp.pid);
       TextLineBase::writeProperties(xml);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/282433

I'm not sure if this is a bit hacky. I don't think so, because we handle all the other property writing by delegating to `TextLineBase::writeProperties`,  but textlinebase doesn't write `Pid::NUMBERS_ONLY`, so we need to specifically write that here.