### PR TITLE
fix #283542: fix a crash on removing vertical frame while linked score is in continuous view

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1483,6 +1483,12 @@ void Score::removeElement(Element* element)
             MeasureBase* mb = toMeasureBase(element);
             measures()->remove(mb);
             System* system = mb->system();
+
+            if (!system) { // vertical boxes are not shown in continuous view so no system
+                  Q_ASSERT(lineMode() && (element->isVBox() || element->isTBox()));
+                  return;
+                  }
+
             Page* page = system->page();
             if (element->isBox() && system->measures().size() == 1) {
                   auto i = std::find(page->systems().begin(), page->systems().end(), system);


### PR DESCRIPTION
Fixes https://musescore.org/en/node/283542.
MeasureBase having no system should (probably) never normally happen but vertical frames in continuous view constitute an exception from this rule. This patch adjusts `Score::removeElement()` to handle this situation correctly and adds the corresponding `Q_ASSERT` to catch the situations when the system absence is an unexpected behavior.