### PR TITLE
fix #288420: Can't pan score while playing when note is selected

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -550,7 +550,7 @@ void ScoreView::mouseMoveEvent(QMouseEvent* me)
                   break;
 
             case ViewState::PLAY:
-                  if (drag && !editData.element)
+                  if (drag)
                         dragScoreView(me);
                   break;
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/288420.

Making sure that editData.element is NULL seems like an unnecessary precaution, and it prevents the panning of a score during playback if an element is selected, which would usually be the case when starting playback at a specific point. There is no way to begin playback while in edit mode, nor is there a way to edit an element during playback.