### PR TITLE
FIX #287864 editstyle.ui show/hide pageList sizing issues

### DIFF
--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -56,6 +56,8 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       bool isTooWide;
       bool isTooHigh;
       bool hasShown;
+      int listWidth;
+      int minWidth;
 
       virtual void showEvent(QShowEvent*);
       virtual void hideEvent(QHideEvent*);


### PR DESCRIPTION
https://musescore.org/en/node/287864
Adds `int listWidth;` and  `int minWidth;`class variables to `class EditStyle` in order to cache the pageList width while it is hidden.  `pageList->setVisible(false)` sets the pageList width to the minimum of 60, so it must be cached while the list is visible.
This PR also fixes these 2 issues - it's all in one function:
https://musescore.org/en/node/287863
https://musescore.org/en/node/287923

I have created an alternative PR for solving this issue by removing the window resizing functionality altogether: #4976.  Merge this PR or that PR, not both.