### PR TITLE
Support excerpt tab changes in script recorder

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2460,6 +2460,9 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
       else
             cs = 0;
 
+      if (ScriptRecorder* rec = getScriptRecorder())
+            rec->recordCurrentScoreChange();
+
       if (cs)
             cs->masterScore()->setPlaybackScore(_playPartOnly ? cs : cs->masterScore());
 

--- a/mscore/script/script.cpp
+++ b/mscore/script/script.cpp
@@ -172,6 +172,17 @@ void ScriptRecorder::recordPaletteElement(Element* e)
       }
 
 //---------------------------------------------------------
+//   ScriptRecorder::recordCurrentScoreChange
+//---------------------------------------------------------
+
+void ScriptRecorder::recordCurrentScoreChange()
+      {
+      if (_recording)
+            _script.addEntry(ExcerptChangeScriptEntry::fromContext(_ctx));
+      syncRecord();
+      }
+
+//---------------------------------------------------------
 //   ScriptRecorder::recordInspectorValueChange
 //---------------------------------------------------------
 

--- a/mscore/script/script.h
+++ b/mscore/script/script.h
@@ -112,6 +112,7 @@ class ScriptRecorder {
       void recordCommand(const QString& name);
       void recordPaletteElement(Element* e);
       void recordInspectorValueChange(const Element*, const InspectorItem&, const QVariant& value);
+      void recordCurrentScoreChange();
       void recordScoreTest(QString scoreName = QString());
       };
 

--- a/mscore/script/scriptentry.h
+++ b/mscore/script/scriptentry.h
@@ -30,6 +30,7 @@ class ScriptEntry {
       static constexpr const char* SCRIPT_CMD = "cmd";
       static constexpr const char* SCRIPT_PALETTE = "palette";
       static constexpr const char* SCRIPT_INSPECTOR = "inspector";
+      static constexpr const char* SCRIPT_EXCERPT_CHANGE = "excerpt";
       static constexpr const char* SCRIPT_TEST = "test";
 
       static QString entryTemplate(const char* entryType) { return QString("%1 %2").arg(entryType); }
@@ -107,5 +108,20 @@ class InspectorScriptEntry : public ScriptEntry {
       static std::unique_ptr<ScriptEntry> deserialize(const QStringList& tokens);
       };
 
+//---------------------------------------------------------
+//   ExcerptChangeEntry
+///   Represents switching between excerpt tabs
+//---------------------------------------------------------
+
+class ExcerptChangeScriptEntry : public ScriptEntry {
+      int _index;
+
+   public:
+      ExcerptChangeScriptEntry(int idx) : _index(idx) {}
+      bool execute(ScriptContext& ctx) const override;
+      QString serialize() const override;
+      static std::unique_ptr<ScriptEntry> fromContext(const ScriptContext&);
+      static std::unique_ptr<ScriptEntry> deserialize(const QStringList& tokens);
+      };
 }     // namespace Ms
 #endif

