### PR TITLE
minor and mostly cosmetic change for MinGW to really find lame_enc.dll

### DIFF
--- a/build/FindLame.cmake
+++ b/build/FindLame.cmake
@@ -1,7 +1,7 @@
 find_path(LAME_INCLUDE_DIR lame/lame.h PATHS /opt/local/include /usr/local/Cellar/lame/*/include ${PROJECT_SOURCE_DIR}/dependencies/include)
 find_path(LAME_INCLUDE_DIR lame/lame.h)
 
-find_library(LAME_LIBRARY NAMES mp3lame PATHS /opt/local/lib /usr/local/Cellar/lame/*/lib ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
+find_library(LAME_LIBRARY NAMES mp3lame lame_enc PATHS /opt/local/lib /usr/local/Cellar/lame/*/lib ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
 find_library(LAME_LIBRARY NAMES mp3lame)
 
 if (LAME_INCLUDE_DIR AND LAME_LIBRARY)


### PR DESCRIPTION
actually to report it as being found during cmake.
Really should have been done as part of #4120