### PR TITLE
fix #287630: changing instrument doesn't switch patch to expressive

### DIFF
--- a/demos/Brassed_Up.mscx
+++ b/demos/Brassed_Up.mscx
@@ -63,7 +63,6 @@
       <showMeasureNumber>0</showMeasureNumber>
       <chordStyle>jazz</chordStyle>
       <chordDescriptionFile>chords_jazz.xml</chordDescriptionFile>
-      <concertPitch>1</concertPitch>
       <slurEndWidth>0.12</slurEndWidth>
       <slurMidWidth>0.25</slurMidWidth>
       <musicalSymbolFont>MuseJazz</musicalSymbolFont>
@@ -417,7 +416,7 @@
       <Measure>
         <voice>
           <KeySig>
-            <accidental>-4</accidental>
+            <accidental>-2</accidental>
             </KeySig>
           <TimeSig>
             <subtype>2</subtype>
@@ -857,6 +856,9 @@
         </Measure>
       <!-- Measure 8 -->
       <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
         <voice>
           <Spanner type="HairPin">
             <HairPin>
@@ -894,6 +896,7 @@
             <subtype>other-dynamics</subtype>
             <velocity>96</velocity>
             <veloChange>-24</veloChange>
+            <veloChangeSpeed>fast</veloChangeSpeed>
             <italic>0</italic>
             <text><i></i><font face="ScoreText"></font><i><font face="MuseJazz Text"></font></i></text>
             </Dynamic>
@@ -1033,10 +1036,6 @@
           <label>coda</label>
           </Marker>
         <voice>
-          <Dynamic>
-            <subtype>f</subtype>
-            <velocity>96</velocity>
-            </Dynamic>
           <Chord>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
@@ -1064,7 +1063,7 @@
                 </prev>
               </Spanner>
             <Articulation>
-              <subtype>articStaccatoBelow</subtype>
+              <subtype>articStaccatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>68</pitch>
@@ -1075,7 +1074,7 @@
           <Chord>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articTenutoBelow</subtype>
+              <subtype>articTenutoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>68</pitch>
@@ -1086,7 +1085,7 @@
           <Chord>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoBelow</subtype>
+              <subtype>articStaccatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>68</pitch>
@@ -1100,7 +1099,7 @@
           <Chord>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articAccentBelow</subtype>
+              <subtype>articAccentAbove</subtype>
               </Articulation>
             <Note>
               <Spanner type="Tie">
@@ -1118,11 +1117,27 @@
               <tpc2>12</tpc2>
               </Note>
             </Chord>
+          <BarLine>
+            <subtype>double</subtype>
+            </BarLine>
           </voice>
         </Measure>
       <!-- Measure 12 -->
       <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
         <voice>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>0</subtype>
+              </HairPin>
+            <next>
+              <location>
+                <fractions>1/2</fractions>
+                </location>
+              </next>
+            </Spanner>
           <Chord>
             <durationType>half</durationType>
             <Note>
@@ -1144,6 +1159,13 @@
             <velocity>96</velocity>
             </Dynamic>
           <Spanner type="HairPin">
+            <prev>
+              <location>
+                <fractions>-1/2</fractions>
+                </location>
+              </prev>
+            </Spanner>
+          <Spanner type="HairPin">
             <HairPin>
               <subtype>1</subtype>
               </HairPin>
@@ -1156,6 +1178,9 @@
             </Spanner>
           <Chord>
             <durationType>half</durationType>
+            <Articulation>
+              <subtype>articAccentBelow</subtype>
+              </Articulation>
             <Note>
               <pitch>67</pitch>
               <tpc>15</tpc>
@@ -1435,6 +1460,9 @@
         </Measure>
       <!-- Measure 16 -->
       <Measure>
+        <LayoutBreak>
+          <subtype>line</subtype>
+          </LayoutBreak>
         <voice>
           <Dynamic>
             <subtype>sfpp</subtype>
