### PR TITLE
Force measures to be redrawn when the "visible" or "stemless" checkboxes are changed in the measure properties dialog

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2610,7 +2610,7 @@ bool Measure::isMeasureRest(int staffIdx) const
                         return false;
                   }
             for (Element* a : s->annotations()) {
-                  if (!a || a->systemFlag() || !a->visible())
+                  if (!a || a->systemFlag() || !a->visible() || a->isFermata())
                         continue;
                   int atrack = a->track();
                   if (atrack >= strack && atrack < etrack)

--- a/mscore/measureproperties.cpp
+++ b/mscore/measureproperties.cpp
@@ -244,11 +244,14 @@ void MeasureProperties::apply()
       {
       Score* score = m->score();
 
+      bool propertiesChanged = false;
       for (int staffIdx = 0; staffIdx < score->nstaves(); ++staffIdx) {
             bool v = visible(staffIdx);
             bool s = slashStyle(staffIdx);
-            if (m->visible(staffIdx) != v || m->slashStyle(staffIdx) != s)
+            if (m->visible(staffIdx) != v || m->slashStyle(staffIdx) != s) {
                   score->undo(new ChangeMStaffProperties(m, staffIdx, v, s));
+                  propertiesChanged = true;
+                  }
             }
 
       m->undoChangeProperty(Pid::REPEAT_COUNT, repeatCount());
@@ -273,6 +276,11 @@ void MeasureProperties::apply()
                   }
 #endif
             }
+
+      if (propertiesChanged) {
+            score->setLayout(m->tick());
+            }
+
       score->select(m, SelectType::SINGLE, 0);
       score->update();
       mscore->timeline()->updateGrid();


### PR DESCRIPTION
Includes fixes for the following issues:
https://musescore.org/en/node/282819
https://musescore.org/en/node/284501
https://musescore.org/en/node/286653

Adds a simple check to see whether any of the checkboxes have been changed, and sets the score to redraw if they have.