### PR TITLE
PulseAudio and PortAudio should not be translated into zh_CN

### DIFF
--- a/share/locale/mscore_zh_CN.ts
+++ b/share/locale/mscore_zh_CN.ts
@@ -16022,12 +16022,12 @@ This will re-evaluate all plugins, picking up any changes that may have occurred
     <message>
         <location filename="../../mscore/prefsdialog.ui" line="2679"/>
         <source>PulseAudio</source>
-        <translation>脉冲音频</translation>
+        <translation>PulseAudio</translation>
     </message>
     <message>
         <location filename="../../mscore/prefsdialog.ui" line="2698"/>
         <source>PortAudio</source>
-        <translation>端口音频</translation>
+        <translation>PortAudio</translation>
     </message>
     <message>
         <location filename="../../mscore/prefsdialog.ui" line="2720"/>


### PR DESCRIPTION
PulseAudio and PortAudio should not be translated into zh_CN, because they don't have a translation in Chinese, and the current translation is weird.