### PR TITLE
Fret diagrams refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ vtest/META-INF
 vtest/Thumbnails
 vtest/Pictures
 .vs
+.vscode
 dependencies
 
 # Downloaded files during build process

--- a/libmscore/fret.cpp
+++ b/libmscore/fret.cpp
@@ -21,6 +21,7 @@
 #include "mscore.h"
 #include "harmony.h"
 #include "staff.h"
+#include "undo.h"
 
 namespace Ms {
 
@@ -37,8 +38,7 @@ static const ElementStyle fretStyle {
       { Sid::fretPlacement,                      Pid::PLACEMENT               },
       { Sid::fretStrings,                        Pid::FRET_STRINGS            },
       { Sid::fretFrets,                          Pid::FRET_FRETS              },
-      { Sid::fretOffset,                         Pid::FRET_OFFSET             },
-      { Sid::fretBarre,                          Pid::FRET_BARRE              },
+      { Sid::fretNut,                            Pid::FRET_NUT                },
       };
 
 //---------------------------------------------------------
@@ -60,78 +60,65 @@ FretDiagram::FretDiagram(const FretDiagram& f)
       _frets      = f._frets;
       _fretOffset = f._fretOffset;
       _maxFrets   = f._maxFrets;
-      maxStrings  = f.maxStrings;
       font        = f.font;
-      _barre      = f._barre;
       _userMag    = f._userMag;
+      _numPos     = f._numPos;
+      _dots       = f._dots;
+      _markers    = f._markers;
+      _barres     = f._barres;
+      _showNut    = f._showNut;
 
-      if (f._dots) {
-            _dots = new char[_strings];
-            memcpy(_dots, f._dots, _strings);
-            }
-      if (f._marker) {
-            _marker = new char[_strings];
-            memcpy(_marker, f._marker, _strings);
-            }
-      if (f._fingering) {
-            _fingering = new char[_strings];
-            memcpy(_fingering, f._fingering, _strings);
-            }
       if (f._harmony)
             _harmony = new Harmony(*f._harmony);
-      else
-            _harmony = 0;
-      }
-
-//---------------------------------------------------------
-//   FretDiagram
-//---------------------------------------------------------
-
-FretDiagram::~FretDiagram()
-      {
-      delete[] _dots;
-      delete[] _marker;
-      delete[] _fingering;
       }
 
 //---------------------------------------------------------
 //   fromString
