### PR TITLE
fix #285432: save offset property for fermata

### DIFF
--- a/libmscore/fermata.cpp
+++ b/libmscore/fermata.cpp
@@ -109,6 +109,8 @@ void Fermata::write(XmlWriter& xml) const
       xml.tag("subtype", Sym::id2name(_symId));
       writeProperty(xml, Pid::TIME_STRETCH);
       writeProperty(xml, Pid::PLAY);
+      if (!isStyled(Pid::OFFSET))
+            writeProperty(xml, Pid::OFFSET);
       Element::writeProperties(xml);
       xml.etag();
       }

--- a/mtest/libmscore/compat206/fermata-ref.mscx
+++ b/mtest/libmscore/compat206/fermata-ref.mscx
@@ -189,6 +189,7 @@
           <Fermata>
             <subtype>fermataAbove</subtype>
             <timeStretch>3</timeStretch>
+            <offset x="-2.05234" y="-4.89487"/>
             </Fermata>
           <Chord>
             <durationType>eighth</durationType>


### PR DESCRIPTION
Originally, the offset property wasn't saved because Pid::OFFSET is styled property which means it isn't saved by Element::writeProperties(). Therefore all we need to do is save it ourselves :) 