### PR TITLE
fix #285100: Crash when moving beam if first note of beam is in the first measure and other notes of beam are in the second measure

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2238,7 +2238,8 @@ void Score::createBeams(Measure* measure)
                                     if (!beamNoContinue(prevCR->beamMode())
                                         && !pm->lineBreak() && !pm->pageBreak() && !pm->sectionBreak()) {
                                           beam = prevCR->beam();
-                                          a1 = beam ? beam->elements().front() : prevCR;
+                                          //a1 = beam ? beam->elements().front() : prevCR;
+                                          a1 = beam ? nullptr : prevCR; // when beam is found, a1 is no longer required.
                                           }
                                     }
                               }
@@ -2358,8 +2359,17 @@ void Score::createBeams(Measure* measure)
                   }
             if (beam)
                   beam->layout1();
-            else if (a1)
+            else if (a1) {
+                  // if a1 is the last chord/rest in current measure
+                  if (a1->segment()->next(SegmentType::ChordRest) == nullptr) {
+                        const auto b = a1->beam();
+                        // if the second chord/rest in a1's beam (it must be in next measure) has forced MID beam mode
+                        if (b && b->elements().startsWith(a1) && b->elements().size()>=2 && b->elements()[1]->beamMode() == Beam::Mode::MID)
+                              // do not delete the origin beam
+                              continue;
+                        }
                   a1->removeDeleteBeam(false);
+                  }
             }
       }
 


### PR DESCRIPTION
<del>See https://musescore.org/en/node/281154#comment-898984.</del>
See https://musescore.org/en/node/285100. This bug applies both 3.0.x and master.
