### PR TITLE
fix #281024: invisible staves affect spacing

### DIFF
--- a/libmscore/segment.h
+++ b/libmscore/segment.h
@@ -84,11 +84,13 @@ class Segment final : public Element {
 
       Segment* next() const               { return _next;   }
       Segment* next(SegmentType) const;
+      Segment* nextActive() const;
       Segment* nextEnabled() const;
       void setNext(Segment* e)            { _next = e;      }
 
       Segment* prev() const               { return _prev;   }
       Segment* prev(SegmentType) const;
+      Segment* prevActive() const;
       Segment* prevEnabled() const;
       void setPrev(Segment* e)            { _prev = e;      }
 
@@ -241,14 +243,38 @@ class Segment final : public Element {
       };
 
 //---------------------------------------------------------
+//   nextActive
+//---------------------------------------------------------
+
+inline Segment* Segment::nextActive() const
+      {
+      Segment* ns = next();
+      while (ns && !(ns->enabled() && ns->visible()))
+            ns = ns->next();
+      return ns;
+      }
+
+//---------------------------------------------------------
 //   nextEnabled
 //---------------------------------------------------------
 
 inline Segment* Segment::nextEnabled() const
       {
-      Segment* ps = next();
-      while (ps && !ps->enabled())
-            ps = ps->next();
+      Segment* ns = next();
+      while (ns && !ns->enabled())
+            ns = ns->next();
+      return ns;
+      }
+
+//---------------------------------------------------------
+//   prevActive
+//---------------------------------------------------------
+
+inline Segment* Segment::prevActive() const
+      {
+      Segment* ps = prev();
+      while (ps && !(ps->enabled() && ps->visible()))
+            ps = ps->prev();
       return ps;
       }
 


### PR DESCRIPTION
See https://musescore.org/en/node/281024 for a clear description of the problem.  If you use anextra staff to write out some complex passage for playback and then set it invisible, it unfortunately still affects the layout of the score, which it did *not* do in 2.3.2.  That renders this common technique essentially useless - you end up with crazy spacing due to the notes on the invisible staves.

Although I feared at first the solution would require deep changes, I think now this isn't so.  I am considering my PR work in progress in that I rather doubt I've actually handled everything that we would need to, and I am also not sure what people will think of the overall approach I am using here.  But my code *is* quite simple, and it should have next to no performance implication, or really much impact at all other than on what it is actually dealing with - layout in the presence of invisible staves.

The main problem is that when we calculate the distance from one segment to the next, we are looking at *all* segments instead of just the ones that actually contain elements on visible staves.  And we do the same when calculating the *width* of each segment, and again when calculating the *duration* (ticks aka Fractions).

So, what I am doing is finding the corresponding places in layout where we were looping through segments using next() or nextEnabled(), and adjusting things to be sure we skip segments with no elements on visible staves.  To simplify this process and keep it efficient, I am setting or clearing the "visible" flag on the segment itself during Segment::createShapes() according to whether we encountered any shapes on visible staves (and, btw, I'm skipping adding shapes on invisible staves to the segment).  So when looping through the segments, all we need to do is check this flag to know if a segment is worth looking at.  I wrote a helper function nextActive() that is like nextEnabled() but checks both enabled & visible flags.

And that's really all there is to it.  I imagine there are possibly additional places where I need to add similar checks, or places where we do need to at least partially process "invisible" segments in order for the playback to work completely, but it does seem to work in the cases I've tried, which is highly encouraging.

As an example, here is a score:

![image](https://user-images.githubusercontent.com/1799936/53834902-6ae3fe80-3f49-11e9-9e7e-7267e89584dc.png)

Here is how it looks in 3.0 with the bottom staff invisible:

![image](https://user-images.githubusercontent.com/1799936/53834967-8bac5400-3f49-11e9-80cf-d13d3d5c209d.png)

And here it is with my changes:

![image](https://user-images.githubusercontent.com/1799936/53835243-3886d100-3f4a-11e9-9934-f79fc142fa43.png)

which is the same as it looks if I simply delete the second staff.

I welcome more eyes on this.  @wschweer especially...

