### PR TITLE
fix #287780: load chord list with start score

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2777,11 +2777,8 @@ static void readStyle(MStyle* style, XmlReader& e)
             }
 
       // make sure we have a chordlist
-      if (!style->chordList()->loaded() && !chordListTag) {
-            if (style->value(Sid::chordsXmlFile).toBool())
-                  style->chordList()->read("chords.xml");
-            style->chordList()->read(newChordDescriptionFile);
-            }
+      if (!chordListTag)
+            style->checkChordList();
 #if 0 // TODO
       //
       //  Compatibility with old scores/styles:

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3619,11 +3619,8 @@ static void readStyle(MStyle* style, XmlReader& e)
             }
 
       // make sure we have a chordlist
-      if (!style->chordList()->loaded() && !chordListTag) {
-            if (style->value(Sid::chordsXmlFile).toBool())
-                  style->chordList()->read("chords.xml");
-            style->chordList()->read(newChordDescriptionFile);
-            }
+      if (!chordListTag)
+            style->checkChordList();
       }
 
 //---------------------------------------------------------

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -2158,6 +2158,20 @@ const ChordDescription* MStyle::chordDescription(int id) const
       }
 
 //---------------------------------------------------------
+//   checkChordList
+//---------------------------------------------------------
+
+void MStyle::checkChordList()
+      {
+      // make sure we have a chordlist
+      if (!_chordList.loaded()) {
+            if (value(Sid::chordsXmlFile).toBool())
+                  _chordList.read("chords.xml");
+            _chordList.read(value(Sid::chordDescriptionFile).toString());
+            }
+      }
+
+//---------------------------------------------------------
 //   setChordList
 //---------------------------------------------------------
 
@@ -2421,12 +2435,8 @@ void MStyle::load(XmlReader& e)
             _chordList.unload();
             }
 
-      // make sure we have a chordlist
-      if (!_chordList.loaded() && !chordListTag) {
-            if (value(Sid::chordsXmlFile).toBool())
-                  _chordList.read("chords.xml");
-            _chordList.read(newChordDescriptionFile);
-            }
+      if (!chordListTag)
+            checkChordList();
       }
 
 //---------------------------------------------------------

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1123,6 +1123,7 @@ class MStyle {
       ChordList* chordList()  { return &_chordList; }
       void setChordList(ChordList*, bool custom = true);    // Style gets ownership of ChordList
       void setCustomChordList(bool t) { _customChordList = t; }
+      void checkChordList();
 
       bool load(QFile* qf);
       void load(XmlReader& e);

--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -585,11 +585,7 @@ MasterScore* MuseScore::getNewFile()
       score->setCreated(true);
       score->fileInfo()->setFile(createDefaultName());
 
-      if (!score->style().chordList()->loaded()) {
-            if (score->styleB(Sid::chordsXmlFile))
-                  score->style().chordList()->read("chords.xml");
-            score->style().chordList()->read(score->styleSt(Sid::chordDescriptionFile));
-            }
+      score->style().checkChordList();
       if (!newWizard->title().isEmpty())
             score->fileInfo()->setFile(newWizard->title());
 
@@ -2311,9 +2307,7 @@ Score::FileError readScore(MasterScore* score, QString name, bool ignoreVersionE
                         score->style().load(&f);
                   }
             else {
-                  if (score->styleB(Sid::chordsXmlFile))
-                        score->style().chordList()->read("chords.xml");
-                  score->style().chordList()->read(score->styleSt(Sid::chordDescriptionFile));
+                  score->style().checkChordList();
                   }
             bool found = false;
             for (auto i : imports) {

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3326,6 +3326,8 @@ static void loadScores(const QStringList& argv)
                               MasterScore* score = mscore->readScore(startScore);
                               if (startScore.startsWith(":/") && score) {
                                     score->setStyle(MScore::defaultStyle());
+                                    score->style().checkChordList();
+                                    score->styleChanged();
                                     score->setName(mscore->createDefaultName());
                                     // TODO score->setPageFormat(*MScore::defaultStyle().pageFormat());
                                     score->doLayout();
@@ -3335,6 +3337,8 @@ static void loadScores(const QStringList& argv)
                                     score = mscore->readScore(":/data/My_First_Score.mscx");
                                     if (score) {
                                           score->setStyle(MScore::defaultStyle());
+                                          score->style().checkChordList();
+                                          score->styleChanged();
                                           score->setName(mscore->createDefaultName());
                                           // TODO score->setPageFormat(*MScore::defaultStyle().pageFormat());
                                           score->doLayout();


### PR DESCRIPTION
See https://musescore.org/en/node/287780

In #4792, a change was made to how the default empty start score "My First Score" gets loaded.  Previously it always came up with base style, but in a group chat, we collectively decided it made more sense to use the (possibly customized) default style instead.  Unfortunately, the way this was implemented turned out to not support chord symbols, since default style doesn't have a chord list.

While it would be possible to change the initialization of the default style, or the behavior of setStyle(), to load a chord list - and this does seems to work - there could be unknown effects from that.  So I elected to just force the chord list to be loaded right after we apply the default style to My_First_Score.  While I was at it I refactored so the code that does this loading is now callable easily as a Style member function.  So if we later decide to do this in setStyle or the defaultStyle initialization after all, it's easy enough.