### PR TITLE
fix #116771: Note's dot's visibility is incorrect when toggling visibility with note and dot selected

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3519,6 +3519,9 @@ void Score::cmdToggleVisible()
       for (Element* e : selection().elements()) {
             if (e->isBracket())     // ignore
                   continue;
+            if (e->isNoteDot() && selection().elements().contains(e->parent()))
+                  // already handled in Note::setProperty() and Rest::setProperty(); don't toggle twice
+                  continue;
             bool spannerSegment = e->isSpannerSegment();
             if (!spannerSegment || !spanners.contains(toSpannerSegment(e)->spanner()))
                   e->undoChangeProperty(Pid::VISIBLE, !e->getProperty(Pid::VISIBLE).toBool());


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/116771.