### PR TITLE
fix #284502: rehearsal mark offset reset on style change

### DIFF
--- a/libmscore/rehearsalmark.cpp
+++ b/libmscore/rehearsalmark.cpp
@@ -23,7 +23,6 @@ namespace Ms {
 
 static const ElementStyle rehearsalMarkStyle {
       { Sid::rehearsalMarkPlacement, Pid::PLACEMENT },
-      { Sid::rehearsalMarkPosAbove, Pid::OFFSET },
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
Not really completely sure why having this line was a problem, I guess because OFFSET is really a text style property and thus not using the wrong entry in the property flags list.  Anyhow, this does fix the problem and I don't see new ones.  Other text elements don't have this, not sure why rehearsal mark was treated differently.