### PR TITLE
fix #285174, fix #287283: add opengl32sw.dll as a (last) fallback

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -660,6 +660,7 @@ if (MINGW)
       ${MINGW_ROOT}/opt/bin/ssleay32.dll
       ${QT_INSTALL_BINS}/libEGL.dll
       ${QT_INSTALL_BINS}/libGLESv2.dll
+      ${QT_INSTALL_BINS}/opengl32sw.dll
       ${QtInstallLibraries}
       ${PROJECT_SOURCE_DIR}/build/qt.conf
       DESTINATION bin)
@@ -889,7 +890,7 @@ else (MINGW)
                   "${QT_INSTALL_BINS}/Qt5XmlPatterns.dll"
                   "${QT_INSTALL_BINS}/Qt5WebChannel.dll"
                   "${QT_INSTALL_BINS}/Qt5QuickWidgets.dll" "${QT_INSTALL_BINS}/Qt5Positioning.dll"
-                  "${QT_INSTALL_BINS}/libEGL.dll" "${QT_INSTALL_BINS}/libGLESv2.dll"
+                  "${QT_INSTALL_BINS}/libEGL.dll" "${QT_INSTALL_BINS}/libGLESv2.dll" "${QT_INSTALL_BINS}/opengl32sw.dll"
                   )
       if (USE_WEBENGINE)
          list(APPEND dlls_to_copy "${QT_INSTALL_BINS}/Qt5WebEngineWidgets.dll" "${QT_INSTALL_BINS}/Qt5WebEngineCore.dll")
@@ -952,6 +953,7 @@ else (MINGW)
             ${QtInstallLibraries}
             ${QT_INSTALL_BINS}/libEGL.dll
             ${QT_INSTALL_BINS}/libGLESv2.dll
+            ${QT_INSTALL_BINS}/opengl32sw.dll
             ${QT_INSTALL_BINS}/Qt5Positioning.dll
             ${QT_INSTALL_BINS}/Qt5WebChannel.dll
             ${PROJECT_SOURCE_DIR}/build/qt.conf


### PR DESCRIPTION
if hardware support is missing and angle fails