### PR TITLE
Fix a crash on crash handler destruction, cover more of the app init stage

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -156,10 +156,6 @@ extern Ms::Synthesizer* createZerberus();
 
 namespace Ms {
 
-#ifdef BUILD_CRASH_REPORTER
-static std::unique_ptr<CrashReporter::Handler> crashHandler;
-#endif
-
 MuseScore* mscore;
 MasterSynthesizer* synti;
 
@@ -6975,6 +6971,13 @@ int main(int argc, char* av[])
       QCoreApplication::setOrganizationDomain("musescore.org");
       QCoreApplication::setApplicationVersion(VERSION);
 
+#ifdef BUILD_CRASH_REPORTER
+      static_assert(sizeof(CRASHREPORTER_EXECUTABLE) > 1,
+         "CRASHREPORTER_EXECUTABLE should be defined to build with crash reporter"
+         );
+      std::unique_ptr<CrashReporter::Handler> crashHandler(new CrashReporter::Handler(QDir::tempPath(), true, CRASHREPORTER_EXECUTABLE));
+#endif
+
       QAccessible::installFactory(AccessibleScoreView::ScoreViewFactory);
       QAccessible::installFactory(AccessibleSearchBox::SearchBoxFactory);
       QAccessible::installFactory(Awl::AccessibleAbstractSlider::AbstractSliderFactory);
@@ -7546,13 +7549,6 @@ int main(int argc, char* av[])
             mscore->showSynthControl(true);
       if (settings.value("mixerVisible", false).toBool())
             mscore->showMixer(true);
-
-#ifdef BUILD_CRASH_REPORTER
-      static_assert(sizeof(CRASHREPORTER_EXECUTABLE) > 1,
-         "CRASHREPORTER_EXECUTABLE should be defined to build with crash reporter"
-         );
-      crashHandler.reset(new CrashReporter::Handler(QDir::tempPath(), true, CRASHREPORTER_EXECUTABLE));
-#endif
 
       return qApp->exec();
       }


### PR DESCRIPTION
This pull request serves two purposes:
1) Fix a crash on the crash handler destruction (which happens according to the received crash reports). It is likely to happen because the Breakpad crash handler destructor uses static variables so should be invoked before those variables destruction. Meanwhile the crash handler object was previously assigned to a static variable in #4679 which makes it unclear which variables will get destroyed first. This commit fixes it, so the crash is likely to disappear too.
2) Move the crash handler initialization as early as possible (right after the QApplication initialization and filling it with some common information). This allows to cover more stages of MuseScore initialization which may potentially have bugs leading to crashes too.