### PR TITLE
fix #287141: select note or rest after deleting spanners or some other elements

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -2199,6 +2199,11 @@ void Score::cmdDeleteSelection()
                               tick = toNote(e)->chord()->tick();
                         else if (e->isRest())
                               tick = toRest(e)->tick();
+                        else if (e->isSpannerSegment())
+                              tick = toSpannerSegment(e)->spanner()->tick();
+                        else if (e->parent()
+                           && (e->parent()->isSegment() || e->parent()->isChord()))
+                              tick = e->parent()->tick();
                         //else tick < 0
                         track = e->track();
                         }


### PR DESCRIPTION
This is a simple option to fix [the issue](https://musescore.org/en/node/287141) with keeping a selection active after removing a slur or some other marking. This patch just makes MuseScore select a note or rest after removing spanners or something that has a chord or a segment as its parent. The problem still persists on undoing the removal operation because of the limited list of the elements for which selection is restored on undo. That one though requires more accuracy since not all elements can be safely referenced from within an undo stack.