### PR TITLE
fix #288474: Particular .mscz file crashes MuseScore

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3648,7 +3648,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                                 Tremolo* t = toChord(e)->tremolo();
                                                 Chord* c1 = t->chord1();
                                                 Chord* c2 = t->chord2();
-                                                if (!t->twoNotes() || (!c1->staffMove() && !c2->staffMove())) {
+                                                if (!t->twoNotes() || (c1 && !c1->staffMove() && c2 && !c2->staffMove())) {
                                                       if (t->chord() == e && t->autoplace())
                                                             skyline.add(t->shape().translated(t->pos() + e->pos() + p));
                                                       }
@@ -4220,7 +4220,7 @@ void LayoutContext::collectPage()
                                                 Tremolo* t = c->tremolo();
                                                 Chord* c1 = t->chord1();
                                                 Chord* c2 = t->chord2();
-                                                if (t->twoNotes() && (c1->staffMove() || c2->staffMove()))
+                                                if (t->twoNotes() && c1 && c2 && (c1->staffMove() || c2->staffMove()))
                                                       t->layout();
                                                 }
                                           }

--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -491,7 +491,7 @@ void LayoutContext::layoutLinear()
                                           Tremolo* t = c->tremolo();
                                           Chord* c1 = t->chord1();
                                           Chord* c2 = t->chord2();
-                                          if (t->twoNotes() && (c1->staffMove() || c2->staffMove()))
+                                          if (t->twoNotes() && c1 && c2 && (c1->staffMove() || c2->staffMove()))
                                                 t->layout();
                                           }
                                     }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3258,7 +3258,7 @@ void Measure::stretchMeasure(qreal targetWidth)
                               Tremolo* tr = c->tremolo();
                               Chord* c1 = tr->chord1();
                               Chord* c2 = tr->chord2();
-                              if (!tr->twoNotes() || (!c1->staffMove() && !c2->staffMove()))
+                              if (!tr->twoNotes() || (c1 && !c1->staffMove() && c2 && !c2->staffMove()))
                                     tr->layout();
                               }
                         }


### PR DESCRIPTION
Not sure at all this is the right way to fix this, but at least it does prevent the crash.
The root cause for the problem is probably somewhere else.