### PR TITLE
remove trailing slashes (/) in include lines

### DIFF
--- a/mscore/importgtp-gp6.cpp
+++ b/mscore/importgtp-gp6.cpp
@@ -48,7 +48,7 @@
 #include <libmscore/glissando.h>
 #include <libmscore/dynamic.h>
 #include <libmscore/arpeggio.h>
-#include <libmscore//volta.h>
+#include <libmscore/volta.h>
 #include <libmscore/instrtemplate.h>
 #include <libmscore/hairpin.h>
 #include <libmscore/fingering.h>


### PR DESCRIPTION
Double slash (//) in a include line prevent linux build when debug symbols are extracted.