### PR TITLE
fix #288383: Crash when inserting notes in voice 2 when first rest is deleted

### DIFF
--- a/libmscore/input.cpp
+++ b/libmscore/input.cpp
@@ -154,13 +154,14 @@ Segment* InputState::nextInputPos() const
       Measure* m = _segment->measure();
       Segment* s = _segment->next1(SegmentType::ChordRest);
       for (; s; s = s->next1(SegmentType::ChordRest)) {
-            if (s->element(_track) || s->measure() != m) {
-                  if (s->element(_track)) {
-                        if (s->element(_track)->isRest() && toRest(s->element(_track))->isGap())
-                              continue;
-                        }
-                  return s;
+            if (s->element(_track)) {
+                  if (s->element(_track)->isRest() && toRest(s->element(_track))->isGap())
+                        m = s->measure();
+                  else
+                        return s;
                   }
+            else if (s->measure() != m)
+                  return s;
             }
       return 0;
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/288383.

`InputState::nextInputPos()` was not returning the appropriate segment when it encountered a gap in voice 2 that was of a different duration than the rest in voice 1. This is because the loop was ending too early due to the fact that `m` was no longer equal to `s->measure()`. This could have been a one-line fix, but I took this opportunity to remove the double check for `if (s->element(_track))`.