### PR TITLE
fix #283545: fix a crash on undoing HBox removal, fix boxes linking in parts

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2799,7 +2799,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
                   }
             else {
                   // a frame, not a measure
-                  if (isMaster())
+                  if (score->isMaster())
                         rmb = mb;
                   else if (rmb && mb != rmb) {
                         mb->linkTo(rmb);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1322,7 +1322,7 @@ void Score::addElement(Element* element)
 
       ElementType et = element->type();
       if (et == ElementType::MEASURE
-         || (et == ElementType::HBOX && element->parent()->type() != ElementType::VBOX)
+         || (et == ElementType::HBOX && !(parent && parent->isVBox()))
          || et == ElementType::VBOX
          || et == ElementType::TBOX
          || et == ElementType::FBOX

--- a/mtest/libmscore/chordsymbol/no-system-ref.mscx
+++ b/mtest/libmscore/chordsymbol/no-system-ref.mscx
@@ -247,6 +247,8 @@
       <Staff id="1">
         <VBox>
           <height>10</height>
+          <linked>
+            </linked>
           <Text>
             <style>Instrument Name (Part)</style>
             <text>Flute</text>
@@ -258,24 +260,20 @@
               <concertClefType>G</concertClefType>
               <transposingClefType>G</transposingClefType>
               <linked>
-                <indexDiff>1</indexDiff>
                 </linked>
               </Clef>
             <TimeSig>
               <linked>
-                <indexDiff>1</indexDiff>
                 </linked>
               <sigN>4</sigN>
               <sigD>4</sigD>
               </TimeSig>
             <Chord>
               <linked>
-                <indexDiff>1</indexDiff>
                 </linked>
               <durationType>quarter</durationType>
               <Note>
                 <linked>
-                  <indexDiff>1</indexDiff>
                   </linked>
                 <pitch>72</pitch>
                 <tpc>14</tpc>


### PR DESCRIPTION
This PR fixes the issue [283545](https://musescore.org/en/node/283545) which actually includes two parts:
1) A crash on undoing a horizontal frame removal, became more prominent with fa65de8b3db72fbe44e330433e761e43f0386069 though it is not really caused by that commit and could probably happen before that patch in some more exotic scenarios. The fix is a simple null pointer check in `Score::addElement()`, in addition to what have been done in fa65de8b3db72fbe44e330433e761e43f0386069.
2) Frames removal (both horizontal and vertical) was not synchronized with extracted parts in some cases. The reason is a typo in 2874c409aef3db5c0834a16632a86c561c664fac that caused a wrong score being checked for being a master score which caused the added frames be not linked. The other similar typo in `edit.cpp` seems to have already been fixed. This PR fixes that typo but a proper linking will only be applied for newly created frames.