### PR TITLE
fix #287620: change barline in part

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -73,6 +73,13 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
                         else
                               generated = false;            // otherwise assume non-generated
 
+                        if (allStaves) {
+                              // use all staves of master score; we will take care of parts in loop through linked staves below
+                              m2 = bl->masterScore()->tick2measure(m2->tick());
+                              if (!m2)
+                                    return;     // should never happen
+                              segment = m2->undoGetSegmentR(segment->segmentType(), segment->rtick());
+                              }
                         const std::vector<Element*>& elist = allStaves ? segment->elist() : std::vector<Element*> { bl };
                         for (Element* e : elist) {
                               if (!e || !e->staff() || !e->isBarLine())


### PR DESCRIPTION
Barline type change operations that are supposed to affect all staves are currently affecting all staves of the current score, plus whatever they are linked to, so it works fine if you make the change in the score.  but if you make it in the part, we only get *those* staves and their linked staves in the score, not the *other* staves in the score.  Fixed to walk through the staff list of the master score instead of current score.

See https://musescore.org/en/node/287620