### PR TITLE
fix #284461: bad layout of diagonal lines with hooks

### DIFF
--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -212,8 +212,9 @@ void TextLineBaseSegment::layout()
       QPointF pp1;
       QPointF pp2(pos2());
 
-      // diagonal line with no text - just use the basic rectangle for line (ignore hooks)
-      if (_text->empty() && _endText->empty() && pp2.y() != 0) {
+      // diagonal line with no text or hooks - just use the basic rectangle for line
+      if (_text->empty() && _endText->empty() && pp2.y() != 0
+          && textLineBase()->beginHookType() == HookType::NONE && textLineBase()->beginHookType() == HookType::NONE) {
             npoints = 2;
             points[0] = pp1;
             points[1] = pp2;
@@ -221,7 +222,7 @@ void TextLineBaseSegment::layout()
             return;
             }
 
-      // line has text or is not diagonal - calculate reasonable bbox
+      // line has text or hooks or is not diagonal - calculate reasonable bbox
 
       qreal x1 = qMin(0.0, pp2.x());
       qreal x2 = qMax(0.0, pp2.x());


### PR DESCRIPTION
See https://musescore.org/en/node/284461.  We had a special case for diagonal lines with no text (designed to produced a tight bbox I guess) that just ignored hooks, and this caused us to skip all the code necessary to lay them out.  So, I just made the special case only apply if no text *or* hooks.  We end up with a bigger bbox, but that's the case already if there is text, and in any case is mostly harmless as we don't use this in autoplace.