### PR TITLE
Slur overadjust

### DIFF
--- a/libmscore/shape.cpp
+++ b/libmscore/shape.cpp
@@ -107,9 +107,13 @@ qreal Shape::minVerticalDistance(const Shape& a) const
       {
       qreal dist = -1000000.0;      // min real
       for (const QRectF& r2 : a) {
+            if (r2.height() <= 0.0)
+                  continue;
             qreal bx1 = r2.left();
             qreal bx2 = r2.right();
             for (const QRectF& r1 : *this) {
+                  if (r1.height() <= 0.0)
+                        continue;
                   qreal ax1 = r1.left();
                   qreal ax2 = r1.right();
                   if (Ms::intersects(ax1, ax2, bx1, bx2))

--- a/libmscore/slur.h
+++ b/libmscore/slur.h
@@ -25,6 +25,7 @@ namespace Ms {
 class SlurSegment final : public SlurTieSegment {
 
    protected:
+      qreal _extraHeight = 0.0;
       virtual void changeAnchor(EditData&, Element*) override;
 
    public:


### PR DESCRIPTION
This is the final (!) tweak to slur layout I wish I had been to figure out in time for 3.0 - a couple of cases where autoplace was overadjusting and placing slurs too far from the notes.

First case is https://musescore.org/en/node/280466 - if any collision is detected, we move the whole slur outside the staff.  Turns out to be because the segment shape includes some zero height rectangles for horizontal spacing purposes.  Skipping these in minVerticalDistance fixes the problem, and perhaps other problems that might stem from a similar cause.

Second case is https://musescore.org/en/node/285173 - for slurs that cover notes high above the end start/end notes, we draw them too flat, again causing the endpoints of the slur to be too far away from the notes themselves.

Here's a very simple comparison.  Before:

![image](https://user-images.githubusercontent.com/1799936/53661658-13c6ec80-3c1e-11e9-8d73-2c9a7ad98eab.png)

After:

![image](https://user-images.githubusercontent.com/1799936/53661638-06116700-3c1e-11e9-95c3-12b77d96b6ac.png)
