### PR TITLE
fix #284794: too much space allocated for small ties

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -3159,11 +3159,6 @@ void Note::setAccidentalType(AccidentalType type)
 Shape Note::shape() const
       {
       QRectF r(bbox());
-      qreal extraTieDistance = score()->styleP(Sid::MinTieLength) * .5;       // make room for ties
-      if (_tieFor)
-            r.adjust(0.0, 0.0, extraTieDistance, 0.0);
-      if (_tieBack)
-            r.adjust(-extraTieDistance, 0.0, 0.0, 0.0);
 
 #ifndef NDEBUG
       Shape shape(r, name());


### PR DESCRIPTION
Early on in 2.0, I had implemented an algorithm to enforce a minimum tie length, so ties between closely-spaced notes would not get lost.  This code - which relied on _spaceLw and _spaceRw for chords - was not functioning in the 3.0 shape-based layout algorithm.  @wschweer added new code to enforce a minimum tie length in Note::shape(), in https://github.com/musescore/MuseScore/commit/ba21d03c758f1bf0abbd12e16118f3073ac4a552, but then a week later (!) @dmitrio95 added code to Chord::shape() in https://github.com/musescore/MuseScore/commit/6e5de1926c80b3c616cfcb303032c49665d61bbf that reinstated the use of _spaceLw and _spaceRw.  This renders the Note:shape() code - which is more simplistic - obsolete and now harmful, as per https://musescore.org/en/node/284794

So, removing the tie adjustment from Note::shape() fixes the latter problem while preserving the original fix for the small ties problem.