### PR TITLE
fix #285888: Crash on removing a horizontal frame twice

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1469,7 +1469,7 @@ void Score::removeElement(Element* element)
             measures()->remove(mb);
             System* system = mb->system();
             Page* page = system->page();
-            if (element->isVBoxBase() && system->measures().size() == 1) {
+            if (element->isBox() && system->measures().size() == 1) {
                   auto i = std::find(page->systems().begin(), page->systems().end(), system);
                   page->systems().erase(i);
                   mb->setSystem(0);


### PR DESCRIPTION
Resolves: [#285888: Crash on removing a horizontal frame twice](https://musescore.org/en/node/285888).

Any Box can be the only MeasureBase in a system, and if such a Box is removed, then this code must be executed.

There is still an open issue about undoing the removal of a horizontal frame, but #4786 resolves that one.