### PR TITLE
fix #281472: MuseScore 3 does not run on macOS 10.10 & 10.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ if (APPLE)
       # of MacOSX.
       #set(CMAKE_OSX_SYSROOT /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk)
 
-      set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12)      # Min version required
+      set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)      # Min version required
       set(HAS_AUDIOFILE TRUE)            # Requires libsndfile
       set(MAC_APPCAST_URL "")
 

--- a/build/travis/job_macos/before_install.sh
+++ b/build/travis/job_macos/before_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export QT_SHORT_VERSION=5.12
-export QT_LONG_VERSION=5.12.0
+export QT_SHORT_VERSION=5.9
+export QT_LONG_VERSION=5.9.3
 export QT_INSTALLER_ROOT=qt-opensource-mac-x64-clang-${QT_LONG_VERSION}
 export QT_INSTALLER_FILENAME=${QT_INSTALLER_ROOT}.dmg
 

--- a/build/travis/job_macos/install.sh
+++ b/build/travis/job_macos/install.sh
@@ -106,10 +106,10 @@ rvm get head
 #  echo "Qt ${QT_LONG_VERSION} already installed"
 #fi
 
-wget -nv http://utils.musescore.org.s3.amazonaws.com/qt5121_mac.zip
+wget -nv http://utils.musescore.org.s3.amazonaws.com/qt593_mac.zip
 mkdir -p $QT_MACOS
-unzip -qq qt5121_mac.zip -d $QT_MACOS
-rm qt5121_mac.zip
+unzip -qq qt593_mac.zip -d $QT_MACOS
+rm qt593_mac.zip
 
 #install sparkle
 export SPARKLE_VERSION=1.20.0

--- a/build/travis/job_macos_lupdate/install.sh
+++ b/build/travis/job_macos_lupdate/install.sh
@@ -5,7 +5,7 @@ if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   exit 0
 fi
 
-wget -nv http://utils.musescore.org.s3.amazonaws.com/qt5121_mac.zip
+wget -nv http://utils.musescore.org.s3.amazonaws.com/qt593_mac.zip
 mkdir -p $QT_MACOS
-unzip -qq qt5121_mac.zip -d $QT_MACOS
-rm qt5121_mac.zip
+unzip -qq qt593_mac.zip -d $QT_MACOS
+rm qt593_mac.zip

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1613,7 +1613,7 @@ MuseScore::MuseScore()
 
       menuFormat->addAction(getAction("add-remove-breaks"));
 
-      QMenu* menuStretch = new QMenu(tr("&Stretch"));
+      menuStretch = new QMenu(tr("&Stretch"));
       for (auto i : { "stretch+", "stretch-", "reset-stretch" })
             menuStretch->addAction(getAction(i));
       Workspace::addMenuAndString(menuStretch, "menu-stretch");
@@ -1699,7 +1699,7 @@ MuseScore::MuseScore()
       //---------------------
 
 #ifndef NDEBUG
-      QMenu* menuDebug = mb->addMenu("Debug");
+      menuDebug = mb->addMenu("Debug");
       menuDebug->setObjectName("Debug");
       a = getAction("no-horizontal-stretch");
       a->setCheckable(true);
@@ -1936,32 +1936,9 @@ void MuseScore::showError()
 
 void MuseScore::retranslate()
       {
+      setMenuTitles();
       _positionLabel->setToolTip(tr("Measure:Beat:Tick"));
-
-      // retranslate the menu
-      menuFile->setTitle(tr("&File"));
-      openRecent->setTitle(tr("Open &Recent"));
-      menuEdit->setTitle(tr("&Edit"));
-      menuView->setTitle(tr("&View"));
-      menuToolbars->setTitle(tr("&Toolbars"));
-      menuWorkspaces->setTitle(tr("W&orkspaces"));
       pref->setText(tr("&Preferences…"));
-      menuAdd->setTitle(tr("&Add"));
-      menuAddMeasures->setTitle(tr("&Measures"));
-      menuAddFrames->setTitle(tr("&Frames"));
-      menuAddText->setTitle(tr("&Text"));
-      menuAddLines->setTitle(tr("&Lines"));
-      menuAddPitch->setTitle(tr("N&otes"));
-      menuAddInterval->setTitle(tr("&Intervals"));
-      menuTuplet->setTitle(tr("T&uplets"));
-      menuFormat->setTitle(tr("F&ormat"));
-      menuTools->setTitle(tr("&Tools"));
-      menuVoices->setTitle(tr("&Voices"));
-      menuMeasure->setTitle(tr("&Measure"));
-      menuPlugins->setTitle(tr("&Plugins"));
-      menuHelp->setTitle(tr("&Help"));
-      menuTours->setTitle(tr("&Tours"));
-
       aboutAction->setText(tr("&About…"));
       aboutQtAction->setText(tr("About &Qt…"));
       aboutMusicXMLAction->setText(tr("About &MusicXML…"));
@@ -1990,7 +1967,91 @@ void MuseScore::retranslate()
       Shortcut::retranslate();
       Workspace::retranslate();
       }
+      
+//---------------------------------------------------------
+//   setMenuTitles
+//---------------------------------------------------------
 
