### PR TITLE
fix #280492: Fretboard diagrams: Offset needs to be renamed and should correspond with the diagram

### DIFF
--- a/mscore/inspector/inspectorFret.cpp
+++ b/mscore/inspector/inspectorFret.cpp
@@ -36,13 +36,16 @@ InspectorFretDiagram::InspectorFretDiagram(QWidget* parent)
             { Pid::PLACEMENT,    0, f.placement,   f.resetPlacement   },
             { Pid::FRET_STRINGS, 0, f.strings,     f.resetStrings     },
             { Pid::FRET_FRETS,   0, f.frets,       f.resetFrets       },
-            { Pid::FRET_OFFSET,  0, f.offset,      f.resetOffset      },
             { Pid::FRET_BARRE,   0, f.barre,       f.resetBarre       },
             };
       const std::vector<InspectorPanel> ppList = {
             { f.title, f.panel }
             };
       mapSignals(iiList, ppList);
+      int fretNumber = toFretDiagram(inspector->element())->fretOffset() + 1;
+      f.fretNumber->setValue(fretNumber);
+      connect(f.fretNumber, SIGNAL(valueChanged(int)), SLOT(fretNumberChanged(int)));
+      connect(f.resetFretNumber, SIGNAL(resetClicked()), SLOT(resetFretNumber()));
       }
 
 //---------------------------------------------------------
@@ -64,6 +67,36 @@ void InspectorFretDiagram::setElement()
       {
       InspectorElementBase::setElement();
       FretDiagram* fd = toFretDiagram(inspector->element());
+      f.diagram->setFretDiagram(fd);
+      }
+
+//---------------------------------------------------------
+//   fretNumberChanged
+//---------------------------------------------------------
+
+void InspectorFretDiagram::fretNumberChanged(int fretNumber)
+      {
+      FretDiagram* fd = toFretDiagram(inspector->element());
+      fd->score()->startCmd();
+      fd->undoChangeProperty(Pid::FRET_OFFSET, fretNumber - 1);
+      fd->score()->endCmd();
+      f.resetFretNumber->setEnabled(fretNumber != 1);
+      f.diagram->setFretDiagram(fd);
+      }
+
+//---------------------------------------------------------
+//   resetFretNumberClicked
+//---------------------------------------------------------
+
+void InspectorFretDiagram::resetFretNumber()
+      {
+      FretDiagram* fd = toFretDiagram(inspector->element());
+      int fretNumber = 1;
+      fd->score()->startCmd();
+      fd->undoChangeProperty(Pid::FRET_OFFSET, fretNumber - 1);
+      fd->score()->endCmd();
+      f.fretNumber->setValue(fretNumber);
+      f.resetFretNumber->setEnabled(false);
       f.diagram->setFretDiagram(fd);
       }
 

--- a/mscore/inspector/inspectorFret.h
+++ b/mscore/inspector/inspectorFret.h
@@ -31,6 +31,8 @@ class InspectorFretDiagram : public InspectorElementBase {
 
    private slots:
       virtual void valueChanged(int idx) override;
+      void fretNumberChanged(int fretNumber);
+      void resetFretNumber();
 
    public:
       InspectorFretDiagram(QWidget* parent);

--- a/mscore/inspector/inspector_fret.ui
+++ b/mscore/inspector/inspector_fret.ui
@@ -207,17 +207,20 @@
       <item row="6" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Offset:</string>
+         <string>Fret number:</string>
         </property>
         <property name="buddy">
-         <cstring>offset</cstring>
+         <cstring>fretNumber</cstring>
         </property>
        </widget>
       </item>
       <item row="6" column="1">
-       <widget class="QSpinBox" name="offset">
+       <widget class="QSpinBox" name="fretNumber">
         <property name="accessibleName">
-         <string>Offset</string>
+         <string>Fret number</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
         </property>
        </widget>
       </item>
@@ -256,7 +259,7 @@
        <widget class="Ms::ResetButton" name="resetBarre" native="true"/>
       </item>
       <item row="6" column="2">
-       <widget class="Ms::ResetButton" name="resetOffset" native="true"/>
+       <widget class="Ms::ResetButton" name="resetFretNumber" native="true"/>
       </item>
      </layout>
     </widget>
@@ -284,7 +287,7 @@
   <tabstop>strings</tabstop>
   <tabstop>frets</tabstop>
   <tabstop>barre</tabstop>
-  <tabstop>offset</tabstop>
+  <tabstop>fretNumber</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/280492.

The notion of a "fret offset" makes sense programmatically, but "fret number" seems to make more sense to the user. Therefore, this exposes the FRET_OFFSET property to the user as a "Fret number" which is equal to `FretDiagram::fretOffset() + 1`. The minimum value for the fret number is 1. The fret number is drawn if and only if it is greater than 1.