### PR TITLE
fix #286531: change staff type works for all options

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -471,6 +471,8 @@ bool BarLine::isBottom() const
 
 void BarLine::draw(QPainter* painter) const
       {
+      if (staff() && !staff()->staffType(tick())->showBarlines())
+            return;
       switch (barLineType()) {
             case BarLineType::NORMAL: {
                   qreal lw = score()->styleP(Sid::barWidth) * mag();

--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -101,7 +101,8 @@ void KeySig::layout()
             }
 
       _sig.keySymbols().clear();
-      if (staff() && !staff()->genKeySig())     // no key sigs on TAB staves
+      // no key sigs on TAB staves or if the staff type says no key sigs
+      if (staff() && !staff()->staffType(tick())->genKeysig())
             return;
 
       // determine current clef for this staff
@@ -300,6 +301,8 @@ Shape KeySig::shape() const
 
 void KeySig::draw(QPainter* p) const
       {
+      if (staff() && !staff()->staffType(tick())->genKeysig())
+            return;
       p->setPen(curColor());
       for (const KeySym& ks: _sig.keySymbols())
             drawSymbol(ks.sym, p, QPointF(ks.pos.x(), ks.pos.y()));

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3622,18 +3622,20 @@ void Measure::addSystemHeader(bool isFirstSystem)
                         }
                   else
                         keysig  = toKeySig(kSegment->element(track));
-                  if (!keysig) {
-                        //
-                        // create missing key signature
-                        //
-                        keysig = new KeySig(score());
-                        keysig->setTrack(track);
-                        keysig->setGenerated(true);
-                        keysig->setParent(kSegment);
-                        kSegment->add(keysig);
+                  if (staff->staffType(tick())->genKeysig()) {
+                        if (!keysig) {
+                              //
+                              // create missing key signature
+                              //
+                              keysig = new KeySig(score());
+                              keysig->setTrack(track);
+                              keysig->setGenerated(true);
+                              keysig->setParent(kSegment);
+                              kSegment->add(keysig);
+                              }
+                        keysig->setKeySigEvent(keyIdx);
+                        keysig->layout();
                         }
-                  keysig->setKeySigEvent(keyIdx);
-                  keysig->layout();
                   kSegment->createShape(staffIdx);
                   kSegment->setEnabled(true);
                   }

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -68,6 +68,7 @@ EditStaff::EditStaff(Staff* s, const Fraction& /*tick*/, QWidget* parent)
       connect(lineDistance,         SIGNAL(valueChanged(double)), SLOT(lineDistanceChanged()));
       connect(showClef,             SIGNAL(clicked()),            SLOT(showClefChanged()));
       connect(showTimesig,          SIGNAL(clicked()),            SLOT(showTimeSigChanged()));
+      connect(showKeysig,           SIGNAL(clicked()),            SLOT(showKeySigChanged()));
       connect(showBarlines,         SIGNAL(clicked()),            SLOT(showBarlinesChanged()));
 
       connect(nextButton,           SIGNAL(clicked()),            SLOT(gotoNextStaff()));
@@ -155,6 +156,7 @@ void EditStaff::updateStaffType()
       lineDistance->setValue(staffType->lineDistance().val());
       showClef->setChecked(staffType->genClef());
       showTimesig->setChecked(staffType->genTimesig());
+      showKeysig->setChecked(staffType->genKeysig());
       showBarlines->setChecked(staffType->showBarlines());
       staffGroupName->setText(qApp->translate("Staff type group name", staffType->groupName()));
       }
@@ -461,6 +463,11 @@ void EditStaff::showClefChanged()
 void EditStaff::showTimeSigChanged()
       {
       staff->staffType(Fraction(0,1))->setGenTimesig(showTimesig->checkState() == Qt::Checked);
+      }
+
+void EditStaff::showKeySigChanged()
+      {
+      staff->staffType(Fraction(0,1))->setGenKeysig(showKeysig->checkState() == Qt::Checked);
       }
 
 void EditStaff::showBarlinesChanged()

--- a/mscore/editstaff.h
+++ b/mscore/editstaff.h
@@ -68,6 +68,7 @@ class EditStaff : public QDialog, private Ui::EditStaffBase {
       void numOfLinesChanged();
       void showClefChanged();
       void showTimeSigChanged();
+      void showKeySigChanged();
       void showBarlinesChanged();
       void gotoNextStaff();
       void gotoPreviousStaff();

--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>760</width>
-    <height>600</height>
+    <height>631</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -46,6 +46,20 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QGridLayout" name="grid_StaffProps">
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="showClef">
+          <property name="text">
+           <string>Show clef</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QCheckBox" name="showTimesig">
+          <property name="text">
+           <string>Show time signature</string>
+          </property>
+         </widget>
+        </item>
         <item row="4" column="2">
          <widget class="QCheckBox" name="cutaway">
           <property name="text">
@@ -53,12 +67,40 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
-         <widget class="QCheckBox" name="hideSystemBarLine">
-          <property name="text">
-           <string>Hide system barline</string>
-          </property>
-         </widget>
+        <item row="0" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Hide when empty:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="hideMode">
+            <item>
+             <property name="text">
+              <string>Auto</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Always</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Never</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Instrument</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item row="1" column="2">
          <widget class="QCheckBox" name="small">
@@ -73,48 +115,10 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="showClef">
+        <item row="6" column="2">
+         <widget class="QPushButton" name="changeStaffType">
           <property name="text">
-           <string>Show clef</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <layout class="QHBoxLayout" name="hLayout_LineColor">
-          <item>
-           <widget class="QLabel" name="labelColor">
-            <property name="text">
-             <string>Staff line color:</string>
-            </property>
-            <property name="buddy">
-             <cstring>color</cstring>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="Awl::ColorLabel" name="color">
-            <property name="focusPolicy">
-             <enum>Qt::TabFocus</enum>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::Box</enum>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="3" column="1">
-         <widget class="QCheckBox" name="showBarlines">
-          <property name="text">
-           <string>Show barlines</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QCheckBox" name="showTimesig">
-          <property name="text">
-           <string>Show time signature</string>
+           <string>Advanced Style Properties…</string>
           </property>
          </widget>
         </item>
@@ -129,13 +133,6 @@
          <widget class="QCheckBox" name="invisible">
           <property name="text">
            <string>Invisible staff lines</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="QPushButton" name="changeStaffType">
-          <property name="text">
-           <string>Advanced Style Properties…</string>
           </property>
          </widget>
         </item>
@@ -266,40 +263,50 @@
           </item>
          </layout>
         </item>
-        <item row="0" column="1">
-         <layout class="QHBoxLayout" name="horizontalLayout">
+        <item row="3" column="2">
+         <layout class="QHBoxLayout" name="hLayout_LineColor">
           <item>
-           <widget class="QLabel" name="label_2">
+           <widget class="QLabel" name="labelColor">
             <property name="text">
-             <string>Hide when empty:</string>
+             <string>Staff line color:</string>
+            </property>
+            <property name="buddy">
+             <cstring>color</cstring>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="hideMode">
-            <item>
-             <property name="text">
-              <string>Auto</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Always</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Never</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Instrument</string>
-             </property>
-            </item>
+           <widget class="Awl::ColorLabel" name="color">
+            <property name="focusPolicy">
+             <enum>Qt::TabFocus</enum>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::Box</enum>
+            </property>
            </widget>
           </item>
          </layout>
+        </item>
+        <item row="6" column="1">
+         <widget class="QCheckBox" name="hideSystemBarLine">
+          <property name="text">
+           <string>Hide system barline</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="showKeysig">
+          <property name="text">
+           <string>Show key signature</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QCheckBox" name="showBarlines">
+          <property name="text">
+           <string>Show barlines</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>
@@ -921,8 +928,6 @@
   <tabstop>hideMode</tabstop>
   <tabstop>showClef</tabstop>
   <tabstop>showTimesig</tabstop>
-  <tabstop>showBarlines</tabstop>
-  <tabstop>hideSystemBarLine</tabstop>
   <tabstop>showIfEmpty</tabstop>
   <tabstop>small</tabstop>
   <tabstop>invisible</tabstop>


### PR DESCRIPTION
Change Staff Type previously didn't work for hiding barlines and not generating key signatures. In this fix I removed the key signature from layout and ceased to draw the symbol. Additionally I also made it so that it wouldn't generate the key signature in the first place when creating system headers. For barlines I just made sure not to draw the barline. 