### PR TITLE
Follow up single-note dynamics: add some forward declarations

### DIFF
--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -17,7 +17,6 @@
 #include "mscore.h"
 #include "notifier.hpp"
 #include "synthesizer/event.h"
-#include "synthesizer/msynthesizer.h"
 #include "interval.h"
 #include "clef.h"
 #include <QtGlobal>
@@ -32,6 +31,7 @@ class XmlReader;
 class Drumset;
 class StringData;
 class ChannelListener;
+class MasterSynthesizer;
 
 //---------------------------------------------------------
 //   StaffName

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -69,7 +69,7 @@
 #include "rehearsalmark.h"
 #include "breath.h"
 #include "instrchange.h"
-#include "synthesizer/msynthesizer.h"
+#include "synthesizerstate.h"
 
 namespace Ms {
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -27,7 +27,6 @@
 #include "spannermap.h"
 #include "layoutbreak.h"
 #include "property.h"
-#include "synthesizer/msynthesizer.h"
 
 namespace Ms {
 
@@ -54,6 +53,7 @@ class KeySig;
 class KeySigEvent;
 class LinkedElements;
 class Lyrics;
+class MasterSynthesizer;
 class Measure;
 class MeasureBase;
 class MuseScoreView;

--- a/libmscore/synthesizerstate.cpp
+++ b/libmscore/synthesizerstate.cpp
@@ -12,7 +12,6 @@
 
 #include "synthesizerstate.h"
 #include "xml.h"
-#include "synthesizer/event.h"
 
 namespace Ms {
 


### PR DESCRIPTION
This just fixes some unnecessary `include`s I left in my SND PR #4541, and replaces them with forward declarations.