### PR TITLE
fix #284347: support Placement property and flip command for fingering

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1428,6 +1428,7 @@ void Score::cmdFlip()
                   }
             else if (e->isTempoText()
                || e->isStaffText()
+               || e->isFingering()
                || e->isDynamic()
                || e->isHairpin()
                || e->isHairpinSegment()

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -29,6 +29,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 static const ElementStyle fingeringStyle {
+      { Sid::fingeringPlacement, Pid::PLACEMENT  },
       };
 
 //---------------------------------------------------------
@@ -68,18 +69,18 @@ ElementType Fingering::layoutType()
 //   calculatePlacement
 //---------------------------------------------------------
 
-void Fingering::calculatePlacement()
+Placement Fingering::calculatePlacement() const
       {
       Note* n = note();
       if (!n)
-            return;
+            return Placement::ABOVE;
       Chord* chord = n->chord();
       Staff* staff = chord->staff();
       Part* part   = staff->part();
       int nstaves  = part->nstaves();
       bool voices  = chord->measure()->hasVoices(staff->idx());
       bool below   = voices ? !chord->up() : (nstaves > 1) && (staff->rstaff() == nstaves - 1);
-      setPlacement(below ? Placement::BELOW : Placement::ABOVE);
+      return below ? Placement::BELOW : Placement::ABOVE;
       }
 
 //---------------------------------------------------------
@@ -221,7 +222,7 @@ QVariant Fingering::propertyDefault(Pid id) const
       {
       switch (id) {
             case Pid::PLACEMENT:
-                  return int(Placement::ABOVE);
+                  return int(calculatePlacement());
             case Pid::SUB_STYLE:
                   return int(Tid::FINGERING);
             default:

--- a/libmscore/fingering.h
+++ b/libmscore/fingering.h
@@ -32,7 +32,7 @@ class Fingering final : public TextBase {
 
       Note* note() const { return toNote(parent()); }
       ElementType layoutType();
-      void calculatePlacement();
+      Placement calculatePlacement() const;
 
       virtual void draw(QPainter*) const override;
       virtual void layout() override;

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2085,7 +2085,8 @@ void Note::layout2()
                   }
             else if (e->isFingering()) {
                   Fingering* f = toFingering(e);
-                  f->calculatePlacement();
+                  if (f->propertyFlags(Pid::PLACEMENT) == PropertyFlags::STYLED)
+                        f->setPlacement(f->calculatePlacement());
                   // layout fingerings that are placed relative to notehead
                   // fingerings placed relative to chord will be laid out later
                   if (f->layoutType() == ElementType::NOTE)

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -1111,6 +1111,8 @@ static const StyleType styleTypes[] {
       { Sid::fermataPosAbove,               "fermataPosAbove",               QPointF(.0, -1.0) },
       { Sid::fermataPosBelow,               "fermataPosBelow",               QPointF(.0, 1.0)  },
       { Sid::fermataMinDistance,            "fermataMinDistance",            Spatium(0.4)  },
+
+      { Sid::fingeringPlacement,            "fingeringPlacement",            int(Placement::ABOVE) },
       };
 
 MStyle  MScore::_baseStyle;

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1088,6 +1088,8 @@ enum class Sid {
       fermataPosBelow,
       fermataMinDistance,
 
+      fingeringPlacement,
+
       STYLES
       };
 

--- a/mscore/inspector/inspectorFingering.cpp
+++ b/mscore/inspector/inspectorFingering.cpp
@@ -22,20 +22,8 @@ namespace Ms {
 //---------------------------------------------------------
 
 InspectorFingering::InspectorFingering(QWidget* parent)
-   : InspectorTextBase(parent)
+   : InspectorStaffText(parent)
       {
-      f.setupUi(addWidget());
-
-      const std::vector<InspectorItem> iiList = {
-            { Pid::SUB_STYLE, 0, f.style,     f.resetStyle     },
-            };
-      const std::vector<InspectorPanel> ppList = {
-            { f.title, f.panel }
-            };
-
-      populateStyle(f.style);
-
-      mapSignals(iiList, ppList);
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspectorFingering.h
+++ b/mscore/inspector/inspectorFingering.h
@@ -13,8 +13,8 @@
 #ifndef __INSPECTOR_FINGERING_H__
 #define __INSPECTOR_FINGERING_H__
 
-#include "inspectorTextBase.h"
-#include "ui_inspector_fingering.h"
+#include "inspector.h"
+#include "ui_inspector_stafftext.h"
 
 namespace Ms {
 
@@ -22,10 +22,8 @@ namespace Ms {
 //   InspectorFingering
 //---------------------------------------------------------
 
-class InspectorFingering : public InspectorTextBase {
+class InspectorFingering : public InspectorStaffText {
       Q_OBJECT
-
-      Ui::InspectorFingering f;
 
    public:
       InspectorFingering(QWidget* parent);

--- a/mtest/guitarpro/fingering.gp4-ref.mscx
+++ b/mtest/guitarpro/fingering.gp4-ref.mscx
@@ -601,7 +601,6 @@
                   <linked>
                     <indexDiff>5</indexDiff>
                     </linked>
-                  <placement>below</placement>
                   <text>T</text>
                   </Fingering>
                 <pitch>62</pitch>
@@ -620,7 +619,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>1</text>
                   </Fingering>
                 <pitch>53</pitch>
@@ -639,7 +637,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>2</text>
                   </Fingering>
                 <pitch>47</pitch>
@@ -658,7 +655,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>3</text>
                   </Fingering>
                 <pitch>55</pitch>
@@ -681,7 +677,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>4</text>
                   </Fingering>
                 <pitch>59</pitch>
@@ -700,7 +695,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>T</text>
                   </Fingering>
                 <pitch>51</pitch>
@@ -719,7 +713,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>I</text>
                   </Fingering>
                 <pitch>61</pitch>
@@ -738,7 +731,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>M</text>
                   </Fingering>
                 <pitch>52</pitch>
@@ -761,7 +753,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>A</text>
                   </Fingering>
                 <pitch>55</pitch>
@@ -780,7 +771,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>O</text>
                   </Fingering>
                 <pitch>56</pitch>

--- a/mtest/guitarpro/fingering.gp5-ref.mscx
+++ b/mtest/guitarpro/fingering.gp5-ref.mscx
@@ -601,7 +601,6 @@
                   <linked>
                     <indexDiff>5</indexDiff>
                     </linked>
-                  <placement>below</placement>
                   <text>T</text>
                   </Fingering>
                 <pitch>62</pitch>
@@ -620,7 +619,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>1</text>
                   </Fingering>
                 <pitch>53</pitch>
@@ -639,7 +637,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>2</text>
                   </Fingering>
                 <pitch>47</pitch>
@@ -658,7 +655,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>3</text>
                   </Fingering>
                 <pitch>55</pitch>
@@ -681,7 +677,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>4</text>
                   </Fingering>
                 <pitch>59</pitch>
@@ -700,7 +695,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>T</text>
                   </Fingering>
                 <pitch>51</pitch>
@@ -719,7 +713,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>I</text>
                   </Fingering>
                 <pitch>61</pitch>
@@ -738,7 +731,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>M</text>
                   </Fingering>
                 <pitch>52</pitch>
@@ -761,7 +753,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>A</text>
                   </Fingering>
                 <pitch>55</pitch>
@@ -780,7 +771,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>O</text>
                   </Fingering>
                 <pitch>56</pitch>

--- a/mtest/guitarpro/fingering.gpx-ref.mscx
+++ b/mtest/guitarpro/fingering.gpx-ref.mscx
@@ -721,7 +721,6 @@
                   <linked>
                     <indexDiff>5</indexDiff>
                     </linked>
-                  <placement>below</placement>
                   <text>O</text>
                   </Fingering>
                 <pitch>62</pitch>
@@ -740,7 +739,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>t</text>
                   </Fingering>
                 <pitch>53</pitch>
@@ -759,7 +757,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>1</text>
                   </Fingering>
                 <pitch>47</pitch>
@@ -778,7 +775,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>2</text>
                   </Fingering>
                 <pitch>55</pitch>
@@ -801,7 +797,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>3</text>
                   </Fingering>
                 <pitch>59</pitch>
@@ -820,7 +815,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>4</text>
                   </Fingering>
                 <pitch>51</pitch>
@@ -839,7 +833,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>P</text>
                   </Fingering>
                 <pitch>61</pitch>
@@ -858,7 +851,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>I</text>
                   </Fingering>
                 <pitch>52</pitch>
@@ -881,7 +873,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>M</text>
                   </Fingering>
                 <pitch>55</pitch>
@@ -900,7 +891,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>A</text>
                   </Fingering>
                 <pitch>56</pitch>
@@ -919,7 +909,6 @@
                 <Fingering>
                   <linked>
                     </linked>
-                  <placement>below</placement>
                   <text>C</text>
                   </Fingering>
                 <pitch>52</pitch>

--- a/mtest/libmscore/parts/voices-ref.mscx
+++ b/mtest/libmscore/parts/voices-ref.mscx
@@ -295,7 +295,6 @@
               <linkedMain/>
               <Fingering>
                 <linkedMain/>
-                <placement>below</placement>
                 <offset x="1.05809" y="-4.67501"/>
                 <text>2</text>
                 </Fingering>
@@ -712,7 +711,6 @@
               <linkedMain/>
               <Fingering>
                 <linkedMain/>
-                <placement>below</placement>
                 <offset x="1.05809" y="-4.67501"/>
                 <text>2</text>
                 </Fingering>


### PR DESCRIPTION
My previous fingering layout PR (merged for 3.0.2) implemented 90% of what was needed to allow the user to place fingerings above or below the staff via the "X" command or the Inspector.  Should have just done the rest then, but better late than never.