### PR TITLE
fix #286067: only highlight beam properties on palette application

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -546,7 +546,6 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
             else {
                   for (Element* e : sel.elements())
                         applyDrop(score, viewer, e, element, modifiers);
-                  selectedIdx = currentIdx;
                   }
             }
       else if (sel.isRange()) {
@@ -573,7 +572,6 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
                         applyDrop(score, viewer, m, element, modifiers, pt);
                         if (m == last)
                               break;
-                        selectedIdx = currentIdx;
                         }
                   }
             else if (element->type() == ElementType::LAYOUT_BREAK) {


### PR DESCRIPTION
When I was first working on this issue, I ended up leaving some artifacts which created some problems. Before I changed my approach to what I did during my pull request, there were some lines of code necessary to update the beam palette on application of an palette element and I didn't remove all of the old code before making the pull request for some reason :). Removal of these lines removes those artifacts and fixes issue https://musescore.org/en/node/286067.