### PR TITLE
fix #287617: set barline span for added staves

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1203,6 +1203,7 @@ void Measure::cmdAddStaves(int sStaff, int eStaff, bool createRest)
                         }
                   if (obl) {
                         BarLine* barline = new BarLine(*obl);
+                        barline->setSpanStaff(score()->staff(staffIdx)->barLineSpan());
                         barline->setTrack(staffIdx * VOICES);
                         barline->setParent(bs);
                         barline->setGenerated(false);

--- a/mscore/instrdialog.cpp
+++ b/mscore/instrdialog.cpp
@@ -303,6 +303,8 @@ void MuseScore::editInstrList()
 
                         staff->init(t, sli->staffType(), cidx);
                         staff->setDefaultClefType(sli->defaultClefType());
+                        if (staffIdx > 0)
+                              staff->setBarLineSpan(masterScore->staff(staffIdx - 1)->barLineSpan());
 
                         masterScore->undoInsertStaff(staff, cidx);
                         ++staffIdx;
@@ -337,6 +339,8 @@ void MuseScore::editInstrList()
                               staff->initFromStaffType(sli->staffType());
                               sli->setStaff(staff);
                               staff->setDefaultClefType(sli->defaultClefType());
+                              if (staffIdx > 0)
+                                    staff->setBarLineSpan(masterScore->staff(staffIdx - 1)->barLineSpan());
 
                               KeySigEvent ke;
                               if (part->staves()->empty())

--- a/mtest/libmscore/splitstaff/splitstaff02-ref.mscx
+++ b/mtest/libmscore/splitstaff/splitstaff02-ref.mscx
@@ -128,7 +128,6 @@
               </Note>
             </Chord>
           <BarLine>
-            <span>1</span>
             </BarLine>
           </voice>
         </Measure>

--- a/mtest/libmscore/splitstaff/splitstaff04-ref.mscx
+++ b/mtest/libmscore/splitstaff/splitstaff04-ref.mscx
@@ -163,7 +163,6 @@
             </Rest>
           <BarLine>
             <subtype>end</subtype>
-            <span>1</span>
             </BarLine>
           </voice>
         </Measure>

--- a/mtest/libmscore/splitstaff/splitstaff05-ref.mscx
+++ b/mtest/libmscore/splitstaff/splitstaff05-ref.mscx
@@ -163,7 +163,6 @@
             </Rest>
           <BarLine>
             <subtype>end</subtype>
-            <span>1</span>
             </BarLine>
           </voice>
         </Measure>


### PR DESCRIPTION
See https://musescore.org/en/node/287617

In https://github.com/musescore/MuseScore/pull/4843/commits/b6bea0ecac5832d9007eb1870cc7969fb5883c93 I added code to make sure added staves inherit modifed barlines (double bars, etc) from the rets of the score.  But in the process, this made them also pick up the barline span fior those barlines, which isn't necessarily appropriate.  So, here I am making two changes.  One, explicitly resetting the span of these barlines to the staff default.  But also, I am setting the staff default for these newly added staves based on the span of the staff above.  This is a quite nice improvement over 2.3.2 - now if you add a staff in the middle of a spanned woodwind section, for example, the barlines are already spanned on the new staff as well.  Works as expected when adding at the end of a spanner section, or at the top of the score - no span in that case.