@@ -1482,6 +1510,7 @@
           <Dynamic>
             <subtype>fp</subtype>
             <velocity>96</velocity>
+            <veloChangeSpeed>fast</veloChangeSpeed>
             </Dynamic>
           <Spanner type="HairPin">
             <prev>
@@ -1493,7 +1522,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articStaccatoBelow</subtype>
+              <subtype>articStaccatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>68</pitch>
@@ -1504,7 +1533,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articStaccatoBelow</subtype>
+              <subtype>articStaccatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>68</pitch>
@@ -1515,7 +1544,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articStaccatoBelow</subtype>
+              <subtype>articStaccatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>68</pitch>
@@ -1526,7 +1555,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articStaccatoBelow</subtype>
+              <subtype>articStaccatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>68</pitch>
@@ -1538,9 +1567,6 @@
         </Measure>
       <!-- Measure 18 -->
       <Measure>
-        <LayoutBreak>
-          <subtype>line</subtype>
-          </LayoutBreak>
         <voice>
           <Chord>
             <durationType>quarter</durationType>
@@ -1596,6 +1622,15 @@
         <voice>
           <Chord>
             <durationType>half</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                </Slur>
+              <next>
+                <location>
+                  <measures>1</measures>
+                  </location>
+                </next>
+              </Spanner>
             <Note>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -1645,6 +1680,13 @@
             </Spanner>
           <Chord>
             <durationType>half</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <measures>-1</measures>
+                  </location>
+                </prev>
+              </Spanner>
             <Note>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -1664,6 +1706,9 @@
             </Spanner>
           <Chord>
             <durationType>half</durationType>
+            <Articulation>
+              <subtype>articAccentBelow</subtype>
+              </Articulation>
             <Note>
               <pitch>61</pitch>
               <tpc>9</tpc>
@@ -1673,6 +1718,42 @@
           <BarLine>
             <subtype>double</subtype>
             </BarLine>
+          </voice>
+        <voice>
+          <Rest>
+            <visible>0</visible>
+            <durationType>half</durationType>
+            </Rest>
+          <Chord>
+            <durationType>half</durationType>
+            <Stem>
+              <visible>0</visible>
+              </Stem>
+            <Note>
+              <visible>0</visible>
+              <Spanner type="Tie">
+                <Tie>
+                  <TieSegment no="0">
+                    <o1 x="19.6824" y="0.466407"/>
+                    <o2 x="0.435451" y="0.100489"/>
+                    <o3 x="0.256804" y="0.111654"/>
+                    <o4 x="7.12881" y="3.12422"/>
+                    </TieSegment>
+                  </Tie>
+                <next>
+                  <location>
+                    <voices>-1</voices>
+                    <measures>1</measures>
+                    <fractions>-1/2</fractions>
+                    </location>
+                  </next>
+                </Spanner>
+              <pitch>68</pitch>
+              <tpc>10</tpc>
+              <tpc2>12</tpc2>
+              <play>0</play>
+              </Note>
+            </Chord>
           </voice>
         </Measure>
       <!-- Measure 21 -->
@@ -1691,6 +1772,15 @@
           <Chord>
             <durationType>half</durationType>
             <Note>
+              <Spanner type="Tie">
+                <prev>
+                  <location>
+                    <voices>1</voices>
+                    <measures>-1</measures>
+                    <fractions>1/2</fractions>
+                    </location>
+                  </prev>
+                </Spanner>
               <pitch>68</pitch>
               <tpc>10</tpc>
               <tpc2>12</tpc2>
@@ -1759,7 +1849,7 @@
                 </prev>
               </Spanner>
             <Articulation>
-              <subtype>articStaccatoBelow</subtype>
+              <subtype>articStaccatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>68</pitch>
@@ -1770,7 +1860,7 @@
           <Chord>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articTenutoBelow</subtype>
+              <subtype>articTenutoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>68</pitch>
@@ -1781,7 +1871,7 @@
           <Chord>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articStaccatoBelow</subtype>
