### PR TITLE
fix #285286: Implemented termination lines for trills

### DIFF
--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -140,6 +140,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::TRILL_TYPE,              false, "",                      P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "trill type")       },
       { Pid::VIBRATO_TYPE,            false, "",                      P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "vibrato type")     },
       { Pid::HAIRPIN_CIRCLEDTIP,      false, "hairpinCircledTip",     P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "hairpin with circled tip") },
+      { Pid::SHOW_TERMINATION_LINE,   false, "showTerminationLine",   P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "show termination line") },
 
       { Pid::HAIRPIN_TYPE,            true,  "",                      P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "hairpin type")     },
       { Pid::HAIRPIN_HEIGHT,          false, "hairpinHeight",         P_TYPE::SPATIUM,             DUMMY_QT_TRANSLATE_NOOP("propertyName", "hairpin height")   },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -158,6 +158,7 @@ enum class Pid {
       TRILL_TYPE,
       VIBRATO_TYPE,
       HAIRPIN_CIRCLEDTIP,
+      SHOW_TERMINATION_LINE,
 
       HAIRPIN_TYPE,
       HAIRPIN_HEIGHT,

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -257,6 +257,8 @@ static const StyleType styleTypes[] {
       { Sid::trillPlacement,          "trillPlacement",          int(Placement::ABOVE)  },
       { Sid::trillPosAbove,           "trillPosAbove",           QPointF(.0, -1) },
       { Sid::trillPosBelow,           "trillPosBelow",           QPointF(.0, 1) },
+      { Sid::trillTerminationLineHeight, "trillTerminationLineHeight", Spatium(1.0) },
+      { Sid::trillTerminationLineWidth,  "trillTerminationLineWidth",  Spatium(0.2) },
 
       { Sid::vibratoPlacement,        "vibratoPlacement",        int(Placement::ABOVE)  },
       { Sid::vibratoPosAbove,         "vibratoPosAbove",         QPointF(.0, -1) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -230,6 +230,8 @@ enum class Sid {
       trillPlacement,
       trillPosAbove,
       trillPosBelow,
+      trillTerminationLineHeight,
+      trillTerminationLineWidth,
 
       vibratoPlacement,
       vibratoPosAbove,

--- a/libmscore/trill.h
+++ b/libmscore/trill.h
@@ -39,6 +39,7 @@ class TrillSegment final : public LineSegment {
       virtual ElementType type() const override  { return ElementType::TRILL_SEGMENT; }
       virtual TrillSegment* clone() const override { return new TrillSegment(*this); }
       virtual void draw(QPainter*) const override;
+      virtual void drawTerminationLine(QPainter*) const;
       virtual bool acceptDrop(EditData&) const override;
       virtual Element* drop(EditData&) override;
       virtual void layout() override;
@@ -71,6 +72,7 @@ class Trill final : public SLine {
       Type _trillType;
       Accidental* _accidental;
       MScore::OrnamentStyle _ornamentStyle; // for use in ornaments such as trill
+      bool _showTerminationLine;
       bool _playArticulation;
 
    public:
@@ -91,6 +93,8 @@ class Trill final : public SLine {
       Type trillType() const              { return _trillType; }
       void setOrnamentStyle(MScore::OrnamentStyle val) { _ornamentStyle = val;}
       MScore::OrnamentStyle ornamentStyle() const { return _ornamentStyle;}
+      void setShowTerminationLine(bool val)  { _showTerminationLine = val;}
+      bool showTerminationLine() const       { return _showTerminationLine; }
       void setPlayArticulation(bool val)  { _playArticulation = val;}
       bool playArticulation() const       { return _playArticulation; }
       QString trillTypeName() const;

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -239,6 +239,8 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { Sid::trillPlacement,          false, trillLinePlacement,      resetTrillLinePlacement  },
       { Sid::trillPosAbove,           false, trillLinePosAbove,       resetTrillLinePosAbove   },
       { Sid::trillPosBelow,           false, trillLinePosBelow,       resetTrillLinePosBelow   },
+      { Sid::trillTerminationLineHeight, false, trillTerminationLineHeight, resetTrillTerminationLineHeight },
+      { Sid::trillTerminationLineWidth,  false, trillTerminationLineWidth,  resetTrillTerminationLineWidth  },
 
       { Sid::vibratoPlacement,        false, vibratoLinePlacement,      resetVibratoLinePlacement  },
       { Sid::vibratoPosAbove,         false, vibratoLinePosAbove,       resetVibratoLinePosAbove   },

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -241,7 +241,7 @@
        </size>
       </property>
       <property name="currentIndex">
-       <number>33</number>
+       <number>19</number>
       </property>
       <widget class="QWidget" name="PageScore">
        <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -7396,7 +7396,7 @@
            <string>Trill Line</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_14">
-           <item row="3" column="0">
+           <item row="5" column="0">
             <spacer name="verticalSpacer_18">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -7516,6 +7516,86 @@
            </item>
            <item row="2" column="1">
             <widget class="Ms::OffsetSelect" name="trillLinePosBelow" native="true"/>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="trillTerminationLineHeightLabel">
+             <property name="text">
+              <string>Termination line height:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="trillTerminationLineWidthLabel">
+             <property name="text">
+              <string>Termination line width:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QDoubleSpinBox" name="trillTerminationLineHeight">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="minimum">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="value">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QDoubleSpinBox" name="trillTerminationLineWidth">
+             <property name="suffix">
+              <string>sp</string>
+             </property>
+             <property name="minimum">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="value">
+              <double>0.200000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="2">
+            <widget class="QToolButton" name="resetTrillTerminationLineHeight">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Termination line height' value</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="2">
+            <widget class="QToolButton" name="resetTrillTerminationLineWidth">
+             <property name="toolTip">
+              <string>Reset to default</string>
+             </property>
+             <property name="accessibleName">
+              <string>Reset 'Termination line width' value</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset resource="musescore.qrc">
+               <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>

--- a/mscore/inspector/inspectorTrill.cpp
+++ b/mscore/inspector/inspectorTrill.cpp
@@ -27,10 +27,11 @@ InspectorTrill::InspectorTrill(QWidget* parent)
       t.setupUi(addWidget());
 
       const std::vector<InspectorItem> iiList = {
-            { Pid::TRILL_TYPE,     0, t.trillType,        t.resetTrillType        },
-            { Pid::PLACEMENT,      0, t.placement,        t.resetPlacement        },
-            { Pid::ORNAMENT_STYLE, 0, t.ornamentStyle,    t.resetOrnamentStyle    },
-            { Pid::PLAY,           0, t.playArticulation, t.resetPlayArticulation }
+            { Pid::TRILL_TYPE,            0, t.trillType,           t.resetTrillType           },
+            { Pid::PLACEMENT,             0, t.placement,           t.resetPlacement           },
+            { Pid::ORNAMENT_STYLE,        0, t.ornamentStyle,       t.resetOrnamentStyle       },
+            { Pid::SHOW_TERMINATION_LINE, 0, t.showTerminationLine, t.resetShowTerminationLine },
+            { Pid::PLAY,                  0, t.playArticulation,    t.resetPlayArticulation    }
             };
       const std::vector<InspectorPanel> ppList = {
             { t.title, t.panel }

--- a/mscore/inspector/inspector_trill.ui
+++ b/mscore/inspector/inspector_trill.ui
@@ -76,6 +76,9 @@
       <property name="verticalSpacing">
        <number>0</number>
       </property>
+      <item row="4" column="3">
+       <widget class="Ms::ResetButton" name="resetPlayArticulation" native="true"/>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
@@ -194,7 +197,7 @@
         </item>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="QCheckBox" name="playArticulation">
         <property name="text">
          <string>Play</string>
@@ -202,16 +205,23 @@
        </widget>
       </item>
       <item row="0" column="3">
-       <widget class="Ms::ResetButton" name="resetTrillType"/>
+       <widget class="Ms::ResetButton" name="resetTrillType" native="true"/>
       </item>
       <item row="1" column="3">
-       <widget class="Ms::ResetButton" name="resetPlacement"/>
+       <widget class="Ms::ResetButton" name="resetPlacement" native="true"/>
       </item>
       <item row="2" column="3">
-       <widget class="Ms::ResetButton" name="resetOrnamentStyle"/>
+       <widget class="Ms::ResetButton" name="resetOrnamentStyle" native="true"/>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="showTerminationLine">
+        <property name="text">
+         <string>Show termination line</string>
+        </property>
+       </widget>
       </item>
       <item row="3" column="3">
-       <widget class="Ms::ResetButton" name="resetPlayArticulation"/>
+       <widget class="Ms::ResetButton" name="resetShowTerminationLine" native="true"/>
       </item>
      </layout>
     </widget>
@@ -231,6 +241,7 @@
   <tabstop>trillType</tabstop>
   <tabstop>placement</tabstop>
   <tabstop>ornamentStyle</tabstop>
+  <tabstop>showTerminationLine</tabstop>
   <tabstop>playArticulation</tabstop>
  </tabstops>
  <resources>


### PR DESCRIPTION
See the suggestion in the issue tracker [here](https://musescore.org/en/node/285286).

The termination line can be toggled on/off with a property in the trills inspector ("Show termination line"). Height and width may be set for the score in the 'Trill' section of the 'Style' dialog, defaulting to height of 1 and width of 0.2 staff spaces.