### PR TITLE
fix #284660: stepping of RMS spinner in SC4 compressor

### DIFF
--- a/effects/compressor/compressor_gui.ui
+++ b/effects/compressor/compressor_gui.ui
@@ -516,6 +516,9 @@
      <property name="maximum">
       <double>1.000000000000000</double>
      </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
     </widget>
    </item>
    <item row="1" column="1">


### PR DESCRIPTION
for a range between 0 and 1 a stepping of 1 doesn't make much sense, 0.1 seems more reasonable