### PR TITLE
Change midi ticks to Fractions in interface for various classes:

### DIFF
--- a/libmscore/check.cpp
+++ b/libmscore/check.cpp
@@ -117,35 +117,33 @@ qDebug("checkScore: remove empty ChordRest segment");
                               }
 #if 0
                         if (cr->tick() > tick) {
-                              int ttick = tick;
-                              int ticks = cr->tick() - tick;
+                              Fraction ttick = tick;
+                              Fraction ticks = cr->tick() - tick;
 
-                              Fraction f = Fraction::fromTicks(ticks) / st->timeStretch(ttick);
+                              Fraction f = ticks / st->timeStretch(ttick);
                               qDebug("  insert %d/%d", f.numerator(), f.denominator());
 
-                              while (ticks > 0) {
+                              while (ticks > Fraction(0,1)) {
                                     Measure* m = tick2measure(ttick);
-                                    int len    = ticks;
+                                    Fraction len    = ticks;
                                     // split notes on measure boundary
                                     if ((ttick + len) > m->tick() + m->ticks())
                                           len = m->tick() + m->ticks() - ttick;
                                     Fraction timeStretch = st->timeStretch(ttick);
-                                    Fraction ff          = Fraction::fromTicks(len);
-qDebug("    - insert %d/%d", ff.numerator(), ff.denominator());
+                                    Fraction ff          = len;
                                     if (ff.numerator() == 0)
                                           break;
                                     Fraction fff = ff / timeStretch;
 
-                                    for (const Duration& d, toDurationList(fff, true)) {
+                                    for (const TDuration& d : toDurationList(fff, true)) {
                                           Rest* rest = new Rest(this);
                                           rest->setDurationType(d);
-                                          rest->setDuration(d.fraction());
+                                          rest->setTicks(d.fraction());
                                           rest->setColor(Qt::red);
-qDebug("    -   Rest %d/%d", d.fraction().numerator(), d.fraction().denominator());
                                           rest->setTrack(track);
-                                          Segment* s = m->getSegment(rest, ttick);
+                                          Segment* s = m->getSegment(SegmentType::ChordRest, ttick);
                                           s->add(rest);
-                                          ttick += (d.fraction() * timeStretch).ticks();
+                                          ttick += d.fraction() * timeStretch;
                                           }
                                     ticks -= len;
                                     }
@@ -155,7 +153,6 @@ qDebug("    -   Rest %d/%d", d.fraction().numerator(), d.fraction().denominator(
                         }
                   Fraction timeStretch = st->timeStretch(tick);
                   Fraction f = cr->globalTicks() * timeStretch;
-//                  qDebug("%s %d + %d = %d", cr->name(), tick, f.ticks(), tick + f.ticks());
                   tick      += f;
                   lcr        = cr;
                   }

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -293,8 +293,6 @@ bool ChordRest::readProperties(XmlReader& e)
             QPointF pt = e.readPoint();
             setOffset(pt * spatium());
             }
-//      else if (tag == "offset")
-//            DurationElement::readProperties(e);
       else if (!DurationElement::readProperties(e))
             return false;
       return true;

--- a/libmscore/cleflist.cpp
+++ b/libmscore/cleflist.cpp
@@ -73,11 +73,11 @@ Fraction ClefList::nextClefTick(const Fraction& tick) const
       {
       if (empty())
             return Fraction(-1, 1);
-//      auto i = upper_bound(tick+1);
-//      auto i = upper_bound(TimePosition(tick + Fraction::fromTicks(1)));
+//      auto i = upper_bound(tick + Fraction::fromTicks(1));
       auto i = upper_bound(TimePosition(tick));
       if (i == end())
-            return Fraction(-1, 1);
+            return -1_Fr;
+
       return i->first.tick();
       }
 }

--- a/libmscore/cleflist.cpp
+++ b/libmscore/cleflist.cpp
@@ -39,11 +39,11 @@ bool ClefTypeList::operator!=(const ClefTypeList& t) const
 //   clef
 //---------------------------------------------------------
 
-ClefTypeList ClefList::clef(int tick) const
+ClefTypeList ClefList::clef(const Fraction& tick) const
       {
       if (empty())
             return ClefTypeList(ClefType::INVALID, ClefType::INVALID);
-      auto i = upper_bound(tick);
+      auto i = upper_bound(TimePosition(tick));
       if (i == begin())
             return ClefTypeList(ClefType::INVALID, ClefType::INVALID);
       return (--i)->second;
@@ -53,11 +53,11 @@ ClefTypeList ClefList::clef(int tick) const
 //   setClef
 //---------------------------------------------------------
 
-void ClefList::setClef(int tick, ClefTypeList ctl)
+void ClefList::setClef(const Fraction& tick, ClefTypeList ctl)
       {
       auto i = find(tick);
       if (i == end())
-            insert(std::pair<int, ClefTypeList>(tick, ctl));
+            insert(tick, ctl);
       else
             i->second = ctl;
       }
@@ -69,14 +69,16 @@ void ClefList::setClef(int tick, ClefTypeList ctl)
 //    return -1, if no such clef
 //---------------------------------------------------------
 
-int ClefList::nextClefTick(int tick) const
+Fraction ClefList::nextClefTick(const Fraction& tick) const
       {
       if (empty())
-            return -1;
-      auto i = upper_bound(tick+1);
+            return Fraction(-1, 1);
+//      auto i = upper_bound(tick+1);
+//      auto i = upper_bound(TimePosition(tick + Fraction::fromTicks(1)));
+      auto i = upper_bound(TimePosition(tick));
       if (i == end())
-            return -1;
-      return i->first;
+            return Fraction(-1, 1);
+      return i->first.tick();
       }
 }
 

--- a/libmscore/cleflist.h
+++ b/libmscore/cleflist.h
@@ -13,7 +13,7 @@
 #ifndef __CLEFLIST_H__
 #define __CLEFLIST_H__
 
-#include "mscore.h"
+#include "types.h"
 #include "clef.h"
 
 namespace Ms {
@@ -22,14 +22,34 @@ class Score;
 
 //---------------------------------------------------------
 //   ClefList
+//    hide std::map interface
 //---------------------------------------------------------
 
-class ClefList : public std::map<int, ClefTypeList> {
+typedef std::map<TimePosition, ClefTypeList> ClefMap;
+
+class ClefList : ClefMap {
+
    public:
       ClefList() {}
-      ClefTypeList clef(int tick) const;
-      void setClef(int tick, ClefTypeList);
-      int nextClefTick(int tick) const;
+      ClefTypeList clef(const Fraction&) const;
+      void setClef(const Fraction&, ClefTypeList);
+      Fraction nextClefTick(const Fraction&) const;
+
+      void erase(const Fraction& t)                    { ClefMap::erase(TimePosition(t));}
+      void erase(const Fraction& b, const Fraction& e) { ClefMap::erase(lower_bound(b), lower_bound(e)); }
+      void erase(iterator i)                           { ClefMap::erase(i); }
+      void clear()                                     { ClefMap::clear(); }
+
+      iterator lower_bound(const Fraction& t)          { return ClefMap::lower_bound(TimePosition(t)); }
+      iterator begin()                                 { return ClefMap::begin(); }
+      const_iterator begin() const                     { return ClefMap::begin(); }
+      iterator end()                                   { return ClefMap::end(); }
+      const_iterator end() const                       { return ClefMap::end(); }
+
+      void insert(iterator a, iterator b)              { ClefMap::insert(a, b); }
+      void insert(const Fraction& f, ClefTypeList c)   { ClefMap::insert(std::pair<TimePosition, ClefTypeList>(TimePosition(f), c)); }
+
+      bool empty() const                               { return ClefMap::empty(); }
       };
 
 }     // namespace Ms

--- a/libmscore/cleflist.h
+++ b/libmscore/cleflist.h
@@ -15,6 +15,7 @@
 
 #include "types.h"
 #include "clef.h"
+#include "timeposition.h"
 
 namespace Ms {
 

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -756,7 +756,7 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
                   mf = s ? 0 : mf->nextMeasure();
                   }
             else {
-                  if (sigmap()->timesig(seg->tick().ticks()).nominal().identical(ns)) {
+                  if (sigmap()->timesig(seg->tick()).nominal().identical(ns)) {
                         // no change to global time signature,
                         // but we need to rewrite any staves with local time signatures
                         for (int i = 0; i < nstaves(); ++i) {
@@ -1062,7 +1062,7 @@ void Score::regroupNotesAndRests(const Fraction& startTick, const Fraction& endT
                                           break;
                                     measure = segment->measure();
                                     std::vector<TDuration> dl;
-                                    dl = toRhythmicDurationList(dd, false, segment->rtick(), sigmap()->timesig(tick.ticks()).nominal(), measure, 1);
+                                    dl = toRhythmicDurationList(dd, false, segment->rtick(), sigmap()->timesig(tick).nominal(), measure, 1);
                                     size_t n = dl.size();
                                     for (size_t i = 0; i < n; ++i) {
                                           const TDuration& d = dl[i];
@@ -2614,7 +2614,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
       else
             tick = last() ? last()->endTick() : Fraction(0,1);
 
-      Fraction f       = sigmap()->timesig(tick.ticks()).nominal(); // use nominal time signature of current measure
+      Fraction f       = sigmap()->timesig(tick).nominal(); // use nominal time signature of current measure
       Measure* om      = 0;                                       // measure base in "this" score
       MeasureBase* rmb = 0;                                       // measure base in root score (for linking)
       Fraction ticks   = { 0, 1 };

--- a/libmscore/fraction.h
+++ b/libmscore/fraction.h
@@ -15,7 +15,6 @@
 #ifndef __FRACTION_H__
 #define __FRACTION_H__
 
-#include "config.h"
 #include "mscore.h"
 
 namespace Ms {
@@ -38,13 +37,11 @@ static int_least64_t gcd(int_least64_t a, int_least64_t b)
       return (a >= 0 ? a : -a);
       }
 
-
 //---------------------------------------------------------
 //   Fraction
 //---------------------------------------------------------
 
 class Fraction {
-
       // ensure 64 bit to avoid overflows in comparisons
       int_least64_t _numerator   { 0 };
       int_least64_t _denominator { 1 };
@@ -58,6 +55,7 @@ class Fraction {
       // no implicit conversion from int to Fraction:
       constexpr Fraction()  {}
       constexpr Fraction(int z, int n) : _numerator { n < 0 ? -z : z }, _denominator { n < 0 ? -n : n } { }
+      explicit constexpr Fraction(int z) : _numerator(z) {}
 #endif
       int numerator() const      { return _numerator;           }
       int denominator() const    { return _denominator;         }
@@ -76,7 +74,10 @@ class Fraction {
 
       bool isZero() const        { return _numerator == 0;      }
       bool isNotZero() const     { return _numerator != 0;      }
-
+      bool gtZero() const        { return _numerator > 0;       }
+      bool geZero() const        { return _numerator >= 0;      }
+      bool ltZero() const        { return _numerator < 0;       }
+      bool leZero() const        { return _numerator <= 0;      }
       bool isValid() const       { return _denominator != 0;    }
 
       // check if two fractions are identical (numerator & denominator)
@@ -88,7 +89,6 @@ class Fraction {
 
       Fraction absValue() const  {
             return Fraction(qAbs(_numerator), _denominator); }
-
 
       // --- reduction --- //
 
@@ -102,7 +102,7 @@ class Fraction {
             {
             const int g = gcd(_numerator, _denominator);
             return Fraction(_numerator / g, _denominator / g);
-            }      
+            }
 
       // --- comparison --- //
 
@@ -230,8 +230,6 @@ class Fraction {
             return static_cast<int>(result);
             }
 
-
-
       QString print() const     { return QString("%1/%2").arg(_numerator).arg(_denominator); }
       QString toString() const  { return print(); }
       operator QVariant() const { return QVariant::fromValue(*this); }
@@ -239,6 +237,8 @@ class Fraction {
 
  inline Fraction operator*(const Fraction& f, int v) { return Fraction(f) *= v; }
  inline Fraction operator*(int v, const Fraction& f) { return Fraction(f) *= v; }
+
+constexpr Fraction operator "" _Fr(unsigned long long i) { return Fraction(static_cast<int_least64_t>(i), 1); };
 
 }     // namespace Ms
 

--- a/libmscore/keylist.cpp
+++ b/libmscore/keylist.cpp
@@ -22,14 +22,14 @@ namespace Ms {
 //    locates the key sig currently in effect at tick
 //---------------------------------------------------------
 
-KeySigEvent KeyList::key(int tick) const
+KeySigEvent KeyList::key(const Fraction& tick) const
       {
       KeySigEvent ke;
       ke.setKey(Key::C);
 
       if (empty())
             return ke;
-      auto i = upper_bound(tick);
+      auto i = upper_bound(TimePosition(tick));
       if (i == begin())
             return ke;
       return (--i)->second;
@@ -39,11 +39,11 @@ KeySigEvent KeyList::key(int tick) const
 //   setKey
 //---------------------------------------------------------
 
-void KeyList::setKey(int tick, KeySigEvent k)
+void KeyList::setKey(const Fraction& tick, KeySigEvent k)
       {
-      auto i = find(tick);
+      auto i = find(TimePosition(tick));
       if (i == end())
-            insert(std::pair<int, KeySigEvent>(tick, k));
+            insert(std::pair<TimePosition, KeySigEvent>(TimePosition(tick), k));
       else
             i->second = k;
       }
@@ -55,12 +55,13 @@ void KeyList::setKey(int tick, KeySigEvent k)
 //    return -1, if no such a key sig
 //---------------------------------------------------------
 
-int KeyList::nextKeyTick(int tick) const
+Fraction KeyList::nextKeyTick(const Fraction& tick) const
       {
       if (empty())
-            return -1;
-      auto i = upper_bound(tick+1);
-      return i == end() ? -1 : i->first;
+            return Fraction(-1, 1);
+//      auto i = upper_bound(tick+1);
+      auto i = upper_bound(TimePosition(tick));
+      return i == end() ? Fraction(-1,1) : i->first.tick();
       }
 
 //---------------------------------------------------------
@@ -69,14 +70,14 @@ int KeyList::nextKeyTick(int tick) const
 //    returns the key before the current key for tick
 //---------------------------------------------------------
 
-KeySigEvent KeyList::prevKey(int tick) const
+KeySigEvent KeyList::prevKey(const Fraction& tick) const
       {
       KeySigEvent kc;
       kc.setKey(Key::C);
 
       if (empty())
             return kc;
-      auto i = upper_bound(tick);
+      auto i = upper_bound(TimePosition(tick));
       if (i == begin())
             return kc;
       --i;
@@ -92,15 +93,15 @@ KeySigEvent KeyList::prevKey(int tick) const
 //    in effect at tick
 //---------------------------------------------------------
 
-int KeyList::currentKeyTick(int tick) const
+Fraction KeyList::currentKeyTick(const Fraction& tick) const
       {
       if (empty())
-            return 0;
-      auto i = upper_bound(tick);
+            return Fraction(0,1);
+      auto i = upper_bound(TimePosition(tick));
       if (i == begin())
-            return 0;
+            return Fraction(0,1);
       --i;
-      return i->first;
+      return i->first.tick();
       }
 
 //---------------------------------------------------------
@@ -119,7 +120,7 @@ void KeyList::read(XmlReader& e, Score* cs)
                         k = Key(e.intAttribute("idx"));
                   KeySigEvent ke;
                   ke.setKey(k);
-                  (*this)[cs->fileDivision(tick)] = ke;
+                  (*this)[TimePosition(Fraction::fromTicks(cs->fileDivision(tick)))] = ke;
                   e.readNext();
                   }
             else

--- a/libmscore/keylist.h
+++ b/libmscore/keylist.h
@@ -13,6 +13,7 @@
 #ifndef __KEYLIST_H__
 #define __KEYLIST_H__
 
+#include "types.h"
 #include "key.h"
 
 namespace Ms {
@@ -25,16 +26,24 @@ class XmlReader;
 //    to keep track of key signature changes
 //---------------------------------------------------------
 
-class KeyList : public std::map<const int, KeySigEvent> {
+typedef std::map<TimePosition, KeySigEvent> KeyMap;
+
+class KeyList : public KeyMap {
 
    public:
-      KeyList() {}
-      KeySigEvent key(int tick) const;
-      KeySigEvent prevKey(int tick) const;
-      void setKey(int tick, KeySigEvent);
-      int nextKeyTick(int tick) const;
-      int currentKeyTick(int tick) const;
+      KeySigEvent key(const Fraction& tick) const;
+      KeySigEvent prevKey(const Fraction& tick) const;
+      void setKey(const Fraction& tick, KeySigEvent);
+      Fraction nextKeyTick(const Fraction& tick) const;
+      Fraction currentKeyTick(const Fraction& tick) const;
+
       void read(XmlReader&, Score*);
+
+      iterator lower_bound(const Fraction& t)          { return KeyMap::lower_bound(TimePosition(t)); }
+      iterator begin()                                 { return KeyMap::begin(); }
+      const_iterator begin() const                     { return KeyMap::begin(); }
+      iterator end()                                   { return KeyMap::end(); }
+      const_iterator end() const                       { return KeyMap::end(); }
       };
 
 }

--- a/libmscore/keylist.h
+++ b/libmscore/keylist.h
@@ -15,6 +15,7 @@
 
 #include "types.h"
 #include "key.h"
+#include "timeposition.h"
 
 namespace Ms {
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2739,11 +2739,11 @@ void Score::getNextMeasure(LayoutContext& lc)
                               }
                         }
                   if (stretch != 0.0 && stretch != 1.0) {
-                        qreal otempo = tempomap()->tempo(segment.tick().ticks());
+                        qreal otempo = tempomap()->tempo(segment.tick());
                         qreal ntempo = otempo / stretch;
                         setTempo(segment.tick(), ntempo);
                         Fraction etick = segment.tick() + segment.ticks() - Fraction(1, 480*4);
-                        auto e = tempomap()->find(etick.ticks());
+                        auto e = tempomap()->find(etick);
                         if (e == tempomap()->end())
                               setTempo(etick, otempo);
                         }
@@ -2764,7 +2764,7 @@ void Score::getNextMeasure(LayoutContext& lc)
                   lc.sig = measure->mmRestFirst()->ticks();
             else
                   lc.sig = measure->ticks();
-            sigmap()->add(lc.tick.ticks(), SigEvent(lc.sig, measure->timesig(), measure->no()));
+            sigmap()->add(lc.tick, SigEvent(lc.sig, measure->timesig(), measure->no()));
             }
 
       Segment* seg = measure->findSegmentR(SegmentType::StartRepeatBarLine, Fraction(0,1));

--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -659,11 +659,11 @@ void LayoutContext::layoutMeasureLinear(MeasureBase* mb)
                               stretch = qMax(stretch, toFermata(e)->timeStretch());
                         }
                   if (stretch != 0.0 && stretch != 1.0) {
-                        qreal otempo = score->tempomap()->tempo(segment.tick().ticks());
+                        qreal otempo = score->tempomap()->tempo(segment.tick());
                         qreal ntempo = otempo / stretch;
                         score->setTempo(segment.tick(), ntempo);
                         Fraction etick = segment.tick() + segment.ticks() - Fraction(1, 480*4);
-                        auto e = score->tempomap()->find(etick.ticks());
+                        auto e = score->tempomap()->find(etick);
                         if (e == score->tempomap()->end())
                               score->setTempo(etick, otempo);
                         }
@@ -690,7 +690,7 @@ void LayoutContext::layoutMeasureLinear(MeasureBase* mb)
                   sig = measure->mmRestFirst()->ticks();
             else
                   sig = measure->ticks();
-            score->sigmap()->add(tick.ticks(), SigEvent(sig, measure->timesig(), measure->no()));
+            score->sigmap()->add(tick, SigEvent(sig, measure->timesig(), measure->no()));
             }
 
       Segment* seg = measure->findSegmentR(SegmentType::StartRepeatBarLine, Fraction(0,1));

--- a/libmscore/mcursor.cpp
+++ b/libmscore/mcursor.cpp
@@ -120,7 +120,7 @@ TimeSig* MCursor::addTimeSig(const Fraction& f)
             ts->setTrack(i * VOICES);
             segment->add(ts);
             }
-      _score->sigmap()->add(_tick.ticks(), SigEvent(f));
+      _score->sigmap()->add(_tick, SigEvent(f));
       return ts;
       }
 

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1868,8 +1868,8 @@ void Measure::read(XmlReader& e, int staffIdx)
             else
                   qDebug("illegal measure size <%s>", qPrintable(e.attribute("len")));
             irregular = true;
-            score()->sigmap()->add(tick().ticks(), SigEvent(_len, _timesig));
-            score()->sigmap()->add((tick() + ticks()).ticks(), SigEvent(_timesig));
+            score()->sigmap()->add(tick(), SigEvent(_len, _timesig));
+            score()->sigmap()->add((endTick()), SigEvent(_timesig));
             }
       else
             irregular = false;
@@ -2153,12 +2153,12 @@ void Measure::readVoice(XmlReader& e, int staffIdx, bool irregular)
                         _timesig    = ts->sig() / timeStretch;
 
                         if (irregular) {
-                              score()->sigmap()->add(tick().ticks(), SigEvent(_len, _timesig));
-                              score()->sigmap()->add((tick() + ticks()).ticks(), SigEvent(_timesig));
+                              score()->sigmap()->add(tick(), SigEvent(_len, _timesig));
+                              score()->sigmap()->add(endTick(), SigEvent(_timesig));
                               }
                         else {
                               _len = _timesig;
-                              score()->sigmap()->add(tick().ticks(), SigEvent(_timesig));
+                              score()->sigmap()->add(tick(), SigEvent(_timesig));
                               }
                         }
                   }
@@ -2404,7 +2404,7 @@ bool Measure::isFinalMeasureOfSection() const
 
 bool Measure::isAnacrusis() const
       {
-      TimeSigFrac timeSig = score()->sigmap()->timesig(tick().ticks()).nominal();
+      TimeSigFrac timeSig = score()->sigmap()->timesig(tick()).nominal();
       return irregular() && ticks() < Fraction::fromTicks(timeSig.ticksPerMeasure());
       }
 

--- a/libmscore/pos.cpp
+++ b/libmscore/pos.cpp
@@ -116,11 +116,11 @@ void Pos::setType(TType t)
 
       if (_type == TType::TICKS) {
             // convert from ticks to frames
-            _frame = tempo->tick2time(_tick, _frame, &sn) * MScore::sampleRate;
+            _frame = tempo->tick2time(Fraction::fromTicks(_tick), _frame, &sn) * MScore::sampleRate;
             }
       else {
             // convert from frames to ticks
-            _tick = tempo->time2tick(_frame / MScore::sampleRate, _tick, &sn);
+            _tick = tempo->time2tick(_frame / MScore::sampleRate, Fraction::fromTicks(_tick), &sn).ticks();
             }
       _type = t;
       }
@@ -260,7 +260,7 @@ bool Pos::operator!=(const Pos& s) const
 unsigned Pos::tick() const
       {
       if (_type == TType::FRAMES)
-            _tick = tempo->time2tick(_frame / MScore::sampleRate, _tick, &sn);
+            _tick = tempo->time2tick(_frame / MScore::sampleRate, Fraction::fromTicks(_tick), &sn).ticks();
       return _tick;
       }
 
@@ -272,8 +272,8 @@ unsigned Pos::frame() const
       {
    if (_type == TType::TICKS) {
             // qreal time = _frame / MScore::sampleRate;
-            // _frame = tempo->tick2time(_tick, time, &sn) * MScore::sampleRate;
-            _frame = tempo->tick2time(_tick) * MScore::sampleRate;
+            // _frame = tempo->tick2time(Fraction::fromTicks(_tick), time, &sn) * MScore::sampleRate;
+            _frame = tempo->tick2time(Fraction::fromTicks(_tick)) * MScore::sampleRate;
             }
       return _frame;
       }
@@ -287,7 +287,7 @@ void Pos::setTick(unsigned pos)
       _tick = pos;
       sn    = -1;
       if (_type == TType::FRAMES)
-            _frame = tempo->tick2time(pos, &sn) * MScore::sampleRate;
+            _frame = tempo->tick2time(Fraction::fromTicks(pos), &sn) * MScore::sampleRate;
       _valid = true;
       }
 
@@ -300,7 +300,7 @@ void Pos::setFrame(unsigned pos)
       _frame = pos;
       sn     = -1;
       if (_type == TType::TICKS)
-            _tick = tempo->time2tick(pos/MScore::sampleRate, &sn);
+            _tick = tempo->time2tick(pos/MScore::sampleRate, &sn).ticks();
       _valid = true;
       }
 
@@ -429,7 +429,7 @@ void PosLen::setLenTick(unsigned len)
       _lenTick = len;
       sn       = -1;
       if (type() == TType::FRAMES)
-            _lenFrame = tempo->tick2time(len, &sn) * MScore::sampleRate;
+            _lenFrame = tempo->tick2time(Fraction::fromTicks(len), &sn) * MScore::sampleRate;
       else
             _lenTick = len;
       }
@@ -442,7 +442,7 @@ void PosLen::setLenFrame(unsigned len)
       {
       sn      = -1;
       if (type() == TType::TICKS)
-            _lenTick = tempo->time2tick(len/MScore::sampleRate, &sn);
+            _lenTick = tempo->time2tick(len/MScore::sampleRate, &sn).ticks();
       else
             _lenFrame = len;
       }
@@ -454,7 +454,7 @@ void PosLen::setLenFrame(unsigned len)
 unsigned PosLen::lenTick() const
       {
       if (type() == TType::FRAMES)
-            _lenTick = tempo->time2tick(_lenFrame/MScore::sampleRate, _lenTick, &sn);
+            _lenTick = tempo->time2tick(_lenFrame/MScore::sampleRate, Fraction::fromTicks(_lenTick), &sn).ticks();
       return _lenTick;
       }
 
@@ -465,7 +465,7 @@ unsigned PosLen::lenTick() const
 unsigned PosLen::lenFrame() const
       {
       if (type() == TType::TICKS)
-            _lenFrame = tempo->tick2time(_lenTick, _lenFrame, &sn) * MScore::sampleRate;
+            _lenFrame = tempo->tick2time(Fraction::fromTicks(_lenTick), _lenFrame, &sn) * MScore::sampleRate;
       return _lenFrame;
       }
 
@@ -522,7 +522,7 @@ bool PosLen::operator==(const PosLen& pl) const
 
 void Pos::mbt(int* bar, int* beat, int* tk) const
       {
-      sig->tickValues(tick(), bar, beat, tk);
+      sig->tickValues(Fraction::fromTicks(tick()), bar, beat, tk);
       }
 
 //---------------------------------------------------------
@@ -561,7 +561,7 @@ void Pos::msf(int* min, int* sec, int* fr, int* subFrame) const
 
 SigEvent Pos::timesig() const
       {
-      return sig->timesig(tick());
+      return sig->timesig(Fraction::fromTicks(tick()));
       }
 
 //---------------------------------------------------------
@@ -573,32 +573,32 @@ SigEvent Pos::timesig() const
 
 void Pos::snap(int raster)
       {
-      setTick(sig->raster(tick(), raster));
+      setTick(sig->raster(Fraction::fromTicks(tick()), raster).ticks());
       }
 
 void Pos::upSnap(int raster)
       {
-      setTick(sig->raster2(tick(), raster));
+      setTick(sig->raster2(Fraction::fromTicks(tick()), raster).ticks());
       }
 
 void Pos::downSnap(int raster)
       {
-      setTick(sig->raster1(tick(), raster));
+      setTick(sig->raster1(Fraction::fromTicks(tick()), raster).ticks());
       }
 
 Pos Pos::snaped(int raster) const
       {
-      return Pos(tempo, sig, sig->raster(tick(), raster));
+      return Pos(tempo, sig, sig->raster(Fraction::fromTicks(tick()), raster).ticks());
       }
 
 Pos Pos::upSnaped(int raster) const
       {
-      return Pos(tempo, sig, sig->raster2(tick(), raster));
+      return Pos(tempo, sig, sig->raster2(Fraction::fromTicks(tick()), raster).ticks());
       }
 
 Pos Pos::downSnaped(int raster) const
       {
-      return Pos(tempo, sig, sig->raster1(tick(), raster));
+      return Pos(tempo, sig, sig->raster1(Fraction::fromTicks(tick()), raster).ticks());
       }
 
 }

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1532,8 +1532,8 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                   m->setTicks(Fraction(sl[0].toInt(), sl[1].toInt()));
             else
                   qDebug("illegal measure size <%s>", qPrintable(e.attribute("len")));
-            m->score()->sigmap()->add(m->tick().ticks(), SigEvent(m->ticks(), m->timesig()));
-            m->score()->sigmap()->add(m->endTick().ticks(), SigEvent(m->timesig()));
+            m->score()->sigmap()->add(m->tick(), SigEvent(m->ticks(), m->timesig()));
+            m->score()->sigmap()->add(m->endTick(), SigEvent(m->timesig()));
             }
 
       Staff* staff = m->score()->staff(staffIdx);
