### PR TITLE
fix #285383, fix #282191 save line properties, set propery default properties for let ring and palm mute, fix hook line drawing

### DIFF
--- a/libmscore/letring.cpp
+++ b/libmscore/letring.cpp
@@ -36,6 +36,10 @@ static const ElementStyle letRingStyle {
       { Sid::letRingTextAlign,                     Pid::END_TEXT_ALIGN         },
       { Sid::letRingHookHeight,                    Pid::BEGIN_HOOK_HEIGHT      },
       { Sid::letRingHookHeight,                    Pid::END_HOOK_HEIGHT        },
+      { Sid::letRingLineStyle,                     Pid::LINE_STYLE             },
+      { Sid::letRingBeginTextOffset,               Pid::BEGIN_TEXT_OFFSET      },
+      { Sid::letRingEndHookType,                   Pid::END_HOOK_TYPE          },
+      { Sid::letRingLineWidth,                     Pid::LINE_WIDTH             },
       };
 
 //---------------------------------------------------------
@@ -57,6 +61,9 @@ LetRing::LetRing(Score* s)
       {
       initElementStyle(&letRingStyle);
       resetProperty(Pid::LINE_VISIBLE);
+
+      resetProperty(Pid::BEGIN_TEXT_PLACE);
+      resetProperty(Pid::BEGIN_TEXT);
       }
 
 //---------------------------------------------------------
@@ -68,15 +75,24 @@ void LetRing::read(XmlReader& e)
       if (score()->mscVersion() < 301)
             e.addSpanner(e.intAttribute("id", -1), this);
       while (e.readNextStartElement()) {
-            if (!TextLineBase::readProperties(e))
+            if (readProperty(e.name(), e, Pid::LINE_WIDTH))
+                  setPropertyFlags(Pid::LINE_WIDTH, PropertyFlags::UNSTYLED);
+            else if (!TextLineBase::readProperties(e))
                   e.unknown();
             }
       }
 
 //---------------------------------------------------------
 //   write
+//   
+//   The removal of this function is potentially a temporary
+//   change. For now, the intended behavior does no more than
+//   the base write function and so we will just use that.
+//
+//   also see palmmute.cpp
 //---------------------------------------------------------
 
+/*
 void LetRing::write(XmlWriter& xml) const
       {
       if (!xml.canWrite(this))
@@ -88,9 +104,10 @@ void LetRing::write(XmlWriter& xml) const
                   writeProperty(xml, spp.pid);
             }
 
-      Element::writeProperties(xml);
+      TextLineBase::writeProperties(xml);
       xml.etag();
       }
+*/
 
 //---------------------------------------------------------
 //   createLineSegment
@@ -122,26 +139,26 @@ QVariant LetRing::propertyDefault(Pid propertyId) const
             case Pid::LINE_VISIBLE:
                   return true;
 
-            case Pid::BEGIN_TEXT_OFFSET:
-                  return score()->styleV(Sid::letRingBeginTextOffset).toPointF();
-
-            case Pid::BEGIN_TEXT_ALIGN:
-            case Pid::CONTINUE_TEXT_ALIGN:
-            case Pid::END_TEXT_ALIGN:
-                  return score()->styleV(Sid::letRingTextAlign);
-
-            case Pid::BEGIN_HOOK_HEIGHT:
-            case Pid::END_HOOK_HEIGHT:
-                  return score()->styleV(Sid::letRingHookHeight);
+            case Pid::CONTINUE_TEXT_OFFSET:
+            case Pid::END_TEXT_OFFSET:
+                  return QPointF(0, 0);
 
             case Pid::BEGIN_FONT_STYLE:
                   return score()->styleV(Sid::letRingFontStyle);
 
             case Pid::BEGIN_TEXT:
                   return score()->styleV(Sid::letRingText);
+            case Pid::CONTINUE_TEXT:
+            case Pid::END_TEXT:
+                  return "";
 
-            case Pid::END_HOOK_TYPE:
-                  return int(HookType::HOOK_90T);
+            case Pid::BEGIN_HOOK_TYPE:
+                  return int(HookType::NONE);
+
+            case Pid::BEGIN_TEXT_PLACE:
+            case Pid::CONTINUE_TEXT_PLACE:
+            case Pid::END_TEXT_PLACE:
+                  return int(PlaceText::AUTO);
 
             default:
                   return TextLineBase::propertyDefault(propertyId);

