### PR TITLE
fix #288437: Range selection is drawn incorrectly

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1209,7 +1209,7 @@ void ScoreView::paint(const QRect& r, QPainter& p)
             if (!ss->enabled())
                   ss = ss->next1MMenabled();
             if (es && !es->enabled())
-                  es = es->prev1MMenabled();
+                  es = es->next1MMenabled();
             if (es && ss->tick() > es->tick())  // start after end?
                   return;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/288437.