### PR TITLE
fix 285370: wrong stem direction in skyline for beamed drum notes

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -334,8 +334,10 @@ void Beam::layout1()
                               }
                         }
                   }
-            for (ChordRest* cr : _elements)
+            for (ChordRest* cr : _elements) {
                   cr->setUp(_up);
+                  cr->layoutStem1();
+                  }
             }
       else {
             //PITCHED STAVES (and TAB's with stems through staves)


### PR DESCRIPTION
See https://musescore.org/en/node/285370.  We need to relayout the stems after computing the correct stem direction in Beam::layout1().  We were doing this for standard staves but not drums.