### PR TITLE
fix #279417: Add brackets after HBox with *Create system header*

### DIFF
--- a/libmscore/bracket.h
+++ b/libmscore/bracket.h
@@ -41,6 +41,7 @@ class Bracket final : public Element {
       // horizontal scaling factor for brace symbol. Cannot be equal to magY or depend on h
       // because layout needs width of brace before knowing height of system...
       qreal _magx;
+      Measure* _measure;
 
    public:
       Bracket(Score*);
@@ -63,6 +64,9 @@ class Bracket final : public Element {
       qreal magx() const                        { return _magx;                 }
 
       System* system() const                    { return (System*)parent(); }
+
+      Measure* measure() const                  { return _measure; }
+      void setMeasure(Measure* measure)         { _measure = measure; }
 
       virtual void setHeight(qreal) override;
       virtual qreal width() const override;

--- a/libmscore/bracket.h
+++ b/libmscore/bracket.h
@@ -41,7 +41,7 @@ class Bracket final : public Element {
       // horizontal scaling factor for brace symbol. Cannot be equal to magY or depend on h
       // because layout needs width of brace before knowing height of system...
       qreal _magx;
-      Measure* _measure;
+      Measure* _measure = nullptr;
 
    public:
       Bracket(Score*);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3431,6 +3431,7 @@ System* Score::collectSystem(LayoutContext& lc)
 
       QPointF pos;
       firstMeasure = true;
+      bool createBrackets = false;
       for (MeasureBase* mb : system->measures()) {
             qreal ww = mb->width();
             if (mb->isMeasure()) {
@@ -3444,10 +3445,15 @@ System* Score::collectSystem(LayoutContext& lc)
                   ww  += rest * m->ticks().ticks() * stretch;
                   m->stretchMeasure(ww);
                   m->layoutStaffLines();
+                  if (createBrackets) {
+                        system->addBrackets(toMeasure(mb));
+                        createBrackets = false;
+                        }
                   }
             else if (mb->isHBox()) {
                   mb->setPos(pos + QPointF(toHBox(mb)->topGap(), 0.0));
                   mb->layout();
+                  createBrackets = toHBox(mb)->createSystemHeader();
                   }
             else if (mb->isVBox())
                   mb->setPos(pos);

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -199,13 +199,7 @@ void System::layoutSystem(qreal xo1)
 
       qreal xoff2 = 0.0;         // x offset for instrument name
 
-      int columns = 0;
-      for (int idx = 0; idx < nstaves; ++idx) {
-            int c = 0;
-            for (auto bi : score()->staff(idx)->brackets())
-                  c = qMax(c, bi->column()+1);
-            columns = qMax(columns, c);
-            }
+      int columns = getBracketsColumnsCount();
 
 #if (!defined (_MSCVER) && !defined (_MSC_VER))
       qreal bracketWidth[columns];
@@ -226,49 +220,8 @@ void System::layoutSystem(qreal xo1)
                   for (auto bi : s->brackets()) {
                         if (bi->column() != i || bi->bracketType() == BracketType::NO_BRACKET)
                               continue;
-                        int firstStaff = staffIdx;
-                        int lastStaff  = staffIdx + bi->bracketSpan() - 1;
-                        if (lastStaff >= nstaves)
-                              lastStaff = nstaves - 1;
-
-                        for (; firstStaff <= lastStaff; ++firstStaff) {
-                              if (score()->staff(firstStaff)->show())
-                                    break;
-                              }
-                        for (; lastStaff >= firstStaff; --lastStaff) {
-                              if (score()->staff(lastStaff)->show())
-                                    break;
-                              }
-                        int span = lastStaff - firstStaff + 1;
-                        //
-                        // do not show bracket if it only spans one
-                        // system due to some invisible staves
-                        //
-                        if ((span > 1) || (bi->bracketSpan() == span)) {
-                              //
-                              // this bracket is visible
-                              //
-                              Bracket* b = 0;
-                              int track = staffIdx * VOICES;
-                              for (int k = 0; k < bl.size(); ++k) {
-                                    if (bl[k]->track() == track && bl[k]->column() == i && bl[k]->bracketType() == bi->bracketType()) {
-                                          b = bl.takeAt(k);
-                                          break;
-                                          }
-                                    }
-                              if (b == 0) {
-                                    b = new Bracket(score());
-                                    b->setBracketItem(bi);
-                                    b->setGenerated(true);
-                                    b->setTrack(track);
-                                    }
-                              add(b);
-//                              if (bi->selected() != b->selected()) {
-//                                    bi->selected() ? score()->select(b) : score()->deselect(b);
-//                                    }
-                              b->setStaffSpan(firstStaff, lastStaff);
-                              bracketWidth[i] = qMax(bracketWidth[i], b->width());
-                              }
+                        Bracket* b = createBracket(bi, i, staffIdx, bl, nullptr);
+                        if (b != nullptr) bracketWidth[i] = qMax(bracketWidth[i], b->width());
                         }
                   }
             if (!staff(staffIdx)->show())
@@ -322,16 +275,7 @@ void System::layoutSystem(qreal xo1)
       //  layout brackets
       //---------------------------------------------------
 
-      for (Bracket* b : _brackets) {
-            qreal xo = -xo1;
-            for (const Bracket* b2 : _brackets) {
-                   if (b->column() > b2->column() &&
-                      ((b->firstStaff() >= b2->firstStaff() && b->firstStaff() <= b2->lastStaff()) ||
-                      (b->lastStaff() >= b2->firstStaff() && b->lastStaff() <= b2->lastStaff())))
-                        xo += b2->width() + bd;
-                   }
-            b->rxpos() = _leftMargin - xo - b->width();
-            }
+      setBracketsXPosition(xo1 + _leftMargin);
 
       //---------------------------------------------------
       //  layout instrument names x position
@@ -358,6 +302,132 @@ void System::layoutSystem(qreal xo1)
                         }
                   }
             idx += p->nstaves();
+            }
+      }
+
+//---------------------------------------------------------
+//   addBrackets
+//   Add brackets in front of this measure, typically behind a HBox
+//---------------------------------------------------------
+
+void System::addBrackets(Measure* measure)
+      {
+      if (_staves.empty())                 // ignore vbox
+            return;
+
+      int nstaves = _staves.size();
+
+      //---------------------------------------------------
+      //  find x position of staves
+      //    create brackets
+      //---------------------------------------------------
+
+      int columns = getBracketsColumnsCount();
+
+      QList<Bracket*> bl;
+      bl.swap(_brackets);
+
+      for (int staffIdx = 0; staffIdx < nstaves; ++staffIdx) {
+            Staff* s = score()->staff(staffIdx);
+            for (int i = 0; i < columns; ++i) {
+                  for (auto bi : s->brackets()) {
+                        if (bi->column() != i || bi->bracketType() == BracketType::NO_BRACKET)
+                              continue;
+                        createBracket(bi, i, staffIdx, bl, measure);
+                        }
+                  }
+            if (!staff(staffIdx)->show())
+                  continue;
+            }
+
+      //---------------------------------------------------
+      //  layout brackets
+      //---------------------------------------------------
+
+      setBracketsXPosition(measure->x());
+
+      _brackets.append(bl);
+      }
+
+//---------------------------------------------------------
+//   createBracket
+//   Create a bracket if it spans more then one visible system
+//   If measure is NULL adds the bracket in front of the system, else in front of the measure.
+//   Returns the bracket if it got created, else NULL
+//---------------------------------------------------------
+
+Bracket* System::createBracket(Ms::BracketItem * bi, int column, int staffIdx, QList<Ms::Bracket *> &bl, Measure* measure)
+      {
+      int nstaves = _staves.size();
+      int firstStaff = staffIdx;
+      int lastStaff = staffIdx + bi->bracketSpan() - 1;
+      if (lastStaff >= nstaves)
+            lastStaff = nstaves - 1;
+
+      for (; firstStaff <= lastStaff; ++firstStaff) {
+            if (score()->staff(firstStaff)->show())
+                  break;
+            }
+      for (; lastStaff >= firstStaff; --lastStaff) {
+            if (score()->staff(lastStaff)->show())
+                  break;
+            }
+      int span = lastStaff - firstStaff + 1;
+      //
+      // do not show bracket if it only spans one
+      // system due to some invisible staves
+      //
+      if ((span > 1) || (bi->bracketSpan() == span)) {
+            //
+            // this bracket is visible
+            //
+            Bracket* b = 0;
+            int track = staffIdx * VOICES;
+            for (int k = 0; k < bl.size(); ++k) {
+                  if (bl[k]->track() == track && bl[k]->column() == column && bl[k]->bracketType() == bi->bracketType() && bl[k]->measure() == measure) {
+                        b = bl.takeAt(k);
+                        break;
+                        }
+                  }
+            if (b == 0) {
+                  b = new Bracket(score());
+                  b->setBracketItem(bi);
+                  b->setGenerated(true);
+                  b->setTrack(track);
+                  b->setMeasure(measure);
+                  }
+            add(b);
+            b->setStaffSpan(firstStaff, lastStaff);
+            return b;
+            }
+
+      return nullptr;
+      }
+
+int System::getBracketsColumnsCount()
+      {
+      int columns = 0;
+      int nstaves = _staves.size();
+      for (int idx = 0; idx < nstaves; ++idx) {
+            for (auto bi : score()->staff(idx)->brackets())
+                  columns = qMax(columns, bi->column() + 1);
+            }
+      return columns;
+      }
+
+void System::setBracketsXPosition(const qreal &xPosition)
+      {
+      qreal bracketDistance = score()->styleP(Sid::bracketDistance);
+      for (Bracket* b1 : _brackets) {
+            qreal xOffset = 0;
+            for (const Bracket* b2 : _brackets) {
+                  bool b1FirstStaffInB2 = (b1->firstStaff() >= b2->firstStaff() && b1->firstStaff() <= b2->lastStaff());
+                  bool b1LastStaffInB2 = (b1->lastStaff() >= b2->firstStaff() && b1->lastStaff() <= b2->lastStaff());
+                  if (b1->column() > b2->column() && 
+                        (b1FirstStaffInB2 || b1LastStaffInB2))
+                        xOffset += b2->width() + bracketDistance;
+                  }
+            b1->rxpos() = xPosition - xOffset - b1->width();
             }
       }
 

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -220,7 +220,7 @@ void System::layoutSystem(qreal xo1)
                   for (auto bi : s->brackets()) {
                         if (bi->column() != i || bi->bracketType() == BracketType::NO_BRACKET)
                               continue;
-                        Bracket* b = createBracket(bi, i, staffIdx, bl, nullptr);
+                        Bracket* b = createBracket(bi, i, staffIdx, bl, this->firstMeasure());
                         if (b != nullptr) bracketWidth[i] = qMax(bracketWidth[i], b->width());
                         }
                   }
