### PR TITLE
fix #284991: Hide empty staves with fermatas

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1250,7 +1250,7 @@ void Score::hideEmptyStaves(System* system, bool isFirstSystem)
                         if (!m->isMeasure())
                               continue;
                         Measure* measure = toMeasure(m);
-                        if (!measure->isMeasureRest(staffIdx)) {
+                        if (!measure->isEmpty(staffIdx)) {
                               hideStaff = false;
                               break;
                               }
@@ -1267,7 +1267,7 @@ void Score::hideEmptyStaves(System* system, bool isFirstSystem)
                                     if (!mb->isMeasure())
                                           continue;
                                     Measure* m = toMeasure(mb);
-                                    if (staff->hideWhenEmpty() == Staff::HideMode::INSTRUMENT && !m->isMeasureRest(st)) {
+                                    if (staff->hideWhenEmpty() == Staff::HideMode::INSTRUMENT && !m->isEmpty(st)) {
                                           hideStaff = false;
                                           break;
                                           }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2610,7 +2610,7 @@ bool Measure::isMeasureRest(int staffIdx) const
                         return false;
                   }
             for (Element* a : s->annotations()) {
-                  if (!a || a->systemFlag() || !a->visible())
+                  if (!a || a->systemFlag() || !a->visible() || a->isFermata())
                         continue;
                   int atrack = a->track();
                   if (atrack >= strack && atrack < etrack)

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2372,7 +2372,7 @@ bool Measure::visible(int staffIdx) const
             }
       if (system() && (system()->staves()->empty() || !system()->staff(staffIdx)->show()))
             return false;
-      if (score()->staff(staffIdx)->cutaway() && isMeasureRest(staffIdx))
+      if (score()->staff(staffIdx)->cutaway() && isEmpty(staffIdx))
             return false;
       return score()->staff(staffIdx)->show() && _mstaves[staffIdx]->visible();
       }
@@ -2585,13 +2585,13 @@ bool Measure::hasVoice(int track) const
       }
 
 //-------------------------------------------------------------------
-//   isMeasureRest
-///   Check if the measure is filled by a full-measure rest or full
-///   of rests on this staff. If staff is -1, then check for
-///   all staves.
+//   isEmpty
+///   Check if the measure is filled by a full-measure rest, or is
+///   full of rests on this staff, that may have fermatas on them.
+///   If staff is -1, then check for all staves.
 //-------------------------------------------------------------------
 
-bool Measure::isMeasureRest(int staffIdx) const
+bool Measure::isEmpty(int staffIdx) const
       {
       int strack;
       int etrack;

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -210,7 +210,7 @@ class Measure final : public MeasureBase {
       void exchangeVoice(int voice1, int voice2, int staffIdx);
       void checkMultiVoices(int staffIdx);
       bool hasVoice(int track) const;
-      bool isMeasureRest(int staffIdx) const;
+      bool isEmpty(int staffIdx) const;
       bool isFullMeasureRest() const;
       bool isRepeatMeasure(Staff* staff) const;
       bool visible(int staffIdx) const;


### PR DESCRIPTION
Marks measures with a bar rest and a fermata as empty, allowing those staves to be hidden.