### PR TITLE
fix #287428: cannot delete clef at start of system

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1506,7 +1506,8 @@ void Score::deleteItem(Element* el)
       {
       if (!el)
             return;
-      if (el->generated() && !(el->isBracket() || el->isBarLine()))          // cannot remove generated elements
+      // cannot remove generated elements
+      if (el->generated() && !(el->isBracket() || el->isBarLine() || el->isClef()))
             return;
 //      qDebug("%s", el->name());
 


### PR DESCRIPTION
See https://musescore.org/en/node/287428.  The code to handle deleting of clef changes at the start of a system (which are technically generated - the real change is the apparently courtesy in the previous measure) was already present, it was just being skipped because we were too eager in ignoring generated elements earlier on.