### PR TITLE
Correct fraction to ticks conversion for negative numbers

### DIFF
--- a/libmscore/fraction.h
+++ b/libmscore/fraction.h
@@ -233,7 +233,8 @@ class Fraction {
             // MScore::division     - ticks per quarter note
             // MScore::division * 4 - ticks per whole note
             // result: rounded (MScore::division * 4 * _numerator * 1.0 / _denominator) value
-            const auto result = (static_cast<int_least64_t>(_numerator) * MScore::division * 4 + (_denominator/2)) / _denominator;
+            const int sgn = (_numerator < 0) ? -1 : 1;
+            const auto result = sgn * (static_cast<int_least64_t>(sgn * _numerator) * MScore::division * 4 + (_denominator/2)) / _denominator;
             return static_cast<int>(result);
             }
 


### PR DESCRIPTION
This commit allows the score from [this issue](https://musescore.org/en/node/287615) be loaded correctly without being reported as corrupted (provided the patch from #4907 is applied to prevent a crash). The score contains a lot of `<location>` tags with negative values inside measures which seems to cause [the patch](https://github.com/musescore/MuseScore/commit/9efd3012424c8f3160325e8d79ffc9ea77c9dfdd) added by @mattmcclinch and @wschweer preventing such kind of errors not working correctly. However I am not sure whether correcting the calculation can cause unexpected side effects since some parts of the file format or the code might have relied on that incorrect behavior. So a careful testing and review of this change would be highly desirable.

The previous formula was erroneous for negative numbers due to the rounding method: it relied on integer division result being rounded down while it is actually rounded to zero (or, in older language
standards - unspecified). This makes a difference for negative numbers, and the ticks result often (always?) differed from the correct result by 1.

This commit corrects the calculation by making the rounding happen only for positive integer numbers division (denominator is assumed to be positive within Fraction class).