### PR TITLE
Plugins API: disable tick property of Element

### DIFF
--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -243,7 +243,7 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY_T( bool, autoplace,       AUTOPLACE                 )
       API_PROPERTY( dashLineLen,             DASH_LINE_LEN             )
       API_PROPERTY( dashGapLen,              DASH_GAP_LEN              )
-      API_PROPERTY_READ_ONLY( tick,          TICK                      )
+//       API_PROPERTY_READ_ONLY( tick,          TICK                      ) // wasn't available in 2.X, disabled due to fractions transition
       API_PROPERTY( playbackVoice1,          PLAYBACK_VOICE1           )
       API_PROPERTY( playbackVoice2,          PLAYBACK_VOICE2           )
       API_PROPERTY( playbackVoice3,          PLAYBACK_VOICE3           )


### PR DESCRIPTION
Disable Element::tick due to fractions transition, at least until
a proper solution on it will be implemented in plugins.
Integer ticks are still available in Segment objects, like it was
for plugins in MuseScore 2.X.