### PR TITLE
fix #288422: shortcuts for add brackets and add parentheses

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2405,7 +2405,21 @@ void Score::cmdIncDecDuration(int nSteps, bool stepDotted)
 
 void Score::cmdAddBracket()
       {
-      for(Element* el : selection().elements()) {
+      for (Element* el : selection().elements()) {
+            if (el->type() == ElementType::ACCIDENTAL) {
+                  Accidental* acc = toAccidental(el);
+                  acc->undoChangeProperty(Pid::ACCIDENTAL_BRACKET, int(AccidentalBracket::BRACKET));
+                  }
+            }
+      }
+
+//---------------------------------------------------------
+//   cmdAddParentheses
+//---------------------------------------------------------
+
+void Score::cmdAddParentheses()
+      {
+      for (Element* el : selection().elements()) {
             if (el->type() == ElementType::NOTE) {
                   Note* n = toNote(el);
                   n->addParentheses();
@@ -3659,6 +3673,7 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "select-all",                 [this]{ cmdSelectAll();                                             }},
             { "select-section",             [this]{ cmdSelectSection();                                         }},
             { "add-brackets",               [this]{ cmdAddBracket();                                            }},
+            { "add-parentheses",            [this]{ cmdAddParentheses();                                        }},
             { "acciaccatura",               [this]{ cmdAddGrace(NoteType::ACCIACCATURA, MScore::division / 2);  }},
             { "appoggiatura",               [this]{ cmdAddGrace(NoteType::APPOGGIATURA, MScore::division / 2);  }},
             { "grace4",                     [this]{ cmdAddGrace(NoteType::GRACE4, MScore::division);            }},

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2434,6 +2434,10 @@ void Score::cmdAddParentheses()
                   h->setRightParen(true);
                   h->render();
                   }
+            else if (el->type() == ElementType::TIMESIG) {
+                  TimeSig* ts = toTimeSig(el);
+                  ts->setLargeParentheses(true);
+                  }
             }
       }
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -480,6 +480,7 @@ class Score : public QObject, public ScoreElement {
       void cmdMoveLyrics(Lyrics*, Direction);
       void cmdIncDecDuration(int nSteps, bool stepDotted = false);
       void cmdAddBracket();
+      void cmdAddParentheses();
       void resetUserStretch();
 
       bool layoutSystem(qreal& minWidth, qreal w, bool, bool);

--- a/mscore/data/shortcuts-Mac.xml
+++ b/mscore/data/shortcuts-Mac.xml
@@ -955,6 +955,10 @@
     <seq>;</seq>
     </SC>
   <SC>
+    <key>add-parentheses</key>
+    <seq>(</seq>
+    </SC>
+  <SC>
     <key>toggle-mmrest</key>
     <seq>M</seq>
     </SC>

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -975,6 +975,10 @@
     <seq>;</seq>
     </SC>
   <SC>
+    <key>add-parentheses</key>
+    <seq>(</seq>
+    </SC>
+  <SC>
     <key>toggle-mmrest</key>
     <seq>M</seq>
     </SC>

--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -991,6 +991,10 @@
     <seq>;</seq>
     </SC>
   <SC>
+    <key>add-parentheses</key>
+    <seq>(</seq>
+    </SC>
+  <SC>
     <key>toggle-mmrest</key>
     <seq>M</seq>
     </SC>

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3409,8 +3409,8 @@ Shortcut Shortcut::_sc[] = {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "add-brackets",
-         QT_TRANSLATE_NOOP("action","Add Brackets to Element"),
-         QT_TRANSLATE_NOOP("action","Add brackets to element"),
+         QT_TRANSLATE_NOOP("action","Add Brackets to Accidental"),
+         QT_TRANSLATE_NOOP("action","Add brackets to accidental"),
          0,
          Icons::brackets_ICON,
          Qt::WindowShortcut


### PR DESCRIPTION
make the shortcut for adding parentheses work (same way as previous did the add brackets shortcut), and give it a default shortcut "(". Restrict add brackets to really only add brackets and work on accidentals only.