### PR TITLE
fix #285781: loading existing scores no longer applies default style, loading parts no longer inherits style from parent

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3771,7 +3771,7 @@ static bool readScore(Score* score, XmlReader& e)
                   else {
                         e.tracks().clear();
                         MasterScore* m = score->masterScore();
-                        Score* s = new Score(m, MScore::defaultStyle());
+                        Score* s = new Score(m, MScore::baseStyle());
                         Excerpt* ex = new Excerpt(m);
 
                         ex->setPartScore(s);

--- a/libmscore/read301.cpp
+++ b/libmscore/read301.cpp
@@ -166,7 +166,7 @@ bool Score::read(XmlReader& e)
                   else {
                         e.tracks().clear();     // ???
                         MasterScore* m = masterScore();
-                        Score* s       = new Score(m, false);
+                        Score* s       = new Score(m, MScore::baseStyle());
                         Excerpt* ex    = new Excerpt(m);
 
                         ex->setPartScore(s);

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -306,7 +306,7 @@ Score::Score(MasterScore* parent, bool forcePartStyle /* = true */)
 Score::Score(MasterScore* parent, const MStyle& s)
    : Score{parent}
       {
-      Score::validScores.erase(this);
+      Score::validScores.insert(this);
       _style  = s;
       }
 
@@ -328,6 +328,7 @@ Score::~Score()
             }
       qDeleteAll(_parts);
       qDeleteAll(_staves);
+      Score::validScores.erase(this);
 //      qDeleteAll(_pages);         // TODO: check
       _masterScore = 0;
       }

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -341,7 +341,7 @@ MasterScore* MuseScore::readScore(const QString& name)
       if (name.isEmpty())
             return 0;
 
-      MasterScore* score = new MasterScore(MScore::defaultStyle());
+      MasterScore* score = new MasterScore(MScore::baseStyle());
       setMidiReopenInProgress(name);
       Score::FileError rv = Ms::readScore(score, name, false);
       if (rv == Score::FileError::FILE_TOO_OLD || rv == Score::FileError::FILE_TOO_NEW || rv == Score::FileError::FILE_CORRUPTED) {
@@ -352,7 +352,7 @@ MasterScore* MuseScore::readScore(const QString& name)
                         delete score;
                         score = new MasterScore();
                         score->setMovements(new Movements());
-                        score->setStyle(MScore::defaultStyle());
+                        score->setStyle(MScore::baseStyle());
                         rv = Ms::readScore(score, name, true);
                         }
                   else

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3310,6 +3310,7 @@ static void loadScores(const QStringList& argv)
 
                               MasterScore* score = mscore->readScore(startScore);
                               if (startScore.startsWith(":/") && score) {
+                                    score->setStyle(MScore::defaultStyle());
                                     score->setName(mscore->createDefaultName());
                                     // TODO score->setPageFormat(*MScore::defaultStyle().pageFormat());
                                     score->doLayout();
@@ -3318,6 +3319,7 @@ static void loadScores(const QStringList& argv)
                               if (score == 0) {
                                     score = mscore->readScore(":/data/My_First_Score.mscx");
                                     if (score) {
+                                          score->setStyle(MScore::defaultStyle());
                                           score->setName(mscore->createDefaultName());
                                           // TODO score->setPageFormat(*MScore::defaultStyle().pageFormat());
                                           score->doLayout();


### PR DESCRIPTION
Currently, when you load a project with parts and non-default styles for the main score, the parts will inherit the styles of the main score on reload. When the part has default styles, the part will load the non-default styles from the main score and so, information will be lost. In some cases, this is just a small inconvenience, but in other cases it can change the notes that are read (in the case of transposition). Here, we instead just load the default style instead of inheriting the style from the parent score. This way, on creation of a part, the default style is loaded and then the part read to load the styles for the specific part itself. I also partially reversed https://github.com/musescore/MuseScore/pull/4633/files as that case is covered under this solution.