### PR TITLE
Fix the look of Fine and To Coda in master repeats palette

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -365,6 +365,7 @@ Palette* MuseScore::newRepeatsPalette()
 
             Marker* mk = new Marker(gscore);
             mk->setMarkerType(markerTypeTable[i].type);
+            mk->styleChanged();
             sp->append(mk, qApp->translate("markerType", markerTypeTable[i].name.toUtf8().constData()));
             }
 


### PR DESCRIPTION
the workspaces had been fixed a while ago, in 436f9fbd47 (?)