### PR TITLE
Fix slow keyboard arrows navigation if chord playback is enabled

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -4479,7 +4479,6 @@ void MuseScore::play(Element* e) const
             Chord* c   = toChord(e);
             Part* part = c->staff()->part();
             Fraction tick   = c->segment() ? c->segment()->tick() : Fraction(0,1);
-            seq->seek(tick.ticks());
             Instrument* instr = part->instrument(tick);
             for (Note* n : c->notes()) {
                   const int channel = instr->channel(n->subchannel())->channel();


### PR DESCRIPTION
When navigating in a large score using keyboard arrows, the navigation becomes very slow if chord playback is enabled (it is by default). This is caused by the fact that chord playback uses `seq->seek()` call which currently:
1. Always leads to regenerating MIDI events for a score
2. Regenerates play events for the whole score, which is a problem for large scores.

The first issue may slightly be optimized, resolving the second one requires probably a larger MIDI rendering subsystem refactoring allowing, among other possible improvements, a "partial layout" for MIDI representation of a score.

While both improvements will be useful for general playback purposes, it looks like chord playback done while editing simply does not use events from a score so there is no point in that `Seq::seek` call. Removing it is exactly what is proposed in this patch.