### PR TITLE
fix #280878: by adding vector empty check in function Ms::Segment::nextAnnotation(Ms::Element * e).

### DIFF
--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1163,7 +1163,7 @@ Element* Segment::getElement(int staff)
 
 Element* Segment::nextAnnotation(Element* e)
       {
-      if (e == _annotations.back())
+      if (_annotations.empty() || e == _annotations.back())
             return nullptr;
       auto i = std::find(_annotations.begin(), _annotations.end(), e);
       Element* next = *(i+1);


### PR DESCRIPTION
I have fixed issue described in https://musescore.org/en/node/280878 . It looks like the cause of this bug is that if the only empty textbox is deselected by pressing ESC, then the _annotation vector's size is already zero when entering the function. However, the following code still attempts to obtain value from the empty vector, which causes a crash. By adding empty check at the front of the function, The dereference error can be bypassed.