### PR TITLE
FIX #288489

### DIFF
--- a/mscore/editstyle.h
+++ b/mscore/editstyle.h
@@ -53,8 +53,7 @@ class EditStyle : public QDialog, private Ui::EditStyleBase {
       QVector<StyleWidget> styleWidgets;
       QButtonGroup* keySigNatGroup;
       QButtonGroup* clefTypeGroup;
-      bool isTooWide;
-      bool isTooHigh;
+      bool isTooBig;
       bool hasShown;
 
       virtual void showEvent(QShowEvent*);


### PR DESCRIPTION
Eliminates the resizing of the editstyle.ui dialog box when showing/hiding the pageList.
See also these issues, which are fixed via removing the functionality entirely:
https://musescore.org/en/node/287864
https://musescore.org/en/node/287863
https://musescore.org/en/node/287923

This PR is an alternative to #4938.  I would recommend merging one or the other, not both.