+              <subtype>articStaccatoAbove</subtype>
               </Articulation>
             <Note>
               <pitch>68</pitch>
@@ -1795,7 +1885,7 @@
           <Chord>
             <durationType>eighth</durationType>
             <Articulation>
-              <subtype>articAccentBelow</subtype>
+              <subtype>articAccentAbove</subtype>
               </Articulation>
             <Note>
               <Spanner type="Tie">
@@ -2471,6 +2561,7 @@
           <Dynamic>
             <subtype>fp</subtype>
             <velocity>96</velocity>
+            <veloChangeSpeed>fast</veloChangeSpeed>
             </Dynamic>
           <Spanner type="HairPin">
             <prev>
@@ -2523,17 +2614,6 @@
                   <subtype>1</subtype>
                   <diagonal>1</diagonal>
                   <anchor>3</anchor>
-                  <Segment>
-                    <subtype>1</subtype>
-                    <offset x="0" y="0"/>
-                    <off2 x="0" y="0"/>
-                    </Segment>
-                  <Segment>
-                    <subtype>3</subtype>
-                    <offset x="0.196511" y="-1.57209"/>
-                    <off2 x="-0.196511" y="1.57209"/>
-                    <offset x="0.196511" y="-1.57209"/>
-                    </Segment>
                   </Glissando>
                 <next>
                   <location>
@@ -2644,6 +2724,9 @@
               <tpc>11</tpc>
               </Note>
             </Chord>
+          <BarLine>
+            <subtype>double</subtype>
+            </BarLine>
           </voice>
         </Measure>
       <!-- Measure 12 -->
@@ -2677,8 +2760,22 @@
                 </location>
               </prev>
             </Spanner>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>1</subtype>
+              </HairPin>
+            <next>
+              <location>
+                <measures>1</measures>
+                <fractions>-1/2</fractions>
+                </location>
+              </next>
+            </Spanner>
           <Chord>
             <durationType>half</durationType>
+            <Articulation>
+              <subtype>articAccentAbove</subtype>
+              </Articulation>
             <Note>
               <pitch>61</pitch>
               <tpc>9</tpc>
@@ -2689,9 +2786,22 @@
       <!-- Measure 13 -->
       <Measure>
         <voice>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <measures>-1</measures>
+                <fractions>1/2</fractions>
+                </location>
+              </prev>
+            </Spanner>
           <Rest>
             <durationType>quarter</durationType>
             </Rest>
+          <Dynamic>
+            <subtype>f</subtype>
+            <velocity>96</velocity>
+            <visible>0</visible>
+            </Dynamic>
           <Chord>
             <durationType>eighth</durationType>
             <Spanner type="Slur">
@@ -2903,17 +3013,6 @@
       <!-- Measure 16 -->
       <Measure>
         <voice>
-          <Spanner type="HairPin">
-            <HairPin>
-              <subtype>0</subtype>
-              <veloChange>24</veloChange>
-              </HairPin>
-            <next>
-              <location>
-                <measures>1</measures>
-                </location>
-              </next>
-            </Spanner>
           <Chord>
             <durationType>whole</durationType>
             <Note>
@@ -2934,6 +3033,9 @@
       <!-- Measure 17 -->
       <Measure>
         <voice>
+          <Rest>
+            <durationType>eighth</durationType>
+            </Rest>
           <Dynamic>
             <subtype>other-dynamics</subtype>
             <velocity>96</velocity>
@@ -2941,13 +3043,6 @@
             <italic>0</italic>
             <text><i></i><font face="ScoreText"></font><i><font face="MuseJazz Text"></font></i></text>
             </Dynamic>
-          <Spanner type="HairPin">
-            <prev>
-              <location>
-                <measures>-1</measures>
-                </location>
-              </prev>
-            </Spanner>
           <Chord>
             <durationType>quarter</durationType>
             <Spanner type="Slur">
