### PR TITLE
Paste half/double

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -903,7 +903,7 @@ void Score::pasteSymbols(XmlReader& e, ChordRest* dst)
 //   cmdPaste
 //---------------------------------------------------------
 
-void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view)
+void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
       {
       if (ms == 0) {
             qDebug("no application mime data");
@@ -981,14 +981,6 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view)
                         qDebug("paste <%s>", data.data());
                   XmlReader e(data);
                   e.setPasteMode(true);
-                  Fraction scale = Fraction(1, 1);
-                  if (_is.noteEntryMethod() == NoteEntryMethod::TIMEWISE) {
-                        Fraction f = _is.duration().fraction();
-                        if (f.isValid() && !f.isZero()) {
-                              scale = f * 4;
-                              scale.reduce();
-                              }
-                        }
                   if (!pasteStaff(e, cr->segment(), cr->staffIdx(), scale))
                         return;
                   }

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -978,6 +978,13 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view)
                   XmlReader e(data);
                   e.setPasteMode(true);
                   Fraction scale = Fraction(1, 1);
+                  if (_is.noteEntryMethod() == NoteEntryMethod::TIMEWISE) {
+                        Fraction f = _is.duration().fraction();
+                        if (f.isValid() && !f.isZero()) {
+                              scale = f * 4;
+                              scale.reduce();
+                              }
+                        }
                   if (!pasteStaff(e, cr->segment(), cr->staffIdx(), scale))
                         return;
                   }

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -176,9 +176,11 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
                               tuplet = new Tuplet(this);
                               tuplet->setTrack(e.track());
                               tuplet->read(e);
-                              tuplet->setTicks(tuplet->ticks() * scale);
-                              Fraction baseLen = tuplet->baseLen().fraction();
-                              tuplet->setBaseLen(baseLen * scale);
+                              if (scale != Fraction(1, 1)) {
+                                    tuplet->setTicks(tuplet->ticks() * scale);
+                                    Fraction baseLen = tuplet->baseLen().fraction();
+                                    tuplet->setBaseLen(baseLen * scale);
+                                    }
                               Measure* measure = tick2measure(tick);
                               tuplet->setParent(measure);
                               tuplet->setTick(tick);
@@ -232,8 +234,10 @@ bool Score::pasteStaff(XmlReader& e, Segment* dst, int dstStaff, Fraction scale)
                                     if (tuplet)
                                           cr->readAddTuplet(tuplet);
                                     e.incTick(cr->actualTicks());