-///  Create diagram from string like "XO-123"
-///  Always assume barre on the first visible fret
+///   Create diagram from string like "XO-123"
+///   Always assume barre on the first visible fret
 //---------------------------------------------------------
 
 FretDiagram* FretDiagram::fromString(Score* score, const QString &s)
       {
       FretDiagram* fd = new FretDiagram(score);
-      fd->setStrings(s.size());
+      int strings = s.size();
+
+      fd->setStrings(strings);
       fd->setFrets(4);
       int offset = 0;
       int barreString = -1;
-      for (int i = 0; i < s.size(); i++) {
+      std::vector<std::pair<int, int>> dotsToAdd;
+
+      for (int i = 0; i < strings; i++) {
             QChar c = s.at(i);
-            if (c == 'X' || c == 'O')
-                  fd->setMarker(i, c.unicode());
+            if (c == 'X' || c == 'O') {
+                  FretMarkerType mt = (c == 'X' ? FretMarkerType::CROSS : FretMarkerType::CIRCLE);
+                  fd->setMarker(i, mt);
+                  }
             else if (c == '-' && barreString == -1) {
-                  fd->setBarre(1);
                   barreString = i;
                   }
             else {
                   int fret = c.digitValue();
                   if (fret != -1) {
-                        fd->setDot(i, fret);
+                        dotsToAdd.push_back(make_pair(i, fret));
                         if (fret - 3 > 0 && offset < fret - 3)
                             offset = fret - 3;
                         }
                   }
             }
-      if (offset > 0) {
+
+      if (offset > 0)
             fd->setFretOffset(offset);
-            for (int i = 0; i < fd->strings(); i++)
-                  if (fd->dot(i))
-                        fd->setDot(i, fd->dot(i) - offset);
+
+      for (std::pair<int, int> d : dotsToAdd) {
+            fd->setDot(d.first, d.second - offset, true);
             }
+
+      // This assumes that any barre goes to the end of the fret
       if (barreString >= 0)
-            fd->setDot(barreString, 1);
+            fd->setBarre(barreString, -1, 1);
+
       return fd;
       }
 
@@ -208,35 +195,44 @@ QLineF FretDiagram::dragAnchor() const
 
 void FretDiagram::setStrings(int n)
       {
-      if (n <= maxStrings) {
-            _strings = n;
+      int difference = n - _strings;
+      if (difference == 0 || n <= 0)
             return;
+
+      // Move all dots, makers, barres to the RIGHT, so we add strings to the left
+      // This is more useful - few instruments need strings added to the right.
+      DotMap tempDots;
+      MarkerMap tempMarkers;
+
+      for (int string = 0; string < _strings; ++string) {
+            if (string + difference < 0)
+                  continue;
+
+            for (auto const& d : dot(string)) {
+                  if (d.exists())
+                        tempDots[string + difference].push_back(FretItem::Dot(d));
+                  }
+
+            if (marker(string).exists())
+                  tempMarkers[string + difference] = marker(string);
             }
-      maxStrings = n;
-      if (_dots) {
-            char* ndots = new char[n];
-            memcpy(ndots, _dots, n);
-            for (int i = _strings; i < n; ++i)
-                  ndots[i] = 0;
-            delete[] _dots;
-            _dots = ndots;
+
+      _dots = tempDots;
+      _markers = tempMarkers;
+
+      for (int fret = 1; fret <= _frets; ++fret) {
+            if (barre(fret).exists()) {
+                  if (_barres[fret].startString + difference <= 0) {
+                        removeBarre(fret);
+                        continue;
+                        }
+
+                  _barres[fret].startString = qMax(0, _barres[fret].startString + difference);
+                  _barres[fret].endString   = _barres[fret].endString == -1 ? -1 : _barres[fret].endString + difference;
+                  }
+
             }
-      if (_marker) {
-            char* nmarker = new char[n];
-            memcpy(nmarker, _marker, n);
-            for (int i = _strings; i < n; ++i)
-                  nmarker[i] = 'O';
-            delete[] _marker;
-            _marker = nmarker;
-            }
-      if (_fingering) {
-            char* nfingering = new char[n];
-            memcpy(nfingering, _fingering, n);
-            for (int i = _strings; i < n; ++i)
-                  nfingering[i] = 0;
-            delete[] _fingering;
-            _fingering = nfingering;
-            }
+
       _strings = n;
       }
 
@@ -252,8 +248,8 @@ void FretDiagram::init(StringData* stringData, Chord* chord)
             setStrings(stringData->strings());
       if (stringData) {
             for (int string = 0; string < _strings; ++string)
-                  _marker[string] = 'X';
-            foreach(const Note* note, chord->notes()) {
+                  setMarker(string, FretMarkerType::CROSS);
+            for (const Note* note : chord->notes()) {
                   int string;
                   int fret;
                   if (stringData->convertPitch(note->pitch(), chord->staff(), chord->segment()->tick(), &string, &fret))
@@ -271,18 +267,26 @@ void FretDiagram::init(StringData* stringData, Chord* chord)
 
 void FretDiagram::draw(QPainter* painter) const
       {
-      qreal _spatium = spatium() * _userMag * score()->styleD(Sid::fretMag);
+      // Init pen and other values
+      qreal _spatium = spatium() * _userMag;
       QPen pen(curColor());
-      pen.setWidthF(lw2);
       pen.setCapStyle(Qt::FlatCap);
-      painter->setPen(pen);
       painter->setBrush(QBrush(QColor(painter->pen().color())));
-      qreal x2 = (_strings-1) * stringDist;
-      painter->drawLine(QLineF(-lw1 * .5, 0.0, x2 + lw1 * .5, 0.0));
 
-      pen.setWidthF(lw1);
+      // x2 is the x val of the rightmost string
+      qreal x2 = (_strings-1) * stringDist;
+
+      // Draw the nut
+      pen.setWidthF(nutLw);
       painter->setPen(pen);
-      qreal y2 = (_frets+1) * fretDist - fretDist * .5;
+      painter->drawLine(QLineF(-stringLw * .5, 0.0, x2 + stringLw * .5, 0.0));
+
+      // Draw strings and frets
+      pen.setWidthF(stringLw);
+      painter->setPen(pen);
+
+      // y2 is the y val of the bottom fretline
+      qreal y2 = fretDist * (_frets + .5);
       for (int i = 0; i < _strings; ++i) {
             qreal x = stringDist * i;
             painter->drawLine(QLineF(x, _fretOffset ? -_spatium * .2 : 0.0, x, y2));
@@ -291,48 +295,99 @@ void FretDiagram::draw(QPainter* painter) const
             qreal y = fretDist * i;
             painter->drawLine(QLineF(0.0, y, x2, y));
             }
+
+      // Setup the font for the markers
       QFont scaledFont(font);
-      scaledFont.setPointSizeF(font.pointSize() * _userMag * score()->styleD(Sid::fretMag));
+      scaledFont.setPointSizeF(font.pointSize() * _userMag * (spatium() / SPATIUM20));
       QFontMetricsF fm(scaledFont, MScore::paintDevice());
       scaledFont.setPointSizeF(scaledFont.pointSizeF() * MScore::pixelRatio);
 
       painter->setFont(scaledFont);
-      qreal dotd = stringDist * .6;
 
-      for (int i = 0; i < _strings; ++i) {
-            if (_dots && _dots[i] && _dots[i] != _barre) {
-                  int fret = _dots[i] - 1;
-                  qreal x = stringDist * i - dotd * .5;
+      // dotd is the diameter of a dot
+      qreal dotd = stringDist * .7;
+
+      // Draw dots, sym pen is used to draw them
+      QPen symPen(pen);
+      symPen.setCapStyle(Qt::RoundCap);
+      qreal symPenWidth = stringLw * 1.2;
+      symPen.setWidthF(symPenWidth);
+
+      for (auto const& i : _dots) {
+            for (auto const& d : i.second) {
+                  if (!d.exists())
+                        continue;
+
+                  int string = i.first;
+                  int fret = d.fret - 1;
+
+                  // Calculate coords of the top left corner of the dot
+                  qreal x = stringDist * string - dotd * .5;
                   qreal y = fretDist * fret + fretDist * .5 - dotd * .5;
-                  painter->drawEllipse(QRectF(x, y, dotd, dotd));
-                  }
-            if (_marker && _marker[i]) {
-                  qreal x = stringDist * i;
-                  qreal y = -fretDist * .3 - fm.ascent();
-                  painter->drawText(QRectF(x, y, .0, .0),
-                     Qt::AlignHCenter|Qt::TextDontClip, QChar(_marker[i]));
-                  }
-            }
-      if (_barre) {
-            int string = -1;
-            for (int i = 0; i < _strings; ++i) {
-                  if (_dots && _dots[i] == _barre) {
-                        string = i;
-                        break;
+
+                  // Draw different symbols
+                  painter->setPen(symPen);
+                  switch (d.dtype) {
+                        case FretDotType::CROSS:
+                              // Give the cross a slightly larger width
+                              symPen.setWidthF(symPenWidth * 1.5);
+                              painter->setPen(symPen);
+                              painter->drawLine(QLineF(x, y, x + dotd, y + dotd));
+                              painter->drawLine(QLineF(x + dotd, y, x, y + dotd));
+                              symPen.setWidthF(symPenWidth);
+                              break;
+                        case FretDotType::SQUARE:
+                              painter->setBrush(Qt::NoBrush);
+                              painter->drawRect(QRectF(x, y, dotd, dotd));
+                              break;
+                        case FretDotType::TRIANGLE:
+                              painter->drawLine(QLineF(x, y + dotd, x + .5 * dotd, y));
+                              painter->drawLine(QLineF(x + .5 * dotd, y, x + dotd, y + dotd));
+                              painter->drawLine(QLineF(x + dotd, y + dotd, x, y + dotd));                                    
+                              break;
+                        case FretDotType::NORMAL:
+                        default:
+                              painter->setBrush(symPen.color());
+                              painter->setPen(Qt::NoPen);
+                              painter->drawEllipse(QRectF(x, y, dotd, dotd));
+                              break;
                         }
                   }
-            if (string != -1) {
-                  qreal x1   = stringDist * string;
-                  qreal y    = fretDist * (_barre-1) + fretDist * .5;
-                  pen.setWidthF((dotd + lw2 * .5) * score()->styleD(Sid::barreLineWidth));
-                  pen.setCapStyle(Qt::RoundCap);
-                  painter->setPen(pen);
-                  painter->drawLine(QLineF(x1, y, x2, y));
-                  }
             }
+
+      // Draw markers
+      painter->setPen(pen);
+      for (auto const& i : _markers) {
+            int string = i.first;
+            FretItem::Marker marker = i.second;
+
+            QChar markerChar = FretItem::markerToChar(marker.mtype);
+
+            qreal x = stringDist * string;
+            qreal y = -fretDist * .3 - fm.ascent();
+            painter->drawText(QRectF(x, y, .0, .0),
+               Qt::AlignHCenter|Qt::TextDontClip, markerChar);
+            }
+
+      // Draw barres
+      for (auto const& i : _barres) {
+            int fret        = i.first;
+            int startString = i.second.startString;
+            int endString   = i.second.endString;
+
+            qreal x1    = stringDist * startString;
+            qreal newX2 = endString == -1 ? x2 : stringDist * endString;
+            qreal y     = fretDist * (fret - 1) + fretDist * .5;
+            pen.setWidthF(dotd * score()->styleD(Sid::barreLineWidth));
+            pen.setCapStyle(Qt::RoundCap);
+            painter->setPen(pen);
+            painter->drawLine(QLineF(x1, y, newX2, y));
+            }
+
+      // Draw fret offset number
       if (_fretOffset > 0) {
             qreal fretNumMag = score()->styleD(Sid::fretNumMag);
-            scaledFont.setPointSizeF(font.pointSize() * fretNumMag * _userMag * score()->styleD(Sid::fretMag) * MScore::pixelRatio);
+            scaledFont.setPointSizeF(scaledFont.pointSizeF() * fretNumMag);
             painter->setFont(scaledFont);
             if (_numPos == 0) {
                   painter->drawText(QRectF(-stringDist *.4, .0, .0, fretDist),
@@ -346,6 +401,8 @@ void FretDiagram::draw(QPainter* painter) const
                   }
             painter->setFont(font);
             }
+
+      // NOTE:JT possible future todo - draw fingerings
       }
 
 //---------------------------------------------------------
@@ -354,24 +411,35 @@ void FretDiagram::draw(QPainter* painter) const
 
 void FretDiagram::layout()
       {
-      qreal _spatium  = spatium() * _userMag * score()->styleD(Sid::fretMag);
-      lw1             = _spatium * 0.08;
-      lw2             = _fretOffset ? lw1 : _spatium * 0.2;
+      qreal _spatium  = spatium() * _userMag;
+      stringLw        = _spatium * 0.08;
+      nutLw           = (_fretOffset || !_showNut) ? stringLw : _spatium * 0.2;
       stringDist      = _spatium * .7;
       fretDist        = _spatium * .8;
 
       qreal w    = stringDist * (_strings - 1);
       qreal h    = _frets * fretDist + fretDist * .5;
       qreal y    = 0.0;
-      qreal dotd = stringDist * .6;
-      qreal x    = -((dotd+lw1) * .5);
-      w         += dotd + lw1;
-      if (_marker) {
-            QFont scaledFont(font);
-            scaledFont.setPointSize(font.pointSize() * _userMag);
-            QFontMetricsF fm(scaledFont, MScore::paintDevice());
-            y  = -(fretDist * .1 + fm.height());
-            h -= y;
+      qreal dotd = stringDist * .7;
+      qreal x    = -((dotd+stringLw) * .5);
+      w         += dotd + stringLw;
+
+      // Always allocate space for markers
+      QFont scaledFont(font);
+      scaledFont.setPointSize(font.pointSize() * _userMag);
+      QFontMetricsF fm(scaledFont, MScore::paintDevice());
+      y  = -(fretDist * .1 + fm.height());
+      h -= y;
+
+      if (_fretOffset > 0) {
+            qreal fretNumMag = score()->styleD(Sid::fretNumMag);
+            scaledFont.setPointSizeF(scaledFont.pointSizeF() * fretNumMag);
+            QFontMetricsF fm2(scaledFont, MScore::paintDevice());
+            qreal numw = fm2.width(QString("%1").arg(_fretOffset+1));
+
+            qreal xdiff = numw + stringDist * .4;
+            w += xdiff;
+            x += _numPos == 0 ? -xdiff : 0;
             }
 
       bbox().setRect(x, y, w, h);
@@ -411,6 +479,8 @@ void FretDiagram::layout()
 
 //---------------------------------------------------------
 //   write
+//    NOTICE: if you are looking to change how fret diagrams are
+//    written, edit the writeNew function. writeOld is purely compatability.
 //---------------------------------------------------------
 
 void FretDiagram::write(XmlWriter& xml) const
@@ -418,28 +488,168 @@ void FretDiagram::write(XmlWriter& xml) const
       if (!xml.canWrite(this))
             return;
       xml.stag(this);
-      Element::writeProperties(xml);
 
+      // Write properties first and only once
+      Element::writeProperties(xml);
       writeProperty(xml, Pid::FRET_STRINGS);
       writeProperty(xml, Pid::FRET_FRETS);
       writeProperty(xml, Pid::FRET_OFFSET);
-      for (int i = 0; i < _strings; ++i) {
-            if ((_dots && _dots[i]) || (_marker && _marker[i]) || (_fingering && _fingering[i])) {
-                  xml.stag(QString("string no=\"%1\"").arg(i));
-                  if (_dots && _dots[i])
-                        xml.tag("dot", _dots[i]);
-                  if (_marker && _marker[i])
-                        xml.tag("marker", _marker[i]);
-                  if (_fingering && _fingering[i])
-                        xml.tag("fingering", _fingering[i]);
-                  xml.etag();
-                  }
-            }
-      writeProperty(xml, Pid::FRET_BARRE);
+      writeProperty(xml, Pid::FRET_NUT);
       writeProperty(xml, Pid::MAG);
+
       if (_harmony)
             _harmony->write(xml);
+
+      // Lowercase f indicates new writing format
+      // TODO: in the next score format version (4) use only write new and discard
+      // the compatability writing.
+      xml.stag("fretDiagram");
+      writeNew(xml);
       xml.etag();
+
+      writeOld(xml);
+      xml.etag();
+      }
+
+//---------------------------------------------------------
+//   writeOld
+//    This is the old method of writing. This is for backwards
+//    compatability with < 3.1 versions.
+//---------------------------------------------------------
+
+void FretDiagram::writeOld(XmlWriter& xml) const
+      {
+      int lowestDotFret = -1;
+      bool multipleDotsOnFret = false;
+
+      // Do some checks for details needed for checking whether to add barres
+      for (int i = 0; i < _strings; ++i) {
+            std::vector<FretItem::Dot> allDots = dot(i);
+
+            bool dotExists = false;
+            for (auto const& d : allDots) {
+                  if (d.exists()) {
+                        dotExists = true;
+                        break;
+                        }
+                  }
+
+            if (!dotExists)
+                  continue;
+
+            for (auto const& d : allDots) {
+                  if (d.exists()) {
+                        if (d.fret < lowestDotFret || lowestDotFret == -1)
+                              lowestDotFret = d.fret;
+                        else if (d.fret == lowestDotFret)
+                              multipleDotsOnFret = true; 
+                        }
+                  }
+            }
+
+      // The old system writes a barre as a bool, which causes no problems in any way, not at all.
+      // So, only write that if the barre is on the lowest fret with a dot,
+      // and there are no other dots on its fret, and it goes all the way to the right.
+      int barreStartString = -1;
+      int barreFret = -1;
+      for (auto const& i : _barres) {
+            FretItem::Barre b = i.second;
+            if (b.exists()) {
+                  int fret = i.first;
+                  if (fret <= lowestDotFret && !multipleDotsOnFret && b.endString == -1) {
+                        barreStartString = b.startString;
+                        barreFret = fret;
+                        break;
+                        }
+                  }
+            }
+
+      for (int i = 0; i < _strings; ++i) {
+            FretItem::Marker m = marker(i);
+            std::vector<FretItem::Dot> allDots = dot(i);
+
+            bool dotExists = false;
+            for (auto const& d : allDots) {
+                  if (d.exists()) {
+                        dotExists = true;
+                        break;
+                        }
+                  }
+
+            if (!dotExists && !m.exists() && i != barreStartString)
+                  continue;
+
+            xml.stag(QString("string no=\"%1\"").arg(i));
+
+            if (m.exists())
+                  xml.tag("marker", FretItem::markerToChar(m.mtype).unicode());
+
+            for (auto const& d : allDots) {
+                  if (d.exists() && !(i == barreStartString && d.fret == barreFret)) {
+                        xml.tag("dot", d.fret);
+                        }
+                  }
+
+            // Add dot so barre will display in pre-3.1
+            if (barreStartString == i) {
+                  xml.tag("dot", barreFret);
+                  }
+
+            xml.etag();
+            }
+
+      if (barreFret > 0)
+            xml.tag("barre", 1);
+      }
+
+//---------------------------------------------------------
+//   writeNew
+//    This is the important one for 3.1+
+//---------------------------------------------------------
+
+void FretDiagram::writeNew(XmlWriter& xml) const
+      {
+      for (int i = 0; i < _strings; ++i) {
+            FretItem::Marker m = marker(i);
+            std::vector<FretItem::Dot> allDots = dot(i);
+
+            bool dotExists = false;
+            for (auto const& d : allDots) {
+                  if (d.exists()) {
+                        dotExists = true;
+                        break;
+                        }
+                  }
+
+            // Only write a string if we have anything to write
+            if (!dotExists && !m.exists())
+                  continue;
+
+            // Start the string writing
+            xml.stag(QString("string no=\"%1\"").arg(i));
+
+            // Write marker
+            if (m.exists())
+                  xml.tag("marker", FretItem::markerTypeToName(m.mtype));
+
+            // Write any dots
+            for (auto const& d : allDots) {
+                  if (d.exists()) {
+                        // TODO: write fingering
+                        xml.tag(QString("dot fret=\"%1\"").arg(d.fret), FretItem::dotTypeToName(d.dtype));
+                        }
+                  }
+
+            xml.etag();
+            }
+
+      for (int f = 1; f <= _frets; ++f) {
+            FretItem::Barre b = barre(f);
+            if (!b.exists())
+                  continue;
+
+            xml.tag(QString("barre start=\"%1\" end=\"%2\"").arg(b.startString).arg(b.endString), f);
+            }
       }
 
 //---------------------------------------------------------
@@ -448,9 +658,25 @@ void FretDiagram::write(XmlWriter& xml) const
 
 void FretDiagram::read(XmlReader& e)
       {
+      // Read the old format first
+      bool hasBarre = false;
+      bool haveReadNew = false;
+
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
-            if (tag == "strings")
+
+            // Check for new format fret diagram
+            if (haveReadNew) {
+                  e.skipCurrentElement();
+                  continue;
+                  }
+            if (tag == "fretDiagram") {
+                  readNew(e);
+                  haveReadNew = true;       
+                  }
+
+            // Then read the rest if there is no new format diagram (compatability read)
+            else if (tag == "strings")
                   readProperty(e, Pid::FRET_STRINGS);
             else if (tag == "frets")
                   readProperty(e, Pid::FRET_FRETS);
@@ -463,15 +689,84 @@ void FretDiagram::read(XmlReader& e)
                         if (t == "dot")
                               setDot(no, e.readInt());
                         else if (t == "marker")
-                              setMarker(no, e.readInt());
-                        else if (t == "fingering")
-                              setFingering(no, e.readInt());
+                              setMarker(no, QChar(e.readInt()) == 'X' ? FretMarkerType::CROSS : FretMarkerType::CIRCLE);
+                        /*else if (t == "fingering")
+                              setFingering(no, e.readInt());*/
                         else
                               e.unknown();
                         }
                   }
             else if (tag == "barre")
-                  readProperty(e, Pid::FRET_BARRE);
+                  hasBarre = e.readBool();
+            else if (tag == "mag")
+                  readProperty(e, Pid::MAG);
+            else if (tag == "Harmony") {
+                  Harmony* h = new Harmony(score());
+                  h->read(e);
+                  add(h);
+                  }
+            else if (!Element::readProperties(e))
+                  e.unknown();
+            }
+
+      // Old handling of barres
+      if (hasBarre) {
+            for (int s = 0; s < _strings; ++s) {
+                  for (auto& d : dot(s)) {
+                        if (d.exists()) {
+                              setBarre(s, -1, d.fret);
+                              return;
+                              }
+                        }
+                  }
+            }
+      }
+
+//---------------------------------------------------------
+//   readNew
+//---------------------------------------------------------
+
+void FretDiagram::readNew(XmlReader& e)
+      {
+      while (e.readNextStartElement()) {
+            const QStringRef& tag(e.name());
+
+            if (tag == "strings")
+                  readProperty(e, Pid::FRET_STRINGS);
+            else if (tag == "frets")
+                  readProperty(e, Pid::FRET_FRETS);
+            else if (tag == "fretOffset")
+                  readProperty(e, Pid::FRET_OFFSET);
+            else if (tag == "showNut")
+                  readProperty(e, Pid::FRET_NUT);
+            else if (tag == "string") {
+                  int no = e.intAttribute("no");
+                  while (e.readNextStartElement()) {
+                        const QStringRef& t(e.name());
+                        if (t == "dot") {
+                              int fret = e.intAttribute("fret", 0);
+                              FretDotType dtype = FretItem::nameToDotType(e.readElementText());
+                              setDot(no, fret, true, dtype);
+                              }
+                        else if (t == "marker") {
+                              FretMarkerType mtype = FretItem::nameToMarkerType(e.readElementText());
+                              setMarker(no, mtype);
+                              }
+                        else if (t == "fingering") {
+                              e.readElementText();
+                              /*setFingering(no, e.readInt()); NOTE:JT todo */
+                              }
+                        else
+                              e.unknown();
+                        }
+                  }
+            else if (tag == "barre") {
+                  int start = e.intAttribute("start", -1);
+                  int end = e.intAttribute("end", -1);
+                  int fret = e.readInt();
+
+                  setBarre(start, end, fret);
+                  }
             else if (tag == "mag")
                   readProperty(e, Pid::MAG);
             else if (tag == "Harmony") {
@@ -486,45 +781,294 @@ void FretDiagram::read(XmlReader& e)
 
 //---------------------------------------------------------
 //   setDot
+//    take a fret value of 0 to mean remove the dot, except with add
+//    where we actually need to pass a fret val.
 //---------------------------------------------------------
 
-void FretDiagram::setDot(int string, int fret)
+void FretDiagram::setDot(int string, int fret, bool add /*= false*/, FretDotType dtype /*= FretDotType::NORMAL*/)
       {
-      if (_dots == 0) {
-            _dots = new char[_strings];
-            memset(_dots, 0, _strings);
-            }
-      if (0 <= string && string < _strings) {
-            _dots[string] = fret;
-            setMarker(string, 0);   // TODO: does not work with undo/redo; should be called explicit
+      if (fret == 0)
+            removeDot(string, fret);
+      else if (string >= 0 && string < _strings) {
+            // Special case - with add, if there is a dot in the position, remove it
+            // If not, add it.
+            if (add) {
+                  if (dot(string, fret)[0].exists()) {
+                        removeDot(string, fret);
+                        return;     // We are done here, all we needed to do was remove a single dot
+                        }
+                  }
+            else
+                  _dots[string].clear();
+
+            _dots[string].push_back(FretItem::Dot(fret, dtype));
+            setMarker(string, FretMarkerType::NONE);
             }
       }
 
 //---------------------------------------------------------
 //   setMarker
+//    Remove any dots and barres if the marker is being set to anything other than none.
 //---------------------------------------------------------
 
-void FretDiagram::setMarker(int string, int m)
+void FretDiagram::setMarker(int string, FretMarkerType mtype)
       {
-      if (_marker == 0) {
-            _marker = new char[_strings];
-            memset(_marker, 0, _strings);
+      if (string >= 0 && string < _strings) {
+            _markers[string] = FretItem::Marker(mtype);
+            if (mtype != FretMarkerType::NONE) {
+                  removeDot(string);
+                  removeBarres(string);
+                  }
             }
-      if (0 <= string && string < _strings)
-            _marker[string] = m;
       }
 
 //---------------------------------------------------------
 //   setFingering
+//    NOTE:JT: todo possible future feature
 //---------------------------------------------------------
 
+#if 0
 void FretDiagram::setFingering(int string, int finger)
       {
-      if (_fingering == 0) {
-            _fingering = new char[_strings];
-            memset(_fingering, 0, _strings);
+      if (_dots.find(string) != _dots.end()) {
+            _dots[string].fingering = finger;
+            qDebug("set finger: s %d finger %d", string, finger);
             }
-      _fingering[string] = finger;
+      }
+#endif
+
+//---------------------------------------------------------
+//   setBarre
+//    We'll accept a value of -1 for the end string, to denote
+//    that the barre goes as far right as possible.
+//    Take a start string value of -1 to mean 'remove this barre'
+//---------------------------------------------------------
+
+void FretDiagram::setBarre(int startString, int endString, int fret)
+      {
+      if (startString == -1)
+            removeBarre(fret);
+      else if (startString >= 0 && endString >= -1 && startString < _strings && endString < _strings)
+            _barres[fret] = FretItem::Barre(startString, endString);
+      }
+
+//---------------------------------------------------------
+//    This version is for clicks on a dot with shift.
+//    If there is no barre at fret, then add one with the string as the start.
+//    If there is a barre with a -1 end string, set the end string to string.
+//    If there is a barre with a set start and end, remove it.
+//    Add may be used in the future if we decide to add dots as default with barres.
+//---------------------------------------------------------
+
+void FretDiagram::setBarre(int string, int fret, bool add /*= false*/)
+      {
+      Q_UNUSED(add);
+
+      FretItem::Barre b = barre(fret);
+      if (!b.exists()) {
+            if (string < _strings - 1) {
+                  _barres[fret] = FretItem::Barre(string, -1);
+                  removeDotsMarkers(string, -1, fret);
+                  }
+            } 
+      else if (b.endString == -1 && b.startString < string) {
+            _barres[fret].endString = string;
+            }
+      else {
+            removeDotsMarkers(b.startString, b.endString, fret);
+            removeBarre(fret);
+            }
+      }
+
+//---------------------------------------------------------
+//   undoSetFretDot
+//---------------------------------------------------------
+
+void FretDiagram::undoSetFretDot(int _string, int _fret, bool _add /*= true*/, FretDotType _dtype /*= FretDotType::NORMAl*/)
+      {
+      for (ScoreElement* e : linkList()) {
+            FretDiagram* fd = toFretDiagram(e);
+            fd->score()->undo(new FretDot(fd, _string, _fret, _add, _dtype));
+            }
+      }
+
+//---------------------------------------------------------
+//   undoSetFretMarker
+//---------------------------------------------------------
+
+void FretDiagram::undoSetFretMarker(int _string, FretMarkerType _mtype)
+      {
+      for (ScoreElement* e : linkList()) {
+            FretDiagram* fd = toFretDiagram(e);
+            fd->score()->undo(new FretMarker(fd, _string, _mtype));
+            }
+      }
+
+//---------------------------------------------------------
+//   undoSetFretBarre
+//    add refers to using multiple dots per string when adding dots automatically
+//---------------------------------------------------------
+
+void FretDiagram::undoSetFretBarre(int _string, int _fret, bool _add /*= false*/)
+      {
+      for (ScoreElement* e : linkList()) {
+            FretDiagram* fd = toFretDiagram(e);
+            fd->score()->undo(new FretBarre(fd, _string, _fret, _add));
+            }
+      }
+
+//---------------------------------------------------------
+//   removeBarre
+//    Remove a barre on a given fret.
+//---------------------------------------------------------
+
+void FretDiagram::removeBarre(int f)
+      {
+      _barres.erase(f);
+      }
+
+//---------------------------------------------------------
+//   removeBarres
+//    Remove barres crossing a certain point. Fret of 0 means any point along
+//    the string.
+//---------------------------------------------------------
+
+void FretDiagram::removeBarres(int string, int fret /*= 0*/)
+      {
+      auto iter = _barres.begin();
+      while (iter != _barres.end()) {
+            int bfret = iter->first;
+            FretItem::Barre b = iter->second;
+
+            if (b.exists() && b.startString <= string && (b.endString >= string || b.endString == -1)) {
+                  if (fret > 0 && fret != bfret)
+                        ++iter;
+                  else
+                        iter = _barres.erase(iter);
+                  }
+            else
+                  ++iter;
+            }
+      }   
+
+//---------------------------------------------------------
+//   removeMarker
+//---------------------------------------------------------
+
+void FretDiagram::removeMarker(int s)
+      {
+      auto it = _markers.find(s);
+      _markers.erase(it);
+      }
+
+//---------------------------------------------------------
+//   removeDot
+//    take a fret value of 0 to mean remove all dots
+//---------------------------------------------------------
+
+void FretDiagram::removeDot(int s, int f /*= 0*/)
+      {
+      if (f > 0) {
+            std::vector<FretItem::Dot> tempDots;
+            for (auto const& d : dot(s)) {
+                  if (d.exists() && d.fret != f)
+                        tempDots.push_back(FretItem::Dot(d));
+                  }
+
+            _dots[s] = tempDots;
+            }
+      else
+            _dots[s].clear();
+
+      if (_dots[s].size() == 0) {
+            auto it = _dots.find(s);
+            _dots.erase(it);
+            }
+      }
+
+//---------------------------------------------------------
+//   removeDotsMarkers
+//    removes all markers between [ss, es] and dots between [ss, es],
+//    where the dots have a fret of fret.
+//---------------------------------------------------------
+
+void FretDiagram::removeDotsMarkers(int ss, int es, int fret)
+      {
+      if (ss == -1)
+            return;
+
+      int end = es == -1 ? _strings : es;
+      for (int string = ss; string <= end; ++string) {
+            removeDot(string, fret);
+
+            if (marker(string).exists())
+                  removeMarker(string);
+            }
+      }
+
+//---------------------------------------------------------
+//   clear
+//---------------------------------------------------------
+
+void FretDiagram::clear()
+      {
+      _barres.clear();
+      _dots.clear();
+      _markers.clear();
+      }
+
+//---------------------------------------------------------
+//   undoFretClear
+//---------------------------------------------------------
+
+void FretDiagram::undoFretClear()
+      {
+      for (ScoreElement* e : linkList()) {
+            FretDiagram* fd = toFretDiagram(e);
+            fd->score()->undo(new FretClear(fd));
+            }
+      }
+
+//---------------------------------------------------------
+//   dot
+//    take fret value of zero to mean all dots 
+//---------------------------------------------------------
+
+std::vector<FretItem::Dot> FretDiagram::dot(int s, int f /*= 0*/) const
+      {
+      if (_dots.find(s) != _dots.end()) {
+            if (f != 0) {
+                  for (auto const& d : _dots.at(s)) {
+                        if (d.fret == f)
+                              return std::vector<FretItem::Dot> { FretItem::Dot(d) };
+                        }
+                  }
+            else
+                  return _dots.at(s);
+            }
+      return std::vector<FretItem::Dot> { FretItem::Dot(0) };
+      }
+
+//---------------------------------------------------------
+//   marker
+//---------------------------------------------------------
+
+FretItem::Marker FretDiagram::marker(int s) const
+      {
+      if (_markers.find(s) != _markers.end())
+            return _markers.at(s);
+      return FretItem::Marker(FretMarkerType::NONE);
+      }
+
+//---------------------------------------------------------
+//   barre
+//---------------------------------------------------------
+
+FretItem::Barre FretDiagram::barre(int f) const
+      {
+      if (_barres.find(f) != _barres.end())
+            return _barres.at(f);
+      return FretItem::Barre(-1, -1);
       }
 
 //---------------------------------------------------------
@@ -603,39 +1147,77 @@ void FretDiagram::scanElements(void* data, void (*func)(void*, Element*), bool a
 void FretDiagram::writeMusicXML(XmlWriter& xml) const
       {
       qDebug("FretDiagram::writeMusicXML() this %p harmony %p", this, _harmony);
-      int strings_ = strings();
       xml.stag("frame");
-      xml.tag("frame-strings", strings_);
+      xml.tag("frame-strings", _strings);
       xml.tag("frame-frets", frets());
       QString strDots = "'";
       QString strMarker = "'";
       QString strFingering = "'";
-      for (int i = 0; i < strings_; ++i) {
-            // TODO print frame note
-            if (_dots)
-                  strDots += QString("%1'").arg(static_cast<int>(_dots[i]));
-            if (_marker)
-                  strMarker += QString("%1'").arg(static_cast<int>(_marker[i]));
-            if (_fingering)
-                  strFingering += QString("%1'").arg(static_cast<int>(_fingering[i]));
-            if (_marker[i] != 88) {
+
+      for (int i = 0; i < _strings; ++i) {
+            int mxmlString = _strings - i;
+
+            std::vector<int> bStarts;
+            std::vector<int> bEnds;
+            for (auto const& j : _barres) {
+                  FretItem::Barre b = j.second;
+                  int fret = j.first;
+                  if (!b.exists())
+                        continue;
+
+                  if (b.startString == i)
+                        bStarts.push_back(fret);
+                  else if (b.endString == i || (b.endString == -1 && mxmlString == 1))
+                        bEnds.push_back(fret);
+                  }
+
+            if (marker(i).exists() && marker(i).mtype == FretMarkerType::CIRCLE) {
                   xml.stag("frame-note");
-                  xml.tag("string", strings_ - i);
-                  if (_dots)
-                        xml.tag("fret", _dots[i]);
-                  else
-                        xml.tag("fret", "0");
+                  xml.tag("string", mxmlString);
+                  xml.tag("fret", "0");
+                  xml.etag();
+                  }
+            else {
+                  // Write dots
+                  for (auto const& d : dot(i)) {
+                        if (!d.exists())
+                              continue;
+                        xml.stag("frame-note");
+                        xml.tag("string", mxmlString);
+                        xml.tag("fret", d.fret);
+                        // TODO: write fingerings
+
+                        // Also write barre if it starts at this dot
+                        if (std::find(bStarts.begin(), bStarts.end(), d.fret) != bStarts.end()) {
+                              xml.tagE("barre type=\"start\"");
+                              bStarts.erase(std::remove(bStarts.begin(), bStarts.end(), d.fret), bStarts.end());
+                              }
+                        if (std::find(bEnds.begin(), bEnds.end(), d.fret) != bEnds.end()) {
+                              xml.tagE("barre type=\"stop\"");
+                              bEnds.erase(std::remove(bEnds.begin(), bEnds.end(), d.fret), bEnds.end());
+                              }
+                        xml.etag();
+                        }
+                  }
+
+            // Write unwritten barres
+            for (int j : bStarts) {
+                  xml.stag("frame-note");
+                  xml.tag("string", mxmlString);
+                  xml.tag("fret", j);
+                  xml.tagE("barre type=\"start\"");
+                  xml.etag();
+                  }
+
+            for (int j : bEnds) {
+                  xml.stag("frame-note");
+                  xml.tag("string", mxmlString);
+                  xml.tag("fret", j);
+                  xml.tagE("barre type=\"stop\"");
                   xml.etag();
                   }
             }
-      qDebug("FretDiagram::writeMusicXML() this %p dots %s marker %s fingering %s",
-             this, qPrintable(strDots), qPrintable(strMarker), qPrintable(strFingering));
-      /*
-      xml.tag("root-step", tpc2stepName(rootTpc));
-      int alter = tpc2alter(rootTpc);
-      if (alter)
-            xml.tag("root-alter", alter);
-      */
+
       xml.etag();
       }
 
@@ -652,8 +1234,8 @@ QVariant FretDiagram::getProperty(Pid propertyId) const
                   return strings();
             case Pid::FRET_FRETS:
                   return frets();
-            case Pid::FRET_BARRE:
-                  return barre();
+            case Pid::FRET_NUT:
+                  return showNut();
             case Pid::FRET_OFFSET:
                   return fretOffset();
             case Pid::FRET_NUM_POS:
@@ -679,8 +1261,8 @@ bool FretDiagram::setProperty(Pid propertyId, const QVariant& v)
             case Pid::FRET_FRETS:
                   setFrets(v.toInt());
                   break;
-            case Pid::FRET_BARRE:
-                  setBarre(v.toInt());
+            case Pid::FRET_NUT:
+                  setShowNut(v.toBool());
                   break;
             case Pid::FRET_OFFSET:
                   setFretOffset(v.toInt());
@@ -701,6 +1283,11 @@ bool FretDiagram::setProperty(Pid propertyId, const QVariant& v)
 
 QVariant FretDiagram::propertyDefault(Pid pid) const
       {
+      // We shouldn't style the fret offset
+      if (pid == Pid::FRET_OFFSET) {
+            return QVariant(0);
+            }
+
       for (const StyledProperty& p : *styledProperties()) {
             if (p.pid == pid) {
                   if (propertyType(pid) == P_TYPE::SP_REAL)
@@ -709,6 +1296,126 @@ QVariant FretDiagram::propertyDefault(Pid pid) const
                   }
             }
       return Element::propertyDefault(pid);
+      }
+
+
+//---------------------------------------------------------
+//   markerToChar
+//---------------------------------------------------------
+
+QChar FretItem::markerToChar(FretMarkerType t)
+      {
+      switch (t) {
+            case FretMarkerType::CIRCLE:
+                  return QChar('O');
+            case FretMarkerType::CROSS:
+                  return QChar('X');
+            case FretMarkerType::NONE:
+            default:
+                  return QChar();
+            }
+      }
+
+//---------------------------------------------------------
+//   markerTypeToName
+//---------------------------------------------------------
+
+const std::vector<FretItem::MarkerTypeNameItem> FretItem::markerTypeNameMap = {
+      { FretMarkerType::CIRCLE,     "circle"    },
+      { FretMarkerType::CROSS,      "cross"     },
+      { FretMarkerType::NONE,       "none"      }
+      };
+
+QString FretItem::markerTypeToName(FretMarkerType t)
+      {
+      for (auto i : FretItem::markerTypeNameMap) {
+            if (i.mtype == t)
+                  return i.name;
+            }
+      qFatal("Unrecognised FretMarkerType!");
+      return QString();       // prevent compiler warnings
+      }
+
+//---------------------------------------------------------
+//   nameToMarkerType
+//---------------------------------------------------------
+
+FretMarkerType FretItem::nameToMarkerType(QString n)
+      {
+      for (auto i : FretItem::markerTypeNameMap) {
+            if (i.name == n)
+                  return i.mtype;
+            }
+      qWarning("Unrecognised marker name!");
+      return FretMarkerType::NONE;       // default
+      }
+
+//---------------------------------------------------------
+//   dotTypeToName
+//---------------------------------------------------------
+
+const std::vector<FretItem::DotTypeNameItem> FretItem::dotTypeNameMap = {
+      { FretDotType::NORMAL,        "normal"    },
+      { FretDotType::CROSS,         "cross"     },
+      { FretDotType::SQUARE,        "square"    },
+      { FretDotType::TRIANGLE,      "triangle"  },
+      };
+
+QString FretItem::dotTypeToName(FretDotType t)
+      {
+      for (auto i : FretItem::dotTypeNameMap) {
+            if (i.dtype == t)
+                  return i.name;
+            }
+      qFatal("Unrecognised FretDotType!");
+      return QString();       // prevent compiler warnings
+      }
+
+//---------------------------------------------------------
+//   nameToDotType
+//---------------------------------------------------------
+
+FretDotType FretItem::nameToDotType(QString n)
+      {
+      for (auto i : FretItem::dotTypeNameMap) {
+            if (i.name == n)
+                  return i.dtype;
+            }
+      qWarning("Unrecognised dot name!");
+      return FretDotType::NORMAL;       // default
+      }
+
+//---------------------------------------------------------
+//   updateStored
+//---------------------------------------------------------
+
+FretUndoData::FretUndoData(FretDiagram* fd)
+      {
+      // We need to store the old barres and markers, since predicting how
+      // adding dots, markers, barres etc. will change things is too difficult.
+      // Update linked fret diagrams:
+      _diagram = fd;
+      _dots = _diagram->_dots;
+      _markers = _diagram->_markers;
+      _barres = _diagram->_barres;
+      }
+
+//---------------------------------------------------------
+//   updateDiagram
+//---------------------------------------------------------
+
+void FretUndoData::updateDiagram()
+      {
+      if (!_diagram) {
+            qFatal("Tried to undo fret diagram change without ever setting diagram!");
+            return;
+            }
+
+      // Reset every fret diagram property of the changed diagram
+      // FretUndoData is a friend of FretDiagram so has access to these private members
+      _diagram->_barres = _barres;
+      _diagram->_markers = _markers;
+      _diagram->_dots = _dots;
       }
 
 }

--- a/libmscore/fret.h
+++ b/libmscore/fret.h
@@ -21,6 +21,92 @@ class StringData;
 class Chord;
 class Harmony;
 
+// Keep this in order - not used directly for comparisons, but the dots will appear in
+// this order in fret multidot mode. See fretproperties.cpp.
+enum class FretDotType : signed char {
+      NORMAL = 0,
+      CROSS,
+      SQUARE,
+      TRIANGLE = 3
+      };
+
+
+enum class FretMarkerType : signed char {
+      NONE,
+      CIRCLE,
+      CROSS
+      };
+
+
+class FretItem {
+   public:
+      struct Barre {
+            int startString;
+            int endString;
+
+            Barre() { startString = endString = -1; }
+            Barre(int s, int e) : startString(s), endString(e) {}
+            bool exists() const { return startString > -1; }
+            };
+
+      struct Dot {
+            int fret                { 0 };
+            FretDotType dtype       { FretDotType::NORMAL };
+            int fingering;          // NOTE:JT - possible future feature?
+
+            Dot() {}
+            Dot(int f, FretDotType t = FretDotType::NORMAL) : fret(f), dtype(t) {}
+            bool exists() const { return fret > 0; }
+            };
+
+      struct Marker {
+            FretMarkerType mtype;
+
+            Marker() { mtype = FretMarkerType::NONE; }
+            Marker(FretMarkerType t) : mtype(t) {}
+            bool exists() const { return mtype != FretMarkerType::NONE; }
+            };
+
+      struct MarkerTypeNameItem {
+            FretMarkerType mtype;
+            const char* name;
+            };
+
+      struct DotTypeNameItem {
+            FretDotType dtype;
+            const char* name;
+            };
+
+      static const std::vector<FretItem::MarkerTypeNameItem> markerTypeNameMap;
+      static const std::vector<FretItem::DotTypeNameItem> dotTypeNameMap;
+
+      static QChar markerToChar(FretMarkerType t);
+      static QString markerTypeToName(FretMarkerType t);
+      static FretMarkerType nameToMarkerType(QString n);
+      static QString dotTypeToName(FretDotType t);
+      static FretDotType nameToDotType(QString n);
+      };
+
+
+// The three main storage containers used by fret diagrams
+typedef std::map<int, FretItem::Barre> BarreMap;
+typedef std::map<int, FretItem::Marker> MarkerMap;
+typedef std::map<int, std::vector<FretItem::Dot>> DotMap;
+
+
+class FretUndoData {
+      FretDiagram* _diagram         { nullptr };
+      BarreMap _barres;
+      MarkerMap _markers;
+      DotMap _dots;
+
+   public:
+      FretUndoData() {}
+      FretUndoData(FretDiagram* fd);
+
+      void updateDiagram();
+      };
+
 //---------------------------------------------------------
 //   @@ FretDiagram
 ///    Fretboard diagram
@@ -28,36 +114,46 @@ class Harmony;
 //   @P userMag    qreal
 //   @P strings    int  number of strings
 //   @P frets      int  number of frets
-//   @P barre      int  barre
 //   @P fretOffset int
+//
+//   Note that, while strings are zero-indexed, frets are one-indexed
 //---------------------------------------------------------
 
 class FretDiagram final : public Element {
-      int _strings;
-      int maxStrings     { 0 };
-      int _frets;
+      int _strings       { 6  };
+      int _frets         { 4  };
       int _fretOffset    { 0  };
       int _maxFrets      { 24 };
-      int _barre         { 0 };
+      bool _showNut      { true };
+      
+      // Barres are stored in the format: K: fret, V: barre struct
+      BarreMap _barres;
 
-      char* _dots        { 0 };
-      char* _marker      { 0 };
-      char* _fingering   { 0 };
+      // Dots stored as K: string, V: dot struct
+      DotMap _dots;
+
+      // Markers stored as K: string, V: marker struct
+      MarkerMap _markers;
 
       Harmony* _harmony  { 0 };
 
-      qreal lw1;
-      qreal lw2;             // top line
+      qreal stringLw;
+      qreal nutLw;
       qreal stringDist;
       qreal fretDist;
       QFont font;
       qreal _userMag     { 1.0   };             // allowed 0.1 - 10.0
       int _numPos;
 
+      void removeDot(int s, int f = 0);
+      void removeBarre(int f);
+      void removeBarres(int string, int fret = 0);
+      void removeMarker(int s);
+      void removeDotsMarkers(int ss, int es, int fret);
+
    public:
       FretDiagram(Score* s);
       FretDiagram(const FretDiagram&);
-      ~FretDiagram();
       virtual void draw(QPainter*) const override;
       virtual FretDiagram* clone() const override { return new FretDiagram(*this); }
 
@@ -68,7 +164,10 @@ class FretDiagram final : public Element {
       virtual ElementType type() const override { return ElementType::FRET_DIAGRAM; }
       virtual void layout() override;
       virtual void write(XmlWriter& xml) const override;
+      void writeNew(XmlWriter& xml) const;
+      void writeOld(XmlWriter& xml) const;
       virtual void read(XmlReader&) override;
+      void readNew(XmlReader&);
       virtual QLineF dragAnchor() const override;
       virtual QPointF pagePos() const override;
 
@@ -76,23 +175,38 @@ class FretDiagram final : public Element {
       void readMusicXML(XmlReader& de);
       void writeMusicXML(XmlWriter& xml) const;
 
-      int strings() const    { return _strings; }
-      int frets()   const    { return _frets; }
+      int  strings() const    { return _strings; }
+      int  frets()   const    { return _frets; }
       void setStrings(int n);
       void setFrets(int n)        { _frets = n; }
-      void setDot(int string, int fret);
-      void setBarre(int fret)     { _barre = fret; }
-      void setMarker(int string, int marker);
-      void setFingering(int string, int finger);
-      int fretOffset() const      { return _fretOffset; }
-      void setFretOffset(int val) { _fretOffset = val;  }
-      int maxFrets() const        { return _maxFrets;   }
-      void setMaxFrets(int val)   { _maxFrets = val;    }
 
-      char dot(int s) const       { return _dots      ? _dots[s]      : 0; }
-      char marker(int s) const    { return _marker    ? _marker[s]    : 0; }
-      char fingering(int s) const { return _fingering ? _fingering[s] : 0; }
-      int barre() const           { return _barre; }
+      void setDot(int string, int fret, bool add = false, FretDotType dtype = FretDotType::NORMAL);
+      void setBarre(int startString, int endString, int fret);
+      void setBarre(int string, int fret, bool add = false);
+      void setMarker(int string, FretMarkerType marker);
+      /*void setFingering(int string, int finger);*/
+      void clear();
+      void undoSetFretDot(int _string, int _fret, bool _add = false, FretDotType _dtype = FretDotType::NORMAL);
+      void undoSetFretMarker(int _string, FretMarkerType _mtype);
+      void undoSetFretBarre(int _string, int _fret, bool _add = false);
+      void undoFretClear();
+      int  fretOffset() const     { return _fretOffset; }
+      void setFretOffset(int val) { _fretOffset = val;  }
+      int  maxFrets() const       { return _maxFrets;   }
+      void setMaxFrets(int val)   { _maxFrets = val;    }
+      bool showNut() const        { return _showNut;    }
+      void setShowNut(bool val)   { _showNut = val;     }
+
+      std::vector<FretItem::Dot> dot(int s, int f = 0) const;
+      FretItem::Marker marker(int s) const;
+      FretItem::Barre barre(int fret) const;
+#if 0 // NOTE:JT possible future feature
+      int fingering(int s) const       { return _fingering ? _fingering[s] : 0; }
+#endif
+
+      BarreMap barres() const             { return _barres; }
+      DotMap dots() const                 { return _dots; }
+      MarkerMap markers() const           { return _markers; }
 
       Harmony* harmony() const { return _harmony; }
 
@@ -112,6 +226,8 @@ class FretDiagram final : public Element {
 
       qreal userMag() const         { return _userMag;   }
       void setUserMag(qreal m)      { _userMag = m;      }
+
+      friend class FretUndoData;
       };
 
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -218,10 +218,10 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::TRACK,                   false, 0,                       P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "track")            },
 
       { Pid::GLISSANDO_STYLE,         true,  "glissandoStyle",        P_TYPE::GLISSANDO_STYLE,     DUMMY_QT_TRANSLATE_NOOP("propertyName", "glissando style")  },
-      { Pid::FRET_STRINGS,            false, "strings",               P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "strings")          },
-      { Pid::FRET_FRETS,              false, "frets",                 P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "frets")            },
-      { Pid::FRET_BARRE,              false, "barre",                 P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "barre")            },
-      { Pid::FRET_OFFSET,             false, "fretOffset",            P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "fret offset")      },
+      { Pid::FRET_STRINGS,            true,  "strings",               P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "strings")          },
+      { Pid::FRET_FRETS,              true,  "frets",                 P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "frets")            },
+      { Pid::FRET_NUT,                true,  "showNut",               P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "show nut")         },
+      { Pid::FRET_OFFSET,             true,  "fretOffset",            P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "fret offset")      },
 
       { Pid::FRET_NUM_POS,            false, "fretNumPos",            P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "fret number position") },
       { Pid::SYSTEM_BRACKET,          false, "type",                  P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "type")             },

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -232,7 +232,7 @@ enum class Pid {
       GLISSANDO_STYLE,
       FRET_STRINGS,
       FRET_FRETS,
-      FRET_BARRE,
+      FRET_NUT,
       FRET_OFFSET,
 
       FRET_NUM_POS,

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -310,8 +310,7 @@ static const StyleType styleTypes[] {
       { Sid::fretPlacement,           "fretPlacement",           int(Placement::ABOVE) },
       { Sid::fretStrings,             "fretStrings",             6 },
       { Sid::fretFrets,               "fretFrets",               5 },
-      { Sid::fretOffset,              "fretOffset",              0 },
-      { Sid::fretBarre,               "fretBarre",               0 },
+      { Sid::fretNut,                 "fretNut",                 QVariant(true) },
 
       { Sid::showPageNumber,          "showPageNumber",          QVariant(true) },
       { Sid::showPageNumberOne,       "showPageNumberOne",       QVariant(false) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -282,8 +282,7 @@ enum class Sid {
       fretPlacement,
       fretStrings,
       fretFrets,
-      fretOffset,
-      fretBarre,
+      fretNut,
 
       showPageNumber,
       showPageNumberOne,

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -406,7 +406,7 @@ Element* UndoMacro::selectedElement(const Selection& sel)
       if (sel.isSingle()) {
             Element* e = sel.element();
             Q_ASSERT(e); // otherwise it shouldn't be "single" selection
-            if (e->isNote() || e->isChordRest() || (e->isTextBase() && !e->isInstrumentName()))
+            if (e->isNote() || e->isChordRest() || (e->isTextBase() && !e->isInstrumentName()) || e->isFretDiagram())
                   return e;
             }
       return nullptr;
@@ -2365,24 +2365,73 @@ void ChangeGap::flip(EditData*)
 //   FretDot
 //---------------------------------------------------------
 
-void FretDot::flip(EditData*)
+void FretDot::redo(EditData*)
       {
-      int ov = fret->dot(string);
-      fret->setDot(string, dot);
-      dot = ov;
-      fret->triggerLayout();
+      undoData = FretUndoData(diagram);
+
+      diagram->setDot(string, fret, add, dtype);
+      diagram->triggerLayout();
+      }
+
+
+void FretDot::undo(EditData*)
+      {
+      undoData.updateDiagram();
+      diagram->triggerLayout();
       }
 
 //---------------------------------------------------------
 //   FretMarker
 //---------------------------------------------------------
 
-void FretMarker::flip(EditData*)
+void FretMarker::redo(EditData*)
       {
-      int om = fret->marker(string);
-      fret->setMarker(string, marker);
-      marker = om;
-      fret->triggerLayout();
+      undoData = FretUndoData(diagram);
+
+      diagram->setMarker(string, mtype);
+      diagram->triggerLayout();
+      }
+
+void FretMarker::undo(EditData*)
+      {
+      undoData.updateDiagram();
+      diagram->triggerLayout();
+      }
+
+//---------------------------------------------------------
+//   FretBarre
+//---------------------------------------------------------
+
+void FretBarre::redo(EditData*)
+      {
+      undoData = FretUndoData(diagram);
+
+      diagram->setBarre(string, fret, add);
+      diagram->triggerLayout();
+      }
+
+void FretBarre::undo(EditData*)
+      {
+      undoData.updateDiagram();
+      diagram->triggerLayout();
+      }
+
+//---------------------------------------------------------
+//   FretClear
+//---------------------------------------------------------
+
+void FretClear::redo(EditData*)
+      {
+      undoData = FretUndoData(diagram);
+
+      diagram->clear();
+      diagram->triggerLayout();
+      }
+
+void FretClear::undo(EditData*)
+      {
+      undoData.updateDiagram();
+      diagram->triggerLayout();
       }
 
 //---------------------------------------------------------

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -39,6 +39,7 @@
 #include "note.h"
 #include "drumset.h"
 #include "rest.h"
+#include "fret.h"
 
 Q_DECLARE_LOGGING_CATEGORY(undoRedo)
 
@@ -1306,14 +1307,19 @@ class ChangeGap : public UndoCommand {
 //---------------------------------------------------------
 
 class FretDot : public UndoCommand {
-      FretDiagram* fret;
+      FretDiagram* diagram;
       int string;
-      int dot;
+      int fret;
+      bool add;
+      FretDotType dtype;
+      FretUndoData undoData;
 
-      void flip(EditData*) override;
+      void redo(EditData*) override;
+      void undo(EditData*) override;
 
    public:
-      FretDot(FretDiagram* f, int _string, int _dot) : fret(f), string(_string), dot(_dot) {}
+      FretDot(FretDiagram* d, int _string, int _fret, bool _add = false, FretDotType _dtype = FretDotType::NORMAL)
+         : diagram(d), string(_string), fret(_fret), add(_add), dtype(_dtype) {}
       UNDO_NAME("FretDot")
       };
 
@@ -1322,15 +1328,52 @@ class FretDot : public UndoCommand {
 //---------------------------------------------------------
 
 class FretMarker : public UndoCommand {
-      FretDiagram* fret;
+      FretDiagram* diagram;
       int string;
-      int marker;
+      FretMarkerType mtype;
+      FretUndoData undoData;
 
-      void flip(EditData*) override;
+      void redo(EditData*) override;
+      void undo(EditData*) override;
 
    public:
-      FretMarker(FretDiagram* f, int _string, int _marker) : fret(f), string(_string), marker(_marker) {}
+      FretMarker(FretDiagram* d, int _string, FretMarkerType _mtype) : diagram(d), string(_string), mtype(_mtype) {}
       UNDO_NAME("FretMarker")
+      };
+
+//---------------------------------------------------------
+//   FretBarre
+//---------------------------------------------------------
+
+class FretBarre : public UndoCommand {
+      FretDiagram* diagram;
+      int string;
+      int fret;
+      bool add;
+      FretUndoData undoData;
+
+      void redo(EditData*) override;
+      void undo(EditData*) override;
+
+   public:
+      FretBarre(FretDiagram* d, int _string, int _fret, bool _add = false) : diagram(d), string(_string), fret(_fret), add(_add) {}
+      UNDO_NAME("FretBarre")
+      };
+
+//---------------------------------------------------------
+//   FretClear
+//---------------------------------------------------------
+
+class FretClear : public UndoCommand {
+      FretDiagram* diagram;
+      FretUndoData undoData;
+
+      void redo(EditData*) override;
+      void undo(EditData*) override;
+
+   public:
+      FretClear(FretDiagram* d) : diagram(d) {}
+      UNDO_NAME("FretClear")
       };
 
 //---------------------------------------------------------

--- a/mscore/fretcanvas.h
+++ b/mscore/fretcanvas.h
@@ -25,6 +25,7 @@ namespace Ms {
 class Accidental;
 class Clef;
 class FretDiagram;
+enum class FretDotType : signed char;
 
 //---------------------------------------------------------
 //   FretCanvas
@@ -37,15 +38,28 @@ class FretCanvas : public QFrame {
       int cstring;
       int cfret;
 
+      bool _automaticDotType   { true };
+      FretDotType _currentDtype;
+      bool _barreMode    { false };
+      bool _multidotMode { false };
+
       virtual void paintEvent(QPaintEvent*);
       virtual void mousePressEvent(QMouseEvent*);
       virtual void mouseMoveEvent(QMouseEvent*);
 
+      void paintDotSymbol(QPainter& p, QPen& pen, qreal y, qreal x, qreal dotd, FretDotType dtype);
       void getPosition(const QPointF& pos, int* string, int* fret);
 
    public:
       FretCanvas(QWidget* parent = 0);
       void setFretDiagram(FretDiagram* fd);
+
+      void setAutomaticDotType(bool v)              { _automaticDotType = v; }
+      void setCurrentDotType(FretDotType t)         { _currentDtype = t; }
+      void setBarreMode(bool v)                     { _barreMode = v; }
+      void setMultidotMode(bool v)                  { _multidotMode = v; }
+      void clear();
+      
       };
 
 

--- a/mscore/fretproperties.cpp
+++ b/mscore/fretproperties.cpp
@@ -108,12 +108,12 @@ void FretCanvas::paintEvent(QPaintEvent* ev)
       double _spatium   = 20.0 * mag;
       double lw1        = _spatium * 0.08;
       int fretOffset    = diagram->fretOffset();
-      double lw2        = fretOffset ? lw1 : _spatium * 0.2;
+      double lw2        = (fretOffset || !diagram->showNut()) ? lw1 : _spatium * 0.2;
       double stringDist = _spatium * .7;
       double fretDist   = _spatium * .8;
       int _strings      = diagram->strings();
       int _frets        = diagram->frets();
-      int _barre        = diagram->barre();
+      double dotd       = stringDist * .6 + lw1;
 
       double w  = (_strings - 1) * stringDist;
       double xo = (width() - w) * .5;
@@ -135,11 +135,17 @@ void FretCanvas::paintEvent(QPaintEvent* ev)
       p.setPen(pen);
       p.setBrush(pen.color());
       double x2 = (_strings-1) * stringDist;
-      p.drawLine(QLineF(-lw1 * .5, 0.0, x2+lw1*.5, 0.0));
+      p.drawLine(QLineF(-lw1 * .5, 0.0, x2 + lw1 * .5, 0.0));
 
       pen.setWidthF(lw1);
       p.setPen(pen);
       double y2 = (_frets+1) * fretDist - fretDist*.5;
+
+      QPen symPen(pen);
+      symPen.setCapStyle(Qt::RoundCap);
+      symPen.setWidthF(lw1 * 1.2);
+
+      // Draw strings and frets
       for (int i = 0; i < _strings; ++i) {
             double x = stringDist * i;
             p.drawLine(QLineF(x, fretOffset ? -_spatium*.2 : 0.0, x, y2));
@@ -148,56 +154,70 @@ void FretCanvas::paintEvent(QPaintEvent* ev)
             double y = fretDist * i;
             p.drawLine(QLineF(0.0, y, x2, y));
             }
+
+      // Draw dots and markers
       for (int i = 0; i < _strings; ++i) {
-            p.setPen(Qt::NoPen);
-            if (diagram->dot(i)) {
-                  double dotd = stringDist * .6 + lw1;
-                  int fret = diagram->dot(i) - 1;
-                  double x = stringDist * i - dotd * .5;
-                  double y = fretDist * fret + fretDist * .5 - dotd * .5;
-                  p.drawEllipse(QRectF(x, y, dotd, dotd));
+            for (auto const& d : diagram->dot(i)) {
+                  if (d.exists()) {
+                        p.setPen(symPen);
+                        int fret = d.fret;
+                        double x = stringDist * i - dotd * .5;
+                        double y = fretDist * (fret - 1) + fretDist * .5 - dotd * .5;
+
+                        paintDotSymbol(p, symPen, x, y, dotd, d.dtype);
+                        }
                   }
             p.setPen(pen);
-            if (diagram->marker(i)) {
+
+            FretItem::Marker mark = diagram->marker(i);
+            if (mark.exists()) {
                   p.setFont(font);
                   double x = stringDist * i;
                   double y = -fretDist * .1;
                   p.drawText(QRectF(x, y, 0.0, 0.0),
-                     Qt::AlignHCenter | Qt::AlignBottom | Qt::TextDontClip, QChar(diagram->marker(i)));
+                     Qt::AlignHCenter | Qt::AlignBottom | Qt::TextDontClip, FretItem::markerToChar(mark.mtype));
                   }
             }
-      if (_barre) {
-            int string = -1;
-            for (int i = 0; i < _strings; ++i) {
-                  if (diagram->dot(i) == _barre) {
-                        string = i;
-                        break;
-                        }
-                  }
-            if (string != -1) {
-                  qreal x1   = stringDist * string;
-                  qreal y    = fretDist * (_barre-1) + fretDist * .5;
-                  pen.setWidthF(stringDist * .6 * .7);      // don’t use style barreLineWidth
-                  pen.setCapStyle(Qt::RoundCap);
-                  p.setPen(pen);
-                  p.drawLine(QLineF(x1, y, x2, y));
-                  }
+
+      // Draw barres
+      p.setPen(pen);
+      for (auto const& i : diagram->barres()) {            
+            int fret        = i.first;
+            int startString = i.second.startString;
+            int endString   = i.second.endString;
+
+            qreal x1   = stringDist * startString;
+            qreal newX2 = endString == -1 ? x2 : stringDist * endString;
+
+            qreal y    = fretDist * (fret - 1) + fretDist * .5;
+            pen.setWidthF(dotd * diagram->score()->styleD(Sid::barreLineWidth));      // don’t use style barreLineWidth - why not?
+            pen.setCapStyle(Qt::RoundCap);
+            p.setPen(pen);
+            p.drawLine(QLineF(x1, y, newX2, y));
             }
+
+      // Draw 'hover' dot
       if ((cfret > 0) && (cfret <= _frets) && (cstring >= 0) && (cstring < _strings)) {
-            double dotd;
-            if (diagram->dot(cstring) != cfret) {
-                  p.setPen(Qt::NoPen);
-                  dotd = stringDist * .6 + lw1;
+            FretItem::Dot cd = diagram->dot(cstring, cfret)[0];
+            std::vector<FretItem::Dot> otherDots = diagram->dot(cstring);
+            FretDotType dtype;
+            symPen.setColor(Qt::lightGray);
+
+            if (cd.exists()) {
+                  dtype = cd.dtype;
+                  symPen.setColor(Qt::red);
                   }
             else {
-                  p.setPen(pen);
-                  dotd = stringDist * .6;
+                  dtype = _automaticDotType ? FretDotType::NORMAL : _currentDtype;
                   }
+            p.setPen(symPen);
+
             double x = stringDist * cstring - dotd * .5;
             double y = fretDist * (cfret-1) + fretDist * .5 - dotd * .5;
             p.setBrush(Qt::lightGray);
-            p.drawEllipse(QRectF(x, y, dotd, dotd));
+            paintDotSymbol(p, symPen, x, y, dotd, dtype);
             }
+
       if (fretOffset > 0) {
             qreal fretNumMag = 2.0; // TODO: get the value from Sid::fretNumMag
             QFont scaledFont(font);
@@ -210,7 +230,37 @@ void FretCanvas::paintEvent(QPaintEvent* ev)
                QString("%1").arg(fretOffset+1));
             p.setFont(font);
             }
+
       QFrame::paintEvent(ev);
+      }
+
+//---------------------------------------------------------
+//   paintDotSymbol
+//---------------------------------------------------------
+
+void FretCanvas::paintDotSymbol(QPainter& p, QPen& pen, qreal x, qreal y, qreal dotd, FretDotType dtype)
+      {
+      switch (dtype) {
+            case FretDotType::CROSS:
+                  p.drawLine(QLineF(x, y, x + dotd, y + dotd));
+                  p.drawLine(QLineF(x + dotd, y, x, y + dotd));
+                  break;
+            case FretDotType::SQUARE:
+                  p.setBrush(Qt::NoBrush);
+                  p.drawRect(QRectF(x, y, dotd, dotd));
+                  break;
+            case FretDotType::TRIANGLE:
+                  p.drawLine(QLineF(x, y + dotd, x + .5 * dotd, y));
+                  p.drawLine(QLineF(x + .5 * dotd, y, x + dotd, y + dotd));
+                  p.drawLine(QLineF(x + dotd, y + dotd, x, y + dotd));                                    
+                  break;
+            case FretDotType::NORMAL:
+            default:
+                  p.setBrush(pen.color());
+                  p.setPen(Qt::NoPen);
+                  p.drawEllipse(QRectF(x, y, dotd, dotd));
+                  break;
+            }
       }
 
 //---------------------------------------------------------
@@ -250,44 +300,73 @@ void FretCanvas::mousePressEvent(QMouseEvent* ev)
             return;
 
       diagram->score()->startCmd();
+
+      // Click above the fret diagram, so change the open/closed string marker
       if (fret == 0) {
-            switch (diagram->marker(string)) {
-                  case 'O':
-                        diagram->score()->undo(new FretMarker(diagram, string, 'X'));
+            switch (diagram->marker(string).mtype) {
+                  case FretMarkerType::CIRCLE:
+                        diagram->undoSetFretMarker(string, FretMarkerType::CROSS);
                         break;
-                  case 'X':
-                        diagram->score()->undo(new FretMarker(diagram, string, 0));
+                  case FretMarkerType::CROSS:
+                        diagram->undoSetFretMarker(string, FretMarkerType::NONE);
                         break;
+                  case FretMarkerType::NONE:
                   default:
-                        diagram->score()->undo(new FretDot(diagram, string, 0));
-                        diagram->score()->undo(new FretMarker(diagram, string, 'O'));
+                        diagram->undoSetFretDot(string, 0);
+                        diagram->undoSetFretMarker(string, FretMarkerType::CIRCLE);
                         break;
                   }
             }
+      // Otherwise, the click is on the fretboard itself
       else {
-            if (diagram->dot(string) == fret) {
-                  diagram->score()->undo(new FretDot(diagram, string, 0));
-                  diagram->score()->undo(new FretMarker(diagram, string, 'O'));
-                  bool removeBarre = true;
-                  if (ev->modifiers() & Qt::ShiftModifier) {
-                        for (int i = 0; i < _strings; ++i) {
-                              if (diagram->dot(i)) {
-                                    removeBarre = false;
+            FretItem::Dot thisDot = diagram->dot(string, fret)[0];
+            bool haveShift = (ev->modifiers() & Qt::ShiftModifier) || _barreMode;
+            bool haveCtrl  = (ev->modifiers() & Qt::ControlModifier) || _multidotMode;
+
+            // Click on an existing dot
+            if (thisDot.exists() && !haveShift)
+                  diagram->undoSetFretDot(string, haveCtrl ? fret : 0, haveCtrl);
+            else {
+                  // Shift adds a barre
+                  if (haveShift)
+                        diagram->undoSetFretBarre(string, fret, haveCtrl);
+                  else {
+                        FretDotType dtype = FretDotType::NORMAL;
+                        if (_automaticDotType && haveCtrl && diagram->dot(string)[0].exists()) {
+                              dtype = FretDotType::TRIANGLE;
+
+                              std::vector<FretDotType> dtypes { 
+                                    FretDotType::NORMAL,
+                                    FretDotType::CROSS,
+                                    FretDotType::SQUARE,
+                                    FretDotType::TRIANGLE
+                              };
+
+                              // Find the lowest dot type that doesn't already exist on the string
+                              for (int i = 0; i < dtypes.size(); i++) {
+                                    FretDotType t = dtypes[i];
+
+                                    bool hasThisType = false;
+                                    for (auto const& dot : diagram->dot(string)) {
+                                          if (dot.dtype == t) {
+                                                hasThisType = true;
+                                                break;
+                                                }
+                                          }
+
+                                    if (hasThisType)
+                                          continue;
+
+                                    dtype = t;
                                     break;
                                     }
                               }
-                        }
-                  if (removeBarre)
-                        diagram->undoChangeProperty(Pid::FRET_BARRE, 0);
-                  }
-            else {
-                  diagram->score()->undo(new FretDot(diagram, string, fret));
-                  diagram->score()->undo(new FretMarker(diagram, string, 'O'));
+                        else if (!_automaticDotType)
+                              dtype = _currentDtype;
 
-                  if (ev->modifiers() & Qt::ShiftModifier)
-                        diagram->undoChangeProperty(Pid::FRET_BARRE, diagram->barre() == fret ? 0 : fret);
-                  else
-                        diagram->undoChangeProperty(Pid::FRET_BARRE, 0);
+                        // Ctrl adds a dot without removing other dots on a string
+                        diagram->undoSetFretDot(string, fret, haveCtrl, dtype);
+                        }
                   }
             }
       diagram->triggerLayout();
@@ -331,6 +410,18 @@ FretCanvas::FretCanvas(QWidget* parent)
 void FretCanvas::setFretDiagram(FretDiagram* fd)
       {
       diagram = fd;
+      update();
+      }
+
+//---------------------------------------------------------
+//   clear
+//---------------------------------------------------------
+
+void FretCanvas::clear()
+      {
+      diagram->score()->startCmd();
+      diagram->undoFretClear();
+      diagram->score()->endCmd();
       update();
       }
 }

--- a/mscore/importgtp-gp6.cpp
+++ b/mscore/importgtp-gp6.cpp
@@ -428,17 +428,17 @@ void GuitarPro6::readChord(QDomNode* diagram, int track)
 
                   // if there are unspecified string values, add the X marker to that string
                   while (counter < string) {
-                        fretDiagram->setMarker(counter, 'X');
+                        fretDiagram->setMarker(counter, FretMarkerType::CROSS);
                         counter++;
                         }
 
                   // look at the specified string/fret and add to diagram
                   if (fret == 0) {
-                        fretDiagram->setMarker(string, '0');
+                        fretDiagram->setMarker(string, FretMarkerType::CIRCLE);
                         counter++;
                         }
                   else {
-                        fretDiagram->setDot(string, fret);
+                        fretDiagram->setDot(string, fret, true);
                         counter++;
                         }
                   }
@@ -448,7 +448,7 @@ void GuitarPro6::readChord(QDomNode* diagram, int track)
 
       // mark any missing strings as 'X'
       while (counter < stringCount) {
-            fretDiagram->setMarker(counter, 'X');
+            fretDiagram->setMarker(counter, FretMarkerType::CROSS);
             counter++;
             }
 

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -1308,15 +1308,15 @@ void GuitarPro::readChord(Segment* seg, int track, int numStrings, QString name,
                   if (i > numStrings - 1) {
                         }
                   else if (currentFret > 0) {
-                        fret->setDot(numStrings - 1 - i, currentFret-firstFret+1);
+                        fret->setDot(numStrings - 1 - i, currentFret - firstFret + 1, true);
                         }
                   else if (currentFret == 0) {
-                        fret->setDot(numStrings - 1 - i, 0);
-                        fret->setMarker(numStrings - 1 - i, '0');
+                        fret->setDot(numStrings - 1 - i, 0, true);
+                        fret->setMarker(numStrings - 1 - i, FretMarkerType::CIRCLE);
                         }
                   else if (currentFret == -1) {
-                        fret->setDot(numStrings - 1 - i, 0);
-                        fret->setMarker(numStrings - 1 - i, 'X');
+                        fret->setDot(numStrings - 1 - i, 0, true);
+                        fret->setMarker(numStrings - 1 - i, FretMarkerType::CROSS);
                         }
                   }
             seg->add(fret);

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -4869,6 +4869,10 @@ FretDiagram* MusicXMLParserPass2::frame()
 
       FretDiagram* fd = new FretDiagram(_score);
 
+      // Format: fret: string
+      std::map<int, int> bStarts;
+      std::map<int, int> bEnds;
+
       while (_e.readNextStartElement()) {
             if (_e.name() == "frame-frets") {
                   int val = _e.readElementText().toInt();
@@ -4880,34 +4884,66 @@ FretDiagram* MusicXMLParserPass2::frame()
             else if (_e.name() == "frame-note") {
                   int fret   = -1;
                   int string = -1;
+                  int actualString = -1;
                   while (_e.readNextStartElement()) {
                         if (_e.name() == "fret")
                               fret = _e.readElementText().toInt();
-                        else if (_e.name() == "string")
+                        else if (_e.name() == "string") {
                               string = _e.readElementText().toInt();
+                              actualString = fd->strings() - string;
+                              }
+                        else if (_e.name() == "barre") {
+                              // Keep barres to be added later
+                              QString t = _e.attributes().value("type").toString();
+                              if (t == "start")
+                                    bStarts[fret] = actualString;
+                              else if (t == "stop")
+                                    bEnds[fret] = actualString;
+                              else
+                                    _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-note barre type %1").arg(t), &_e);
+                              skipLogCurrElem();
+                              }
                         else
                               skipLogCurrElem();
                         }
                   _logger->logDebugInfo(QString("FretDiagram::readMusicXML string %1 fret %2").arg(string).arg(fret), &_e);
+
                   if (string > 0) {
                         if (fret == 0)
-                              fd->setMarker(fd->strings() - string, 79 /* ??? */);
+                              fd->setMarker(actualString, FretMarkerType::CIRCLE);
                         else if (fret > 0)
-                              fd->setDot(fd->strings() - string, fret);
+                              fd->setDot(actualString, fret, true);
                         }
+                  else
+                        _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-note string %1").arg(string), &_e);
                   }
             else if (_e.name() == "frame-strings") {
                   int val = _e.readElementText().toInt();
                   if (val > 0) {
                         fd->setStrings(val);
-                        for (int i = 0; i < val; ++i)
-                              fd->setMarker(i, 88 /* ??? */);
+                        for (int i = 0; i < val; ++i) {
+                              // MXML Spec: any string without a dot or other marker has a closed string
+                              // cross marker above it.
+                              fd->setMarker(i, FretMarkerType::CROSS);
+                              }
                         }
                   else
                         _logger->logError(QString("FretDiagram::readMusicXML: illegal frame-strings %1").arg(val), &_e);
                   }
             else
                   skipLogCurrElem();
+            }
+
+      // Finally add barres
+      for (auto const& i : bStarts) {
+            int fret = i.first;
+            int startString = i.second;
+
+            if (bEnds.find(fret) == bEnds.end())
+                  continue;
+
+            int endString = bEnds[fret];
+            fd->setBarre(startString, endString, fret);
             }
 
       return fd;

--- a/mscore/inspector/inspectorFret.cpp
+++ b/mscore/inspector/inspectorFret.cpp
@@ -36,16 +36,33 @@ InspectorFretDiagram::InspectorFretDiagram(QWidget* parent)
             { Pid::PLACEMENT,    0, f.placement,   f.resetPlacement   },
             { Pid::FRET_STRINGS, 0, f.strings,     f.resetStrings     },
             { Pid::FRET_FRETS,   0, f.frets,       f.resetFrets       },
-            { Pid::FRET_BARRE,   0, f.barre,       f.resetBarre       },
+            { Pid::FRET_NUT,     0, f.showNut,     f.resetShowNut     },
             };
       const std::vector<InspectorPanel> ppList = {
             { f.title, f.panel }
             };
+
+      dotTypeButtons = {
+            f.circleSelect,
+            f.crossSelect,
+            f.triangleSelect,
+            f.squareSelect
+            };
+
       mapSignals(iiList, ppList);
       int fretNumber = toFretDiagram(inspector->element())->fretOffset() + 1;
       f.fretNumber->setValue(fretNumber);
-      connect(f.fretNumber, SIGNAL(valueChanged(int)), SLOT(fretNumberChanged(int)));
-      connect(f.resetFretNumber, SIGNAL(resetClicked()), SLOT(resetFretNumber()));
+      f.resetFretNumber->setEnabled(fretNumber != 1);
+      connect(f.fretNumber,      SIGNAL(valueChanged(int)), SLOT(fretNumberChanged(int)));
+      connect(f.resetFretNumber, SIGNAL(resetClicked()),    SLOT(resetFretNumber()));
+
+      connect(f.circleSelect,   SIGNAL(toggled(bool)), SLOT(circleButtonToggled(bool)));
+      connect(f.crossSelect,    SIGNAL(toggled(bool)), SLOT(crossButtonToggled(bool)));
+      connect(f.triangleSelect, SIGNAL(toggled(bool)), SLOT(triangleButtonToggled(bool)));
+      connect(f.squareSelect,   SIGNAL(toggled(bool)), SLOT(squareButtonToggled(bool)));
+      connect(f.toggleBarre,    SIGNAL(toggled(bool)), SLOT(barreButtonToggled(bool)));
+      connect(f.toggleMultidot, SIGNAL(toggled(bool)), SLOT(multidotButtonToggled(bool)));
+      connect(f.clearButton,    SIGNAL(clicked()),     SLOT(clearButtonClicked()));
       }
 
 //---------------------------------------------------------
@@ -100,5 +117,88 @@ void InspectorFretDiagram::resetFretNumber()
       f.diagram->setFretDiagram(fd);
       }
 
+//---------------------------------------------------------
+//   genericButtonToggled
+//---------------------------------------------------------
+
+void InspectorFretDiagram::genericButtonToggled(QPushButton* b, bool v, FretDotType dtype)
+      {
+      for (QPushButton* p : dotTypeButtons) {
+            p->blockSignals(true);
+            p->setChecked(false);
+            }
+
+      if (v) {
+            f.diagram->setCurrentDotType(dtype);
+            b->setChecked(true);
+            }
+      
+      f.diagram->setAutomaticDotType(!v);
+
+      for (QPushButton* p : dotTypeButtons)
+            p->blockSignals(false);
+      }
+//---------------------------------------------------------
+//   circleButtonToggled
+//---------------------------------------------------------
+
+void InspectorFretDiagram::circleButtonToggled(bool v) 
+      {
+      genericButtonToggled(f.circleSelect, v, FretDotType::NORMAL);
+      }
+
+//---------------------------------------------------------
+//   crossButtonToggled
+//---------------------------------------------------------
+
+void InspectorFretDiagram::crossButtonToggled(bool v) 
+      {
+      genericButtonToggled(f.crossSelect, v, FretDotType::CROSS);
+      }
+
+//---------------------------------------------------------
+//   squareButtonToggled
+//---------------------------------------------------------
+
+void InspectorFretDiagram::squareButtonToggled(bool v) 
+      {
+      genericButtonToggled(f.squareSelect, v, FretDotType::SQUARE);
+      }
+
+//---------------------------------------------------------
+//   triangleButtonToggled
+//---------------------------------------------------------
+
+void InspectorFretDiagram::triangleButtonToggled(bool v) 
+      {
+      genericButtonToggled(f.triangleSelect, v, FretDotType::TRIANGLE);
+      }
+
+//---------------------------------------------------------
+//   barreButtonToggled
+//---------------------------------------------------------
+
+void InspectorFretDiagram::barreButtonToggled(bool v) 
+      {
+      f.diagram->setBarreMode(v);
+      }
+
+//---------------------------------------------------------
+//   multidotButtonToggled
+//---------------------------------------------------------
+
+void InspectorFretDiagram::multidotButtonToggled(bool v) 
+      {
+      f.diagram->setMultidotMode(v);
+      }
+
+//---------------------------------------------------------
+//   clearButtonClicked
+//---------------------------------------------------------
+
+void InspectorFretDiagram::clearButtonClicked() 
+      {
+      f.diagram->clear();
+      }
 }
 

--- a/mscore/inspector/inspectorFret.h
+++ b/mscore/inspector/inspectorFret.h
@@ -28,11 +28,21 @@ class InspectorFretDiagram : public InspectorElementBase {
 
       Ui::InspectorFretDiagram   f;
       virtual void setElement() override;
+      void genericButtonToggled(QPushButton* b, bool v, FretDotType dtype);
+      std::vector<QPushButton*> dotTypeButtons;
 
    private slots:
       virtual void valueChanged(int idx) override;
       void fretNumberChanged(int fretNumber);
       void resetFretNumber();
+
+      void circleButtonToggled(bool v);
+      void crossButtonToggled(bool v);
+      void squareButtonToggled(bool v);
+      void triangleButtonToggled(bool v);
+      void barreButtonToggled(bool v);
+      void multidotButtonToggled(bool v);
+      void clearButtonClicked();
 
    public:
       InspectorFretDiagram(QWidget* parent);

--- a/mscore/inspector/inspector_fret.ui
+++ b/mscore/inspector/inspector_fret.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>183</width>
-    <height>459</height>
+    <width>220</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="accessibleName">
@@ -70,12 +70,12 @@
    <item>
     <widget class="QWidget" name="panel" native="true">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>10</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0">
+     <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0,0" columnstretch="1,0,0">
       <property name="leftMargin">
        <number>3</number>
       </property>
@@ -91,18 +91,21 @@
       <property name="spacing">
        <number>3</number>
       </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Scale:</string>
+      <item row="2" column="2">
+       <widget class="Ms::ResetButton" name="resetStrings" native="true"/>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="frets">
+        <property name="accessibleName">
+         <string>Frets</string>
         </property>
-        <property name="buddy">
-         <cstring>mag</cstring>
+        <property name="minimum">
+         <number>1</number>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="mag">
+      <item row="2" column="1">
+       <widget class="QSpinBox" name="strings">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -110,29 +113,10 @@
          </sizepolicy>
         </property>
         <property name="accessibleName">
-         <string>Scale</string>
+         <string>Strings</string>
         </property>
         <property name="minimum">
-         <double>0.200000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>50.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.200000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Placement:</string>
-        </property>
-        <property name="buddy">
-         <cstring>placement</cstring>
+         <number>1</number>
         </property>
        </widget>
       </item>
@@ -159,82 +143,7 @@
         </item>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Frets:</string>
-        </property>
-        <property name="buddy">
-         <cstring>frets</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="5" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Barré:</string>
-        </property>
-        <property name="buddy">
-         <cstring>barre</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Strings:</string>
-        </property>
-        <property name="buddy">
-         <cstring>strings</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QSpinBox" name="frets">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Frets</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QSpinBox" name="strings">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Strings</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QSpinBox" name="barre">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Barré</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>Fret number:</string>
@@ -244,23 +153,10 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
-       <widget class="QSpinBox" name="fretNumber">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Fret number</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-       </widget>
+      <item row="0" column="2">
+       <widget class="Ms::ResetButton" name="resetMag" native="true"/>
       </item>
-      <item row="7" column="0" colspan="3">
+      <item row="12" column="0" colspan="3">
        <widget class="Ms::FretCanvas" name="diagram">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -279,15 +175,76 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="Ms::ResetButton" name="resetMag" native="true">
+      <item row="5" column="2">
+       <widget class="Ms::ResetButton" name="resetFretNumber" native="true"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Frets:</string>
+        </property>
+        <property name="buddy">
+         <cstring>frets</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Strings:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QSpinBox" name="barre">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="accessibleName">
+         <string>Barré</string>
+        </property>
        </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="Ms::ResetButton" name="resetPlacement" native="true"/>
+      </item>
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="mag">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Scale</string>
+        </property>
+        <property name="minimum">
+         <double>0.200000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>50.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.200000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="Ms::ResetButton" name="resetShowNut" native="true">
+        <property name="accessibleName">
+         <string>Reset show nut</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="Ms::ResetButton" name="resetFrets" native="true"/>
       </item>
       <item row="1" column="2">
        <widget class="Ms::ResetButton" name="resetPlacement" native="true">
@@ -299,43 +256,234 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
-       <widget class="Ms::ResetButton" name="resetStrings" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="5" column="1">
+       <widget class="QSpinBox" name="fretNumber">
+        <property name="accessibleName">
+         <string>Fret number</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
         </property>
        </widget>
       </item>
-      <item row="3" column="2">
-       <widget class="Ms::ResetButton" name="resetFrets" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Placement:</string>
+        </property>
+        <property name="buddy">
+         <cstring>placement</cstring>
         </property>
        </widget>
       </item>
-      <item row="5" column="2">
-       <widget class="Ms::ResetButton" name="resetBarre" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Scale:</string>
+        </property>
+        <property name="buddy">
+         <cstring>mag</cstring>
         </property>
        </widget>
       </item>
-      <item row="6" column="2">
-       <widget class="Ms::ResetButton" name="resetFretNumber" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="11" column="0" colspan="3">
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="1" column="3">
+         <widget class="QPushButton" name="squareSelect">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>1</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="accessibleName">
+           <string>Use square symbol</string>
+          </property>
+          <property name="text">
+           <string>□</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QPushButton" name="crossSelect">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>1</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="accessibleName">
+           <string>Use cross symbol</string>
+          </property>
+          <property name="text">
+           <string>X</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="4">
+         <widget class="QPushButton" name="triangleSelect">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>1</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="accessibleName">
+           <string>Use triangle symbol</string>
+          </property>
+          <property name="text">
+           <string>△</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QPushButton" name="circleSelect">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>1</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="accessibleName">
+           <string>Use black dot symbol</string>
+          </property>
+          <property name="text">
+           <string>⚫</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QPushButton" name="toggleBarre">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>1</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Add a barre (shift)</string>
+          </property>
+          <property name="accessibleName">
+           <string>Add a barre</string>
+          </property>
+          <property name="text">
+           <string>Barre</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="4">
+         <widget class="QPushButton" name="clearButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>1</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="accessibleName">
+           <string>Clear the fret diagram</string>
+          </property>
+          <property name="text">
+           <string>Clear</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="2" colspan="2">
+         <widget class="QPushButton" name="toggleMultidot">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>1</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Add multiple dots per string (ctrl)</string>
+          </property>
+          <property name="toolTipDuration">
+           <number>-1</number>
+          </property>
+          <property name="accessibleName">
+           <string>Add multiple dots per string</string>
+          </property>
+          <property name="text">
+           <string>Multiple dots</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="showNut">
+        <property name="accessibleName">
+         <string>Show nut</string>
+        </property>
+        <property name="text">
+         <string>Show nut</string>
+        </property>
+        <property name="minimum" stdset="0">
+         <number>1</number>
         </property>
        </widget>
       </item>
@@ -346,15 +494,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Ms::ResetButton</class>
-   <extends>QWidget</extends>
-   <header>inspector/resetButton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>Ms::FretCanvas</class>
    <extends>QFrame</extends>
    <header>fretcanvas.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Ms::ResetButton</class>
+   <extends>QWidget</extends>
+   <header>inspector/resetButton.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -362,10 +510,7 @@
   <tabstop>title</tabstop>
   <tabstop>mag</tabstop>
   <tabstop>placement</tabstop>
-  <tabstop>strings</tabstop>
   <tabstop>frets</tabstop>
-  <tabstop>barre</tabstop>
-  <tabstop>fretNumber</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -234,7 +234,7 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( glissandoStyle,          GLISSANDO_STYLE           )
       API_PROPERTY( fretStrings,             FRET_STRINGS              )
       API_PROPERTY( fretFrets,               FRET_FRETS                )
-      API_PROPERTY( fretBarre,               FRET_BARRE                )
+      /*API_PROPERTY( fretBarre,               FRET_BARRE                )*/
       API_PROPERTY( fretOffset,              FRET_OFFSET               )
       API_PROPERTY( fretNumPos,              FRET_NUM_POS              )
       API_PROPERTY( systemBracket,           SYSTEM_BRACKET            )

--- a/mtest/libmscore/selectionfilter/selectionfilter11-base-ref.xml
+++ b/mtest/libmscore/selectionfilter/selectionfilter11-base-ref.xml
@@ -5,6 +5,26 @@
       <voice id="0">0</voice>
       </voiceOffset>
     <FretDiagram>
+      <fretDiagram>
+        <string no="0">
+          <marker>cross</marker>
+          </string>
+        <string no="1">
+          <dot fret="3">normal</dot>
+          </string>
+        <string no="2">
+          <dot fret="2">normal</dot>
+          </string>
+        <string no="3">
+          <marker>circle</marker>
+          </string>
+        <string no="4">
+          <marker>circle</marker>
+          </string>
+        <string no="5">
+          <dot fret="1">normal</dot>
+          </string>
+        </fretDiagram>
       <string no="0">
         <marker>88</marker>
         </string>

--- a/mtest/libmscore/selectionfilter/updateReference
+++ b/mtest/libmscore/selectionfilter/updateReference
@@ -9,6 +9,7 @@ cp ../../../build.debug/mtest/libmscore/selectionfilter/selectionfilter6-base.xm
 cp ../../../build.debug/mtest/libmscore/selectionfilter/selectionfilter7-base.xml selectionfilter7-base-ref.xml
 cp ../../../build.debug/mtest/libmscore/selectionfilter/selectionfilter8-base.xml selectionfilter8-base-ref.xml
 cp ../../../build.debug/mtest/libmscore/selectionfilter/selectionfilter9-base.xml selectionfilter9-base-ref.xml
+cp ../../../build.debug/mtest/libmscore/selectionfilter/selectionfilter11-base.xml selectionfilter11-base-ref.xml
 cp ../../../build.debug/mtest/libmscore/selectionfilter/selectionfilter12-base.xml selectionfilter12-base-ref.xml
 cp ../../../build.debug/mtest/libmscore/selectionfilter/selectionfilter13-base.xml selectionfilter13-base-ref.xml
 cp ../../../build.debug/mtest/libmscore/selectionfilter/selectionfilter14-base.xml selectionfilter14-base-ref.xml


### PR DESCRIPTION
This is in response to [the fretboard diagram EPIC](https://musescore.org/en/node/283681). I realized when looking through some of the issues that to fix many of them (i.e. partial barres), a full refactor would be needed. So, this is what I've come up with. Code review, as always, is very much appreciated.

Todo: nothing. I would like to implement playback of fret diagrams, and chord names, and saving to palettes, but that is code for another pull request I think. So, this should be ready for merge. 

This fixes:

[#284966: Fretboard diagrams: barre lost on copying; and when saving to workspace](https://musescore.org/en/node/284966)
[#283759: Fretboard diagrams: Barré property is redundant](https://musescore.org/en/node/283759)
[#283682: Fretboard diagrams: allow multiple barrés](https://musescore.org/en/node/283681) (although not fully - multiple barres per fret is a very niche feature and relatively difficult to implement)
[#283678: Fretboard diagrams: barré applied wrongly if there is another dot already at same position](https://musescore.org/en/node/283678)
[#283676: Fretboard diagrams: barré deleted when separate dot is added afterwards at same position](https://musescore.org/en/node/283676)
[#283674: Fretboard diagrams: barré deleted when you add a dot at another position](https://musescore.org/en/node/283674)
[#283452: Editing Fretboard Diagrams](https://musescore.org/en/node/283452)
[#275658: The ability to draw partial barre is missing for fretboard diagrams](https://musescore.org/en/node/275658)
[#285324: Fretboard diagram anomalies with MS3 3.0.4.5763](https://musescore.org/en/node/285324)
[#285616: Musescore Leaves Dots Under Barres in Chord Diagrams](https://musescore.org/en/node/285616)
[#285613: Barre Deletes Dots on Higher Frets](https://musescore.org/en/node/285613)
[#280575: Copy&Paste Fretboard diagram’s number is mirrored.](https://musescore.org/en/node/280575)
[#283762: Fretboard diagrams: remove some "Set as style" buttons](https://musescore.org/en/node/283762)
[#283679: Fretboard diagrams: symbols on top of diagram, and position number do not resize when scaling is changed](https://musescore.org/en/node/283679)