### PR TITLE
Barline issues

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -81,15 +81,6 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
                                     e->score()->undo(new ChangeProperty(e, Pid::BARLINE_TYPE, QVariant::fromValue(barType), PropertyFlags::NOSTYLE));
                                     e->score()->undo(new ChangeProperty(e, Pid::GENERATED, false, PropertyFlags::NOSTYLE));
                                     }
-                              else {
-                                    auto score = bl->score();
-                                    BarLine* newBl = new BarLine(score);
-                                    newBl->setBarLineType(barType);
-                                    newBl->setParent(segment1);
-                                    newBl->setTrack(0);
-                                    newBl->setSpanStaff(score->nstaves());
-                                    newBl->score()->undo(new AddElement(newBl));
-                                    }
                               }
                         }
                   }

--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -1051,12 +1051,20 @@ qreal BarLine::layoutWidth(Score* score, BarLineType type)
 void BarLine::layout()
       {
       setPos(QPointF());
+      // barlines hidden on this staff
+      if (staff() && segment()) {
+            if ((!staff()->staffType(tick())->showBarlines() && segment()->segmentType() == SegmentType::EndBarLine)
+                || (staff()->hideSystemBarLine() && segment()->segmentType() == SegmentType::BeginBarLine)) {
+                  setbbox(QRectF());
+                  return;
+                  }
+            }
+
       setMag(score()->styleB(Sid::scaleBarlines) && staff() ? staff()->mag(tick()) : 1.0);
       qreal _spatium = spatium();
       y1 = _spatium * .5 * _spanFrom;
       y2 = _spatium * .5 * (8.0 + _spanTo);
 
-      // bar lines not hidden
       qreal w = layoutWidth(score(), barLineType()) * mag();
       QRectF r(0.0, y1, w, y2 - y1);
 
@@ -1104,6 +1112,15 @@ void BarLine::layout()
 
 void BarLine::layout2()
       {
+      // barlines hidden on this staff
+      if (staff() && segment()) {
+            if ((!staff()->staffType(tick())->showBarlines() && segment()->segmentType() == SegmentType::EndBarLine)
+                || (staff()->hideSystemBarLine() && segment()->segmentType() == SegmentType::BeginBarLine)) {
+                  setbbox(QRectF());
+                  return;
+                  }
+            }
+
       getY();
       bbox().setTop(y1);
       bbox().setBottom(y2);

--- a/libmscore/barline.h
+++ b/libmscore/barline.h
@@ -51,7 +51,7 @@ struct BarLineTableItem {
 //---------------------------------------------------------
 //   @@ BarLine
 //
-//   @P barLineType  enum  (BarLineType.NORMAL, .DOUBLE, .START_REPEAT, .END_REPEAT, .BROKEN, .END, .DOTTED)
+//   @P barLineType  enum  (BarLineType.NORMAL, .DOUBLE, .START_REPEAT, .END_REPEAT, .BROKEN, .END, .END_START_REPEAT, .DOTTED)
 //---------------------------------------------------------
 
 class BarLine final : public Element {

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3254,14 +3254,20 @@ void Score::cmdToggleLayoutBreak(LayoutBreak::Type type)
                         default: {
                               // find measure
                               Measure* measure = toMeasure(el->findMeasure());
+                              // for start repeat, attach brek to previous measure
+                              if (el->isBarLine()) {
+                                    BarLine* bl = toBarLine(el);
+                                    if (bl->barLineType() == BarLineType::START_REPEAT)
+                                          measure = measure->prevMeasure();
+                                    }
                               // if measure is mmrest, then propagate to last original measure
                               if (measure)
                                     mb = measure->isMMRest() ? measure->mmRestLast() : measure;
                               }
                         }
                   }
-                  if (mb)
-                        mbl.append(mb);
+            if (mb)
+                  mbl.append(mb);
             }
       // toggle the breaks
       for (MeasureBase* mb: mbl) {

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3254,8 +3254,8 @@ void Score::cmdToggleLayoutBreak(LayoutBreak::Type type)
                         default: {
                               // find measure
                               Measure* measure = toMeasure(el->findMeasure());
-                              // for start repeat, attach brek to previous measure
-                              if (el->isBarLine()) {
+                              // for start repeat, attach break to previous measure
+                              if (measure && el->isBarLine()) {
                                     BarLine* bl = toBarLine(el);
                                     if (bl->barLineType() == BarLineType::START_REPEAT)
                                           measure = measure->prevMeasure();

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1728,14 +1728,16 @@ void Score::deleteItem(Element* el)
                               Measure* m2 = m->isMMRest() ? m->mmRestFirst() : m;
                               for (Score* lscore : score()->scoreList()) {
                                     Measure* lmeasure = lscore->tick2measure(m2->tick());
-                                    lmeasure->undoChangeProperty(Pid::REPEAT_START, false);
+                                    if (lmeasure)
+                                          lmeasure->undoChangeProperty(Pid::REPEAT_START, false);
                                     }
                               }
                         else if (bl->barLineType() == BarLineType::END_REPEAT) {
                               Measure* m2 = m->isMMRest() ? m->mmRestLast() : m;
                               for (Score* lscore : score()->scoreList()) {
                                     Measure* lmeasure = lscore->tick2measure(m2->tick());
-                                    lmeasure->undoChangeProperty(Pid::REPEAT_END, false);
+                                    if (lmeasure)
+                                          lmeasure->undoChangeProperty(Pid::REPEAT_END, false);
                                     }
                               }
                         else {

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1724,12 +1724,23 @@ void Score::deleteItem(Element* el)
                         undoRemoveElement(el);
                         }
                   else {
-                        if (bl->barLineType() == BarLineType::START_REPEAT)
-                              m->undoChangeProperty(Pid::REPEAT_START, false);
-                        else if (bl->barLineType() == BarLineType::END_REPEAT)
-                              m->undoChangeProperty(Pid::REPEAT_END, false);
-                        else
+                        if (bl->barLineType() == BarLineType::START_REPEAT) {
+                              Measure* m2 = m->isMMRest() ? m->mmRestFirst() : m;
+                              for (Score* lscore : score()->scoreList()) {
+                                    Measure* lmeasure = lscore->tick2measure(m2->tick());
+                                    lmeasure->undoChangeProperty(Pid::REPEAT_START, false);
+                                    }
+                              }
+                        else if (bl->barLineType() == BarLineType::END_REPEAT) {
+                              Measure* m2 = m->isMMRest() ? m->mmRestLast() : m;
+                              for (Score* lscore : score()->scoreList()) {
+                                    Measure* lmeasure = lscore->tick2measure(m2->tick());
+                                    lmeasure->undoChangeProperty(Pid::REPEAT_END, false);
+                                    }
+                              }
+                        else {
                               bl->undoChangeProperty(Pid::BARLINE_TYPE, QVariant::fromValue(BarLineType::NORMAL));
+                              }
                         }
                   }
                   break;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3600,6 +3600,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                               BarLine* bl = toBarLine(s.element(0));
                               if (bl) {
                                     qreal w = BarLine::layoutWidth(score(), bl->barLineType());
+                                    // TODO: actual vertical position and height for staff?
                                     skyline.add(QRectF(0.0, 0.0, w, spatium() * 4.0).translated(bl->pos() + p));
                                     }
                               }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1759,7 +1759,7 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
 
       Measure* mmr = m->mmRest();
       if (mmr) {
-            // resuse existing mmrest
+            // reuse existing mmrest
             if (mmr->ticks() != len) {
                   Segment* s = mmr->findSegmentR(SegmentType::EndBarLine, mmr->ticks());
                   // adjust length
@@ -1788,7 +1788,7 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                   if (e) {
                         bool generated = e->generated();
                         if (!ds->element(staffIdx * VOICES)) {
-                              Element* ee = e->clone();
+                              Element* ee = generated ? e->clone() : e->linkedClone();
                               ee->setGenerated(generated);
                               ee->setParent(ds);
                               undoAddElement(ee);
@@ -1796,6 +1796,8 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                         else {
                               BarLine* bd = toBarLine(ds->element(staffIdx * VOICES));
                               BarLine* bs = toBarLine(e);
+                              if (!generated && !bd->links())
+                                    undo(new Link(bd, bs));
                               if (bd->barLineType() != bs->barLineType()) {
                                     // change directly when generating mmrests, do not change underlying measures or follow links
                                     undo(new ChangeProperty(bd, Pid::BARLINE_TYPE, QVariant::fromValue(bs->barLineType()), PropertyFlags::NOSTYLE));

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1517,8 +1517,20 @@ Element* Measure::drop(EditData& data)
                         if (cbl)
                               cbl->drop(data);
                         }
-                  else if (bl->barLineType() == BarLineType::START_REPEAT)
-                        undoChangeProperty(Pid::REPEAT_START, true);
+                  else if (bl->barLineType() == BarLineType::START_REPEAT) {
+                        Measure* m2 = isMMRest() ? mmRestFirst() : this;
+                        for (Score* lscore : score()->scoreList()) {
+                              Measure* lmeasure = lscore->tick2measure(m2->tick());
+                              lmeasure->undoChangeProperty(Pid::REPEAT_START, true);
+                              }
+                        }
+                  else if (bl->barLineType() == BarLineType::END_REPEAT) {
+                        Measure* m2 = isMMRest() ? mmRestLast() : this;
+                        for (Score* lscore : score()->scoreList()) {
+                              Measure* lmeasure = lscore->tick2measure(m2->tick());
+                              lmeasure->undoChangeProperty(Pid::REPEAT_END, true);
+                              }
+                        }
                   else {
                         // drop to first end barline
                         seg = findSegmentR(SegmentType::EndBarLine, ticks());

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1124,6 +1124,7 @@ void Measure::cmdAddStaves(int sStaff, int eStaff, bool createRest)
       score()->undo(new InsertStaves(this, sStaff, eStaff));
 
       Segment* ts = findSegment(SegmentType::TimeSig, tick());
+      Segment* bs = findSegmentR(SegmentType::EndBarLine, ticks());
 
       for (int i = sStaff; i < eStaff; ++i) {
             Staff* staff = score()->staff(i);
@@ -1187,6 +1188,25 @@ void Measure::cmdAddStaves(int sStaff, int eStaff, bool createRest)
                         score()->undoAddElement(timesig);
                         if (constructed)
                               delete ots;
+                        }
+                  }
+
+            // replicate barline
+            if (bs) {
+                  BarLine* obl = nullptr;
+                  for (unsigned track = 0; track < _mstaves.size() * VOICES; ++track) {
+                        Element* e = bs->element(track);
+                        if (e && !e->generated()) {
+                              obl = toBarLine(e);
+                              break;
+                              }
+                        }
+                  if (obl) {
+                        BarLine* barline = new BarLine(*obl);
+                        barline->setTrack(staffIdx * VOICES);
+                        barline->setParent(bs);
+                        barline->setGenerated(false);
+                        score()->undoAddElement(barline);
                         }
                   }
             }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1541,24 +1541,28 @@ Element* Measure::drop(EditData& data)
                         Measure* m2 = isMMRest() ? mmRestFirst() : this;
                         for (Score* lscore : score()->scoreList()) {
                               Measure* lmeasure = lscore->tick2measure(m2->tick());
-                              lmeasure->undoChangeProperty(Pid::REPEAT_START, true);
+                              if (lmeasure)
+                                    lmeasure->undoChangeProperty(Pid::REPEAT_START, true);
                               }
                         }
                   else if (bl->barLineType() == BarLineType::END_REPEAT) {
                         Measure* m2 = isMMRest() ? mmRestLast() : this;
                         for (Score* lscore : score()->scoreList()) {
                               Measure* lmeasure = lscore->tick2measure(m2->tick());
-                              lmeasure->undoChangeProperty(Pid::REPEAT_END, true);
+                              if (lmeasure)
+                                    lmeasure->undoChangeProperty(Pid::REPEAT_END, true);
                               }
                         }
                   else if (bl->barLineType() == BarLineType::END_START_REPEAT) {
                         Measure* m2 = isMMRest() ? mmRestLast() : this;
                         for (Score* lscore : score()->scoreList()) {
                               Measure* lmeasure = lscore->tick2measure(m2->tick());
-                              lmeasure->undoChangeProperty(Pid::REPEAT_END, true);
-                              lmeasure = lmeasure->nextMeasure();
-                              if (lmeasure)
-                                    lmeasure->undoChangeProperty(Pid::REPEAT_START, true);
+                              if (lmeasure) {
+                                    lmeasure->undoChangeProperty(Pid::REPEAT_END, true);
+                                    lmeasure = lmeasure->nextMeasure();
+                                    if (lmeasure)
+                                          lmeasure->undoChangeProperty(Pid::REPEAT_START, true);
+                                    }
                               }
                         }
                   else {

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1551,6 +1551,16 @@ Element* Measure::drop(EditData& data)
                               lmeasure->undoChangeProperty(Pid::REPEAT_END, true);
                               }
                         }
+                  else if (bl->barLineType() == BarLineType::END_START_REPEAT) {
+                        Measure* m2 = isMMRest() ? mmRestLast() : this;
+                        for (Score* lscore : score()->scoreList()) {
+                              Measure* lmeasure = lscore->tick2measure(m2->tick());
+                              lmeasure->undoChangeProperty(Pid::REPEAT_END, true);
+                              lmeasure = lmeasure->nextMeasure();
+                              if (lmeasure)
+                                    lmeasure->undoChangeProperty(Pid::REPEAT_START, true);
+                              }
+                        }
                   else {
                         // drop to first end barline
                         seg = findSegmentR(SegmentType::EndBarLine, ticks());

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -228,6 +228,7 @@ enum class BarLineType {
       END_REPEAT       = 8,
       BROKEN           = 0x10,
       END              = 0x20,
+      END_START_REPEAT = 0x40,
       DOTTED           = 0x80
       };
 

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -81,7 +81,7 @@ static const StyleVal2 style114[] = {
       { Sid::lyricsDashForce,              QVariant(false) },
       { Sid::frameSystemDistance,          Spatium(1.0) },
       { Sid::minMeasureWidth,              Spatium(4.0) },
-      { Sid::endBarDistance,               Spatium(0.30) },
+//      { Sid::endBarDistance,               Spatium(0.30) },
 
       { Sid::repeatBarTips,                QVariant(false) },
       { Sid::startBarlineSingle,           QVariant(false) },
@@ -1586,7 +1586,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                                           t = BarLineType::END;
                                           break;
                                     case 6:
-                                          // TODO t = BarLineType::END_START_REPEAT;
+                                          t = BarLineType::END_START_REPEAT;
                                           break;
                                     }
                               barLine->setBarLineType(t);

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -1314,13 +1314,13 @@ bool Staff::setProperty(Pid id, const QVariant& v)
                         if (s && s->element(track))
                               blList.push_back(s->element(track));
                         if (Measure* mm = m->mmRest()) {
-                              Segment* s = mm->getSegmentR(SegmentType::EndBarLine, mm->ticks());
-                              if (s && s->element(track))
-                                    blList.push_back(s->element(track));
+                              Segment* ss = mm->getSegmentR(SegmentType::EndBarLine, mm->ticks());
+                              if (ss && ss->element(track))
+                                    blList.push_back(ss->element(track));
                               }
                         }
                   for (Element* e : blList) {
-                        if (e->isBarLine() && !e->generated())
+                        if (e && e->isBarLine() && !e->generated())
                               toBarLine(e)->setSpanStaff(v.toInt());
                         }
                   }

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -1304,8 +1304,26 @@ bool Staff::setProperty(Pid id, const QVariant& v)
             case Pid::PLAYBACK_VOICE4:
                   setPlaybackVoice(3, v.toBool());
                   break;
-            case Pid::STAFF_BARLINE_SPAN:
+            case Pid::STAFF_BARLINE_SPAN: {
                   setBarLineSpan(v.toInt());
+                  // update non-generated barlines
+                  int track = idx() * VOICES;
+                  std::vector<Element*> blList;
+                  for (Measure* m = score()->firstMeasure(); m; m = m->nextMeasure()) {
+                        Segment* s = m->getSegmentR(SegmentType::EndBarLine, m->ticks());
+                        if (s && s->element(track))
+                              blList.push_back(s->element(track));
+                        if (Measure* mm = m->mmRest()) {
+                              Segment* s = mm->getSegmentR(SegmentType::EndBarLine, mm->ticks());
+                              if (s && s->element(track))
+                                    blList.push_back(s->element(track));
+                              }
+                        }
+                  for (Element* e : blList) {
+                        if (e->isBarLine() && !e->generated())
+                              toBarLine(e)->setSpanStaff(v.toInt());
+                        }
+                  }
                   break;
             case Pid::STAFF_BARLINE_SPAN_FROM:
                   setBarLineFrom(v.toInt());

--- a/mscore/capella.cpp
+++ b/mscore/capella.cpp
@@ -893,8 +893,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
 //TODO                        if (pm && (st == BarLineType::DOUBLE || st == BarLineType::END || st == BarLineType::BROKEN))
 //                              pm->setEndBarLineType(st, false, true);
 
-//TODO                        if (st == BarLineType::START_REPEAT || st == BarLineType::END_START_REPEAT) {
-                        if (st == BarLineType::START_REPEAT) {
+                        if (st == BarLineType::START_REPEAT || st == BarLineType::END_START_REPEAT) {
                               Measure* nm = 0; // the next measure (the one started by this barline)
                               nm = score->getCreateMeasure(tick);
                               // qDebug("nm %p", nm);
@@ -902,8 +901,7 @@ static Fraction readCapVoice(Score* score, CapVoice* cvoice, int staffIdx, const
                                     nm->setRepeatStart(true);
                               }
 
-//                        if (st == BarLineType::END_REPEAT || st == BarLineType::END_START_REPEAT) {
-                        if (st == BarLineType::END_REPEAT) {
+                        if (st == BarLineType::END_REPEAT || st == BarLineType::END_START_REPEAT) {
                               if (pm)
                                     pm->setRepeatEnd(true);
                               }
@@ -2411,7 +2409,7 @@ void CapExplicitBarline::read()
       else if (type == 2) _type = BarLineType::END;
       else if (type == 3) _type = BarLineType::END_REPEAT;
       else if (type == 4) _type = BarLineType::START_REPEAT;
-//TODO      else if (type == 5) _type = BarLineType::END_START_REPEAT;
+      else if (type == 5) _type = BarLineType::END_START_REPEAT;
       else if (type == 6) _type = BarLineType::BROKEN;
       else _type = BarLineType::NORMAL; // default
       _barMode = b >> 4;         // 0 = auto, 1 = nur Zeilen, 2 = durchgezogen

--- a/mscore/capxml.cpp
+++ b/mscore/capxml.cpp
@@ -165,7 +165,7 @@ void CapExplicitBarline::readCapx(XmlReader& e)
       else if (type == "end") _type = BarLineType::END;
       else if (type == "repEnd") _type = BarLineType::END_REPEAT;
       else if (type == "repBegin") _type = BarLineType::START_REPEAT;
-//TODO      else if (type == "repEndBegin") _type = BarLineType::END_START_REPEAT;
+      else if (type == "repEndBegin") _type = BarLineType::END_START_REPEAT;
       else if (type == "dashed") _type = BarLineType::BROKEN;
       else _type = BarLineType::NORMAL; // default
       _barMode = 0;

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1572,7 +1572,7 @@ void ExportMusicXml::barlineRight(Measure* m)
                               _xml.tag("bar-style", QString("dotted"));
                               break;
                         case BarLineType::END:
-//                        case BarLineType::END_START_REPEAT:
+                        case BarLineType::END_START_REPEAT:
                               _xml.tag("bar-style", QString("light-heavy"));
                               break;
                         default:
@@ -1586,8 +1586,7 @@ void ExportMusicXml::barlineRight(Measure* m)
             }
       if (volta)
             ending(_xml, volta, false);
-//      if (bst == BarLineType::END_REPEAT || bst == BarLineType::END_START_REPEAT)
-      if (bst == BarLineType::END_REPEAT)
+      if (bst == BarLineType::END_REPEAT || bst == BarLineType::END_START_REPEAT)
             {
             if (m->repeatCount() > 2) {
                   _xml.tagE(QString("repeat direction=\"backward\" times=\"%1\"").arg(m->repeatCount()));

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -2829,8 +2829,7 @@ Score::FileError importGTP(MasterScore* score, const QString& name)
 
       for (Measure* m1 = score->firstMeasure(); m1; m1 = m1->nextMeasure(), ++idx) {
             const GpBar& bar = gp->bars[idx];
-            //TODO            if (bar.barLine != BarLineType::NORMAL && bar.barLine != BarLineType::END_REPEAT && bar.barLine != BarLineType::START_REPEAT && bar.barLine != BarLineType::END_START_REPEAT)
-            if (bar.barLine != BarLineType::NORMAL && bar.barLine != BarLineType::END_REPEAT && bar.barLine != BarLineType::START_REPEAT)
+            if (bar.barLine != BarLineType::NORMAL && bar.barLine != BarLineType::END_REPEAT && bar.barLine != BarLineType::START_REPEAT && bar.barLine != BarLineType::END_START_REPEAT)
                   m1->setEndBarLineType(bar.barLine, 0);
             }
       if (score->lastMeasure() && score->lastMeasure()->endBarLineType() != BarLineType::NORMAL)

--- a/mscore/importove.cpp
+++ b/mscore/importove.cpp
@@ -1254,8 +1254,7 @@ void OveToMScore::convertMeasureMisc(Measure* measure, int part, int staff, int 
                   break;
             }
 
-//TODO      if (bartype != BarLineType::NORMAL && bartype != BarLineType::END_REPEAT && bartype != BarLineType::START_REPEAT && bartype != BarLineType::END_START_REPEAT && bartype != BarLineType::END)
-      if (bartype != BarLineType::NORMAL && bartype != BarLineType::END_REPEAT && bartype != BarLineType::START_REPEAT && bartype != BarLineType::END)
+      if (bartype != BarLineType::NORMAL && bartype != BarLineType::END_REPEAT && bartype != BarLineType::START_REPEAT && bartype != BarLineType::END_START_REPEAT && bartype != BarLineType::END)
             measure->setEndBarLineType(bartype, 0);
 
       if (bartype == BarLineType::END_REPEAT)

--- a/mscore/inspector/inspectorBarline.cpp
+++ b/mscore/inspector/inspectorBarline.cpp
@@ -91,16 +91,16 @@ void InspectorBarLine::setElement()
       // enable / disable individual type combo items according to score and selected bar line status
       bool bMultiStaff  = bl->score()->nstaves() > 1;
       BarLineType blt   = bl->barLineType();
-//      bool isRepeat     = blt & (BarLineType::START_REPEAT | BarLineType::END_REPEAT | BarLineType::END_START_REPEAT);
-      bool isRepeat     = blt & (BarLineType::START_REPEAT | BarLineType::END_REPEAT);
+      bool isRepeat     = blt & (BarLineType::START_REPEAT | BarLineType::END_REPEAT | BarLineType::END_START_REPEAT);
+//      bool isRepeat     = blt & (BarLineType::START_REPEAT | BarLineType::END_REPEAT);
 
       const QStandardItemModel* model = qobject_cast<const QStandardItemModel*>(b.type->model());
       int i = 0;
       for (auto& k : BarLine::barLineTable) {
             QStandardItem* item = model->item(i);
             // if combo item is repeat type, should be disabled for multi-staff scores
-//            if (k.type & (BarLineType::START_REPEAT | BarLineType::END_REPEAT | BarLineType::END_START_REPEAT)) {
-            if (k.type & (BarLineType::START_REPEAT | BarLineType::END_REPEAT)) {
+            if (k.type & (BarLineType::START_REPEAT | BarLineType::END_REPEAT | BarLineType::END_START_REPEAT)) {
+//            if (k.type & (BarLineType::START_REPEAT | BarLineType::END_REPEAT)) {
                   // disable / enable
                   item->setFlags(bMultiStaff ?
                         item->flags() & ~(Qt::ItemIsSelectable|Qt::ItemIsEnabled) :

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -382,6 +382,7 @@ Palette* MuseScore::newRepeatsPalette()
             switch (bti->type) {
                   case BarLineType::START_REPEAT:
                   case BarLineType::END_REPEAT:
+                  case BarLineType::END_START_REPEAT:
                         break;
                   default:
                         continue;

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1231,6 +1231,9 @@ void Timeline::barline_meta(Segment* seg, int* stagger, int pos)
                   case BarLineType::END_REPEAT:
                         repeat_text = QString("End repeat");
                         break;
+                  case BarLineType::END_START_REPEAT:
+                        repeat_text = QString("End-start repeat");
+                        break;
                   case BarLineType::DOUBLE:
                         repeat_text = QString("Double barline");
                         break;

--- a/mtest/libmscore/compat114/accidentals-ref.mscx
+++ b/mtest/libmscore/compat114/accidentals-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/articulations-ref.mscx
+++ b/mtest/libmscore/compat114/articulations-ref.mscx
@@ -8,7 +8,6 @@
       <minSystemDistance>9.2</minSystemDistance>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.2</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/chord_symbol-ref.mscx
+++ b/mtest/libmscore/compat114/chord_symbol-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/clef_missing_first-ref.mscx
+++ b/mtest/libmscore/compat114/clef_missing_first-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/clefs-ref.mscx
+++ b/mtest/libmscore/compat114/clefs-ref.mscx
@@ -8,7 +8,6 @@
       <minSystemDistance>9.2</minSystemDistance>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.2</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/drumset-ref.mscx
+++ b/mtest/libmscore/compat114/drumset-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/fingering-ref.mscx
+++ b/mtest/libmscore/compat114/fingering-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/hairpin-ref.mscx
+++ b/mtest/libmscore/compat114/hairpin-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
+++ b/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
@@ -8,7 +8,6 @@
       <minSystemDistance>9.2</minSystemDistance>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.2</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/keysig-ref.mscx
+++ b/mtest/libmscore/compat114/keysig-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/noteheads-ref.mscx
+++ b/mtest/libmscore/compat114/noteheads-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/notes-ref.mscx
+++ b/mtest/libmscore/compat114/notes-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/ottava-ref.mscx
+++ b/mtest/libmscore/compat114/ottava-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/pedal-ref.mscx
+++ b/mtest/libmscore/compat114/pedal-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/slurs-ref.mscx
+++ b/mtest/libmscore/compat114/slurs-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/style-ref.mscx
+++ b/mtest/libmscore/compat114/style-ref.mscx
@@ -167,6 +167,8 @@
             </Rest>
           <BarLine>
             <subtype>end</subtype>
+            <linked>
+              </linked>
             </BarLine>
           </voice>
         </Measure>
@@ -418,6 +420,7 @@
             </Rest>
           <BarLine>
             <subtype>end</subtype>
+            <linkedMain/>
             </BarLine>
           </voice>
         </Measure>

--- a/mtest/libmscore/compat114/style-ref.mscx
+++ b/mtest/libmscore/compat114/style-ref.mscx
@@ -14,7 +14,6 @@
       <systemFrameDistance>6</systemFrameDistance>
       <frameSystemDistance>6</frameSystemDistance>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <repeatBarTips>1</repeatBarTips>
       <startBarlineSingle>1</startBarlineSingle>
       <startBarlineMultiple>0</startBarlineMultiple>

--- a/mtest/libmscore/compat114/tamtam-ref.mscx
+++ b/mtest/libmscore/compat114/tamtam-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/text_scaling-ref.mscx
+++ b/mtest/libmscore/compat114/text_scaling-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/textline-ref.mscx
+++ b/mtest/libmscore/compat114/textline-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/textstyles-ref.mscx
+++ b/mtest/libmscore/compat114/textstyles-ref.mscx
@@ -11,7 +11,6 @@
       <lyricsDashForce>0</lyricsDashForce>
       <systemFrameDistance>1</systemFrameDistance>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <repeatBarTips>1</repeatBarTips>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.2</bracketDistance>

--- a/mtest/libmscore/compat114/title-ref.mscx
+++ b/mtest/libmscore/compat114/title-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/tremolo2notes-ref.mscx
+++ b/mtest/libmscore/compat114/tremolo2notes-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/tuplets-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/tuplets_1-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_1-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/tuplets_2-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_2-ref.mscx
@@ -7,7 +7,6 @@
     <Style>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
-      <endBarDistance>0.3</endBarDistance>
       <bracketWidth>0.35</bracketWidth>
       <bracketDistance>0.25</bracketDistance>
       <clefLeftMargin>0.5</clefLeftMargin>

--- a/mtest/libmscore/compat114/updateReference
+++ b/mtest/libmscore/compat114/updateReference
@@ -22,12 +22,13 @@ cp $S/text_scaling-test.mscx             text_scaling-ref.mscx
 cp $S/textstyles-test.mscx               textstyles-ref.mscx
 cp $S/title-test.mscx                    title-ref.mscx
 cp $S/tremolo2notes-test.mscx            tremolo2notes-ref.mscx
-cp $S/markers-test.mscx                  markers-ref.mscx
+#cp $S/markers-test.mscx                  markers-ref.mscx
 cp $S/drumset-test.mscx                  drumset-ref.mscx
 cp $S/tuplets-test.mscx                  tuplets-ref.mscx
 cp $S/tuplets_1-test.mscx                tuplets_1-ref.mscx
 cp $S/tuplets_2-test.mscx                tuplets_2-ref.mscx
 cp $S/fingering-test.mscx                fingering-ref.mscx
 cp $S/ottava-test.mscx                   ottava-ref.mscx
-cp $S/pedal-test.mscx                   pedal-ref.mscx
+cp $S/pedal-test.mscx                    pedal-ref.mscx
 cp $S/textline-test.mscx                 textline-ref.mscx
+cp $S/tamtam-test.mscx                   tamtam-ref.mscx

--- a/mtest/libmscore/compat206/hairpin-ref.mscx
+++ b/mtest/libmscore/compat206/hairpin-ref.mscx
@@ -1065,6 +1065,8 @@
               </Rest>
             <BarLine>
               <subtype>end</subtype>
+              <linked>
+                </linked>
               </BarLine>
             </voice>
           </Measure>

--- a/mtest/libmscore/splitstaff/splitstaff02-ref.mscx
+++ b/mtest/libmscore/splitstaff/splitstaff02-ref.mscx
@@ -127,6 +127,9 @@
               <tpc>15</tpc>
               </Note>
             </Chord>
+          <BarLine>
+            <span>1</span>
+            </BarLine>
           </voice>
         </Measure>
       <Measure>

--- a/mtest/libmscore/splitstaff/splitstaff04-ref.mscx
+++ b/mtest/libmscore/splitstaff/splitstaff04-ref.mscx
@@ -161,6 +161,10 @@
           <Rest>
             <durationType>quarter</durationType>
             </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
           </voice>
         </Measure>
       </Staff>

--- a/mtest/libmscore/splitstaff/splitstaff05-ref.mscx
+++ b/mtest/libmscore/splitstaff/splitstaff05-ref.mscx
@@ -161,6 +161,10 @@
           <Rest>
             <durationType>quarter</durationType>
             </Rest>
+          <BarLine>
+            <subtype>end</subtype>
+            <span>1</span>
+            </BarLine>
           </voice>
         </Measure>
       </Staff>

--- a/mtest/libmscore/tools/undoAddLineBreaks01-ref.mscx
+++ b/mtest/libmscore/tools/undoAddLineBreaks01-ref.mscx
@@ -991,6 +991,8 @@
           <BarLine>
             <subtype>end</subtype>
             <span>1</span>
+            <linked>
+              </linked>
             </BarLine>
           </voice>
         </Measure>
@@ -1003,6 +1005,7 @@
           <BarLine>
             <subtype>end</subtype>
             <span>1</span>
+            <linkedMain/>
             </BarLine>
           </voice>
         </Measure>

--- a/mtest/libmscore/tools/undoAddLineBreaks02-ref.mscx
+++ b/mtest/libmscore/tools/undoAddLineBreaks02-ref.mscx
@@ -973,6 +973,8 @@
           <BarLine>
             <subtype>end</subtype>
             <span>1</span>
+            <linked>
+              </linked>
             </BarLine>
           </voice>
         </Measure>
@@ -985,6 +987,7 @@
           <BarLine>
             <subtype>end</subtype>
             <span>1</span>
+            <linkedMain/>
             </BarLine>
           </voice>
         </Measure>

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -1276,6 +1276,12 @@
             <subtype>end-repeat</subtype>
             </BarLine>
           </Cell>
+        <Cell name="End-start repeat">
+          <staff>1</staff>
+          <BarLine>
+            <subtype>end-start-repeat</subtype>
+            </BarLine>
+          </Cell>
         <Cell name="Dashed barline">
           <staff>1</staff>
           <BarLine>
@@ -2175,7 +2181,13 @@
             <subtype>end-repeat</subtype>
             </BarLine>
           </Cell>
-        </Palette>
+        <Cell name="End-start repeat">
+          <staff>1</staff>
+          <BarLine>
+            <subtype>end-start-repeat</subtype>
+            </BarLine>
+          </Cell>
+      </Palette>
       <Palette name="Fretboard Diagrams">
         <gridWidth>42</gridWidth>
         <gridHeight>45</gridHeight>

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -48,7 +48,7 @@
           <KeySig>
             <accidental>1</accidental>
             </KeySig>
-          </Cell>voiceActions
+          </Cell>
         <Cell name="D major, B minor">
           <staff>1</staff>
           <KeySig>
@@ -204,7 +204,7 @@
           </Cell>
         <Cell name="4/4 common time">
           <staff>1</staff>
-          <TimeSig>voiceActions
+          <TimeSig>
             <subtype>1</subtype>
             <sigN>4</sigN>
             <sigD>4</sigD>
@@ -357,7 +357,7 @@
           <HairPin id="5">
             <subtype>2</subtype>
             <beginText>cresc.</beginText>
-            <continueText>(cresc.)</continueText>voiceActions
+            <continueText>(cresc.)</continueText>
             <track>0</track>
             </HairPin>
           </Cell>
@@ -387,7 +387,7 @@
             <track>0</track>
             <length>200</length>
             <endings>2</endings>
-            </Volta>voiceActions
+            </Volta>
           </Cell>
         <Cell name="Seconda volta, open">
           <Volta id="9">
@@ -465,7 +465,13 @@
           <staff>1</staff>
           <BarLine>
             <subtype>end-repeat</subtype>
-            </BarLine>voiceActions
+            </BarLine>
+          </Cell>
+        <Cell name="End-start repeat">
+          <staff>1</staff>
+          <BarLine>
+            <subtype>end-start-repeat</subtype>
+            </BarLine>
           </Cell>
         <Cell name="Dashed barline">
           <staff>1</staff>
@@ -774,6 +780,12 @@
         <Cell name="End repeat">
           <BarLine>
             <subtype>end-repeat</subtype>
+            </BarLine>
+          </Cell>
+        <Cell name="End-start repeat">
+          <staff>1</staff>
+          <BarLine>
+            <subtype>end-start-repeat</subtype>
             </BarLine>
           </Cell>
         </Palette>


### PR DESCRIPTION
So far I have fixes for:

https://musescore.org/en/node/286017
https://musescore.org/en/node/280912
https://musescore.org/en/node/102821

Currently, we don't link barlines between score & parts.  If we decided we wanted to, then this would change the approach used here, but I didn't want t change anything so fundamental, so I link barlines by their staves or scores.  The commit to fix the second & third issues listed here actually fixes quite a few related problems (eg, deleting a repeat on an mmrest does nothing, also issues with barlines getting marked "non-generated" and then not responding to changes in span for the staff).  So it's actually a very significant fix.

The code as I have it is good, I think, but I'd still like to look into https://musescore.org/en/node/282696 and https://musescore.org/en/node/283366.  I don't think this will require visiting existing code, but it does mean re-thinking some things about "generated" status, so who knows.