### PR TITLE
fix #286240: fix a crash on score save when editing a bracket

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4590,8 +4590,11 @@ Element* ScoreView::getEditElement()
 
 void ScoreView::onElementDestruction(Element* e)
       {
-      if (editData.element == e)
+      if (editData.element == e) {
             editData.element = nullptr;
+            if (editMode())
+                  changeState(ViewState::NORMAL);
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fixes https://musescore.org/en/node/286240.
Many parts of the `ScoreView` class code assume that `edtiData.element` is not a null pointer when the view is in edit mode. Meanwhile layout may delete some elements, and that resets `editData.element`. This commit ensures that the view also leaves edit mode if it happens.