### PR TITLE
fix #288227: Copy-paste tied notes included in linked staves in a score with parts leads to crash

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -3755,8 +3755,15 @@ static Element* findLinkedVoiceElement(Element* e, Staff* nstaff)
 
       if (de) {
             QList<int> l = de->tracks().values(strack);
-            if (l.isEmpty())
+            if (l.isEmpty()) {
+                  // simply return the first linked element whose staff is equal to nstaff
+                  for (ScoreElement* ee : e->linkList()) {
+                        Element* el = toElement(ee);
+                        if (el->staff() == nstaff)
+                              return el;
+                        }
                   return 0;
+                  }
             for (int i : l) {
                   if (nstaff->idx() * VOICES <= i && (nstaff->idx() + 1) * VOICES > i) {
                         dtrack = i;
@@ -3789,8 +3796,15 @@ static Chord* findLinkedChord(Chord* c, Staff* nstaff)
 
       if (de) {
             QList<int> l = de->tracks().values(strack);
-            if (l.isEmpty())
+            if (l.isEmpty()) {
+                  // simply return the first linked chord whose staff is equal to nstaff
+                  for (ScoreElement* ee : c->linkList()) {
+                        Chord* ch = toChord(ee);
+                        if (ch->staff() == nstaff)
+                              return ch;
+                        }
                   return 0;
+                  }
             for (int i : l) {
                   if (nstaff->idx() * VOICES <= i && (nstaff->idx() + 1) * VOICES > i) {
                         dtrack = i;

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3773,9 +3773,9 @@ static bool readScore(Score* score, XmlReader& e)
                         Excerpt* ex = new Excerpt(m);
 
                         ex->setPartScore(s);
-                        ex->setTracks(e.tracks());
                         e.setLastMeasure(nullptr);
                         readScore(s, e);
+                        ex->setTracks(e.tracks());
                         m->addExcerpt(ex);
                         }
                   }

--- a/libmscore/read301.cpp
+++ b/libmscore/read301.cpp
@@ -170,9 +170,9 @@ bool Score::read(XmlReader& e)
                         Excerpt* ex    = new Excerpt(m);
 
                         ex->setPartScore(s);
-                        ex->setTracks(e.tracks());
                         e.setLastMeasure(nullptr);
                         s->read(e);
+                        ex->setTracks(e.tracks());
                         m->addExcerpt(ex);
                         }
                   }


### PR DESCRIPTION
See https://musescore.org/en/node/288227, and especially my comment there.