### PR TITLE
fix #153006: opening opened file will switch to that file

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -317,8 +317,11 @@ Score* MuseScore::openScore(const QString& fn, bool switchTab)
       QFileInfo fi(fn);
       QString path = fi.canonicalFilePath();
       for (Score* s : scoreList) {
-            if (s->masterScore()->fileInfo()->canonicalFilePath() == path)
+            if (s->masterScore()->fileInfo()->canonicalFilePath() == path) {
+                  if (switchTab)
+                        setCurrentScoreView(scoreList.indexOf(s->masterScore()));
                   return 0;
+                  }
             }
 
       MasterScore* score = readScore(fn);


### PR DESCRIPTION
When you currently open a score that is already opened, nothing happens. With this change, opening a score will switch to that score. This is a pretty simple fix, but should provide some good results. The infrastructure is already all there to scroll the bar to the correct location and show the right tab.