### PR TITLE
fix #283828: get rid of staff lines for the end-start-repeat barline in the Repeats palette

### DIFF
--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -2182,7 +2182,6 @@
             </BarLine>
           </Cell>
         <Cell name="End-start repeat">
-          <staff>1</staff>
           <BarLine>
             <subtype>end-start-repeat</subtype>
             </BarLine>

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -783,7 +783,6 @@
             </BarLine>
           </Cell>
         <Cell name="End-start repeat">
-          <staff>1</staff>
           <BarLine>
             <subtype>end-start-repeat</subtype>
             </BarLine>


### PR DESCRIPTION
get rid of staff lines for the end-start-repeat barline in the Repeats palette