### PR TITLE
Play selected staves only if there is a range selection

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2361,6 +2361,52 @@ int Note::ppitch() const
       }
 
 //---------------------------------------------------------
+//   mutePlayback
+//---------------------------------------------------------
+
+bool Note::mutePlayback() const
+      {
+      const MasterScore* ms = masterScore();
+      const Score* playbackScore = ms->playbackScore();
+      if (score() != playbackScore && links()) {
+            for (const ScoreElement* se : *links()) {
+                  if (se->score() == playbackScore)
+                        return toNote(se)->mutePlayback();
+                  }
+            }
+
+      const Staff* st = staff();
+      const Instrument* instr = st->part()->instrument(chord()->tick());
+      const Channel* ch = instr->playbackChannel(subchannel(), ms);
+      if (ch->mute() || ch->soloMute() || !st->playbackVoice(voice()))
+            return true;
+
+      const Selection& sel = score()->selection();
+      if (sel.isRange()) {
+            const int stIdx = staffIdx();
+            if (stIdx < sel.staffStart() || sel.staffEnd() <= stIdx) {
+                  // it may happen that at least some linked staff is selected
+                  bool linkedSelected = false;
+                  if (links()) {
+                        for (const ScoreElement* se : *links()) {
+                              if (se->score() == playbackScore) {
+                                    const int seStaffIdx = toNote(se)->staffIdx();
+                                    if (sel.staffStart() <= seStaffIdx && seStaffIdx < sel.staffEnd()) {
+                                          linkedSelected = true;
+                                          break;
+                                          }
+                                    }
+                              }
+                        }
+                  if (!linkedSelected)
+                        return true;
+                  }
+            }
+
+      return false;
+      }
+
+//---------------------------------------------------------
 //   epitch
 //    effective pitch, i.e. a pitch which is visible in the
 //    currently used written notation.

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -326,6 +326,7 @@ class Note final : public Element {
       int pitch() const                   { return _pitch;    }
       int ppitch() const;           ///< playback pitch
       int epitch() const;           ///< effective pitch
+      bool mutePlayback() const;    ///< whether the note should be muted during the playback
       qreal tuning() const                { return _tuning;   }
       void setTuning(qreal v)             { _tuning = v;      }
       void undoSetTpc(int v);

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -518,12 +518,9 @@ void Seq::playEvent(const NPlayEvent& event, unsigned framePos)
             bool mute = false;
 
             const Note* note = event.note();
-            if (note) {
-                  Staff* staff      = note->staff();
-                  Instrument* instr = staff->part()->instrument(note->chord()->tick());
-                  const Channel* a = instr->playbackChannel(note->subchannel(), cs);
-                  mute = a->mute() || a->soloMute() || !staff->playbackVoice(note->voice());
-                  }
+            if (note)
+                  mute = note->mutePlayback();
+
             if (!mute) {
                   if (event.discard()) { // ignore noteoff but restrike noteon
                         if (event.velo() > 0)


### PR DESCRIPTION
This is another usability patch that can probably be considered a proof of concept right now but may still  be useful.

This patch addresses [another request](https://musescore.org/en/handbook/developers-handbook/ux-design/design-reviews-and-responses/tantacrul-music-software#30%3A03_-_Playback_selection_only) mentioned in the Tantacrul's video review which is about playing only selected staves if some range selection is present. Having tested it a bit, I actually find it a convenient way of a selective score playback though it is still limited on large scores by performance issues due to regenerating MIDI events on each playback start.

The main possible issue is that selection also plays important role in editing process so maybe in some cases this new range selection effect may interfere with the editing process. So the main question here is probably whether such scenarios exist and whether they are common enough not to apply selected staves playback by default.