### PR TITLE
fix #284525: fix "Join Measure" command crash for MM rests

### DIFF
--- a/libmscore/joinMeasure.cpp
+++ b/libmscore/joinMeasure.cpp
@@ -25,8 +25,12 @@ namespace Ms {
 
 void Score::cmdJoinMeasure(Measure* m1, Measure* m2)
       {
-      if (!m2)
+      if (!m1 || !m2)
             return;
+      if (m1->isMMRest())
+            m1 = m1->mmRestFirst();
+      if (m2->isMMRest())
+            m2 = m2->mmRestLast();
       startCmd();
 
       deselectAll();


### PR DESCRIPTION
See https://musescore.org/en/node/284525.