### PR TITLE
Do not generate thumbnails before their usage in New Score Wizard

### DIFF
--- a/mscore/scoreInfo.cpp
+++ b/mscore/scoreInfo.cpp
@@ -11,6 +11,8 @@
 //=============================================================================
 
 #include "scoreInfo.h"
+#include "icons.h"
+#include "musescore.h"
 
 namespace Ms {
 
@@ -20,6 +22,14 @@ namespace Ms {
 
 QPixmap ScoreInfo::pixmap() const
       {
+      if (_pixmap.isNull()) {
+            // load or generate an actual thumbnail for the score
+            _pixmap = mscore->extractThumbnail(filePath());
+            if (_pixmap.isNull()) {
+                  // couldn't load/generate thumbnail so display generic icon
+                  _pixmap = icons[int(Icons::file_ICON)]->pixmap(QSize(50,60));
+                  }
+            }
       return _pixmap;
       }
 

--- a/mscore/scoreInfo.h
+++ b/mscore/scoreInfo.h
@@ -20,7 +20,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 class ScoreInfo : public QFileInfo {
-      QPixmap _pixmap;
+      mutable QPixmap _pixmap;
 
    public:
       ScoreInfo() {}

--- a/mscore/templateBrowser.cpp
+++ b/mscore/templateBrowser.cpp
@@ -101,16 +101,9 @@ TemplateItem* TemplateBrowser::genTemplateItem(QTreeWidgetItem* p, const QFileIn
                   const qreal cornerRadius = 12.0;
                   painter.drawRoundedRect(QRect(QPoint(0, 0), thumbnailSize), cornerRadius, cornerRadius);
                   painter.end();
+
+                  QPixmapCache::insert(fi.filePath(), pm);
                   }
-            else {
-                  // load or generate an actual thumbnail for the score
-                  pm = mscore->extractThumbnail(fi.filePath());
-                  if (pm.isNull()) {
-                        // couldn't load/generate thumbnail so display generic icon
-                        pm = icons[int(Icons::file_ICON)]->pixmap(QSize(50,60));
-                        }
-                  }
-            QPixmapCache::insert(fi.filePath(), pm);
             }
 
       si.setPixmap(pm);


### PR DESCRIPTION
As the idea of #4770 turned out to have some issues (maybe temporary), there is a need for other ways to optimize the new score wizard performance. This PR makes thumbnails generation be conducted on demand thus largely improving the wizard's startup time. Still for some templates there may be a small but noticeable delay between the item choice and thumbnail showing. This can probably be improved by generation of thumbnails in parallel with the dialog execution but this is not included to this PR.