### PR TITLE
fix #287022: layout of tie after turning off header elements

### DIFF
--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -675,7 +675,7 @@ TieSegment* Tie::layoutBack(System* system)
       segment->setSystem(system);
 
       qreal x;
-      Segment* seg = endNote()->chord()->segment()->prev();
+      Segment* seg = endNote()->chord()->segment()->prevEnabled();
       if (seg) {
             // find maximum width
             qreal width = 0.0;


### PR DESCRIPTION
See https://musescore.org/en/node/287022