### PR TITLE
Allow changing duration of multiple notes

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1289,7 +1289,7 @@ void ChordRest::removeMarkings(bool /* keepTremolo */)
 //   isBefore
 //---------------------------------------------------------
 
-bool ChordRest::isBefore(ChordRest* o)
+bool ChordRest::isBefore(const ChordRest* o) const
       {
       if (!o || this == o)
             return true;

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -176,7 +176,7 @@ class ChordRest : public DurationElement {
       bool isFullMeasureRest() const { return _durationType == TDuration::DurationType::V_MEASURE; }
       virtual void removeMarkings(bool keepTremolo = false);
 
-      bool isBefore(ChordRest*);
+      bool isBefore(const ChordRest*) const;
 
       void undoAddAnnotation(Element*);
       };


### PR DESCRIPTION
Addresses another [UX issue](https://musescore.org/en/handbook/developers-handbook/ux-design/design-reviews-and-responses/tantacrul-music-software#29%3A41_-_Change_duration_multiple) mentioned in the Tantacrul's video review. This patch allows changing duration of multiple notes just by applying the same length changing operation for every chord/rest. As suggested by @anatoly-os, the order of applying the operation is determined by the chords/rests position: length changes for the last chord/rest first.

This change should probably be useful as it is but in some cases it yields not ideal results, for example:
- when lengthening chords so that they overlap with the second measure (only the last chord gets properly lengthened and tied);
- when lengthening notes so that they start to overlap.

Still these changes are undoable so it should be possible to reverse them, whichever the result is.

There is also no explicit prohibition of applying this operation to range selection in the current version of the patch. It is easy to add it but there is also another alternative. We can just ignore any non-ChordRest elements in the selection and change note length for all of them, and this will still work. This should allow, for example, to range-select the whole segment and change note lengths in it. However this makes it easier to make some mistake if the wrong button is pressed while a range is selected. Does it make sense to allow changing notes duration for range selection or is it better to forbid it at all?