### PR TITLE
add double articulations to the My_First_Score template

### DIFF
--- a/share/templates/My_First_Score.mscx
+++ b/share/templates/My_First_Score.mscx
@@ -68,9 +68,21 @@
           <gateTime>67</gateTime>
           </Articulation>
         <Articulation name="sforzato">
-          <velocity>120</velocity>
-          <gateTime>100</gateTime>
-          </Articulation>
+            <velocity>150</velocity>
+            <gateTime>100</gateTime>
+        </Articulation>
+        <Articulation name="sforzatoStaccato">
+              <velocity>150</velocity>
+              <gateTime>50</gateTime>
+        </Articulation>
+        <Articulation name="marcatoStaccato">
+              <velocity>120</velocity>
+              <gateTime>50</gateTime>
+        </Articulation>
+        <Articulation name="marcatoTenuto">
+              <velocity>120</velocity>
+              <gateTime>100</gateTime>
+        </Articulation>
         <Channel>
           <program value="0"/>
           <synti>Fluid</synti>


### PR DESCRIPTION
The changes were missed because My_First_Score template was in .mscz format