### PR TITLE
Fixes for system distances, margins, and spacers

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3949,7 +3949,7 @@ void LayoutContext::collectPage()
                                     }
                               }
                         if (!fixedDistance)
-                              distance = qMax(distance, -curSystem->minTop());
+                              distance = qMax(distance, curSystem->minTop());
                         }
                   }
 //TODO-ws ??

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1294,6 +1294,10 @@ void Score::hideEmptyStaves(System* system, bool isFirstSystem)
                   if (ss->show())
                         systemIsEmpty = false;
                   }
+            else if (!staff->show()) {
+                  // TODO: OK to check this first and not bother with checking if empty?
+                  ss->setShow(false);
+                  }
             else {
                   systemIsEmpty = false;
                   ss->setShow(true);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3932,10 +3932,11 @@ void LayoutContext::collectPage()
                   else {
                         distance = score->styleP(Sid::staffUpperBorder);
                         bool fixedDistance = false;
+                        // TODO: curSystem->spacerDistance(true)
                         for (MeasureBase* mb : curSystem->measures()) {
                               if (mb->isMeasure()) {
                                     Measure* m = toMeasure(mb);
-                                    Spacer* sp = m->vspacerUp(0);
+                                    Spacer* sp = m->vspacerUp(0);       // TODO: first visible?
                                     if (sp) {
                                           if (sp->spacerType() == SpacerType::FIXED) {
                                                 distance = sp->gap();
@@ -4025,15 +4026,18 @@ void LayoutContext::collectPage()
             if (!breakPage) {
                   qreal dist = prevSystem->minDistance(curSystem) + curSystem->height();
                   Box* vbox = curSystem->vbox();
-                  if (vbox)
+                  if (vbox) {
                         dist += vbox->bottomGap();
-                  else if (!prevSystem->hasFixedDownDistance())
-                        dist += qMax(curSystem->minBottom(), slb);
-
-                  breakPage  = (y + dist) >= ey && breakPages;
+                        }
+                  else if (!prevSystem->hasFixedDownDistance()) {
+                        qreal margin = qMax(curSystem->minBottom(), curSystem->spacerDistance(false));
+                        dist += qMax(margin, slb);
+                        }
+                  breakPage = (y + dist) >= ey && breakPages;
                   }
             if (breakPage) {
-                  qreal dist = qMax(prevSystem->minBottom(), slb);
+                  qreal dist = qMax(prevSystem->minBottom(), prevSystem->spacerDistance(false));
+                  dist = qMax(dist, slb);
                   layoutPage(page, ey - (y + dist));
                   // We don't accept current system to this page
                   // so rollback rangeDone variable as well.

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1219,10 +1219,10 @@ qreal System::minTop() const
 qreal System::minBottom() const
       {
       if (vbox())
-            return vbox()->height() + vbox()->bottomGap();
+            return vbox()->bottomGap();
       SysStaff* s = lastVisibleSysStaff();
       if (s)
-            return s->skyline().south().max();
+            return s->skyline().south().max() - s->bbox().height();
       return 0.0;
       }
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -496,7 +496,7 @@ void System::layout2()
                         }
                   sp = m->vspacerUp(si2);
                   if (sp)
-                        dist = qMax(dist, sp->gap());
+                        dist = qMax(dist, sp->gap() + h);
                   }
             if (!fixedSpace) {
                   qreal d = score()->lineMode() ? 0.0 : ss->skyline().minDistance(System::staff(si2)->skyline());

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -1227,6 +1227,35 @@ qreal System::minBottom() const
       }
 
 //---------------------------------------------------------
+//   spacerDistance
+//    Return the distance needed due to spacers
+//---------------------------------------------------------
+
+qreal System::spacerDistance(bool up) const
+      {
+      SysStaff* ss = up ? firstVisibleSysStaff() : lastVisibleSysStaff();
+      if (!ss)
+            return 0.0;
+      qreal dist = 0.0;
+      int staff = ss->idx;
+      for (MeasureBase* mb : measures()) {
+            if (mb->isMeasure()) {
+                  Measure* m = toMeasure(mb);
+                  Spacer* sp = up ? m->vspacerUp(staff) : m->vspacerDown(staff);
+                  if (sp) {
+                        if (sp->spacerType() == SpacerType::FIXED) {
+                              dist = sp->gap();
+                              break;
+                              }
+                        else
+                              dist = qMax(dist, sp->gap());
+                        }
+                  }
+            }
+      return dist;
+      }
+
+//---------------------------------------------------------
 //   moveBracket
 //---------------------------------------------------------
 

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -163,6 +163,7 @@ class System final : public Element {
       qreal bottomDistance(int staffIdx, const SkylineLine&) const;
       qreal minTop() const;
       qreal minBottom() const;
+      qreal spacerDistance(bool up) const;
 
       void moveBracket(int staffIdx, int srcCol, int dstCol);
       bool hasFixedDownDistance() const { return fixedDownDistance; }

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1130,7 +1130,7 @@ void ScoreView::paint(const QRect& r, QPainter& p)
                         if (MScore::showSystemBoundingRect) {
                               for (const System* system : page->systems()) {
                                     QPointF pt(system->ipos());
-                                    qreal h = system->minBottom() + system->minTop();
+                                    qreal h = system->height() + system->minBottom() + system->minTop();
                                     p.translate(pt);
                                     QRectF rect(0.0, -system->minTop(), system->width(), h);
                                     p.drawRect(rect);


### PR DESCRIPTION
This PR fixes a number of related issues involving system distance, margins, and spacers:

https://musescore.org/en/node/284635 - last system of page has extra staff height gap below it
https://musescore.org/en/node/284641 - context above/below invisible staves affects system spacing
https://musescore.org/en/node/284637 - elements above top staff of system can extend off the page
https://musescore.org/en/node/281253 - staff spacer doesn't work at bottom of page
https://musescore.org/en/node/283365 - staff spacer up overlaps staff above

For the first of the issues listed, there are a couple of other bugs fixed with the same change: too few systems fitting on a page because of the extra 4sp gap, also an extra 4sp extra gap above vertical frames, also bad drawing of Debug / Show System Bounding Rectangles.  All due to the same problem, all fixed with the same simple change.

For the second of these, chances are good this also fixes a number of other bugs involving invisible staves.  In theory, SysStaff::show() - normally used to find out if a staff is hidden on a particular system - is supposed to also reflect whether the staff is set invisible in Edit / Instruments, so we don't have to check both flags all over the place.  But it turns out this was only happening if "Hie empty staves" is true; if false, then SysStaff::show() always returns true.  By fixing this here, now all code that checks only SysStaff::show() will start working.  I know I just fixed a bug with that a few days ago (#4693) that would also have been fixed with this change.

For the last issue, there was some doubt in my mind at first whether this was a bug or a deliberate design change.  Now that I understand this code better - and also observe it works as expected between *systems* but not between *staves* - I can see clearly this was a bug all along.  Unfortunately, it means people who had worked around this by making their staff spacers up unnecessarily tall will need to readjust them.

Anyhow, bottom line: with these changes, scores will on average require slightly fewer pages and yet be more loosely spaced on the page, because we are no longer wasting 4sp at the bottom of each page or wasting space from elements on invisible staves.  Respecting the skyline above the top staff to keep elements from flying off the page will mean less need for spacers, but when used, spacers will work more reliably.