### PR TITLE
fix #281957 move highlight update to work for cursor changes and on click of elements that aren't notes

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -367,7 +367,6 @@ void ScoreView::mousePressEventNormal(QMouseEvent* ev)
             }
       _score->update();
       mscore->endCmd();
-      mscore->updatePaletteBeamMode(clickOffElement);
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2177,6 +2177,7 @@ void MuseScore::updatePaletteBeamMode(bool unselect)
             if (p->name() == "Beam Properties") {
                   if (unselect) {
                         p->setSelected(-1);
+                        p->update();
                         return;
                         }
                   const Selection sel = cs->selection();
@@ -2205,6 +2206,7 @@ void MuseScore::updatePaletteBeamMode(bool unselect)
                               break;
                         default:
                               p->setSelected(-1);
+                              p->update();
                               return;
                         }
                         for (int i = 0; i < p->size(); ++i) {
@@ -5815,6 +5817,8 @@ void MuseScore::endCmd()
             selectionChanged(SelState::NONE);
             }
       updateInspector();
+      if (cv && paletteBox)
+            updatePaletteBeamMode(cv->clickOffElement);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
I originally had a bit of a flawed implementation where the palette didn't update when clicking onto a different non-chordrest element and also didn't update when changing the selection using the arrow keys. This modification fixes that by moving the updatePaletteBeamMode() function to Musescore::endCmd() instead. I considered using selectionChanged() instead, but there were a few problems with that. When the user applies a new palette element (changing the beam mode by dragging or double clicking on a cell), the selection doesn't change, but the beam mode does change. For that reason I removed the call from mousePressEventNormal() to endCmd(). Let me know if you see a way this could be further improved!