### PR TITLE
fix #286794: permanent courtesy time signatures after style change

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1269,7 +1269,9 @@ void Score::spatiumChanged(qreal oldValue, qreal newValue)
 
 static void updateStyle(void*, Element* e)
       {
+      bool v = e->generated();
       e->styleChanged();
+      e->setGenerated(v);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/286794.  We've been getting these reports for some time but until now had no way to reproduce this particular case.  Thanks to cadiz1, we have steps.

The turns out to be that a style change triggers updating all styled properties for all elements, and for time signatures, this causes them to be marked non-generated.  That basically locks in any courtesy signatures, although since the segment is still marked "trailer", it can get cleaned up on layout change and thus doesn't get completely locked in until you save & reload.

Most changes to most properties for an element *should* cause it to get non-generated, and I think we should consider doing this somewhat globally.  But, changes due only to a style update should not trigger this.  Thus, I elected to fix the bug by preserving the generated status of elements when calling updateStyle().  It is effective, seems safe (unlikely to have bad effects), and should also continue to work well if we get more aggressive in the future about marking things non-generated.

One open question on the bug here: is there a way to automatically fix existing scores with this problem? 
 We would need to identify time signatures on read that were already written to scores erroneously, and re-mark them generated.  But I can't think of any non-hacky ways to detect whether a time signature we are reading really was non-generated or not.