### PR TITLE
fix #287662: transpose keys

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -551,6 +551,8 @@ bool KeySig::isChange() const
       {
       if (!staff())
             return false;
+      if (!segment() || segment()->segmentType() != SegmentType::KeySig)
+            return false;
       Fraction keyTick = tick();
       return staff()->currentKeyTick(keyTick) == keyTick;
       }

--- a/libmscore/transpose.cpp
+++ b/libmscore/transpose.cpp
@@ -424,7 +424,7 @@ bool Score::transpose(TransposeMode mode, TransposeDirection direction, Key trKe
                               }
                         }
                   else if (e->isKeySig() && trKeys && mode != TransposeMode::DIATONICALLY) {
-#if 1
+#if 0
                         bool startKey = segment->tick() == s1->tick();
                         QList<ScoreElement*> ll = e->linkList();
                         for (ScoreElement* scoreElement : ll) {


### PR DESCRIPTION
See https://musescore.org/en/node/287662 and also https://musescore.org/en/node/70201 and https://musescore.org/en/node/286058.  Feels like we keep going around in circles a bit here, but the part issue has been around a very long time (original issue report was from 2015!

There are a few ways to fix this, but I'm mindful of also not breaking https://musescore.org/en/node/280390 or anything else previously working again.

My solution is here is to replace our current use of undo(new ChangeKeySig())) with undoChangeKeySig.  This way we get handling of parts for free.  It also does good things with the generated flag.  The two prices we pay for this: we need to pass in the concert key signature (meaning an extra transpose operation here), and we do need to skip the header key signatures (which was the solution I originally rejected in #4669).  But I think I've covered my bases here.

Review and testing most definitely welcome!