--- a/libmscore/letring.h
+++ b/libmscore/letring.h
@@ -47,7 +47,7 @@ class LetRing final : public TextLineBase {
       virtual LetRing* clone() const override   { return new LetRing(*this);   }
       virtual ElementType type() const override { return ElementType::LET_RING; }
       virtual void read(XmlReader&) override;
-      virtual void write(XmlWriter& xml) const override;
+//      virtual void write(XmlWriter& xml) const override;
       LineSegment* createLineSegment();
       virtual QVariant propertyDefault(Pid propertyId) const override;
       virtual Sid getPropertyStyle(Pid) const override;

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -978,7 +978,8 @@ void SLine::writeProperties(XmlWriter& xml) const
       //
       bool modified = false;
       for (const SpannerSegment* seg : spannerSegments()) {
-            if (!seg->autoplace() || !seg->visible() || (!seg->isStyled(Pid::OFFSET) && !seg->offset().isNull())) {
+            if (!seg->autoplace() || !seg->visible() || 
+               (!seg->isStyled(Pid::OFFSET) && (!seg->offset().isNull() || !seg->userOff2().isNull()))) {
                   modified = true;
                   break;
                   }

--- a/libmscore/palmmute.cpp
+++ b/libmscore/palmmute.cpp
@@ -37,6 +37,10 @@ static const ElementStyle palmMuteStyle {
       { Sid::palmMuteHookHeight,                    Pid::BEGIN_HOOK_HEIGHT      },
       { Sid::palmMuteHookHeight,                    Pid::END_HOOK_HEIGHT        },
       { Sid::palmMutePosBelow,                      Pid::OFFSET                 },
+      { Sid::palmMuteLineStyle,                     Pid::LINE_STYLE             },
+      { Sid::palmMuteBeginTextOffset,               Pid::BEGIN_TEXT_OFFSET      },
+      { Sid::palmMuteEndHookType,                   Pid::END_HOOK_TYPE          },
+      { Sid::palmMuteLineWidth,                     Pid::LINE_WIDTH             },
       };
 
 //---------------------------------------------------------
@@ -76,6 +80,9 @@ PalmMute::PalmMute(Score* s)
       {
       initElementStyle(&palmMuteStyle);
       resetProperty(Pid::LINE_VISIBLE);
+
+      resetProperty(Pid::BEGIN_TEXT_PLACE);
+      resetProperty(Pid::BEGIN_TEXT);
       }
 
 //---------------------------------------------------------
@@ -87,27 +94,39 @@ void PalmMute::read(XmlReader& e)
       if (score()->mscVersion() < 301)
             e.addSpanner(e.intAttribute("id", -1), this);
       while (e.readNextStartElement()) {
-            if (!TextLineBase::readProperties(e))
+            if (readProperty(e.name(), e, Pid::LINE_WIDTH))
+                  setPropertyFlags(Pid::LINE_WIDTH, PropertyFlags::UNSTYLED);
+            else if (!TextLineBase::readProperties(e))
                   e.unknown();
             }
       }
 
 //---------------------------------------------------------
 //   write
+//   
+//   The removal of this function is potentially a temporary
+//   change. For now, the intended behavior does no more than
+//   the base write function and so we will just use that.
+//   
+//   also see letring.cpp
 //---------------------------------------------------------
 
+/*
 void PalmMute::write(XmlWriter& xml) const
       {
       if (!xml.canWrite(this))
             return;
       xml.stag(this);
 
-      for (const StyledProperty& spp : *styledProperties())
-            writeProperty(xml, spp.pid);
+      for (const StyledProperty& spp : *styledProperties()) {
+            if(!isStyled(spp.pid))
+                  writeProperty(xml, spp.pid);
+            }
 
-      Element::writeProperties(xml);
+      TextLineBase::writeProperties(xml);
       xml.etag();
       }
+*/
 
 //---------------------------------------------------------
 //   createLineSegment
@@ -144,26 +163,26 @@ QVariant PalmMute::propertyDefault(Pid propertyId) const
             case Pid::LINE_VISIBLE:
                   return true;
 
-            case Pid::BEGIN_TEXT_OFFSET:
-                  return score()->styleV(Sid::palmMuteBeginTextOffset).toPointF();
-
-            case Pid::BEGIN_TEXT_ALIGN:
-            case Pid::CONTINUE_TEXT_ALIGN:
-            case Pid::END_TEXT_ALIGN:
-                  return score()->styleV(Sid::palmMuteTextAlign);
-
-            case Pid::BEGIN_HOOK_HEIGHT:
-            case Pid::END_HOOK_HEIGHT:
-                  return score()->styleV(Sid::palmMuteHookHeight);
+            case Pid::CONTINUE_TEXT_OFFSET:
+            case Pid::END_TEXT_OFFSET:
+                  return QPointF(0, 0);
 
 //TODOws            case Pid::BEGIN_FONT_ITALIC:
 //                  return score()->styleV(Sid::palmMuteFontItalic);
 
             case Pid::BEGIN_TEXT:
                   return score()->styleV(Sid::palmMuteText);
+            case Pid::CONTINUE_TEXT:
+            case Pid::END_TEXT:
+                  return "";
 
-            case Pid::END_HOOK_TYPE:
-                  return int(HookType::HOOK_90T);
+            case Pid::BEGIN_HOOK_TYPE:
+                  return int(HookType::NONE);
+
+            case Pid::BEGIN_TEXT_PLACE:
+            case Pid::CONTINUE_TEXT_PLACE:
+            case Pid::END_TEXT_PLACE:
+                  return int(PlaceText::AUTO);
 
             default:
                   return TextLineBase::propertyDefault(propertyId);

--- a/libmscore/palmmute.h
+++ b/libmscore/palmmute.h
@@ -53,7 +53,7 @@ class PalmMute final : public TextLineBase {
       virtual PalmMute* clone() const override  { return new PalmMute(*this);   }
       virtual ElementType type() const override { return ElementType::PALM_MUTE; }
       virtual void read(XmlReader&) override;
-      virtual void write(XmlWriter& xml) const override;
+//      virtual void write(XmlWriter& xml) const override;
       LineSegment* createLineSegment();
       virtual QVariant propertyDefault(Pid propertyId) const override;
 

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -20,6 +20,7 @@
 #include "page.h"
 #include "mscore.h"
 #include "clef.h"
+#include "textlinebase.h"
 #include "tuplet.h"
 #include "layout.h"
 #include "property.h"
@@ -1081,12 +1082,13 @@ static const StyleType styleTypes[] {
       { Sid::letRingLineStyle,              "letRingLineStyle",             QVariant(int(Qt::DashLine)) },
       { Sid::letRingBeginTextOffset,        "letRingBeginTextOffset",       QPointF(0.0, 0.15) },
       { Sid::letRingText,                   "letRingText",                  "let ring" },
-      { Sid::letRingFrameType,              "letRingFrameType",          int(FrameType::NO_FRAME) },
-      { Sid::letRingFramePadding,           "letRingFramePadding",       0.2 },
-      { Sid::letRingFrameWidth,             "letRingFrameWidth",         0.1 },
-      { Sid::letRingFrameRound,             "letRingFrameRound",         0 },
-      { Sid::letRingFrameFgColor,           "letRingFrameFgColor",       QColor(0, 0, 0, 255) },
-      { Sid::letRingFrameBgColor,           "letRingFrameBgColor",       QColor(255, 255, 255, 0) },
+      { Sid::letRingFrameType,              "letRingFrameType",             int(FrameType::NO_FRAME) },
+      { Sid::letRingFramePadding,           "letRingFramePadding",          0.2 },
+      { Sid::letRingFrameWidth,             "letRingFrameWidth",            0.1 },
+      { Sid::letRingFrameRound,             "letRingFrameRound",            0 },
+      { Sid::letRingFrameFgColor,           "letRingFrameFgColor",          QColor(0, 0, 0, 255) },
+      { Sid::letRingFrameBgColor,           "letRingFrameBgColor",          QColor(255, 255, 255, 0) },
+      { Sid::letRingEndHookType,            "letRingEndHookType",           int(HookType::HOOK_90T) },
 
       { Sid::palmMuteFontFace,              "palmMuteFontFace",              "FreeSerif" },
       { Sid::palmMuteFontSize,              "palmMuteFontSize",              10.0 },
@@ -1108,6 +1110,7 @@ static const StyleType styleTypes[] {
       { Sid::palmMuteFrameRound,            "palmMuteFrameRound",            0 },
       { Sid::palmMuteFrameFgColor,          "palmMuteFrameFgColor",          QColor(0, 0, 0, 255) },
       { Sid::palmMuteFrameBgColor,          "palmMuteFrameBgColor",          QColor(255, 255, 255, 0) },
+      { Sid::palmMuteEndHookType,           "palmMuteEndHookType",           int(HookType::HOOK_90T) },
 
       { Sid::fermataPosAbove,               "fermataPosAbove",               QPointF(.0, -1.0) },
       { Sid::fermataPosBelow,               "fermataPosBelow",               QPointF(.0, 1.0)  },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1063,6 +1063,7 @@ enum class Sid {
       letRingFrameRound,
       letRingFrameFgColor,
       letRingFrameBgColor,
+      letRingEndHookType,
 
       palmMuteFontFace,
       palmMuteFontSize,
@@ -1084,6 +1085,7 @@ enum class Sid {
       palmMuteFrameRound,
       palmMuteFrameFgColor,
       palmMuteFrameBgColor,
+      palmMuteEndHookType,
 
       fermataPosAbove,
       fermataPosBelow,

--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -114,7 +114,16 @@ void TextLineBaseSegment::draw(QPainter* painter) const
             painter->drawLines(&points[2], 1);
             }
       else {
-            for (int i = 0; i < npoints; ++i)
+            int start = 0;
+            //if there is an end hook, draw it with a solid line
+            if (npoints > 1) {
+                  painter->drawLines(&points[0], 1);
+                  painter->drawLines(&points[1], 1);
+                  pen.setStyle(Qt::SolidLine);
+                  painter->setPen(pen);
+                  start = 2;
+                  }
+            for (int i = start; i < npoints; ++i)
                   painter->drawLines(&points[i], 1);
             }
       }
@@ -432,8 +441,10 @@ void TextLineBase::spatiumChanged(qreal /*ov*/, qreal /*nv*/)
 
 void TextLineBase::writeProperties(XmlWriter& xml) const
       {
-      for (Pid pid : pids)
-            writeProperty(xml, pid);
+      for (Pid pid : pids) {
+            if (!isStyled(pid)) 
+                  writeProperty(xml, pid);
+            }
       SLine::writeProperties(xml);
       }
 


### PR DESCRIPTION
Multiple changes here which probably should have been in different commits, but here we go. So the first issue was that palm mute and let ring didn't save their properties. This was because they called Element::writeProperties() which doesn't write all properties related to itself. It was also writing the wrong properties as well as properties which were not necessary to write (already default or completely empty tags). I ended up just using the base TextLineBase::writeProperties() since these two lines had a majority of the properties that are written by it's base class TextLineBase. After that I only had to make some changes to the propertyDefault() function which, from my understanding, had some redundant code. 

After this the changes were saved, but I realized certain default properties were never applied even though they existed in the default styles in styles.cpp. This lead to issue 282191 and was a pretty easy fix. The default text, line mode, and hook mode were all there. I just needed to actually include those properties in the ElementStyle. One small thing I noticed was that the hook also followed the line pattern when it's normally always solid in practice. As a result I slightly modified the draw() function for TextLineBase to draw ending hooks with Qt::SolidLine

I didn't completely remove the writeProperties() functions for the two since I'm unsure if this is the best long term change. For now though, it was the easiest thing so I kept the code there and just commented it out.

Edit: Forgot to mention one little thing. There was also an issue with saving offsets for all lines in general. Users are able to modify the line using 3 grips, the last one changing something called offset2 or something like that. When saving a line, however, it only checked if Pid::OFFSET was nonzero and unstyled/nostyle which meant that you could make a change to a line and not have it saved. This affected all lines that derived from TextLineBase.cpp I fixed this too.