### PR TITLE
fix #287102: Remove Selected Range (Timewise Delete) of a partial not…

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -572,7 +572,7 @@ void Score::createCRSequence(const Fraction& f, ChordRest* cr, const Fraction& t
             ChordRest* ncr = toChordRest(cr->clone());
             ncr->setDurationType(d);
             ncr->setTicks(d.fraction());
-
+            undoAddCR(ncr, measure, measure->tick() + tick);
             if (cr->isChord() && ocr) {
                   Chord* nc = toChord(ncr);
                   Chord* oc = toChord(ocr);
@@ -588,7 +588,7 @@ void Score::createCRSequence(const Fraction& f, ChordRest* cr, const Fraction& t
                         undoAddElement(tie);
                         }
                   }
-            undoAddCR(ncr, measure, tick);
+            
             tick += ncr->actualTicks();
             ocr = ncr;
             }


### PR DESCRIPTION
…e in another voice leads to crash.

Resolves https://musescore.org/en/node/287102 by:
- Change the tick that is passed to `undoAddCR` to an absolute one.
- Call `undoAddCR` before the tie is added, so the segment of the cloned `ncr` is valid.