-                                    cr->setTicks(cr->ticks() * scale);
-                                    cr->setDurationType(cr->ticks());
+                                    if (scale != Fraction(1, 1)) {
+                                          cr->setTicks(cr->ticks() * scale);
+                                          cr->setDurationType(cr->ticks());
+                                          }
                                     if (cr->isChord()) {
                                           Chord* chord = toChord(cr);
                                           // disallow tie across barline within two-note tremolo

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -881,7 +881,7 @@ class Score : public QObject, public ScoreElement {
       void styleChanged();
 
       void cmdPaste(const QMimeData* ms, MuseScoreView* view);
-      bool pasteStaff(XmlReader&, Segment* dst, int staffIdx);
+      bool pasteStaff(XmlReader&, Segment* dst, int staffIdx, Fraction scale = Fraction(1, 1));
       void readAddConnector(ConnectorInfoReader* info, bool pasteMode) override;
       void pasteSymbols(XmlReader& e, ChordRest* dst);
       void renderMidi(EventMap* events, const SynthesizerState& synthState);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -880,7 +880,7 @@ class Score : public QObject, public ScoreElement {
       void spatiumChanged(qreal oldValue, qreal newValue);
       void styleChanged();
 
-      void cmdPaste(const QMimeData* ms, MuseScoreView* view);
+      void cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale = Fraction(1, 1));
       bool pasteStaff(XmlReader&, Segment* dst, int staffIdx, Fraction scale = Fraction(1, 1));
       void readAddConnector(ConnectorInfoReader* info, bool pasteMode) override;
       void pasteSymbols(XmlReader& e, ChordRest* dst);

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -53,6 +53,14 @@
     <seq>Ctrl+V</seq>
     </SC>
   <SC>
+    <key>paste-half</key>
+    <seq>Ctrl+Shift+Q</seq>
+    </SC>
+  <SC>
+    <key>paste-double</key>
+    <seq>Ctrl+Shift+W</seq>
+    </SC>
+  <SC>
     <key>swap</key>
     <seq>Ctrl+Shift+X</seq>
     </SC>

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1324,6 +1324,8 @@ MuseScore::MuseScore()
       menuEdit->addAction(getAction("cut"));
       menuEdit->addAction(getAction("copy"));
       menuEdit->addAction(getAction("paste"));
+      menuEdit->addAction(getAction("paste-half"));
+      menuEdit->addAction(getAction("paste-double"));
       menuEdit->addAction(getAction("swap"));
       menuEdit->addAction(getAction("delete"));
 

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1713,11 +1713,11 @@ void ScoreView::normalSwap()
 //   normalPaste
 //---------------------------------------------------------
 
-bool ScoreView::normalPaste()
+bool ScoreView::normalPaste(Fraction scale)
       {
       _score->startCmd();
       const QMimeData* ms = QApplication::clipboard()->mimeData();
-      _score->cmdPaste(ms, this);
+      _score->cmdPaste(ms, this, scale);
       bool rv = MScore::_error == MS_NO_ERROR;
       _score->endCmd();
       return rv;
@@ -1796,6 +1796,21 @@ void ScoreView::cmd(const char* s)
                   normalPaste();
             else if (state == ViewState::EDIT)
                   editPaste();
+            }
+      else if (cmd == "paste-half") {
+            normalPaste(Fraction(1, 2));
+            }
+      else if (cmd == "paste-double") {
+            normalPaste(Fraction(2, 1));
+            }
+      else if (cmd == "paste-special") {
+            Fraction scale = Fraction(1, 1);
+            Fraction duration = _score->inputState().duration().fraction();
+            if (duration.isValid() && !duration.isZero()) {
+                  scale = duration * 4;
+                  scale.reduce();
+                  }
+            normalPaste(scale);
             }
       else if (cmd == "swap") {
             if (state == ViewState::NORMAL)

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -267,7 +267,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void normalCut();
       void normalCopy();
       void fotoModeCopy();
-      bool normalPaste();
+      bool normalPaste(Fraction scale = Fraction(1, 1));
       void normalSwap();
 
       void cloneElement(Element* e);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -215,6 +215,36 @@ Shortcut Shortcut::_sc[] = {
          },
       {
          MsWidget::SCORE_TAB,
+         STATE_NORMAL,
+         "paste-half",
+         QT_TRANSLATE_NOOP("action","Paste Half Duration"),
+         QT_TRANSLATE_NOOP("action","Paste half duration"),
+         0,
+         Icons::paste_ICON,
+         Qt::ApplicationShortcut
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL,
+         "paste-double",
+         QT_TRANSLATE_NOOP("action","Paste Double Duration"),
+         QT_TRANSLATE_NOOP("action","Paste double duration"),
+         0,
+         Icons::paste_ICON,
+         Qt::ApplicationShortcut
+         },
+      {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL,
+         "paste-special",
+         QT_TRANSLATE_NOOP("action","Paste Special"),
+         QT_TRANSLATE_NOOP("action","Paste special"),
+         0,
+         Icons::paste_ICON,
+         Qt::ApplicationShortcut
+         },
+      {
+         MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY | STATE_EDIT | STATE_TEXT_EDIT | STATE_LYRICS_EDIT
             | STATE_HARMONY_FIGBASS_EDIT,
          "swap",


### PR DESCRIPTION
Here are the bones of a paste half/double facility, to address the common request for a diminution/augmentation feature (halve or double a selection).  See for example https://musescore.org/en/node/278980.

The implementation is extremely simple.  It's all contained within the existing pasteStaff code, and I merely adjust the duration of each ChordRest and Tuplet as I read it, adjusting the current tick as I go.  It's only around a dozen lines of code, but so far it seems to handle everything I've thrown at it.

All we need now is a real UI.  Here is a discussion I started on that topic: https://musescore.org/en/node/287253

For review/testing purposes, I have a temporary UI that works as follows:

1) switch to note input / insert (aka timewise) sub-mode
2) exit note input mode, so you're back in normal mode, but with the insert sub-mode still selected
3) select a duration icon on the toolbar

Now, copy/paste will scale the selection according to the selected duration: quarter note = 1:1, half note = 2:1, eighth note = 1:2, etc.  In other words, make a selection, copy, choose a destination, paste - the result is scaled accordingly.

I personally envision a simple UI that basically consists of two new commands "paste half" and "paste double", but the idea of a "paste special" command with dialog box is not without merit.  Let's see how the forum discussion plays out.  Meanwhile, feel free to test the implementation itself!

