### PR TITLE
fix #283568: part name should not be linked

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4137,11 +4137,9 @@ void Score::undoAddElement(Element* element)
             const LinkedElements* links = parent->links();
             // don't link part name
             if (et == ElementType::TEXT) {
-#if 0 // TODO-ws
                   Text* t = toText(element);
-                  if (t->subStyle() == ElementStyle::INSTRUMENT_EXCERPT)
+                  if (t->tid() == Tid::INSTRUMENT_EXCERPT)
                         links = 0;
-#endif
                   }
             if (links == 0) {
                   undo(new AddElement(element));

--- a/libmscore/excerpt.cpp
+++ b/libmscore/excerpt.cpp
@@ -719,7 +719,11 @@ void Excerpt::cloneStaves(Score* oscore, Score* score, const QList<int>& map, QM
                   // layout breaks other than section were skipped above,
                   // but section breaks do need to be cloned & linked
                   // other measure-attached elements (?) are cloned but not linked
-                  if (e->isTextBase() || e->isLayoutBreak()) {
+                  if (e->isText() && toText(e)->tid() == Tid::INSTRUMENT_EXCERPT) {
+                        // skip part name in score
+                        continue;
+                        }
+                  else if (e->isTextBase() || e->isLayoutBreak()) {
                         ne = e->clone();
                         ne->setAutoplace(true);
                         ne->linkTo(e);


### PR DESCRIPTION
See https://musescore.org/en/node/283568.  A simple matter to skip part names when creating excerpts and to skip linking them when adding new ones.  The latter even had a TODO in the source, looks like it was leftover from the text style re-architecture.