### PR TITLE
Save login information immediately

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -404,8 +404,6 @@ void MuseScore::closeEvent(QCloseEvent* ev)
 
       writeSettings();
 
-      _loginManager->save();
-
       ev->accept();
 
       if (Shortcut::dirty)

--- a/mscore/network/loginmanager.cpp
+++ b/mscore/network/loginmanager.cpp
@@ -438,6 +438,8 @@ void LoginManager::onLoginReply(QNetworkReply* reply, int code, const QJsonObjec
             }
       else
             emit loginError(getErrorString(reply, obj));
+
+      save();
       }
 
 //---------------------------------------------------------
@@ -455,6 +457,8 @@ void LoginManager::onLoginRefreshReply(QNetworkReply* reply, int code, const QJs
             _accessToken.clear();
             _refreshToken.clear();
             }
+
+      save();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Makes MuseScore save login information used to keep a user logged into musescore.com immediately after receiving it. Previously it was saved only on MuseScore application exit which led to loosing this information in case of an incorrect termination of MuseScore, for example, in case of a crash.