### PR TITLE
fix #282333: fix a crash on adding lyrics on certain scores

### DIFF
--- a/libmscore/textedit.cpp
+++ b/libmscore/textedit.cpp
@@ -71,12 +71,14 @@ void TextBase::startEdit(EditData& ed)
 void TextBase::endEdit(EditData& ed)
       {
       TextEditData* ted = static_cast<TextEditData*>(ed.getData(this));
-      score()->undoStack()->remove(ted->startUndoIdx);           // remove all undo/redo records
+      const QString actualText = xmlText();
+      UndoStack* undo = score()->undoStack();
+      while (undo->getCurIdx() > ted->startUndoIdx)
+            undo->undo(&ed);
 
       // replace all undo/redo records collected during text editing with
       // one property change
 
-      QString actualText = xmlText();
       if (ted->oldXmlText.isEmpty()) {
             UndoStack* us = score()->undoStack();
             UndoCommand* ucmd = us->last();
@@ -93,7 +95,6 @@ void TextBase::endEdit(EditData& ed)
                                     ed.element = 0;
                                     }
                               else {
-                                    setXmlText(ted->oldXmlText);  // reset text to value before editing
                                     us->reopen();
                                     // combine undo records of text creation with text editing
                                     undoChangeProperty(Pid::TEXT, actualText);
@@ -113,7 +114,6 @@ void TextBase::endEdit(EditData& ed)
             score()->endCmd();
             return;
             }
-      setXmlText(ted->oldXmlText);                    // reset text to value before editing
       score()->startCmd();
       undoChangeProperty(Pid::TEXT, actualText);      // change property to set text to actual value again
                                                       // this also changes text of linked elements

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -147,6 +147,8 @@ class UndoStack {
       int cleanState;
       int curIdx;
 
+      void remove(int idx);
+
    public:
       UndoStack();
       ~UndoStack();
@@ -163,7 +165,6 @@ class UndoStack {
       int state() const             { return stateList[curIdx];    }
       bool isClean() const          { return cleanState == state();     }
       int getCurIdx() const         { return curIdx; }
-      void remove(int idx);
       bool empty() const            { return !canUndo() && !canRedo();  }
       UndoMacro* current() const    { return curCmd;               }
       UndoMacro* last() const       { return curIdx > 0 ? list[curIdx-1] : 0; }


### PR DESCRIPTION
Fixes https://musescore.org/en/node/282333.

The crash happens due to incorrect usage of `UndoStack::remove()` function which causes some elements be mistakenly deleted. In this case, the deleted elements are Hooks created during the layout after initially adding an empty lyrics syllable. This patch replaces calling  `UndoStack::remove()` in text editing process with simply undoing the operations that lay on undo stack. The `remove()` function itself is made private in `UndoStack` class as it probably shouldn't be used by any code except that of `UndoStack` itself.

As a side effect, this makes it unnecessary for `TextBase::endEdit()` function to restore the old text of the element and fixes the issues that result from forgetting to restore the text correctly in case the new text value is empty:
https://musescore.org/en/node/282238
https://musescore.org/en/node/280014