### PR TITLE
Fixes to various aspects of stafftype

### DIFF
--- a/libmscore/staff.h
+++ b/libmscore/staff.h
@@ -96,7 +96,6 @@ class Staff final : public ScoreElement {
       VeloList _velocities;         ///< cached value
       PitchList _pitchOffsets;      ///< cached value
 
-      void scaleChanged(double oldValue, double newValue);
       void fillBrackets(int);
       void cleanBrackets();
 
@@ -201,6 +200,7 @@ class Staff final : public ScoreElement {
       const StaffType* constStaffType(const Fraction&) const;
       StaffType* staffType(const Fraction&);
       StaffType* setStaffType(const Fraction&, const StaffType&);
+      void removeStaffType(const Fraction&);
       void staffTypeListChanged(const Fraction&);
 
       bool isPitchedStaff(const Fraction&) const;
@@ -236,6 +236,7 @@ class Staff final : public ScoreElement {
       void setUserDist(qreal val)   { _userDist = val;   }
 
       void spatiumChanged(qreal /*oldValue*/, qreal /*newValue*/);
+      void localSpatiumChanged(double oldVal, double newVal, Fraction tick);
       bool genKeySig();
       bool showLedgerLines(const Fraction&) const;
 

--- a/libmscore/stafftypechange.cpp
+++ b/libmscore/stafftypechange.cpp
@@ -58,12 +58,10 @@ void StaffTypeChange::read(XmlReader& e)
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "StaffType") {
-                  StaffType st;
-                  st.read(e);
-                  if (staff())
-                        _staffType = staff()->setStaffType(measure()->tick(), st);
-                  else
-                        _staffType = new StaffType(st);     // drag&drop operation
+                  StaffType* st = new StaffType();
+                  st->read(e);
+                  // Measure::add() will replace this with a pointer to a copy in the staff
+                  _staffType = st;
                   }
             else if (!Element::readProperties(e))
                   e.unknown();
@@ -85,7 +83,7 @@ void StaffTypeChange::spatiumChanged(qreal, qreal)
 
 void StaffTypeChange::layout()
       {
-      qreal _spatium = spatium();
+      qreal _spatium = score()->spatium();
       setbbox(QRectF(-lw*.5, -lw*.5, _spatium * 2.5 + lw, _spatium*2.5 + lw));
       if (measure()) {
             qreal y = -1.5 * _spatium - height() + measure()->system()->staff(staffIdx())->y();
@@ -190,11 +188,21 @@ bool StaffTypeChange::setProperty(Pid propertyId, const QVariant& v)
             case Pid::STAFF_GEN_KEYSIG:
                   _staffType->setGenKeysig(v.toBool());
                   break;
-            case Pid::MAG:
+            case Pid::MAG: {
+                  qreal _spatium = spatium();
                   _staffType->setUserMag(v.toDouble());
+                  Staff* _staff = staff();
+                  if (_staff)
+                        _staff->localSpatiumChanged(_spatium, spatium(), tick());
+                  }
                   break;
-            case Pid::SMALL:
+            case Pid::SMALL: {
+                  qreal _spatium = spatium();
                   _staffType->setSmall(v.toBool());
+                  Staff* _staff = staff();
+                  if (_staff)
+                        _staff->localSpatiumChanged(_spatium, spatium(), tick());
+                  }
                   break;
             case Pid::STAFF_YOFFSET:
                   _staffType->setYoffset(v.value<Spatium>());

--- a/libmscore/stafftypelist.h
+++ b/libmscore/stafftypelist.h
@@ -22,7 +22,7 @@ class XmlReader;
 //---------------------------------------------------------
 //   StaffTypeList
 //    this list is instantiated for every staff
-//    to keep track of key signature changes
+//    to keep track of staff type changes
 //---------------------------------------------------------
 
 class StaffTypeList : public std::map<int, StaffType> {

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -558,6 +558,7 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
                 || element->type() == ElementType::TBOX
                 || element->type() == ElementType::MEASURE
                 || element->type() == ElementType::BRACKET
+                || element->type() == ElementType::STAFFTYPE_CHANGE
                 || (element->type() == ElementType::ICON
                     && (toIcon(element)->iconType() == IconType::VFRAME
                         || toIcon(element)->iconType() == IconType::HFRAME


### PR DESCRIPTION
This started as what I thought would be a simple fix for an issue with scaling of chord symbols when making a staff small - but it turned out to open a can of worms.  I saw that we were calling spatiumChanged() upon setting the "scale" property but not for "small", and that furthermore, we were doing this globally and thus not just for the staff in question or taking staff type changes into account.  So I put the mostly-unused localSpatiumChanged functions to work, updating elements only for the staff and tick range affected.  And along the way, needed to revamp how stafftype changes get added and removed, as neither delete nor undo were doing what they should.

Here is the list of issues fixed:

https://musescore.org/en/node/276620
https://musescore.org/en/node/287852
https://musescore.org/en/node/287839
https://musescore.org/en/node/287885
https://musescore.org/en/node/287807

I left TODO notes in the code regarding how we manage the stafftype changes on undo/redo.  What I have works a lot better than what we have now, but it does mean we throw away the properties associated with the stafftype change on delete.  Undo brings the stafftype change back, but with a fresh set of properties as if it were newly added.  There would be ways around this if we created a copy constructor and/or assignment operator for stafftype, but as it is, there is no way to remove the stafftype from the list on delete and then still have it be valid on undo.