### PR TITLE
fix #283177: insert measure at beginning of system repeats keysig

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2740,7 +2740,7 @@ void Score::insertMeasure(ElementType type, MeasureBase* measure, bool createEmp
                                     if (!s->enabled())
                                           continue;
                                     Element* e = s->element(staffIdx * VOICES);
-                                    if (!e)
+                                    if (!e || e->generated())
                                           continue;
                                     Element* ee = 0;
                                     if (e->isKeySig()) {


### PR DESCRIPTION
See https://musescore.org/en/node/283177#comment-904081 for analysis.  This PR implements the simplest solution: don't bother moving generated elements when inserting measures.  It seems logical enough - generated elements get removed and re-generated as necessary during layout, and I couldn't get this to fail in my testing.  Still, I definitely appreciate more eyes on this to be sure I'm not missing something.

Steps to reproduce the problem, BTW (since the original report was a little vague):

- use default score (with line breaks every 4 bars)
- add keysig to first measure
- select bar 5 (first of second system)
- insert measure
- delete break at end of first system

Result: the (generated) keysig in measure 5 remains, even though it is now in the middle of the first system