### PR TITLE
Move the whole segment on dragging a note

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2396,7 +2396,12 @@ int Note::customizeVelocity(int velo) const
 void Note::editDrag(EditData& ed)
       {
       Chord* ch = chord();
-      if (ch->notes().size() == 1) {
+      Segment* seg = ch->segment();
+      if (seg) {
+            const Spatium deltaSp = Spatium(ed.delta.x() / spatium());
+            seg->undoChangeProperty(Pid::LEADING_SPACE, seg->extraLeadingSpace() + deltaSp);
+            }
+      else if (ch->notes().size() == 1) {
             // if the chord contains only this note, then move the whole chord
             // including stem, flag etc.
             ch->undoChangeProperty(Pid::OFFSET, ch->offset() + offset() + ed.delta);


### PR DESCRIPTION
Addresses the part of the [spacing adjustments issue](https://musescore.org/en/handbook/developers-handbook/ux-design/design-reviews-and-responses/tantacrul-music-software#29%3A09_-_Spacing_adjustments) raised in the Tantacrul's video review. It looks like it would be move intuitive if dragging a note after double-clicking it moved the whole segment rather than just this note or chord. This patch implements exactly that (not sure that handling cases with no segment still makes sense though). As always, any suggestions and remarks on the proposed solution are welcome!