@@ -2956,17 +3051,20 @@
               <next>
                 <location>
                   <measures>1</measures>
-                  <fractions>3/4</fractions>
+                  <fractions>5/8</fractions>
                   </location>
                 </next>
               </Spanner>
+            <Articulation>
+              <subtype>articAccentAbove</subtype>
+              </Articulation>
             <Note>
               <pitch>65</pitch>
               <tpc>13</tpc>
               </Note>
             </Chord>
           <Chord>
-            <durationType>quarter</durationType>
+            <durationType>eighth</durationType>
             <Note>
               <pitch>60</pitch>
               <tpc>14</tpc>
@@ -3036,7 +3134,7 @@
               <prev>
                 <location>
                   <measures>-1</measures>
-                  <fractions>-3/4</fractions>
+                  <fractions>-5/8</fractions>
                   </location>
                 </prev>
               </Spanner>
@@ -3156,6 +3254,9 @@
             </Dynamic>
           <Chord>
             <durationType>half</durationType>
+            <Articulation>
+              <subtype>articAccentAbove</subtype>
+              </Articulation>
             <Note>
               <pitch>55</pitch>
               <tpc>15</tpc>
@@ -3686,7 +3787,7 @@
           <Chord>
             <durationType>quarter</durationType>
             <Articulation>
-              <subtype>articMarcatoAbove</subtype>
+              <subtype>articAccentAbove</subtype>
               </Articulation>
             <Note>
               <pitch>55</pitch>
@@ -3990,6 +4091,7 @@
           <Dynamic>
             <subtype>fp</subtype>
             <velocity>96</velocity>
+            <veloChangeSpeed>fast</veloChangeSpeed>
             </Dynamic>
           <Spanner type="HairPin">
             <prev>
@@ -4105,11 +4207,24 @@
               <tpc>13</tpc>
               </Note>
             </Chord>
+          <BarLine>
+            <subtype>double</subtype>
+            </BarLine>
           </voice>
         </Measure>
       <!-- Measure 12 -->
       <Measure>
         <voice>
+          <Spanner type="HairPin">
+            <HairPin>
+              <subtype>0</subtype>
+              </HairPin>
+            <next>
+              <location>
+                <fractions>1/2</fractions>
+                </location>
+              </next>
+            </Spanner>
           <Chord>
             <durationType>half</durationType>
             <Note>
@@ -4121,6 +4236,13 @@
             <subtype>f</subtype>
             <velocity>96</velocity>
             </Dynamic>
+          <Spanner type="HairPin">
+            <prev>
+              <location>
+                <fractions>-1/2</fractions>
+                </location>
+              </prev>
+            </Spanner>
           <Spanner type="HairPin">
             <HairPin>
               <subtype>1</subtype>
@@ -4134,6 +4256,9 @@
             </Spanner>
           <Chord>
             <durationType>half</durationType>
+            <Articulation>
+              <subtype>articAccentAbove</subtype>
+              </Articulation>
             <Note>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -4438,6 +4563,7 @@
           <Dynamic>
             <subtype>fp</subtype>
             <velocity>96</velocity>
+            <veloChangeSpeed>fast</veloChangeSpeed>
             </Dynamic>
           <Spanner type="HairPin">
             <prev>
@@ -4541,6 +4667,15 @@
         <voice>
           <Chord>
             <durationType>half</durationType>
+            <Spanner type="Slur">
+              <Slur>
+                </Slur>
+              <next>
+                <location>
+                  <measures>1</measures>
+                  </location>
+                </next>
+              </Spanner>
             <Note>
               <pitch>51</pitch>
               <tpc>11</tpc>
@@ -4570,6 +4705,13 @@
             </Spanner>
           <Chord>
             <durationType>half</durationType>
+            <Spanner type="Slur">
+              <prev>
+                <location>
+                  <measures>-1</measures>
+                  </location>
+                </prev>
+              </Spanner>
             <Note>
               <pitch>56</pitch>
               <tpc>10</tpc>
