### PR TITLE
fix #287841: Crash when adding tempo marking on multimeasure rest

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1534,6 +1534,17 @@ void MuseScore::addTempo()
       cs->undoAddElement(tt);
       cs->select(tt, SelectType::SINGLE, 0);
       cs->endCmd();
+      Measure* m = tt->findMeasure();
+      if (m && m->hasMMRest() && tt->links()) {
+            Measure* mmRest = m->mmRest();
+            for (ScoreElement* se : *tt->links()) {
+                  TempoText* tt1 = toTempoText(se);
+                  if (tt != tt1 && tt1->findMeasure() == mmRest) {
+                        tt = tt1;
+                        break;
+                        }
+                  }
+            }
       cv->startEditMode(tt);
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/287841.

This solution is based on code from #4509.

Note: Adding a second Tempo Text to an mmRest causes a crash. #4846 solves that issue.