### PR TITLE
fix #284644: offset of instrument name when generating parts

### DIFF
--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -211,7 +211,6 @@ void Excerpt::createExcerpt(Excerpt* excerpt)
       if (!partLabel.isEmpty()) {
             Text* txt = new Text(score, Tid::INSTRUMENT_EXCERPT);
             txt->setPlainText(partLabel);
-            txt->setTrack(0);
             measure->add(txt);
             score->setMetaTag("partName", partLabel);
             }


### PR DESCRIPTION
See https://musescore.org/en/node/284644.  The offset is because the default placement for text is below (not sure why, but it is), and this causes TextBase::layout() to add in a staff height.  It only does this if the text has a staff, but for no obvious reason (including checking history), we were setting the track of the instrument name to 0 on generating the part, rather than leaving it at the default -1.  It fixes itself on reload because we weren't actually writing the track to the file, and on read it got set to -1 correctly.