### PR TITLE
fix #286530: scaling of dot, lines, and more in parts

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -216,7 +216,7 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
             score->setMetaTag("partName", partLabel);
             }
 
-      // layout score
+      // initial layout of score
       score->addLayoutFlags(LayoutFlag::FIX_PITCH_VELO);
       score->doLayout();
 
@@ -273,7 +273,13 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
                   }
             }
 
-      // layout score
+      // update style values if spatium different for part
+      if (oscore->spatium() != score->spatium()) {
+            //score->spatiumChanged(oscore->spatium(), score->spatium());
+            score->styleChanged();
+            }
+
+      // second layout of score
       score->setPlaylistDirty();
       oscore->rebuildMidiMapping();
       oscore->updateChannel();

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2737,6 +2737,8 @@ void Note::setScore(Score* s)
             _tieFor->setScore(s);
       if (_accidental)
             _accidental->setScore(s);
+      for (NoteDot* dot : _dots)
+            dot->setScore(s);
       for (Element* el : _el)
             el->setScore(s);
       }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -300,6 +300,8 @@ Score::Score(MasterScore* parent, bool forcePartStyle /* = true */)
                   style().set(Sid::dividerRight, false);
                   }
             }
+      // update style values
+      _style.precomputeValues();
       _synthesizerState = parent->_synthesizerState;
       _mscVersion = parent->_mscVersion;
       }


### PR DESCRIPTION
See https://musescore.org/en/node/286530

Two separate issues here with similar effects.  For stems, lines, tuplets, and probably some other elements, we simply weren't updating the styled properties of the cloned elements.  Many things get updated anyhow during the course of layout, but some things aren't - only on construction of the element or on styleChanged().  So, we just needed a call to styleChanged() upon generating the parts.

For dots, the issue was that after cloning the notes, we then call Note::setScore(), but this function forgot to update the dots.  So the dots on the note act like they belong to the master score instead of the part.

Both trivial fixes (one I figured out what was going on, anyhow).  For safety, I also added a Style::precomputeValues() call on generating the part, but this isn't technically necessary as long we promise not to change any spatium-dependent style values after Sid::spatium itself.