@@ -4588,6 +4730,9 @@
             </Spanner>
           <Chord>
             <durationType>half</durationType>
+            <Articulation>
+              <subtype>articAccentAbove</subtype>
+              </Articulation>
             <Note>
               <pitch>58</pitch>
               <tpc>12</tpc>
@@ -5233,6 +5378,9 @@
               <tpc>11</tpc>
               </Note>
             </Chord>
+          <BarLine>
+            <subtype>double</subtype>
+            </BarLine>
           </voice>
         </Measure>
       <!-- Measure 12 -->
@@ -5266,6 +5414,9 @@
             </Spanner>
           <Chord>
             <durationType>quarter</durationType>
+            <Articulation>
+              <subtype>articAccentAbove</subtype>
+              </Articulation>
             <Note>
               <pitch>51</pitch>
               <tpc>11</tpc>
@@ -5593,6 +5744,9 @@
             </Spanner>
           <Chord>
             <durationType>quarter</durationType>
+            <Articulation>
+              <subtype>articAccentAbove</subtype>
+              </Articulation>
             <Note>
               <pitch>51</pitch>
               <tpc>11</tpc>

--- a/fluid/fluid.cpp
+++ b/fluid/fluid.cpp
@@ -611,6 +611,19 @@ QStringList Fluid::soundFonts() const
       }
 
 //---------------------------------------------------------
+//   soundFontsInfo
+//---------------------------------------------------------
+
+std::vector<SoundFontInfo> Fluid::soundFontsInfo() const
+      {
+      std::vector<SoundFontInfo> sl;
+      sl.reserve(sfonts.size());
+      for (SFont* f : sfonts)
+            sl.emplace_back(QFileInfo(f->get_name()).fileName(), f->fontName());
+      return sl;
+      }
+
+//---------------------------------------------------------
 //   loadSoundFont
 //    return false on error
 //---------------------------------------------------------

--- a/fluid/fluid.h
+++ b/fluid/fluid.h
@@ -382,7 +382,8 @@ class Fluid : public Synthesizer {
       virtual bool loadSoundFonts(const QStringList& s);
       virtual bool addSoundFont(const QString& s);
       virtual bool removeSoundFont(const QString& s);
-      virtual QStringList soundFonts() const;
+      QStringList soundFonts() const;
+      std::vector<SoundFontInfo> soundFontsInfo() const override;
 
       void start_voice(Voice* voice);
       Voice* alloc_voice(unsigned id, Sample* sample, int chan, int key, int vel, double vt);

--- a/fluid/sfont.cpp
+++ b/fluid/sfont.cpp
@@ -908,6 +908,9 @@ void SFont::process_info(int size)
                   /* force terminate info item (don't forget uint8 info ID) */
                   *(item + chunk.size) = '\0';
                   infos.append(item);
+
+                  if (id == INAM_ID)
+                        _fontName = QString(reinterpret_cast<char*>(item + 1));
                   }
             else
                   throw(QString("Invalid chunk id in INFO chunk"));

