### PR TITLE
fix #277769: timeline updated when not visible

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -2226,6 +2226,9 @@ void Timeline::wheelEvent(QWheelEvent* event)
 
 void Timeline::updateGrid()
       {
+      if (!isVisible())
+            return;
+
       if (_score && _score->firstMeasure()) {
             drawGrid(nstaves(), _score->nmeasures());
             updateView();
@@ -2299,6 +2302,9 @@ void Timeline::objectDestroyed(QObject* obj)
 
 void Timeline::updateView()
       {
+      if (!isVisible())
+            return;
+
       if (_cv && _score) {
             QRectF canvas = QRectF(_cv->matrix().inverted().mapRect(_cv->geometry()));
 


### PR DESCRIPTION
This PR is based on the @jthistle's #4109 and just reflects [my suggestion](https://github.com/musescore/MuseScore/pull/4109#issuecomment-436915352) to improve it. With that little addition this patch makes performance of large scores scrolling and editing much better if the timeline is turned off so it partially resolves some issues mentioned in https://musescore.org/en/node/280952.