### PR TITLE
fix #279980, fix #287723, fix #186111: rehearsal mark alignment

### DIFF
--- a/libmscore/rehearsalmark.cpp
+++ b/libmscore/rehearsalmark.cpp
@@ -47,17 +47,32 @@ void RehearsalMark::layout()
       Segment* s = segment();
       if (s) {
             if (s->rtick().isZero()) {
-                  // first CR of measure, decide whether to align to barline
-                  if (!s->prev() && align() & Align::CENTER) {
-                        // measure with no clef / keysig / timesig
-                        rxpos() -= s->x();
+                  // first CR of measure, alignment is hcenter or right (the usual cases)
+                  // align with barline, point just after header, or start of measure depending on context
+
+                  Measure* m = s->measure();
+                  Segment* header = s->prev();  // possibly just a start repeat
+                  qreal measureX = -s->x();
+                  Segment* repeat = m->findSegmentR(SegmentType::StartRepeatBarLine, Fraction(0, 1));
+                  qreal barlineX = repeat ? repeat->x() - s->x() : measureX;
+                  System* sys = m->system();
+                  bool systemFirst = (sys && sys->firstMeasure() == m);
+
+                  if (!header || repeat || !systemFirst) {
+                        // no header, or header with repeat, or header mid-system - align with barline
+                        rxpos() = barlineX;
                         }
-                  else if (align() & Align::RIGHT) {
-                        // measure with clef / keysig / timesig, rehearsal mark right aligned
-                        // align left edge of rehearsal to barline if that is further to left
-                        qreal leftX = bbox().x();
-                        qreal barlineX = -s->x();
-                        rxpos() += qMin(leftX, barlineX) + width();
+                  else {
+                        // header at start of system
+                        // align to a point just after the header
+                        Element* e = header->element(track());      // TODO: firstVisibleStaff
+                        qreal w = e ? e->width() : header->width();
+                        rxpos() = header->x() + w - s->x();
+
+                        // special case for right aligned rehearsal marks at start of system
+                        // left align with start of measure if that is further left
+                        if (align() & Align::RIGHT)
+                              rxpos() = qMin(rpos().x(), measureX + width());
                         }
                   }
             autoplaceSegmentElement(styleP(Sid::rehearsalMarkMinDistance));


### PR DESCRIPTION
There's been a bunch of give and take over the years on the best way to position rehearsal marks with respect to horizontal alignment.  While we have a solution that works decently well in a lot of cases, it does not do well well if there are repeats, or in the case of mid-measure key changes.  Also, there was a regression between 2.3.2 and 3.0 where we lost correct alignment of right-aligned rehearsal marks (here: https://github.com/musescore/MuseScore/commit/c1726bbaf762ad31572500bfff3aec296f43c4e9#diff-2ee382c946a5e3ac5f7506d72dae8919).

This PR address these issues.  It's not a big change; it just restructures the calculations in a way that covers the different cases: (header / no header, repeat / no repeat, start / middle of system, left / right / center alignment.  The calculations themselves are basically same as always, I just apply them more consistently.  Only real new aspect is the specific check for repeats.

Here is the result:

![image](https://user-images.githubusercontent.com/1799936/56099794-cf8e6380-5ece-11e9-8ea4-9b956ee0babd.png)