+void MuseScore::setMenuTitles()
+      {
+      menuFile->setTitle(tr("&File"));
+      openRecent->setTitle(tr("Open &Recent"));
+      menuEdit->setTitle(tr("&Edit"));
+      menuView->setTitle(tr("&View"));
+      menuToolbars->setTitle(tr("&Toolbars"));
+      menuWorkspaces->setTitle(tr("W&orkspaces"));
+      menuAdd->setTitle(tr("&Add"));
+      menuAddMeasures->setTitle(tr("&Measures"));
+      menuAddFrames->setTitle(tr("&Frames"));
+      menuAddText->setTitle(tr("&Text"));
+      menuAddLines->setTitle(tr("&Lines"));
+      menuAddPitch->setTitle(tr("N&otes"));
+      menuAddInterval->setTitle(tr("&Intervals"));
+      menuTuplet->setTitle(tr("T&uplets"));
+      menuFormat->setTitle(tr("F&ormat"));
+      menuStretch->setTitle(tr("&Stretch"));
+      menuTools->setTitle(tr("&Tools"));
+      menuVoices->setTitle(tr("&Voices"));
+      menuMeasure->setTitle(tr("&Measure"));
+      menuPlugins->setTitle(tr("&Plugins"));
+      menuHelp->setTitle(tr("&Help"));
+      menuTours->setTitle(tr("&Tours"));
+#ifndef NDEBUG
+      menuDebug->setTitle("Debug");  // not translated
+#endif
+      }
+
+//---------------------------------------------------------
+//   updateMenu
+//---------------------------------------------------------
+
+void MuseScore::updateMenu(QMenu*& menu, QString menu_id, QString name)
+      {
+      QMenu* m = Workspace::findMenuFromString(menu_id);
+      if (m) {
+            menu = m;
+            if (name != "")
+                  menu->setObjectName(name);
+            }
+      }
+
+//---------------------------------------------------------
+//   updateMenus
+//---------------------------------------------------------
+
+void MuseScore::updateMenus()
+      {
+      updateMenu(menuFile,        "menu-file",         "File");
+      updateMenu(openRecent,      "menu-open-recent",  "");
+      updateMenu(menuEdit,        "menu-edit",         "Edit");
+      updateMenu(menuView,        "menu-view",         "View");
+      updateMenu(menuToolbars,    "menu-toolbars",     "");
+      updateMenu(menuWorkspaces,  "menu-workspaces",   "");
+      updateMenu(menuAdd,         "menu-add",          "Add");
+      updateMenu(menuAddMeasures, "menu-add-measures", "");
+      updateMenu(menuAddFrames,   "menu-add-frames",   "");
+      updateMenu(menuAddText,     "menu-add-text",     "");
+      updateMenu(menuAddLines,    "menu-add-lines",    "");
+      updateMenu(menuAddPitch,    "menu-add-pitch",    "");
+      updateMenu(menuAddInterval, "menu-add-interval", "");
+      updateMenu(menuTuplet,      "menu-tuplet",       "");
+      updateMenu(menuFormat,      "menu-format",       "Format");
+      updateMenu(menuStretch,     "menu-stretch",      "");
+      updateMenu(menuTools,       "menu-tools",        "Tools");
+      updateMenu(menuVoices,      "menu-voices",       "");
+      updateMenu(menuMeasure,     "menu-measure",      "");
+      updateMenu(menuPlugins,     "menu-plugins",      "Plugins");
+      updateMenu(menuHelp,        "menu-help",         "Help");
+      updateMenu(menuTours,       "menu-tours",        "");
+#ifndef NDEBUG
+      updateMenu(menuDebug,       "menu-debug",        "Debug");
+#endif
+      connect(openRecent,     SIGNAL(aboutToShow()),       SLOT(openRecentMenu()));
+      connect(openRecent,     SIGNAL(triggered(QAction*)), SLOT(selectScore(QAction*)));
+      connect(menuWorkspaces, SIGNAL(aboutToShow()),       SLOT(showWorkspaceMenu()));
+      setMenuTitles();
+      }
+      
 //---------------------------------------------------------
 //   resizeEvent
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -310,6 +310,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QMenu* menuTuplet;
 
       QMenu* menuFormat;
+      QMenu* menuStretch;
       QMenu* menuTools;
       QMenu* menuVoices;
       QMenu* menuMeasure;
@@ -317,6 +318,9 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QMenu* menuPlugins;
       QMenu* menuHelp;
       QMenu* menuTours;
+#ifndef NDEBUG
+      QMenu* menuDebug;
+#endif
       AlbumManager* albumManager           { 0 };
 
       QWidget* _searchDialog               { 0 };
@@ -442,6 +446,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       virtual void showEvent(QShowEvent *event);
 
       void retranslate();
+      void setMenuTitles();
+      void updateMenu(QMenu*& menu, QString menu_id, QString objectName);
 
       void playVisible(bool flag);
       void launchBrowser(const QString whereTo);
@@ -803,6 +809,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       WorkspaceDialog* workspaceDialog() { return _workspaceDialog; }
       void updateIcons();
