### PR TITLE
Try to fix a crash on crash handler destruction

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7071,10 +7071,13 @@ int main(int argc, char* av[])
       QCoreApplication::setApplicationVersion(VERSION);
 
 #ifdef BUILD_CRASH_REPORTER
+      {
       static_assert(sizeof(CRASHREPORTER_EXECUTABLE) > 1,
          "CRASHREPORTER_EXECUTABLE should be defined to build with crash reporter"
          );
-      std::unique_ptr<CrashReporter::Handler> crashHandler(new CrashReporter::Handler(QDir::tempPath(), true, CRASHREPORTER_EXECUTABLE));
+      CrashReporter::Handler* crashHandler = new CrashReporter::Handler(QDir::tempPath(), true, CRASHREPORTER_EXECUTABLE);
+      QObject::connect(app, &QCoreApplication::aboutToQuit, [crashHandler]() { delete crashHandler; });
+      }
 #endif
 
       QAccessible::installFactory(AccessibleScoreView::ScoreViewFactory);


### PR DESCRIPTION
This is another attempt to fix a crash on crash handler destruction (see #4759). The current fix is based on an assumption that the current crashes may be related to differences in variables destruction process between the cases when quitting the program is caused by `exit()` call or by `return` statement inside the `main()` function. This patch tries to resolve the issue by binding the crash handler destruction process to [`QCoreApplication::aboutToQuit()`](https://doc.qt.io/qt-5/qcoreapplication.html#aboutToQuit) signal which should probably behave equally in both cases.

Similar to #4873, there doesn't seem to be a reliable way to check whether this actually helps except for tracking new crash reports.