### PR TITLE
fix #279131: change anchor of slurs attached to grace notes

### DIFF
--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -24,10 +24,6 @@
 
 namespace Ms {
 
-Element* SlurTie::editEndElement;
-Element* SlurTie::editStartElement;
-QList<SlurOffsets> SlurTie::editUps;
-
 //---------------------------------------------------------
 //   draw
 //---------------------------------------------------------
@@ -101,6 +97,15 @@ static ChordRest* searchCR(Segment* segment, int startTrack, int endTrack)
       }
 
 //---------------------------------------------------------
+//   startEdit
+//---------------------------------------------------------
+
+void SlurSegment::startEdit(EditData& ed)
+      {
+      SlurTieSegment::startEdit(ed);
+      }
+
+//---------------------------------------------------------
 //   edit
 //    return true if event is accepted
 //---------------------------------------------------------
@@ -162,25 +167,71 @@ bool SlurSegment::edit(EditData& ed)
 
 void SlurSegment::changeAnchor(EditData& ed, Element* element)
       {
+      ChordRest* cr = element->isChordRest() ? toChordRest(element) : nullptr;
+      ChordRest* scr = spanner()->startCR();
+      ChordRest* ecr = spanner()->endCR();
+      if (!cr || !scr || !ecr)
+            return;
+
+      // save current start/end elements
+      for (ScoreElement* e : spanner()->linkList()) {
+            Spanner* sp = toSpanner(e);
+            score()->undoStack()->push1(new ChangeStartEndSpanner(sp, sp->startElement(), sp->endElement()));
+            }
+
       if (ed.curGrip == Grip::START) {
-            Fraction ticks = spanner()->endElement()->tick() - element->tick();
-            spanner()->undoChangeProperty(Pid::SPANNER_TICK, element->tick());
+            spanner()->undoChangeProperty(Pid::SPANNER_TICK, cr->tick());
+            Fraction ticks = ecr->tick() - cr->tick();
             spanner()->undoChangeProperty(Pid::SPANNER_TICKS, ticks);
-            int diff = element->track() - spanner()->track();
+            int diff = cr->track() - spanner()->track();
             for (auto e : spanner()->linkList()) {
                   Spanner* s = toSpanner(e);
                   s->undoChangeProperty(Pid::TRACK, s->track() + diff);
                   }
-
-            if (score()->spannerMap().removeSpanner(spanner()))
-                  score()->addSpanner(spanner());
+            scr = cr;
             }
       else {
-            spanner()->undoChangeProperty(Pid::SPANNER_TICKS,  element->tick() - spanner()->startElement()->tick());
-            int diff = element->track() - spanner()->track();
+            Fraction ticks = cr->tick() - scr->tick();
+            spanner()->undoChangeProperty(Pid::SPANNER_TICKS, ticks);
+            int diff = cr->track() - spanner()->track();
             for (auto e : spanner()->linkList()) {
                   Spanner* s = toSpanner(e);
                   s->undoChangeProperty(Pid::SPANNER_TRACK2, s->track() + diff);
+                  }
+            ecr = cr;
+            }
+
+      // update start/end elements (which could be grace notes)
+      for (ScoreElement* lsp : spanner()->linkList()) {
+            Spanner* sp = static_cast<Spanner*>(lsp);
+            if (sp == spanner()) {
+                  score()->undo(new ChangeSpannerElements(sp, scr, ecr));
+                  }
+            else {
+                  Element* se = 0;
+                  Element* ee = 0;
+                  if (scr) {
+                        QList<ScoreElement*> sel = scr->linkList();
+                        for (ScoreElement* lcr : sel) {
+                              Element* le = toElement(lcr);
+                              if (le->score() == sp->score() && le->track() == sp->track()) {
+                                    se = le;
+                                    break;
+                                    }
+                              }
+                        }
+                  if (ecr) {
+                        QList<ScoreElement*> sel = ecr->linkList();
+                        for (ScoreElement* lcr : sel) {
+                              Element* le = toElement(lcr);
+                              if (le->score() == sp->score() && le->track() == sp->track2()) {
+                                    ee = le;
+                                    break;
+                                    }
+                              }
+                        }
+                  score()->undo(new ChangeStartEndSpanner(sp, se, ee));
+                  sp->layout();
                   }
             }
 
@@ -193,6 +244,15 @@ void SlurSegment::changeAnchor(EditData& ed, Element* element)
             ed.view->startEdit(newSegment, ed.curGrip);
             triggerLayout();
             }
+      }
+
+//---------------------------------------------------------
+//   endEdit
+//---------------------------------------------------------
+
+void SlurSegment::endEdit(EditData& ed)
+      {
+      SlurTieSegment::endEdit(ed);
       }
 
 //---------------------------------------------------------

--- a/libmscore/slur.h
+++ b/libmscore/slur.h
@@ -41,7 +41,9 @@ class SlurSegment final : public SlurTieSegment {
       void layoutSegment(const QPointF& p1, const QPointF& p2);
 
       bool isEdited() const;
+      virtual void startEdit(EditData&) override;
       virtual bool edit(EditData&) override;
+      virtual void endEdit(EditData&) override;
       virtual void updateGrips(EditData&) const override;
 
       Slur* slur() const { return toSlur(spanner()); }

--- a/libmscore/slurtie.cpp
+++ b/libmscore/slurtie.cpp
@@ -107,8 +107,9 @@ void SlurTieSegment::startEdit(EditData& ed)
 //   endEdit
 //---------------------------------------------------------
 
-void SlurTieSegment::endEdit(EditData&)
+void SlurTieSegment::endEdit(EditData& ed)
       {
+      Element::endEdit(ed);
       }
 
 //---------------------------------------------------------

--- a/libmscore/slurtie.h
+++ b/libmscore/slurtie.h
@@ -128,10 +128,6 @@ class SlurTieSegment : public SpannerSegment {
 class SlurTie : public Spanner {
       int _lineType;    // 0 = solid, 1 = dotted, 2 = dashed, 3 = wide dashed
 
-      static Element* editStartElement;
-      static Element* editEndElement;
-      static QList<SlurOffsets> editUps;
-
    protected:
       bool _up;               // actual direction
 


### PR DESCRIPTION
The code that originally allowed one to change anchors of slurs involving grace notes was lost here: https://github.com/musescore/MuseScore/commit/6d301fbbf5ec55b4708b19b4bf65d923045071e3.  Not sure if it was actually working at that time, but this was similar to the 2.3.2 code that did work.  Basically, I'm just reinstating that code but updating it for how things are structured now.  BTW, doing all the work in changeAnchor() rather than putting some of it off until endEdit() simplified undo/redo.