### PR TITLE
fix #282890: save figured bass style parameters

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -98,6 +98,9 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       //   idx                --- showPercent      --- widget          --- resetButton
       { Sid::figuredBassAlignment,    false, fbAlign,                 0                    },
       { Sid::figuredBassStyle,        false, fbStyle,                 0                    },
+      { Sid::figuredBassFontSize,     false, doubleSpinFBSize,        0                    },
+      { Sid::figuredBassYOffset,      false, doubleSpinFBVertPos,     0                    },
+      { Sid::figuredBassLineHeight,   true,  spinFBLineHeight,        0                    },
       { Sid::tabClef,                 false, ctg,                     0                    },
       { Sid::keySigNaturals,          false, ksng,                    0                    },
       { Sid::voltaLineStyle,          false, voltaLineStyle,          resetVoltaLineStyle  },


### PR DESCRIPTION
Figured bass styles previously didn't save from the UI since the UI elements were never connected to the style values. As a result the fix only basically required connecting the spin boxes to the corresponding style values. The spin box for Line Height, however, was a percentage which is represented by a double in the Style ID. The code to account for this was mostly there, except for when the spin box value is changed. I ended up putting this inside of valueChanged() since there was already code that modified values for different SIDs. I thought about writing a different function to connect, but there would only be one change from the actual function so I just opted to use this approach instead.