### PR TITLE
fix #285479: Implement scrolling a screen at a time in page view

### DIFF
--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -365,12 +365,20 @@
     <seq>Shift+Down</seq>
     </SC>
   <SC>
-    <key>page-prev</key>
+    <key>scr-prev</key>
     <seq>PgUp</seq>
     </SC>
   <SC>
-    <key>page-next</key>
+    <key>scr-next</key>
     <seq>PgDown</seq>
+    </SC>
+  <SC>
+    <key>page-prev</key>
+    <seq>Ctrl+PgUp</seq>
+    </SC>
+  <SC>
+    <key>page-next</key>
+    <seq>Ctrl+PgDown</seq>
     </SC>
   <SC>
     <key>page-top</key>

--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -363,12 +363,20 @@
     <seq>Shift+Down</seq>
     </SC>
   <SC>
-    <key>page-prev</key>
+    <key>scr-prev</key>
     <seq>PgUp</seq>
     </SC>
   <SC>
-    <key>page-next</key>
+    <key>scr-next</key>
     <seq>PgDown</seq>
+    </SC>
+  <SC>
+    <key>page-prev</key>
+    <seq>Ctrl+PgUp</seq>
+    </SC>
+  <SC>
+    <key>page-next</key>
+    <seq>Ctrl+PgDown</seq>
     </SC>
   <SC>
     <key>page-top</key>

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -341,6 +341,8 @@ class ScoreView : public QWidget, public MuseScoreView {
       qreal yoffset() const;
       void setOffset(qreal x, qreal y);
       QSizeF fsize() const;
+      void screenNext();
+      void screenPrev();
       void pageNext();
       void pagePrev();
       void pageTop();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1089,6 +1089,18 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
+         "scr-prev",
+         QT_TRANSLATE_NOOP("action","Screen: Previous")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
+         "scr-next",
+         QT_TRANSLATE_NOOP("action","Screen: Next")
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_NOTE_ENTRY,
          "page-prev",
          QT_TRANSLATE_NOOP("action","Page: Previous")
          },


### PR DESCRIPTION
This is a WIP. See https://musescore.org/en/node/284563 and https://musescore.org/en/node/285479 for the discussion and the issue. I still want to do the following:

- [ ] ~~Add new functions to go to the start and end of a _system_.~~

- [ ] ~~Implement a way to use the arrows for scrolling the canvas when nothing is selected.~~

- [ ] ~~Fix the glitches during scrolling when option "Limit scroll area to page borders" is selected.~~

The last one especially I didn't give much thought to yet. 

EDIT: Current state of PR: PgUp and PgDn now scrolls one screen at a time in Page View (moves the canvas to show what was just cut off at the top/bottom of the view), instead of moving the canvas to the top of the next/previous page. Ctrl+PgUp/Dn now does what plain PgUp and PgDn did before. I am proposing to make this a self-contained change and do the other things I listed as separate PRs (because it is not at all clear to me how the best way forward is, and bundling it all together makes it difficult for you to approve one part and merging while asking for a different implementation of another).