### PR TITLE
Fix incorrect data type in readLongLong

### DIFF
--- a/zerberus/sfz.cpp
+++ b/zerberus/sfz.cpp
@@ -320,7 +320,7 @@ void ZInstrument::addRegion(SfzRegion& r)
 static void readLongLong(const QString& data, long long& val)
       {
       bool ok;
-      float d = data.toLongLong(&ok);
+      long long d = data.toLongLong(&ok);
       if (ok)
             val = d;
       }


### PR DESCRIPTION
Storing a long long in a float causes conversion errors