### PR TITLE
Barline spacing issues

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3972,7 +3972,11 @@ void Measure::setStretchedWidth(qreal w)
 
 static bool hasAccidental(Segment* s)
       {
+      Score* score = s->score();
       for (int track = 0; track < s->score()->ntracks(); ++track) {
+            Staff* staff = score->staff(track2staff(track));
+            if (!staff->show())
+                  continue;
             Element* e = s->element(track);
             if (!e || !e->isChord())
                   continue;

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -4025,6 +4025,10 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
                   continue;
                   }
             Segment* ns = s->nextActive();
+            // end barline might be disabled
+            // but still consider it for spacing of previous segment
+            if (!ns)
+                  ns = s->next(SegmentType::BarLineType);
             qreal w;
 
             if (ns) {


### PR DESCRIPTION
A couple of glitches with spacing before and after barlines not responding to style settings properly:

https://musescore.org/en/node/288162
https://musescore.org/en/node/288207

For the first, the fix was obvious - modify hasAccidental to skip invisible staves.

For the second, the issue is the final barline is disabled and hence skipped when computing the width of the previous segment.  I thought of a few ways around this, but settled for what I have here - just checking immediately after getting a null value from nextActive() to see if there is an end barline and using it always to help us calculate the width of the previous segment.  This has the least chance of adverse effects elsewhere.

BTW, nextActive() is a function I added recently to help us ignore segments that only have notes on invisible staves, so I wondered at first if that previous change is what broke this.  But actually, the code previously used nextEnabled(), which would have also skipped the end barline and thus produced the same error.