### PR TITLE
fix #63301: comma shortcuts now save

### DIFF
--- a/mscore/shortcut.h
+++ b/mscore/shortcut.h
@@ -181,7 +181,7 @@ class Shortcut {
       static QActionGroup* getActionGroupForWidget(MsWidget w);
       static QActionGroup* getActionGroupForWidget(MsWidget w, Qt::ShortcutContext newShortcutContext);
 
-      static QString keySeqToString(const QKeySequence& keySeq, QKeySequence::SequenceFormat fmt);
+      static QString keySeqToString(const QKeySequence& keySeq, QKeySequence::SequenceFormat fmt, bool escapeKeyStr = false);
       static QKeySequence keySeqFromString(const QString& str, QKeySequence::SequenceFormat fmt);
       };
 


### PR DESCRIPTION
Comma shortcuts used to work in 1.3 and since 2.0 no longer works. This is because we use commas as delimiters for saving QKeySequences. For this fix I introduced "\\" as an escape character which now escapes backslashes and commas. This uses some regex for reading and simply adds an extra backslash to those specified characters when saving. Everything in the UI is identical to before, so this change only affects saving and loading.

Edit: Oops I just made a force push because I realize I added an extra line of whitespace that didn't need to be there.