### PR TITLE
fix #284341: alignment of hairpin lines is off

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -97,7 +97,7 @@ void HairpinSegment::layout()
                   Segment* start = hairpin()->startSegment();
                   if (start && start->system() == sys)
                         sd = toDynamic(start->findAnnotation(ElementType::DYNAMIC, _trck, _trck));
-                  if (sd && sd->visible() && sd->autoplace()) {
+                  if (sd && sd->visible() && sd->autoplace() && sd->placement() == hairpin()->placement()) {
                         const qreal sdRight = sd->bbox().right() + sd->pos().x()
                                               + sd->segment()->pos().x() + sd->measure()->pos().x();
                         const qreal dist    = sdRight - pos().x() + score()->styleP(Sid::autoplaceHairpinDynamicsDistance);
@@ -114,11 +114,11 @@ void HairpinSegment::layout()
                         // systems may be unknown at layout stage.
                         ed = toDynamic(end->findAnnotation(ElementType::DYNAMIC, _trck, _trck));
                         }
-                  if (ed && ed->visible() && ed->autoplace()) {
+                  if (ed && ed->visible() && ed->autoplace() && ed->placement() == hairpin()->placement()) {
                         const qreal edLeft  = ed->bbox().left() + ed->pos().x()
                                               + ed->segment()->pos().x() + ed->measure()->pos().x();
                         const qreal dist    = edLeft - pos2().x() - pos().x() - score()->styleP(Sid::autoplaceHairpinDynamicsDistance);
-                        if (dist < 0.0 || dist >= 3.0 * spatium())
+                        if (dist < 0.0 || dist >= 3.0 * _spatium)
                               rxpos2() += dist;
                         // prepare to align vertically
                         if (hairpin()->placeBelow())
@@ -148,8 +148,8 @@ void HairpinSegment::layout()
                   x1 = _text->width() + _spatium * .5;
 
             QTransform t;
-            qreal h1 = hairpin()->hairpinHeight().val()     * spatium() * .5;
-            qreal h2 = hairpin()->hairpinContHeight().val() * spatium() * .5;
+            qreal h1 = hairpin()->hairpinHeight().val()     * _spatium * .5;
+            qreal h2 = hairpin()->hairpinContHeight().val() * _spatium * .5;
 
             qreal len;
             qreal x = pos2().x();
@@ -240,7 +240,7 @@ void HairpinSegment::layout()
             qreal minDistance = spatium() * .7;
             qreal ymax = pos().y();
             qreal d;
-            qreal ddiff = spatium() * 0.5;
+            qreal ddiff = hairpin()->isLineType() ? 0.0 : _spatium * 0.5;
 
             SkylineLine sl(!hairpin()->placeAbove());
             sl.add(shape().translated(pos()));

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -210,7 +210,7 @@ static const StyleType styleTypes[] {
       { Sid::hairpinPosAbove,         "hairpinPosAbove",         QPointF(0.0, -3.5) },
       { Sid::hairpinPosBelow,         "hairpinPosBelow",         QPointF(.0, 3.5) },
       { Sid::hairpinLinePosAbove,     "hairpinLinePosAbove",     QPointF(0.0, -3.0) },
-      { Sid::hairpinLinePosBelow,     "hairpinLinePosBelow",     QPointF(.0, 3.0) },
+      { Sid::hairpinLinePosBelow,     "hairpinLinePosBelow",     QPointF(.0, 4.0) },
       { Sid::hairpinHeight,           "hairpinHeight",           Spatium(1.2) },
       { Sid::hairpinContHeight,       "hairpinContHeight",       Spatium(0.5) },
       { Sid::hairpinLineWidth,        "hairpinWidth",            Spatium(0.13) },


### PR DESCRIPTION
Two separate small errors I needed to correct here - the default value for hairpinLinePosBelow, and skipping the 0.5sp offset diff adjustment when comparing the vertical position of dynamics and hairpins, if the hairpin is actually a hairpin line.

Also I noticed the autoplace code was trying to align dynamics and hairpins even when one is above and the other below, so I corrected that too.  And a marginal performance improvement by using the cached value of _spatium.