### PR TITLE
fix #279707 automatic updates on Linux

### DIFF
--- a/build/travis/job2_AppImage/build.sh
+++ b/build/travis/job2_AppImage/build.sh
@@ -52,8 +52,7 @@ then # Build is marked UNSTABLE inside CMakeLists.txt
                         BUILD_NUMBER='${TRAVIS_BUILD_NUMBER}' \
                         LABEL='Portable Nightly Build'"
     cp -f build/travis/resources/splash-nightly.png mscore/data/splash.png
-    update_info="" # automatic updates disabled for nightlies as it requires
-    # changes on the server. See https://github.com/musescore/MuseScore/pull/4757.
+    update_info="zsync|http://ftp.osuosl.org/pub/musescore-nightlies/linux/${TARGET_ARCH}/MuseScoreNightly-${branch}-${TARGET_ARCH}.AppImage.zsync"
   else
     # This is someone developing on their own fork
     export BINTRAY_VERSION="${date}-${branch}-${revision}"
@@ -129,11 +128,7 @@ if [ "${upload}" ]; then
   else
     if [[ "${TRAVIS_REPO_SLUG}" == "musescore/MuseScore" ]]; then
       # this is an official build (stable or nightly)
-      ./build/travis/job2_AppImage/osuosl.sh build.release/MuseScore*.AppImage
-      if [[ -f build.release/MuseScore*.AppImage.zsync ]]; then
-        # upload zsync delta for automatic updates
-        ./build/travis/job2_AppImage/osuosl.sh build.release/MuseScore*.AppImage.zsync
-      fi
+      ./build/travis/job2_AppImage/osuosl.sh build.release/MuseScore*.AppImage # just the AppImage
     else
       # This is a developer building on their personal fork
       ./build/travis/job2_AppImage/bintray.sh build.release/MuseScore*.AppImage* # both AppImage and zsync

--- a/build/travis/job2_AppImage/osuosl.sh
+++ b/build/travis/job2_AppImage/osuosl.sh
@@ -57,8 +57,19 @@ case "${ARCH}" in
     ;;
 esac
 
-# transfer file
-scp -C -i $SSH_INDENTITY $FILE musescore-nightlies@ftp-osl.osuosl.org:ftp/linux/$ARCH_NAME/$FILE_UPLOAD_PATH
+OSUOSL_SLUG="musescore-nightlies@ftp-osl.osuosl.org"
 
-# delete old files
-ssh -i $SSH_INDENTITY musescore-nightlies@ftp-osl.osuosl.org "cd ~/ftp/linux/$ARCH_NAME; ls MuseScoreNightly* -t | tail -n +41 | xargs -r rm"
+# transfer file
+scp -C -i "${SSH_INDENTITY}" "${FILE}"       "${OSUOSL_SLUG}:ftp/linux/${ARCH_NAME}/${FILE_UPLOAD_PATH}"
+scp -C -i "${SSH_INDENTITY}" "${FILE}.zsync" "${OSUOSL_SLUG}:ftp/linux/${ARCH_NAME}/${FILE_UPLOAD_PATH}.zsync"
+
+if [[ "$FILE_UPLOAD_PATH" == MuseScoreNightly* ]]; then
+  # delete old nightlies and create latest symlink to uploaded file
+  ssh -i "${SSH_INDENTITY}" "${OSUOSL_SLUG}" <<EOF
+cd ~/ftp/linux/${ARCH_NAME}
+ls -t MuseScoreNightly*.AppImage       | tail -n +41 | xargs -r rm
+ls -t MuseScoreNightly*.AppImage.zsync | tail -n +41 | xargs -r rm
+ln -sf "${FILE_UPLOAD_PATH}"       "MuseScoreNightly-${TRAVIS_BRANCH}-${ARCH}.AppImage"
+ln -sf "${FILE_UPLOAD_PATH}.zsync" "MuseScoreNightly-${TRAVIS_BRANCH}-${ARCH}.AppImage.zsync"
+EOF
+fi


### PR DESCRIPTION
- Also updates AppImage to type 2 for more features and squashfs compression

I can't test the changes in `osuosl.sh` so you will need to do this for yourself. The update mechanism requires a stable URL, so I symlink `MuseScoreNightly-latest-x86_64.AppImage` to the most recent nightly file (i.e. the one being uploaded). If the servers don't allow symlinks then you can just create a copy of the uploaded file instead. Stable releases don't require symlinks because they are stored on GitHub; the update mechanism is able to query the latest version via the GitHub API.

Updates require external tool like [AppImageUpdate](https://github.com/AppImage/AppImageUpdate) or [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher/). If the updates work as expected then I can bundle an updater inside the AppImage itself to make it truly self-updating, just like on Windows and macOS.