### PR TITLE
fix #284383: Integer division by zero exception in Fraction::ticks()

### DIFF
--- a/mscore/continuouspanel.cpp
+++ b/mscore/continuouspanel.cpp
@@ -326,7 +326,7 @@ void ContinuousPanel::paint(const QRect&, QPainter& painter)
 
                   // Draw staff lines
                   StaffLines newStaffLines(*toStaffLines(e));
-                  newStaffLines.setParent(parent);
+                  newStaffLines.setParent(parent->measure());
                   newStaffLines.setTrack(e->track());
                   newStaffLines.layoutForWidth(bg.width());
                   newStaffLines.setColor(color);


### PR DESCRIPTION
Fixes https://musescore.org/en/node/284383.