### PR TITLE
Skylines construction optimization

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3508,6 +3508,9 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                   if (!mb->isMeasure())
                         continue;
                   Measure* m = toMeasure(mb);
+                  if (MeasureNumber* mno = m->noText(staffIdx))
+                        ss->skyline().add(mno->bbox().translated(m->pos() + mno->pos()));
+                  ss->skyline().add(m->staffLines(staffIdx)->bbox().translated(m->pos()));
                   for (Segment& s : m->segments()) {
                         if (!s.enabled() || s.isTimeSigType())       // hack: ignore time signatures
                               continue;
@@ -3535,7 +3538,6 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                                 }
                                           for (auto n : c->notes())
                                                 notes.push_back(n);
-                                          std::list<Fingering*> fingerings;
                                           for (Note* note : notes) {
                                                 for (Element* e : note->el()) {
                                                       if (e->isFingering()) {
@@ -3562,10 +3564,6 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                     }
                               }
                         }
-                  ss->skyline().add(m->staffLines(staffIdx)->bbox().translated(m->pos()));
-                  MeasureNumber* mno = m->noText(staffIdx);
-                  if (mno)
-                        ss->skyline().add(mno->bbox().translated(m->pos() + mno->pos()));
                   }
             }
 

--- a/libmscore/skyline.h
+++ b/libmscore/skyline.h
@@ -27,30 +27,45 @@ class Shape;
 //---------------------------------------------------------
 
 struct SkylineSegment {
+      qreal x;
       qreal y;
       qreal w;
 
-      SkylineSegment(qreal _y, qreal _w) : y(_y), w(_w) {}
+      SkylineSegment(qreal _x, qreal _y, qreal _w) : x(_x), y(_y), w(_w) {}
       };
 
 //---------------------------------------------------------
 //   SkylineLine
 //---------------------------------------------------------
 
-struct SkylineLine : public std::vector<SkylineSegment> {
+class SkylineLine {
       const bool north;
+      std::vector<SkylineSegment> seg;
+      typedef std::vector<SkylineSegment>::iterator SegIter;
+      typedef std::vector<SkylineSegment>::const_iterator SegConstIter;
+
+      SegIter insert(SegIter i, qreal x, qreal y, qreal w);
+      void append(qreal x, qreal y, qreal w);
+      SegIter find(qreal x);
+      SegConstIter find(qreal x) const;
 
    public:
       SkylineLine(bool n) : north(n) {}
-      void add(qreal x, qreal y, qreal w);
       void add(const Shape& s);
       void add(const QRectF& r);
+      void add(qreal x, qreal y, qreal w);
+      void clear() { seg.clear(); }
       void paint(QPainter&) const;
       void dump() const;
       qreal minDistance(const SkylineLine&) const;
       qreal max() const;
       bool valid(const SkylineSegment& s) const;
       bool isNorth() const { return north; }
+
+      SegIter begin() { return seg.begin(); }
+      SegConstIter begin() const { return seg.begin(); }
+      SegIter end() { return seg.end(); }
+      SegConstIter end() const { return seg.end(); }
       };
 
 //---------------------------------------------------------


### PR DESCRIPTION
This pull request is intended to optimize skylines construction process in two ways:
1) Staff lines are added to the constructed skyline before other elements. As a large part of other shapes  usually lay below the skylines such shapes do not get added to skylines separately which reduces a number of the constructed skyline segments. This can speed up both skyline construction and its later usage.
2) Use a binary search for finding a position to insert new skyline segments. This requires tracking x coordinates of the skyline segments but this makes it possible to get rid of the linear search of the segment insert position which makes the process of skylines construction faster.

As this optimization concerns only score layout it presents very little (≈3%) difference while testing on score conversion to various fileformats (like it was performed [here](https://github.com/musescore/MuseScore/pull/4699/#issuecomment-465680988)). However more specific benchmark ([mtest benchmark](https://github.com/dmitrio95/MuseScore/blob/master/mtest/libmscore/layout/tst_benchmark.cpp)) shows a difference on layout operations. Here are the results of running that test on the [OpenScore edition](https://musescore.com/openscore/scores/4861738) of the Mozart's Symphony No.41 ("Jupiter") that was converted to MuseScore 3 fileformat, the benchmark was run for 5 times, and average results are presented here. All results are presented in milliseconds (except the percentage difference). Errors are calculated as standard deviations for the benchmark results set.

| benchmark                | master (March 4, 21e5a7c96701dd073cbf7500581fbdfcc75dad47) | Optimized skylines | Difference, % |
|--------------------------|------------------------------------------------------------|--------------------|---------------|
| Score reading            | 558.6 ± 6.7                                                | 563.2 ± 20.0         | -0.8          |
| Full layout (benchmark1) | 949.8 ± 8.3                                                | 883.8 ± 21.5       | 6.9           |
| Full layout (benchmark2) | 968.6 ± 18.3                                               | 880.0 ± 5.9          | 9.1           |
| Partial layout           | 69.6 ± 0.9                                                 | 63.2 ± 1.1         | 9.2           |

The results show that this optimization indeed does not influence score reading (without performing a layout) while making a performance gain of about 7—9% for layout operations.
