### PR TITLE
fix #270765:Update Layout for plugin manager

### DIFF
--- a/mscore/plugin/pluginManager.ui
+++ b/mscore/plugin/pluginManager.ui
@@ -38,6 +38,9 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinAndMaxSize</enum>
+      </property>
       <item row="0" column="0">
        <widget class="QLabel" name="label_19">
         <property name="text">


### PR DESCRIPTION
Issue: https://musescore.org/en/node/270765

Made some changes in the layout in order to fix the wrong sizePolicy of the QPushButton which didn't show the text properly when loaded at the first time

Before:

![wrong-button-size-config](https://user-images.githubusercontent.com/41850468/53697304-41668e00-3df6-11e9-995e-a67d7e6f2fbc.png)

After:

![correct-button-size-config](https://user-images.githubusercontent.com/41850468/53697310-4a575f80-3df6-11e9-9794-3494d5138283.png)