--- a/mtest/testscript/scripts/excerptchange.mscx
+++ b/mtest/testscript/scripts/excerptchange.mscx
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <programVersion>3.1.0</programVersion>
+  <programRevision>8920c76</programRevision>
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Synthesizer>
+      </Synthesizer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2018-11-12</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Linux</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Treble</metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          <synti>Fluid</synti>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <linkedMain/>
+        <Text>
+          <linkedMain/>
+          <style>Title</style>
+          <text>Treble</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <TimeSig>
+            <linkedMain/>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Chord>
+            <linkedMain/>
+            <durationType>quarter</durationType>
+            <Note>
+              <linkedMain/>
+              <pitch>69</pitch>
+              <tpc>17</tpc>
+              </Note>
+            </Chord>
+          <Rest>
+            <linkedMain/>
+            <durationType>quarter</durationType>
+            </Rest>
+          <Rest>
+            <linkedMain/>
+            <durationType>half</durationType>
+            </Rest>
+          </voice>
+        </Measure>
+      </Staff>
+    <Score>
+      <LayerTag id="0" tag="default"></LayerTag>
+      <currentLayer>0</currentLayer>
+      <Synthesizer>
+        </Synthesizer>
+      <Division>480</Division>
+      <Style>
+        <pageWidth>8.27</pageWidth>
+        <pageHeight>11.69</pageHeight>
+        <pagePrintableWidth>7.4826</pagePrintableWidth>
+        <lastSystemFillLimit>0</lastSystemFillLimit>
+        <createMultiMeasureRests>1</createMultiMeasureRests>
+        <Spatium>1.76389</Spatium>
+        </Style>
+      <showInvisible>1</showInvisible>
+      <showUnprintable>1</showUnprintable>
+      <showFrames>1</showFrames>
+      <showMargins>0</showMargins>
+      <metaTag name="partName">Piano</metaTag>
+      <Part>
+        <Staff id="1">
+          <linkedTo>1</linkedTo>
+          <StaffType group="pitched">
+            <name>stdNormal</name>
+            </StaffType>
+          </Staff>
+        <trackName>Piano</trackName>
+        <Instrument>
+          <longName>Piano</longName>
+          <shortName>Pno.</shortName>
+          <trackName>Piano</trackName>
+          <minPitchP>21</minPitchP>
+          <maxPitchP>108</maxPitchP>
+          <minPitchA>21</minPitchA>
+          <maxPitchA>108</maxPitchA>
+          <instrumentId>keyboard.piano</instrumentId>
+          <Articulation>
+            <velocity>100</velocity>
+            <gateTime>95</gateTime>
+            </Articulation>
+          <Articulation name="staccatissimo">
+            <velocity>100</velocity>
+            <gateTime>33</gateTime>
+            </Articulation>
+          <Articulation name="staccato">
+            <velocity>100</velocity>
+            <gateTime>50</gateTime>
+            </Articulation>
+          <Articulation name="portato">
+            <velocity>100</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="tenuto">
+            <velocity>100</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Articulation name="marcato">
+            <velocity>120</velocity>
+            <gateTime>67</gateTime>
+            </Articulation>
+          <Articulation name="sforzato">
+            <velocity>120</velocity>
+            <gateTime>100</gateTime>
+            </Articulation>
+          <Channel>
+            <program value="0"/>
+            <synti>Fluid</synti>
+            </Channel>
+          </Instrument>
+        </Part>
+      <Staff id="1">
+        <VBox>
+          <height>10</height>
+          <linked>
+            </linked>
+          <Text>
+            <linked>
+              </linked>
+            <style>Title</style>
+            <text>Treble</text>
+            </Text>
+          <Text>
+            <style>Instrument Name (Part)</style>
+            <text>Piano</text>
+            </Text>
+          </VBox>
+        <Measure>
+          <voice>
+            <TimeSig>
+              <linked>
+                </linked>
+              <sigN>4</sigN>
+              <sigD>4</sigD>
+              </TimeSig>
+            <Chord>
+              <linked>
+                </linked>
+              <durationType>quarter</durationType>
+              <Note>
+                <linked>
+                  </linked>
+                <color r="255" g="0" b="0" a="255"/>
+                <pitch>69</pitch>
+                <tpc>17</tpc>
+                </Note>
+              </Chord>
+            <Rest>
+              <linked>
+                </linked>
+              <durationType>quarter</durationType>
+              </Rest>
+            <Rest>
+              <linked>
+                </linked>
+              <durationType>half</durationType>
+              </Rest>
+            </voice>
+          </Measure>
+        </Staff>
+      <name>Piano</name>
+      </Score>
+    </Score>
+  </museScore>

--- a/mtest/testscript/scripts/excerptchange.script
+++ b/mtest/testscript/scripts/excerptchange.script
@@ -1,0 +1,11 @@
+init init/TrebleWithPart.mscx
+cmd note-input
+cmd note-a
+cmd escape
+excerpt 1
+cmd note-input
+cmd escape
+inspector Note color #ff0000
+cmd del-empty-measures
+excerpt 0
+test score excerptchange.mscx


### PR DESCRIPTION
This PR extends the script recorder capabilities a bit further and adds to it a support for excerpt tab switches. This allows testing scenarios involving some actions made in the linked parts which is relatively often necessary to reproduce certain bugs.