### PR TITLE
fix #287883: corrupt sextuplets

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3626,8 +3626,8 @@ void ScoreView::cmdTuplet(int n, ChordRest* cr)
       f.reduce();       //measure duration might not be reduced
       Fraction ratio(n, f.numerator());
       Fraction fr(1, f.denominator());
-      while (ratio.numerator() >= ratio.denominator()*2) {
-            ratio *= Fraction(1,2);
+      while (ratio.numerator() >= ratio.denominator() * 2) {
+            ratio.setDenominator(ratio.denominator() * 2);  // operator*= reduces, we don't want that here
             fr    *= Fraction(1,2);
             }
 


### PR DESCRIPTION
See https://musescore.org/en/node/287883 (this was originally reported on Facebook, BTW)

We could add a non-reduced-multiply operator to Fraction, or we could re-introduce the /= operator with an int parameter that was formerly used here but was commented out during the tick/Fraction changeover, not sure why.  I'll let someone else deal with that; I just wanted to get this working.