### PR TITLE
fix #283828: add back end-start repeat barline

### DIFF
--- a/libmscore/barline.h
+++ b/libmscore/barline.h
@@ -51,7 +51,7 @@ struct BarLineTableItem {
 //---------------------------------------------------------
 //   @@ BarLine
 //
-//   @P barLineType  enum  (BarLineType.NORMAL, .DOUBLE, .START_REPEAT, .END_REPEAT, .BROKEN, .END, .DOTTED)
+//   @P barLineType  enum  (BarLineType.NORMAL, .DOUBLE, .START_REPEAT, .END_REPEAT, .BROKEN, .END, .END_START_REPEAT, .DOTTED)
 //---------------------------------------------------------
 
 class BarLine final : public Element {

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1728,6 +1728,10 @@ void Score::deleteItem(Element* el)
                               m->undoChangeProperty(Pid::REPEAT_START, false);
                         else if (bl->barLineType() == BarLineType::END_REPEAT)
                               m->undoChangeProperty(Pid::REPEAT_END, false);
+                        else if (bl->barLineType() == BarLineType::END_START_REPEAT) {
+                              m->undoChangeProperty(Pid::REPEAT_START, false);
+                              m->undoChangeProperty(Pid::REPEAT_END, false);
+                              }
                         else
                               bl->undoChangeProperty(Pid::BARLINE_TYPE, QVariant::fromValue(BarLineType::NORMAL));
                         }

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -679,6 +679,7 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                                     BarLineType blt = toBarLine(e)->barLineType();
                                     switch (blt) {
                                           case BarLineType::END_REPEAT:
+                                          case BarLineType::END_START_REPEAT:
                                                 // skip dots
                                                 x += symWidth(SymId::repeatDot);
                                                 x += score()->styleS(Sid::endBarDistance).val() * _spatium;

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3414,7 +3414,11 @@ qreal Measure::createEndBarLines(bool isLastMeasureInSystem)
                   }
 
             bool force = false;
-            if (repeatEnd()) {
+            if (!isLastMeasureInSystem && repeatEnd() && nextMeasure()->repeatStart()) {
+                  t = BarLineType::END_START_REPEAT;
+                  force = true;
+                  }
+            else if (repeatEnd()) {
                   t = BarLineType::END_REPEAT;
                   force = true;
                   }

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -228,6 +228,7 @@ enum class BarLineType {
       END_REPEAT       = 8,
       BROKEN           = 0x10,
       END              = 0x20,
+      END_START_REPEAT = 0x40,
       DOTTED           = 0x80
       };
 

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1586,7 +1586,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                                           t = BarLineType::END;
                                           break;
                                     case 6:
-                                          // TODO t = BarLineType::END_START_REPEAT;
+                                          t = BarLineType::END_START_REPEAT;
                                           break;
                                     }
                               barLine->setBarLineType(t);

--- a/mscore/capella.cpp
+++ b/mscore/capella.cpp
@@ -893,8 +893,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
 //TODO                        if (pm && (st == BarLineType::DOUBLE || st == BarLineType::END || st == BarLineType::BROKEN))
 //                              pm->setEndBarLineType(st, false, true);
 
-//TODO                        if (st == BarLineType::START_REPEAT || st == BarLineType::END_START_REPEAT) {
-                        if (st == BarLineType::START_REPEAT) {
+                        if (st == BarLineType::START_REPEAT || st == BarLineType::END_START_REPEAT) {
                               Measure* nm = 0; // the next measure (the one started by this barline)
                               nm = score->getCreateMeasure(tick);
                               // qDebug("nm %p", nm);
@@ -902,8 +901,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                                     nm->setRepeatStart(true);
                               }
 
-//                        if (st == BarLineType::END_REPEAT || st == BarLineType::END_START_REPEAT) {
-                        if (st == BarLineType::END_REPEAT) {
+                        if (st == BarLineType::END_REPEAT || st == BarLineType::END_START_REPEAT) {
                               if (pm)
                                     pm->setRepeatEnd(true);
                               }
@@ -2411,7 +2409,7 @@ void CapExplicitBarline::read()
       else if (type == 2) _type = BarLineType::END;
       else if (type == 3) _type = BarLineType::END_REPEAT;
       else if (type == 4) _type = BarLineType::START_REPEAT;
-//TODO      else if (type == 5) _type = BarLineType::END_START_REPEAT;
+      else if (type == 5) _type = BarLineType::END_START_REPEAT;
       else if (type == 6) _type = BarLineType::BROKEN;
       else _type = BarLineType::NORMAL; // default
       _barMode = b >> 4;         // 0 = auto, 1 = nur Zeilen, 2 = durchgezogen

--- a/mscore/capxml.cpp
+++ b/mscore/capxml.cpp
@@ -165,7 +165,7 @@ void CapExplicitBarline::readCapx(XmlReader& e)
       else if (type == "end") _type = BarLineType::END;
       else if (type == "repEnd") _type = BarLineType::END_REPEAT;
       else if (type == "repBegin") _type = BarLineType::START_REPEAT;
-//TODO      else if (type == "repEndBegin") _type = BarLineType::END_START_REPEAT;
+      else if (type == "repEndBegin") _type = BarLineType::END_START_REPEAT;
       else if (type == "dashed") _type = BarLineType::BROKEN;
       else _type = BarLineType::NORMAL; // default
       _barMode = 0;

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1572,7 +1572,7 @@ void ExportMusicXml::barlineRight(Measure* m)
                               _xml.tag("bar-style", QString("dotted"));
                               break;
                         case BarLineType::END:
-//                        case BarLineType::END_START_REPEAT:
+                        case BarLineType::END_START_REPEAT:
                               _xml.tag("bar-style", QString("light-heavy"));
                               break;
                         default:
@@ -1586,8 +1586,7 @@ void ExportMusicXml::barlineRight(Measure* m)
             }
       if (volta)
             ending(_xml, volta, false);
-//      if (bst == BarLineType::END_REPEAT || bst == BarLineType::END_START_REPEAT)
-      if (bst == BarLineType::END_REPEAT)
+      if (bst == BarLineType::END_REPEAT || bst == BarLineType::END_START_REPEAT)
             {
             if (m->repeatCount() > 2) {
                   _xml.tagE(QString("repeat direction=\"backward\" times=\"%1\"").arg(m->repeatCount()));

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -2829,8 +2829,7 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
 
       for (Measure* m1 = score->firstMeasure(); m1; m1 = m1->nextMeasure(), ++idx) {
             const GpBar& bar = gp->bars[idx];
-            //TODO            if (bar.barLine != BarLineType::NORMAL && bar.barLine != BarLineType::END_REPEAT && bar.barLine != BarLineType::START_REPEAT && bar.barLine != BarLineType::END_START_REPEAT)
-            if (bar.barLine != BarLineType::NORMAL && bar.barLine != BarLineType::END_REPEAT && bar.barLine != BarLineType::START_REPEAT)
+            if (bar.barLine != BarLineType::NORMAL && bar.barLine != BarLineType::END_REPEAT && bar.barLine != BarLineType::START_REPEAT && bar.barLine != BarLineType::END_START_REPEAT)
                   m1->setEndBarLineType(bar.barLine, 0);
             }
       if (score->lastMeasure() && score->lastMeasure()->endBarLineType() != BarLineType::NORMAL)

--- a/mscore/importove.cpp
+++ b/mscore/importove.cpp
@@ -1254,8 +1254,7 @@ void OveToMScore::convertMeasureMisc(Measure* measure, int part, int staff, int 
                   break;
             }
 
-//TODO      if (bartype != BarLineType::NORMAL && bartype != BarLineType::END_REPEAT && bartype != BarLineType::START_REPEAT && bartype != BarLineType::END_START_REPEAT && bartype != BarLineType::END)
-      if (bartype != BarLineType::NORMAL && bartype != BarLineType::END_REPEAT && bartype != BarLineType::START_REPEAT && bartype != BarLineType::END)
+      if (bartype != BarLineType::NORMAL && bartype != BarLineType::END_REPEAT && bartype != BarLineType::START_REPEAT && bartype != BarLineType::END_START_REPEAT && bartype != BarLineType::END)
             measure->setEndBarLineType(bartype, 0);
 
       if (bartype == BarLineType::END_REPEAT)

--- a/mscore/inspector/inspectorBarline.cpp
+++ b/mscore/inspector/inspectorBarline.cpp
@@ -91,16 +91,14 @@ void InspectorBarLine::setElement()
       // enable / disable individual type combo items according to score and selected bar line status
       bool bMultiStaff  = bl->score()->nstaves() > 1;
       BarLineType blt   = bl->barLineType();
-//      bool isRepeat     = blt & (BarLineType::START_REPEAT | BarLineType::END_REPEAT | BarLineType::END_START_REPEAT);
-      bool isRepeat     = blt & (BarLineType::START_REPEAT | BarLineType::END_REPEAT);
+      bool isRepeat     = blt & (BarLineType::START_REPEAT | BarLineType::END_REPEAT | BarLineType::END_START_REPEAT);
 
       const QStandardItemModel* model = qobject_cast<const QStandardItemModel*>(b.type->model());
       int i = 0;
       for (auto& k : BarLine::barLineTable) {
             QStandardItem* item = model->item(i);
             // if combo item is repeat type, should be disabled for multi-staff scores
-//            if (k.type & (BarLineType::START_REPEAT | BarLineType::END_REPEAT | BarLineType::END_START_REPEAT)) {
-            if (k.type & (BarLineType::START_REPEAT | BarLineType::END_REPEAT)) {
+            if (k.type & (BarLineType::START_REPEAT | BarLineType::END_REPEAT | BarLineType::END_START_REPEAT)) {
                   // disable / enable
                   item->setFlags(bMultiStaff ?
                         item->flags() & ~(Qt::ItemIsSelectable|Qt::ItemIsEnabled) :

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -381,6 +381,7 @@ Palette* MuseScore::newRepeatsPalette()
             switch (bti->type) {
                   case BarLineType::START_REPEAT:
                   case BarLineType::END_REPEAT:
+                  case BarLineType::END_START_REPEAT:
                         break;
                   default:
                         continue;

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1231,6 +1231,9 @@ void Timeline::barline_meta(Segment* seg, int* stagger, int pos)
                   case BarLineType::END_REPEAT:
                         repeat_text = QString("End repeat");
                         break;
+                  case BarLineType::END_START_REPEAT:
+                        repeat_text = QString("End-start repeat");
+                        break;
                   case BarLineType::DOUBLE:
                         repeat_text = QString("Double barline");
                         break;

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -1276,6 +1276,12 @@
             <subtype>end-repeat</subtype>
             </BarLine>
           </Cell>
+        <Cell name="End-start repeat">
+          <staff>1</staff>
+          <BarLine>
+            <subtype>end-start-repeat</subtype>
+            </BarLine>
+          </Cell>
         <Cell name="Dashed barline">
           <staff>1</staff>
           <BarLine>
@@ -2173,6 +2179,11 @@
         <Cell name="End repeat">
           <BarLine>
             <subtype>end-repeat</subtype>
+            </BarLine>
+          </Cell>
+        <Cell name="End-start repeat">
+          <BarLine>
+            <subtype>end-start-repeat</subtype>
             </BarLine>
           </Cell>
         </Palette>

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -467,6 +467,12 @@
             <subtype>end-repeat</subtype>
             </BarLine>voiceActions
           </Cell>
+        <Cell name="End-start repeat">
+          <staff>1</staff>
+          <BarLine>
+            <subtype>end-start-repeat</subtype>
+            </BarLine>
+          </Cell>
         <Cell name="Dashed barline">
           <staff>1</staff>
           <BarLine>
@@ -774,6 +780,11 @@
         <Cell name="End repeat">
           <BarLine>
             <subtype>end-repeat</subtype>
+            </BarLine>
+          </Cell>
+        <Cell name="End-start repeat">
+          <BarLine>
+            <subtype>end-start-repeat</subtype>
             </BarLine>
           </Cell>
         </Palette>


### PR DESCRIPTION
Re-implemented via the code from d435c3e and the code removed in 1167ae6.

WIP (and help needed), current problems:

1. the end-start repeat barline looks bad in the palettes
2. applying it adds a start and an end repeat to the same measure instead of adding the end repeat to the next measure (edit: seems pretty much solved)