### PR TITLE
fix #287577: draw barlines correctly during edit

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -294,6 +294,17 @@ BarLine::~BarLine()
       }
 
 //---------------------------------------------------------
+//   canvasPos
+//---------------------------------------------------------
+
+QPointF BarLine::canvasPos() const
+      {
+      QPointF pos = Element::canvasPos();
+      pos.ry() += measure()->system()->staff(staffIdx())->y();
+      return pos;
+      }
+
+//---------------------------------------------------------
 //   pagePos
 //---------------------------------------------------------
 
@@ -616,7 +627,7 @@ void BarLine::drawEditMode(QPainter* p, EditData& ed)
       BarLineEditData* bed = static_cast<BarLineEditData*>(ed.getData(this));
       y1 += bed->yoff1;
       y2 += bed->yoff2;
-      QPointF pos(pagePos());
+      QPointF pos(canvasPos());
       p->translate(pos);
       BarLine::draw(p);
       p->translate(-pos);

--- a/libmscore/barline.h
+++ b/libmscore/barline.h
@@ -81,7 +81,8 @@ class BarLine final : public Element {
       virtual void write(XmlWriter& xml) const override;
       virtual void read(XmlReader&) override;
       virtual void draw(QPainter*) const override;
-      virtual QPointF pagePos() const override;      ///< position in canvas coordinates
+      virtual QPointF canvasPos() const override;    ///< position in canvas coordinates
+      virtual QPointF pagePos() const override;      ///< position in page coordinates
       virtual void layout() override;
       void layout2();
       virtual void scanElements(void* data, void (*func)(void*, Element*), bool all=true) override;


### PR DESCRIPTION
See https://musescore.org/en/node/287577.
