### PR TITLE
fix #285332: tremolo added to skyline of all staves

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3548,11 +3548,13 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                     if (!e->visible())
                                           continue;
                                     int effectiveTrack = e->vStaffIdx() * VOICES + e->voice();
-                                    if (effectiveTrack >= strack && effectiveTrack < etrack)
+                                    if (effectiveTrack >= strack && effectiveTrack < etrack) {
                                           skyline.add(e->shape().translated(e->pos() + p));
-                                    if (e->isChord() && toChord(e)->tremolo()) {
-                                          Tremolo* t = toChord(e)->tremolo();
-                                          skyline.add(t->shape().translated(t->pos() + p));
+                                          if (e->isChord() && toChord(e)->tremolo()) {
+                                                Tremolo* t = toChord(e)->tremolo();
+                                                if (t->chord() == e && t->autoplace())
+                                                      skyline.add(t->shape().translated(t->pos() + e->pos() + p));
+                                                }
                                           }
                                     }
                               }


### PR DESCRIPTION
After checking to see if a chord is on the current staff, we add it to skyline, but then we were adding the chord's tremolo without checking the staff, so it was getting added to all staves.  This PR moves the tremolo code under the check for the staff of the chord.  It also fixes the shape translation right - we weren't adding in the chord offset, so the tremolo skyline position was off, noticeable if the chord itself was offset.  Also, we were adding two-note tremolo to the skyline twice, once for each note, leading to detection of phantom collisions.  And we weren't skipping this if autoplace is disabled.