### PR TITLE
fix #285602: note line does not appear until reload

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -820,12 +820,12 @@ SpannerSegment* SLine::layoutSystem(System* system)
 //---------------------------------------------------------
 //   layout
 //    compute segments from tick1 tick2
-//    (obsolete)
+//    (used for palette, edit mode, and layout of note lines and glissandi)
 //---------------------------------------------------------
 
 void SLine::layout()
       {
-      if (score() == gscore || (tick() == Fraction(-1,1)) || (ticks() == Fraction(0,1))) {
+      if (score() == gscore || (tick() == Fraction(-1,1)) || (tick2() == Fraction::fromTicks(1))) {
             //
             // when used in a palette or while dragging from palette,
             // SLine has no parent and


### PR DESCRIPTION
See https://musescore.org/en/node/285602.

As I surmised, this broke with the tick/fraction change.  The problem is we're never laying out the segments for the note line when first added because it has a tick count of 0 and the new code is skipping layout in that case.  This seems to have been a mistranslation of the original, which has tick2() == 1 in that same place:

https://github.com/wschweer/MuseScore/commit/ec3be9a99af2ef9084203cf9daba7ddfba2cb4cd#diff-97d139714d630a8f95d269d78b4d8fb1L537

Replacing that with ticks() == Fraction(0, 1) is what broke note lines, replacing it with a more literal translation fixes it.  If you want to know where that tets originally came from, it's something from five years ago:

https://github.com/musescore/MuseScore/commit/5be74db332e198ea303f54e8da7214a73682f69d

to fix:

https://musescore.org/en/node/29886

I can't say I truly understand any of this, but my change here restores whatever was the case prior to the tick/fraction change, so it should be OK if 3.0.5 is.