### PR TITLE
Set SVG icon size to 128×128px

### DIFF
--- a/assets/msc-icon-master.svg
+++ b/assets/msc-icon-master.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="512px" height="512px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="128px" height="128px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52 (66869) - http://www.bohemiancoding.com/sketch -->
     <title>msc-icon-master</title>
     <desc>Created with Sketch.</desc>

--- a/assets/mscx-icon.svg
+++ b/assets/mscx-icon.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="512px" height="512px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="128px" height="128px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52 (66869) - http://www.bohemiancoding.com/sketch -->
     <title>mscx-icon</title>
     <desc>Created with Sketch.</desc>

--- a/assets/mscz-icon.svg
+++ b/assets/mscz-icon.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="512px" height="512px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="128px" height="128px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52 (66869) - http://www.bohemiancoding.com/sketch -->
     <title>mscz-icon</title>
     <desc>Created with Sketch.</desc>

--- a/assets/musescore-icon-round.svg
+++ b/assets/musescore-icon-round.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="960px" height="960px" viewBox="0 0 960 960" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="128px" height="128px" viewBox="0 0 960 960" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52 (66869) - http://www.bohemiancoding.com/sketch -->
     <title>musescore-icon-round</title>
     <desc>Created with Sketch.</desc>

--- a/assets/musicxml-icon-master.svg
+++ b/assets/musicxml-icon-master.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="512px" height="512px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="128px" height="128px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52 (66869) - http://www.bohemiancoding.com/sketch -->
     <title>musicxml-icon-master</title>
     <desc>Created with Sketch.</desc>

--- a/assets/mxl-icon.svg
+++ b/assets/mxl-icon.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="512px" height="512px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="128px" height="128px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52 (66869) - http://www.bohemiancoding.com/sketch -->
     <title>mxl-icon</title>
     <desc>Created with Sketch.</desc>

--- a/assets/xml-icon.svg
+++ b/assets/xml-icon.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="48" width="48" version="1.0" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="128px" width="128px" viewBox="0 0 48 48" version="1.0" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/">
  <defs>
   <linearGradient id="e" x1="302.86" gradientUnits="userSpaceOnUse" y1="366.65" gradientTransform="matrix(.067325 0 0 .0147 -.34114 37.04)" x2="302.86" y2="609.51">
    <stop stop-opacity="0" offset="0"/>


### PR DESCRIPTION
According to freedesktop.org specs, the icon size should be the same as the size set for the directory; for `scalable`, this is 128px.

This caused problems e.g. when publishing the app to [Flathub](https://flathub.org/), where this was checked and thus blocking release, and had to be [patched around](https://github.com/flathub/org.musescore.MuseScore/blob/master/org.musescore.MuseScore.yaml#L110-L113).

Seeing as all the icons had different sizes, it shouldn’t cause problems on other platforms.