@@ -1800,8 +1800,8 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                       || (clef->clefType() == ClefType::PERC && !isDrumStaff)
                       || (clef->clefType() != ClefType::PERC && isDrumStaff)) {
                         clef->setClefType(ClefType::G);
-                        staff->clefList().erase(e.tick().ticks());
-                        staff->clefList().insert(std::pair<int,ClefType>(e.tick().ticks(), ClefType::G));
+                        staff->clefList().erase(e.tick());
+                        staff->clefList().insert(e.tick(), ClefType::G);
                         }
 
                   // there may be more than one clef segment for same tick position
@@ -2386,14 +2386,14 @@ static void readStaff(Staff* staff, XmlReader& e)
                         if (e.name() == "clef") {
                               int tick    = e.intAttribute("tick", 0);
                               ClefType ct = readClefType(e.attribute("idx", "0"));
-                              staff->clefList().insert(std::pair<int,ClefType>(_score->fileDivision(tick), ct));
+                              staff->clefList().insert(Fraction::fromTicks(_score->fileDivision(tick)), ct);
                               e.readNext();
                               }
                         else
                               e.unknown();
                         }
                   if (staff->clefList().empty())
-                        staff->clefList().insert(std::pair<int,ClefType>(0, ClefType::G));
+                        staff->clefList().insert(Fraction(0,1), ClefType::G);
                   }
             else if (tag == "keylist")
                   staff->keyList()->read(e, _score);
