### PR TITLE
fix 287993: bad layout of pedal before start repeat

### DIFF
--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -235,6 +235,14 @@ QPointF Pedal::linePos(Grip grip, System** sys) const
                                           break;
                                     }
                               else if (seg->segmentType() == SegmentType::EndBarLine) {
+                                    if (!seg->enabled()) {
+                                          // disabled barline layout is not reliable
+                                          // use width of measure instead
+                                          Measure* m = seg->measure();
+                                          s = seg->system();
+                                          x = m->width() + m->pos().x() - nhw * 2;
+                                          seg = nullptr;
+                                          }
                                     break;
                                     }
                               }


### PR DESCRIPTION
See https://musescore.org/en/node/287993

We are trying to layout to the end barline, but it's disabled (the start repeat in the next bar takes precedence).  Therefore the position of the end barline is not reliable.  This fix uses the measure width instead.