### PR TITLE
FIX #287602 Page Settings and Units Issues

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3520,6 +3520,15 @@ void Score::undoChangeStyleVal(Sid idx, const QVariant& v)
       }
 
 //---------------------------------------------------------
+//   undoChangePageSettings
+//---------------------------------------------------------
+
+void Score::undoChangePageSettings(QPageSize& ps, MPageLayout& odd, MPageLayout& even)
+{
+      undo(new ChangePageSettings(this, ps, odd, even));
+}
+
+//---------------------------------------------------------
 //   undoChangePageNumberOffset
 //---------------------------------------------------------
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1444,7 +1444,7 @@ static void checkDivider(bool left, System* s, qreal yOffset)
                   }
             else {
                   divider->rypos() += s->score()->styleD(Sid::dividerRightY) * SPATIUM20;
-                  divider->rxpos() =  s->score()->styleD(Sid::pagePrintableWidth) * DPI - divider->width();
+                  divider->rxpos() =  s->score()->style().pageOdd().paintWidth() - divider->width();
                   divider->rxpos() += s->score()->styleD(Sid::dividerRightX) * SPATIUM20;
                   }
             }
@@ -3302,7 +3302,7 @@ System* Score::collectSystem(LayoutContext& lc)
       qreal layoutSystemMinWidth = 0;
       bool firstMeasure = true;
       bool createHeader = false;
-      qreal systemWidth = styleD(Sid::pagePrintableWidth) * DPI;
+      qreal systemWidth = style().pageOdd().paintWidth();
       system->setWidth(systemWidth);
 
       // save state of measure

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -79,13 +79,6 @@ inline int trackZeroVoice(int track) { return track & ~3;    }
 
 static const int MAX_TAGS = 32;
 
-static constexpr qreal INCH      = 25.4;
-static constexpr qreal PPI       = 72.0;           // printer points per inch
-static constexpr qreal DPI_F     = 5;
-static constexpr qreal DPI       = 72.0 * DPI_F;
-static constexpr qreal SPATIUM20 = 5.0 * (DPI / 72.0);
-static constexpr qreal DPMM      = DPI / INCH;
-
 static constexpr int MAX_STAVES  = 4;
 
 static const int  SHADOW_NOTE_LIGHT       = 135;
@@ -311,6 +304,7 @@ class MScore {
       static MStyle _baseStyle;          // buildin initial style
       static MStyle _defaultStyle;       // buildin modified by preferences
       static MStyle* _defaultStyleForParts;
+      static QPageLayout::Unit _unitsValue; // copy of preferences[PREF_APP_PAGE_UNITS_VALUE]
 
       static QString _globalShare;
       static int _hRaster, _vRaster;
@@ -328,6 +322,7 @@ class MScore {
       static std::vector<MScoreError> errorList;
 
       static void init();
+      static void initPageSizes();
 
       static const MStyle& baseStyle()             { return _baseStyle;            }
       static MStyle& defaultStyle()                { return _defaultStyle;         }
@@ -335,7 +330,10 @@ class MScore {
 
       static bool readDefaultStyle(QString file);
       static void setDefaultStyle(const MStyle& s) { _defaultStyle = s; }
+      static void setDefaultStyleForParts(MStyle* s) { _defaultStyleForParts = s; }
       static void defaultStyleForPartsHasChanged();
+      static void setUnitsValue(int val)    { _unitsValue = QPageLayout::Unit(val);   }
+      static int  unitsValue()              { return int(_unitsValue);  }
 
       static const QString& globalShare()   { return _globalShare; }
       static qreal hRaster()                { return _hRaster;     }
@@ -403,6 +401,12 @@ class MScore {
       static void setError(MsError e) { _error = e; }
       static const char* errorMessage();
       static const char* errorGroup();
+
+      // used by pagesettings.cpp to group paper sizes by type
+      static std::vector<int> sizesCommon; // requires alternate sort order
+      static std::set<int> sizesMetric;
+      static std::set<int> sizesImperial;
+      static std::set<int> sizesOther;
       };
 
 //---------------------------------------------------------

--- a/libmscore/page.cpp
+++ b/libmscore/page.cpp
@@ -444,7 +444,8 @@ QList<Element*> Page::elements()
 qreal Page::tm() const
       {
       return ((!score()->styleB(Sid::pageTwosided) || isOdd())
-         ? score()->styleD(Sid::pageOddTopMargin) : score()->styleD(Sid::pageEvenTopMargin)) * DPI;
+              ? score()->style().pageOdd().topMargin()
+              : score()->style().pageEven().topMargin());
       }
 
 //---------------------------------------------------------
@@ -454,7 +455,8 @@ qreal Page::tm() const
 qreal Page::bm() const
       {
       return ((!score()->styleB(Sid::pageTwosided) || isOdd())
-         ? score()->styleD(Sid::pageOddBottomMargin) : score()->styleD(Sid::pageEvenBottomMargin)) * DPI;
+              ? score()->style().pageOdd().bottomMargin()
+              : score()->style().pageEven().bottomMargin());
       }
 
 //---------------------------------------------------------
@@ -464,7 +466,8 @@ qreal Page::bm() const
 qreal Page::lm() const
       {
       return ((!score()->styleB(Sid::pageTwosided) || isOdd())
-         ? score()->styleD(Sid::pageOddLeftMargin) : score()->styleD(Sid::pageEvenLeftMargin)) * DPI;
+              ? score()->style().pageOdd().leftMargin()
+              : score()->style().pageEven().leftMargin());
       }
 
 //---------------------------------------------------------
@@ -473,7 +476,9 @@ qreal Page::lm() const
 
 qreal Page::rm() const
       {
-      return (score()->styleD(Sid::pageWidth) - score()->styleD(Sid::pagePrintableWidth)) * DPI - lm();
+      return ((!score()->styleB(Sid::pageTwosided) || isOdd())
+              ? score()->style().pageOdd().rightMargin()
+              : score()->style().pageEven().rightMargin());
       }
 
 //---------------------------------------------------------

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2686,7 +2686,7 @@ static void readStyle(MStyle* style, XmlReader& e)
                   e.skipCurrentElement();
                   }
             else if (tag == "Spatium")
