### PR TITLE
fix #287613: set as staff default with multiple barlines selected

### DIFF
--- a/mscore/inspector/inspectorBarline.cpp
+++ b/mscore/inspector/inspectorBarline.cpp
@@ -65,15 +65,29 @@ InspectorBarLine::InspectorBarLine(QWidget* parent)
 
 void InspectorBarLine::setAsStaffDefault()
       {
-      BarLine* bl = toBarLine(inspector->element());
-      Staff* staff = bl->staff();
-      Score* score = bl->score();
+      BarLine* ebl = toBarLine(inspector->element());
+      QVariant span = ebl->getProperty(Pid::BARLINE_SPAN);
+      QVariant spanFrom = ebl->getProperty(Pid::BARLINE_SPAN_FROM);
+      QVariant spanTo = ebl->getProperty(Pid::BARLINE_SPAN_TO);
+
+      std::set<Staff*> staffList;
+
+      Score* score = ebl->score();
       score->startCmd();
-      staff->undoChangeProperty(Pid::STAFF_BARLINE_SPAN,      bl->getProperty(Pid::BARLINE_SPAN));
-      staff->undoChangeProperty(Pid::STAFF_BARLINE_SPAN_FROM, bl->getProperty(Pid::BARLINE_SPAN_FROM));
-      staff->undoChangeProperty(Pid::STAFF_BARLINE_SPAN_TO,   bl->getProperty(Pid::BARLINE_SPAN_TO));
-      if (bl->barLineType() == BarLineType::NORMAL)
-            bl->setGenerated(true);
+      for (Element* e : *inspector->el()) {
+            if (!e || !e->isBarLine())
+                  continue;
+            BarLine* bl = toBarLine(e);
+            Staff* staff = bl->staff();
+            if (std::find(staffList.begin(), staffList.end(), staff) == staffList.end()) {
+                  staff->undoChangeProperty(Pid::STAFF_BARLINE_SPAN,      span);
+                  staff->undoChangeProperty(Pid::STAFF_BARLINE_SPAN_FROM, spanFrom);
+                  staff->undoChangeProperty(Pid::STAFF_BARLINE_SPAN_TO,   spanTo);
+                  staffList.insert(staff);
+                  }
+            if (bl->barLineType() == BarLineType::NORMAL)
+                  bl->setGenerated(true);
+            }
       score->endCmd();
       }
 


### PR DESCRIPTION
Seems straightforward enough, we just need to process the command for each barline in the current selection (I optimized it to not process the same staff multiple times).