### PR TITLE
fix #270765:Update Layout for Plugin-Manager

### DIFF
--- a/mscore/plugin/pluginManager.ui
+++ b/mscore/plugin/pluginManager.ui
@@ -38,6 +38,9 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetMinAndMaxSize</enum>
+        </property>
       <item row="0" column="0">
        <widget class="QLabel" name="label_19">
         <property name="text">

--- a/mscore/plugin/pluginManager.ui
+++ b/mscore/plugin/pluginManager.ui
@@ -38,9 +38,9 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetMinAndMaxSize</enum>
-        </property>
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinAndMaxSize</enum>
+      </property>
       <item row="0" column="0">
        <widget class="QLabel" name="label_19">
         <property name="text">


### PR DESCRIPTION
Issue: https://musescore.org/en/node/270765

Made some changes in the layout in order to fix the wrong sizePolicy of the QPushButton which didn't show the text properly when loaded for the first time.

Before:

![wrong-button-size-config](https://user-images.githubusercontent.com/41850468/53731736-ab883d00-3ea1-11e9-88ad-f1e440e6e6bb.png)

After: 

![correct-button-size-config](https://user-images.githubusercontent.com/41850468/53731754-bba01c80-3ea1-11e9-8e1d-9a3d37a75b56.png)

