### PR TITLE
fix #284380: articulations on beamed notes

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2647,10 +2647,6 @@ void Score::getNextMeasure(LayoutContext& lc)
                                           if (l)
                                                 l->layout();
                                           }
-                                    if (cr->isChord()) {
-                                          Chord* c = toChord(cr);
-                                          c->layoutArticulations();
-                                          }
                                     }
                               }
                         }
@@ -3625,8 +3621,11 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                         continue;
                   ChordRest* cr = toChordRest(e);
                   // articulations
-                  if (cr->isChord())
-                        toChord(cr)->layoutArticulations2();
+                  if (cr->isChord()) {
+                        Chord* c = toChord(cr);
+                        c->layoutArticulations();
+                        c->layoutArticulations2();
+                        }
                   // tuplets
                   // sanity check
                   if (notTopBeam(cr))


### PR DESCRIPTION
This has been broken a long time, at least for the alpha, so not related to my changes during the beta, but I'm quite surprised I didn't notice this.  Anyhow, layout of staccato and tenuto on the stem side of beamed notes (eg, in multivoice context) is very bad.  That is because we are doing it before we calculate the true stem lengths based on the beam angle.  So we can get things like this:

![image](https://user-images.githubusercontent.com/1799936/53050319-4a4e7b80-3456-11e9-8b98-a94ae3ac3a78.png)

This PR gives us what we want, which is this:

![image](https://user-images.githubusercontent.com/1799936/53050501-ab764f00-3456-11e9-868b-46002f712a7c.png)

All I did was move the layoutArticulations() call to after beams are laid out - actually right before the call to layoutArticulations2().  In principle, these two functions could probably be merged, but that's a bit riskier I think.  The first mostly handles "close to stem" articulations but also does some more general handling like setting direction for everything.