### PR TITLE
Selection of overlapping elements

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1080,6 +1080,18 @@ Element* Element::name2Element(const QStringRef& s, Score* sc)
 
 bool elementLessThan(const Element* const e1, const Element* const e2)
       {
+      if (e1->z() == e2->z()) {
+            if (e1->selected())
+                  return false;
+            else if (e2->selected())
+                  return true;
+            else if (!e1->visible())
+                  return true;
+            else if (!e2->visible())
+                  return false;
+            else
+                  return e1->track() > e2->track();
+            }
       return e1->z() <= e2->z();
       }
 

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -305,12 +305,29 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                         }
                   }
             else {
-                  if (st == SelectType::ADD && e->selected())
-                        e->score()->deselect(e);
-                  else
+                  if (st == SelectType::ADD) {
+                        // e is the top element in stacking order,
+                        // but we want to replace it with "first non-measure element after a selected element"
+                        // (if such an element exists)
+                        QList<Element*> ll = elementsNear(editData.startMove);
+                        bool found = false;
+                        for (Element* ee : ll) {
+                              if (found) {
+                                    e = ee;
+                                    if (!e->isMeasure())
+                                          break;
+                                    }
+                              else if (ee->selected()) {
+                                    found = true;
+                                    ee->score()->deselect(ee);
+                                    e = nullptr;
+                                    }
+                              }
+                        }
+                  if (e)
                         e->score()->select(e, st, -1);
                   }
-            if (e->isNote()) {
+            if (e && e->isNote()) {
                   e->score()->updateCapo();
                   mscore->play(e);
                   }

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -336,10 +336,14 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
                         _score->setUpdateAll();
                         clickOffElement = false;
                         }
+                  else if (st == SelectType::ADD)
+                        clickOffElement = false;
                   else
                         clickOffElement = true;
                   }
-            else if (st != SelectType::ADD)
+            else if (st == SelectType::ADD)
+                  clickOffElement = false;
+            else
                   clickOffElement = true;
             }
       _score->update();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4312,47 +4312,54 @@ static bool elementLower(const Element* e1, const Element* e2)
             return false;
       if (!e2->selectable())
             return true;
+      if (e1->isNote() && e2->isStem())
+            return true;
+      if (e2->isNote() && e1->isStem())
+            return false;
       if (e1->z() == e2->z()) {
+            // same stacking order, prefer non-hidden elements
             if (e1->type() == e2->type()) {
                   if (e1->type() == ElementType::NOTEDOT) {
                         const NoteDot* n1 = static_cast<const NoteDot*>(e1);
                         const NoteDot* n2 = static_cast<const NoteDot*>(e2);
                         if (n1->note() && n1->note()->hidden())
-                              return n2;
-                        else
-                              return n1;
+                              return false;
+                        else if (n2->note() && n2->note()->hidden())
+                              return true;
                         }
                   else if (e1->type() == ElementType::NOTE) {
                         const Note* n1 = static_cast<const Note*>(e1);
                         const Note* n2 = static_cast<const Note*>(e2);
                         if (n1->hidden())
-                              return n2;
-                        else
-                              return n1;
+                              return false;
+                        else if (n2->hidden())
+                              return true;
                         }
                   }
+            // different types, or same type but nothing hidden - use track
+            return e1->track() <= e2->track();
             }
-      return e1->z() < e2->z();
+
+      // default case, use stacking order
+      return e1->z() <= e2->z();
       }
 
-
-
 //---------------------------------------------------------
-//   elementNear
+//   elementsNear
 //---------------------------------------------------------
 
-Element* ScoreView::elementNear(QPointF p)
+QList<Element*> ScoreView::elementsNear(QPointF p)
       {
+      QList<Element*> ll;
       Page* page = point2page(p);
       if (!page)
-            return 0;
+            return ll;
 
       p       -= page->pos();
       double w = (preferences.getInt(PREF_UI_CANVAS_MISC_SELECTIONPROXIMITY) * .5) / matrix().m11();
       QRectF r(p.x() - w, p.y() - w, 3.0 * w, 3.0 * w);
 
       QList<Element*> el = page->items(r);
-      QList<Element*> ll;
       for (Element* e : el) {
             e->itemDiscovered = 0;
             if (!e->selectable() || e->isPage())
@@ -4372,12 +4379,22 @@ Element* ScoreView::elementNear(QPointF p)
                         ll.append(e);
                   }
             }
+      if (!ll.empty())
+            qSort(ll.begin(), ll.end(), elementLower);
+      return ll;
+      }
+
+//---------------------------------------------------------
+//   elementNear
+//---------------------------------------------------------
+
+Element* ScoreView::elementNear(QPointF p)
+      {
+      QList<Element*> ll = elementsNear(p);
       if (ll.empty()) {
             // qDebug("  nothing found");
             return 0;
             }
-      qSort(ll.begin(), ll.end(), elementLower);
-
 #if 0
       qDebug("==");
       for (const Element* e : ll)

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -397,6 +397,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void onElementDestruction(Element*) override;
 
       virtual Element* elementNear(QPointF);
+      QList<Element*> elementsNear(QPointF);
 //      void editFretDiagram(FretDiagram*);
       void editBendProperties(Bend*);
       void editTremoloBarProperties(TremoloBar*);


### PR DESCRIPTION
This fixes a bunch of annoying glitches in how selection works in the presence of overlapping elements and also improve the behavior of Ctrl+click.  With this PR, the following changes will be seen:

- when noteheads overlap, clicking will select the topmost note instead of the hidden one underneath
- in other cases of overlap of elements of the same type, the lower voice will win (currently this is non-deterministic)
- when clicking the area near where a note and stem intersect, the note will win instead of the stem
- stacking order continues to determine the winner in other cases

plus:

- when there are overlapping elements, Ctrl+click will cycle through them all one at a time
- when right-clicking an empty area, the selection will no longer be lost

The Ctrl+click to cycle through elements behavior is the main change here, and it's important to note this will not change the usual case of no overlaps - Ctrl+click will add the element to the selection if it is not already, remove it if it is.  But if there is an overlap, then on Ctrl+click of an already-selected element, not only is it removed from the selection, but the next one down is added.  When you hit the end of the stack, the bottom element is removed, and then the next time it starts over with the top.