### PR TITLE
fix #285591: accidentals should tuck under notes

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1977,8 +1977,8 @@ void Chord::layoutPitched()
       // HACK: if stem is up on previous chord and it is beamed,
       // shape won't be reliable, and accidentals in this chord may intersect it
       // this check catches "some" of those cases
-      if (_beam && _beam->up())
-            _spaceLw = lll;
+      //if (_beam && _beam->up())
+      //      _spaceLw = lll;
 
       if (gnb) {
               qreal xl = -(lll + minNoteDistance) - chordX;

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1849,6 +1849,8 @@ void Chord::layoutPitched()
                   // but here perhaps we create more padding in *front* of accidental?
                   x -= score()->styleP(Sid::accidentalDistance) * mag_;
                   lll = qMax(lll, -x);
+                  if (accidental->autoplace())
+                        _spaceLw = qMax(_spaceLw, lll);
                   }
 
             // allow extra space for shortened ties
@@ -1926,6 +1928,8 @@ void Chord::layoutPitched()
             _arpeggio->layout();    // only for width() !
             _arpeggio->setHeight(0.0);
             lll        += _arpeggio->width() + arpeggioDistance + chordX;
+            if (_arpeggio->autoplace())
+                  _spaceLw = lll;
             qreal y1   = upnote->pos().y() - upnote->headHeight() * .5;
             _arpeggio->setPos(-lll, y1);
             // _arpeggio->layout() called in layoutArpeggio2()
@@ -2002,7 +2006,7 @@ void Chord::layoutPitched()
             if (e->type() == ElementType::SLUR)     // we cannot at this time as chordpositions are not fixed
                   continue;
             e->layout();
-            if (e->type() == ElementType::CHORDLINE) {
+            if (e->type() == ElementType::CHORDLINE && e->autoplace()) {
                   QRectF tbbox = e->bbox().translated(e->pos());
                   qreal lx = tbbox.left() + chordX;
                   qreal rx = tbbox.right() + chordX;


### PR DESCRIPTION
The intent of this is to fix https://musescore.org/en/node/285591, and I'm coming close but running into issues.  So I'm submitting this PR as a work in progress, hoping maybe someone else can see a way out.

The good news is that my initial analysis was correct, simply leaving accidentals and other elements out of _spaceLw and _spaceRw *does* solve the problem.  It turns out we can't just remove the code calculating those variables because this is also the code used to *position* the symbols attached to chords.  But I was able to separate out the positioning from the allocation of space easily enough.  There is a slight complication with grace notes (which use the same code recursively), but nothing we shouldn't be able to solve.  I was able to get the following with little effort:

![image](https://user-images.githubusercontent.com/1799936/54059189-85baab00-41b5-11e9-9576-79b808049faa.png)

This is much better than 3.0.4 (which is similar to both 2.3.2 and current master):

![image](https://user-images.githubusercontent.com/1799936/54059091-2492d780-41b5-11e9-9ebe-9a6b684efa20.png)

Unfortunately, there is a problem with certain beamed note groups where the final stem direction and length is not known until long after segment spacing has been finalized.  In these cases, it is quite possible that at the point we are calculating the minimum distance between segment shapes, we might decide it is safe to tuck an accidental above a note, but it turns out to create overlap with the previous stem once its final direction and length are determined.  Thus we get the following:

![image](https://user-images.githubusercontent.com/1799936/54059211-9703b780-41b5-11e9-83cd-80a722b72e38.png)

This was the case in earlier 3.0 builds as well, we just didn't notice it (or maybe someone did, but it never got addressed).

The only solution I see is to figure out the beaming earlier in the layout process, but then there are also reasons why it needs to be as late as it does, so I don't see a way out.

Maybe someone else wants to take it from here?