### PR TITLE
fix #278830: generate timesig after section break

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3234,7 +3234,7 @@ System* Score::collectSystem(LayoutContext& lc)
                         }
                   else {
                         if (createHeader) {
-                              m->addSystemHeader(false);
+                              m->addSystemHeader(true);
                               createHeader = false;
                               }
                         else if (m->header())
@@ -3444,7 +3444,7 @@ System* Score::collectSystem(LayoutContext& lc)
                   ww  += rest * m->ticks().ticks() * stretch;
                   m->stretchMeasure(ww);
                   m->layoutStaffLines();
-                  }
+            }
             else if (mb->isHBox()) {
                   mb->setPos(pos + QPointF(toHBox(mb)->topGap(), 0.0));
                   mb->layout();
@@ -3452,7 +3452,7 @@ System* Score::collectSystem(LayoutContext& lc)
             else if (mb->isVBox())
                   mb->setPos(pos);
             pos.rx() += ww;
-            }
+      }
       system->setWidth(pos.x());
 
       layoutSystemElements(system, lc);

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3527,6 +3527,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
       int staffIdx = 0;
       Segment* kSegment = findFirstR(SegmentType::KeySig, Fraction(0,1));
       Segment* cSegment = findFirstR(SegmentType::HeaderClef, Fraction(0,1));
+      Segment* tSegment = findFirstR(SegmentType::TimeSig, Fraction(0,1));
 
       for (const Staff* staff : score()->staves()) {
             const int track = staffIdx * VOICES;
@@ -3662,6 +3663,33 @@ void Measure::addSystemHeader(bool isFirstSystem)
             else {
                   if (cSegment)
                         cSegment->setEnabled(false);
+                  }
+
+            bool needTimeSig = isFirstSystem;
+            if (needTimeSig) {
+                  TimeSig* timesig;
+                  if (!tSegment) {
+                        tSegment = new Segment(this, SegmentType::TimeSig, Fraction(0, 1));
+                        tSegment->setHeader(true);
+                        add(tSegment);
+                        timesig = 0;
+                        }
+                  else
+                        timesig = toTimeSig(tSegment->element(track));
+                  if (!timesig) {
+                        //
+                        // create missing time signature
+                        //
+                        timesig = new TimeSig(score());
+                        timesig->setTrack(track);
+                        timesig->setGenerated(true);
+                        timesig->setParent(tSegment);
+                        tSegment->add(timesig);
+                        }
+                  timesig->setSig(this->timesig());
+                  timesig->layout();
+                  tSegment->createShape(staffIdx);
+                  tSegment->setEnabled(true);
                   }
             ++staffIdx;
             }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3685,12 +3685,13 @@ void Measure::addSystemHeader(bool isFirstSystem)
                         timesig->setGenerated(true);
                         timesig->setParent(tSegment);
                         tSegment->add(timesig);
+                        timesig->setSig(this->timesig());
+                        timesig->layout();
+                        tSegment->createShape(staffIdx);
+                        tSegment->setEnabled(true);
                         }
-                  timesig->setSig(this->timesig());
-                  timesig->layout();
-                  tSegment->createShape(staffIdx);
-                  tSegment->setEnabled(true);
                   }
+
             ++staffIdx;
             }
       //

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3665,7 +3665,8 @@ void Measure::addSystemHeader(bool isFirstSystem)
                         cSegment->setEnabled(false);
                   }
 
-            bool needTimeSig = isFirstSystem;
+            bool firstMeasureHasTimeSig = system()->firstMeasure()->findFirstR(SegmentType::TimeSig, Fraction(0, 1));
+            bool needTimeSig = isFirstSystem && firstMeasureHasTimeSig;
             if (needTimeSig) {
                   TimeSig* timesig;
                   if (!tSegment) {


### PR DESCRIPTION
This PR adds a generated time signature to the system header after a section break and after a HBox when *Create System Header* is enabled.