### PR TITLE
eliminate page sizes from Jazz templates

### DIFF
--- a/share/templates/05-Jazz/01-Jazz_Lead_Sheet.mscx
+++ b/share/templates/05-Jazz/01-Jazz_Lead_Sheet.mscx
@@ -9,9 +9,6 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.5</pageWidth>
-      <pageHeight>11</pageHeight>
-      <pagePrintableWidth>7.7126</pagePrintableWidth>
       <lyricsLineThickness>0.3</lyricsLineThickness>
       <lyricsOddFontFace>MuseJazz Text</lyricsOddFontFace>
       <lyricsEvenFontFace>MuseJazz Text</lyricsEvenFontFace>

--- a/share/templates/05-Jazz/02-Big_Band.mscx
+++ b/share/templates/05-Jazz/02-Big_Band.mscx
@@ -9,11 +9,6 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.5</pageWidth>
-      <pageHeight>11</pageHeight>
-      <pagePrintableWidth>7.7126</pagePrintableWidth>
-      <pageEvenBottomMargin>0.393701</pageEvenBottomMargin>
-      <pageOddBottomMargin>0.393701</pageOddBottomMargin>
       <lyricsLineThickness>0.3</lyricsLineThickness>
       <lyricsOddFontFace>MuseJazz Text</lyricsOddFontFace>
       <lyricsEvenFontFace>MuseJazz Text</lyricsEvenFontFace>

--- a/share/templates/05-Jazz/03-Jazz_Combo.mscx
+++ b/share/templates/05-Jazz/03-Jazz_Combo.mscx
@@ -9,9 +9,6 @@
       </Synthesizer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.5</pageWidth>
-      <pageHeight>11</pageHeight>
-      <pagePrintableWidth>7.7126</pagePrintableWidth>
       <lyricsLineThickness>0.3</lyricsLineThickness>
       <lyricsOddFontFace>MuseJazz Text</lyricsOddFontFace>
       <lyricsEvenFontFace>MuseJazz Text</lyricsEvenFontFace>


### PR DESCRIPTION
Otherwise scores created from these templates come out as Letter, even in Europe, where it should be A4