@@ -2849,10 +2849,10 @@ Score::FileError MasterScore::read114(XmlReader& e)
                               int tick   = e.attribute("tick").toInt();
                               double tmp = e.readElementText().toDouble();
                               tick       = (tick * MScore::division + _fileDivision/2) / _fileDivision;
-                              auto pos   = tm.find(tick);
+                              auto pos   = tm.find(Fraction::fromTicks(tick));
                               if (pos != tm.end())
                                     tm.erase(pos);
-                              tm.setTempo(tick, tmp);
+                              tm.setTempo(Fraction::fromTicks(tick), tmp);
                         }
                         else if (e.name() == "relTempo")
                               e.readElementText();
@@ -3021,7 +3021,7 @@ Score::FileError MasterScore::read114(XmlReader& e)
                   s->setBarLineSpan(nstaves() - idx);
                   }
             for (auto i : s->clefList()) {
-                  Fraction tick   = Fraction::fromTicks(i.first);
+                  Fraction tick   = i.first.tick();
                   ClefType clefId = i.second._concertClef;
                   Measure* m      = tick2measure(tick);
                   if (!m)
@@ -3049,7 +3049,7 @@ Score::FileError MasterScore::read114(XmlReader& e)
             // create missing KeySig
             KeyList* km = s->keyList();
             for (auto i = km->begin(); i != km->end(); ++i) {
-                  Fraction tick = Fraction::fromTicks(i->first);
+                  Fraction tick = i->first.tick();
                   if (tick < Fraction(0,1)) {
                         qDebug("read114: Key tick %d", tick.ticks());
                         continue;
@@ -3208,9 +3208,9 @@ Score::FileError MasterScore::read114(XmlReader& e)
       // some 1.3 scores have tempolist but no tempo text
       fixTicks();
       for (auto i : tm) {
-            Fraction tick = Fraction::fromTicks(i.first);
+            Fraction tick = i.first.tick();
             qreal tempo   = i.second.tempo;
-            if (tempomap()->tempo(tick.ticks()) != tempo) {
+            if (tempomap()->tempo(tick) != tempo) {
                   TempoText* tt = new TempoText(this);
                   tt->setXmlText(QString("<sym>metNoteQuarterUp</sym> = %1").arg(qRound(tempo*60)));
                   tt->setTempo(tempo);

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -2752,8 +2752,8 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
             else
                   qDebug("illegal measure size <%s>", qPrintable(e.attribute("len")));
             irregular = true;
-            score->sigmap()->add(m->tick().ticks(), SigEvent(m->ticks(), m->timesig()));
-            score->sigmap()->add(m->endTick().ticks(), SigEvent(m->timesig()));
+            score->sigmap()->add(m->tick(), SigEvent(m->ticks(), m->timesig()));
+            score->sigmap()->add(m->endTick(), SigEvent(m->timesig()));
             }
       else
             irregular = false;
@@ -3061,12 +3061,12 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                         m->setTimesig(ts->sig() / timeStretch);
 
                         if (irregular) {
-                              score->sigmap()->add(m->tick().ticks(), SigEvent(m->ticks(), m->timesig()));
-                              score->sigmap()->add(m->endTick().ticks(), SigEvent(m->timesig()));
+                              score->sigmap()->add(m->tick(), SigEvent(m->ticks(), m->timesig()));
+                              score->sigmap()->add(m->endTick(), SigEvent(m->timesig()));
                               }
                         else {
                               m->setTicks(m->timesig());
-                              score->sigmap()->add(m->tick().ticks(), SigEvent(m->timesig()));
+                              score->sigmap()->add(m->tick(), SigEvent(m->timesig()));
                               }
                         }
                   }

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1024,7 +1024,7 @@ void renderArpeggio(Chord *chord, QList<NoteEventList> & ell)
             NoteEventList* events = &(ell)[i];
             events->clear();
 
-            auto tempoRatio = chord->score()->tempomap()->tempo(chord->tick().ticks()) / Score::defaultTempo();
+            auto tempoRatio = chord->score()->tempomap()->tempo(chord->tick()) / Score::defaultTempo();
             int ot = (l * j * 1000) / chord->upNote()->playTicks() *
                         tempoRatio * chord->arpeggio()->Stretch();
 
@@ -1863,9 +1863,9 @@ void Score::createPlayEvents()
 
 void Score::renderMetronome(EventMap* events, Measure* m, const Fraction& tickOffset)
       {
-      int msrTick         = m->tick().ticks();
+      Fraction msrTick    = m->tick();
       qreal tempo         = tempomap()->tempo(msrTick);
-      TimeSigFrac timeSig = sigmap()->timesig(msrTick).nominal();
+      TimeSigFrac timeSig = sigmap()->timesig(m->tick()).nominal();
 
       int clickTicks      = timeSig.isBeatedCompound(tempo) ? timeSig.beatTicks() : timeSig.dUnitTicks();
       int endTick         = m->endTick().ticks();
@@ -1873,14 +1873,14 @@ void Score::renderMetronome(EventMap* events, Measure* m, const Fraction& tickOf
       int rtick;
 
       if (m->isAnacrusis()) {
-            int rem = m->ticks().ticks() % clickTicks;
+            Fraction rem = Fraction::fromTicks(m->ticks().ticks() % clickTicks);
             msrTick += rem;
-            rtick = rem + timeSig.ticksPerMeasure() - m->ticks().ticks();
+            rtick = rem.ticks() + timeSig.ticksPerMeasure() - m->ticks().ticks();
             }
       else
             rtick = 0;
 
-      for (int tick = msrTick; tick < endTick; tick += clickTicks, rtick += clickTicks)
+      for (int tick = msrTick.ticks(); tick < endTick; tick += clickTicks, rtick += clickTicks)
             events->insert(std::pair<int,NPlayEvent>(tick + tickOffset.ticks(), NPlayEvent(timeSig.rtick2beatType(rtick))));
       }
 

--- a/libmscore/repeatlist.cpp
+++ b/libmscore/repeatlist.cpp
@@ -180,10 +180,10 @@ void RepeatList::update()
       for(RepeatSegment* s : *this) {
             s->utick      = utick;
             s->utime      = t;
-            qreal ct      = tl->tick2time(s->tick);
+            qreal ct      = tl->tick2time(Fraction::fromTicks(s->tick));
             s->timeOffset = t - ct;
             utick        += s->len();
-            t            += tl->tick2time(s->tick + s->len()) - ct;
+            t            += tl->tick2time(Fraction::fromTicks(s->tick + s->len())) - ct;
             }
       }
 
@@ -235,7 +235,7 @@ qreal RepeatList::utick2utime(int tick) const
       for (unsigned i = ii; i < n; ++i) {
             if ((tick >= at(i)->utick) && ((i + 1 == n) || (tick < at(i+1)->utick))) {
                   int t     = tick - (at(i)->utick - at(i)->tick);
-                  qreal tt = _score->tempomap()->tick2time(t) + at(i)->timeOffset;
+                  qreal tt = _score->tempomap()->tick2time(Fraction::fromTicks(t)) + at(i)->timeOffset;
                   return tt;
                   }
             }
@@ -253,7 +253,7 @@ int RepeatList::utime2utick(qreal t) const
       for (unsigned i = ii; i < n; ++i) {
             if ((t >= at(i)->utime) && ((i + 1 == n) || (t < at(i+1)->utime))) {
                   idx2 = i;
-                  return _score->tempomap()->time2tick(t - at(i)->timeOffset) + (at(i)->utick - at(i)->tick);
+                  return _score->tempomap()->time2tick(t - at(i)->timeOffset).ticks() + (at(i)->utick - at(i)->tick);
                   }
             }
       if (MScore::debugMode) {

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -418,7 +418,7 @@ void Score::fixTicks()
       if (isMaster()) {
             tempomap()->clear();
             sigmap()->clear();
-            sigmap()->add(0, SigEvent(fm->ticks(),  fm->timesig(), 0));
+            sigmap()->add(Fraction(0,1), SigEvent(fm->ticks(),  fm->timesig(), 0));
             }
 
       for (MeasureBase* mb = first(); mb; mb = mb->next()) {
@@ -509,14 +509,14 @@ void Score::fixTicks()
             if (isMaster() && (!sig.identical(m->ticks()) || !nomSig.identical(m->timesig()))) {
                   sig    = m->ticks();
                   nomSig = m->timesig();
-                  sigmap()->add(tick.ticks(), SigEvent(sig, nomSig,  m->no()));
+                  sigmap()->add(tick, SigEvent(sig, nomSig,  m->no()));
                   }
 
             tick += measureTicks;
             }
       // Now done in getNextMeasure(), do we keep?
       if (tempomap()->empty())
-            tempomap()->setTempo(0, _defaultTempo);
+            tempomap()->setTempo(Fraction(0,1), _defaultTempo);
       }
 
 //---------------------------------------------------------
@@ -1294,7 +1294,7 @@ Measure* Score::getCreateMeasure(const Fraction& tick)
                   m->setTimesig(ts);
                   m->setTicks(ts);
                   measures()->add(toMeasureBase(m));
-                  lastTick += Fraction::fromTicks(ts.ticks());
+                  lastTick += ts;
                   }
             }
       return tick2measure(tick);
@@ -1558,7 +1558,7 @@ void Score::removeElement(Element* element)
                   {
                   TempoText* tt = toTempoText(element);
                   Fraction tick = tt->segment()->tick();
-                  tempomap()->delTempo(tick.ticks());
+                  tempomap()->delTempo(tick);
                   }
                   break;
             case ElementType::INSTRUMENT_CHANGE: {
@@ -2088,7 +2088,7 @@ bool Score::appendScore(Score* score, bool addPageBreak, bool addSectionBreak)
                         }
                   // other key signatures (initial other than "C", non-initial)
                   for (auto k : *(st->keyList())) {
-                        Fraction tick = Fraction::fromTicks(k.first);
+                        Fraction tick = k.first.tick();
                         KeySigEvent key = k.second;
                         joinedStaff->setKey(tick + tickOfAppend, key);
                         }
@@ -2462,7 +2462,7 @@ void Score::adjustKeySigs(int sidx, int eidx, KeyList km)
       for (int staffIdx = sidx; staffIdx < eidx; ++staffIdx) {
             Staff* staff = _staves[staffIdx];
             for (auto i = km.begin(); i != km.end(); ++i) {
-                  Fraction tick = Fraction::fromTicks(i->first);
+                  Fraction tick = i->first.tick();
                   Measure* measure = tick2measure(tick);
                   if (!measure)
                         continue;
@@ -3285,7 +3285,7 @@ void Score::setTempo(Segment* segment, qreal tempo)
 
 void Score::setTempo(const Fraction& tick, qreal tempo)
       {
-      tempomap()->setTempo(tick.ticks(), tempo);
+      tempomap()->setTempo(tick, tempo);
       _playlistDirty = true;
       }
 
@@ -3295,7 +3295,7 @@ void Score::setTempo(const Fraction& tick, qreal tempo)
 
 void Score::removeTempo(const Fraction& tick)
       {
-      tempomap()->delTempo(tick.ticks());
+      tempomap()->delTempo(tick);
       _playlistDirty = true;
       }
 
@@ -3317,14 +3317,14 @@ void Score::resetTempo()
 void Score::resetTempoRange(const Fraction& tick1, const Fraction& tick2)
       {
       const bool zeroInRange = (tick1 <= Fraction(0,1) && tick2 > Fraction(0,1));
-      tempomap()->clearRange(tick1.ticks(), tick2.ticks());
+      tempomap()->clearRange(tick1, tick2);
       if (zeroInRange)
-            tempomap()->setTempo(0, _defaultTempo);
-      sigmap()->clearRange(tick1.ticks(), tick2.ticks());
+            tempomap()->setTempo(Fraction(0,1), _defaultTempo);
+      sigmap()->clearRange(tick1, tick2);
       if (zeroInRange) {
             Measure* m = firstMeasure();
             if (m)
-                  sigmap()->add(0, SigEvent(m->ticks(),  m->timesig(), 0));
+                  sigmap()->add(Fraction(0,1), SigEvent(m->ticks(),  m->timesig(), 0));
             }
       }
 
@@ -3334,7 +3334,7 @@ void Score::resetTempoRange(const Fraction& tick1, const Fraction& tick2)
 
 void Score::setPause(const Fraction& tick, qreal seconds)
       {
-      tempomap()->setPause(tick.ticks(), seconds);
+      tempomap()->setPause(tick, seconds);
       _playlistDirty = true;
       }
 
@@ -3344,7 +3344,7 @@ void Score::setPause(const Fraction& tick, qreal seconds)
 
 qreal Score::tempo(const Fraction& tick) const
       {
-      return tempomap()->tempo(tick.ticks());
+      return tempomap()->tempo(tick);
       }
 
 //---------------------------------------------------------

--- a/libmscore/sig.h
+++ b/libmscore/sig.h
@@ -13,7 +13,7 @@
 #ifndef __AL_SIG_H__
 #define __AL_SIG_H__
 
-#include "fraction.h"
+#include "types.h"
 
 namespace Ms {
 
@@ -122,34 +122,33 @@ class SigEvent {
 //   SigList
 //---------------------------------------------------------
 
-class TimeSigMap : public std::map<int, SigEvent > {
+class TimeSigMap : public std::map<TimePosition, SigEvent > {
       void normalize();
 
    public:
       TimeSigMap() {}
 
-      void add(int tick, const Fraction&);
-      void add(int tick, const SigEvent& ev);
+      void add(const Fraction& tick, const Fraction&);
+      void add(const Fraction& tick, const SigEvent& ev);
 
-      void del(int tick);
+      void del(const Fraction& tick);
 
-      void clearRange(int tick1, int tick2);
+      void clearRange(const Fraction& tick1, const Fraction& tick2);
 
       void read(XmlReader&, int fileDiv);
       void write(XmlWriter&) const;
       void dump() const;
 
-      const SigEvent& timesig(int tick) const;
-      const SigEvent& timesig(const Fraction& f) const { return timesig(f.ticks()); }
+      const SigEvent& timesig(const Fraction& tick) const;
 
-      void tickValues(int t, int* bar, int* beat, int* tick) const;
+      void tickValues(const Fraction& t, int* bar, int* beat, int* tick) const;
       int bar2tick(int bar, int beat) const;
-      QString pos(int t) const;
+      QString pos(const Fraction& tick) const;
 
-      unsigned raster(unsigned tick, int raster) const;
-      unsigned raster1(unsigned tick, int raster) const;    // round down
-      unsigned raster2(unsigned tick, int raster) const;    // round up
-      int rasterStep(unsigned tick, int raster) const;
+      Fraction raster(const Fraction& tick, int raster) const;
+      Fraction raster1(const Fraction& tick, int raster) const;    // round down
+      Fraction raster2(const Fraction& tick, int raster) const;    // round up
+      int rasterStep(const Fraction& tick, int raster) const;
       };
 
 }     // namespace Ms

--- a/libmscore/sig.h
+++ b/libmscore/sig.h
@@ -14,6 +14,7 @@
 #define __AL_SIG_H__
 
 #include "types.h"
+#include "timeposition.h"
 
 namespace Ms {
 

--- a/libmscore/staff.h
+++ b/libmscore/staff.h
@@ -26,6 +26,7 @@
 #include "stafftypelist.h"
 #include "groups.h"
 #include "scoreElement.h"
+#include "sig.h"
 
 namespace Ms {
 
@@ -67,10 +68,11 @@ class Staff final : public ScoreElement {
       Part* _part       { 0 };
 
       ClefList clefs;
-      ClefTypeList _defaultClefType;
-
       KeyList _keys;
-      std::map<int,TimeSig*> timesigs;
+      std::map<TimePosition, TimeSig*> timesigs;
+      StaffTypeList _staffTypeList;
+
+      ClefTypeList _defaultClefType;
 
       QList <BracketItem*> _brackets;
       int  _barLineSpan        { false };    ///< true - span barline to next staff
@@ -85,8 +87,6 @@ class Staff final : public ScoreElement {
 
       QColor _color            { MScore::defaultColor };
       qreal _userDist          { 0.0   };       ///< user edited extra distance
-
-      StaffTypeList _staffTypeList;
 
       QMap<int,int> _channelList[VOICES];
       QMap<int,SwingParameters> _swingList;
@@ -150,9 +150,9 @@ class Staff final : public ScoreElement {
 
       const Groups& group(const Fraction&) const;
 
-      KeyList* keyList()                      { return &_keys;                  }
-      Key key(const Fraction& tick) const     { return keySigEvent(tick).key(); }
-      KeySigEvent keySigEvent(const Fraction&) const;
+      KeyList* keyList()                               { return &_keys;                  }
+      Key key(const Fraction& tick) const              { return keySigEvent(tick).key(); }
+      KeySigEvent keySigEvent(const Fraction& t) const { return _keys.key(t); }
       Fraction nextKeyTick(const Fraction&) const;
       Fraction currentKeyTick(const Fraction&) const;
       KeySigEvent prevKey(const Fraction&) const;

--- a/libmscore/stafftypelist.cpp
+++ b/libmscore/stafftypelist.cpp
@@ -10,9 +10,10 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#include "types.h"
 #include "stafftypelist.h"
 #include "xml.h"
-#include "score.h"
+//#include "score.h"
 
 namespace Ms {
 
@@ -25,7 +26,7 @@ const StaffType& StaffTypeList::staffType(const Fraction& tick) const
       static const StaffType st;
       if (empty())
             return st;
-      auto i = upper_bound(tick.ticks());
+      auto i = upper_bound(TimePosition(tick));
       if (i == begin())
             return st;
       return (--i)->second;
@@ -38,7 +39,7 @@ const StaffType& StaffTypeList::staffType(const Fraction& tick) const
 StaffType& StaffTypeList::staffType(const Fraction& tick)
       {
       Q_ASSERT(!empty());
-      auto i = upper_bound(tick.ticks());
+      auto i = upper_bound(TimePosition(tick));
       Q_ASSERT(i != begin());
       return (--i)->second;
       }
@@ -50,10 +51,10 @@ StaffType& StaffTypeList::staffType(const Fraction& tick)
 StaffType* StaffTypeList::setStaffType(const Fraction& tick, const StaffType& st)
       {
       Q_ASSERT(tick >= Fraction(0,1));
-      auto i = find(tick.ticks());
+      auto i = find(tick);
       StaffType* nst;
       if (i == end()) {
-            auto k = insert(std::pair<int, StaffType>(tick.ticks(), st));
+            auto k = insert(std::pair<TimePosition, StaffType>(TimePosition(tick), st));
             nst = &(k.first->second);
             }
       else {
@@ -67,9 +68,9 @@ StaffType* StaffTypeList::setStaffType(const Fraction& tick, const StaffType& st
 //   StaffTypeList::read
 //---------------------------------------------------------
 
+#if 0
 void StaffTypeList::read(XmlReader& /*e*/, Score* /*cs*/)
       {
-#if 0
       while (e.readNextStartElement()) {
             if (e.name() == "key") {
                   Key k;
@@ -86,8 +87,8 @@ void StaffTypeList::read(XmlReader& /*e*/, Score* /*cs*/)
             else
                   e.unknown();
             }
-#endif
       }
+#endif
 
 }
 

--- a/libmscore/stafftypelist.h
+++ b/libmscore/stafftypelist.h
@@ -13,6 +13,7 @@
 #ifndef __STAFFTYPELIST_H__
 #define __STAFFTYPELIST_H__
 
+#include "types.h"
 #include "stafftype.h"
 
 namespace Ms {
@@ -25,14 +26,20 @@ class XmlReader;
 //    to keep track of key signature changes
 //---------------------------------------------------------
 
-class StaffTypeList : public std::map<int, StaffType> {
+typedef std::map<TimePosition, StaffType> StaffTypeMap;
+
+class StaffTypeList : StaffTypeMap {
 
    public:
       StaffTypeList() {}
       StaffType& staffType(const Fraction&);
       const StaffType& staffType(const Fraction&) const;
       StaffType* setStaffType(const Fraction&, const StaffType&);
-      void read(XmlReader&, Score*);
+//      void read(XmlReader&, Score*);
+
+      iterator find(const Fraction& t) { return StaffTypeMap::find(TimePosition(t)); }
+      iterator end()                   { return StaffTypeMap::end(); }
+      const_iterator end() const       { return StaffTypeMap::end(); }
       };
 
 }

--- a/libmscore/stafftypelist.h
+++ b/libmscore/stafftypelist.h
@@ -15,6 +15,7 @@
 
 #include "types.h"
 #include "stafftype.h"
+#include "timeposition.h"
 
 namespace Ms {
 

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1148,6 +1148,7 @@ typedef std::vector<StyledProperty> ElementStyle;
 
 typedef std::array<StyledProperty, TEXT_STYLE_SIZE> TextStyle;
 
+enum class Tid;
 
 const TextStyle* textStyle(Tid);
 const TextStyle* textStyle(const char*);

--- a/libmscore/tempo.h
+++ b/libmscore/tempo.h
@@ -14,6 +14,7 @@
 #define __AL_TEMPO_H__
 
 #include "types.h"
+#include "timeposition.h"
 
 namespace Ms {
 

--- a/libmscore/tempo.h
+++ b/libmscore/tempo.h
@@ -13,6 +13,8 @@
 #ifndef __AL_TEMPO_H__
 #define __AL_TEMPO_H__
 
+#include "types.h"
+
 namespace Ms {
 
 class XmlWriter;
@@ -42,33 +44,33 @@ struct TEvent {
 //   Tempomap
 //---------------------------------------------------------
 
-class TempoMap : public std::map<int, TEvent> {
+class TempoMap : public std::map<TimePosition, TEvent> {
       int _tempoSN;           // serial no to track tempo changes
       qreal _tempo;           // tempo if not using tempo list (beats per second)
       qreal _relTempo;        // rel. tempo
 
       void normalize();
-      void del(int tick);
+      void del(const Fraction& tick);
 
    public:
       TempoMap();
       void clear();
-      void clearRange(int tick1, int tick2);
+      void clearRange(const Fraction& tick1, const Fraction& tick2);
 
       void dump() const;
 
-      qreal tempo(int tick) const;
+      qreal tempo(const Fraction& tick) const;
 
-      qreal tick2time(int tick, int* sn = 0) const;
-      qreal tick2timeLC(int tick, int* sn) const;
-      qreal tick2time(int tick, qreal time, int* sn) const;
-      int time2tick(qreal time, int* sn = 0) const;
-      int time2tick(qreal time, int tick, int* sn) const;
+      qreal tick2time(const Fraction& tick, int* sn = 0) const;
+      qreal tick2timeLC(const Fraction& tick, int* sn) const;
+      qreal tick2time(const Fraction& tick, qreal time, int* sn) const;
+      Fraction time2tick(qreal time, int* sn = 0) const;
+      Fraction time2tick(qreal time, const Fraction& tick, int* sn) const;
       int tempoSN() const { return _tempoSN; }
 
-      void setTempo(int t, qreal);
-      void setPause(int t, qreal);
-      void delTempo(int tick);
+      void setTempo(const Fraction& t, qreal);
+      void setPause(const Fraction& t, qreal);
+      void delTempo(const Fraction& tick);
 
       void setRelTempo(qreal val);
       qreal relTempo() const { return _relTempo; }

--- a/libmscore/timeposition.h
+++ b/libmscore/timeposition.h
@@ -1,0 +1,38 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2019 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENSE.GPL
+//=============================================================================
+
+#ifndef __TIMEPOSITION_H__
+#define __TIMEPOSITION_H__
+
+#include "fraction.h"
+
+namespace Ms {
+//---------------------------------------------------------
+//   TimePosition
+//    helper class used as key in std::map for
+//    ClefList, KeyList, StafftypeList
+//---------------------------------------------------------
+
+class TimePosition {
+      Fraction f;
+      qreal t;                // cached float value of fraction
+
+   public:
+      TimePosition(const Fraction& t) : f(t), t(qreal(t.numerator())/qreal(t.denominator())) {}
+      const Fraction& tick() const                 { return f; }
+      bool operator<(const TimePosition& tp) const { return t < tp.t; }
+      };
+} // namespace
+
+#endif
+
+

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -14,7 +14,6 @@
 #define __TYPES_H__
 
 #include "config.h"
-#include "fraction.h"
 
 namespace Ms {
 #ifdef SCRIPT_INTERFACE
@@ -432,22 +431,6 @@ Q_ENUM_NS(Placement)
 Q_ENUM_NS(SegmentType)
 Q_ENUM_NS(Tid)
 #endif
-
-//---------------------------------------------------------
-//   TimePosition
-//    helper class used as key in std::map for
-//    ClefList, KeyList, StafftypeList
-//---------------------------------------------------------
-
-class TimePosition {
-      Fraction f;
-      qreal t;                // cached float value of fraction
-
-   public:
-      TimePosition(const Fraction& t) : f(t), t(qreal(t.numerator())/qreal(t.denominator())) {}
-      const Fraction& tick() const                 { return f; }
-      bool operator<(const TimePosition& tp) const { return t < tp.t; }
-      };
 
 //hack: to force the build system to run moc on this file
 class Mops : public QObject {

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -14,6 +14,7 @@
 #define __TYPES_H__
 
 #include "config.h"
+#include "fraction.h"
 
 namespace Ms {
 #ifdef SCRIPT_INTERFACE
@@ -431,6 +432,22 @@ Q_ENUM_NS(Placement)
 Q_ENUM_NS(SegmentType)
 Q_ENUM_NS(Tid)
 #endif
+
+//---------------------------------------------------------
+//   TimePosition
+//    helper class used as key in std::map for
+//    ClefList, KeyList, StafftypeList
+//---------------------------------------------------------
+
+class TimePosition {
+      Fraction f;
+      qreal t;                // cached float value of fraction
+
+   public:
+      TimePosition(const Fraction& t) : f(t), t(qreal(t.numerator())/qreal(t.denominator())) {}
+      const Fraction& tick() const                 { return f; }
+      bool operator<(const TimePosition& tp) const { return t < tp.t; }
+      };
 
 //hack: to force the build system to run moc on this file
 class Mops : public QObject {

--- a/libmscore/volta.cpp
+++ b/libmscore/volta.cpp
@@ -341,9 +341,9 @@ void Volta::setTempo() const
       if (startMeasure && endMeasure) {
             if (!endMeasure->repeatEnd())
                   return;
-            Fraction startTick = startMeasure->tick() - Fraction::fromTicks(1);
+            Fraction startTick = startMeasure->tick() - Fraction::fromTicks(1);     // HACK
             Fraction endTick  = endMeasure->endTick() - Fraction::fromTicks(1);
-            qreal tempoBeforeVolta = score()->tempomap()->tempo(startTick.ticks());
+            qreal tempoBeforeVolta = score()->tempomap()->tempo(startTick);
             score()->setTempo(endTick, tempoBeforeVolta);
             }
       }

--- a/mscore/bb.cpp
+++ b/mscore/bb.cpp
@@ -92,7 +92,7 @@ BBFile::~BBFile()
 bool BBFile::read(const QString& name)
       {
       _siglist.clear();
-      _siglist.add(0, Fraction(4, 4));        // debug
+      _siglist.add(Fraction(0,1), Fraction(4, 4));        // debug
 
       _path = name;
       QFile f(name);
@@ -413,7 +413,7 @@ Score::FileError importBB(MasterScore* score, const QString& name)
             Measure* measure  = new Measure(score);
             Fraction tick = Fraction::fromTicks(score->sigmap()->bar2tick(i, 0));
             measure->setTick(tick);
-            Fraction ts = score->sigmap()->timesig(tick.ticks()).timesig();
+            Fraction ts = score->sigmap()->timesig(tick).timesig();
             measure->setTimesig(ts);
             measure->setTicks(ts);
             score->measures()->add(measure);

--- a/mscore/capella.cpp
+++ b/mscore/capella.cpp
@@ -842,7 +842,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                         Fraction f(o->numerator, 1 << o->log2Denom);
                         SigEvent ne(f);
                         if (!(se == ne))
-                              score->sigmap()->add(tick.ticks(), ne);
+                              score->sigmap()->add(tick, ne);
 
                         // do not add timesig again
                         Measure* m = score->getCreateMeasure(tick);
@@ -1155,7 +1155,7 @@ void convertCapella(Score* score, Capella* cap, bool capxMode)
       // set the initial time signature
       CapStaff* cs = cap->systems[0]->staves[0];
       if (cs->log2Denom <= 7)
-            score->sigmap()->add(0, Fraction(cs->numerator, 1 << cs->log2Denom));
+            score->sigmap()->add(Fraction(0,1), Fraction(cs->numerator, 1 << cs->log2Denom));
 
       // create parts and staves
       Staff* bstaff = 0;

--- a/mscore/debugger/debugger.cpp
+++ b/mscore/debugger/debugger.cpp
@@ -861,11 +861,11 @@ void SegmentView::setElement(Element* e)
 
       Segment* s = (Segment*)e;
       ShowElementBase::setElement(e);
-      int tick = s->tick().ticks();
+      Fraction tick = s->tick();
       TimeSigMap* sm = s->score()->sigmap();
 
       int bar = -1, beat = -1, ticks = -1;
-      if (tick >= 0)
+      if (tick >= Fraction(0,1))
             sm->tickValues(tick, &bar, &beat, &ticks);
       sb.bar->setValue(bar);
       sb.beat->setValue(beat);

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -593,7 +593,7 @@ MasterScore* MuseScore::getNewFile()
       if (!newWizard->title().isEmpty())
             score->fileInfo()->setFile(newWizard->title());
 
-      score->sigmap()->add(0, timesig);
+      score->sigmap()->add(Fraction(0,1), timesig);
 
       Fraction firstMeasureTicks = pickupMeasure ? Fraction(pickupTimesigZ, pickupTimesigN) : timesig;
 
@@ -3026,7 +3026,7 @@ static void findTextByType(void* data, Element* element)
             titleStrings->append(text->plainText());
             }
       }
-      
+
 QJsonObject MuseScore::saveMetadataJSON(Score* score)
       {
       auto boolToString = [](bool b) { return b ? "true" : "false"; };
@@ -3144,7 +3144,7 @@ QJsonObject MuseScore::saveMetadataJSON(Score* score)
       jsonPageformat.insert("width", round(score->styleD(Sid::pageWidth) * INCH));
       jsonPageformat.insert("twosided", boolToString(score->styleB(Sid::pageTwosided)));
       json.insert("pageFormat", jsonPageformat);
-      
+
       //text frames metadata
       QJsonObject jsonTypeData;
       static std::vector<std::pair<QString, Tid>> namesTypesList {
@@ -3163,7 +3163,7 @@ QJsonObject MuseScore::saveMetadataJSON(Score* score)
             jsonTypeData.insert(nameType.first, typeData);
             }
       json.insert("textFramesData", jsonTypeData);
-      
+
       return json;
       }
 
@@ -3176,20 +3176,20 @@ public:
       jsonFormatFile.open(QIODevice::WriteOnly);
       jsonFormatFile.write("{\n");
       }
-      
+
       ~CustomJsonWriter()
       {
       jsonFormatFile.write("\n}\n");
       jsonFormatFile.close();
       }
-      
+
       void addKey(const char* arrayName)
       {
       jsonFormatFile.write("\"");
       jsonFormatFile.write(arrayName);
       jsonFormatFile.write("\": ");
       }
-      
+
       void addValue(const QByteArray& data, bool lastJsonElement = false, bool isJson = false)
       {
       if (!isJson)
@@ -3200,12 +3200,12 @@ public:
       if (!lastJsonElement)
             jsonFormatFile.write(",\n");
       }
-      
+
       void openArray()
       {
       jsonFormatFile.write(" [");
       }
-      
+
       void closeArray(bool lastJsonElement = false)
       {
       jsonFormatFile.write("]");
@@ -3213,11 +3213,11 @@ public:
             jsonFormatFile.write(",");
       jsonFormatFile.write("\n");
       }
-      
+
 private:
       QFile jsonFormatFile;
 };
-      
+
 //---------------------------------------------------------
 //   exportMp3AsJSON
 //---------------------------------------------------------
@@ -3294,7 +3294,7 @@ bool MuseScore::exportAllMediaFiles(const QString& inFilePath, const QString& ou
             jsonWriter.addValue(pngData.toBase64(), lastArrayValue);
             }
       jsonWriter.closeArray();
-      
+
       jsonWriter.addKey("svgs");
       jsonWriter.openArray();
       for (int i = 0; i < score->pages().size(); ++i) {
@@ -3317,14 +3317,14 @@ bool MuseScore::exportAllMediaFiles(const QString& inFilePath, const QString& ou
       jsonWriter.addValue(partDataPos.toBase64());
       partPosDevice.close();
       partDataPos.clear();
-      
+
       //export score .mpos
       partPosDevice.open(QIODevice::ReadWrite);
       savePositions(score.get(), &partPosDevice, false);
       jsonWriter.addKey("mposXML");
       jsonWriter.addValue(partDataPos.toBase64());
       }
-      
+
       //export score pdf
       jsonWriter.addKey("pdf");
       jsonWriter.addValue(exportPdfAsJSON(score.get()));
@@ -3338,7 +3338,7 @@ bool MuseScore::exportAllMediaFiles(const QString& inFilePath, const QString& ou
       jsonWriter.addKey("midi");
       jsonWriter.addValue(midiData.toBase64());
       }
-      
+
       {
       //export musicxml
       QByteArray mxmlData;
@@ -3348,7 +3348,7 @@ bool MuseScore::exportAllMediaFiles(const QString& inFilePath, const QString& ou
       jsonWriter.addKey("mxml");
       jsonWriter.addValue(mxmlData.toBase64());
       }
-      
+
       //export metadata
       QJsonDocument doc(mscore->saveMetadataJSON(score.get()));
       jsonWriter.addKey("metadata");

--- a/mscore/importmidi/importmidi_beat.cpp
+++ b/mscore/importmidi/importmidi_beat.cpp
@@ -269,7 +269,7 @@ std::vector<ReducedFraction> findTimeSignatures(const ReducedFraction &timeSigFr
 void setTimeSig(TimeSigMap *sigmap, const ReducedFraction &timeSig)
       {
       sigmap->clear();
-      sigmap->add(0, timeSig.fraction());
+      sigmap->add(Fraction(0,1), timeSig.fraction());
       }
 
 void findBeatLocations(
@@ -278,7 +278,7 @@ void findBeatLocations(
             double ticksPerSec)
       {
       const size_t MIN_BEAT_COUNT = 8;
-      const auto barFractions = findTimeSignatures(ReducedFraction(sigmap->timesig(0).timesig()));
+      const auto barFractions = findTimeSignatures(ReducedFraction(sigmap->timesig(Fraction(0,1)).timesig()));
       const std::vector<
                  std::function<double(const std::pair<const ReducedFraction, MidiChord> &, double)>
                        >
@@ -327,7 +327,7 @@ void findBeatLocations(
                               Meter::fractionDenominatorToUserValue(beatData.timeSig.denominator()));
             }
       else {
-            const auto currentTimeSig = ReducedFraction(sigmap->timesig(0).timesig());
+            const auto currentTimeSig = ReducedFraction(sigmap->timesig(Fraction(0,1)).timesig());
             data->trackOpers.timeSigNumerator.setDefaultValue(
                               Meter::fractionNumeratorToUserValue(currentTimeSig.numerator()));
             data->trackOpers.timeSigDenominator.setDefaultValue(

--- a/mscore/importmidi/importmidi_inner.cpp
+++ b/mscore/importmidi/importmidi_inner.cpp
@@ -260,7 +260,7 @@ namespace MidiBar {
 ReducedFraction findBarStart(const ReducedFraction &time, const TimeSigMap *sigmap)
       {
       int barIndex, beat, tick;
-      sigmap->tickValues(time.ticks(), &barIndex, &beat, &tick);
+      sigmap->tickValues(time.fraction(), &barIndex, &beat, &tick);
       return ReducedFraction::fromTicks(sigmap->bar2tick(barIndex, 0));
       }
 

--- a/mscore/importmidi/importmidi_key.cpp
+++ b/mscore/importmidi/importmidi_key.cpp
@@ -48,7 +48,7 @@ void assignKeyListToStaff(const KeyList &kl, Staff *staff)
       Key pkey = Key::C;
 
       for (auto it = kl.begin(); it != kl.end(); ++it) {
-            const int tick = it->first;
+            const Fraction tick = it->first.tick();
             Key key  = it->second.key();
             if ((key == Key::C) && (key == pkey))     // don’t insert unnecessary C key
                   continue;
@@ -57,11 +57,11 @@ void assignKeyListToStaff(const KeyList &kl, Staff *staff)
             ks->setTrack(track);
             ks->setGenerated(false);
             ks->setKey(key);
-            ks->setMag(staff->mag(Fraction::fromTicks(tick)));
-            Measure* m = score->tick2measure(Fraction::fromTicks(tick));
+            ks->setMag(staff->mag(tick));
+            Measure* m = score->tick2measure(tick);
             if (!m)
                   continue;
-            Segment* seg = m->getSegment(SegmentType::KeySig, Fraction::fromTicks(tick));
+            Segment* seg = m->getSegment(SegmentType::KeySig, tick);
             seg->add(ks);
             }
       }
@@ -144,7 +144,7 @@ void recognizeMainKeySig(QList<MTrack> &tracks)
                   ke.setKey(key);
 
                   KeyList &staffKeyList = *track.staff->keyList();
-                  staffKeyList[0] = ke;
+                  staffKeyList[TimePosition(Fraction(0,1))] = ke;
                   assignKeyListToStaff(staffKeyList, track.staff);
                   }
             }

--- a/mscore/importmidi/importmidi_quant.cpp
+++ b/mscore/importmidi/importmidi_quant.cpp
@@ -353,10 +353,10 @@ bool isHumanPerformance(
                                     quantForLen(MChord::maxNoteLen(chord), basicQuant));
             const auto onTime = quantizeValue(chord.first, quant);
             int barIndex, beat, tick;
-            sigmap->tickValues(onTime.ticks(), &barIndex, &beat, &tick);
+            sigmap->tickValues(onTime.fraction(), &barIndex, &beat, &tick);
 
             const auto barStart = ReducedFraction::fromTicks(sigmap->bar2tick(barIndex, 0));
-            const auto barFraction = ReducedFraction(sigmap->timesig(barStart.ticks()).timesig());
+            const auto barFraction = ReducedFraction(sigmap->timesig(barStart.fraction()).timesig());
             const auto beatLen = Meter::beatLength(barFraction);
 
             if (((onTime - barStart) / beatLen).reduced().denominator() == 1
@@ -1262,7 +1262,7 @@ void quantizeOnTimes(
                               currentBarIndex = chordIt->second.barIndex;
                               barStart = ReducedFraction::fromTicks(
                                                 sigmap->bar2tick(currentBarIndex, 0));
-                              barFraction = ReducedFraction(sigmap->timesig(barStart.ticks()).timesig());
+                              barFraction = ReducedFraction(sigmap->timesig(barStart.fraction()).timesig());
                               if (!currentlyInTuplet)
                                     rangeStart = barStart;
                               }

--- a/mscore/importmidi/importmidi_simplify.cpp
+++ b/mscore/importmidi/importmidi_simplify.cpp
@@ -221,7 +221,7 @@ void minimizeNumberOfRests(
 
                   const auto barStart = MidiBar::findBarStart(note.offTime, sigmap);
                   const auto barFraction = ReducedFraction(
-                                                sigmap->timesig(barStart.ticks()).timesig());
+                                                sigmap->timesig(barStart.fraction()).timesig());
                   auto durationStart = (it->first > barStart) ? it->first : barStart;
 
                   if (it->second.isInTuplet) {

--- a/mscore/importmidi/importmidi_tempo.cpp
+++ b/mscore/importmidi/importmidi_tempo.cpp
@@ -41,7 +41,7 @@ double findBasicTempo(const std::multimap<int, MTrack> &tracks, bool isHumanPerf
 
 void setTempoToScore(Score *score, int tick, double beatsPerSecond)
       {
-      if (score->tempomap()->find(tick) != score->tempomap()->end())
+      if (score->tempomap()->find(Fraction::fromTicks(tick)) != score->tempomap()->end())
             return;
                   // don't repeat tempo, always set only tempo for tick 0
       if (tick > 0 && score->tempo(Fraction::fromTicks(tick)) == beatsPerSecond)
@@ -145,7 +145,7 @@ void setTempo(const std::multimap<int, MTrack> &tracks, Score *score)
             }
 
       if (score->tempomap()->empty())
-            score->tempomap()->setTempo(0, 2.0);      // default tempo
+            score->tempomap()->setTempo(Fraction(0,1), 2.0);      // default tempo
       }
 
 } // namespace MidiTempo

--- a/mscore/importmidi/importmidi_tuplet.cpp
+++ b/mscore/importmidi/importmidi_tuplet.cpp
@@ -1038,7 +1038,7 @@ void findTuplets(
       const auto endBarTick = ReducedFraction::fromTicks(
                                     sigmap->bar2tick(startBarChordIt->second.barIndex + 1, 0));
 
-      const auto barFraction = ReducedFraction(sigmap->timesig(startBarTick.ticks()).timesig());
+      const auto barFraction = ReducedFraction(sigmap->timesig(startBarTick.fraction()).timesig());
       std::vector<TupletInfo> tuplets = detectTuplets(startBarChordIt, endBarChordIt, startBarTick,
                                                       barFraction, chords, basicQuant, barIndex);
       if (tuplets.empty())

--- a/mscore/importmidi/importmidi_voice.cpp
+++ b/mscore/importmidi/importmidi_voice.cpp
@@ -130,7 +130,7 @@ int findDurationCountInGroup(
       auto onTime = chordOnTime;
       auto onTimeBarStart = MidiBar::findBarStart(onTime, sigmap);
       auto onTimeBarFraction = ReducedFraction(
-                        sigmap->timesig(onTimeBarStart.ticks()).timesig());
+                        sigmap->timesig(onTimeBarStart.fraction()).timesig());
 
       for (int i: groupOfIndexes) {
             const auto &offTime = notes[i].offTime;
@@ -140,7 +140,7 @@ int findDurationCountInGroup(
 
             if (offTimeBarStart != onTimeBarStart) {
                   const auto offTimeBarFraction = ReducedFraction(
-                              sigmap->timesig(offTimeBarStart.ticks()).timesig());
+                              sigmap->timesig(offTimeBarStart.fraction()).timesig());
 
                   const auto tupletsForDuration = MidiTuplet::findTupletsInBarForDuration(
                               voice, onTimeBarStart, onTime, offTimeBarStart - onTime, tuplets);
@@ -896,7 +896,7 @@ bool doVoiceSeparation(
 int findBarIndexForOffTime(const ReducedFraction &offTime, const TimeSigMap *sigmap)
       {
       int barIndex, beat, tick;
-      sigmap->tickValues(offTime.ticks(), &barIndex, &beat, &tick);
+      sigmap->tickValues(offTime.fraction(), &barIndex, &beat, &tick);
       if (beat == 0 && tick == 0)
             --barIndex;
       return barIndex;

--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -742,7 +742,7 @@ static void doCredits(Score* score, const CreditWordsList& credits, const int pa
 
 static void fixupSigmap(MxmlLogger* logger, Score* score, const QVector<Fraction>& measureLength)
       {
-      auto it = score->sigmap()->find(0);
+      auto it = score->sigmap()->find(Fraction(0,1));
 
       if (it == score->sigmap()->end()) {
             // no valid timesig at tick = 0
@@ -751,7 +751,7 @@ static void fixupSigmap(MxmlLogger* logger, Score* score, const QVector<Fraction
             // if there is no first measure, we probably don't care,
             // but set a default anyway.
             Fraction tsig = measureLength.isEmpty() ? Fraction(4, 4) : measureLength.at(0);
-            score->sigmap()->add(0, tsig);
+            score->sigmap()->add(Fraction(0,1), tsig);
             }
       }
 
@@ -2247,7 +2247,7 @@ void MusicXMLParserPass1::time(const Fraction cTime)
             int btp = 0;       // beat-type as integer
             if (determineTimeSig(_logger, &_e, beats, beatType, timeSymbol, st, bts, btp)) {
                   _timeSigDura = Fraction(bts, btp);
-                  _score->sigmap()->add(cTime.ticks(), _timeSigDura);
+                  _score->sigmap()->add(cTime, _timeSigDura);
                   }
             }
       }

--- a/mscore/importove.cpp
+++ b/mscore/importove.cpp
@@ -748,7 +748,7 @@ void OveToMScore::convertSignatures(){
             Fraction f(tt.numerator_, tt.denominator_);
 
             TimeSigMap* sigmap = score_->sigmap();
-            sigmap->add(tt.tick_, f);
+            sigmap->add(Fraction::fromTicks(tt.tick_), f);
 
             Measure* measure  = score_->tick2measure(Fraction::fromTicks(tt.tick_));
             if(measure){
@@ -1134,7 +1134,7 @@ void OveToMScore::convertMeasures() {
             if (mb->type() != ElementType::MEASURE)
                   continue;
             Measure* measure = static_cast<Measure*>(mb);
-            int tick = measure->tick().ticks();
+            Fraction tick = measure->tick();
             measure->setTicks(score_->sigmap()->timesig(tick).timesig());
             measure->setTimesig(score_->sigmap()->timesig(tick).timesig()); //?
             convertMeasure(measure);

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -238,15 +238,15 @@ void MuseScore::editInstrList()
             int interval = firstStaff->part()->instrument()->transpose().chromatic;
             normalizedC = transposeKey(normalizedC, interval);
             for (auto i = tmpKeymap.begin(); i != tmpKeymap.end(); ++i) {
-                  int tick = i->first;
+                  TimePosition tp = i->first;
                   Key oKey = i->second.key();
-                  tmpKeymap[tick].setKey(transposeKey(oKey, interval));
+                  tmpKeymap[tp].setKey(transposeKey(oKey, interval));
                   }
             }
       // create initial keyevent for transposing instrument if necessary
       auto i = tmpKeymap.begin();
-      if (i == tmpKeymap.end() || i->first != 0)
-            tmpKeymap[0].setKey(normalizedC);
+      if (i == tmpKeymap.end() || !i->first.tick().isZero())
+            tmpKeymap[TimePosition(Fraction(0,1))].setKey(normalizedC);
 
       //
       // process modified partitur list

--- a/mscore/jackaudio.cpp
+++ b/mscore/jackaudio.cpp
@@ -324,7 +324,7 @@ void JackAudio::timebase(jack_transport_state_t state, jack_nframes_t /*nframes*
                   return;
 
             pos->valid = JackPositionBBT;
-            int curTick = audio->seq->score()->repeatList()->utick2tick(audio->seq->getCurTick());
+            Fraction curTick = Fraction::fromTicks(audio->seq->score()->repeatList()->utick2tick(audio->seq->getCurTick()));
             int bar,beat,tick;
             audio->seq->score()->sigmap()->tickValues(curTick, &bar, &beat, &tick);
             // Providing the final tempo

--- a/mscore/mediadialog.cpp
+++ b/mscore/mediadialog.cpp
@@ -159,10 +159,10 @@ void MediaDialog::addAudioPressed()
             return;
 
       qreal t = 0;
-      int tick = 0;
-      qreal lastTempo = tmo->tempo(0);
+      Fraction tick = Fraction(0,1);
+      qreal lastTempo = tmo->tempo(Fraction(0,1));
       TempoMap* tmn = new TempoMap();
-      tmn->setTempo(0, lastTempo);
+      tmn->setTempo(Fraction(0,1), lastTempo);
       int resolution = 25;
       while (!syncFile.atEnd()) {
             for (int i = 0; !syncFile.atEnd() && i < resolution-1; i++)
@@ -179,13 +179,13 @@ void MediaDialog::addAudioPressed()
             qreal tPerformance = sl[1].trimmed().toDouble();
 
             // timestamp of last
-            int scoreTick = tmo->time2tick(tScore);
+            Fraction scoreTick = tmo->time2tick(tScore);
             qreal deltaError = tmo->tick2time(scoreTick) - tScore;
-            int dt = scoreTick - tick;
+            Fraction dt = scoreTick - tick;
             qreal deltaTime = tPerformance - t;
 
             if (deltaTime > 0) {
-                  qreal tempo = dt / (480 * deltaTime);
+                  qreal tempo = dt.ticks() / (480 * deltaTime);
                   if(tempo != lastTempo) {
                   qDebug() << tempo;
                         tmn->setTempo(tick, tempo);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4666,7 +4666,7 @@ void MuseScore::setPos(const Fraction& t)
 
       TimeSigMap* s = cs->sigmap();
       int bar, beat, tick;
-      s->tickValues(t.ticks(), &bar, &beat, &tick);
+      s->tickValues(t, &bar, &beat, &tick);
       _positionLabel->setText(QString("%1:%2:%3")
          .arg(bar + 1,  3, 10, QLatin1Char(' '))
          .arg(beat + 1, 2, 10, QLatin1Char('0'))

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -184,7 +184,7 @@ void PlayPanel::setScore(Score* s)
       posSlider->setEnabled(enable);
       tempoSlider->setEnabled(enable);
       if (cs && seq && seq->canStart()) {
-            setTempo(cs->tempomap()->tempo(0));
+            setTempo(cs->tempomap()->tempo(Fraction(0,1)));
             setRelTempo(cs->tempomap()->relTempo());
             setEndpos(cs->repeatList()->ticks());
             Fraction tick = cs->pos(POS::CURRENT);
@@ -316,8 +316,8 @@ void PlayPanel::updatePosLabel(int utick)
       int tick = 0;
       if (cs) {
             tick = cs->repeatList()->utick2tick(utick);
-            cs->sigmap()->tickValues(tick, &bar, &beat, &t);
-            double tpo = cs->tempomap()->tempo(tick) * cs->tempomap()->relTempo();
+            cs->sigmap()->tickValues(Fraction::fromTicks(tick), &bar, &beat, &t);
+            double tpo = cs->tempomap()->tempo(Fraction::fromTicks(tick)) * cs->tempomap()->relTempo();
             setTempo(tpo);
             }
       char buffer[32];

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -234,7 +234,7 @@ std::pair<int, float> ScoreAccessibility::barbeat(Element *e)
             }
       else if (p->type() == ElementType::SEGMENT) {
             Segment* seg = static_cast<Segment*>(p);
-            tsm->tickValues(seg->tick().ticks(), &bar, &beat, &ticks);
+            tsm->tickValues(seg->tick(), &bar, &beat, &ticks);
             }
       else if (p->type() == ElementType::MEASURE) {
             Measure* m = static_cast<Measure*>(p);

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -641,7 +641,7 @@ void Seq::addCountInClicks()
       const Fraction plPos = cs->playPos();
       Measure*    m        = cs->tick2measure(plPos);
       Fraction   msrTick   = m->tick();
-      qreal tempo          = cs->tempomap()->tempo(msrTick.ticks());
+      qreal tempo          = cs->tempomap()->tempo(msrTick);
       TimeSigFrac timeSig  = cs->sigmap()->timesig(m->tick()).nominal();
 
       const int clickTicks = timeSig.isBeatedCompound(tempo) ? timeSig.beatTicks() : timeSig.dUnitTicks();
@@ -1478,8 +1478,8 @@ void Seq::heartBeatTimeout()
             --ppos;
       mutex.unlock();
 
-      if (cs && cs->sigmap()->timesig(getCurTick()).nominal()!=prevTimeSig) {
-            prevTimeSig = cs->sigmap()->timesig(getCurTick()).nominal();
+      if (cs && cs->sigmap()->timesig(Fraction::fromTicks(getCurTick())).nominal()!=prevTimeSig) {
+            prevTimeSig = cs->sigmap()->timesig(Fraction::fromTicks(getCurTick())).nominal();
             emit timeSigChanged();
             }
       if (cs && curTempo()!=prevTempo) {
@@ -1573,7 +1573,7 @@ void Seq::updateSynthesizerState(int tick1, int tick2)
 double Seq::curTempo() const
       {
       if (playPos != events.end())
-            return cs ? cs->tempomap()->tempo(playPos->first) : 0.0;
+            return cs ? cs->tempomap()->tempo(Fraction::fromTicks(playPos->first)) : 0.0;
 
       return 0.0;
       }

--- a/mtest/libmscore/parts/tst_parts.cpp
+++ b/mtest/libmscore/parts/tst_parts.cpp
@@ -265,7 +265,9 @@ void TestParts::appendMeasure()
 
       QVERIFY(saveCompareScore(score, "part-all-appendmeasures.mscx", DIR + "part-all-appendmeasures.mscx"));
 
+      score->startCmd();
       score->undoRedo(true, 0);
+      score->endCmd();
 
       QVERIFY(saveCompareScore(score, "part-all-uappendmeasures.mscx", DIR + "part-all-uappendmeasures.mscx"));
       delete score;
@@ -288,7 +290,9 @@ void TestParts::insertMeasure()
 
       // QVERIFY(saveCompareScore(score, "part-all-insertmeasures.mscx", DIR + "part-all-insertmeasures.mscx"));
 
+      score->startCmd();
       score->undoRedo(true, 0);
+      score->endCmd();
 
       QVERIFY(saveCompareScore(score, "part-all-uinsertmeasures.mscx", DIR + "part-all-uinsertmeasures.mscx"));
       delete score;


### PR DESCRIPTION
KeyList, StafftypeList ClefList, timesig, sigmap, tempomap.
The sorting key for maps is a qreal calculated from a Fraction. This avoids
Fraction compares and allows for fast double/float compares during std::map lookup.