### PR TITLE
fix #285500: slur between voices

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -406,7 +406,7 @@ void SlurSegment::layoutSegment(const QPointF& p1, const QPointF& p2)
                                     gdist = qMax(gdist, dist);
                               }
                         }
-                  if (gdist <= slurMaxMove || tries >= 2)
+                  if (!intersection || gdist <= slurMaxMove || tries >= 2)
                         break;
                   // slur would be moved too far
                   // try again with a steeper curve


### PR DESCRIPTION
See https://musescore.org/en/node/285500.  A not common usage, but one my recent change would otherwise make worse.  I wasn't checking to see if there was actually an intersection before curving the slur more to avoid a large adjustment that was actually not going to need to be applied.  This PR fixes that.