-                  style->set(Sid::spatium, e.readDouble() * DPMM);
+                  style->spatium301(e);
             else if (tag == "page-layout") {
                   PageFormat pf;
                   initPageFormat(style, &pf);
@@ -2871,7 +2871,7 @@ Score::FileError MasterScore::read114(XmlReader& e)
             else if (tag == "SyntiSettings")
                   _synthesizerState.read(e);
             else if (tag == "Spatium")
-                  setSpatium (e.readDouble() * DPMM);
+                  style().spatium301(e);
             else if (tag == "Division")
                   _fileDivision = e.readInt();
             else if (tag == "showInvisible")
@@ -2920,6 +2920,7 @@ Score::FileError MasterScore::read114(XmlReader& e)
             else if (tag == "page-layout") {
                   PageFormat pf;
                   readPageFormat(&pf, e);
+                  setPageFormat(&style(), pf);
                   }
             else if (tag == "copyright" || tag == "rights") {
                   Text* text = new Text(this);

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -366,23 +366,27 @@ struct StyleVal2 {
 
 static std::map<QString, std::map<Sid, QVariant>> excessTextStyles206;
 
-//---------------------------------------------------------
-//   setPageFormat
-//    set Style from PageFormat
-//---------------------------------------------------------
-
+//------------------------------------------------------------------------------
+//   setPageFormat - converts from PageFormat to MStyle
+//      These values might vary very slightly from the default due to rounding,
+//      and also due tothe unit conversions for v114, which stored the values in
+//      demi-points at 144ppi.
+//      MStyle::fuzzySet() does not replace the current value if it is within
+//      the specified tolerance, currently +/- 0.0001
+//------------------------------------------------------------------------------
 void setPageFormat(MStyle* style, const PageFormat& pf)
       {
-      style->set(Sid::pageWidth,            pf.size().width());
-      style->set(Sid::pageHeight,           pf.size().height());
-      style->set(Sid::pagePrintableWidth,   pf.printableWidth());
-      style->set(Sid::pageEvenLeftMargin,   pf.evenLeftMargin());
-      style->set(Sid::pageOddLeftMargin,    pf.oddLeftMargin());
-      style->set(Sid::pageEvenTopMargin,    pf.evenTopMargin());
-      style->set(Sid::pageEvenBottomMargin, pf.evenBottomMargin());
-      style->set(Sid::pageOddTopMargin,     pf.oddTopMargin());
-      style->set(Sid::pageOddBottomMargin,  pf.oddBottomMargin());
-      style->set(Sid::pageTwosided,         pf.twosided());
+      style->fuzzySet(Sid::pageWidth,            pf.size().width());
+      style->fuzzySet(Sid::pageHeight,           pf.size().height());
+      style->fuzzySet(Sid::pagePrintableWidth,   pf.printableWidth());
+      style->fuzzySet(Sid::pageEvenLeftMargin,   pf.evenLeftMargin());
+      style->fuzzySet(Sid::pageOddLeftMargin,    pf.oddLeftMargin());
+      style->fuzzySet(Sid::pageEvenTopMargin,    pf.evenTopMargin());
+      style->fuzzySet(Sid::pageEvenBottomMargin, pf.evenBottomMargin());
+      style->fuzzySet(Sid::pageOddTopMargin,     pf.oddTopMargin());
+      style->fuzzySet(Sid::pageOddBottomMargin,  pf.oddBottomMargin());
+      style->fuzzySet(Sid::pageTwosided,         pf.twosided());
+      style->toPageLayout301();
       }
 
 //---------------------------------------------------------
@@ -3540,7 +3544,7 @@ static void readStyle(MStyle* style, XmlReader& e)
             if (tag == "TextStyle")
                   readTextStyle206(style, e, excessTextStyles206);
             else if (tag == "Spatium")
-                  style->set(Sid::spatium, e.readDouble() * DPMM);
+                  style->spatium301(e);
             else if (tag == "page-layout")
                   readPageFormat(style, e);
             else if (tag == "displayInConcertPitch")

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -276,22 +276,14 @@ Score::Score(MasterScore* parent, bool forcePartStyle /* = true */)
             // inherit most style settings from parent
             _style = parent->style();
 
-            static const Sid styles[] = {
-                  Sid::pageWidth,
-                  Sid::pageHeight,
-                  Sid::pagePrintableWidth,
-                  Sid::pageEvenLeftMargin,
-                  Sid::pageOddLeftMargin,
-                  Sid::pageEvenTopMargin,
-                  Sid::pageEvenBottomMargin,
-                  Sid::pageOddTopMargin,
-                  Sid::pageOddBottomMargin,
-                  Sid::pageTwosided,
-                  Sid::spatium
-                  };
-            // but borrow defaultStyle page layout settings
-            for (auto i : styles)
-                  _style.set(i, MScore::defaultStyle().value(i));
+            // but use default page layout settings
+            MStyle s = MScore::defaultStyle();
+            style().setPageSize(s.pageSize());
+            style().setPageOdd (s.pageOdd());
+            style().setPageEven(s.pageEven());
+            style().set(Sid::pageTwosided, s.value(Sid::pageTwosided));
+            style().set(Sid::spatium,      s.value(Sid::spatium));
+
             // and force some style settings that just make sense for parts
             if (forcePartStyle) {
                   style().set(Sid::concertPitch, false);
@@ -347,6 +339,7 @@ Score::~Score()
 
 //---------------------------------------------------------
 //   Score::clone
+//         Clones a score by cloning its text XML, not its binary objects.
 //         To create excerpt clone to show when changing PageSettings
 //         Use MasterScore::clone() instead
 //---------------------------------------------------------
@@ -3489,7 +3482,7 @@ qreal Score::tempo(const Fraction& tick) const
 
 qreal Score::loWidth() const
       {
-      return styleD(Sid::pageWidth) * DPI;
+      return style().pageOdd().width();
       }
 
 //---------------------------------------------------------
@@ -3498,7 +3491,7 @@ qreal Score::loWidth() const
 
 qreal Score::loHeight() const
       {
-      return styleD(Sid::pageHeight) * DPI;
+      return style().pageOdd().height();
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -647,6 +647,7 @@ class Score : public QObject, public ScoreElement {
       void undoRemoveBracket(Bracket*);
       void undoInsertTime(const Fraction& tick, const Fraction& len);
       void undoChangeStyleVal(Sid idx, const QVariant& v);
+      void undoChangePageSettings(QPageSize& ps, MPageLayout& odd, MPageLayout& even);
       void undoChangePageNumberOffset(int po);
 
       Note* setGraceNote(Chord*,  int pitch, NoteType type, int len);

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1110,6 +1110,96 @@ enum class Sid {
       STYLES
       };
 
+// Internal resolution factor that multiplies values originally in points
+static constexpr qreal DPI_F = 5; // screen resolution factor
+
+// Unit conversion factors
+static constexpr qreal INCH  = 25.4;  // millimeters per inch
+static constexpr qreal PICA  = 12.0;  // points per pica and didot per cicero
+static constexpr qreal DIDOT = 1.06574601373228; // didot per point
+static constexpr qreal PPI   = 72.0;  // PostScript points per inch
+static constexpr qreal DPI   = DPI_F * PPI; // 360.0 dots per inch
+static constexpr qreal DPMM  = DPI / INCH;  //  14.173228346 dots per millimeter
+
+// Default spatium values: MuseScore and MusicXML
+// Both values are equivalent: 25.0 @360dpi == 10.0 @144dpi == 5pt
+static constexpr qreal SPATIUM20   = DPI_F * (DPI / PPI); // 25.0 == 5pt == DPI_F * DPI_F
+static constexpr qreal SPATIUM_XML = 10.0;  // MusicXML, in demi-points @144dpi
+
+//------------------------------------------------------------------------------
+//   PageUnit
+//    Qt provides only an enumeration for units: QPageLayout::Unit
+//    MuseScore needs all this additional data per unit. The data is for:
+//     a) Display and widget control settings for pagesettings.ui
+//     b) Contents for the units drop-down lists in pagesettings and prefsdialog
+//     c) Unrounded unit conversions, because QPageLayout rounds everything
+//     d) _key is a lookup key and the value written to the .mscx file
+//     e) _isMetric determines the base page size, A4 or Letter
+//------------------------------------------------------------------------------
+struct PageUnit {
+      const char* _key;   // never translated
+      const char* _name;
+      const char* _suffix;
+      bool _isMetric;     // used to configure default page size
+      int _decimals;      // number of decimal places for QDoubleSpinBox
+      qreal _step;        // for spin widgets in specific units
+      qreal _stepSpatium; // ditto
+      qreal _max;         // max width and height value
+      qreal _factor;      // conversion-to-points factor
+      qreal _inchFactor;  // conversion-to-inches factor for 3.01 and earlier
+
+public:
+      const char* key()    const { return _key;            }
+      const char* name()   const { return _name;           }
+      const char* suffix() const { return _suffix;         }
+      bool isMetric()      const { return _isMetric;       }
+      int decimals()       const { return _decimals;       }
+      qreal step()         const { return _step;           }
+      qreal stepSpatium()  const { return _stepSpatium;    }
+      qreal max()          const { return _max;            }
+      qreal factor()       const { return _factor;         }
+      qreal paintFactor()  const { return _factor * DPI_F; } // converts spatium to/from user units
+      qreal inchFactor()   const { return _inchFactor;     } ///4.00 obsolete - converts user units to/from inches
+      };
+
+//------------------------------------------------------------------------------
+//   pageUnits - array of PageUnit, contents and order mimic QPageLayout::Unit
+//------------------------------------------------------------------------------
+const PageUnit pageUnits[] = { 
+      { "Millimeters", QT_TRANSLATE_NOOP("unitName", "Millimeters"), QT_TRANSLATE_NOOP("unitSuffix", "mm"), true,  2, 1.00, 0.200,  9999.99, PPI / INCH,   1.0 / INCH },
+      { "Points",      QT_TRANSLATE_NOOP("unitName", "Points"),      QT_TRANSLATE_NOOP("unitSuffix", "pt"), false, 0, 1.00, 0.200, 99999.99, 1.0,          1.0 / PPI  },
+      { "Inches",      QT_TRANSLATE_NOOP("unitName", "Inches"),      QT_TRANSLATE_NOOP("unitSuffix", "in"), false, 2, 0.05, 0.005,  2000.99, PPI,          1.0 },
+      { "Picas",       QT_TRANSLATE_NOOP("unitName", "Picas"),       QT_TRANSLATE_NOOP("unitSuffix", "p" ), false, 2, 1.00, 0.100,  9999.99, PICA,         1.0   / (PPI / PICA) },
+      { "Didot",       QT_TRANSLATE_NOOP("unitName", "Didot"),       QT_TRANSLATE_NOOP("unitSuffix", "dd"), true,  0, 1.00, 0.005, 99999.99, DIDOT,        DIDOT / PPI          },
+      { "Cicero",      QT_TRANSLATE_NOOP("unitName", "Cicero"),      QT_TRANSLATE_NOOP("unitSuffix", "c" ), true,  2, 1.00, 0.100,  9999.99, DIDOT * PICA, DIDOT / (PPI / PICA) },
+      };
+
+// QPageLayout rounds everything. For screen layout and file storage values,
+// including MusicXML, greater precision is required. MPageLayout provides
+// that additional precision, along with methods that return converted values.
+class MPageLayout : public QPageLayout {
+   private:
+      double factor() const{ return pageUnits[int(units())].factor();      }
+   public:
+      // For MusicXML and the analogous functions below
+      double widthPoints()        const { return fullRect().width()  * factor(); }
+      double heightPoints()       const { return fullRect().height() * factor(); }
+      double leftMarginPoints()   const { return margins().left()    * factor(); }
+      double rightMarginPoints()  const { return margins().right()   * factor(); }
+      double topMarginPoints()    const { return margins().top()     * factor(); }
+      double bottomMarginPoints() const { return margins().bottom()  * factor(); }
+      double paintWidthPoints()   const { return paintRect().width() * factor(); }
+
+      // For screen layout
+      double width()        const { return widthPoints()        * DPI_F; }
+      double height()       const { return heightPoints()       * DPI_F; }
+      double leftMargin()   const { return leftMarginPoints()   * DPI_F; }
+      double rightMargin()  const { return rightMarginPoints()  * DPI_F; }
+      double topMargin()    const { return topMarginPoints()    * DPI_F; }
+      double bottomMargin() const { return bottomMarginPoints() * DPI_F; }
+      double paintWidth()   const { return paintWidthPoints()   * DPI_F; }
+      };
+
 //---------------------------------------------------------
 //   MStyle
 //    the name "Style" gives problems with some microsoft
@@ -1120,17 +1210,34 @@ class MStyle {
       std::array<QVariant, int(Sid::STYLES)> _values;
       std::array<qreal, int(Sid::STYLES)> _precomputedValues;
 
+      QPageSize _pageSize;
+      MPageLayout _pageOdd;
+      MPageLayout _pageEven;
+
       ChordList _chordList;
       bool _customChordList;        // if true, chordlist will be saved as part of score
+
+      double fuzzyDefault(Sid sid, double epsilon = 0.0001); // defined in read301.cpp
 
    public:
       MStyle();
 
       void precomputeValues();
+      void initPageLayout();
+
       QVariant value(Sid idx) const;
       qreal pvalue(Sid idx) const    { return _precomputedValues[int(idx)]; }
       void set(Sid idx, const QVariant& v);
 
+      QPageSize& pageSize()   { return _pageSize; }
+      MPageLayout& pageOdd()  { return _pageOdd;  }
+      MPageLayout& pageEven() { return _pageEven; }
+      const QPageSize& pageSize() const   { return _pageSize; }
+      const MPageLayout& pageOdd() const  { return _pageOdd;  }
+      const MPageLayout& pageEven() const { return _pageEven; }
+      void setPageSize(QPageSize& val)    { _pageSize = val; }
+      void setPageOdd(MPageLayout& val)   { _pageOdd  = val; }
+      void setPageEven(MPageLayout& val)  { _pageEven = val; }
       bool isDefault(Sid idx) const;
 
       const ChordDescription* chordDescription(int id) const;
@@ -1151,6 +1258,12 @@ class MStyle {
       static const char* valueType(const Sid);
       static const char* valueName(const Sid);
       static Sid styleIdx(const QString& name);
+
+      void toPageLayout301(); // these five are defined in read301.cpp
+      void fromPageLayout301();
+      void spatium301(XmlReader& e);
+      void fuzzySet(Sid sid, double val, double factor = 1.0, double epsilon = 0.0001);
+      QPageSize::PageSizeId pageSizeId301(QSizeF& size) const;
       };
 
 //---------------------------------------------------------

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1519,6 +1519,28 @@ void ChangeStyleVal::flip(EditData*)
       }
 
 //---------------------------------------------------------
+//   ChangePageSettings::flip
+//---------------------------------------------------------
+
+void ChangePageSettings::flip(EditData*)
+      {
+      MStyle& style = score->style();
+      QPageSize ps1 = style.pageSize();
+      MPageLayout odd1 = style.pageOdd();
+      MPageLayout even1 = style.pageEven();
+
+      style.setPageSize(ps);
+      style.setPageOdd(odd);
+      style.setPageEven(even);
+
+      ps = ps1;
+      odd = odd1;
+      even = even1;
+
+      score->styleChanged();
+      }
+
+//---------------------------------------------------------
 //   ChangePageNumberOffset::flip
 //---------------------------------------------------------
 

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -671,6 +671,24 @@ class ChangeStyleVal : public UndoCommand {
       };
 
 //---------------------------------------------------------
+//   ChangePageSettings
+//---------------------------------------------------------
+
+class ChangePageSettings : public UndoCommand {
+      Score* score;
+      QPageSize ps;
+      MPageLayout odd;
+      MPageLayout even;
+
+      void flip(EditData*) override;
+
+   public:
+      ChangePageSettings(Score* s, QPageSize& ps, MPageLayout& odd, MPageLayout& even)
+                     : score(s), ps(ps), odd(odd), even(even) {}
+      UNDO_NAME("ChangePageSettings")
+      };
+
+//---------------------------------------------------------
 //   ChangePageNumberOffset
 //---------------------------------------------------------
 

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -278,11 +278,12 @@ class ExportMusicXml {
       Ottava const* ottavas[MAX_NUMBER_LEVEL];
       Trill const* trills[MAX_NUMBER_LEVEL];
       int div;
-      double millimeters;
-      int tenths;
+      double scale; // a multiplier, used in the getTenths functions
       TrillHash _trillStart;
       TrillHash _trillStop;
       MxmlInstrumentMap instrMap;
+
+      static constexpr int TENTHS = 40; // as defined in the MusicXML spec
 
       int findBracket(const TextLine* tl) const;
       int findDashes(const TextLineBase* tl) const;
@@ -314,10 +315,21 @@ public:
       ExportMusicXml(Score* s)
             : _xml(s)
             {
-            _score = s; _tick = { 0,1 }; div = 1; tenths = 40;
-            millimeters = _score->spatium() * tenths / (10 * DPMM);
+            _score = s;
+            _tick  = Fraction();
+            div    = 1;
+
+            // At the default value of SPATIUM20 = 5pt = 25dots @360dpi, the
+            // getTenths functions return values in units @144dpi.
+            // PPI = 72 = 144 / 2;  There is no existing constant = 144, so this
+            // is the formula to derive the 2 without using literal values:
+            double factor = (SPATIUM_XML * DPI_F) / SPATIUM20; // (10 * 5) / 25 = 2
+
+            // If the spatium != the default, values are scaled proportionally
+            scale = (s->spatium() / SPATIUM20) * factor;
             }
       void write(QIODevice* dev);
+      void defaults();
       void credits(XmlWriter& xml);
       void moveToTick(const Fraction& t);
       void words(Text const* const text, int staff);
@@ -331,7 +343,7 @@ public:
       void tempoText(TempoText const* const text, int staff);
       void harmony(Harmony const* const, FretDiagram const* const fd, int offset = 0);
       Score* score() const { return _score; };
-      double getTenthsFromInches(double) const;
+      double getTenthsFromPoints(double) const;
       double getTenthsFromDots(double) const;
       };
 
@@ -398,10 +410,11 @@ static QString addPositioningAttributes(Element const* const el, bool isSpanStar
             }
 
       // convert into spatium tenths for MusicXML
-      defaultX *=  10 / spatium;
-      defaultY *=  -10 / spatium;
-      relativeX *=  10 / spatium;
-      relativeY *=  -10 / spatium;
+      double factor = SPATIUM_XML / spatium;
+      defaultX  *=  factor;
+      defaultY  *= -factor;
+      relativeX *=  factor;
+      relativeY *= -factor;
 
       QString res;
       if (fabsf(defaultX) > positionElipson)
@@ -1131,52 +1144,42 @@ void ExportMusicXml::calcDivisions()
       }
 
 //---------------------------------------------------------
-//   writePageFormat
-//---------------------------------------------------------
-
-static void writePageFormat(const Score* const s, XmlWriter& xml, double conversion)
-      {
-      xml.stag("page-layout");
-
-      xml.tag("page-height", s->styleD(Sid::pageHeight) * conversion);
-      xml.tag("page-width", s->styleD(Sid::pageWidth) * conversion);
-
-      QString type("both");
-      if (s->styleB(Sid::pageTwosided)) {
-            type = "even";
-            xml.stag(QString("page-margins type=\"%1\"").arg(type));
-            xml.tag("left-margin",   s->styleD(Sid::pageEvenLeftMargin) * conversion);
-            xml.tag("right-margin",  s->styleD(Sid::pageOddLeftMargin) * conversion);
-            xml.tag("top-margin",    s->styleD(Sid::pageEvenTopMargin)  * conversion);
-            xml.tag("bottom-margin", s->styleD(Sid::pageEvenBottomMargin) * conversion);
-            xml.etag();
-            type = "odd";
-            }
-      xml.stag(QString("page-margins type=\"%1\"").arg(type));
-      xml.tag("left-margin",   s->styleD(Sid::pageOddLeftMargin) * conversion);
-      xml.tag("right-margin",  s->styleD(Sid::pageEvenLeftMargin) * conversion);
-      xml.tag("top-margin",    s->styleD(Sid::pageOddTopMargin) * conversion);
-      xml.tag("bottom-margin", s->styleD(Sid::pageOddBottomMargin) * conversion);
-      xml.etag();
-
-      xml.etag();
-      }
-
-//---------------------------------------------------------
 //   defaults
 //---------------------------------------------------------
 
-// _spatium = DPMM * (millimeter * 10.0 / tenths);
-
-static void defaults(XmlWriter& xml, const Score* const s, double& millimeters, const int& tenths)
+void ExportMusicXml::defaults()
       {
-      xml.stag("defaults");
-      xml.stag("scaling");
-      xml.tag("millimeters", millimeters);
-      xml.tag("tenths", tenths);
-      xml.etag();
+      _xml.stag("defaults");
+      _xml.stag("scaling");
+      _xml.tag("millimeters", _score->spatium() * TENTHS / (SPATIUM_XML * DPMM));
+      _xml.tag("tenths",      TENTHS);
+      _xml.etag();
 
-      writePageFormat(s, xml, INCH / millimeters * tenths);
+      MStyle& style = _score->style();
+      MPageLayout& odd = style.pageOdd();
+      _xml.stag("page-layout");
+      _xml.tag("page-height", getTenthsFromPoints(odd.heightPoints()));
+      _xml.tag("page-width",  getTenthsFromPoints(odd.widthPoints()));
+
+      QString type("both");
+      if (_score->styleB(Sid::pageTwosided)) {
+            type = "even";
+            MPageLayout& even = style.pageEven();
+            _xml.stag(QString("page-margins type=\"%1\"").arg(type));
+            _xml.tag("left-margin",   getTenthsFromPoints(even.leftMarginPoints()));
+            _xml.tag("right-margin",  getTenthsFromPoints(even.rightMarginPoints()));
+            _xml.tag("top-margin",    getTenthsFromPoints(even.topMarginPoints()));
+            _xml.tag("bottom-margin", getTenthsFromPoints(even.bottomMarginPoints()));
+            _xml.etag();
+            type = "odd";
+            }
+      _xml.stag(QString("page-margins type=\"%1\"").arg(type));
+      _xml.tag("left-margin",   getTenthsFromPoints(odd.leftMarginPoints()));
+      _xml.tag("right-margin",  getTenthsFromPoints(odd.rightMarginPoints()));
+      _xml.tag("top-margin",    getTenthsFromPoints(odd.topMarginPoints()));
+      _xml.tag("bottom-margin", getTenthsFromPoints(odd.bottomMarginPoints()));
+      _xml.etag();
+      _xml.etag();
 
       // TODO: also write default system layout here
       // when exporting only manual or no breaks, system-distance is not written at all
@@ -1186,10 +1189,10 @@ static void defaults(XmlWriter& xml, const Score* const s, double& millimeters, 
       // for music (TODO), words and lyrics, use Tid STAFF (typically used for words)
       // and LYRIC1 to get MusicXML defaults
 
-      // TODO xml.tagE("music-font font-family=\"TBD\" font-size=\"TBD\"");
-      xml.tagE(QString("word-font font-family=\"%1\" font-size=\"%2\"").arg(s->styleSt(Sid::staffTextFontFace)).arg(s->styleD(Sid::staffTextFontSize)));
-      xml.tagE(QString("lyric-font font-family=\"%1\" font-size=\"%2\"").arg(s->styleSt(Sid::lyricsOddFontFace)).arg(s->styleD(Sid::lyricsOddFontSize)));
-      xml.etag();
+      // TODO _xml.tagE("music-font font-family=\"TBD\" font-size=\"TBD\"");
+      _xml.tagE(QString("word-font font-family=\"%1\" font-size=\"%2\"").arg(_score->styleSt(Sid::staffTextFontFace)).arg(_score->styleD(Sid::staffTextFontSize)));
+      _xml.tagE(QString("lyric-font font-family=\"%1\" font-size=\"%2\"").arg(_score->styleSt(Sid::lyricsOddFontFace)).arg(_score->styleD(Sid::lyricsOddFontSize)));
+      _xml.etag();
       }
 
 
@@ -1243,12 +1246,13 @@ void ExportMusicXml::credits(XmlWriter& xml)
       QString rights = _score->metaTag("copyright");
 
       // determine page formatting
-      const double h  = getTenthsFromInches(_score->styleD(Sid::pageHeight));
-      const double w  = getTenthsFromInches(_score->styleD(Sid::pageWidth));
-      const double lm = getTenthsFromInches(_score->styleD(Sid::pageOddLeftMargin));
-      const double rm = getTenthsFromInches(_score->styleD(Sid::pageEvenLeftMargin));
-      //const double tm = getTenthsFromInches(_score->styleD(Sid::pageOddTopMargin));
-      const double bm = getTenthsFromInches(_score->styleD(Sid::pageOddBottomMargin));
+      MPageLayout& odd = _score->style().pageOdd();
+      const double h  = getTenthsFromPoints(odd.heightPoints());
+      const double w  = getTenthsFromPoints(odd.widthPoints());
+      const double lm = getTenthsFromPoints(odd.leftMarginPoints());
+      const double rm = getTenthsFromPoints(odd.rightMarginPoints());
+      const double bm = getTenthsFromPoints(odd.bottomMarginPoints());
+      //const double tm = getTenthsFromPoints(odd.topMarginPoints());
       //qDebug("page h=%g w=%g lm=%g rm=%g tm=%g bm=%g", h, w, lm, rm, tm, bm);
 
       // write the credits
@@ -2675,7 +2679,7 @@ static QString notePosition(const ExportMusicXml* const expMxml, const Note* con
       QString res;
 
       if (preferences.getBool(PREF_EXPORT_MUSICXML_EXPORTLAYOUT)) {
-            const double pageHeight  = expMxml->getTenthsFromInches(expMxml->score()->styleD(Sid::pageHeight));
+            const double pageHeight = expMxml->getTenthsFromPoints(expMxml->score()->style().pageOdd().heightPoints());
 
             const auto chord = note->chord();
 
@@ -3757,7 +3761,7 @@ void ExportMusicXml::textLine(TextLine const* const tl, int staff, const Fractio
                   }
             else
                   lineEnd = "down";
-            rest += QString(" end-length=\"%1\"").arg(hookHeight * 10);
+            rest += QString(" end-length=\"%1\"").arg(hookHeight * SPATIUM_XML);
             }
 
       rest += addPositioningAttributes(tl, tl->tick() == tick);
@@ -4758,12 +4762,12 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
                   }
 
             if (doLayout) {
+                  MPageLayout& odd = score()->style().pageOdd();
                   _xml.stag(QString("print%1").arg(newThing));
-                  const double pageWidth  = getTenthsFromInches(score()->styleD(Sid::pageWidth));
-                  const double lm = getTenthsFromInches(score()->styleD(Sid::pageOddLeftMargin));
-                  const double rm = getTenthsFromInches(score()->styleD(Sid::pageWidth)
-                                                        - score()->styleD(Sid::pagePrintableWidth) - score()->styleD(Sid::pageOddLeftMargin));
-                  const double tm = getTenthsFromInches(score()->styleD(Sid::pageOddTopMargin));
+                  const double pw = getTenthsFromPoints(odd.widthPoints());
+                  const double lm = getTenthsFromPoints(odd.leftMarginPoints());
+                  const double rm = getTenthsFromPoints(odd.rightMarginPoints());
+                  const double tm = getTenthsFromPoints(odd.topMarginPoints());
 
                   // System Layout
 
@@ -4779,7 +4783,7 @@ void ExportMusicXml::print(const Measure* const m, const int partNr, const int f
 
                         // Find the right margin of the system.
                         double systemLM = getTenthsFromDots(mmR1->pagePos().x() - system->page()->pagePos().x()) - lm;
-                        double systemRM = pageWidth - rm - (getTenthsFromDots(system->bbox().width()) + lm);
+                        double systemRM = pw - rm - lm - getTenthsFromDots(system->bbox().width());
 
                         _xml.stag("system-layout");
                         _xml.stag("system-margins");
@@ -5333,7 +5337,7 @@ void ExportMusicXml::write(QIODevice* dev)
       identification(_xml, _score);
 
       if (preferences.getBool(PREF_EXPORT_MUSICXML_EXPORTLAYOUT)) {
-            defaults(_xml, _score, millimeters, tenths);
+            defaults();
             credits(_xml);
             }
 
@@ -5380,7 +5384,7 @@ void ExportMusicXml::write(QIODevice* dev)
                   const bool isFirstActualMeasure = (irregularMeasureNo + measureNo + pickupMeasureNo) == 4;
 
                   if (preferences.getBool(PREF_EXPORT_MUSICXML_EXPORTLAYOUT))
-                        measureTag += QString(" width=\"%1\"").arg(QString::number(m->bbox().width() / DPMM / millimeters * tenths,'f',2));
+                        measureTag += QString(" width=\"%1\"").arg(QString::number(getTenthsFromDots(m->bbox().width()),'f',2));
 
                   _xml.stag(measureTag);
 
@@ -5612,14 +5616,14 @@ bool saveMxl(Score* score, const QString& name)
       return true;
       }
 
-double ExportMusicXml::getTenthsFromInches(double inches) const
+double ExportMusicXml::getTenthsFromPoints(double val) const
       {
-      return inches * INCH / millimeters * tenths;
+      return val * scale;
       }
 
 double ExportMusicXml::getTenthsFromDots(double dots) const
       {
-      return dots / DPMM / millimeters * tenths;
+      return dots * scale / DPI_F;
       }
 
 //---------------------------------------------------------
@@ -5634,7 +5638,7 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
       // since we now support placement of chord symbols over "empty" beats directly,
       // and wedon't generally export position info for other elements
       // it's just as well to not bother doing so here
-      //double rx = h->offset().x()*10;
+      //double rx = h->offset().x()*SPATIUM_XML;
       //QString relative;
       //if (rx > 0) {
       //      relative = QString(" relative-x=\"%1\"").arg(QString::number(rx,'f',2));
@@ -5781,4 +5785,3 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
       }
 
 }
-

--- a/mscore/magbox.cpp
+++ b/mscore/magbox.cpp
@@ -140,8 +140,8 @@ double MagBox::getMag(ScoreView* canvas) const
       qreal pmag           = mscore->physicalDotsPerInch() / DPI;
       double cw            = canvas->width();
       double ch            = canvas->height();
-      qreal pw             = score->styleD(Sid::pageWidth);
-      qreal ph             = score->styleD(Sid::pageHeight);
+      qreal pw             = score->style().pageOdd().width();
+      qreal ph             = score->style().pageOdd().height();
       double nmag;
 
       switch (idx) {
@@ -156,13 +156,13 @@ double MagBox::getMag(ScoreView* canvas) const
             case MagIdx::MAG_1600:    nmag = 16.0 * pmag; break;
 
             case MagIdx::MAG_PAGE_WIDTH:      // page width
-                  nmag = cw / (pw * DPI);
+                  nmag = cw / pw;
                   break;
 
             case MagIdx::MAG_PAGE:     // page
                   {
-                  double mag1 = cw / (pw *  DPI);
-                  double mag2 = ch / (ph * DPI);
+                  double mag1 = cw / pw;
+                  double mag2 = ch / ph;
                   nmag  = (mag1 > mag2) ? mag2 : mag1;
                   }
                   break;
@@ -172,12 +172,12 @@ double MagBox::getMag(ScoreView* canvas) const
                   double mag1 = 0;
                   double mag2 = 0;
                   if (MScore::verticalOrientation()) {
-                        mag1 = ch / (ph * 2 * DPI +  MScore::verticalPageGap);
-                        mag2 = cw / (pw * DPI);
+                        mag1 = ch / (ph * 2 +  MScore::verticalPageGap);
+                        mag2 = cw / pw;
                         }
                   else {
-                        mag1 = cw / (pw * 2 * DPI + 50);
-                        mag2 = ch / (ph * DPI);
+                        mag1 = cw / (pw * 2 + 50);
+                        mag2 = ch / ph;
                         }
                   nmag  = (mag1 > mag2) ? mag2 : mag1;
                   }

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3325,7 +3325,6 @@ static void loadScores(const QStringList& argv)
                                     score->style().checkChordList();
                                     score->styleChanged();
                                     score->setName(mscore->createDefaultName());
-                                    // TODO score->setPageFormat(*MScore::defaultStyle().pageFormat());
                                     score->doLayout();
                                     score->setCreated(true);
                                     }
@@ -3336,7 +3335,6 @@ static void loadScores(const QStringList& argv)
                                           score->style().checkChordList();
                                           score->styleChanged();
                                           score->setName(mscore->createDefaultName());
-                                          // TODO score->setPageFormat(*MScore::defaultStyle().pageFormat());
                                           score->doLayout();
                                           score->setCreated(true);
                                           }
@@ -7389,10 +7387,14 @@ int main(int argc, char* av[])
             QPrinter p;
             if (p.isValid()) {
 //                  qDebug("set paper size from default printer");
-                  QRectF psf = p.paperRect(QPrinter::Inch);
-                  MScore::defaultStyle().set(Sid::pageWidth,  psf.width());
-                  MScore::defaultStyle().set(Sid::pageHeight, psf.height());
-                  MScore::defaultStyle().set(Sid::pagePrintableWidth, psf.width()-20.0/INCH);
+                  MStyle& def = MScore::defaultStyle();
+                  QPageSize ps = p.pageLayout().pageSize();
+                  MPageLayout& odd  = def.pageOdd();
+                  MPageLayout& even = def.pageEven();
+
+                  def.setPageSize(ps);
+                  odd.setPageSize(ps);
+                  even.setPageSize(ps);
                   }
             }
 #endif

--- a/mscore/noteGroups.cpp
+++ b/mscore/noteGroups.cpp
@@ -53,8 +53,9 @@ Score* NoteGroups::createScore(int n, TDuration::DurationType t, std::vector<Cho
             chord->setStemDirection(Direction::UP);
             chords->push_back(chord);
             }
-      c.score()->style().set(Sid::pageOddTopMargin, 16.0/INCH);
-      c.score()->style().set(Sid::pageOddLeftMargin, 0.0);
+      c.score()->style().pageOdd().setUnits(QPageLayout::Millimeter);
+      c.score()->style().pageOdd().setTopMargin(16);
+      c.score()->style().pageOdd().setLeftMargin(0);
 
       c.score()->parts().front()->setLongName("");
       c.score()->style().set(Sid::linearStretch, 1.3);

--- a/mscore/pagesettings.cpp
+++ b/mscore/pagesettings.cpp
@@ -12,6 +12,7 @@
 
 #include "globals.h"
 #include "pagesettings.h"
+#include "preferences.h"
 #include "libmscore/page.h"
 #include "libmscore/style.h"
 #include "libmscore/score.h"
@@ -21,7 +22,6 @@
 #include "musescore.h"
 
 namespace Ms {
-
 //---------------------------------------------------------
 //   PageSettings
 //---------------------------------------------------------
@@ -41,39 +41,50 @@ PageSettings::PageSettings(QWidget* parent)
 
       static_cast<QVBoxLayout*>(previewGroup->layout())->insertWidget(0, sa);
 
-      mmUnit = true;      // should be made a global configuration item
-
-      if (mmUnit)
-            mmButton->setChecked(true);
-      else
-            inchButton->setChecked(true);
-
       MuseScore::restoreGeometry(this);
 
-      for (int i = 0; i < QPageSize::LastPageSize; ++i)
-            pageGroup->addItem(QPageSize::name(QPageSize::PageSizeId(i)), i);
+      typesList->addItem("Common");
+      typesList->addItem("Metric");
+      typesList->addItem("Imperial");
+      typesList->addItem("Other");
 
-      connect(mmButton,             SIGNAL(clicked()),            SLOT(mmClicked()));
-      connect(inchButton,           SIGNAL(clicked()),            SLOT(inchClicked()));
-      connect(buttonApply,          SIGNAL(clicked()),            SLOT(apply()));
-      connect(buttonApplyToAllParts,SIGNAL(clicked()),            SLOT(applyToAllParts()));
-      connect(buttonOk,             SIGNAL(clicked()),            SLOT(ok()));
-      connect(portraitButton,       SIGNAL(clicked()),            SLOT(orientationClicked()));
-      connect(landscapeButton,      SIGNAL(clicked()),            SLOT(orientationClicked()));
-      connect(twosided,             SIGNAL(toggled(bool)),        SLOT(twosidedToggled(bool)));
-      connect(pageHeight,           SIGNAL(valueChanged(double)), SLOT(pageHeightChanged(double)));
-      connect(pageWidth,            SIGNAL(valueChanged(double)), SLOT(pageWidthChanged(double)));
-      connect(oddPageTopMargin,     SIGNAL(valueChanged(double)), SLOT(otmChanged(double)));
-      connect(oddPageBottomMargin,  SIGNAL(valueChanged(double)), SLOT(obmChanged(double)));
-      connect(oddPageLeftMargin,    SIGNAL(valueChanged(double)), SLOT(olmChanged(double)));
-      connect(oddPageRightMargin,   SIGNAL(valueChanged(double)), SLOT(ormChanged(double)));
-      connect(evenPageTopMargin,    SIGNAL(valueChanged(double)), SLOT(etmChanged(double)));
-      connect(evenPageBottomMargin, SIGNAL(valueChanged(double)), SLOT(ebmChanged(double)));
-      connect(evenPageRightMargin,  SIGNAL(valueChanged(double)), SLOT(ermChanged(double)));
-      connect(evenPageLeftMargin,   SIGNAL(valueChanged(double)), SLOT(elmChanged(double)));
-      connect(pageGroup,            SIGNAL(activated(int)),       SLOT(pageFormatSelected(int)));
-      connect(spatiumEntry,         SIGNAL(valueChanged(double)), SLOT(spatiumChanged(double)));
-      connect(pageOffsetEntry,      SIGNAL(valueChanged(int)),    SLOT(pageOffsetChanged(int)));
+      for (int i = 0; i <= QPageSize::Cicero; ++i)
+            unitsList->addItem(QString("%1 (%2)").arg(pageUnits[i].name())
+                                                 .arg(pageUnits[i].suffix()));
+
+      // The dialog box rounds the spatium to 3 decimal places.
+      // These member variables are the default value ofSPATIUM20 converted to
+      // each unit and rounded to 3 decimals. These variables are used to avoid
+      // rounding errors by forcing the unrounded default value of SPATIUM20.
+      double spPoints = SPATIUM20 / DPI_F; // SPATIUM20 in points == 5pt
+      sp20_mm = rint(SPATIUM20 / DPMM * 1000) / 1000; // millimeters
+      sp20_in = rint(SPATIUM20 / DPI  * 1000) / 1000; // inches
+      sp20_p  = rint(spPoints  / PICA * 1000) / 1000; // picas
+      spPoints /= DIDOT;                   // SPATIUM20 in didot
+      sp20_dd = rint(spPoints         * 1000) / 1000; // didot
+      sp20_c  = rint(spPoints  / PICA * 1000) / 1000; // cicero
+
+      connect(buttonBox,        SIGNAL(clicked(QAbstractButton*)), SLOT(okCancel(QAbstractButton*)));
+      connect(resetToDefault,   SIGNAL(clicked()), SLOT(setToDefault()));
+      connect(applyToParts,     SIGNAL(clicked()), SLOT(applyToAllParts()));
+      connect(twosided,         SIGNAL(toggled(bool)), SLOT(twosidedToggled(bool)));
+      connect(portrait,         SIGNAL(toggled(bool)), SLOT(orientationToggled(bool)));
+      connect(landscape,        SIGNAL(toggled(bool)), SLOT(orientationToggled(bool)));
+      connect(pageOffset,       SIGNAL(valueChanged(int)),    SLOT(pageOffsetChanged(int)));
+      connect(pageWidth,        SIGNAL(valueChanged(double)), SLOT(widthChanged(double)));
+      connect(pageHeight,       SIGNAL(valueChanged(double)), SLOT(heightChanged(double)));
+      connect(staffSpace,       SIGNAL(valueChanged(double)), SLOT(spatiumChanged(double)));
+      connect(oddTopMargin,     SIGNAL(valueChanged(double)), SLOT(otmChanged(double)));
+      connect(oddBottomMargin,  SIGNAL(valueChanged(double)), SLOT(obmChanged(double)));
+      connect(oddLeftMargin,    SIGNAL(valueChanged(double)), SLOT(olmChanged(double)));
+      connect(oddRightMargin,   SIGNAL(valueChanged(double)), SLOT(ormChanged(double)));
+      connect(evenTopMargin,    SIGNAL(valueChanged(double)), SLOT(etmChanged(double)));
+      connect(evenBottomMargin, SIGNAL(valueChanged(double)), SLOT(ebmChanged(double)));
+      connect(evenRightMargin,  SIGNAL(valueChanged(double)), SLOT(ermChanged(double)));
+      connect(evenLeftMargin,   SIGNAL(valueChanged(double)), SLOT(elmChanged(double)));
+      connect(typesList,        SIGNAL(currentIndexChanged(int)), SLOT(typeChanged(int)));
+      connect(sizesList,        SIGNAL(currentIndexChanged(int)), SLOT(sizeChanged()));
+      connect(unitsList,        SIGNAL(currentIndexChanged(int)), SLOT(unitsChanged()));
       }
 
 //---------------------------------------------------------
@@ -88,7 +99,6 @@ PageSettings::~PageSettings()
 //---------------------------------------------------------
 //   hideEvent
 //---------------------------------------------------------
-
 void PageSettings::hideEvent(QHideEvent* ev)
       {
       MuseScore::saveGeometry(this);
@@ -108,159 +118,285 @@ void PageSettings::setScore(Score* s)
 
       clonedScore->doLayout();
       preview->setScore(clonedScore);
-      buttonApplyToAllParts->setEnabled(!cs->isMaster());
-      updateValues();
-      updatePreview(0);
+      applyToParts->setEnabled(!cs->isMaster());
+      updateWidgets();
+      updatePreview();
       }
 
 //---------------------------------------------------------
-//   blockSignals
+//   blockSignals - helper for updateWidgets
 //---------------------------------------------------------
 
 void PageSettings::blockSignals(bool block)
       {
-      for (auto w : { oddPageTopMargin, oddPageBottomMargin, oddPageLeftMargin, oddPageRightMargin,
-         evenPageTopMargin, evenPageBottomMargin, evenPageLeftMargin, evenPageRightMargin, spatiumEntry,
-         pageWidth, pageHeight } )
+      for (auto w : { oddTopMargin, oddBottomMargin, oddLeftMargin, oddRightMargin,
+                     evenTopMargin,evenBottomMargin,evenLeftMargin,evenRightMargin,
+                     staffSpace } )
             {
             w->blockSignals(block);
             }
-      pageOffsetEntry->blockSignals(block);
-      pageGroup->blockSignals(block);
+      twosided->blockSignals(block);
+      typesList->blockSignals(block);
+      sizesList->blockSignals(block);
+      unitsList->blockSignals(block);
+      portrait->blockSignals(block);
+      landscape->blockSignals(block);
+      pageOffset->blockSignals(block);
       }
 
 //---------------------------------------------------------
-//   setMarginsMax
+//   getPaperType()
 //---------------------------------------------------------
 
-void PageSettings::setMarginsMax(double pw)
+PaperType PageSettings::getPaperType(int id)
       {
-      oddPageLeftMargin->setMaximum(pw);
-      oddPageRightMargin->setMaximum(pw);
-      evenPageLeftMargin->setMaximum(pw);
-      evenPageRightMargin->setMaximum(pw);
+      for (auto i = MScore::sizesCommon.begin(); i != MScore::sizesCommon.end(); ++i) {
+            if (*i == id)
+                  return PaperType::Common;
+            }
+      if (MScore::sizesMetric.find(id) != MScore::sizesMetric.end())
+            return PaperType::Metric;
+      else if (MScore::sizesImperial.find(id) != MScore::sizesImperial.end())
+            return PaperType::Imperial;
+      else if (MScore::sizesOther.find(id) != MScore::sizesOther.end())
+            return PaperType::Other;
+      else
+            return PaperType::NOTYPE; // it's a Custom page size
       }
 
 //---------------------------------------------------------
-//   updateValues
-//    set gui values from style
+//   updatePreview
 //---------------------------------------------------------
 
-void PageSettings::updateValues()
+void PageSettings::updatePreview()
       {
-      Score* score = preview->score();
-      bool mm = mmButton->isChecked();
+      preview->score()->doLayout();
+      preview->layoutChanged();
+      }
 
+//---------------------------------------------------------
+//   updateWidgets
+//    set widget values from preview->score()
+//---------------------------------------------------------
+
+void PageSettings::updateWidgets(bool onlyUnits)
+      {
       blockSignals(true);
+      Score* score = preview->score();
+      MPageLayout& odd  = score->style().pageOdd();
+      MPageLayout& even = score->style().pageEven();
+      bool isGlobal = preferences.getBool(PREF_APP_PAGE_UNITS_GLOBAL);
+      int idxUnit;
 
-      const char* suffix;
-      double singleStepSize;
-      double singleStepScale;
-      if (mm) {
-            suffix = "mm";
-            singleStepSize = 1.0;
-            singleStepScale = 0.2;
+      if (isGlobal) { // .setUnits() must precede the setting of widget values
+            idxUnit = preferences.getInt(PREF_APP_PAGE_UNITS_VALUE);
+            odd.setUnits(QPageLayout::Unit(idxUnit));  // handles conversions
+            even.setUnits(QPageLayout::Unit(idxUnit)); // for widget display.
             }
-      else {
-            suffix = "in";
-            singleStepSize = 0.05;
-            singleStepScale = 0.005;
-            }
-      for (auto w : { oddPageTopMargin, oddPageBottomMargin, oddPageLeftMargin, oddPageRightMargin, evenPageTopMargin,
-         evenPageBottomMargin, evenPageLeftMargin, evenPageRightMargin, spatiumEntry, pageWidth, pageHeight } )
-            {
-            w->setSuffix(suffix);
-            w->setSingleStep(singleStepSize);
-            }
-      spatiumEntry->setSingleStep(singleStepScale);
+      else
+            idxUnit = int(odd.units());
 
-      double f = mm ? INCH : 1.0;
+      unitsList->setCurrentIndex(idxUnit);
+      unitsGroup->setVisible(!isGlobal);
 
-      double w = score->styleD(Sid::pageWidth);
-      double h = score->styleD(Sid::pageHeight);
-      setMarginsMax(w * f);
+      if (!onlyUnits) { // if only units are changing, these widgets are unaffected
+            PaperType type;
+            QPageSize::PageSizeId psid = score->style().pageSize().id();
+            if (psid == QPageSize::Custom) {
+                  type = PaperType::Common;        // gotta choose one, Custom is any type
+                  if (odd.width() > odd.height())
+                        landscape->setChecked(true);
+                  else
+                        portrait ->setChecked(true);
+                }
+            else {
+                  type = getPaperType(int(psid));
+                  if (type == PaperType::NOTYPE) { // fallback, in case a psid becomes invalid
+                        type = PaperType::Common;
+                        psid = QPageSize::Custom;
+                        }
+                  if (odd.orientation() == QPageLayout::Portrait)
+                        portrait ->setChecked(true);
+                  else
+                        landscape->setChecked(true);
+                  }
+            typesList->setCurrentIndex(int(type)); // typesList blocks signals - cleaner that way
+            typeChanged(int(type), false);         // typeChanged() loads sizesList
+            sizesList->setCurrentIndex(sizesList->findData(int(psid)));
 
-      double pw = score->styleD(Sid::pagePrintableWidth);
-      pageGroup->setCurrentIndex(int(QPageSize::id(QSizeF(w, h), QPageSize::Inch, QPageSize::FuzzyOrientationMatch)));
+            bool is2 = score->styleB(Sid::pageTwosided);
+            twosided->setChecked(is2);
+            for (auto w : { evenTopMargin, evenBottomMargin, evenLeftMargin, evenRightMargin })
+                  w->setEnabled(is2);
 
-      oddPageTopMargin->setValue(score->styleD(Sid::pageOddTopMargin) * f);
-      oddPageBottomMargin->setValue(score->styleD(Sid::pageOddBottomMargin) * f);
-      oddPageLeftMargin->setValue(score->styleD(Sid::pageOddLeftMargin) * f);
-      oddPageRightMargin->setValue((w - pw - score->styleD(Sid::pageOddLeftMargin)) * f);
-
-      evenPageTopMargin->setValue(score->styleD(Sid::pageEvenTopMargin) * f);
-      evenPageBottomMargin->setValue(score->styleD(Sid::pageEvenBottomMargin) * f);
-      evenPageLeftMargin->setValue(score->styleD(Sid::pageEvenLeftMargin) * f);
-      evenPageRightMargin->setValue((w - pw - score->styleD(Sid::pageEvenLeftMargin)) * f);
-      pageHeight->setValue(h * f);
-      pageWidth->setValue(w * f);
-
-      double f1 = mm ? 1.0/DPMM : 1.0/DPI;
-      spatiumEntry->setValue(score->spatium() * f1);
-
-
-      bool _twosided = score->styleB(Sid::pageTwosided);
-      evenPageTopMargin->setEnabled(_twosided);
-      evenPageBottomMargin->setEnabled(_twosided);
-      evenPageLeftMargin->setEnabled(_twosided);
-      evenPageRightMargin->setEnabled(_twosided);
-
-      if (twosided->isChecked()) {
-            evenPageRightMargin->setValue(oddPageLeftMargin->value());
-            evenPageLeftMargin->setValue(oddPageRightMargin->value());
-            }
-      else {
-            evenPageRightMargin->setValue(oddPageRightMargin->value());
-            evenPageLeftMargin->setValue(oddPageLeftMargin->value());
+            pageOffset->setValue(score->pageNumberOffset() + 1);
             }
 
-      landscapeButton->setChecked(score->styleD(Sid::pageWidth) > score->styleD(Sid::pageHeight));
-      portraitButton->setChecked(score->styleD(Sid::pageWidth) <= score->styleD(Sid::pageHeight));
+      PageUnit unit = pageUnits[idxUnit];
+      int decimals = unit.decimals();
+      bool isLessPrecise = (decimals < pageWidth->decimals());
+      if (!isLessPrecise) // if decimals is increasing or maintaining, update now
+            updateDecimals(score, &unit, decimals);
 
-      twosided->setChecked(_twosided);
+      double max = unit.max(); // same for maximum
+      bool isSmaller = (max < pageWidth->maximum());
+      if (!isSmaller)
+            updateMaximum(max);
 
-      pageOffsetEntry->setValue(score->pageNumberOffset() + 1);
+      // Set the margin and width/height values, all QDoubleSpinBox widgets
+      QMarginsF marg = odd.margins();
+      oddTopMargin->setValue(marg.top());
+      oddBottomMargin->setValue(marg.bottom());
+      oddLeftMargin->setValue(marg.left());
+      oddRightMargin->setValue(marg.right());
+
+      marg = even.margins();
+      evenTopMargin->setValue(marg.top());
+      evenBottomMargin->setValue(marg.bottom());
+      evenLeftMargin->setValue(marg.left());
+      evenRightMargin->setValue(marg.right());
+
+      updateWidthHeight(odd.fullRect()); // blocks signals for the width and height widgets
+
+      if (isLessPrecise) // if decimals is decreasing, update last
+          updateDecimals(score, &unit, decimals);
+
+      if (!isSmaller)    // if maximum is decreasing, update last
+            updateMaximum(max);
 
       blockSignals(false);
       }
 
 //---------------------------------------------------------
-//   inchClicked
+//   updateDecimals
+//   - updates margin and width/height widget decimal property (and others)
+//   - decimals can truncate, causing numerical errors
+//   - called only by updateWidgets()
 //---------------------------------------------------------
-
-void PageSettings::inchClicked()
+void PageSettings::updateDecimals(Score* score, PageUnit *unit, int decimals)
       {
-      mmUnit = false;
-      updateValues();
+      double step = unit->step();
+      const char* suffix = unit->suffix();
+
+      for (auto w : { oddTopMargin, oddBottomMargin, oddLeftMargin, oddRightMargin,
+                     evenTopMargin,evenBottomMargin,evenLeftMargin,evenRightMargin,
+                     pageWidth, pageHeight } )
+            {
+            w->setDecimals(decimals);
+            w->setSuffix(suffix);
+            w->setSingleStep(step);
+            }
+      staffSpace->setSingleStep(unit->stepSpatium());
+      staffSpace->setSuffix(suffix);
+      staffSpace->setValue(score->spatium() / unit->paintFactor());
       }
 
 //---------------------------------------------------------
-//   mmClicked
+//   updateMaximum
+//   - updates max page width and height values
+//   - max values can truncate, causing numerical errors
+//   - max values prevent int overflows in pageFullWidth/Height styles
+//   - called only by updateWidgets()
 //---------------------------------------------------------
-
-void PageSettings::mmClicked()
+void PageSettings::updateMaximum(double max)
       {
-      mmUnit = true;
-      updateValues();
+      pageWidth->setMaximum(max);
+      pageHeight->setMaximum(max);
       }
 
 //---------------------------------------------------------
-//   orientationClicked
-//    swap width/height
+//   updateWidthHeight - updates Width and Height widgets
 //---------------------------------------------------------
 
-void PageSettings::orientationClicked()
+void PageSettings::updateWidthHeight(const QRectF& rect)
       {
-      qreal w = preview->score()->styleD(Sid::pageWidth);
-      qreal h = preview->score()->styleD(Sid::pageHeight);
+      pageWidth ->blockSignals(true);
+      pageHeight->blockSignals(true);
+      pageWidth ->setValue(rect.width());
+      pageHeight->setValue(rect.height());
+      pageWidth ->blockSignals(false);
+      pageHeight->blockSignals(false);
+      }
 
-      preview->score()->style().set(Sid::pageWidth, h);
-      preview->score()->style().set(Sid::pageHeight, w);
+//---------------------------------------------------------
+//   typeChanged - populates sizesList based on typesList
+//         isSignal == false when called by updateWidgets
+//---------------------------------------------------------
 
-      double f = mmUnit ? 1.0/INCH : 1.0;
-      preview->score()->style().set(Sid::pagePrintableWidth, h - (oddPageLeftMargin->value() + oddPageRightMargin->value()) * f);
-      updateValues();
-      updatePreview(0);
+void PageSettings::typeChanged(int idx, bool isSignal)
+      {
+      std::set<int>* sizes;
+      switch (PaperType(idx)) {
+            case PaperType::Common:
+                  sizes = 0;
+                  break;
+            case PaperType::Metric:
+                  sizes = &MScore::sizesMetric;
+                  break;
+            case PaperType::Imperial:
+                  sizes = &MScore::sizesImperial;
+                  break;
+            case PaperType::Other:
+                  sizes = &MScore::sizesOther;
+                  break;
+            default:
+                  Q_ASSERT_X(false, "PageSettings::typeChanged", "PaperType not set!");
+                  return;
+            }
+      sizesList->clear(); // Custom is at the top of every list
+      sizesList->addItem(QPageSize::name(QPageSize::Custom), int(QPageSize::Custom));
+      if (sizes) {
+            for (auto i = sizes->begin(); i != sizes->end(); ++i)
+                  sizesList->addItem(QPageSize::name(QPageSize::PageSizeId(*i)), *i);
+            }
+      else { // Common is a vector
+            for (auto i = MScore::sizesCommon.begin(); i != MScore::sizesCommon.end(); ++i)
+                  sizesList->addItem(QPageSize::name(QPageSize::PageSizeId(*i)), *i);
+            }
+
+      // Find the current page size's index in the new list of sizes, or use
+      // Custom (= 0). Even if it's a preset size, if it doesn't exist in this
+      // type's list, then the list must display Custom. But if the currentIndex
+      // is Custom, then maybe it's a preset size in this new type's list.
+      if (isSignal) {
+            int id = sizesList->currentData().toInt(); // current PageSizeId as int
+            if (QPageSize::PageSizeId(id) != QPageSize::Custom)
+                  sizesList->setCurrentIndex(qMax(0, sizesList->findData(id)));
+            else // try to find the page size by the width and height
+                  widthHeightChanged(pageWidth->value(), pageHeight->value(), true);
+            }
+      }
+
+//---------------------------------------------------------
+//   sizeChanged
+//---------------------------------------------------------
+
+void PageSettings::sizeChanged()
+      {
+      QPageSize::PageSizeId psid = QPageSize::PageSizeId(sizesList->currentData().toInt());
+      Score* score = preview->score();
+      MStyle& style = score->style();
+      QPageSize::Unit unit = QPageSize::Unit(style.pageOdd().units());
+      QPageSize qps;
+
+      bool isPreset = (psid != QPageSize::Custom);
+      if (isPreset)
+            qps = QPageSize(psid);
+      else
+            qps = QPageSize(QSizeF(pageWidth->value(), pageHeight->value()),
+                            unit,
+                            QPageSize::name(psid),
+                            QPageSize::ExactMatch);
+
+      style.setPageSize(qps);
+      style.pageOdd ().setPageSize(qps);
+      style.pageEven().setPageSize(qps);
+
+      if (isPreset) { // switching to Custom doesn't change the actual page size
+            QRectF rect = qps.rect(unit);
+            updateWidthHeight(rect);
+            updatePreview();
+            }
       }
 
 //---------------------------------------------------------
@@ -270,44 +406,343 @@ void PageSettings::orientationClicked()
 void PageSettings::twosidedToggled(bool flag)
       {
       preview->score()->style().set(Sid::pageTwosided, flag);
-      updateValues();
-      updatePreview(1);
+
+      for (auto w : { evenTopMargin, evenBottomMargin, evenLeftMargin, evenRightMargin })
+            w->setEnabled(flag);
+
+      evenLeftMargin ->blockSignals(true);
+      evenRightMargin->blockSignals(true);
+      if (flag) {
+            evenLeftMargin ->setValue(oddRightMargin ->value());
+            evenRightMargin->setValue(oddLeftMargin->value());
+            }
+      else {
+            evenLeftMargin ->setValue(oddLeftMargin ->value());
+            evenRightMargin->setValue(oddRightMargin->value());
+            }
+      evenLeftMargin ->blockSignals(false);
+      evenRightMargin->blockSignals(false);
+
+      updatePreview();
       }
 
 //---------------------------------------------------------
-//   apply
+//   widthChanged, heightChanged, and widthHeightChanged
+//    manually changing width/height
 //---------------------------------------------------------
 
-void PageSettings::apply()
+void PageSettings::widthChanged(double val)
       {
-      applyToScore(cs);
-      mscore->endCmd();
+      widthHeightChanged(val, pageHeight->value(), false);
+      }
+void PageSettings::heightChanged(double val)
+      {
+      widthHeightChanged(pageWidth->value(), val, false);
+      }
+void PageSettings::widthHeightChanged(double w, double h, bool byType)
+      {
+      // QPageSize::FuzzyMatch is +/-3pt. Now that there is a pageSize XML
+      // tag, there is no need for fuzzy matches except reading older scores.
+      // Using exact matches here is cleaner for custom sizes. It's a hassle
+      // to check both orientations for a match, but the results are clean.
+      // QPageSize rounds inches and millimeters to 2 decimals, and points to
+      // whole integers. Exact match is only that exact, which is good. For
+      // example: using inches, entering 8.5 x 10.83 selects Quarto page size.
+      MStyle& style = preview->score()->style();
+      QSizeF size = QSizeF(w, h);
+      // Is the new page size custom or preset? MuseScore uses only a subset of
+      // the QPageSize::PageSizeId enum. Extra validation via getPaperType().
+      PaperType type = PaperType::NOTYPE;
+      QPageSize::Unit unit = QPageSize::Unit(unitsList->currentIndex());
+      QPageSize::PageSizeId psid = QPageSize::id(size, unit, QPageSize::ExactMatch);
+      if (psid != QPageSize::Custom) {
+            type = getPaperType(int(psid));
+            if (type == PaperType::NOTYPE)
+                  psid = QPageSize::Custom;
+            else if (!portrait->isChecked()) {
+                  portrait->blockSignals(true);
+                  portrait->setChecked(true);
+                  portrait->blockSignals(false);
+                  }
+            }
+      else {
+            size.transpose(); // try to match it in Landscape orientation
+            psid = QPageSize::id(size, unit, QPageSize::ExactMatch);
+            if (psid != QPageSize::Custom) {
+                  type = getPaperType(int(psid));
+                  if (type == PaperType::NOTYPE)
+                        psid = QPageSize::Custom;
+                  else if (!landscape->isChecked()) {
+                        landscape->blockSignals(true);
+                        landscape->setChecked(true);
+                        landscape->blockSignals(false);
+                        }
+                  }
+            if (psid == QPageSize::Custom)
+                  size.transpose(); // revert to Portrait for use below
+            }
+
+      int idx = sizesList->findData(int(psid));
+      if (idx < 0) { // psid is a preset in another type's list.
+            if (byType) { // indicates that typesList.currentIndex must not change
+                  psid = QPageSize::Custom;
+                  size = QSizeF(w, h); // reset it, in case it was transposed
+            }
+            else
+                  typesList->setCurrentIndex(int(type)); // populates sizesList
+
+            idx = sizesList->findData(int(psid));
+            }
+
+      // Set the list index, if it has changed
+      if (idx != sizesList->currentIndex()) {
+            sizesList->blockSignals(true);
+            sizesList->setCurrentIndex(idx);
+            sizesList->blockSignals(false);
+            }
+
+      // Update the style
+      QPageSize qps;
+      if (psid != QPageSize::Custom)
+            qps = QPageSize(psid);
+      else // Custom always portrait until orientation is stored in the .mscx file
+            qps = QPageSize(size, unit, QPageSize::name(psid), QPageSize::ExactMatch);
+
+      style.setPageSize(qps);
+      style.pageOdd ().setPageSize(qps);
+      style.pageEven().setPageSize(qps);
+
+      updatePreview();
       }
 
 //---------------------------------------------------------
-//   applyToScore
+//   orientationToggled
+//    a pair of radio buttons that toggle the page orientation
+//    it swaps width and height values, but not margins.
+//---------------------------------------------------------
+void PageSettings::orientationToggled(bool)
+      {
+      MStyle& style = preview->score()->style();
+      if (style.pageSize().id() != QPageSize::Custom) {
+            // Until orientation is stored in the .mscx file, custom page sizes
+            // are always portrait, and toggling these radio buttons only flips
+            // the width and height. Orientation is meaningless for custom sizes,
+            // as it has always been.  It's based only on width > height, and it
+            // only exists inside this dialog.
+            QPageLayout::Orientation orient = portrait->isChecked()
+                                            ? QPageLayout::Portrait
+                                            : QPageLayout::Landscape;
+            style.pageOdd ().setOrientation(orient);
+            style.pageEven().setOrientation(orient);
+            }
+      updateWidthHeight(style.pageOdd().fullRect());
+      updatePreview();
+      }
+
+//// Margins /////////////////////////////////////////////
+// this code could be much more compact if the signals provided a "this",
+// the element, the spin box. There might be a way to do that in Qt with events.
+//---------------------------------------------------------
+//   marginMinMax - helper for all 8 margins' signals, handles out of range error
+//---------------------------------------------------------
+double PageSettings::marginMinMax(double val, double max, QDoubleSpinBox* spinner)
+      {
+      double minMax = val < 0 ? 0 : max;
+      spinner->blockSignals(true);
+      spinner->setValue(minMax);
+      spinner->blockSignals(false);
+      return minMax;
+      }
+//// top and bottom first, they have no odd/even synchronzation
+//---------------------------------------------------------
+//   otmChanged - odd top margin
 //---------------------------------------------------------
 
-void PageSettings::applyToScore(Score* s)
+void PageSettings::otmChanged(double val)
       {
-      s->startCmd();
-      double f  = mmUnit ? 1.0/INCH : 1.0;
-      double f1 = mmUnit ? DPMM : DPI;
+      MPageLayout& layout = preview->score()->style().pageOdd();
+      if (!layout.setTopMargin(val)) // only error is out of range
+            layout.setTopMargin(marginMinMax(val, layout.maximumMargins().top(), oddTopMargin));
+      updatePreview();
+      }
 
-      s->undoChangeStyleVal(Sid::pageWidth, pageWidth->value() * f);
-      s->undoChangeStyleVal(Sid::pageHeight, pageHeight->value() * f);
-      s->undoChangeStyleVal(Sid::pagePrintableWidth, (pageWidth->value() - oddPageLeftMargin->value() - oddPageRightMargin->value())  * f);
-      s->undoChangeStyleVal(Sid::pageEvenTopMargin, evenPageTopMargin->value() * f);
-      s->undoChangeStyleVal(Sid::pageEvenBottomMargin, evenPageBottomMargin->value() * f);
-      s->undoChangeStyleVal(Sid::pageEvenLeftMargin, evenPageLeftMargin->value() * f);
-      s->undoChangeStyleVal(Sid::pageOddTopMargin, oddPageTopMargin->value() * f);
-      s->undoChangeStyleVal(Sid::pageOddBottomMargin, oddPageBottomMargin->value() * f);
-      s->undoChangeStyleVal(Sid::pageOddLeftMargin, oddPageLeftMargin->value() * f);
-      s->undoChangeStyleVal(Sid::pageTwosided, twosided->isChecked());
-      s->undoChangeStyleVal(Sid::spatium, spatiumEntry->value() * f1);
-      s->undoChangePageNumberOffset(pageOffsetEntry->value() - 1);
+//---------------------------------------------------------
+//   obmChanged - odd bottom margin
+//---------------------------------------------------------
 
-      s->endCmd();
+void PageSettings::obmChanged(double val)
+      {
+      MPageLayout& layout = preview->score()->style().pageOdd();
+      if (!layout.setBottomMargin(val)) // only error is out of range
+            layout.setTopMargin(marginMinMax(val, layout.maximumMargins().bottom(), oddBottomMargin));
+      updatePreview();
+}
+
+//---------------------------------------------------------
+//   etmChanged - even top margin
+//---------------------------------------------------------
+
+void PageSettings::etmChanged(double val)
+      {
+      MPageLayout& layout = preview->score()->style().pageEven();
+      if (!layout.setTopMargin(val)) // only error is out of range
+            layout.setTopMargin(marginMinMax(val, layout.maximumMargins().top(), evenTopMargin));
+      updatePreview();
+      }
+
+//---------------------------------------------------------
+//   ebmChanged - even bottom margin
+//---------------------------------------------------------
+
+void PageSettings::ebmChanged(double val)
+      {
+      MPageLayout& layout = preview->score()->style().pageEven();
+      if (!layout.setBottomMargin(val)) // only error is out of range
+            layout.setTopMargin(marginMinMax(val, layout.maximumMargins().bottom(), evenBottomMargin));
+      updatePreview();
+      }
+
+//// Left and right margins synchronize across odd/even pages
+//---------------------------------------------------------
+//   lrMargins - helper for the left/right margin valueChanged signals
+//---------------------------------------------------------
+void PageSettings::lrMargins(double val, bool isLeft, bool isOdd, QDoubleSpinBox* spinOne)
+      {
+      MStyle& style = preview->score()->style();
+      MPageLayout& one   = isOdd ? style.pageOdd()  : style.pageEven();
+      MPageLayout& other = isOdd ? style.pageEven() : style.pageOdd();
+      QDoubleSpinBox* spinOther;
+
+      bool b = isLeft ? one.setLeftMargin(val) : one.setRightMargin(val);
+      if (!b) {                    // val exceeds the max
+            double marg = isLeft ? one.maximumMargins().left()
+                                 : one.maximumMargins().right();
+            val = marginMinMax(val, marg, spinOne);
+            if (isLeft)
+                  one.setLeftMargin(val);
+            else
+                  one.setRightMargin(val);
+            }
+
+      if (isLeft) {
+            other.setRightMargin(val);
+            if (twosided->isChecked())
+                  spinOther = isOdd ? evenRightMargin : oddRightMargin;
+            else
+                  spinOther = evenLeftMargin; // even left margin is disabled
+            }
+      else {
+            other.setLeftMargin(val);
+            if (twosided->isChecked())
+                  spinOther = isOdd ? evenLeftMargin  : oddLeftMargin;
+            else
+                  spinOther = evenRightMargin; // even right margin is disabled
+            }
+      spinOther->blockSignals(true);
+      spinOther->setValue(val);
+      spinOther->blockSignals(false);
+
+      updatePreview();
+      }
+
+//---------------------------------------------------------
+//   olmChanged - odd left margin
+//---------------------------------------------------------
+
+void PageSettings::olmChanged(double val)
+      {
+      lrMargins(val, true, true, oddLeftMargin);
+      }
+
+//---------------------------------------------------------
+//   ormChanged - odd right margin
+//---------------------------------------------------------
+
+void PageSettings::ormChanged(double val)
+      {
+      lrMargins(val, false, true, oddRightMargin);
+      }
+
+//---------------------------------------------------------
+//   elmChanged - even left margin
+//---------------------------------------------------------
+
+void PageSettings::elmChanged(double val)
+      {
+      lrMargins(val, true, false, evenLeftMargin);
+      }
+
+//---------------------------------------------------------
+//   ermChanged - even right margin
+//---------------------------------------------------------
+
+void PageSettings::ermChanged(double val)
+      {
+      lrMargins(val, false, false, evenRightMargin);
+      }
+//// end margins ////
+//---------------------------------------------------------
+//   spatiumChanged
+//---------------------------------------------------------
+
+void PageSettings::spatiumChanged(double val)
+      {
+      Score* score  = preview->score();
+      double oldVal = score->spatium();
+      double newVal;
+      QPageLayout::Unit unit = score->style().pageOdd().units();
+
+      if ((unit == QPageLayout::Millimeter && val == sp20_mm) ||
+          (unit == QPageLayout::Inch       && val == sp20_in) ||
+          (unit == QPageLayout::Pica       && val == sp20_p)  ||
+          (unit == QPageLayout::Didot      && val == sp20_dd) ||
+          (unit == QPageLayout::Cicero     && val == sp20_c))
+            newVal = SPATIUM20; // force the default value
+      else
+            newVal = val * pageUnits[int(unit)].paintFactor();
+
+      score->setSpatium(newVal);
+      score->spatiumChanged(oldVal, newVal);
+      updatePreview();
+      }
+
+//---------------------------------------------------------
+//   pageOffsetChanged
+//---------------------------------------------------------
+
+void PageSettings::pageOffsetChanged(int val)
+      {
+      preview->score()->setPageNumberOffset(val-1);
+      updatePreview();
+      }
+
+//---------------------------------------------------------
+//   unitsChanged
+//---------------------------------------------------------
+
+void PageSettings::unitsChanged()
+      {
+      QPageLayout::Unit u = QPageLayout::Unit(unitsList->currentIndex());
+      MStyle& style = preview->score()->style();
+      style.pageOdd().setUnits(u);
+      style.pageEven().setUnits(u);
+      updateWidgets(true);
+      }
+
+///////////////////// Buttons /////////////////////////////
+//---------------------------------------------------------
+//   setToDefault
+//---------------------------------------------------------
+
+void PageSettings::setToDefault()
+      {
+      MStyle& style = preview->score()->style();
+      MStyle& def   = MScore::defaultStyle();
+      style.setPageOdd(def.pageOdd());
+      style.setPageEven(def.pageEven());
+      style.setPageSize(def.pageSize());
+      updateWidgets();
+      updatePreview();
       }
 
 //---------------------------------------------------------
@@ -316,18 +751,77 @@ void PageSettings::applyToScore(Score* s)
 
 void PageSettings::applyToAllParts()
       {
+      cs->startCmd();
       for (Excerpt* e : cs->excerpts())
-            applyToScore(e->partScore());
+            applyToScore(e->partScore(), false);
+      cs->endCmd();
       }
 
 //---------------------------------------------------------
-//   ok
+//   applyToScore
 //---------------------------------------------------------
 
-void PageSettings::ok()
+void PageSettings::applyToScore(Score* score, bool runCmd)
       {
-      apply();
-      done(0);
+      Score* prev = preview->score();
+      QPageSize& psize = prev->style().pageSize();
+      MPageLayout& odd = prev->style().pageOdd();
+      MPageLayout& even = prev->style().pageEven();
+
+      // Has anything changed? This prevents extra undo commands on the stack
+      // when the user clicks Apply or OK with no changes.
+      if (score->styleB(Sid::pageTwosided) == twosided->isChecked() &&
+          score->pageNumberOffset()        == prev->pageNumberOffset() &&
+          score->spatium()                 == prev->spatium() &&
+          score->style().pageSize().id()   == prev->style().pageSize().id())
+            {
+            MPageLayout& sOdd  = score->style().pageOdd();
+            MPageLayout& sEven = score->style().pageEven();
+            if (sOdd.units()             == odd.units() &&
+                sOdd.orientation()       == odd.orientation() &&
+                sOdd.fullRect().width()  == odd.fullRect().width() &&
+                sOdd.fullRect().height() == odd.fullRect().height() &&
+                sOdd.margins().left()    == odd.margins().left() &&
+                sOdd.margins().right()   == odd.margins().right() &&
+                sOdd.margins().top()     == odd.margins().top() &&
+                sOdd.margins().bottom()  == odd.margins().bottom() &&
+                sEven.margins().top()    == even.margins().top() &&
+                sEven.margins().bottom() == even.margins().bottom())
+                  {
+                  return; // nothing has changed
+                  }
+            }
+
+      if (runCmd)
+            score->startCmd();
+      score->undoChangePageNumberOffset(pageOffset->value() - 1); // why isn't this a style?
+      score->undoChangePageSettings(psize, odd, even);
+      score->undoChangeStyleVal(Sid::spatium,      prev->spatium());
+      score->undoChangeStyleVal(Sid::pageTwosided, twosided->isChecked());
+      if (runCmd)
+            score->endCmd();
+      }
+
+//---------------------------------------------------------
+//   okCancel
+//---------------------------------------------------------
+
+void PageSettings::okCancel(QAbstractButton* b)
+      {
+      switch (buttonBox->standardButton(b)) {
+            case QDialogButtonBox::Apply:
+                  applyToScore(cs);
+                  break;
+            case QDialogButtonBox::Ok:
+                  applyToScore(cs);
+                  done(0);
+                  break;
+            case QDialogButtonBox::Cancel:
+                  done(0);
+                  break;
+            default:
+                  break;
+            }
       }
 
 //---------------------------------------------------------
@@ -339,242 +833,4 @@ void PageSettings::done(int val)
       cs->setLayoutAll();     // HACK
       QDialog::done(val);
       }
-
-//---------------------------------------------------------
-//   pageFormatSelected
-//---------------------------------------------------------
-
-void PageSettings::pageFormatSelected(int size)
-      {
-      if (size >= 0) {
-            Score* s  = preview->score();
-            int id    = pageGroup->currentData().toInt();
-            QSizeF sz = QPageSize::size(QPageSize::PageSizeId(id), QPageSize::Inch);
-
-            s->style().set(Sid::pageWidth, sz.width());
-            s->style().set(Sid::pageHeight, sz.height());
-
-            double f  = mmUnit ? 1.0/INCH : 1.0;
-            s->style().set(Sid::pagePrintableWidth, sz.width() - (oddPageLeftMargin->value() + oddPageRightMargin->value())  * f);
-            updateValues();
-            updatePreview(0);
-            }
-      }
-
-//---------------------------------------------------------
-//   otmChanged
-//---------------------------------------------------------
-
-void PageSettings::otmChanged(double val)
-      {
-      if (mmUnit)
-            val /= INCH;
-      preview->score()->style().set(Sid::pageOddTopMargin, val);
-      updatePreview(1);
-      }
-
-//---------------------------------------------------------
-//   olmChanged
-//---------------------------------------------------------
-
-void PageSettings::olmChanged(double val)
-      {
-      if (mmUnit)
-            val /= INCH;
-
-      if (twosided->isChecked()) {
-            evenPageRightMargin->blockSignals(true);
-            evenPageRightMargin->setValue(val * (mmUnit ? INCH : 1.0));
-            evenPageRightMargin->blockSignals(false);
-            }
-      else {
-            evenPageLeftMargin->blockSignals(true);
-            evenPageLeftMargin->setValue(val * (mmUnit ? INCH : 1.0));
-            evenPageLeftMargin->blockSignals(false);
-            }
-      Score* s = preview->score();
-      s->style().set(Sid::pageOddLeftMargin, val);
-      s->style().set(Sid::pagePrintableWidth, s->styleD(Sid::pageWidth) - s->styleD(Sid::pageEvenLeftMargin) - val);
-
-      updatePreview(0);
-      }
-
-//---------------------------------------------------------
-//   ormChanged
-//---------------------------------------------------------
-
-void PageSettings::ormChanged(double val)
-      {
-      if (mmUnit)
-            val /= INCH;
-
-      Score* s = preview->score();
-      if (twosided->isChecked()) {
-            evenPageLeftMargin->blockSignals(true);
-            evenPageLeftMargin->setValue(val * (mmUnit ? INCH : 1.0));
-            s->style().set(Sid::pageEvenLeftMargin, val);
-            evenPageLeftMargin->blockSignals(false);
-            }
-      else {
-            evenPageRightMargin->blockSignals(true);
-            evenPageRightMargin->setValue(val * (mmUnit ? INCH : 1.0));
-            evenPageRightMargin->blockSignals(false);
-            }
-      s->style().set(Sid::pagePrintableWidth, s->styleD(Sid::pageWidth) - s->styleD(Sid::pageOddLeftMargin) - val);
-      updatePreview(0);
-      }
-
-//---------------------------------------------------------
-//   obmChanged
-//---------------------------------------------------------
-
-void PageSettings::obmChanged(double val)
-      {
-      if (mmUnit)
-            val /= INCH;
-      preview->score()->style().set(Sid::pageOddBottomMargin, val);
-      updatePreview(1);
-      }
-
-//---------------------------------------------------------
-//   etmChanged
-//---------------------------------------------------------
-
-void PageSettings::etmChanged(double val)
-      {
-      if (mmUnit)
-            val /= INCH;
-      preview->score()->style().set(Sid::pageEvenTopMargin, val);
-      updatePreview(1);
-      }
-
-//---------------------------------------------------------
-//   elmChanged
-//---------------------------------------------------------
-
-void PageSettings::elmChanged(double val)
-      {
-      double f  = mmUnit ? 1.0/INCH : 1.0;
-      val *= f;
-
-      if (twosided->isChecked()) {
-            oddPageRightMargin->blockSignals(true);
-            oddPageRightMargin->setValue(val * (mmUnit ? INCH : 1.0));
-            oddPageRightMargin->blockSignals(false);
-            }
-      Score* s = preview->score();
-      s->style().set(Sid::pageEvenLeftMargin, val);
-      s->style().set(Sid::pagePrintableWidth, s->styleD(Sid::pageWidth) - evenPageRightMargin->value() * f - val);
-      updatePreview(0);
-      }
-
-//---------------------------------------------------------
-//   ermChanged
-//---------------------------------------------------------
-
-void PageSettings::ermChanged(double val)
-      {
-      if (mmUnit)
-            val /= INCH;
-
-      if (twosided->isChecked()) {
-            oddPageLeftMargin->blockSignals(true);
-            oddPageLeftMargin->setValue(val * (mmUnit ? INCH : 1.0));
-            oddPageLeftMargin->blockSignals(false);
-            }
-      Score* s = preview->score();
-      s->style().set(Sid::pagePrintableWidth, s->styleD(Sid::pageWidth) - s->styleD(Sid::pageEvenLeftMargin) - val);
-      s->style().set(Sid::pageOddLeftMargin, val);
-      updatePreview(0);
-      }
-
-//---------------------------------------------------------
-//   ebmChanged
-//---------------------------------------------------------
-
-void PageSettings::ebmChanged(double val)
-      {
-      if (mmUnit)
-            val /= INCH;
-      preview->score()->style().set(Sid::pageEvenBottomMargin, val);
-      updatePreview(1);
-      }
-
-//---------------------------------------------------------
-//   spatiumChanged
-//---------------------------------------------------------
-
-void PageSettings::spatiumChanged(double val)
-      {
-      val *= mmUnit ? DPMM : DPI;
-      double oldVal = preview->score()->spatium();
-      preview->score()->setSpatium(val);
-      preview->score()->spatiumChanged(oldVal, val);
-      updatePreview(0);
-      }
-
-//---------------------------------------------------------
-//   pageOffsetChanged
-//---------------------------------------------------------
-
-void PageSettings::pageOffsetChanged(int val)
-      {
-      preview->score()->setPageNumberOffset(val-1);
-      updatePreview(0);
-      }
-
-//---------------------------------------------------------
-//   pageHeightChanged
-//---------------------------------------------------------
-
-void PageSettings::pageHeightChanged(double val)
-      {
-      double val2 = pageWidth->value();
-      if (mmUnit) {
-            val /= INCH;
-            val2 /= INCH;
-            }
-      pageGroup->setCurrentIndex(0);      // custom
-      preview->score()->style().set(Sid::pageHeight, val);
-      preview->score()->style().set(Sid::pageWidth, val2);
-
-      updatePreview(1);
-      }
-
-//---------------------------------------------------------
-//   pageWidthChanged
-//---------------------------------------------------------
-
-void PageSettings::pageWidthChanged(double val)
-      {
-      setMarginsMax(val);
-
-      double f    = mmUnit ? 1.0/INCH : 1.0;
-      double val2 = pageHeight->value() * f;
-      val        *= f;
-      pageGroup->setCurrentIndex(0);      // custom
-      preview->score()->style().set(Sid::pageWidth, val);
-      preview->score()->style().set(Sid::pageHeight, val2);
-      preview->score()->style().set(Sid::pagePrintableWidth, val - (oddPageLeftMargin->value() + evenPageLeftMargin->value()) * f);
-      updatePreview(0);
-      }
-
-//---------------------------------------------------------
-//   updatePreview
-//---------------------------------------------------------
-
-void PageSettings::updatePreview(int val)
-      {
-      updateValues();
-      switch(val) {
-            case 0:
-                  preview->score()->doLayout();
-                  break;
-            case 1:
-                  preview->score()->doLayout();
-                  break;
-            }
-      preview->layoutChanged();
-      }
 }
-

--- a/mscore/pagesettings.h
+++ b/mscore/pagesettings.h
@@ -22,38 +22,58 @@ class MasterScore;
 class Score;
 class Navigator;
 
+enum class PaperType { // 4 paper size types for the typesList combo box
+      NOTYPE = -1,
+      Common,
+      Metric,
+      Imperial,
+      Other
+      };
+
 //---------------------------------------------------------
 //   PageSettings
 //---------------------------------------------------------
+struct PageUnit; // instead of #include "libmscore/style.h"
 
 class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
       Q_OBJECT
 
-      Navigator* preview;
-      bool mmUnit;
       Score* cs;
       Score* clonedScore;
+      Navigator* preview;
+      double sp20_mm;
+      double sp20_in;
+      double sp20_p;
+      double sp20_dd;
+      double sp20_c;
 
 //      std::unique_ptr<Score> clonedScoreForNavigator;
 
       virtual void hideEvent(QHideEvent*);
-      void updateValues();
-      void updatePreview(int);
+      void updateWidgets(bool onlyUnits = false);
+      void updateDecimals(Score *score, PageUnit *unit, int decimals);
+      void updateMaximum(double max);
+      void updateWidthHeight(const QRectF & rect);
+      void updatePreview();
       void blockSignals(bool);
-      void applyToScore(Score*);
-      void setMarginsMax(double);
+      void applyToScore(Score* s, bool runCmd = true);
+      void lrMargins(double val, bool isLeft, bool isOdd, QDoubleSpinBox* spinOne);
+      void widthHeightChanged(double w, double h, bool byType);
+      double marginMinMax(double val, double max, QDoubleSpinBox* spinner);
+      PaperType getPaperType(int id);
 
    private slots:
-      void mmClicked();
-      void inchClicked();
-      void pageFormatSelected(int);
+      void typeChanged(int idx, bool isSignal = true);
+      void sizeChanged();
+      void unitsChanged();
 
-      void apply();
+      void setToDefault();
       void applyToAllParts();
-      void ok();
+      void okCancel(QAbstractButton*);
       void done(int val);
 
-      void twosidedToggled(bool);
+      void twosidedToggled(bool b);
+      void orientationToggled(bool);
       void otmChanged(double val);
       void obmChanged(double val);
       void olmChanged(double val);
@@ -63,10 +83,9 @@ class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
       void elmChanged(double val);
       void ermChanged(double val);
       void spatiumChanged(double val);
-      void pageHeightChanged(double);
-      void pageWidthChanged(double);
+      void widthChanged(double val);
+      void heightChanged(double val);
       void pageOffsetChanged(int val);
-      void orientationClicked();
 
    protected:
       virtual void retranslate() { retranslateUi(this); }
@@ -76,8 +95,6 @@ class PageSettings : public AbstractDialog, private Ui::PageSettingsBase {
       ~PageSettings();
       void setScore(Score*);
       };
-
-
 } // namespace Ms
 #endif
 

--- a/mscore/pagesettings.ui
+++ b/mscore/pagesettings.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>489</width>
+    <width>528</width>
     <height>520</height>
    </rect>
   </property>
@@ -63,7 +63,7 @@
     </widget>
    </item>
    <item row="0" column="0" rowspan="2">
-    <layout class="QVBoxLayout" stretch="0,0,0">
+    <layout class="QVBoxLayout" name="leftLayout" stretch="0,0,0">
      <property name="spacing">
       <number>6</number>
      </property>
@@ -80,36 +80,12 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QGroupBox" name="groupBox">
+      <widget class="QGroupBox" name="sizeGroup">
        <property name="title">
         <string>Page Size</string>
        </property>
        <layout class="QGridLayout">
-        <item row="3" column="0">
-         <widget class="QRadioButton" name="portraitButton">
-          <property name="text">
-           <string>Portrait</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0" colspan="2">
-         <widget class="QComboBox" name="pageGroup"/>
-        </item>
-        <item row="4" column="0">
-         <widget class="QCheckBox" name="twosided">
-          <property name="text">
-           <string>Two sided</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QRadioButton" name="landscapeButton">
-          <property name="text">
-           <string>Landscape</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
+        <item row="5" column="1">
          <widget class="QDoubleSpinBox" name="pageWidth">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -118,25 +94,12 @@
            </sizepolicy>
           </property>
           <property name="maximum">
-           <double>2000.000000000000000</double>
+           <double>9999.989999999999782</double>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
-         <widget class="QDoubleSpinBox" name="pageHeight">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximum">
-           <double>2000.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_3">
+        <item row="6" column="0">
+         <widget class="QLabel" name="heightLabel">
           <property name="text">
            <string>Height:</string>
           </property>
@@ -145,8 +108,56 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
+        <item row="7" column="1">
+         <widget class="QRadioButton" name="landscape">
+          <property name="text">
+           <string>Landscape</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QRadioButton" name="portrait">
+          <property name="text">
+           <string>Portrait</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QDoubleSpinBox" name="pageHeight">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximum">
+           <double>9999.989999999999782</double>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0" colspan="2">
+         <widget class="QComboBox" name="sizesList">
+          <property name="toolTip">
+           <string>Page Size</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QComboBox" name="typesList">
+          <property name="toolTip">
+           <string>Paper Type</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="twosided">
+          <property name="text">
+           <string>Two sided</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="widthLabel">
           <property name="text">
            <string>Width:</string>
           </property>
@@ -155,17 +166,30 @@
           </property>
          </widget>
         </item>
+        <item row="4" column="0" colspan="2">
+         <widget class="Line" name="line">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_2">
+      <widget class="QGroupBox" name="scalingGroup">
        <property name="title">
         <string>Scaling</string>
        </property>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="spLabel">
           <property name="toolTip">
            <string>Distance between two lines on a standard 5-line staff</string>
           </property>
@@ -176,12 +200,12 @@
            <string>Staff space (sp):</string>
           </property>
           <property name="buddy">
-           <cstring>spatiumEntry</cstring>
+           <cstring>staffSpace</cstring>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QDoubleSpinBox" name="spatiumEntry">
+         <widget class="QDoubleSpinBox" name="staffSpace">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -195,7 +219,7 @@
            <double>0.001000000000000</double>
           </property>
           <property name="maximum">
-           <double>999.990000000000009</double>
+           <double>999.999000000000024</double>
           </property>
           <property name="singleStep">
            <double>0.200000000000000</double>
@@ -209,22 +233,31 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_6">
+      <widget class="QGroupBox" name="unitsGroup">
        <property name="title">
-        <string>Unit</string>
+        <string>Units</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_1">
-        <item row="0" column="0">
-         <widget class="QRadioButton" name="inchButton">
-          <property name="text">
-           <string>Inch (in)</string>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="unitsList">
+          <property name="currentText">
+           <string/>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="QRadioButton" name="mmButton">
+        <item row="0" column="0">
+         <widget class="QLabel" name="unitsLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="text">
-           <string>Millimeter (mm)</string>
+           <string>Unit of Measure:</string>
           </property>
          </widget>
         </item>
@@ -234,7 +267,7 @@
     </layout>
    </item>
    <item row="3" column="0" colspan="2">
-    <layout class="QHBoxLayout">
+    <layout class="QHBoxLayout" name="buttonLayout">
      <property name="leftMargin">
       <number>0</number>
      </property>
@@ -248,53 +281,30 @@
       <number>0</number>
      </property>
      <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>131</width>
-         <height>31</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonApplyToAllParts">
+      <widget class="QPushButton" name="resetToDefault">
        <property name="text">
-        <string>Apply to all Parts</string>
+        <string>Reset to Default</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonApply">
+      <widget class="QPushButton" name="applyToParts">
        <property name="text">
-        <string>Apply</string>
+        <string>Apply to All Parts</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonOk">
-       <property name="text">
-        <string>OK</string>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonCancel">
-       <property name="text">
-        <string>Cancel</string>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item row="0" column="1">
-    <layout class="QVBoxLayout">
+    <layout class="QVBoxLayout" name="rightLayout">
      <property name="spacing">
       <number>6</number>
      </property>
@@ -311,13 +321,13 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QGroupBox" name="groupBox_3">
+      <widget class="QGroupBox" name="oddGroup">
        <property name="title">
         <string>Odd Page Margins</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_3">
         <item row="1" column="0" colspan="2">
-         <widget class="QDoubleSpinBox" name="oddPageLeftMargin">
+         <widget class="QDoubleSpinBox" name="oddLeftMargin">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -330,7 +340,7 @@
          </widget>
         </item>
         <item row="1" column="3" colspan="2">
-         <widget class="QDoubleSpinBox" name="oddPageRightMargin">
+         <widget class="QDoubleSpinBox" name="oddRightMargin">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -343,7 +353,7 @@
          </widget>
         </item>
         <item row="2" column="1" colspan="3">
-         <widget class="QDoubleSpinBox" name="oddPageBottomMargin">
+         <widget class="QDoubleSpinBox" name="oddBottomMargin">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -356,7 +366,7 @@
          </widget>
         </item>
         <item row="1" column="2">
-         <spacer name="horizontalSpacer_2">
+         <spacer name="oddSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -372,7 +382,7 @@
          </spacer>
         </item>
         <item row="0" column="1" colspan="3">
-         <widget class="QDoubleSpinBox" name="oddPageTopMargin">
+         <widget class="QDoubleSpinBox" name="oddTopMargin">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -388,13 +398,13 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_4">
+      <widget class="QGroupBox" name="evenGroup">
        <property name="title">
         <string>Even Page Margins</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
         <item row="1" column="3" colspan="2">
-         <widget class="QDoubleSpinBox" name="evenPageRightMargin">
+         <widget class="QDoubleSpinBox" name="evenRightMargin">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -407,7 +417,7 @@
          </widget>
         </item>
         <item row="2" column="1" colspan="3">
-         <widget class="QDoubleSpinBox" name="evenPageBottomMargin">
+         <widget class="QDoubleSpinBox" name="evenBottomMargin">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -420,7 +430,7 @@
          </widget>
         </item>
         <item row="1" column="0" colspan="2">
-         <widget class="QDoubleSpinBox" name="evenPageLeftMargin">
+         <widget class="QDoubleSpinBox" name="evenLeftMargin">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -433,7 +443,7 @@
          </widget>
         </item>
         <item row="1" column="2">
-         <spacer name="horizontalSpacer_3">
+         <spacer name="evenSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -449,7 +459,7 @@
          </spacer>
         </item>
         <item row="0" column="1" colspan="3">
-         <widget class="QDoubleSpinBox" name="evenPageTopMargin">
+         <widget class="QDoubleSpinBox" name="evenTopMargin">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -465,19 +475,19 @@
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <layout class="QHBoxLayout" name="offsetLayout">
        <item>
-        <widget class="QLabel" name="label_12">
+        <widget class="QLabel" name="offsetLabel">
          <property name="text">
           <string>First page number:</string>
          </property>
          <property name="buddy">
-          <cstring>pageOffsetEntry</cstring>
+          <cstring>pageOffset</cstring>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QSpinBox" name="pageOffsetEntry">
+        <widget class="QSpinBox" name="pageOffset">
          <property name="minimum">
           <number>-99</number>
          </property>
@@ -493,62 +503,23 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>pageGroup</tabstop>
+  <tabstop>sizesList</tabstop>
   <tabstop>pageWidth</tabstop>
   <tabstop>pageHeight</tabstop>
-  <tabstop>portraitButton</tabstop>
-  <tabstop>landscapeButton</tabstop>
-  <tabstop>twosided</tabstop>
-  <tabstop>spatiumEntry</tabstop>
-  <tabstop>inchButton</tabstop>
-  <tabstop>mmButton</tabstop>
-  <tabstop>oddPageTopMargin</tabstop>
-  <tabstop>oddPageLeftMargin</tabstop>
-  <tabstop>oddPageRightMargin</tabstop>
-  <tabstop>oddPageBottomMargin</tabstop>
-  <tabstop>evenPageTopMargin</tabstop>
-  <tabstop>evenPageLeftMargin</tabstop>
-  <tabstop>evenPageRightMargin</tabstop>
-  <tabstop>evenPageBottomMargin</tabstop>
-  <tabstop>pageOffsetEntry</tabstop>
-  <tabstop>buttonApplyToAllParts</tabstop>
-  <tabstop>buttonApply</tabstop>
-  <tabstop>buttonOk</tabstop>
-  <tabstop>buttonCancel</tabstop>
+  <tabstop>portrait</tabstop>
+  <tabstop>landscape</tabstop>
+  <tabstop>staffSpace</tabstop>
+  <tabstop>oddTopMargin</tabstop>
+  <tabstop>oddLeftMargin</tabstop>
+  <tabstop>oddRightMargin</tabstop>
+  <tabstop>oddBottomMargin</tabstop>
+  <tabstop>evenTopMargin</tabstop>
+  <tabstop>evenLeftMargin</tabstop>
+  <tabstop>evenRightMargin</tabstop>
+  <tabstop>evenBottomMargin</tabstop>
+  <tabstop>pageOffset</tabstop>
+  <tabstop>applyToParts</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonOk</sender>
-   <signal>clicked()</signal>
-   <receiver>PageSettingsBase</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>278</x>
-     <y>253</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>96</x>
-     <y>254</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonCancel</sender>
-   <signal>clicked()</signal>
-   <receiver>PageSettingsBase</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>369</x>
-     <y>253</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>179</x>
-     <y>282</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -69,11 +69,17 @@ void Preferences::init(bool storeInMemoryOnly)
 
       QString wd = QString("%1/%2").arg(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)).arg(QCoreApplication::applicationName());
 
