### PR TITLE
fix #285227: Wiggly line too short for some trill line types

### DIFF
--- a/libmscore/trill.cpp
+++ b/libmscore/trill.cpp
@@ -117,9 +117,9 @@ void TrillSegment::symbolLine(SymId start, SymId fill, SymId end)
 
       _symbols.clear();
       _symbols.push_back(start);
-      qreal w1 = f->bbox(start, mag).width();
-      qreal w2 = f->width(fill, mag);
-      qreal w3 = f->width(end, mag);
+      qreal w1 = f->advance(start, mag);
+      qreal w2 = f->advance(fill, mag);
+      qreal w3 = f->advance(end, mag);
       int n    = lrint((w - w1 - w3) / w2);
       for (int i = 0; i < n; ++i)
            _symbols.push_back(fill);


### PR DESCRIPTION
Before:
![trill](https://user-images.githubusercontent.com/8159281/53574010-00a91380-3b6f-11e9-853a-0209f5656430.png)

All trill line types now extend to the end handle.