### PR TITLE
fix #286948: horizontal tie normally

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -658,16 +658,12 @@ void Measure::layout2()
                         Chord* c = toChord(cr);
                         for (const Note* note : c->notes()) {
                               Tie* t = note->tieFor();
-                              if (t) {
-                                    TieSegment* ts = t->layoutFor(system());
-                                    //system->staff(ch->staffIdx())->skyline().add(ts->shape().translated(ts->pos()));
-                                    }
+                              if (t)
+                                    t->layoutFor(system());
                               t = note->tieBack();
                               if (t) {
-                                    if (t->startNote()->tick() < stick) {
-                                          TieSegment* ts = t->layoutBack(system());
-                                          //system->staff(ch->staffIdx())->skyline().add(ts->shape().translated(ts->pos()));
-                                          }
+                                    if (t->startNote()->tick() < stick)
+                                          t->layoutBack(system());
                                     }
                               for (Spanner* sp : note->spannerFor())
                                     sp->layout();

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -490,18 +490,24 @@ void Tie::slurPos(SlurPos* sp)
       else
             sp->system2 = ec->measure()->system();
 
+      // force tie to be horizontal except for cross-staff or if there is a difference of enharmonic spelling
+      bool horizontal = startNote()->tpc() == endNote()->tpc() && sc->vStaffIdx() == ec->vStaffIdx();
+
       hw = endNote()->tabHeadWidth(stt);
       if ((ec->notes().size() > 1) || (ec->stem() && !ec->up() && !_up)) {
             xo = endNote()->x() - hw * 0.12;
-            yo = endNote()->pos().y() + yOffInside;
+            if (!horizontal)
+                  yo = endNote()->pos().y() + yOffInside;
             }
       else if (shortStart) {
             xo = endNote()->x() + hw * 0.15;
-            yo = endNote()->pos().y() + yOffOutside;
+            if (!horizontal)
+                  yo = endNote()->pos().y() + yOffOutside;
             }
       else {
             xo = endNote()->x() + hw * 0.35;
-            yo = endNote()->pos().y() + yOffOutside;
+            if (!horizontal)
+                  yo = endNote()->pos().y() + yOffOutside;
             }
       sp->p2 += QPointF(xo, yo);
 


### PR DESCRIPTION
Slight regression introduce by my cross-staff slur fix - by allowing different vertical positions for the tie endpoints to support cross-staff notation and enharmonic ties, it invited slight differences for some combinations of stem & tie directions even in the normal case.  Fixed by forcing the tie to be horizontal - as was the case before - *except* for cross-staff and enharmonic ties.