### PR TITLE
Start sequencer after a possible app settings re-init on first start

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7498,11 +7498,6 @@ int main(int argc, char* av[])
       gscore->setScoreFont(scoreFont);
       gscore->setNoteHeadWidth(scoreFont->width(SymId::noteheadBlack, gscore->spatium()) / SPATIUM20);
 
-      if (!noSeq) {
-            if (!seq->init())
-                  qDebug("sequencer init failed");
-            }
-
       //read languages list
       mscore->readLanguages(mscoreGlobalShare + "locale/languages.xml");
 
@@ -7543,6 +7538,11 @@ int main(int argc, char* av[])
                   QString keyboardLayout = preferences.getString(PREF_APP_KEYBOARDLAYOUT);
                   StartupWizard::autoSelectShortcuts(keyboardLayout);
                   }
+            }
+
+      if (!noSeq) {
+            if (!seq->init())
+                  qDebug("sequencer init failed");
             }
 
       QApplication::instance()->installEventFilter(mscore);


### PR DESCRIPTION
This may fix the crash on Windows in paCallback (portmidi) that may be caused by an attempt to read the invalid QSettings instance that gets [deleted](https://github.com/dmitrio95/MuseScore/blob/668036bd1d3751cfce4c9143c05a7696a90e5596/mscore/preferences.cpp#L33) on [preferences.init() call](https://github.com/dmitrio95/MuseScore/blob/668036bd1d3751cfce4c9143c05a7696a90e5596/mscore/musescore.cpp#L7525) that is made after showing the Startup Wizard.

Unfortunately I couldn't reproduce the crash myself so the only way to check whether this will fix it is probably tracking new crash reports.