### PR TITLE
fix #282275: Crash when changing Time Signature in parts

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -817,8 +817,8 @@ void Score::cmdAddTimeSig(Measure* fm, int staffIdx, TimeSig* ts, bool local)
             // try to rewrite the measures first
             // we will only add time signatures if this succeeds
             // this means, however, that the rewrite cannot depend on the time signatures being in place
-            if (fm) {
-                  if (!mScore->rewriteMeasures(fm, ns, local ? staffIdx : -1)) {
+            if (mf) {
+                  if (!mScore->rewriteMeasures(mf, ns, local ? staffIdx : -1)) {
                         undoStack()->current()->unwind();
                         return;
                         }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/282275.

See also #4781 for relevant discussion.