### PR TITLE
fix #288250: instrument change does not transpose

### DIFF
--- a/mscore/propertymenu.cpp
+++ b/mscore/propertymenu.cpp
@@ -508,7 +508,7 @@ void ScoreView::elementPropertyAction(const QString& cmd, Element* e)
                               auto i = part->instruments()->upper_bound(tickStart.ticks());    // find(), ++i
                               Fraction tickEnd;
                               if (i == part->instruments()->end())
-                                    tickEnd = Fraction(-1,0);
+                                    tickEnd = Fraction(-1, 1);
                               else
                                     tickEnd = Fraction::fromTicks(i->first);
                               ic->score()->transpositionChanged(part, oldV, tickStart, tickEnd);


### PR DESCRIPTION
See https://musescore.org/en/node/288250.  Looks to have been just a simple typo during the tick/fraction change - see https://github.com/musescore/MuseScore/commit/ec3be9a99af2ef9084203cf9daba7ddfba2cb4cd#diff-45c092674691d6d7403d33735bf497bfL511.