### PR TITLE
fix #284046: Breaths & Pauses accumulate offset

### DIFF
--- a/libmscore/breath.cpp
+++ b/libmscore/breath.cpp
@@ -64,11 +64,11 @@ void Breath::layout()
       bool palette = (track() == -1);
       if (!palette) {
             if (isCaesura())
-                  setPos(x(), spatium());
+                  setPos(rxpos(), spatium());
             else if ((score()->styleSt(Sid::MusicalSymbolFont) == "Emmentaler") && (symId() == SymId::breathMarkComma))
-                  setPos(x(), 0.5 * spatium());
+                  setPos(rxpos(), 0.5 * spatium());
             else
-                  setPos(x(), -0.5 * spatium());
+                  setPos(rxpos(), -0.5 * spatium());
             }
       setbbox(symBbox(_symId));
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/284046

The problem is that setting from `x()` include the offset, so we end up incrementing the x position by the offset. `rxpos()` doesn't include offset.