### PR TITLE
fix #281957 beam property highlighting for selected notes

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -344,6 +344,7 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
             }
       _score->update();
       mscore->endCmd();
+      mscore->updatePaletteBeamMode(clickOffElement);
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -101,6 +101,7 @@
 #include "libmscore/excerpt.h"
 #include "libmscore/synthesizerstate.h"
 #include "libmscore/utils.h"
+#include "libmscore/icon.h"
 
 #include "driver.h"
 
@@ -2151,6 +2152,66 @@ void MuseScore::selectionChanged(SelState selectionState)
             }
       if (_inspector)
             updateInspector();
+      }
+
+//---------------------------------------------------------
+//   updatePaletteBeamMode
+//
+//   Updates the selected index of the Beam Properties
+//   palette to reflect the beam mode of the selected
+//   chord rest
+//---------------------------------------------------------
+
+void MuseScore::updatePaletteBeamMode(bool unselect)
+      {
+      for (Palette* p : paletteBox->palettes()) {
+            if (p->name() == "Beam Properties") {
+                  if (unselect) {
+                        p->setSelected(-1);
+                        return;
+                        }
+                  const Selection sel = cs->selection();
+                  const ChordRest* cr = sel.cr();
+                  if (sel.isSingle() && cr) {
+                        Beam::Mode bm = cr->beamMode();
+                        IconType type;
+                        switch (bm) {
+                        case Beam::Mode::BEGIN:
+                              type = IconType::SBEAM;
+                              break;
+                        case Beam::Mode::MID:
+                              type = IconType::MBEAM;
+                              break;
+                        case Beam::Mode::NONE:
+                              type = IconType::NBEAM;
+                              break;
+                        case Beam::Mode::BEGIN32:
+                              type = IconType::BEAM32;
+                              break;
+                        case Beam::Mode::BEGIN64:
+                              type = IconType::BEAM64;
+                              break;
+                        case Beam::Mode::AUTO:
+                              type = IconType::AUTOBEAM;
+                              break;
+                        default:
+                              p->setSelected(-1);
+                              return;
+                        }
+                        for (int i = 0; i < p->size(); ++i) {
+                              if (toIcon(p->element(i))->iconType() == type) {
+                                    p->setSelected(i);
+                                    p->update();
+                                    return;
+                                    }
+                              }
+                  }
+                  else {
+                        p->setSelected(-1);
+                        }
+                  p->update();
+                  }
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -619,6 +619,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void showPluginManager();
 
 //      void updateTabNames();
+      void updatePaletteBeamMode(bool unselect = false);
       QProgressBar* showProgressBar();
       void hideProgressBar();
       void addRecentScore(Score*);

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -534,6 +534,7 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
             else {
                   for (Element* e : sel.elements())
                         applyDrop(score, viewer, e, element, modifiers);
+                  selectedIdx = currentIdx;
                   }
             }
       else if (sel.isRange()) {
@@ -560,6 +561,7 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
                         applyDrop(score, viewer, m, element, modifiers, pt);
                         if (m == last)
                               break;
+                        selectedIdx = currentIdx;
                         }
                   }
             else if (element->type() == ElementType::LAYOUT_BREAK) {


### PR DESCRIPTION
This should fix the problem listed in https://musescore.org/en/node/281957

I am currently doing the processing inside musescore.cpp in a new public function. This function is called once on every mouse click event. Originally I had the processing being done once per call to the selectionChanged() function, but I noticed that didn't get called each time elements are unselected. I moved it back to the endCmd() function, but again there wasn't an easy way of seeing whether the note was still selected so I moved it back to simply the mousePressEventNormal() using the clickOffElement member to determine whether the note was still selected.

For the processing itself, I'm looping through the palettes within the paletteBox to find a Beam Palette if it exists. From there I use a switch statement to map the Beam::Mode of the current ChordRest (again if it exists) to the corresponding IconType to find the index of the correct cell. From there I loop through the cells in the Beam Palette that we found until I reach the matching Beam::Mode. Then, I set the selected index of the palette to the index of the correct cell and update the palette to repaint it. This function takes in a bool for whether or not to unselect and this is used when it is called from the Mouse click event to tell whether the element has been clicked off. If that parameter is true, the selection index is set to -1 so that none of the cells are painted dark blue. There is no need to call the update or repaint function here, but I don't exactly know why so I just assume that there is something else that happens when clicking off an element that updates the palette.

I know this might be a bit of a clunky solution, but based on how things are set up it's the best way I see so far. I've done a bit of profiling and it seems to take very little time. The loops and switch that do exist are short loops so that makes sense.

I have some ideas for optimizations and can elaborate on those if you would like me to, but for now and for what this fix is for I think this should appropriate. Of course let me know if you disagree! As for future improvements, it's possible to potentially implement the same concept for other attributes and other available Palettes. In that case, though, performance will be an issue so it would take a bit of reworking of the palette structure. I have some other ideas for this as well if you'd like me to elaborate.