### PR TITLE
fix #286616, fix #287432: handling of header/trailer on mmrests

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1809,13 +1809,14 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                   if (e && e->isClef()) {
                         Clef* clef = toClef(e);
                         if (!mmrClefSeg->element(track)) {
-                              Clef* mmrClef = clef->clone();
+                              Clef* mmrClef = clef->generated() ? clef->clone() : toClef(clef->linkedClone());
                               mmrClef->setParent(mmrClefSeg);
                               undoAddElement(mmrClef);
                               }
                         else {
                               Clef* mmrClef = toClef(mmrClefSeg->element(track));
                               mmrClef->setClefType(clef->clefType());
+                              mmrClef->setShowCourtesy(clef->showCourtesy());
                               }
                         }
                   }
@@ -1873,6 +1874,8 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
       if (cs) {
             if (ns == 0)
                   ns = mmr->undoGetSegmentR(SegmentType::Clef, lm->ticks());
+            ns->setEnabled(cs->enabled());
+            ns->setTrailer(cs->trailer());
             for (int staffIdx = 0; staffIdx < _staves.size(); ++staffIdx) {
                   int track = staffIdx * VOICES;
                   Clef* clef = toClef(cs->element(track));
@@ -1885,8 +1888,10 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                         }
                   }
             }
-      else if (ns)
+      else if (ns) {
+            // TODO: remove elements from ns?
             undo(new RemoveElement(ns));
+            }
 
       //
       // check for time signature
@@ -1896,13 +1901,15 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
       if (cs) {
             if (ns == 0)
                   ns = mmr->undoGetSegmentR(SegmentType::TimeSig, Fraction(0,1));
+            ns->setEnabled(cs->enabled());
+            ns->setHeader(cs->header());
             for (int staffIdx = 0; staffIdx < _staves.size(); ++staffIdx) {
                   int track = staffIdx * VOICES;
                   TimeSig* ts = toTimeSig(cs->element(track));
                   if (ts) {
                         TimeSig* nts = toTimeSig(ns->element(track));
                         if (!nts) {
-                              nts = ts->clone();
+                              nts = ts->generated() ? ts->clone() : toTimeSig(ts->linkedClone());
                               nts->setParent(ns);
                               undo(new AddElement(nts));
                               }
@@ -1913,8 +1920,10 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                         }
                   }
             }
-      else if (ns)
+      else if (ns) {
+            // TODO: remove elements from ns?
             undo(new RemoveElement(ns));
+            }
 
       //
       // check for ambitus
@@ -1941,8 +1950,10 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                         }
                   }
             }
-      else if (ns)
+      else if (ns) {
+            // TODO: remove elements from ns?
             undo(new RemoveElement(ns));
+            }
 
       //
       // check for key signature
@@ -1952,27 +1963,37 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
       if (cs) {
             if (ns == 0)
                   ns = mmr->undoGetSegmentR(SegmentType::KeySig, Fraction(0,1));
+            ns->setEnabled(cs->enabled());
+            ns->setHeader(cs->header());
             for (int staffIdx = 0; staffIdx < _staves.size(); ++staffIdx) {
                   int track = staffIdx * VOICES;
-                  KeySig* ts  = toKeySig(cs->element(track));
-                  KeySig* nts = toKeySig(ns->element(track));
-                  if (ts) {
-                        if (!nts) {
-                              KeySig* nks = ts->clone();
+                  KeySig* ks  = toKeySig(cs->element(track));
+                  if (ks) {
+                        KeySig* nks = toKeySig(ns->element(track));
+                        if (!nks) {
+                              nks = ks->generated() ? ks->clone() : toKeySig(ks->linkedClone());
                               nks->setParent(ns);
                               undo(new AddElement(nks));
                               }
                         else {
-                              if (!(nts->keySigEvent() == ts->keySigEvent())) {
-                                    bool addKey = ts->isChange();
-                                    undo(new ChangeKeySig(nts, ts->keySigEvent(), nts->showCourtesy(), addKey));
+                              if (!(nks->keySigEvent() == ks->keySigEvent())) {
+                                    bool addKey = ks->isChange();
+                                    undo(new ChangeKeySig(nks, ks->keySigEvent(), nks->showCourtesy(), addKey));
                                     }
                               }
                         }
                   }
             }
-      else if (ns && ns->empty())
-            undo(new RemoveElement(ns));
+      else if (ns) {
+            ns->setEnabled(false);
+            // TODO: remove elements from ns, then delete ns
+            // previously we removed the segment if not empty,
+            // but this resulted in "stale" keysig in mmrest after removed from underlying measure
+            //undo(new RemoveElement(ns));
+            }
+
+      mmr->checkHeader();
+      mmr->checkTrailer();
 
       //
       // check for rehearsal mark etc.

--- a/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
+++ b/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
@@ -97,6 +97,7 @@
             <transposingClefType>G</transposingClefType>
             </Clef>
           <TimeSig>
+            <linkedMain/>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
@@ -110,6 +111,9 @@
         <multiMeasureRest>4</multiMeasureRest>
         <voice>
           <TimeSig>
+            <linked>
+              <indexDiff>-1</indexDiff>
+              </linked>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>

--- a/mtest/libmscore/compat114/style-ref.mscx
+++ b/mtest/libmscore/compat114/style-ref.mscx
@@ -146,6 +146,7 @@
             <transposingClefType>G</transposingClefType>
             </Clef>
           <TimeSig>
+            <linkedMain/>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
@@ -159,6 +160,9 @@
         <multiMeasureRest>32</multiMeasureRest>
         <voice>
           <TimeSig>
+            <linked>
+              <indexDiff>-1</indexDiff>
+              </linked>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>

--- a/mtest/libmscore/measure/mmrest-ref.mscx
+++ b/mtest/libmscore/measure/mmrest-ref.mscx
@@ -97,6 +97,7 @@
       <Measure>
         <voice>
           <TimeSig>
+            <linkedMain/>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
@@ -113,6 +114,9 @@
           </LayoutBreak>
         <voice>
           <TimeSig>
+            <linked>
+              <indexDiff>-1</indexDiff>
+              </linked>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>

--- a/mtest/testscript/scripts/#173381-mmrest-copy.mscx
+++ b/mtest/testscript/scripts/#173381-mmrest-copy.mscx
@@ -94,6 +94,7 @@
       <Measure>
         <voice>
           <TimeSig>
+            <linkedMain/>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>
@@ -107,6 +108,9 @@
         <multiMeasureRest>3</multiMeasureRest>
         <voice>
           <TimeSig>
+            <linked>
+              <indexDiff>-1</indexDiff>
+              </linked>
             <sigN>4</sigN>
             <sigD>4</sigD>
             </TimeSig>


### PR DESCRIPTION
A few more issues involve extra key signatures or other elements appearing on certain operations involving multimeasure rests.  See https://musescore.org/en/node/286616 and https://musescore.org/en/node/287432.  There are a few other glitches fixed by this that didn't seem worth submitting additional reports for.

Three main aspects to my changes here, involving the handling of header & trailer elements when creating mmrests:

1) link any non-generated clef, time signature, or key signature between mmrest and underlying measure
2) set the ENABLED and HEADER/TRAILER flags on the segments when copying elements
3) set the HEADER/TRAILER flags on the mmrest itself