### PR TITLE
fix #285651 swap chord symbol placement with X shortcut

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1480,7 +1480,8 @@ void Score::cmdFlip()
                || e->isPedalSegment()
                || e->isFermata()
                || e->isLyrics()
-               || e->isTrillSegment()) {
+               || e->isTrillSegment()
+               || e->isHarmony()) {
                   e->undoChangeProperty(Pid::AUTOPLACE, true);
                   // getProperty() delegates call from spannerSegment to Spanner:
                   Placement p = Placement(e->getProperty(Pid::PLACEMENT).toInt());

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -269,10 +269,10 @@ static const StyleType styleTypes[] {
       { Sid::harmonyPlacement,         "harmonyPlacement",       int(Placement::ABOVE) },
 
       { Sid::chordSymbolAPosAbove,      "chordSymbolPosAbove",       QPointF(.0, -2.5) },
-      { Sid::chordSymbolAPosBelow,      "chordSymbolPosBelow",       QPointF(.0, 3.5) },
+      { Sid::chordSymbolAPosBelow,      "chordSymbolPosBelow",       QPointF(.0, 7.0) },
 
       { Sid::chordSymbolBPosAbove,      "chordSymbolBPosAbove",      QPointF(.0, -5.0) },
-      { Sid::chordSymbolBPosBelow,      "chordSymbolBPosBelow",      QPointF(.0, 3.5) },
+      { Sid::chordSymbolBPosBelow,      "chordSymbolBPosBelow",      QPointF(.0, 7.0) },
 
       { Sid::chordSymbolAFontFace,      "chordSymbolAFontFace",      "FreeSerif" },
       { Sid::chordSymbolAFontSize,      "chordSymbolAFontSize",      12.0 },

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -245,9 +245,13 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { Sid::vibratoPosAbove,         false, vibratoLinePosAbove,       resetVibratoLinePosAbove   },
       { Sid::vibratoPosBelow,         false, vibratoLinePosBelow,       resetVibratoLinePosBelow   },
 
-      { Sid::harmonyFretDist,         false, harmonyFretDist,         0 },
-      { Sid::minHarmonyDistance,      false, minHarmonyDistance,      0 },
-      { Sid::maxHarmonyBarDistance,   false, maxHarmonyBarDistance,   0 },
+      { Sid::harmonyFretDist,         false, harmonyFretDist,         resetHarmonyFretDist          },
+      { Sid::minHarmonyDistance,      false, minHarmonyDistance,      resetMinHarmonyDistance       },
+      { Sid::maxHarmonyBarDistance,   false, maxHarmonyBarDistance,   resetMaxHarmonyBarDistance    },
+      { Sid::chordSymbolAPosAbove,    false, chordSymbolPosAbove,     resetChordSymbolPosAbove      },
+      { Sid::chordSymbolAPosBelow,    false, chordSymbolPosBelow,     resetChordSymbolPosBelow      },
+      { Sid::chordSymbolBPosAbove,    false, chordSymbolBPosAbove,    resetChordSymbolBPosAbove      },
+      { Sid::chordSymbolBPosBelow,    false, chordSymbolBPosBelow,    resetChordSymbolBPosBelow      },
 
       { Sid::tupletVHeadDistance,     false, tupletVHeadDistance,     resetTupletVHeadDistance      },
       { Sid::tupletVStemDistance,     false, tupletVStemDistance,     resetTupletVStemDistance      },

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -10338,32 +10338,30 @@
               <property name="verticalSpacing">
                <number>3</number>
               </property>
-              <item row="1" column="1">
-               <widget class="QDoubleSpinBox" name="minHarmonyDistance">
-                <property name="suffix">
-                 <string>sp</string>
+              <item row="2" column="2">
+               <widget class="QToolButton" name="resetMaxHarmonyBarDistance">
+                <property name="toolTip">
+                 <string>Reset to default</string>
                 </property>
-                <property name="minimum">
-                 <double>-50.000000000000000</double>
+                <property name="accessibleName">
+                 <string>Reset 'Maximum Barline Distance' value</string>
                 </property>
-                <property name="maximum">
-                 <double>10.000000000000000</double>
+                <property name="text">
+                 <string/>
                 </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.500000000000000</double>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                 </property>
                </widget>
               </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_79">
+              <item row="0" column="5">
+               <widget class="Ms::OffsetSelect" name="chordSymbolPosAbove" native="true"/>
+              </item>
+              <item row="2" column="4">
+               <widget class="QLabel" name="label_92">
                 <property name="text">
-                 <string>Distance to fretboard diagram:</string>
-                </property>
-                <property name="buddy">
-                 <cstring>harmonyFretDist</cstring>
+                 <string>Position above (b):</string>
                 </property>
                </widget>
               </item>
@@ -10389,6 +10387,57 @@
                 </property>
                </widget>
               </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_79">
+                <property name="text">
+                 <string>Distance to fretboard diagram:</string>
+                </property>
+                <property name="buddy">
+                 <cstring>harmonyFretDist</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <widget class="QToolButton" name="resetChordSymbolPosAbove">
+                <property name="toolTip">
+                 <string>Reset to default</string>
+                </property>
+                <property name="accessibleName">
+                 <string>Reset 'Position Above' value</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="4">
+               <widget class="QLabel" name="label_17">
+                <property name="text">
+                 <string>Position above:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QToolButton" name="resetHarmonyFretDist">
+                <property name="toolTip">
+                 <string>Reset to default</string>
+                </property>
+                <property name="accessibleName">
+                 <string>Reset 'Distance to Fretboard Diagram' value</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="0">
                <widget class="QLabel" name="label_1001">
                 <property name="text">
@@ -10399,18 +10448,29 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="5">
-               <spacer name="horizontalSpacer_11">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+              <item row="1" column="4">
+               <widget class="QLabel" name="label_90">
+                <property name="text">
+                 <string>Position below:</string>
                 </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
+               </widget>
+              </item>
+              <item row="1" column="6">
+               <widget class="QToolButton" name="resetChordSymbolPosBelow">
+                <property name="toolTip">
+                 <string>Reset to default</string>
                 </property>
-               </spacer>
+                <property name="accessibleName">
+                 <string>Reset 'Position Below' value</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
               </item>
               <item row="2" column="0">
                <widget class="QLabel" name="label_1002">
@@ -10421,6 +10481,9 @@
                  <cstring>maxHarmonyBarDistance</cstring>
                 </property>
                </widget>
+              </item>
+              <item row="1" column="5">
+               <widget class="Ms::OffsetSelect" name="chordSymbolPosBelow" native="true"/>
               </item>
               <item row="2" column="1">
                <widget class="QDoubleSpinBox" name="maxHarmonyBarDistance">
@@ -10438,6 +10501,89 @@
                 </property>
                 <property name="value">
                  <double>3.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QToolButton" name="resetMinHarmonyDistance">
+                <property name="toolTip">
+                 <string>Reset to default</string>
+                </property>
+                <property name="accessibleName">
+                 <string>Reset 'Minimum Chord Spacing' value</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="minHarmonyDistance">
+                <property name="suffix">
+                 <string>sp</string>
+                </property>
+                <property name="minimum">
+                 <double>-50.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>10.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.500000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="4">
+               <widget class="QLabel" name="label_93">
+                <property name="text">
+                 <string>Position below (b):</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="5">
+               <widget class="Ms::OffsetSelect" name="chordSymbolBPosAbove" native="true"/>
+              </item>
+              <item row="3" column="5">
+               <widget class="Ms::OffsetSelect" name="chordSymbolBPosBelow" native="true"/>
+              </item>
+              <item row="2" column="6">
+               <widget class="QToolButton" name="resetChordSymbolBPosAbove">
+                <property name="toolTip">
+                 <string>Reset to default</string>
+                </property>
+                <property name="accessibleName">
+                 <string>Reset 'Position Above' value</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="6">
+               <widget class="QToolButton" name="resetChordSymbolBPosBelow">
+                <property name="toolTip">
+                 <string>Reset to default</string>
+                </property>
+                <property name="accessibleName">
+                 <string>Reset 'Position Below' value</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="musescore.qrc">
+                  <normaloff>:/data/icons/edit-reset.svg</normaloff>:/data/icons/edit-reset.svg</iconset>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
All the infrastructure was already set up, so all that was needed was to add a line to allow the shortcut to apply to chord symbols too.