### PR TITLE
fix #284012 and #287515: Crash by editing/selecting entire score when another hidden staff contains beamed notes

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3661,8 +3661,13 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
 
       for (Segment* s : sl) {
             for (Element* e : s->elist()) {
-                  if (!e || !e->isChordRest() || !score()->staff(e->staffIdx())->show())
+                  if (!e || !e->isChordRest() || !score()->staff(e->staffIdx())->show()) {
+                        // the beam and its system may still be referenced when selecting all,
+                        // even if the staff is invisible. The old system is invalid and does cause problems in #284012
+                        if (e && e->isChordRest() && !score()->staff(e->staffIdx())->show() && toChordRest(e)->beam())
+                              toChordRest(e)->beam()->setParent(nullptr);
                         continue;
+                        }
                   ChordRest* cr = toChordRest(e);
 
                   // layout beam


### PR DESCRIPTION
…den staff contains beamed notes.

Resolves https://musescore.org/en/node/287515 and https://musescore.org/en/node/284012.

And I believe they are caused the same way.