### PR TITLE
fix #283690: For breath marks, automatic placement is still active, although disabled.

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3623,16 +3623,19 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                           continue;
                                     int effectiveTrack = e->vStaffIdx() * VOICES + e->voice();
                                     if (effectiveTrack >= strack && effectiveTrack < etrack) {
-                                          skyline.add(e->shape().translated(e->pos() + p));
-                                          if (e->isChord() && toChord(e)->tremolo()) {
-                                                Tremolo* t = toChord(e)->tremolo();
-                                                Chord* c1 = t->chord1();
-                                                Chord* c2 = t->chord2();
-                                                if (!t->twoNotes() || (!c1->staffMove() && !c2->staffMove())) {
-                                                      if (t->chord() == e && t->autoplace())
-                                                            skyline.add(t->shape().translated(t->pos() + e->pos() + p));
+                                          if (e->autoplace()) {
+                                                skyline.add(e->shape().translated(e->pos() + p));
+                                                if (e->isChord() && toChord(e)->tremolo()) {
+                                                      Tremolo* t = toChord(e)->tremolo();
+                                                      Chord* c1 = t->chord1();
+                                                      Chord* c2 = t->chord2();
+                                                      if (!t->twoNotes() || (!c1->staffMove() && !c2->staffMove())) {
+                                                            if (t->chord() == e && t->autoplace())
+                                                                  skyline.add(t->shape().translated(t->pos() + e->pos() + p));
+                                                            }
                                                       }
                                                 }
+                                                
                                           }
                                     }
                               }


### PR DESCRIPTION
Resolves https://musescore.org/en/node/283690.

<del>I also fix the case when automatic placement is disabled for notes and stems.</del>

However, for the breath mark, the shape of the segment is fine. The problem occurs in the process of creating skylines in `Score::layoutSystemElements`. If the breath mark is moved lower, the skyline is also affected by the breath mark's offset, even if the breath mark's automatic placement is disabled. Then the lyrics are set according to the skyline.

<del>The current solution is to use `ipos()` instead of `pos()` when calculating the shape of chords or the skyline if there's no automatic placement, so the offset made by the user will be ignored.</del> I'm not sure whether this has potential bad influence but it does fix the issue.

The current solution is not to add the autoplace disabled elements to the skyline.