### PR TITLE
fix #288014: write melisma ticks in a 3.0.5-compatible way

### DIFF
--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -93,6 +93,7 @@ void Lyrics::write(XmlWriter& xml) const
                   };
             xml.tag("syllabic", sl[int(_syllabic)]);
             }
+      xml.tag("ticks", _ticks.ticks(), 0); // pre-3.1 compatibility: write integer ticks under <ticks> tag
       writeProperty(xml, Pid::LYRIC_TICKS);
 
       TextBase::writeProperties(xml);
@@ -135,6 +136,8 @@ bool Lyrics::readProperties(XmlReader& e)
                   qDebug("bad syllabic property");
             }
       else if (tag == "ticks")            // obsolete
+            _ticks = e.readFraction(); // will fall back to reading integer ticks on older scores
+      else if (tag == "ticks_f")
             _ticks = e.readFraction();
       else if (readProperty(tag, e, Pid::PLACEMENT))
             ;

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -207,7 +207,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::VERSE,                   true,  "no",                    P_TYPE::ZERO_INT,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "verse")            },
 
       { Pid::SYLLABIC,                true,  "syllabic",              P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "syllabic")         },
-      { Pid::LYRIC_TICKS,             true,  "ticks",                 P_TYPE::FRACTION,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "ticks")            },
+      { Pid::LYRIC_TICKS,             true,  "ticks_f",               P_TYPE::FRACTION,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "ticks")            },
       { Pid::VOLTA_ENDING,            true,  "endings",               P_TYPE::INT_LIST,            DUMMY_QT_TRANSLATE_NOOP("propertyName", "endings")          },
       { Pid::LINE_VISIBLE,            true,  "lineVisible",           P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "visible line")     },
       { Pid::MAG,                     false, "mag",                   P_TYPE::REAL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "mag")              },

--- a/mtest/libmscore/copypastesymbollist/copypastesymbollist-lyrics-ref.mscx
+++ b/mtest/libmscore/copypastesymbollist/copypastesymbollist-lyrics-ref.mscx
@@ -143,7 +143,8 @@
             <durationType>eighth</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <ticks>1/4</ticks>
+              <ticks>480</ticks>
+              <ticks_f>1/4</ticks_f>
               <text>min</text>
               </Lyrics>
             <Note>
@@ -310,7 +311,8 @@
             <durationType>eighth</durationType>
             <Lyrics>
               <syllabic>end</syllabic>
-              <ticks>1/4</ticks>
+              <ticks>480</ticks>
+              <ticks_f>1/4</ticks_f>
               <text>min</text>
               </Lyrics>
             <Note>

--- a/mtest/libmscore/spanners/lyricsline02-ref.mscx
+++ b/mtest/libmscore/spanners/lyricsline02-ref.mscx
@@ -88,7 +88,8 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <ticks>1/4</ticks>
+              <ticks>480</ticks>
+              <ticks_f>1/4</ticks_f>
               <text>A</text>
               </Lyrics>
             <Note>

--- a/mtest/libmscore/spanners/lyricsline02.mscx
+++ b/mtest/libmscore/spanners/lyricsline02.mscx
@@ -88,7 +88,8 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <ticks>3/4</ticks>
+              <ticks>1440</ticks>
+              <ticks_f>3/4</ticks_f>
               <text>A</text>
               </Lyrics>
             <Note>

--- a/mtest/libmscore/spanners/lyricsline03.mscx
+++ b/mtest/libmscore/spanners/lyricsline03.mscx
@@ -92,7 +92,8 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <ticks>3/4</ticks>
+              <ticks>1440</ticks>
+              <ticks_f>3/4</ticks_f>
               <text>A</text>
               </Lyrics>
             <Note>

--- a/mtest/libmscore/spanners/lyricsline04.mscx
+++ b/mtest/libmscore/spanners/lyricsline04.mscx
@@ -92,7 +92,8 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <ticks>1/4</ticks>
+              <ticks>480</ticks>
+              <ticks_f>1/4</ticks_f>
               <text>A</text>
               </Lyrics>
             <Note>

--- a/mtest/libmscore/spanners/lyricsline05-ref.mscx
+++ b/mtest/libmscore/spanners/lyricsline05-ref.mscx
@@ -87,7 +87,8 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <ticks>1/4</ticks>
+              <ticks>480</ticks>
+              <ticks_f>1/4</ticks_f>
               <text>A</text>
               </Lyrics>
             <Note>

--- a/mtest/libmscore/spanners/lyricsline05.mscx
+++ b/mtest/libmscore/spanners/lyricsline05.mscx
@@ -87,7 +87,8 @@
           <Chord>
             <durationType>quarter</durationType>
             <Lyrics>
-              <ticks>5/4</ticks>
+              <ticks>2400</ticks>
+              <ticks_f>5/4</ticks_f>
               <text>A</text>
               </Lyrics>
             <Note>


### PR DESCRIPTION
Fixes a file format compatibility issue on writing lyrics with melisma: https://musescore.org/en/node/288014