### PR TITLE
Fix tests after merging #4779

### DIFF
--- a/libmscore/letring.cpp
+++ b/libmscore/letring.cpp
@@ -64,6 +64,10 @@ LetRing::LetRing(Score* s)
 
       resetProperty(Pid::BEGIN_TEXT_PLACE);
       resetProperty(Pid::BEGIN_TEXT);
+      resetProperty(Pid::CONTINUE_TEXT_PLACE);
+      resetProperty(Pid::CONTINUE_TEXT);
+      resetProperty(Pid::END_TEXT_PLACE);
+      resetProperty(Pid::END_TEXT);
       }
 
 //---------------------------------------------------------

--- a/libmscore/palmmute.cpp
+++ b/libmscore/palmmute.cpp
@@ -83,6 +83,10 @@ PalmMute::PalmMute(Score* s)
 
       resetProperty(Pid::BEGIN_TEXT_PLACE);
       resetProperty(Pid::BEGIN_TEXT);
+      resetProperty(Pid::CONTINUE_TEXT_PLACE);
+      resetProperty(Pid::CONTINUE_TEXT);
+      resetProperty(Pid::END_TEXT_PLACE);
+      resetProperty(Pid::END_TEXT);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Fixes test failures after merging #4779 due to having certain properties of `PalmMute` and `LetRing` uninitialized.