### PR TITLE
Update_Timeline_Tempo

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -329,7 +329,7 @@ void TRowLabels::restrict_scroll(int value)
             if (graphics_rect_item) {
                   QRectF rectf = graphics_rect_item->rect();
                   rectf.setY(qreal(scrollbar_value + y));
-                  rectf.setHeight(20);
+                  rectf.setHeight(25);
                   graphics_rect_item->setRect(rectf);
                   }
             else if (graphics_line_item) {

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -329,7 +329,7 @@ void TRowLabels::restrict_scroll(int value)
             if (graphics_rect_item) {
                   QRectF rectf = graphics_rect_item->rect();
                   rectf.setY(qreal(scrollbar_value + y));
-                  rectf.setHeight(25);
+                  rectf.setHeight(20);
                   graphics_rect_item->setRect(rectf);
                   }
             else if (graphics_line_item) {
@@ -1466,9 +1466,14 @@ bool Timeline::addMetaValue(int x, int pos, QString meta_text, int row, ElementT
             graphics_text_item->setY(grid_height * row + verticalScrollBar()->value() - 2);
             item_to_add = graphics_text_item;
             }
+      else if (row == 0 ) {
+            graphics_text_item->setX(x);
+            graphics_text_item->setY(grid_height * row + verticalScrollBar()->value() - 6);
+            item_to_add = graphics_text_item;
+            }
       else {
             graphics_text_item->setX(x);
-            graphics_text_item->setY(grid_height * row + verticalScrollBar()->value());
+            graphics_text_item->setY(grid_height * row + verticalScrollBar()->value() - 1);
             item_to_add = graphics_text_item;
             }
 

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -115,8 +115,8 @@ class TRowLabels : public QGraphicsView {
 class Timeline : public QGraphicsView {
       Q_OBJECT
 
-      int grid_width = 20;
-      int grid_height = 20;
+      int grid_width = 25;
+      int grid_height = 25;
       int max_zoom = 50;
       int min_zoom = 5;
       int spacing = 5;

--- a/mscore/timeline.h
+++ b/mscore/timeline.h
@@ -115,8 +115,8 @@ class TRowLabels : public QGraphicsView {
 class Timeline : public QGraphicsView {
       Q_OBJECT
 
-      int grid_width = 25;
-      int grid_height = 25;
+      int grid_width = 20;
+      int grid_height = 20;
       int max_zoom = 50;
       int min_zoom = 5;
       int spacing = 5;


### PR DESCRIPTION
Changed the height of the cell in order to prevent the crossing over of the grid lines on the Tempo Segment.
Before:
![timeline](https://user-images.githubusercontent.com/41850468/53029331-99180780-348e-11e9-93e3-c97a2bc98ffe.png)
 After:
![timeline2](https://user-images.githubusercontent.com/41850468/53029344-a33a0600-348e-11e9-9d47-082727eb6a45.png)
