### PR TITLE
fix #285605, fix #228531, fix #77396: repeat barline, then clef

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3523,6 +3523,28 @@ qreal Measure::createEndBarLines(bool isLastMeasureInSystem)
             seg->createShapes();
             }
 
+      // set relative position of end barline and clef
+      // if end repeat, clef goes after, otherwise clef goes before
+      Segment* clefSeg = findSegmentR(SegmentType::Clef, ticks());
+      if (clefSeg) {
+            if (clefSeg) {
+                  Segment* s1;
+                  Segment* s2;
+                  if (repeatEnd()) {
+                        s1 = seg;
+                        s2 = clefSeg;
+                        }
+                  else {
+                        s1 = clefSeg;
+                        s2 = seg;
+                        }
+                  if (s1->next() != s2) {
+                        _segments.remove(s1);
+                        _segments.insert(s1, s2);
+                        }
+                  }
+            }
+
       // fix segment layout
       Segment* s = seg->prevActive();
       if (s) {
@@ -3803,7 +3825,7 @@ void Measure::addSystemTrailer(Measure* nm)
             s->setEnabled(false);
             }
 
-      // courtesy key signatures
+      // courtesy key signatures, clefs
 
       int n      = score()->nstaves();
       bool show  = hasCourtesyKeySig();
@@ -3848,11 +3870,12 @@ void Measure::addSystemTrailer(Measure* nm)
                   Clef* clef = toClef(clefSegment->element(track));
                   if (clef) {
                         clef->setSmall(true);
-                        if (!score()->genCourtesyClef() || repeatEnd() || isFinalMeasure || !clef->showCourtesy())
+                        if (!score()->genCourtesyClef() || isFinalMeasure || !clef->showCourtesy())
                               clef->clear();          // make invisible
                         }
                   }
             }
+
       checkTrailer();
       }
 

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -2066,9 +2066,9 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
             // w = qMax(w, minRight()) + d;
             }
       else if (st & (SegmentType::Clef | SegmentType::HeaderClef)) {
-            if (nst == SegmentType::KeySig)
+            if (nst == SegmentType::KeySig || nst == SegmentType::KeySigAnnounce)
                   w += score()->styleP(Sid::clefKeyDistance);
-            else if (nst == SegmentType::TimeSig)
+            else if (nst == SegmentType::TimeSig || nst == SegmentType::TimeSigAnnounce)
                   w += score()->styleP(Sid::clefTimesigDistance);
             else if (nst & (SegmentType::EndBarLine | SegmentType::StartRepeatBarLine))
                   w += score()->styleP(Sid::clefBarlineDistance);
@@ -2092,6 +2092,8 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
                   w += score()->styleP(Sid::keysigLeftMargin);
             else if (nst == SegmentType::TimeSigAnnounce)
                   w += score()->styleP(Sid::timesigLeftMargin);
+            else if (nst == SegmentType::Clef)
+                  w += score()->styleP(Sid::clefLeftMargin);
             }
       else if (st == SegmentType::TimeSig && nst == SegmentType::StartRepeatBarLine)
             w += score()->styleP(Sid::timesigBarlineDistance);


### PR DESCRIPTION
Clefs changes currently don't display at all when an end repeat is present.  Normally a clef change would display before the barline, but as per https://musescore.org/en/node/77396, for repeats it should display after.  This is also true of "courtesy" clefs that appear at the end of a system (technically, these are the real clefs; the one at the start of the next line is the generated one).  So, these weren't displaying at all either, as per https://musescore.org/en/node/228531.  Worse, even normal clef changes mid-system were not displaying when an end repeat was present - see https://musescore.org/en/node/285605, the most critical of these related bugs.

Fixing things to display the clef as we did in 2.3.2 was easy - that's the one-line change to addSystemTrailer().  But getting it to display after the barline is trickier.  While it would be possible to solve the courtesy problem by continuing suppressing it in the trailer and then generating a new one in the header, that doesn't solve the mid-system problem, and it also doesn't help continuous view.  So here I am taking an alternate approach: during createEndBarlines, I actually check whether an end repeat and clef are both present, and I actually rearrange the segments accordingly.

Normally, the segment order is fixed by the values in the SegmentType enum, so short of creating a new segment type and making larger changes of the code, this seemed the best way.  It keeps the changes very localized.  Another alternative would be to do the swap on the add of the clef as well as the change of the barline type.

As it is, though, this seems the simplest way.  It works mid-system, end of system, works page and continuous view, it works regardless of the order of adding the clef or changing the barline type, it works if a start repeat is also present.