### PR TITLE
export track and instrument names to MIDI files

### DIFF
--- a/mscore/exportmidi.h
+++ b/mscore/exportmidi.h
@@ -47,6 +47,7 @@ class ExportMidi {
 
       PauseMap pauseMap;
 
+      void copyStringToEvent(const QString& string, MidiEvent& event);
       void writeHeader();
 
    public:


### PR DESCRIPTION
Makes the exported MIDI files more pretty and easier to use (use case: choir scores in which people want to listen to only their voice or have it highlighted in their MIDI player - difficult without track names)