### PR TITLE
fix #274614, fix #273783: fix crashes on stopping sequencer during soundfond loading

### DIFF
--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -345,7 +345,9 @@ void Seq::start()
 
 void Seq::stop()
       {
-      if (state == Transport::STOP)
+      const bool seqStopped = (state == Transport::STOP);
+      const bool driverStopped = !_driver || _driver->getState() == Transport::STOP;
+      if (seqStopped && driverStopped)
             return;
 
       if (oggInit) {


### PR DESCRIPTION
This pull request should fix these crashes:
https://musescore.org/en/node/274614
https://musescore.org/en/node/273783

The previous `Seq::stop()` code seems to assume that the sequencer state matches the underlying audiosystem driver state when this function gets called. Still this assumption may get violated if there is a significant time lag between switching the driver to the playback mode and receiving the first callbacks (`Seq::process()`) from it. This is exactly the case of the initial soundfont loading which takes place in parallel, may take a significant time and doesn't prevent a user from starting/stopping a playback or doing any other related operations. Adjusting the code to take into account the fact that the sequencer state and the driver state may be different fixes the issue.