### PR TITLE
fix #284345, fix #281127: interpretation of grand staff distance

### DIFF
--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -442,6 +442,17 @@ void System::layout2()
             Staff* staff2  = score()->staff(si2);
             qreal dist     = h;
 
+#if 1
+            if (staff->part() == staff2->part()) {
+                  Measure* m = firstMeasure();
+                  qreal mag = m ? staff->mag(m->tick()) : 1.0;
+                  dist += akkoladeDistance * mag;
+                  }
+            else {
+                  dist += staffDistance;
+                  }
+#else
+            // TODO: provide style setting or brace property to allow braces to also define a grand staff
             switch (staff2->innerBracket()) {
                   case BracketType::BRACE:
                         dist += akkoladeDistance;
@@ -453,6 +464,7 @@ void System::layout2()
                         dist += staffDistance;
                         break;
                   }
+#endif
             dist += staff2->userDist();
 #if 0
             for (MeasureBase* mb : ml) {


### PR DESCRIPTION
See https://musescore.org/en/node/281127 and https://musescore.org/en/node/284345.

My change here addresses the first by reverting the basic change to how we interpret grand staff distance: in 2.3.2, it was "staves that are part of the same instrument", in 3.0 thus far, it is "staves that are connected by a curly brace".  No one seems to like the change, so I have reverted it but left the old code ifdef'ed out should we wish to provide this behavior as an option somehow.  Meanwhile, I have also implemented scaling for grand staff distance so small staves get smaller space, as per the second of the two linked issues.

Here is the result.  The score uses a grand staff distance of 5 sp and a staff distance of 8 sp.  Recorder is small but the distance is not scaled because this is staff distance.  SA and TB are different instruments so they use staff distance despite being connected by a curly brace.  All three staves of the organ obey grand staff distance even though not connected by a curly brace, and since it is small, the distance is scaled, but not the distance to the cello below.

![image](https://user-images.githubusercontent.com/1799936/53036542-2e86ad80-3435-11e9-9693-ba01bb85a110.png)
