### PR TITLE
fix #285923: wrong properties on double-click line over range

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -682,6 +682,7 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
                   for (int i = sel.staffStart(); i < endStaff; ++i) {
                         Spanner* spanner = static_cast<Spanner*>(element->clone());
                         spanner->setScore(score);
+                        spanner->styleChanged();
                         score->cmdAddSpanner(spanner, i, startSegment, endSegment);
                         }
                   }


### PR DESCRIPTION
See https://musescore.org/en/node/285923.

This uses the same strategy as #4354, which solved the problem for double-click with a single/list selection but unfortunately missed the similar case of double-click with a range selection.