### PR TITLE
fix #287445, fix #287484, fix #284074: line style issues

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -48,7 +48,7 @@ static const ElementStyle hairpinStyle {
       { Sid::hairpinHeight,                      Pid::HAIRPIN_HEIGHT             },
       { Sid::hairpinContHeight,                  Pid::HAIRPIN_CONT_HEIGHT        },
       { Sid::hairpinPlacement,                   Pid::PLACEMENT                  },
-      { Sid::hairpinPosAbove,                    Pid::OFFSET                     },
+      { Sid::hairpinPosBelow,                    Pid::OFFSET                     },
       { Sid::hairpinLineStyle,                   Pid::LINE_STYLE                 },
       };
 
@@ -861,6 +861,9 @@ QVariant Hairpin::propertyDefault(Pid id) const
 
             case Pid::VELO_CHANGE_METHOD:
                   return int(VeloChangeMethod::NORMAL);
+
+            case Pid::PLACEMENT:
+                  return score()->styleV(Sid::hairpinPlacement);
 
             default:
                   return TextLineBase::propertyDefault(id);

--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -999,6 +999,11 @@ void SLine::writeProperties(XmlWriter& xml) const
       for (const SpannerSegment* seg : spannerSegments()) {
             xml.stag("Segment", seg);
             xml.tag("subtype", int(seg->spannerSegmentType()));
+            // TODO:
+            // NOSTYLE offset written in Element::writeProperties,
+            // so we probably don't need to duplicate it here
+            // see https://musescore.org/en/node/286848
+            //if (seg->propertyFlags(Pid::OFFSET) & PropertyFlags::UNSTYLED)
             xml.tag("offset", seg->offset() / _spatium);
             xml.tag("off2", seg->userOff2() / _spatium);
             seg->Element::writeProperties(xml);

--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -51,6 +51,8 @@ static const ElementStyle pedalStyle {
 void PedalSegment::layout()
       {
       TextLineBaseSegment::layout();
+      if (isStyled(Pid::OFFSET))
+            roffset() = pedal()->propertyDefault(Pid::OFFSET).toPointF();
       autoplaceSpannerSegment();
       }
 
@@ -181,6 +183,9 @@ QVariant Pedal::propertyDefault(Pid propertyId) const
 
             case Pid::LINE_VISIBLE:
                   return true;
+
+            case Pid::PLACEMENT:
+                  return score()->styleV(Sid::pedalPlacement);
 
             default:
                   return TextLineBase::propertyDefault(propertyId);

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -507,8 +507,8 @@ static const StyleType styleTypes[] {
       { Sid::autoplaceVerticalAlignRange, "autoplaceVerticalAlignRange",     int(VerticalAlignRange::SYSTEM) },
 
       { Sid::textLinePlacement,         "textLinePlacement",         int(Placement::ABOVE)  },
-      { Sid::textLinePosAbove,          "textLinePosAbove",          QPointF(.0, -3.5) },
-      { Sid::textLinePosBelow,          "textLinePosBelow",          QPointF(.0, 3.5) },
+      { Sid::textLinePosAbove,          "textLinePosAbove",          QPointF(.0, -1.0) },
+      { Sid::textLinePosBelow,          "textLinePosBelow",          QPointF(.0, 1.0) },
       { Sid::textLineFrameType,         "textLineFrameType",          int(FrameType::NO_FRAME) },
       { Sid::textLineFramePadding,      "textLineFramePadding",       0.2 },
       { Sid::textLineFrameWidth,        "textLineFrameWidth",         0.1 },

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -34,6 +34,8 @@ static const ElementStyle textLineStyle {
       { Sid::textLineTextAlign,                  Pid::BEGIN_TEXT_ALIGN        },
       { Sid::textLineTextAlign,                  Pid::CONTINUE_TEXT_ALIGN     },
       { Sid::textLineTextAlign,                  Pid::END_TEXT_ALIGN          },
+      { Sid::textLinePlacement,                  Pid::PLACEMENT               },
+      { Sid::textLinePosAbove,                   Pid::OFFSET                  },
       };
 
 //---------------------------------------------------------
@@ -43,7 +45,6 @@ static const ElementStyle textLineStyle {
 TextLineSegment::TextLineSegment(Spanner* sp, Score* s)
    : TextLineBaseSegment(sp, s, ElementFlag::MOVABLE | ElementFlag::ON_STAFF)
       {
-      setPlacement(Placement::ABOVE);
       }
 
 //---------------------------------------------------------
@@ -53,6 +54,8 @@ TextLineSegment::TextLineSegment(Spanner* sp, Score* s)
 void TextLineSegment::layout()
       {
       TextLineBaseSegment::layout();
+      if (isStyled(Pid::OFFSET))
+            roffset() = textLine()->propertyDefault(Pid::OFFSET).toPointF();
       autoplaceSpannerSegment();
       }
 
@@ -65,7 +68,6 @@ TextLine::TextLine(Score* s)
       {
       initElementStyle(&textLineStyle);
 
-      setPlacement(Placement::ABOVE);
       setBeginText("");
       setContinueText("");
       setEndText("");
@@ -89,6 +91,22 @@ TextLine::TextLine(const TextLine& tl)
       {
       }
 
+//---------------------------------------------------------
+//   write
+//---------------------------------------------------------
+
+void TextLine::write(XmlWriter& xml) const
+      {
+      if (!xml.canWrite(this))
+            return;
+      xml.stag(this);
+      // other styled properties are included in TextLineBase pids list
+      writeProperty(xml, Pid::PLACEMENT);
+      writeProperty(xml, Pid::OFFSET);
+      TextLineBase::writeProperties(xml);
+      xml.etag();
+      }
+
 static const ElementStyle textLineSegmentStyle {
       { Sid::textLinePosAbove,      Pid::OFFSET       },
       { Sid::textLineMinDistance,   Pid::MIN_DISTANCE },
@@ -110,6 +128,24 @@ LineSegment* TextLine::createLineSegment()
       }
 
 //---------------------------------------------------------
+//   getPropertyStyle
+//---------------------------------------------------------
+
+Sid TextLineSegment::getPropertyStyle(Pid pid) const
+      {
+      if (pid == Pid::OFFSET)
+            return spanner()->placeAbove() ? Sid::textLinePosAbove : Sid::textLinePosBelow;
+      return TextLineBaseSegment::getPropertyStyle(pid);
+      }
+
+Sid TextLine::getPropertyStyle(Pid pid) const
+      {
+      if (pid == Pid::OFFSET)
+            return placeAbove() ? Sid::textLinePosAbove : Sid::textLinePosBelow;
+      return TextLineBase::getPropertyStyle(pid);
+      }
+
+//---------------------------------------------------------
 //   propertyDefault
 //---------------------------------------------------------
 
@@ -117,7 +153,7 @@ QVariant TextLine::propertyDefault(Pid propertyId) const
       {
       switch (propertyId) {
             case Pid::PLACEMENT:
-                  return int(Placement::ABOVE);
+                  return score()->styleV(Sid::textLinePlacement);
             case Pid::BEGIN_TEXT:
             case Pid::CONTINUE_TEXT:
             case Pid::END_TEXT:

--- a/libmscore/textline.h
+++ b/libmscore/textline.h
@@ -24,6 +24,9 @@ class Note;
 //---------------------------------------------------------
 
 class TextLineSegment final : public TextLineBaseSegment {
+
+      virtual Sid getPropertyStyle(Pid) const override;
+
    public:
       TextLineSegment(Spanner* sp, Score* s);
       virtual ElementType type() const override       { return ElementType::TEXTLINE_SEGMENT; }
@@ -37,6 +40,9 @@ class TextLineSegment final : public TextLineBaseSegment {
 //---------------------------------------------------------
 
 class TextLine final : public TextLineBase {
+
+      virtual Sid getPropertyStyle(Pid) const override;
+
    public:
       TextLine(Score* s);
       TextLine(const TextLine&);
@@ -44,6 +50,7 @@ class TextLine final : public TextLineBase {
 
       virtual TextLine* clone() const           { return new TextLine(*this); }
       virtual ElementType type() const          { return ElementType::TEXTLINE; }
+      virtual void write(XmlWriter&) const override;
       virtual LineSegment* createLineSegment() override;
       virtual QVariant propertyDefault(Pid) const override;
       };

--- a/libmscore/trill.cpp
+++ b/libmscore/trill.cpp
@@ -47,6 +47,7 @@ int trillTableSize() {
 
 static const ElementStyle trillStyle {
       { Sid::trillPlacement, Pid::PLACEMENT },
+      { Sid::trillPosAbove,  Pid::OFFSET    },
       };
 
 //---------------------------------------------------------
@@ -136,6 +137,9 @@ void TrillSegment::layout()
       {
       if (staff())
             setMag(staff()->mag(tick()));
+      if (spanner()->placeBelow())
+            rypos() = staff() ? staff()->height() : 0.0;
+
       if (isSingleType() || isBeginType()) {
             Accidental* a = trill()->accidental();
             if (a) {
@@ -164,6 +168,8 @@ void TrillSegment::layout()
             }
       else
             symbolLine(SymId::wiggleTrill, SymId::wiggleTrill);
+      if (isStyled(Pid::OFFSET))
+            roffset() = trill()->propertyDefault(Pid::OFFSET).toPointF();
 
       autoplaceSpannerSegment();
       }
@@ -264,7 +270,6 @@ Trill::Trill(Score* s)
       _ornamentStyle = MScore::OrnamentStyle::DEFAULT;
       setPlayArticulation(true);
       initElementStyle(&trillStyle);
-      resetProperty(Pid::OFFSET);
       }
 
 Trill::~Trill()

--- a/libmscore/vibrato.h
+++ b/libmscore/vibrato.h
@@ -29,6 +29,7 @@ class VibratoSegment final : public LineSegment {
 
       void symbolLine(SymId start, SymId fill);
       void symbolLine(SymId start, SymId fill, SymId end);
+      virtual Sid getPropertyStyle(Pid) const override;
 
    protected:
    public:
@@ -51,6 +52,9 @@ class VibratoSegment final : public LineSegment {
 //---------------------------------------------------------
 
 class Vibrato final : public SLine {
+
+      virtual Sid getPropertyStyle(Pid) const override;
+
    public:
       enum class Type : char {
             GUITAR_VIBRATO, GUITAR_VIBRATO_WIDE, VIBRATO_SAWTOOTH, VIBRATO_SAWTOOTH_WIDE


### PR DESCRIPTION
See https://musescore.org/en/node/287445 and https://musescore.org/en/node/287484.  There are a number of problems with different types of lines with respect to the placement and offset style settings.  For some, the placement and/or offset style settings are completely ignored.  For others, there are problems only if you change the placement style setting from the default - the change is only partially honored, and lines revert to the old default on reset, and/or changes to the placement property get lost on save/reload.  I have a fairly complete list of all the problems in https://musescore.org/en/node/287445.

This PR fixes everything as far as I can tell.  Each line type had its own handling of these properties, so no surprise things were inconsistent.  I just made things consistent.  The main line type has PLACEMENT and OFFSET in its elementStyle array, the segment has OFFSET, and I check isStyled() on OFFSET on layout and grab the appropriate propertyDefault, etc.  There's not one big block of code I could factor out, it's a couple of lines each in a bunch of functions.

I very much doubt the tests will pass on this, and in any event, I also need to decide what to do about vibrato and text line elements, which previously completely ignored the style setting for offset and were placed directly above the staff but with my changes will now appear further above as per the style settings.  It might make sense to change the style defaults to explicitly set the offset to be consistent with what you ended up getting anyhow in 3.0.5.  I invite comment on that especially.