### PR TITLE
fix #281154: Crash with first note of measure set to beam middle and …

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2233,7 +2233,9 @@ void Score::createBeams(Measure* measure)
                               if (prevCR) {
                                     const Measure* pm = prevCR->measure();
                                     if (!beamNoContinue(prevCR->beamMode())
-                                        && !pm->lineBreak() && !pm->pageBreak() && !pm->sectionBreak()) {
+                                        && !pm->lineBreak() && !pm->pageBreak() && !pm->sectionBreak()
+                                        && prevCR->durationType().type() >= TDuration::DurationType::V_EIGHTH
+                                        && prevCR->durationType().type() <= TDuration::DurationType::V_1024TH) {
                                           beam = prevCR->beam();
                                           //a1 = beam ? beam->elements().front() : prevCR;
                                           a1 = beam ? nullptr : prevCR; // when beam is found, a1 is no longer required.


### PR DESCRIPTION
…nothing to beam to

See https://musescore.org/en/node/281154.
This issue was reopened because of the problem reported in https://musescore.org/en/node/284646.

More specifically, it's the file [Brahms Op114 Trio 3rd Mvt.mscz](https://musescore.org/sites/musescore.org/files/2019-02/Brahms%20Op114%20Trio%203rd%20Mvt.mscz).
In measure 87 of that file, the beam is incorrectly beamed to the half note in measure 86.

This PR, along with #4743(merged now), can fix that.