### PR TITLE
fix #286821: common instruments filter only lists common instruments

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -406,8 +406,8 @@ void populateGenreCombo(QComboBox* combo)
                   defaultIndex = i;
             ++i;
             }
-      combo->setCurrentIndex(defaultIndex);
       combo->blockSignals(false);
+      combo->setCurrentIndex(defaultIndex);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
When the instrument dialog is created and the instrument list is populated, the combobox signals are blocked to set everything up without constantly calling the index changed. One of these lines of code is to set the current filter to the "common" filter. Since signals are blocked, however, that line of code never actually filters the instrument list. The change just moves that single line after signals are re-enabled.