### PR TITLE
fix #280428: tab beams added to skyline

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2161,6 +2161,8 @@ void Chord::layoutTablature()
                   score()->undo(new RemoveElement(_stem));
             if (_hook)
                   score()->undo(new RemoveElement(_hook));
+            if (_beam)
+                  score()->undo(new RemoveElement(_beam));
             }
       // if stem is required but missing, add it;
       // set stem position (stem length is set in Chord:layoutStem() )


### PR DESCRIPTION
Beams that were added at one point and then removed (eg, on a change of staff style settings to a stemless style) never *truly* got removed.  So they still got added to the skyline.  I could have elected to just check before adding them to the skyline if they really need to be there, but what I did here seems the more correct solution, actually removing them along the stems.  Decent chance this fixes some other obscure bugs along the way.