### PR TITLE
Autoplace user customization

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -426,11 +426,11 @@ const char* Articulation::symId2ArticulationName(SymId symId)
             case SymId::articStaccatoAbove:
             case SymId::articStaccatoBelow:
                   return "staccato";
-                  
+
             case SymId::articAccentStaccatoAbove:
             case SymId::articAccentStaccatoBelow:
                   return "sforzatoStaccato";
-                  
+
             case SymId::articMarcatoStaccatoAbove:
             case SymId::articMarcatoStaccatoBelow:
                   return "marcatoStaccato";
@@ -442,7 +442,7 @@ const char* Articulation::symId2ArticulationName(SymId symId)
             case SymId::articMarcatoTenutoAbove:
             case SymId::articMarcatoTenutoBelow:
                   return "marcatoTenuto";
-                  
+
             case SymId::articTenutoAbove:
             case SymId::articTenutoBelow:
                   return "tenuto";
@@ -591,8 +591,8 @@ QString Articulation::accessibleInfo() const
 
 void Articulation::doAutoplace()
       {
-      qreal minDistance = score()->styleP(Sid::dynamicsMinDistance);
-      if (autoplace() && visible() && parent()) {
+      qreal minDistance = score()->styleS(Sid::articulationMinDistance).val() * spatium();
+      if (autoplace() && parent()) {
             Segment* s = segment();
             Measure* m = measure();
             int si     = staffIdx();

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -2416,7 +2416,7 @@ QVariant Beam::propertyDefault(Pid id) const
 
 void Beam::addSkyline(Skyline& sk)
       {
-      if (beamSegments.empty() || !autoplace() || !visible())
+      if (beamSegments.empty() || !addToSkyline())
             return;
       qreal lw2 = point(score()->styleS(Sid::beamWidth)) * .5 * mag();
       const QLineF* bs = beamSegments.front();

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3155,20 +3155,20 @@ QString Chord::accessibleExtraInfo() const
 Shape Chord::shape() const
       {
       Shape shape;
-      if (_hook && _hook->autoplace() && _hook->visible())
+      if (_hook && _hook->addToSkyline())
             shape.add(_hook->shape().translated(_hook->pos()));
-      if (_stem && _stem->autoplace() && _stem->visible())
+      if (_stem && _stem->addToSkyline())
             shape.add(_stem->shape().translated(_stem->pos()));
-      if (_stemSlash && _stemSlash->autoplace() && _stemSlash->visible())
+      if (_stemSlash && _stemSlash->addToSkyline())
             shape.add(_stemSlash->shape().translated(_stemSlash->pos()));
-      if (_arpeggio && _arpeggio->autoplace() && _arpeggio->visible())
+      if (_arpeggio && _arpeggio->addToSkyline())
             shape.add(_arpeggio->shape().translated(_arpeggio->pos()));
 //      if (_tremolo)
 //            shape.add(_tremolo->shape().translated(_tremolo->pos()));
       for (Note* note : _notes)
             shape.add(note->shape().translated(note->pos()));
       for (Element* e : el()) {
-            if (e->autoplace() && e->visible())
+            if (e->addToSkyline())
                   shape.add(e->shape().translated(e->pos()));
             }
       for (Chord* chord : _graceNotes)    // process grace notes last, needed for correct shape calculation
@@ -3385,7 +3385,7 @@ void Chord::layoutArticulations2()
                   }
             }
       for (Articulation* a : _articulations) {
-            if (a->autoplace() && a->visible()) {
+            if (a->addToSkyline()) {
                   Segment* s = segment();
                   Measure* m = s->measure();
                   QRectF r = a->bbox().translated(a->pos() + pos());
@@ -3415,12 +3415,12 @@ void Chord::layoutArticulations3(Slur* slur)
       Measure* m = measure();
       SysStaff* sstaff = m->system() ? m->system()->staff(staffIdx()) : nullptr;
       for (Articulation* a : _articulations) {
-            if (a->layoutCloseToNote() || !a->autoplace() || !slur->autoplace() || !slur->visible())
+            if (a->layoutCloseToNote() || !a->autoplace() || !slur->addToSkyline())
                   continue;
             Shape aShape = a->shape().translated(a->pos() + pos() + s->pos() + m->pos());
             Shape sShape = ss->shape().translated(ss->pos());
             if (aShape.intersects(sShape)) {
-                  qreal d = score()->styleP(Sid::dynamicsMinDistance);
+                  qreal d = score()->styleS(Sid::articulationMinDistance).val() * spatium();
                   if (slur->up()) {
                         d += qMax(aShape.minVerticalDistance(sShape), 0.0);
                         a->rypos() -= d;
@@ -3431,7 +3431,7 @@ void Chord::layoutArticulations3(Slur* slur)
                         a->rypos() += d;
                         aShape.translateY(d);
                         }
-                  if (sstaff)
+                  if (sstaff && a->addToSkyline())
                         sstaff->skyline().add(aShape);
                   }
             }

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1196,9 +1196,9 @@ Shape ChordRest::shape() const
       qreal x2 = -1000000.0;
       bool adjustWidth = false;
       for (Lyrics* l : _lyrics) {
-            if (!l || !l->visible() || !l->autoplace())
+            if (!l || !l->addToSkyline())
                   continue;
-            qreal lmargin = styleP(Sid::lyricsMinDistance) * .5;
+            qreal lmargin = score()->styleS(Sid::lyricsMinDistance).val() * spatium() * 0.5;
             qreal rmargin = lmargin;
             Lyrics::Syllabic syl = l->syllabic();
             if ((syl == Lyrics::Syllabic::BEGIN || syl == Lyrics::Syllabic::MIDDLE) && score()->styleB(Sid::lyricsDashForce))
@@ -1219,7 +1219,7 @@ Shape ChordRest::shape() const
       qreal x2 = -1000000.0;
       bool adjustWidth = false;
       for (Element* e : segment()->annotations()) {
-            if (!e || !e->visible() || !e->autoplace())
+            if (!e || !e->addToSkyline())
                   continue;
             if (e->isHarmony() && e->staffIdx() == staffIdx()) {
                   Harmony* h = toHarmony(e);

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3562,6 +3562,39 @@ void Score::cmdRelayout()
       }
 
 //---------------------------------------------------------
+//   cmdToggleAutoplace
+//---------------------------------------------------------
+
+void Score::cmdToggleAutoplace(bool all)
+      {
+      if (all) {
+            bool val = !styleB(Sid::autoplaceEnabled);
+            undoChangeStyleVal(Sid::autoplaceEnabled, val);
+            setLayoutAll();
+            }
+      else {
+            QSet<Element*> spanners;
+            for (Element* e : selection().elements()) {
+                  if (e->isSpannerSegment()) {
+                        if (Element* ee = e->propertyDelegate(Pid::AUTOPLACE))
+                              e = ee;
+                        // spanner segments may each have their own autoplace setting
+                        // but if they delegate to spanner, only toggle once
+                        if (e->isSpanner()) {
+                              if (spanners.contains(e))
+                                    continue;
+                              spanners.insert(e);
+                              }
+                        }
+                  PropertyFlags pf = e->propertyFlags(Pid::AUTOPLACE);
+                  if (pf == PropertyFlags::STYLED)
+                        pf = PropertyFlags::UNSTYLED;
+                  e->undoChangeProperty(Pid::AUTOPLACE, !e->getProperty(Pid::AUTOPLACE).toBool(), pf);
+                  }
+            }
+      }
+
+//---------------------------------------------------------
 //   cmd
 //---------------------------------------------------------
 
@@ -3718,6 +3751,8 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "page-break",                 [this]{ cmdToggleLayoutBreak(LayoutBreak::Type::PAGE);              }},
             { "section-break",              [this]{ cmdToggleLayoutBreak(LayoutBreak::Type::SECTION);           }},
             { "relayout",                   [this]{ cmdRelayout();                                              }},
+            { "toggle-autoplace",           [this]{ cmdToggleAutoplace(false);                                  }},
+            { "autoplace-enabled",          [this]{ cmdToggleAutoplace(true);                                   }},
             { "",                           [this]{                                                             }},
             };
 

--- a/libmscore/dynamic.cpp
+++ b/libmscore/dynamic.cpp
@@ -264,7 +264,7 @@ void Dynamic::doAutoplace()
       if (!(s && autoplace()))
             return;
 
-      qreal minDistance = score()->styleP(Sid::dynamicsMinDistance);
+      qreal minDistance = score()->styleS(Sid::dynamicsMinDistance).val() * spatium();
       QRectF r          = bbox().translated(pos() + s->pos() + s->measure()->pos());
       Skyline& sl       = s->measure()->system()->staff(staffIdx())->skyline();
       SkylineLine sk(!placeAbove());

--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1114,6 +1114,17 @@ void collectElements(void* data, Element* e)
       }
 
 //---------------------------------------------------------
+//   autoplace
+//---------------------------------------------------------
+
+bool Element::autoplace() const
+      {
+      if (!score() || !score()->styleB(Sid::autoplaceEnabled))
+          return false;
+      return !flag(ElementFlag::NO_AUTOPLACE);
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 
@@ -1836,7 +1847,10 @@ void Element::startDrag(EditData& ed)
       ElementEditData* eed = new ElementEditData();
       eed->e = this;
       eed->pushProperty(Pid::OFFSET);
+      eed->pushProperty(Pid::AUTOPLACE);
       ed.addData(eed);
+      if (ed.modifiers & Qt::AltModifier)
+            setAutoplace(false);
       }
 
 //---------------------------------------------------------
@@ -2141,7 +2155,7 @@ void Element::autoplaceSegmentElement(qreal minDistance)
 
 void Element::autoplaceSegmentElement(qreal minDistance)
       {
-      if (visible() && autoplace() && parent()) {
+      if (autoplace() && parent()) {
             Segment* s = toSegment(parent());
             Measure* m = s->measure();
 
@@ -2150,6 +2164,9 @@ void Element::autoplaceSegmentElement(qreal minDistance)
                   const int firstVis = m->system()->firstVisibleStaff();
                   if (firstVis < score()->nstaves())
                         si = firstVis;
+                  }
+            else {
+                  minDistance *= staff()->mag(tick());
                   }
 
             SysStaff* ss = m->system()->staff(si);
@@ -2173,7 +2190,8 @@ void Element::autoplaceSegmentElement(qreal minDistance)
                   rypos() += yd;
                   r.translate(QPointF(0.0, yd));
                   }
-            ss->skyline().add(r);
+            if (addToSkyline() && minDistance >= 0.0)
+                  ss->skyline().add(r);
             }
       }
 
@@ -2183,7 +2201,7 @@ void Element::autoplaceSegmentElement(qreal minDistance)
 
 void Element::autoplaceMeasureElement(qreal minDistance)
       {
-      if (visible() && autoplace() && parent()) {
+      if (autoplace() && parent()) {
             Measure* m = toMeasure(parent());
             int si     = staffIdx();
 
@@ -2207,7 +2225,8 @@ void Element::autoplaceMeasureElement(qreal minDistance)
                   rypos() += yd;
                   r.translate(QPointF(0.0, yd));
                   }
-            ss->skyline().add(r);
+            if (addToSkyline() && minDistance >= 0.0)
+                  ss->skyline().add(r);
             }
       }
 

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -402,8 +402,9 @@ class Element : public ScoreElement {
       uint tag() const                 { return _tag;                      }
       void setTag(uint val)            { _tag = val;                       }
 
-      bool autoplace() const           { return !flag(ElementFlag::NO_AUTOPLACE); }
-      void setAutoplace(bool v)        { setFlag(ElementFlag::NO_AUTOPLACE, !v); }
+      bool autoplace() const;
+      virtual void setAutoplace(bool v)   { setFlag(ElementFlag::NO_AUTOPLACE, !v); }
+      bool addToSkyline() const           { return !(_flags & (ElementFlag::INVISIBLE|ElementFlag::NO_AUTOPLACE)); }
 
       virtual QVariant getProperty(Pid) const override;
       virtual bool setProperty(Pid, const QVariant&) override;

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -143,7 +143,8 @@ void Fingering::layout()
                                     Note* un = chord->upNote();
                                     top = qMin(0.0, un->y() + un->bbox().top());
                                     }
-                              top -= spatium() * 0.5;
+                              qreal minDistance = score()->styleS(Sid::fingeringMinDistance).val() * spatium();
+                              top -= minDistance;
                               qreal diff = (bbox().bottom() + ipos().y() + n->y()) - top;
                               if (diff > 0.0)
                                     rypos() -= diff;
@@ -171,7 +172,8 @@ void Fingering::layout()
                                     Note* dn = chord->downNote();
                                     bottom = qMax(vStaff->height(), dn->y() + dn->bbox().bottom());
                                     }
-                              bottom += spatium() * 0.5;
+                              qreal minDistance = score()->styleS(Sid::fingeringMinDistance).val() * spatium();
+                              bottom += minDistance;
                               qreal diff = bottom - (bbox().top() + ipos().y() + n->y());
                               if (diff > 0.0)
                                     rypos() += diff;

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -20,6 +20,7 @@
 #include "segment.h"
 #include "mscore.h"
 #include "harmony.h"
+#include "staff.h"
 
 namespace Ms {
 
@@ -385,7 +386,7 @@ void FretDiagram::layout()
       autoplaceSegmentElement(minDistance);
       if (_harmony)
             _harmony->layout();
-      if (_harmony && _harmony->visible() && _harmony->autoplace() && _harmony->parent()) {
+      if (_harmony && _harmony->autoplace() && _harmony->parent()) {
             Segment* s = toSegment(parent());
             Measure* m = s->measure();
             int si     = staffIdx();
@@ -396,13 +397,15 @@ void FretDiagram::layout()
             SkylineLine sk(false);
             sk.add(r.x(), r.bottom(), r.width());
             qreal d = sk.minDistance(ss->skyline().north());
+            minDistance *= staff()->mag(tick());
             if (d > -minDistance) {
                   qreal yd = d + minDistance;
                   yd *= -1.0;
                   _harmony->rypos() += yd;
                   r.translate(QPointF(0.0, yd));
                   }
-            ss->skyline().add(r);
+            if (_harmony->addToSkyline())
+                  ss->skyline().add(r);
             }
       }
 

--- a/libmscore/jump.cpp
+++ b/libmscore/jump.cpp
@@ -101,7 +101,7 @@ QString Jump::jumpTypeUserName() const
 void Jump::layout()
       {
       TextBase::layout();
-      autoplaceMeasureElement(0.5 * spatium());
+      autoplaceMeasureElement(styleP(Sid::repeatMinDistance));
       }
 
 //---------------------------------------------------------

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -282,7 +282,7 @@ Shape KeySig::shape() const
       {
       QRectF box(bbox());
       const Staff* st = staff();
-      if (st && autoplace() && visible()) {
+      if (st && addToSkyline()) {
             // Extend key signature shape up and down to
             // the first ledger line height to ensure that
             // no notes will be too close to the keysig.

--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -491,7 +491,7 @@ void LayoutContext::layoutLinear()
                                           Tremolo* t = c->tremolo();
                                           Chord* c1 = t->chord1();
                                           Chord* c2 = t->chord2();
-                                          if (t->twoNotes() && (c1->staffMove() || c2->staffMove()))
+                                          if (t->twoNotes() && c1 && c2 && (c1->staffMove() || c2->staffMove()))
                                                 t->layout();
                                           }
                                     }

--- a/libmscore/letring.cpp
+++ b/libmscore/letring.cpp
@@ -49,7 +49,7 @@ static const ElementStyle letRingStyle {
 void LetRingSegment::layout()
       {
       TextLineBaseSegment::layout();
-      autoplaceSpannerSegment(spatium() * .7);
+      autoplaceSpannerSegment(styleP(Sid::letRingMinDistance));
       }
 
 //---------------------------------------------------------

--- a/libmscore/marker.cpp
+++ b/libmscore/marker.cpp
@@ -174,7 +174,7 @@ void Marker::layout()
       if (layoutToParentWidth() && !(align() & (Align::RIGHT | Align::HCENTER)))
             rxpos() -= width() * 0.5;
 
-      autoplaceMeasureElement(0.5 * spatium());
+      autoplaceMeasureElement(styleP(Sid::repeatMinDistance));
       }
 
 //---------------------------------------------------------

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3288,7 +3288,7 @@ void Measure::stretchMeasure(qreal targetWidth)
                               Tremolo* tr = c->tremolo();
                               Chord* c1 = tr->chord1();
                               Chord* c2 = tr->chord2();
-                              if (!tr->twoNotes() || (!c1->staffMove() && !c2->staffMove()))
+                              if (!tr->twoNotes() || (c1 && !c1->staffMove() && c2 && !c2->staffMove()))
                                     tr->layout();
                               }
                         }

--- a/libmscore/mscore.cpp
+++ b/libmscore/mscore.cpp
@@ -72,7 +72,6 @@ bool MScore::showBoundingRect    = false;
 bool MScore::showSystemBoundingRect    = false;
 bool MScore::showCorruptedMeasures = true;
 bool MScore::useFallbackFont       = true;
-bool MScore::autoplaceSlurs        = true;
 // #endif
 
 bool  MScore::saveTemplateMode = false;

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -375,7 +375,6 @@ class MScore {
       static bool showSystemBoundingRect;
       static bool showCorruptedMeasures;
       static bool useFallbackFont;
-      static bool autoplaceSlurs;
 // #endif
       static bool debugMode;
       static bool testMode;

--- a/libmscore/ottava.cpp
+++ b/libmscore/ottava.cpp
@@ -59,7 +59,7 @@ static const ElementStyle ottavaStyle {
 void OttavaSegment::layout()
       {
       TextLineBaseSegment::layout();
-      autoplaceSpannerSegment(spatium() * .7);
+      autoplaceSpannerSegment(styleP(Sid::ottavaMinDistance));
       }
 
 //---------------------------------------------------------

--- a/libmscore/palmmute.cpp
+++ b/libmscore/palmmute.cpp
@@ -50,7 +50,7 @@ static const ElementStyle palmMuteStyle {
 void PalmMuteSegment::layout()
       {
       TextLineBaseSegment::layout();
-      autoplaceSpannerSegment(spatium() * .7);
+      autoplaceSpannerSegment(styleP(Sid::palmMuteMinDistance));
       }
 
 //---------------------------------------------------------

--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -51,7 +51,7 @@ static const ElementStyle pedalStyle {
 void PedalSegment::layout()
       {
       TextLineBaseSegment::layout();
-      autoplaceSpannerSegment(spatium() * .7);
+      autoplaceSpannerSegment(styleP(Sid::pedalMinDistance));
       }
 
 //---------------------------------------------------------

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -1016,7 +1016,7 @@ Shape Rest::shape() const
                   shape.add(symBbox(SymId::augmentationDot).translated(dot->pos()));
             }
       for (Element* e : el()) {
-            if (e->autoplace() && e->visible())
+            if (e->addToSkyline())
                   shape.add(e->shape().translated(e->pos()));
             }
       return shape;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -728,6 +728,7 @@ class Score : public QObject, public ScoreElement {
       void addRefresh(const QRectF&);
 
       void cmdRelayout();
+      void cmdToggleAutoplace(bool all);
 
       bool playNote() const                 { return _updateState._playNote; }
       void setPlayNote(bool v)              { _updateState._playNote = v;    }

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1897,7 +1897,7 @@ void Segment::createShape(int staffIdx)
             int effectiveTrack = e->vStaffIdx() * VOICES + e->voice();
             if (effectiveTrack >= strack && effectiveTrack < etrack) {
                   setVisible(true);
-                  if (e->autoplace())
+                  if (e->addToSkyline())
                         s.add(e->shape().translated(e->pos()));
                   }
             }
@@ -1906,7 +1906,7 @@ void Segment::createShape(int staffIdx)
             if (!e || e->staffIdx() != staffIdx)
                   continue;
             setVisible(true);
-            if (!e->autoplace())
+            if (!e->addToSkyline())
                   continue;
 
             if (e->isHarmony()) {

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -365,7 +365,7 @@ void SlurSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
       _extraHeight = 0.0;
       computeBezier();
 
-      if (MScore::autoplaceSlurs && autoplace() && system()) {
+      if (autoplace() && system()) {
             bool up = slur()->up();
             Segment* ls = system()->lastMeasure()->last();
             Segment* fs = system()->firstMeasure()->first();
@@ -376,6 +376,7 @@ void SlurSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
             qreal slurMaxMove = spatium();
             bool intersection = false;
             qreal gdist = 0.0;
+            qreal minDistance = score()->styleS(Sid::SlurMinDistance).val() * spatium();
             for (int tries = 1; true; ++tries) {
                   for (Segment* s = fs; s && s != ls; s = s->next1()) {
                         if (!s->enabled())
@@ -420,7 +421,7 @@ void SlurSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
                   gdist = 0.0;
                   }
             if (intersection && gdist > 0.0) {
-                  qreal min = score()->styleP(Sid::SlurMinDistance) + gdist;
+                  qreal min = minDistance + gdist;
                   rypos() += up ? -min : min;
                   }
             }
@@ -453,7 +454,7 @@ static qreal fixArticulations(qreal yo, Chord* c, qreal _up, bool stemSide = fal
       //
 #if 1
       for (Articulation* a : c->articulations()) {
-            if (!a->layoutCloseToNote() || !a->autoplace() || !a->visible())
+            if (!a->layoutCloseToNote() || !a->addToSkyline())
                   continue;
             // skip if articulation on stem side but slur is not or vice versa
             if ((a->up() == c->up()) != stemSide)

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -858,6 +858,17 @@ void Spanner::setVisible(bool f)
       }
 
 //---------------------------------------------------------
+//   setAutoplace
+//---------------------------------------------------------
+
+void Spanner::setAutoplace(bool f)
+      {
+      for (SpannerSegment* ss : spannerSegments())
+            ss->Element::setAutoplace(f);
+      Element::setAutoplace(f);
+      }
+
+//---------------------------------------------------------
 //   setColor
 //---------------------------------------------------------
 
@@ -1341,7 +1352,9 @@ void SpannerSegment::autoplaceSpannerSegment(qreal minDistance)
       if (spanner()->anchor() == Spanner::Anchor::NOTE)
             return;
 
-      if (visible() && autoplace()) {
+      if (autoplace()) {
+            if (!systemFlag() && !spanner()->systemFlag())
+                  minDistance *= staff()->mag(spanner()->tick());
             SkylineLine sl(!spanner()->placeAbove());
             sl.add(shape().translated(pos()));
             if (spanner()->placeAbove()) {

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -254,6 +254,7 @@ class Spanner : public Element {
 
       virtual void setSelected(bool f) override;
       virtual void setVisible(bool f) override;
+      virtual void setAutoplace(bool f) override;
       virtual void setColor(const QColor& col) override;
       Spanner* nextSpanner(Element* e, int activeStaff);
       Spanner* prevSpanner(Element* e, int activeStaff);

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -652,7 +652,7 @@ static const StyleType styleTypes[] {
       { Sid::stringNumberFrameRound,        "stringNumberFrameRound",        0 },
       { Sid::stringNumberFrameFgColor,      "stringNumberFrameFgColor",      QColor(0, 0, 0, 255) },
       { Sid::stringNumberFrameBgColor,      "stringNumberFrameBgColor",      QColor(255, 255, 255, 0) },
-      { Sid::stringNumberOffset,            "stringNumberOffset",            QPointF(0.0, -2.0) },
+      { Sid::stringNumberOffset,            "stringNumberOffset",            QPointF(0.0, 0.0) },
 
       { Sid::longInstrumentFontFace,        "longInstrumentFontFace",       "FreeSerif" },
       { Sid::longInstrumentFontSize,        "longInstrumentFontSize",       12.0 },
@@ -1117,6 +1117,22 @@ static const StyleType styleTypes[] {
       { Sid::fermataMinDistance,            "fermataMinDistance",            Spatium(0.4)  },
 
       { Sid::fingeringPlacement,            "fingeringPlacement",            int(Placement::ABOVE) },
+
+      { Sid::articulationMinDistance,       "articulationMinDistance",       Spatium(0.5)  },
+      { Sid::fingeringMinDistance,          "fingeringMinDistance",          Spatium(0.5)  },
+      { Sid::hairpinMinDistance,            "hairpinMinDistance",            Spatium(0.7)  },
+      { Sid::letRingMinDistance,            "letRingMinDistance",            Spatium(0.7)  },
+      { Sid::ottavaMinDistance,             "ottavaMinDistance",             Spatium(0.7)  },
+      { Sid::palmMuteMinDistance,           "palmMuteMinDistance",           Spatium(0.7)  },
+      { Sid::pedalMinDistance,              "pedalMinDistance",              Spatium(0.7)  },
+      { Sid::repeatMinDistance,             "repeatMinDistance",             Spatium(0.5)  },
+      { Sid::textLineMinDistance,           "textLineMinDistance",           Spatium(0.7)  },
+      { Sid::trillMinDistance,              "trillMinDistance",              Spatium(1.0)  },
+      { Sid::vibratoMinDistance,            "vibratoMinDistance",            Spatium(1.0)  },
+      { Sid::voltaMinDistance,              "voltaMinDistance",              Spatium(1.0)  },
+
+      { Sid::autoplaceEnabled,              "autoplaceEnabled",              true },
+
       };
 
 MStyle  MScore::_baseStyle;

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1093,6 +1093,21 @@ enum class Sid {
 
       fingeringPlacement,
 
+      articulationMinDistance,
+      fingeringMinDistance,
+      hairpinMinDistance,
+      letRingMinDistance,
+      ottavaMinDistance,
+      palmMuteMinDistance,
+      pedalMinDistance,
+      repeatMinDistance,
+      textLineMinDistance,
+      trillMinDistance,
+      vibratoMinDistance,
+      voltaMinDistance,
+
+      autoplaceEnabled,
+
       STYLES
       };
 

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -53,7 +53,7 @@ TextLineSegment::TextLineSegment(Spanner* sp, Score* s)
 void TextLineSegment::layout()
       {
       TextLineBaseSegment::layout();
-      autoplaceSpannerSegment(spatium() * .7);
+      autoplaceSpannerSegment(styleP(Sid::textLineMinDistance));
       }
 
 //---------------------------------------------------------

--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -354,7 +354,7 @@ Shape TimeSig::shape() const
       {
       QRectF box(bbox());
       const Staff* st = staff();
-      if (st && autoplace() && visible()) {
+      if (st && addToSkyline()) {
             // Extend time signature shape up and down to
             // the first ledger line height to ensure that
             // no notes will be too close to the timesig.

--- a/libmscore/trill.cpp
+++ b/libmscore/trill.cpp
@@ -165,7 +165,7 @@ void TrillSegment::layout()
       else
             symbolLine(SymId::wiggleTrill, SymId::wiggleTrill);
 
-      autoplaceSpannerSegment(spatium() * 1.0);
+      autoplaceSpannerSegment(styleP(Sid::trillMinDistance));
       }
 
 //---------------------------------------------------------

--- a/libmscore/vibrato.cpp
+++ b/libmscore/vibrato.cpp
@@ -122,7 +122,7 @@ void VibratoSegment::layout()
       else
             symbolLine(SymId::wiggleVibrato, SymId::wiggleVibrato);
 
-      autoplaceSpannerSegment(spatium() * 1.0);
+      autoplaceSpannerSegment(styleP(Sid::vibratoMinDistance));
       }
 
 //---------------------------------------------------------

--- a/libmscore/volta.cpp
+++ b/libmscore/volta.cpp
@@ -62,7 +62,7 @@ VoltaSegment::VoltaSegment(Spanner* sp, Score* s) : TextLineBaseSegment(sp, s, E
 void VoltaSegment::layout()
       {
       TextLineBaseSegment::layout();
-      autoplaceSpannerSegment(spatium() * 1.0);
+      autoplaceSpannerSegment(styleP(Sid::voltaMinDistance));
       }
 
 //---------------------------------------------------------

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -1014,4 +1014,8 @@
     <key>toggle-insert-mode</key>
     <seq>Ctrl+I</seq>
     </SC>
+    <SC>
+      <key>toggle-autoplace</key>
+      <seq>=</seq>
+      </SC>
   </Shortcuts>

--- a/mscore/inspector/inspectorElementBase.cpp
+++ b/mscore/inspector/inspectorElementBase.cpp
@@ -12,6 +12,7 @@
 
 #include "inspector.h"
 #include "libmscore/element.h"
+#include "libmscore/score.h"
 #include "inspectorElementBase.h"
 
 namespace Ms {
@@ -46,6 +47,13 @@ void InspectorElementBase::setElement()
             e.offset->setSuffix("sp");
       else
             e.offset->setSuffix("mm");
+      if (inspector->element()->score()->styleB(Sid::autoplaceEnabled)) {
+            e.autoplace->setEnabled(true);
+            }
+      else {
+            e.autoplace->setEnabled(false);
+            e.resetAutoplace->setEnabled(false);
+            }
       }
 
 } // namespace Ms

--- a/mscore/inspector/inspectorGroupElement.cpp
+++ b/mscore/inspector/inspectorGroupElement.cpp
@@ -32,6 +32,8 @@ InspectorGroupElement::InspectorGroupElement(QWidget* parent)
       connect(ge.setColor, SIGNAL(clicked()), SLOT(setColor()));
       connect(ge.setVisible, SIGNAL(clicked()), SLOT(setVisible()));
       connect(ge.setInvisible, SIGNAL(clicked()), SLOT(setInvisible()));
+      connect(ge.enableAutoplace, SIGNAL(clicked()), SLOT(enableAutoplace()));
+      connect(ge.disableAutoplace, SIGNAL(clicked()), SLOT(disableAutoplace()));
 
       //
       // Select
@@ -119,6 +121,40 @@ void InspectorGroupElement::setInvisible()
       for (Element* e : *inspector->el()) {
             if (e->getProperty(Pid::VISIBLE).toBool())
                   e->undoChangeProperty(Pid::VISIBLE, false);
+            }
+      score->endCmd();
+      }
+
+//---------------------------------------------------------
+//   enableAutoplace
+//---------------------------------------------------------
+
+void InspectorGroupElement::enableAutoplace()
+      {
+      if (inspector->el()->isEmpty())
+            return;
+      Score* score = inspector->el()->front()->score();
+      score->startCmd();
+      for (Element* e : *inspector->el()) {
+            if (!e->getProperty(Pid::AUTOPLACE).toBool())
+                  e->undoChangeProperty(Pid::AUTOPLACE, true);
+            }
+      score->endCmd();
+      }
+
+//---------------------------------------------------------
+//   disableAutoplace
+//---------------------------------------------------------
+
+void InspectorGroupElement::disableAutoplace()
+      {
+      if (inspector->el()->isEmpty())
+            return;
+      Score* score = inspector->el()->front()->score();
+      score->startCmd();
+      for (Element* e : *inspector->el()) {
+            if (e->getProperty(Pid::AUTOPLACE).toBool())
+                  e->undoChangeProperty(Pid::AUTOPLACE, false);
             }
       score->endCmd();
       }

--- a/mscore/inspector/inspectorGroupElement.h
+++ b/mscore/inspector/inspectorGroupElement.h
@@ -34,6 +34,8 @@ class InspectorGroupElement : public InspectorBase {
       void setColor();
       void setVisible();
       void setInvisible();
+      void enableAutoplace();
+      void disableAutoplace();
       void notesClicked();
       void graceNotesClicked();
       void restsClicked();

--- a/mscore/inspector/inspector_group_element.ui
+++ b/mscore/inspector/inspector_group_element.ui
@@ -108,6 +108,26 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QPushButton" name="enableAutoplace">
+        <property name="focusPolicy">
+         <enum>Qt::TabFocus</enum>
+        </property>
+        <property name="text">
+         <string>Enable Autoplace</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QPushButton" name="disableAutoplace">
+        <property name="focusPolicy">
+         <enum>Qt::TabFocus</enum>
+        </property>
+        <property name="text">
+         <string>Disable Autoplace</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -126,6 +146,8 @@
   <tabstop>setColor</tabstop>
   <tabstop>setVisible</tabstop>
   <tabstop>setInvisible</tabstop>
+  <tabstop>enableAutoplace</tabstop>
+  <tabstop>disableAutoplace</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1727,10 +1727,6 @@ MuseScore::MuseScore()
       menuDebug->addAction(a);
       a = getAction("relayout");
       menuDebug->addAction(a);
-      a = getAction("autoplace-slurs");
-      a->setCheckable(true);
-      a->setChecked(MScore::autoplaceSlurs);
-      menuDebug->addAction(a);
       Workspace::addMenuAndString(menuDebug, "menu-debug");
 #endif
 
@@ -6249,13 +6245,6 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             }
       else if (cmd == "show-corrupted-measures") {
             MScore::showCorruptedMeasures = a->isChecked();
-            if (cs) {
-                  cs->setLayoutAll();
-                  cs->update();
-                  }
-            }
-      else if (cmd == "autoplace-slurs") {
-            MScore::autoplaceSlurs = a->isChecked();
             if (cs) {
                   cs->setLayoutAll();
                   cs->update();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3630,6 +3630,23 @@ Shortcut Shortcut::_sc[] = {
          Qt::WindowShortcut
          },
       {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "toggle-autoplace",
+         QT_TRANSLATE_NOOP("action","Toggle Automatic Placement"),
+         QT_TRANSLATE_NOOP("action","Toggle 'Automatic Placement' for selected elements")
+         },
+      {
+         MsWidget::MAIN_WINDOW,
+         STATE_ALL,
+         "autoplace-enabled",
+         QT_TRANSLATE_NOOP("action","Toggle Automatic Placement Globally"),
+         QT_TRANSLATE_NOOP("action","Toggle 'Automatic Placement' globally"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::ApplicationShortcut
+         },
+      {
          MsWidget::MAIN_WINDOW,
          STATE_ALL,
          "report-bug",
@@ -3742,16 +3759,6 @@ Shortcut Shortcut::_sc[] = {
          Icons::Invalid_ICON,
          Qt::ApplicationShortcut
          },
-      {
-         MsWidget::MAIN_WINDOW,
-         STATE_ALL,
-         "autoplace-slurs",
-         "Autoplace Slurs",
-         "Autoplace slurs",
-         0,
-         Icons::Invalid_ICON,
-         Qt::ApplicationShortcut
-         }
 #endif
       };
 


### PR DESCRIPTION
This actually works pretty well as is, but I would definitely appreciate feedback on the direction of this before I worry about polishing up any UI elements.

Basically, in response to common requests to be able to disable autoplace, I've done the following:

- added a bunch more "autoplace min distance" style settings for element types, and made sure setitngs things to, say, -99 works to effectively disable autoplace for that element type
- added commands to toggle autoplace per element and globally
- made Alt+drag automatically disable autoplace while adjusting elements
- overall, made behavior of autoplace a bit more consistent relative to what happens if you disable it for an element, or make the element invisible (in the latter case, still *placing* the element normally, but not adding it to the skyline)
