### PR TITLE
Save segment and stem properties correctly

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1727,7 +1727,11 @@ bool Element::isUserModified() const
                         return true;
                   }
             }
-      return !visible() || !offset().isNull() || (color() != MScore::defaultColor);
+      for (Pid p : {Pid::VISIBLE, Pid::OFFSET, Pid::COLOR, Pid::Z, Pid::AUTOPLACE}) {
+            if (getProperty(p) != propertyDefault(p))
+                  return true;
+            }
+      return false;
       }
 
 //---------------------------------------------------------

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -895,8 +895,10 @@ bool Segment::setProperty(Pid propertyId, const QVariant& v)
                   break;
             case Pid::LEADING_SPACE:
                   setExtraLeadingSpace(v.value<Spatium>());
-                  for (Element* e : _elist)
-                        if(e) e->setGenerated(false);
+                  for (Element* e : _elist) {
+                        if(e) 
+                              e->setGenerated(false);
+                        }
                   break;
             default:
                   return Element::setProperty(propertyId, v);

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -895,6 +895,8 @@ bool Segment::setProperty(Pid propertyId, const QVariant& v)
                   break;
             case Pid::LEADING_SPACE:
                   setExtraLeadingSpace(v.value<Spatium>());
+                  for (Element* e : _elist)
+                        if(e) e->setGenerated(false);
                   break;
             default:
                   return Element::setProperty(propertyId, v);


### PR DESCRIPTION
Two saving issues fixed here. The first one was leading spaces which are saved only when the element is no generated. This is normally fine, but segments are a bit disconnected from the elements related to it and so changing a segment property (which includes leading space) doesn't set the generated flag properly for related elements. Since segments contain elements for different voices, I opted to just set all of the elements related to a segment to not be generated because they all should have the leading space applied. Reading and writing segments goes by the segment anyway so if I understand the code and tested it correctly it shouldn't create issues or redundancy anyway. There are also checks in place to ensure that segments are not read and written more than once.

The second issue has to do with saving stacking order for stems. Originally this was thought to be similar to the above issue, but it's actually not. Stems are not written as a directly connected element to segments, but instead as a part of a chord which makes sense. There it writes the stem if it isUserModified(). This is a function that is used in only a few places and is a bit old. That function checks the styled properties of the element and compares it to the property default. This is good, but there are also the standard properties that all elements have and can be changed through the inspector. There's a line to check for these, but it doesn't check for all the properties.

https://musescore.org/en/node/139846
https://musescore.org/en/node/279245