### PR TITLE
fix #284503: bad concert pitch toggle in style dialog

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -512,6 +512,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       connect(swingEighth,         SIGNAL(toggled(bool)),             SLOT(setSwingParams(bool)));
       connect(swingSixteenth,      SIGNAL(toggled(bool)),             SLOT(setSwingParams(bool)));
 
+      connect(concertPitch,        SIGNAL(toggled(bool)),             SLOT(concertPitchToggled(bool)));
       connect(hideEmptyStaves,     SIGNAL(clicked(bool)), dontHideStavesInFirstSystem, SLOT(setEnabled(bool)));
       connect(lyricsDashMinLength, SIGNAL(valueChanged(double)),      SLOT(lyricsDashMinLengthValueChanged(double)));
       connect(lyricsDashMaxLength, SIGNAL(valueChanged(double)),      SLOT(lyricsDashMaxLengthValueChanged(double)));
@@ -1066,6 +1067,15 @@ void EditStyle::setSwingParams(bool checked)
             }
       cs->undo(new ChangeStyleVal(cs, Sid::swingUnit, val));
       cs->update();
+      }
+
+//---------------------------------------------------------
+//   concertPitchToggled
+//---------------------------------------------------------
+
+void EditStyle::concertPitchToggled(bool checked)
+      {
+      cs->cmdConcertPitchChanged(checked, true);
       }
 
 //---------------------------------------------------------

--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -68,6 +68,7 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       void toggleFooterOddEven(bool);
       void buttonClicked(QAbstractButton*);
       void setSwingParams(bool);
+      void concertPitchToggled(bool);
       void lyricsDashMinLengthValueChanged(double);
       void lyricsDashMaxLengthValueChanged(double);
       void systemMinDistanceValueChanged(double);


### PR DESCRIPTION
Merely toggling the style setting isn't enough, need to call cmdConcertPitchChanged, so I set up a signal/slot for that.