--- a/fluid/sfont.h
+++ b/fluid/sfont.h
@@ -64,6 +64,7 @@ class SFont {
 
       SFVersion _version;		// sound font version
       SFVersion romver;		      // ROM version
+      QString _fontName;
       QList<unsigned char*> infos;	// list of info strings (1st byte is ID)
 
       void read_listchunk(SFChunk* chunk);
@@ -119,6 +120,7 @@ class SFont {
       SFVersion version() const                 { return _version; }
       int bankOffset() const                    { return _bankOffset; }
       void setBankOffset(int val)               { _bankOffset = val; }
+      QString fontName() const                  { return _fontName; }
 
       friend class Preset;
       };

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4545,9 +4545,9 @@ void MasterScore::setLayout(const Fraction& t)
 //    the value of the expressive parameter.
 //---------------------------------------------------------
 
+
 void MasterScore::updateExpressive(MasterSynthesizer* m)
       {
-      qDebug("update expressive!");
       SynthesizerState s = synthesizerState();
       SynthesizerGroup g = s.group("master");
 
@@ -4589,7 +4589,22 @@ void MasterScore::updateExpressive(MasterSynthesizer* m, bool expressive, bool f
                   }
             }
 
-      // Rebuild midi mappings to be safe
+      }
+
+//---------------------------------------------------------
+//   rebuildAndUpdateExpressive
+//    implicitly rebuild midi mappings as well. Should be preferred over
+//    just updateExpressive, in most cases.
+//---------------------------------------------------------
+
+void MasterScore::rebuildAndUpdateExpressive(MasterSynthesizer* m)
+      {
+      // Rebuild midi mappings to make sure we have playback channels
+      rebuildMidiMapping();
+
+      updateExpressive(m);
+
+      // Rebuild midi mappings again to be safe
       rebuildMidiMapping();
       }
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4545,7 +4545,6 @@ void MasterScore::setLayout(const Fraction& t)
 //    the value of the expressive parameter.
 //---------------------------------------------------------
 
