### PR TITLE
fix #288190: crash on drag&drop barline

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -307,7 +307,11 @@ BarLine::~BarLine()
 QPointF BarLine::canvasPos() const
       {
       QPointF pos = Element::canvasPos();
-      pos.ry() += measure()->system()->staff(staffIdx())->y();
+      if (parent()) {
+            System* system = measure()->system();
+            qreal yoff = system ? system->staff(staffIdx())->y() : 0.0;
+            pos.ry() += yoff;
+            }
       return pos;
       }
 


### PR DESCRIPTION
See issue https://musescore.org/en/node/288190.  Bug came in when I didn't take the word "correctly" seriously enough here: https://github.com/musescore/MuseScore/pull/4915#discussion_r277130166 :-).  During drag&drop, we call canvasPos for a barline with no parent yet, so this ended up dereferencing a null pointer.