+      void updateMenus();
 
       Inspector* inspector()           { return _inspector; }
       PluginCreator* pluginCreator()   { return _pluginCreator; }

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -687,20 +687,13 @@ void Workspace::read(XmlReader& e)
                   saveMenuBar = true;
                   QMenuBar* mb = mscore->menuBar();
                   mb->clear();
+                  menuToStringList.clear();
                   while (e.readNextStartElement()) {
                         if (e.hasAttribute("name")) { // is a menu
                               QString menu_id = e.attribute("name");
-                              QMenu* menu = findMenuFromString(menu_id);
-                              if (menu) {
-                                    menu->clear();
-                                    mb->addMenu(menu);
-                                    readMenu(e, menu);
-                                    }
-                              else {
-                                    menu = new QMenu(menu_id);
-                                    mb->addMenu(menu);
-                                    readMenu(e, menu);
-                                    }
+                              QMenu* menu = mb->addMenu(menu_id);
+                              addMenuAndString(menu, menu_id);
+                              readMenu(e, menu);
                               }
                         else { // is an action
                               QString action_id = e.readXml();
@@ -712,6 +705,7 @@ void Workspace::read(XmlReader& e)
                                     }
                               }
                         }
+                  mscore->updateMenus();
                   }
             else if (tag == "State") {
                   saveComponents = true;
@@ -755,17 +749,9 @@ void Workspace::readMenu(XmlReader& e, QMenu* menu)
       while (e.readNextStartElement()) {
             if (e.hasAttribute("name")) { // is a menu
                   QString menu_id = e.attribute("name");
-                  QMenu* new_menu = findMenuFromString(menu_id);
-                  if (new_menu) {
-                        new_menu->clear();
-                        menu->addMenu(new_menu);
-                        readMenu(e, new_menu);
-                        }
-                  else {
-                        new_menu = new QMenu(menu_id);
-                        menu->addMenu(new_menu);
-                        readMenu(e, new_menu);
-                        }
+                  QMenu* new_menu = menu->addMenu(menu_id);
+                  addMenuAndString(new_menu, menu_id);
+                  readMenu(e, new_menu);
                   }
             else { // is an action
                   QString action_id = e.readXml();
@@ -799,20 +785,13 @@ void Workspace::readGlobalMenuBar()
                         if (e.name() == "MenuBar") {
                               QMenuBar* mb = mscore->menuBar();
                               mb->clear();
+                              menuToStringList.clear();
                               while (e.readNextStartElement()) {
                                     if (e.hasAttribute("name")) { // is a menu
                                           QString menu_id = e.attribute("name");
-                                          QMenu* menu = findMenuFromString(menu_id);
-                                          if (menu) {
-                                                menu->clear();
-                                                mb->addMenu(menu);
-                                                readMenu(e, menu);
-                                                }
-                                          else {
-                                                menu = new QMenu(menu_id);
-                                                mb->addMenu(menu);
-                                                readMenu(e, menu);
-                                                }
+                                          QMenu* menu = mb->addMenu(menu_id);
+                                          addMenuAndString(menu, menu_id);
+                                          readMenu(e, menu);
                                           }
                                     else { // is an action
                                           QString action_id = e.readXml();
@@ -824,6 +803,7 @@ void Workspace::readGlobalMenuBar()
                                                 }
                                           }
                                     }
+                              mscore->updateMenus();
                               }
                         else
                               e.unknown();

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -49,7 +49,6 @@ class Workspace : public QObject {
 
       static QString findStringFromAction(QAction* action);
       static QAction* findActionFromString(QString string);
-      static QMenu* findMenuFromString(QString string);
       static QString findStringFromMenu(QMenu* menu);
 
       QString _name;
@@ -100,6 +99,7 @@ class Workspace : public QObject {
       static void addActionAndString(QAction* action, QString string);
       static void addRemainingFromMenuBar(QMenuBar* mb);
       static void addMenuAndString(QMenu* menu, QString string);
+      static QMenu* findMenuFromString(QString string);
 
       bool getSaveComponents()       { return saveComponents; }
       void setSaveComponents(bool s) { saveComponents = s;    }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/281472.

The bug in Qt <= 5.9.7 that results in a crash is triggered by adding an old `QMenu` object back into the menu bar after the menu bar has been cleared. This prevents the crash by only adding new `QMenu` objects to the menu bar. 

Some menus have an object name—set with `setObjectName()`—and some do not. For the ones that do, after the menu is recreated it is given the same object name as the old menu.

The code that sets the menu titles has been moved out of `MuseScore::retranslate()` into a new function`MuseScore::setMenuTitles()` so that the newly created menus can be given their proper titles without having to retranslate everything.

Now the `MuseScore` class maintains references to the “Stretch” menu and the “Debug” menu (if applicable) so that they can be given their proper titles after the menus are recreated.

Now `Workspace::menuToStringList` only contains the menus that are present in the current workspace.

In order for the `MuseScore` class to be able to maintain accurate references to the menu objects, `Workspace::findMenuFromString()`—which was previously a private method—has been made public.

Travis once again uses Qt 5.9.3 to build the package for macOS.

The macOS Deployment target has been changed to 10.10.