-
 void MasterScore::updateExpressive(MasterSynthesizer* m)
       {
       SynthesizerState s = synthesizerState();

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1319,6 +1319,7 @@ class MasterScore : public Score {
       int getNextFreeDrumMidiMapping();
       void enqueueMidiEvent(MidiInputEvent ev) { _midiInputQueue.enqueue(ev); }
       void updateChannel();
+      void rebuildAndUpdateExpressive(MasterSynthesizer* m);
       void updateExpressive(MasterSynthesizer* m);
       void updateExpressive(MasterSynthesizer* m, bool expressive, bool force = false);
       void setSoloMute();

--- a/mscore/editstaff.cpp
+++ b/mscore/editstaff.cpp
@@ -190,7 +190,6 @@ void EditStaff::updateInstrument()
       minPitchP->setText(midiCodeToStr(_minPitchP));
       maxPitchP->setText(midiCodeToStr(_maxPitchP));
       singleNoteDynamics->setChecked(instrument.singleNoteDynamics());
-      staff->score()->masterScore()->updateExpressive(synti);
 
       // only show string data controls if instrument has strings
       int numStr = instrument.stringData() ? instrument.stringData()->strings() : 0;
@@ -385,6 +384,7 @@ void EditStaff::apply()
 
       score->update();
       score->masterScore()->updateChannel();
+      staff->score()->masterScore()->rebuildAndUpdateExpressive(synti);
       }
 
 //---------------------------------------------------------

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -760,6 +760,10 @@ MasterScore* MuseScore::getNewFile()
       if (!copyright.isEmpty())
             score->setMetaTag("copyright", copyright);
 
+      if (synti)
+            score->setSynthesizerState(synti->state());
+
+      // Call this even if synti doesn't exist - we need to rebuild either way
       score->rebuildAndUpdateExpressive(synti);
 
       {
@@ -2246,6 +2250,10 @@ Score::FileError readScore(MasterScore* score, QString name, bool ignoreVersionE
       QString suffix  = info.suffix().toLower();
       score->setName(info.completeBaseName());
       score->setImportedFilePath(name);
+
+      // Set the default synthesizer state before we read
+      if (synti)
+            score->setSynthesizerState(synti->state());
 
       if (suffix == "mscz" || suffix == "mscx") {
             Score::FileError rv = score->loadMsc(name, ignoreVersionError);

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -760,11 +760,7 @@ MasterScore* MuseScore::getNewFile()
       if (!copyright.isEmpty())
             score->setMetaTag("copyright", copyright);
 
-      score->rebuildMidiMapping();
-
-      // We need a midi mapping to be able to update the expressive
-      score->updateExpressive(synti);
-      score->rebuildMidiMapping();
+      score->rebuildAndUpdateExpressive(synti);
 
       {
             ScoreLoad sl;

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -532,8 +532,7 @@ void MuseScore::editInstrList()
 
       masterScore->setLayoutAll();
       masterScore->endCmd();
-      masterScore->rebuildMidiMapping();
-      masterScore->updateExpressive(synti);
+      masterScore->rebuildAndUpdateExpressive(synti);
       seq->initInstruments();
       }
 

--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -459,7 +459,7 @@ void SynthControl::updateGui()
 
 void SynthControl::updateExpressivePatches()
       {
-      _score->masterScore()->updateExpressive(synti);
+      _score->masterScore()->rebuildAndUpdateExpressive(synti);
       updateMixer();
       }
 

--- a/synthesizer/synthesizer.h
+++ b/synthesizer/synthesizer.h
@@ -23,6 +23,18 @@ class Synth;
 class SynthesizerGui;
 
 //---------------------------------------------------------
+//   SoundFontInfo
+//---------------------------------------------------------
+
+struct SoundFontInfo {
+      QString fileName;
+      QString fontName;
+
+      SoundFontInfo(QString _fileName) : fileName(_fileName), fontName(_fileName) {}
+      SoundFontInfo(QString _fileName, QString _fontName) : fileName(_fileName), fontName(_fontName) {}
+      };
+
+//---------------------------------------------------------
 //   Synthesizer
 //---------------------------------------------------------
 
@@ -48,7 +60,7 @@ class Synthesizer {
       virtual bool addSoundFont(const QString&)    { return false; }
       virtual bool removeSoundFont(const QString&) { return false; }
 
-      virtual QStringList soundFonts() const = 0;
+      virtual std::vector<SoundFontInfo> soundFontsInfo() const = 0;
 
       virtual void process(unsigned, float*, float*, float*) = 0;
       virtual void play(const PlayEvent&) = 0;

--- a/zerberus/zerberus.cpp
+++ b/zerberus/zerberus.cpp
@@ -327,6 +327,19 @@ QStringList Zerberus::soundFonts() const
       }
 
 //---------------------------------------------------------
+//   soundFontsInfo
+//---------------------------------------------------------
+
+std::vector<Ms::SoundFontInfo> Zerberus::soundFontsInfo() const
+      {
+      std::vector<Ms::SoundFontInfo> sl;
+      sl.reserve(instruments.size());
+      for (ZInstrument* i : instruments)
+            sl.emplace_back(i->path());
+      return sl;
+      }
+
+//---------------------------------------------------------
 //   addSoundFont
 //---------------------------------------------------------
 

--- a/zerberus/zerberus.h
+++ b/zerberus/zerberus.h
@@ -130,7 +130,8 @@ class Zerberus : public Ms::Synthesizer {
       virtual bool removeSoundFont(const QString&);
       virtual bool loadSoundFonts(const QStringList&);
       virtual bool removeSoundFonts(const QStringList& fileNames);
-      virtual QStringList soundFonts() const;
+      QStringList soundFonts() const;
+      std::vector<Ms::SoundFontInfo> soundFontsInfo() const override;
 
       virtual const QList<Ms::MidiPatch*>& getPatchInfo() const override { return patches; }
       


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/287630

The addition of the `rebuildAndUpdateExpressive` function is something I should have done a while ago - `updateExpressive` will crash if the `playbackChannel` for any given channel is invalid, which will happen if the midi mappings aren't rebuilt before calling it. This function always rebuilds these mappings, making it inherently safer, so I have replaced _some_ occurrences of `updateExpressive` with it.

I'd also like to sneak in a commit to update the Brassed Up demo, just making it look and sound a bit better :)

And I'd also like to commit [another fix](https://musescore.org/en/node/287701) at the same time, because with two separate PRs there would be merge conflicts.

The last commit is one I've chosen to leave separate because it's not a necessary part of any of the other commits, rather a potential fix for an issue that doesn't exist yet. If it's really necessary, I could rebase it.