+      int units = int(QPageLayout::Millimeter);
+      if (!MScore::testMode && QLocale().measurementSystem() != QLocale::MetricSystem)
+            units = int(QPageLayout::Inch); // testMode forces Millimeters
+
       _allPreferences = prefs_map_t(
       {
             {PREF_APP_AUTOSAVE_AUTOSAVETIME,                       new IntPreference(2 /* minutes */, false)},
             {PREF_APP_AUTOSAVE_USEAUTOSAVE,                        new BoolPreference(true, false)},
             {PREF_APP_KEYBOARDLAYOUT,                              new StringPreference("US - International")},
+            {PREF_APP_PAGE_UNITS_GLOBAL,                           new BoolPreference(true, false)},
+            {PREF_APP_PAGE_UNITS_VALUE,                            new IntPreference(units, false)},
             {PREF_APP_PATHS_INSTRUMENTLIST1,                       new StringPreference(":/data/instruments.xml", false)},
             {PREF_APP_PATHS_INSTRUMENTLIST2,                       new StringPreference("", false)},
             {PREF_APP_PATHS_MYIMAGES,                              new StringPreference(QFileInfo(QString("%1/%2").arg(wd).arg(QCoreApplication::translate("images_directory", "Images"))).absoluteFilePath(), false)},
@@ -435,7 +441,8 @@ QMap<QString, QVariant> Preferences::getDefaultLocalPreferences() {
       bool tmp = useLocalPrefs;
       useLocalPrefs = false;
       QMap<QString, QVariant> defaultLocalPreferences;
-      for (QString s : {PREF_UI_CANVAS_BG_USECOLOR,
+      for (QString s : {PREF_APP_PAGE_UNITS_VALUE,
+                        PREF_UI_CANVAS_BG_USECOLOR,
                         PREF_UI_CANVAS_FG_USECOLOR,
                         PREF_UI_CANVAS_BG_COLOR,
                         PREF_UI_CANVAS_FG_COLOR,
@@ -463,6 +470,8 @@ QMap<QString, QVariant> Preferences::getDefaultLocalPreferences() {
             QVariant value = get(s);
             if (!value.isValid())
                   value = _allPreferences.value(s)->defaultValue();
+            if (s == PREF_APP_PAGE_UNITS_VALUE)
+                  MScore::setUnitsValue(value.toInt());
             defaultLocalPreferences.insert(s, value);
             }
       useLocalPrefs = tmp;

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -80,6 +80,8 @@ enum class MusicxmlExportBreaks : char {
 #define PREF_APP_AUTOSAVE_AUTOSAVETIME                      "application/autosave/autosaveTime"
 #define PREF_APP_AUTOSAVE_USEAUTOSAVE                       "application/autosave/useAutosave"
 #define PREF_APP_KEYBOARDLAYOUT                             "application/keyboardLayout"
+#define PREF_APP_PAGE_UNITS_GLOBAL                          "application/pageUnits/global"
+#define PREF_APP_PAGE_UNITS_VALUE                           "application/pageUnits/value"
 // file path of instrument templates
 #define PREF_APP_PATHS_INSTRUMENTLIST1                      "application/paths/instrumentList1"
 #define PREF_APP_PATHS_INSTRUMENTLIST2                      "application/paths/instrumentList2"

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>834</width>
-    <height>569</height>
+    <width>879</width>
+    <height>572</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -214,120 +214,6 @@
              <string>Show tours</string>
             </property>
            </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QGroupBox" name="oscServer">
-         <property name="title">
-          <string>OSC Remote Control</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_9">
-          <item>
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string extracomment="The UDP port number on which the MuseScore OSC server will listen on">Port number:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="oscPort">
-            <property name="accessibleName">
-             <string>Port number</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>65535</number>
-            </property>
-            <property name="value">
-             <number>5282</number>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_15">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QGroupBox" name="autoSave">
-         <property name="title">
-          <string>Auto Save</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <layout class="QHBoxLayout">
-          <property name="spacing">
-           <number>9</number>
-          </property>
-          <property name="leftMargin">
-           <number>9</number>
-          </property>
-          <property name="topMargin">
-           <number>9</number>
-          </property>
-          <property name="rightMargin">
-           <number>9</number>
-          </property>
-          <property name="bottomMargin">
-           <number>9</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="label_25">
-            <property name="text">
-             <string>Save every:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="autoSaveTime">
-            <property name="accessibleName">
-             <string>Select delay (in minutes) between auto saves</string>
-            </property>
-            <property name="suffix">
-             <string extracomment="minutes">min</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="value">
-             <number>2</number>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>
@@ -772,6 +658,160 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="3" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <widget class="QGroupBox" name="autoSave">
+             <property name="title">
+              <string>Auto Save</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <layout class="QHBoxLayout">
+              <property name="spacing">
+               <number>9</number>
+              </property>
+              <property name="leftMargin">
+               <number>9</number>
+              </property>
+              <property name="topMargin">
+               <number>9</number>
+              </property>
+              <property name="rightMargin">
+               <number>9</number>
+              </property>
+              <property name="bottomMargin">
+               <number>9</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="label_25">
+                <property name="text">
+                 <string>Save every:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="autoSaveTime">
+                <property name="accessibleName">
+                 <string>Select delay (in minutes) between auto saves</string>
+                </property>
+                <property name="suffix">
+                 <string extracomment="minutes">min</string>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="value">
+                 <number>2</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="oscServer">
+             <property name="title">
+              <string>OSC Remote Control</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_9">
+              <item>
+               <widget class="QLabel" name="label">
+                <property name="text">
+                 <string extracomment="The UDP port number on which the MuseScore OSC server will listen on">Port number:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="oscPort">
+                <property name="accessibleName">
+                 <string>Port number</string>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>65535</number>
+                </property>
+                <property name="value">
+                 <number>5282</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="unitsGroup">
+           <property name="minimumSize">
+            <size>
+             <width>232</width>
+             <height>80</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>Page Units</string>
+           </property>
+           <widget class="QRadioButton" name="unitsGlobal">
+            <property name="geometry">
+             <rect>
+              <x>9</x>
+              <y>32</y>
+              <width>111</width>
+              <height>17</height>
+             </rect>
+            </property>
+            <property name="text">
+             <string>Global:</string>
+            </property>
+           </widget>
+           <widget class="QRadioButton" name="unitsByScore">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="geometry">
+             <rect>
+              <x>9</x>
+              <y>54</y>
+              <width>111</width>
+              <height>17</height>
+             </rect>
+            </property>
+            <property name="text">
+             <string>by Score</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+           <widget class="QComboBox" name="unitsList">
+            <property name="geometry">
+             <rect>
+              <x>90</x>
+              <y>28</y>
+              <width>69</width>
+              <height>20</height>
+             </rect>
+            </property>
+            <property name="sizeAdjustPolicy">
+             <enum>QComboBox::AdjustToContents</enum>
+            </property>
+           </widget>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -4198,9 +4238,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>iconHeight</tabstop>
   <tabstop>fontFamily</tabstop>
   <tabstop>fontSize</tabstop>
-  <tabstop>autoSave</tabstop>
   <tabstop>autoSaveTime</tabstop>
-  <tabstop>oscServer</tabstop>
   <tabstop>oscPort</tabstop>
   <tabstop>bgColorButton</tabstop>
   <tabstop>bgColorLabel</tabstop>
@@ -4325,6 +4363,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>advancedSearch</tabstop>
  </tabstops>
  <resources>
+  <include location="musescore.qrc"/>
   <include location="musescore.qrc"/>
  </resources>
  <connections/>

--- a/mtest/libmscore/clef/clef-1-ref.mscx
+++ b/mtest/libmscore/clef/clef-1-ref.mscx
@@ -5,7 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/clef/clef-3-ref.mscx
+++ b/mtest/libmscore/clef/clef-3-ref.mscx
@@ -5,9 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
       <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/mtest/libmscore/clef/updateReference
+++ b/mtest/libmscore/clef/updateReference
@@ -1,5 +1,6 @@
 #!/bin/bash
-
 cp ../../../build.debug/mtest/libmscore/clef/clef-1.mscx clef-1-ref.mscx
 cp ../../../build.debug/mtest/libmscore/clef/clef-2.mscx clef-2-ref.mscx
+cp ../../../build.debug/mtest/libmscore/clef/clef-3.mscx clef-3-ref.mscx
+
 

--- a/mtest/libmscore/compat114/accidentals-ref.mscx
+++ b/mtest/libmscore/compat114/accidentals-ref.mscx
@@ -26,7 +26,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/articulations-ref.mscx
+++ b/mtest/libmscore/compat114/articulations-ref.mscx
@@ -28,7 +28,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/chord_symbol-ref.mscx
+++ b/mtest/libmscore/compat114/chord_symbol-ref.mscx
@@ -5,6 +5,9 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pageWidth>8.5</pageWidth>
+      <pageHeight>11</pageHeight>
+      <pagePrintableWidth>7.7126</pagePrintableWidth>
       <lyricsDashForce>0</lyricsDashForce>
       <minMeasureWidth>4</minMeasureWidth>
       <bracketWidth>0.35</bracketWidth>
@@ -26,7 +29,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/clef_missing_first-ref.mscx
+++ b/mtest/libmscore/compat114/clef_missing_first-ref.mscx
@@ -26,7 +26,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/clefs-ref.mscx
+++ b/mtest/libmscore/compat114/clefs-ref.mscx
@@ -28,7 +28,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/drumset-ref.mscx
+++ b/mtest/libmscore/compat114/drumset-ref.mscx
@@ -26,7 +26,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
+++ b/mtest/libmscore/compat114/hor_frame_and_mmrest-ref.mscx
@@ -28,7 +28,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/keysig-ref.mscx
+++ b/mtest/libmscore/compat114/keysig-ref.mscx
@@ -26,7 +26,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/noteheads-ref.mscx
+++ b/mtest/libmscore/compat114/noteheads-ref.mscx
@@ -26,7 +26,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/notes-ref.mscx
+++ b/mtest/libmscore/compat114/notes-ref.mscx
@@ -26,7 +26,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/slurs-ref.mscx
+++ b/mtest/libmscore/compat114/slurs-ref.mscx
@@ -26,7 +26,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/style-ref.mscx
+++ b/mtest/libmscore/compat114/style-ref.mscx
@@ -82,7 +82,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/textstyles-ref.mscx
+++ b/mtest/libmscore/compat114/textstyles-ref.mscx
@@ -5,6 +5,7 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
+      <pageTwosided>0</pageTwosided>
       <staffUpperBorder>6</staffUpperBorder>
       <staffLowerBorder>2</staffLowerBorder>
       <minSystemDistance>9.5</minSystemDistance>

--- a/mtest/libmscore/compat114/tremolo2notes-ref.mscx
+++ b/mtest/libmscore/compat114/tremolo2notes-ref.mscx
@@ -26,7 +26,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat114/tuplets-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets-ref.mscx
@@ -26,7 +26,7 @@
       <voltaPosAbove x="0" y="-2"/>
       <keySigNaturals>1</keySigNaturals>
       <tupletOufOfStaff>0</tupletOufOfStaff>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/compat206/articulations-double-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-double-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.26771</pageWidth>
-      <pageHeight>11.6929</pageHeight>
-      <pagePrintableWidth>7.48031</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
@@ -1802,15 +1793,6 @@
       <currentLayer>0</currentLayer>
       <Division>480</Division>
       <Style>
-        <pageWidth>8.27</pageWidth>
-        <pageHeight>11.69</pageHeight>
-        <pagePrintableWidth>7.4826</pagePrintableWidth>
-        <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-        <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-        <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-        <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-        <pageOddTopMargin>0.393701</pageOddTopMargin>
-        <pageOddBottomMargin>0.787403</pageOddBottomMargin>
         <lastSystemFillLimit>0</lastSystemFillLimit>
         <createMultiMeasureRests>1</createMultiMeasureRests>
         <Spatium>1.76389</Spatium>

--- a/mtest/libmscore/compat206/barlines-ref.mscx
+++ b/mtest/libmscore/compat206/barlines-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>

--- a/mtest/libmscore/compat206/fermata-ref.mscx
+++ b/mtest/libmscore/compat206/fermata-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>

--- a/mtest/libmscore/compat206/hairpin-ref.mscx
+++ b/mtest/libmscore/compat206/hairpin-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.26771</pageWidth>
-      <pageHeight>11.6929</pageHeight>
-      <pagePrintableWidth>7.48031</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>
@@ -649,15 +640,9 @@
       <currentLayer>0</currentLayer>
       <Division>480</Division>
       <Style>
-        <pageWidth>4.13</pageWidth>
-        <pageHeight>5.83</pageHeight>
-        <pagePrintableWidth>3.3426</pagePrintableWidth>
-        <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-        <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-        <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-        <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-        <pageOddTopMargin>0.393701</pageOddTopMargin>
-        <pageOddBottomMargin>0.787403</pageOddBottomMargin>
+        <pageWidth>4.13386</pageWidth>
+        <pageHeight>5.82677</pageHeight>
+        <pagePrintableWidth>3.34646</pagePrintableWidth>
         <createMultiMeasureRests>1</createMultiMeasureRests>
         <Spatium>1.76389</Spatium>
         </Style>

--- a/mtest/libmscore/compat206/intrumentNameAlign-ref.mscx
+++ b/mtest/libmscore/compat206/intrumentNameAlign-ref.mscx
@@ -8,12 +8,6 @@
       <pageWidth>8.5</pageWidth>
       <pageHeight>11</pageHeight>
       <pagePrintableWidth>7.7126</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>

--- a/mtest/libmscore/copypaste/copypaste25-ref.mscx
+++ b/mtest/libmscore/copypaste/copypaste25-ref.mscx
@@ -5,9 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <Spatium>1.76389</Spatium>
       </Style>

--- a/mtest/libmscore/copypaste/updateReference
+++ b/mtest/libmscore/copypaste/updateReference
@@ -6,7 +6,7 @@ else
    S=../../../build.debug/mtest/libmscore/copypaste
 fi
 
-for a in 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 50; do
+for a in 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 50; do
       echo cp $S/copypaste${a}.mscx copypaste${a}-ref.mscx
       cp $S/copypaste${a}.mscx copypaste${a}-ref.mscx
       done

--- a/mtest/libmscore/measure/measure-10-ref.mscx
+++ b/mtest/libmscore/measure/measure-10-ref.mscx
@@ -16,7 +16,7 @@
       <beamMinLen>1.25</beamMinLen>
       <propertyDistanceStem>0.5</propertyDistanceStem>
       <keySigNaturals>1</keySigNaturals>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/measure/measure-4-ref.mscx
+++ b/mtest/libmscore/measure/measure-4-ref.mscx
@@ -16,7 +16,7 @@
       <beamMinLen>1.25</beamMinLen>
       <propertyDistanceStem>0.5</propertyDistanceStem>
       <keySigNaturals>1</keySigNaturals>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/measure/measure-5-ref.mscx
+++ b/mtest/libmscore/measure/measure-5-ref.mscx
@@ -16,7 +16,7 @@
       <beamMinLen>1.25</beamMinLen>
       <propertyDistanceStem>0.5</propertyDistanceStem>
       <keySigNaturals>1</keySigNaturals>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/measure/measure-6-ref.mscx
+++ b/mtest/libmscore/measure/measure-6-ref.mscx
@@ -16,7 +16,7 @@
       <beamMinLen>1.25</beamMinLen>
       <propertyDistanceStem>0.5</propertyDistanceStem>
       <keySigNaturals>1</keySigNaturals>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/measure/measure-7-ref.mscx
+++ b/mtest/libmscore/measure/measure-7-ref.mscx
@@ -16,7 +16,7 @@
       <beamMinLen>1.25</beamMinLen>
       <propertyDistanceStem>0.5</propertyDistanceStem>
       <keySigNaturals>1</keySigNaturals>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/measure/measure-8-ref.mscx
+++ b/mtest/libmscore/measure/measure-8-ref.mscx
@@ -16,7 +16,7 @@
       <beamMinLen>1.25</beamMinLen>
       <propertyDistanceStem>0.5</propertyDistanceStem>
       <keySigNaturals>1</keySigNaturals>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/measure/measure-9-ref.mscx
+++ b/mtest/libmscore/measure/measure-9-ref.mscx
@@ -16,7 +16,7 @@
       <beamMinLen>1.25</beamMinLen>
       <propertyDistanceStem>0.5</propertyDistanceStem>
       <keySigNaturals>1</keySigNaturals>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/measure/mmrest-ref.mscx
+++ b/mtest/libmscore/measure/mmrest-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.26771</pageWidth>
-      <pageHeight>11.6929</pageHeight>
-      <pagePrintableWidth>7.48031</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <createMultiMeasureRests>1</createMultiMeasureRests>
       <Spatium>1.76389</Spatium>

--- a/mtest/libmscore/measure/undoDelInitialVBox_269919-ref.mscx
+++ b/mtest/libmscore/measure/undoDelInitialVBox_269919-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.26771</pageWidth>
-      <pageHeight>11.6929</pageHeight>
-      <pagePrintableWidth>7.48031</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <Spatium>1.76389</Spatium>
       </Style>

--- a/mtest/libmscore/measure/updateReference
+++ b/mtest/libmscore/measure/updateReference
@@ -3,19 +3,21 @@
 P=../../../build.debug
 #P=../../../../MuseScore-build
 
-cp $P/mtest/libmscore/measure/measure-1.mscx measure-1-ref.mscx
-cp $P/mtest/libmscore/measure/measure-2.mscx measure-2-ref.mscx
-cp $P/mtest/libmscore/measure/measure-3.mscx measure-3-ref.mscx
-cp $P/mtest/libmscore/measure/measure-4.mscx measure-4-ref.mscx
-cp $P/mtest/libmscore/measure/measure-5.mscx measure-5-ref.mscx
-cp $P/mtest/libmscore/measure/measure-6.mscx measure-6-ref.mscx
-cp $P/mtest/libmscore/measure/measure-7.mscx measure-7-ref.mscx
-cp $P/mtest/libmscore/measure/measure-8.mscx measure-8-ref.mscx
-cp $P/mtest/libmscore/measure/measure-9.mscx measure-9-ref.mscx
+cp $P/mtest/libmscore/measure/measure-1.mscx  measure-1-ref.mscx
+cp $P/mtest/libmscore/measure/measure-2.mscx  measure-2-ref.mscx
+cp $P/mtest/libmscore/measure/measure-3.mscx  measure-3-ref.mscx
+cp $P/mtest/libmscore/measure/measure-4.mscx  measure-4-ref.mscx
+cp $P/mtest/libmscore/measure/measure-5.mscx  measure-5-ref.mscx
+cp $P/mtest/libmscore/measure/measure-6.mscx  measure-6-ref.mscx
+cp $P/mtest/libmscore/measure/measure-7.mscx  measure-7-ref.mscx
+cp $P/mtest/libmscore/measure/measure-8.mscx  measure-8-ref.mscx
+cp $P/mtest/libmscore/measure/measure-9.mscx  measure-9-ref.mscx
 cp $P/mtest/libmscore/measure/measure-10.mscx measure-10-ref.mscx
-cp $P/mtest/libmscore/measure/measure-insert_bf_key.mscx measure-insert_bf_key-ref.mscx
-cp $P/mtest/libmscore/measure/measure-insert_bf_key-2.mscx measure-insert_bf_key-2-ref.mscx
-cp $P/mtest/libmscore/measure/measure-insert_bf_key_undo.mscx measure-insert_bf_key.mscx
-cp $P/mtest/libmscore/measure/measure-insert_bf_clef.mscx measure-insert_bf_clef-ref.mscx
-cp $P/mtest/libmscore/measure/measure-insert_bf_clef-2.mscx measure-insert_bf_clef-2-ref.mscx
+cp $P/mtest/libmscore/measure/mmrest.mscx mmrest-ref.mscx
+cp $P/mtest/libmscore/measure/measure-insert_bf_key.mscx       measure-insert_bf_key-ref.mscx
+cp $P/mtest/libmscore/measure/measure-insert_bf_key-2.mscx     measure-insert_bf_key-2-ref.mscx
+cp $P/mtest/libmscore/measure/measure-insert_bf_key_undo.mscx  measure-insert_bf_key.mscx
+cp $P/mtest/libmscore/measure/measure-insert_bf_clef.mscx      measure-insert_bf_clef-ref.mscx
+cp $P/mtest/libmscore/measure/measure-insert_bf_clef-2.mscx    measure-insert_bf_clef-2-ref.mscx
 cp $P/mtest/libmscore/measure/measure-insert_bf_clef_undo.mscx measure-insert_bf_clef.mscx
+cp $P/mtest/libmscore/measure/undoDelInitialVBox_269919.mscx   undoDelInitialVBox_269919-ref.mscx

--- a/mtest/libmscore/spanners/linecolor01-ref.mscx
+++ b/mtest/libmscore/spanners/linecolor01-ref.mscx
@@ -5,9 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
       <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/mtest/libmscore/spanners/updateReference
+++ b/mtest/libmscore/spanners/updateReference
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning02.mscx    glissando-cloning02-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/glissando01.mscx            glissando01-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning01.mscx    glissando-cloning01-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning02.mscx    glissando-cloning02-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning03.mscx    glissando-cloning03-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning04.mscx    glissando-cloning04-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning05.mscx    glissando-cloning05-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning02.mscx     glissando-cloning02-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/glissando01.mscx             glissando01-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning01.mscx     glissando-cloning01-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning02.mscx     glissando-cloning02-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning03.mscx     glissando-cloning03-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning04.mscx     glissando-cloning04-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/glissando-cloning05.mscx     glissando-cloning05-ref.mscx
 cp ../../../build.debug/mtest/libmscore/spanners/glissando-crsossstaff01.mscx glissando-crossstaff01-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/glissando-graces01.mscx     glissando-graces01-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/lyricsline02.mscx           lyricsline02-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/lyricsline03.mscx           lyricsline03-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/lyricsline04.mscx           lyricsline04-ref.mscx
-cp ../../../build.debug/mtest/libmscore/spanners/lyricsline05.mscx           lyricsline05-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/glissando-graces01.mscx      glissando-graces01-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/lyricsline02.mscx            lyricsline02-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/lyricsline03.mscx            lyricsline03-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/lyricsline04.mscx            lyricsline04-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/lyricsline05.mscx            lyricsline05-ref.mscx
+cp ../../../build.debug/mtest/libmscore/spanners/linecolor01.mscx             linecolor01-ref.mscx

--- a/mtest/libmscore/split/split183846-irregular-hn-hn-qn-qn-hn-hn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-hn-hn-qn-qn-hn-hn-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>

--- a/mtest/libmscore/split/split183846-irregular-qn-qn-wn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-qn-qn-wn-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>

--- a/mtest/libmscore/split/split183846-irregular-verylong-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-verylong-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>

--- a/mtest/libmscore/split/split183846-irregular-wn-wn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wn-wn-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>

--- a/mtest/libmscore/split/split183846-irregular-wn-wr-wn-hr-qr-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wn-wr-wn-hr-qr-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>

--- a/mtest/libmscore/split/split183846-irregular-wr-wn-wr-hn-qn-ref.mscx
+++ b/mtest/libmscore/split/split183846-irregular-wr-wn-wr-hn-qn-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsDashForce>0</lyricsDashForce>
       <doubleBarDistance>0.46</doubleBarDistance>
       <endBarDistance>0.65</endBarDistance>

--- a/mtest/libmscore/split/split184061-keep-tie-before-break-voice-4-ref.mscx
+++ b/mtest/libmscore/split/split184061-keep-tie-before-break-voice-4-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>

--- a/mtest/libmscore/split/split184061-keep-tie-ref.mscx
+++ b/mtest/libmscore/split/split184061-keep-tie-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>

--- a/mtest/libmscore/split/split184061-no-tie-ref.mscx
+++ b/mtest/libmscore/split/split184061-no-tie-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>

--- a/mtest/libmscore/split/split184061-other-inst-only-one-tie-ref.mscx
+++ b/mtest/libmscore/split/split184061-other-inst-only-one-tie-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lyricsMinBottomDistance>4</lyricsMinBottomDistance>
       <clefLeftMargin>0.64</clefLeftMargin>
       <clefKeyRightMargin>1.75</clefKeyRightMargin>

--- a/mtest/libmscore/timesig/timesig-05-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-05-ref.mscx
@@ -5,9 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
       <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/mtest/libmscore/timesig/timesig-06-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-06-ref.mscx
@@ -5,9 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
       <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/mtest/libmscore/timesig/timesig-07-ref.mscx
+++ b/mtest/libmscore/timesig/timesig-07-ref.mscx
@@ -5,9 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
       <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/mtest/libmscore/transpose/undoTranspose01-ref.mscx
+++ b/mtest/libmscore/transpose/undoTranspose01-ref.mscx
@@ -15,7 +15,7 @@
       <beamWidth>0.48</beamWidth>
       <beamMinLen>1.25</beamMinLen>
       <propertyDistanceStem>0.5</propertyDistanceStem>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/transpose/undoTranspose02-ref.mscx
+++ b/mtest/libmscore/transpose/undoTranspose02-ref.mscx
@@ -15,7 +15,7 @@
       <beamWidth>0.48</beamWidth>
       <beamMinLen>1.25</beamMinLen>
       <propertyDistanceStem>0.5</propertyDistanceStem>
-      <Spatium>1.764</Spatium>
+      <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>
     <showUnprintable>1</showUnprintable>

--- a/mtest/libmscore/tuplet/nestedTuplets_addStaff-ref.mscx
+++ b/mtest/libmscore/tuplet/nestedTuplets_addStaff-ref.mscx
@@ -5,15 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.26771</pageWidth>
-      <pageHeight>11.6929</pageHeight>
-      <pagePrintableWidth>7.48031</pagePrintableWidth>
-      <pageEvenLeftMargin>0.393701</pageEvenLeftMargin>
-      <pageOddLeftMargin>0.393701</pageOddLeftMargin>
-      <pageEvenTopMargin>0.393701</pageEvenTopMargin>
-      <pageEvenBottomMargin>0.787403</pageEvenBottomMargin>
-      <pageOddTopMargin>0.393701</pageOddTopMargin>
-      <pageOddBottomMargin>0.787403</pageOddBottomMargin>
       <lastSystemFillLimit>0</lastSystemFillLimit>
       <tupletOufOfStaff>0</tupletOufOfStaff>
       <Spatium>1.76389</Spatium>

--- a/mtest/libmscore/tuplet/updateReference
+++ b/mtest/libmscore/tuplet/updateReference
@@ -12,5 +12,6 @@ for a in 1; do
       cp $S/split2.mscx split2-ref.mscx
       cp $S/split3.mscx split3-ref.mscx
       cp $S/split4.mscx split4-ref.mscx
+      cp $S/nestedTuplets_addStaff.mscx nestedTuplets_addStaff-ref.mscx
       done
 

--- a/mtest/libmscore/unrollrepeats/clef-key-ts-ref.mscx
+++ b/mtest/libmscore/unrollrepeats/clef-key-ts-ref.mscx
@@ -5,9 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
       <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/mtest/libmscore/unrollrepeats/pickup-measure-ref.mscx
+++ b/mtest/libmscore/unrollrepeats/pickup-measure-ref.mscx
@@ -5,9 +5,6 @@
     <currentLayer>0</currentLayer>
     <Division>480</Division>
     <Style>
-      <pageWidth>8.27</pageWidth>
-      <pageHeight>11.69</pageHeight>
-      <pagePrintableWidth>7.4826</pagePrintableWidth>
       <Spatium>1.76389</Spatium>
       </Style>
     <showInvisible>1</showInvisible>

--- a/mtest/libmscore/unrollrepeats/updateReference
+++ b/mtest/libmscore/unrollrepeats/updateReference
@@ -1,0 +1,4 @@
+#!/bin/sh
+cp ../../../build.debug/mtest/libmscore/unrollrepeats/clef-key-ts-test.mscx    clef-key-ts-ref.mscx
+cp ../../../build.debug/mtest/libmscore/unrollrepeats/pickup-measure-test.mscx pickup-measure-ref.mscx
+

--- a/mtest/testutils.cpp
+++ b/mtest/testutils.cpp
@@ -235,9 +235,7 @@ bool MTest::saveCompareMusicXmlScore(MasterScore* score, const QString& saveName
 bool MTest::savePdf(MasterScore* cs, const QString& saveName)
       {
       QPrinter printerDev(QPrinter::HighResolution);
-      double w = cs->styleD(Sid::pageWidth);
-      double h = cs->styleD(Sid::pageHeight);
-      printerDev.setPaperSize(QSizeF(w,h), QPrinter::Inch);
+      printerDev.setPageSize(cs->style().pageSize());
 
       printerDev.setCreator("MuseScore Version: " VERSION);
       printerDev.setFullPage(true);


### PR DESCRIPTION
This is the first PR in a series of PRs that are pieces of this PR that was deemed to be too broad: https://github.com/musescore/MuseScore/pull/4456

A new [EPIC] issue has been created here:
https://musescore.org/en/node/287602

This code no longer relies on the `Sid::pageWhatever` values at run-time.  `Sid::pageTwosided` is the only exception to that.  Instead the MPageLayout objects provide all the numeric values for page size and margins.  That is the primary reason why these changes extend to so many source files.
The page width/height/margins style values are only used when reading/writing from/to a .mscx file.