@@ -356,7 +356,7 @@ void System::addBrackets(Measure* measure)
 //   Returns the bracket if it got created, else NULL
 //---------------------------------------------------------
 
-Bracket* System::createBracket(Ms::BracketItem * bi, int column, int staffIdx, QList<Ms::Bracket *> &bl, Measure* measure)
+Bracket* System::createBracket(Ms::BracketItem* bi, int column, int staffIdx, QList<Ms::Bracket *>& bl, Measure* measure)
       {
       int nstaves = _staves.size();
       int firstStaff = staffIdx;
@@ -415,7 +415,7 @@ int System::getBracketsColumnsCount()
       return columns;
       }
 
-void System::setBracketsXPosition(const qreal &xPosition)
+void System::setBracketsXPosition(const qreal xPosition)
       {
       qreal bracketDistance = score()->styleP(Sid::bracketDistance);
       for (Bracket* b1 : _brackets) {

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -114,6 +114,14 @@ class System final : public Element {
 
       void layoutSystem(qreal);
 
+      int getBracketsColumnsCount();
+
+      void setBracketsXPosition(const qreal &xOffset);
+
+      Bracket* createBracket(Ms::BracketItem * bi, int column, int staffIdx, QList<Ms::Bracket *> &bl, Measure* measure);
+
+      void addBrackets(Measure* measure);
+
       void layout2();                     ///< Called after Measure layout.
       void clear();                       ///< Clear measure list.
 

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -92,7 +92,11 @@ class System final : public Element {
       SysStaff* firstVisibleSysStaff() const;
       SysStaff* lastVisibleSysStaff() const;
 
-   public:
+      int getBracketsColumnsCount();
+      void setBracketsXPosition(const qreal xOffset);
+      Bracket* createBracket(Ms::BracketItem* bi, int column, int staffIdx, QList<Ms::Bracket *>& bl, Measure* measure);
+
+public:
       System(Score*);
       ~System();
       virtual System* clone() const override      { return new System(*this); }
@@ -113,12 +117,6 @@ class System final : public Element {
       Page* page() const                    { return (Page*)parent(); }
 
       void layoutSystem(qreal);
-
-      int getBracketsColumnsCount();
-
-      void setBracketsXPosition(const qreal &xOffset);
-
-      Bracket* createBracket(Ms::BracketItem * bi, int column, int staffIdx, QList<Ms::Bracket *> &bl, Measure* measure);
 
       void addBrackets(Measure* measure);
 


### PR DESCRIPTION
This PR add brackets to the system after a HBox with *Create system header*. Contrary to standard brackets, which are anchored in front of the system, this brackets are anchored to a measure. 