### PR TITLE
Implement partial MIDI rendering during playback

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -17,6 +17,7 @@
 
 #include <set>
 
+#include "rendermidi.h"
 #include "score.h"
 #include "volta.h"
 #include "note.h"
@@ -71,12 +72,6 @@ namespace Ms {
     //    }
     //    return 0;
     //}
-
-enum class DynamicsRenderMethod : signed char {
-      FIXED_MAX,
-      SEG_START,
-      SIMPLE
-      };
 
 struct StaffRenderData {
       Fraction lastHairpinStart = Fraction(-1, 1);
@@ -1211,152 +1206,146 @@ void Score::updateVelo()
       }
 
 //---------------------------------------------------------
-//   renderStaff
+//   renderStaffSegment
 //---------------------------------------------------------
 
-void Score::renderStaff(EventMap* events, Staff* staff, DynamicsRenderMethod method, int cc)
+void MidiRenderer::renderStaffChunk(const Chunk& chunk, EventMap* events, Staff* staff, DynamicsRenderMethod method, int cc)
       {
-      Measure* lastMeasure = 0;
+      Measure* start = chunk.startMeasure();
+      Measure* end = chunk.endMeasure();
+      const int tickOffset = chunk.tickOffset();
+
+      Measure* lastMeasure = start->prevMeasure();
       StaffRenderData renderData;
 
-      for (const RepeatSegment* rs : repeatList()) {
-            Fraction startTick  = Fraction::fromTicks(rs->tick);
-            Fraction endTick    = startTick + Fraction::fromTicks(rs->len());
-            int tickOffset = rs->utick - rs->tick;
-            for (Measure* m = tick2measure(startTick); m; m = m->nextMeasure()) {
-                  if (lastMeasure && m->isRepeatMeasure(staff)) {
-                        int offset = (m->tick() - lastMeasure->tick()).ticks();
-                        collectMeasureEvents(events, lastMeasure, staff, renderData, tickOffset + offset, method, cc);
-                        }
-                  else {
-                        lastMeasure = m;
-                        collectMeasureEvents(events, lastMeasure, staff, renderData, tickOffset, method, cc);
-                        }
-                  if (m->tick() + m->ticks() >= endTick)
-                        break;
+      for (Measure* m = start; m != end; m = m->nextMeasure()) {
+            if (lastMeasure && m->isRepeatMeasure(staff)) {
+                  int offset = (m->tick() - lastMeasure->tick()).ticks();
+                  collectMeasureEvents(events, lastMeasure, staff, renderData, tickOffset + offset, method, cc);
+                  }
+            else {
+                  lastMeasure = m;
+                  collectMeasureEvents(events, lastMeasure, staff, renderData, tickOffset, method, cc);
                   }
             }
 
-      for (std::pair<int, NPlayEvent> event : renderData.tempPlayEvents) {
-            events->insert(std::pair<int, NPlayEvent>(event.first, event.second));
-            }
+      events->insert(renderData.tempPlayEvents.begin(), renderData.tempPlayEvents.end());
       }
 
 //---------------------------------------------------------
 //   renderSpanners
 //---------------------------------------------------------
 
-void Score::renderSpanners(EventMap* events)
+void MidiRenderer::renderSpanners(const Chunk& chunk, EventMap* events)
       {
-      for (const RepeatSegment* rs : repeatList()) {
-            int tickOffset = rs->utick - rs->tick;
-            int utick1 = rs->utick;
-            int tick1 = repeatList().utick2tick(utick1);
-            int tick2 = tick1 + rs->len();
-            std::map<int, std::vector<std::pair<int, std::pair<bool, int>>>> channelPedalEvents;
-            for (const auto& sp : _spanner.map()) {
-                  Spanner* s = sp.second;
+      const int tickOffset = chunk.tickOffset();
+      const int tick1 = chunk.tick1();
+      const int tick2 = chunk.tick2();
 
-                  int staff = s->staffIdx();
-                  int idx = s->staff()->channel(s->tick(), 0);
-                  int channel = s->part()->instrument(s->tick())->channel(idx)->channel();
+      std::map<int, std::vector<std::pair<int, std::pair<bool, int>>>> channelPedalEvents;
+      for (const auto& sp : score->spannerMap().map()) {
+            Spanner* s = sp.second;
 
-                  if (s->isPedal() || s->isLetRing()) {
-                        channelPedalEvents.insert({channel, std::vector<std::pair<int, std::pair<bool, int>>>()});
-                        std::vector<std::pair<int, std::pair<bool, int>>> pedalEventList = channelPedalEvents.at(channel);
-                        std::pair<int, std::pair<bool, int>> lastEvent;
+            int staff = s->staffIdx();
+            int idx = s->staff()->channel(s->tick(), 0);
+            int channel = s->part()->instrument(s->tick())->channel(idx)->channel();
 
-                        if (!pedalEventList.empty())
-                              lastEvent = pedalEventList.back();
-                        else
-                              lastEvent = std::pair<int, std::pair<bool, int>>(0, std::pair<bool, int>(true, staff));
+            if (s->isPedal() || s->isLetRing()) {
+                  channelPedalEvents.insert({channel, std::vector<std::pair<int, std::pair<bool, int>>>()});
+                  std::vector<std::pair<int, std::pair<bool, int>>> pedalEventList = channelPedalEvents.at(channel);
+                  std::pair<int, std::pair<bool, int>> lastEvent;
 
-                        int st = s->tick().ticks();
-                        if (st >= tick1 && st < tick2) {
-                              // Handle "overlapping" pedal segments (usual case for connected pedal line)
-                              if (lastEvent.second.first == false && lastEvent.first >= (st + tickOffset + 2)) {
-                                    channelPedalEvents.at(channel).pop_back();
-                                    channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(st + tickOffset + 1, std::pair<bool, int>(false, staff)));
-                                    }
-                              int a = st + tickOffset + 2;
-                              channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(a, std::pair<bool, int>(true, staff)));
-                              }
-                        if (s->tick2().ticks() >= tick1 && s->tick2().ticks() <= tick2) {
-                              int t = s->tick2().ticks() + tickOffset + 1;
-                              if (t > repeatList().last()->utick + repeatList().last()->len())
-                                    t = repeatList().last()->utick + repeatList().last()->len();
-                              channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(t, std::pair<bool, int>(false, staff)));
-                              }
-                        }
-                  else if (s->isVibrato()) {
-                        int stick = s->tick().ticks();
-                        int etick = s->tick2().ticks();
-                        if (stick >= tick2 || etick < tick1)
-                              continue;
-
-                        if (stick < tick1)
-                              stick = tick1;
-                        if (etick > tick2)
-                              etick = tick2;
-
-                        // from start to end of trill, send bend events at regular interval
-                        Vibrato* t = toVibrato(s);
-                        // guitar vibrato, up only
-                        int spitch = 0; // 1/8 (100 is a semitone)
-                        int epitch = 12;
-                        if (t->vibratoType() == Vibrato::Type::GUITAR_VIBRATO_WIDE) {
-                              spitch = 0; // 1/4
-                              epitch = 25;
-                              }
-                        // vibrato with whammy bar up and down
-                        else if (t->vibratoType() == Vibrato::Type::VIBRATO_SAWTOOTH_WIDE) {
-                              spitch = 25; // 1/16
-                              epitch = -25;
-                              }
-                        else if (t->vibratoType() == Vibrato::Type::VIBRATO_SAWTOOTH) {
-                              spitch = 12;
-                              epitch = -12;
-                              }
-
-                        int j = 0;
-                        int delta = MScore::division / 8; // 1/8 note
-                        int lastPointTick = stick;
-                        while (lastPointTick < etick) {
-                              int pitch = (j % 4 < 2) ? spitch : epitch;
-                              int nextPitch = ((j+1) % 4 < 2) ? spitch : epitch;
-                              int nextPointTick = lastPointTick + delta;
-                              for (int i = lastPointTick; i <= nextPointTick; i += 16) {
-                                    double dx = ((i - lastPointTick) * 60) / delta;
-                                    int p = pitch + dx * (nextPitch - pitch) / delta;
-                                    int midiPitch = (p * 16384) / 1200 + 8192;
-                                    int msb = midiPitch / 128;
-                                    int lsb = midiPitch % 128;
-                                    NPlayEvent ev(ME_PITCHBEND, channel, lsb, msb);
-                                    ev.setOriginatingStaff(staff);
-                                    events->insert(std::pair<int, NPlayEvent>(i + tickOffset, ev));
-                                    }
-                              lastPointTick = nextPointTick;
-                              j++;
-                              }
-                        NPlayEvent ev(ME_PITCHBEND, channel, 0, 64); // no pitch bend
-                        ev.setOriginatingStaff(staff);
-                        events->insert(std::pair<int, NPlayEvent>(etick + tickOffset, ev));
-                        }
+                  if (!pedalEventList.empty())
+                        lastEvent = pedalEventList.back();
                   else
-                        continue;
-                  }
+                        lastEvent = std::pair<int, std::pair<bool, int>>(0, std::pair<bool, int>(true, staff));
 
-            for (const auto& pedalEvents : channelPedalEvents) {
-                  int channel = pedalEvents.first;
-                  for (const auto& pe : pedalEvents.second) {
-                        NPlayEvent event;
-                        if (pe.second.first == true)
-                              event = NPlayEvent(ME_CONTROLLER, channel, CTRL_SUSTAIN, 127);
-                        else
-                              event = NPlayEvent(ME_CONTROLLER, channel, CTRL_SUSTAIN, 0);
-                        event.setOriginatingStaff(pe.second.second);
-                        events->insert(std::pair<int,NPlayEvent>(pe.first, event));
+                  int st = s->tick().ticks();
+                  if (st >= tick1 && st < tick2) {
+                        // Handle "overlapping" pedal segments (usual case for connected pedal line)
+                        if (lastEvent.second.first == false && lastEvent.first >= (st + tickOffset + 2)) {
+                              channelPedalEvents.at(channel).pop_back();
+                              channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(st + tickOffset + 1, std::pair<bool, int>(false, staff)));
+                              }
+                        int a = st + tickOffset + 2;
+                        channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(a, std::pair<bool, int>(true, staff)));
                         }
+                  if (s->tick2().ticks() >= tick1 && s->tick2().ticks() <= tick2) {
+                        int t = s->tick2().ticks() + tickOffset + 1;
+                        const RepeatSegment& lastRepeat = *score->repeatList().back();
+                        if (t > lastRepeat.utick + lastRepeat.len())
+                              t = lastRepeat.utick + lastRepeat.len();
+                        channelPedalEvents.at(channel).push_back(std::pair<int, std::pair<bool, int>>(t, std::pair<bool, int>(false, staff)));
+                        }
+                  }
+            else if (s->isVibrato()) {
+                  int stick = s->tick().ticks();
+                  int etick = s->tick2().ticks();
+                  if (stick >= tick2 || etick < tick1)
+                        continue;
+
+                  if (stick < tick1)
+                        stick = tick1;
+                  if (etick > tick2)
+                        etick = tick2;
+
+                  // from start to end of trill, send bend events at regular interval
+                  Vibrato* t = toVibrato(s);
+                  // guitar vibrato, up only
+                  int spitch = 0; // 1/8 (100 is a semitone)
+                  int epitch = 12;
+                  if (t->vibratoType() == Vibrato::Type::GUITAR_VIBRATO_WIDE) {
+                        spitch = 0; // 1/4
+                        epitch = 25;
+                        }
+                  // vibrato with whammy bar up and down
+                  else if (t->vibratoType() == Vibrato::Type::VIBRATO_SAWTOOTH_WIDE) {
+                        spitch = 25; // 1/16
+                        epitch = -25;
+                        }
+                  else if (t->vibratoType() == Vibrato::Type::VIBRATO_SAWTOOTH) {
+                        spitch = 12;
+                        epitch = -12;
+                        }
+
+                  int j = 0;
+                  int delta = MScore::division / 8; // 1/8 note
+                  int lastPointTick = stick;
+                  while (lastPointTick < etick) {
+                        int pitch = (j % 4 < 2) ? spitch : epitch;
+                        int nextPitch = ((j+1) % 4 < 2) ? spitch : epitch;
+                        int nextPointTick = lastPointTick + delta;
+                        for (int i = lastPointTick; i <= nextPointTick; i += 16) {
+                              double dx = ((i - lastPointTick) * 60) / delta;
+                              int p = pitch + dx * (nextPitch - pitch) / delta;
+                              int midiPitch = (p * 16384) / 1200 + 8192;
+                              int msb = midiPitch / 128;
+                              int lsb = midiPitch % 128;
+                              NPlayEvent ev(ME_PITCHBEND, channel, lsb, msb);
+                              ev.setOriginatingStaff(staff);
+                              events->insert(std::pair<int, NPlayEvent>(i + tickOffset, ev));
+                              }
+                        lastPointTick = nextPointTick;
+                        j++;
+                        }
+                  NPlayEvent ev(ME_PITCHBEND, channel, 0, 64); // no pitch bend
+                  ev.setOriginatingStaff(staff);
+                  events->insert(std::pair<int, NPlayEvent>(etick + tickOffset, ev));
+                  }
+            else
+                  continue;
+            }
+
+      for (const auto& pedalEvents : channelPedalEvents) {
+            int channel = pedalEvents.first;
+            for (const auto& pe : pedalEvents.second) {
+                  NPlayEvent event;
+                  if (pe.second.first == true)
+                        event = NPlayEvent(ME_CONTROLLER, channel, CTRL_SUSTAIN, 127);
+                  else
+                        event = NPlayEvent(ME_CONTROLLER, channel, CTRL_SUSTAIN, 0);
+                  event.setOriginatingStaff(pe.second.second);
+                  events->insert(std::pair<int,NPlayEvent>(pe.first, event));
                   }
             }
       }
@@ -2378,11 +2367,14 @@ void Score::createPlayEvents(Chord* chord)
       // don’t change event list if type is PlayEventType::User
       }
 
-void Score::createPlayEvents()
+void Score::createPlayEvents(Measure* start, Measure* end)
       {
+      if (!start)
+            start = firstMeasure();
+
       int etrack = nstaves() * VOICES;
       for (int track = 0; track < etrack; ++track) {
-            for (Measure* m = firstMeasure(); m; m = m->nextMeasure()) {
+            for (Measure* m = start; m != end; m = m->nextMeasure()) {
                   // skip linked staves, except primary
                   if (!m->score()->staff(track / VOICES)->primaryStaff())
                         continue;
@@ -2399,13 +2391,29 @@ void Score::createPlayEvents()
 
 //---------------------------------------------------------
 //   renderMetronome
+///   add metronome tick events
 //---------------------------------------------------------
 
-void Score::renderMetronome(EventMap* events, Measure* m, const Fraction& tickOffset)
+void MidiRenderer::renderMetronome(const Chunk& chunk, EventMap* events)
+      {
+      const int tickOffset = chunk.tickOffset();
+      Measure* start = chunk.startMeasure();
+      Measure* end = chunk.endMeasure();
+
+      for (Measure* m = start; m != end; m = m->nextMeasure())
+            renderMetronome(events, m, Fraction::fromTicks(tickOffset));
+      }
+
+//---------------------------------------------------------
+//   renderMetronome
+///   add metronome tick events
+//---------------------------------------------------------
+
+void MidiRenderer::renderMetronome(EventMap* events, Measure* m, const Fraction& tickOffset)
       {
       int msrTick         = m->tick().ticks();
-      qreal tempo         = tempomap()->tempo(msrTick);
-      TimeSigFrac timeSig = sigmap()->timesig(msrTick).nominal();
+      qreal tempo         = score->tempomap()->tempo(msrTick);
+      TimeSigFrac timeSig = score->sigmap()->timesig(msrTick).nominal();
 
       int clickTicks      = timeSig.isBeatedCompound(tempo) ? timeSig.beatTicks() : timeSig.dUnitTicks();
       int endTick         = m->endTick().ticks();
@@ -2436,15 +2444,27 @@ void Score::renderMidi(EventMap* events, const SynthesizerState& synthState)
 
 void Score::renderMidi(EventMap* events, bool metronome, bool expandRepeats, const SynthesizerState& synthState)
       {
-      updateSwing();
-      updateCapo();
-      createPlayEvents();
-
       masterScore()->setExpandRepeats(expandRepeats);
-      masterScore()->updateChannel();
-      updateVelo();
+      MidiRenderer(masterScore()).renderScore(events, synthState, metronome);
+      }
 
-      SynthesizerState s = synthesizerState();
+void MidiRenderer::renderScore(EventMap* events, const SynthesizerState& synthState, bool metronome)
+      {
+      updateState();
+      for (const Chunk& chunk : chunks) {
+            renderChunk(chunk, events, synthState, metronome);
+            }
+      }
+
+void MidiRenderer::renderChunk(const Chunk& chunk, EventMap* events, const SynthesizerState& synthState, bool metronome)
+      {
+      // TODO: avoid doing it multiple times for the same measures
+      score->createPlayEvents(chunk.startMeasure(), chunk.endMeasure());
+
+      score->updateChannel();
+      score->updateVelo();
+
+      SynthesizerState s = score->synthesizerState();
       int method = s.method();
       int cc = s.ccToUse();
 
@@ -2453,7 +2473,7 @@ void Score::renderMidi(EventMap* events, bool metronome, bool expandRepeats, con
       if (method == -1) {
             method = synthState.method();
             cc = synthState.ccToUse();
-            
+
             if (method == -1) {
                   // fall back to defaults - this may be needed to pass tests,
                   // since sometimes the synth state is not init
@@ -2480,29 +2500,143 @@ void Score::renderMidi(EventMap* events, bool metronome, bool expandRepeats, con
             }
 
       // create note & other events
-      for (Staff* part : _staves)
-            renderStaff(events, part, renderMethod, cc);
+      for (Staff* st : score->staves())
+            renderStaffChunk(chunk, events, st, renderMethod, cc);
       events->fixupMIDI();
 
       // create sustain pedal events
-      renderSpanners(events);
+      renderSpanners(chunk, events);
 
-      if (!metronome)
-            return;
-      // add metronome ticks
-      for (const RepeatSegment* rs : repeatList()) {
-            int startTick  = rs->tick;
-            int endTick    = startTick + rs->len();
-            int tickOffset = rs->utick - rs->tick;
+      if (metronome)
+            renderMetronome(chunk, events);
+      }
 
-            //
-            //    add metronome tick events
-            //
-            for (Measure* m = tick2measure(Fraction::fromTicks(startTick)); m; m = m->nextMeasure()) {
-                  renderMetronome(events, m, Fraction::fromTicks(tickOffset));
-                  if (m->endTick().ticks() >= endTick)
-                        break;
-                  }
+//---------------------------------------------------------
+//   MidiRenderer::updateState
+//---------------------------------------------------------
+
+void MidiRenderer::updateState()
+      {
+      if (needUpdate) {
+            // Update the related structures inside score
+            // to avoid doing it multiple times on chunks rendering
+            score->updateSwing();
+            score->updateCapo();
+
+            updateChunksPartition();
+
+            needUpdate = false;
             }
+      }
+
+//---------------------------------------------------------
+//   MidiRenderer::updateChunksPartition
+//---------------------------------------------------------
+
+void MidiRenderer::updateChunksPartition()
+      {
+      chunks.clear();
+
+      for (const RepeatSegment* rs : score->repeatList()) {
+            const int tickOffset = rs->utick - rs->tick;
+
+            if (!minChunkSize) {
+                  // just make chunks corresponding to repeat segments
+                  chunks.emplace_back(tickOffset, rs->firstMeasure(), rs->lastMeasure());
+                  continue;
+                  }
+
+            Measure* end = rs->lastMeasure()->nextMeasure();
+            int count = 0;
+            bool needBreak = false;
+            Measure* chunkStart = nullptr;
+            for (Measure* m = rs->firstMeasure(); m != end; m = m->nextMeasure()) {
+                  if (!chunkStart)
+                        chunkStart = m;
+                  if ((++count) >= minChunkSize)
+                        needBreak = true;
+                  if (needBreak) {
+                        // Check for hairpins that overlap measure end:
+                        // hairpins should be inside one chunk, if possible
+                        const int endTick = m->endTick().ticks();
+                        const auto& spanners = score->spannerMap().findOverlapping(endTick - 1, endTick);
+                        bool canBreak = true;
+                        for (const auto& interval : spanners) {
+                              const Spanner* sp = interval.value;
+                              if (sp->isHairpin() && sp->tick2().ticks() > endTick) {
+                                    canBreak = false;
+                                    break;
+                                    }
+                              }
+
+                        if (canBreak) {
+                              chunks.emplace_back(tickOffset, chunkStart, m);
+                              chunkStart = nullptr;
+                              needBreak = false;
+                              count = 0;
+                              }
+                        }
+                  }
+            if (chunkStart) // last measures did not get added to chunk list
+                  chunks.emplace_back(tickOffset, chunkStart, rs->lastMeasure());
+            }
+      }
+
+//---------------------------------------------------------
+//   MidiRenderer::getChunkAt
+//---------------------------------------------------------
+
+MidiRenderer::Chunk MidiRenderer::getChunkAt(int utick)
+      {
+      updateState();
+
+      auto it = std::upper_bound(chunks.begin(), chunks.end(), utick, [](int utick, const Chunk& ch) { return utick < ch.utick1(); });
+      if (it == chunks.begin())
+            return Chunk();
+      --it;
+      const Chunk& ch = *it;
+      if (ch.utick2() <= utick)
+            return Chunk();
+      return ch;
+      }
+
+//---------------------------------------------------------
+//   RangeMap::setOccupied
+//---------------------------------------------------------
+
+void RangeMap::setOccupied(int tick1, int tick2)
+      {
+      auto it1 = status.upper_bound(tick1);
+      const bool beforeBegin = (it1 == status.begin());
+      if (beforeBegin || (--it1)->second != Range::BEGIN) {
+            if (!beforeBegin && it1->first == tick1)
+                  status.erase(it1);
+            else
+                  status.insert(std::make_pair(tick1, Range::BEGIN));
+            }
+
+      const auto it2 = status.lower_bound(tick2);
+      const bool afterEnd = (it2 == status.end());
+      if (afterEnd || it2->second != Range::END) {
+            if (!afterEnd && it2->first == tick2)
+                  status.erase(it2);
+            else
+                  status.insert(std::make_pair(tick2, Range::END));
+            }
+      }
+
+//---------------------------------------------------------
+//   RangeMap::occupiedRangeEnd
+//---------------------------------------------------------
+
+int RangeMap::occupiedRangeEnd(int tick) const
+      {
+      const auto it = status.upper_bound(tick);
+      if (it == status.begin())
+            return tick;
+      const int rangeEnd = (it == status.end()) ? tick : it->first;
+      if (it->second == Range::END)
+            return rangeEnd;
+      return tick;
       }
 }

--- a/libmscore/rendermidi.h
+++ b/libmscore/rendermidi.h
@@ -1,0 +1,116 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2019 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+//=============================================================================
+
+#ifndef __RENDERMIDI_H__
+#define __RENDERMIDI_H__
+
+#include "fraction.h"
+#include "measure.h"
+
+namespace Ms {
+
+class EventMap;
+class MasterScore;
+class Staff;
+class SynthesizerState;
+
+enum class DynamicsRenderMethod : signed char {
+      FIXED_MAX,
+      SEG_START,
+      SIMPLE
+      };
+
+//---------------------------------------------------------
+//   RangeMap
+///   Helper class to keep track of status of status of
+///   certain parts of score or MIDI representation.
+//---------------------------------------------------------
+
+class RangeMap {
+      enum class Range { BEGIN, END };
+      std::map<int, Range> status;
+
+   public:
+      void setOccupied(int tick1, int tick2);
+      void setOccupied(std::pair<int, int> range) { setOccupied(range.first, range.second); }
+
+      int occupiedRangeEnd(int tick) const;
+
+      void clear() { status.clear(); }
+      };
+
+//---------------------------------------------------------
+//   MidiRenderer
+///   MIDI renderer for a score
+//---------------------------------------------------------
+
+class MidiRenderer {
+      MasterScore* score;
+      bool needUpdate = true;
+      int minChunkSize = 0;
+
+   public:
+      class Chunk {
+            int _tickOffset;
+            Measure* first;
+            Measure* last;
+
+         public:
+            Chunk(int tickOffset, Measure* fst, Measure* lst)
+               : _tickOffset(tickOffset), first(fst), last(lst) {}
+
+            Chunk() // "invalid chunk" constructor
+               : _tickOffset(0), first(nullptr), last(nullptr) {}
+
+            operator bool() const { return bool(first); }
+            int tickOffset() const { return _tickOffset; }
+            Measure* startMeasure() const { return first; }
+            Measure* endMeasure() const { return last ? last->nextMeasure() : nullptr; }
+            int tick1() const { return first->tick().ticks(); }
+            int tick2() const { return last ? last->endTick().ticks() : tick1(); }
+            int utick1() const { return tick1() + tickOffset(); }
+            int utick2() const { return tick2() + tickOffset(); }
+            };
+
+   private:
+      std::vector<Chunk> chunks;
+
+      void updateChunksPartition();
+      void updateState();
+
+      void renderStaffChunk(const Chunk&, EventMap* events, Staff*, DynamicsRenderMethod method, int cc);
+      void renderSpanners(const Chunk&, EventMap* events);
+      void renderMetronome(const Chunk&, EventMap* events);
+      void renderMetronome(EventMap* events, Measure* m, const Fraction& tickOffset);
+
+   public:
+      explicit MidiRenderer(MasterScore* s) : score(s) {}
+
+      void renderScore(EventMap* events, const SynthesizerState& synthState, bool metronome = true);
+      void renderChunk(const Chunk&, EventMap* events, const SynthesizerState& synthState, bool metronome = true);
+
+      void setScoreChanged() { needUpdate = true; }
+      void setMinChunkSize(int sizeMeasures) { minChunkSize = sizeMeasures; needUpdate = true; }
+
+      Chunk getChunkAt(int utick);
+      };
+
+} // namespace Ms
+
+#endif

--- a/libmscore/repeatlist.cpp
+++ b/libmscore/repeatlist.cpp
@@ -105,6 +105,7 @@ RepeatSegment::RepeatSegment(RepeatSegment * const rs, Measure * const fromMeasu
 
 void RepeatSegment::addMeasure(Measure * const m)
       {
+      Q_ASSERT(measureList.empty() || measureList.back().first->nextMeasure() == m);
       if (measureList.empty()) {
             tick = m->tick().ticks();
             }
@@ -296,14 +297,14 @@ void RepeatList::dump() const
       {
 #if 0
       qDebug("==Dump Repeat List:==");
-      foreach(const RepeatSegment* s, *this) {
+      for (const RepeatSegment* s : *this) {
             qDebug("%p  tick: %3d(%d) %3d(%d) len %d(%d) beats  %f + %f", s,
                s->utick / MScore::division,
                s->utick / MScore::division / 4,
                s->tick / MScore::division,
                s->tick / MScore::division / 4,
-               s->len / MScore::division,
-               s->len / MScore::division / 4,
+               s->len() / MScore::division,
+               s->len() / MScore::division / 4,
                s->utime, s->timeOffset);
             }
 #endif

--- a/libmscore/repeatlist.h
+++ b/libmscore/repeatlist.h
@@ -40,6 +40,9 @@ class RepeatSegment {
       int len() const;
       int playbackCount(Measure * const) const;
 
+      Measure* firstMeasure() const { return measureList.empty() ? nullptr : measureList.front().first; }
+      Measure* lastMeasure() const  { return measureList.empty() ? nullptr : measureList.back().first;  }
+
       friend class RepeatList;
       };
 

--- a/libmscore/repeatlist.h
+++ b/libmscore/repeatlist.h
@@ -52,7 +52,9 @@ class RepeatList: public QList<RepeatSegment*>
       Score* _score;
       mutable unsigned idx1, idx2;   // cached values
 
-      RepeatSegment* rs;            // tmp value during unwind()
+      bool _expanded = false;
+      bool _scoreChanged = true;
+
       std::map<Volta*, Measure*> _voltaRanges; // open volta possibly ends past the end of its spanner, used during unwind
       std::set<Jump*> _jumpsTaken;   // take the jumps only once, so track them during unwind
 
@@ -63,16 +65,23 @@ class RepeatList: public QList<RepeatSegment*>
       int findStartFromRepeatCount(Measure * const startFrom) const;
       bool isFinalPlaythrough(Measure * const measure, QList<RepeatSegment*>::const_iterator repeatSegmentIt) const;
 
+      void unwind();
+      void flatten();
+
    public:
       RepeatList(Score* s);
-      void unwind();
+      RepeatList(const RepeatList&) = delete;
+      RepeatList& operator=(const RepeatList&) = delete;
+      ~RepeatList();
+      void update(bool expand);
+      void setScoreChanged() { _scoreChanged = true; }
       int utick2tick(int tick) const;
       int tick2utick(int tick) const;
       void dump() const;
       int utime2utick(qreal) const;
       qreal utick2utime(int) const;
-      void update();
-      int ticks();
+      void updateTempo();
+      int ticks() const;
       };
 
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -826,7 +826,7 @@ class Score : public QObject, public ScoreElement {
       void setAutosaveDirty(bool v)  { _autosaveDirty = v;    }
       bool autosaveDirty() const     { return _autosaveDirty; }
       bool playlistDirty()           { return _playlistDirty; }
-      void setPlaylistDirty()        { _playlistDirty = true; }
+      virtual void setPlaylistDirty();
 
       void spell();
       void spell(int startStaff, int endStaff, Segment* startSegment, Segment* endSegment);
@@ -939,10 +939,9 @@ class Score : public QObject, public ScoreElement {
 
       Measure* searchLabel(const QString& s, Measure* startMeasure = nullptr, Measure* endMeasure = nullptr);
       Measure* searchLabelWithinSectionFirst(const QString& s, Measure* sectionStartMeasure, Measure* sectionEndMeasure);
-      virtual inline RepeatList* repeatList() const;
+      virtual inline const RepeatList& repeatList() const;
       qreal utick2utime(int tick) const;
       int utime2utick(qreal utime) const;
-      void updateRepeatList(bool expandRepeats);
 
       void nextInputPos(ChordRest* cr, bool);
       void cmdMirrorNoteHead();
@@ -1210,6 +1209,7 @@ class MasterScore : public Score {
       TimeSigMap* _sigmap;
       TempoMap* _tempomap;
       RepeatList* _repeatList;
+      bool _expandRepeats = true;
       QList<Excerpt*> _excerpts;
       std::vector<PartChannelSettingsLink> _playbackSettingsLinks;
       Score* _playbackScore = nullptr;
@@ -1259,7 +1259,12 @@ class MasterScore : public Score {
       virtual UndoStack* undoStack() const override                   { return _movements->undo(); }
       virtual TimeSigMap* sigmap() const override                     { return _sigmap;     }
       virtual TempoMap* tempomap() const override                     { return _tempomap;   }
-      virtual RepeatList* repeatList()  const override                { return _repeatList; }
+
+      void setExpandRepeats(bool expandRepeats);
+      void updateRepeatListTempo();
+      virtual const RepeatList& repeatList() const override;
+      void setPlaylistDirty() override;
+
       virtual QList<Excerpt*>& excerpts() override                    { return _excerpts;   }
       virtual const QList<Excerpt*>& excerpts() const override        { return _excerpts;   }
       virtual QQueue<MidiInputEvent>* midiInputQueue() override       { return &_midiInputQueue;    }
@@ -1369,7 +1374,7 @@ class ScoreLoad {
       };
 
 inline UndoStack* Score::undoStack() const             { return _masterScore->undoStack();      }
-inline RepeatList* Score::repeatList()  const          { return _masterScore->repeatList();     }
+inline const RepeatList& Score::repeatList()  const    { return _masterScore->repeatList();     }
 inline TempoMap* Score::tempomap() const               { return _masterScore->tempomap();       }
 inline TimeSigMap* Score::sigmap() const               { return _masterScore->sigmap();         }
 inline QList<Excerpt*>& Score::excerpts()              { return _masterScore->excerpts();       }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -96,7 +96,6 @@ enum class Key;
 enum class HairpinType : signed char;
 enum class SegmentType;
 enum class OttavaType : char;
-enum class DynamicsRenderMethod : signed char;
 
 extern bool showRubberBand;
 
@@ -518,11 +517,6 @@ class Score : public QObject, public ScoreElement {
       void resetTempo();
       void resetTempoRange(const Fraction& tick1, const Fraction& tick2);
 
-      void renderStaff(EventMap* events, Staff*, DynamicsRenderMethod method, int cc);
-      void renderSpanners(EventMap* events);
-      void renderMetronome(EventMap* events, Measure* m, const Fraction& tickOffset);
-      void updateVelo();
-
       void deleteSpannersFromRange(const Fraction& t1, const Fraction& t2, int trackStart, int trackEnd, const SelectionFilter& filter);
       void deleteAnnotationsFromRange(Segment* segStart, Segment* segEnd, int trackStart, int trackEnd, const SelectionFilter& filter);
       ChordRest* deleteRange(Segment* segStart, Segment* segEnd, int trackStart, int trackEnd, const SelectionFilter& filter);
@@ -897,9 +891,10 @@ class Score : public QObject, public ScoreElement {
       void addLyrics(const Fraction& tick, int staffIdx, const QString&);
 
       void updateSwing();
-      void createPlayEvents();
+      void createPlayEvents(Measure* start = nullptr, Measure* end = nullptr);
 
       void updateCapo();
+      void updateVelo();
 
       void cmdConcertPitchChanged(bool, bool /*useSharpsFlats*/);
 

--- a/libmscore/unrollrepeats.cpp
+++ b/libmscore/unrollrepeats.cpp
@@ -151,11 +151,10 @@ MasterScore* MasterScore::unrollRepeats()
       score->setName(original->title()+"_unrolled");
 
       // figure out repeat structure
-      original->repeatList()->unwind();
-      original->setPlaylistDirty();
+      original->setExpandRepeats(true);
 
       // if no repeats, just return the score as-is
-      if (original->repeatList()->count() == 1)
+      if (original->repeatList().size() == 1)
             return score;
 
       // remove excerpts for now (they are re-created after unrolling master score)
@@ -167,7 +166,7 @@ MasterScore* MasterScore::unrollRepeats()
 
       // follow along with the repeatList
       bool first = true;
-      for (const RepeatSegment* rs: *(original->repeatList()) ) {
+      for (const RepeatSegment* rs: original->repeatList()) {
             Fraction startTick = Fraction::fromTicks(rs->tick);
             Fraction endTick   = Fraction::fromTicks(rs->tick + rs->len());
 

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -478,7 +478,7 @@ void ScoreView::mousePressEvent(QMouseEvent* ev)
                         if (e->isNote())
                               e = e->parent();
                         ChordRest* cr = toChordRest(e);
-                        seq->seek(seq->score()->repeatList()->tick2utick(cr->tick().ticks()));
+                        seq->seek(seq->score()->repeatList().tick2utick(cr->tick().ticks()));
                         }
                   }
                   break;

--- a/mscore/exportmidi.cpp
+++ b/mscore/exportmidi.cpp
@@ -84,7 +84,7 @@ void ExportMidi::writeHeader()
       //--------------------------------------------
 
       TimeSigMap* sigmap = cs->sigmap();
-      foreach(const RepeatSegment* rs, *cs->repeatList()) {
+      for (const RepeatSegment* rs : cs->repeatList()) {
             int startTick  = rs->tick;
             int endTick    = startTick + rs->len();
             int tickOffset = rs->utick - rs->tick;
@@ -135,7 +135,7 @@ void ExportMidi::writeHeader()
             KeyList* keys = staff->keyList();
 
             bool initialKeySigFound = false;
-            for (const RepeatSegment* rs : *cs->repeatList()) {
+            for (const RepeatSegment* rs : cs->repeatList()) {
                   int startTick  = rs->tick;
                   int endTick    = startTick + rs->len();
                   int tickOffset = rs->utick - rs->tick;
@@ -370,7 +370,7 @@ void ExportMidi::PauseMap::calculate(const Score* s)
       tempomapWithPauses = new TempoMap();
       tempomapWithPauses->setRelTempo(tempomap->relTempo());
 
-      foreach(const RepeatSegment* rs, *s->repeatList()) {
+      for (const RepeatSegment* rs : s->repeatList()) {
             int startTick  = rs->tick;
             int endTick    = startTick + rs->len();
             int tickOffset = rs->utick - rs->tick;

--- a/mscore/jackaudio.cpp
+++ b/mscore/jackaudio.cpp
@@ -321,11 +321,11 @@ void JackAudio::timebase(jack_transport_state_t state, jack_nframes_t /*nframes*
                   audio->stopTransport();
             }
       else if (audio->seq->isRunning()) {
-            if (!audio->seq->score()->repeatList() || !audio->seq->score()->sigmap())
+            if (!audio->seq->score()->masterScore())
                   return;
 
             pos->valid = JackPositionBBT;
-            int curTick = audio->seq->score()->repeatList()->utick2tick(audio->seq->getCurTick());
+            int curTick = audio->seq->score()->repeatList().utick2tick(audio->seq->getCurTick());
             int bar,beat,tick;
             audio->seq->score()->sigmap()->tickValues(curTick, &bar, &beat, &tick);
             // Providing the final tempo

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5852,7 +5852,7 @@ void MuseScore::setPlayRepeats(bool repeat)
       preferences.setPreference(PREF_APP_PLAYBACK_PLAYREPEATS, repeat);
       MScore::playRepeats = repeat;
       if (cs) {
-            cs->updateRepeatList(repeat);
+            cs->masterScore()->setExpandRepeats(repeat);
             emit cs->playlistChanged();
             }
       }

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -598,8 +598,8 @@ void PianorollEditor::keyReleased(int /*p*/)
 void PianorollEditor::heartBeat(Seq* s)
       {
       unsigned tick = s->getCurTick();
-      if (score()->repeatList())
-            tick = score()->repeatList()->utick2tick(tick);
+      if (score()->masterScore())
+            tick = score()->masterScore()->repeatList().utick2tick(tick);
       if (locator[0].tick() != tick) {
             posChanged(POS::CURRENT, tick);
             if (preferences.getBool(PREF_APP_PLAYBACK_FOLLOWSONG))

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -191,7 +191,7 @@ void PlayPanel::setScore(Score* s)
       if (cs && seq && seq->canStart()) {
             setTempo(cs->tempomap()->tempo(0));
             setRelTempo(cs->tempomap()->relTempo());
-            setEndpos(cs->repeatList()->ticks());
+            setEndpos(cs->repeatList().ticks());
             Fraction tick = cs->pos(POS::CURRENT);
             heartBeat(tick.ticks(), tick.ticks(), 0);
             }
@@ -323,7 +323,7 @@ void PlayPanel::updatePosLabel(int utick)
       int t = 0;
       int tick = 0;
       if (cs) {
-            tick = cs->repeatList()->utick2tick(utick);
+            tick = cs->repeatList().utick2tick(utick);
             cs->sigmap()->tickValues(tick, &bar, &beat, &t);
             double tpo = cs->tempomap()->tempo(tick) * cs->tempomap()->relTempo();
             setTempo(tpo);

--- a/mscore/savePositions.cpp
+++ b/mscore/savePositions.cpp
@@ -35,7 +35,7 @@ static void saveMeasureEvents(XmlWriter& xml, Measure* m, int offset)
       for (Segment* s = m->first(SegmentType::ChordRest); s; s = s->next(SegmentType::ChordRest)) {
             int tick = s->tick().ticks() + offset;
             int id = segs[(void*)s];
-            int time = lrint(m->score()->repeatList()->utick2utime(tick) * 1000);
+            int time = lrint(m->score()->repeatList().utick2utime(tick) * 1000);
             xml.tagE(QString("event elid=\"%1\" position=\"%2\"")
                .arg(id)
                .arg(time)
@@ -115,8 +115,8 @@ bool MuseScore::savePositions(Score* score, QIODevice* device, bool segments)
             }
 
       xml.stag("events");
-      score->updateRepeatList(true);
-      foreach(const RepeatSegment* rs, *score->repeatList()) {
+      score->masterScore()->setExpandRepeats(true);
+      for (const RepeatSegment* rs : score->repeatList()) {
             int startTick  = rs->tick;
             int endTick    = startTick + rs->len();
             int tickOffset = rs->utick - rs->tick;
@@ -126,7 +126,7 @@ bool MuseScore::savePositions(Score* score, QIODevice* device, bool segments)
                         else {
                               int tick = m->tick().ticks() + tickOffset;
                               int i = segs[(void*)m];
-                              int time = lrint(m->score()->repeatList()->utick2utime(tick) * 1000);
+                              int time = lrint(m->score()->repeatList().utick2utime(tick) * 1000);
                               xml.tagE(QString("event elid=\"%1\" position=\"%2\"")
                                  .arg(i)
                                  .arg(time)

--- a/mscore/seq.h
+++ b/mscore/seq.h
@@ -20,6 +20,7 @@
 #ifndef __SEQ_H__
 #define __SEQ_H__
 
+#include "libmscore/rendermidi.h"
 #include "libmscore/sequencer.h"
 #include "libmscore/fraction.h"
 #include "synthesizer/event.h"
@@ -132,7 +133,14 @@ class Seq : public QObject, public Sequencer {
       double meterPeakValue[2];
       int peakTimer[2];
 
-      EventMap events;                    // playlist for playback mode (pre-rendered)
+      EventMap events;                    // playlist for playback mode
+      EventMap::const_iterator eventsEnd;
+      EventMap renderEvents;              // event list that is rendered in background
+      RangeMap renderEventsStatus;
+      MidiRenderer midi;
+      QFuture<void> midiRenderFuture;
+      bool allowBackgroundRendering = false; // should be set to true only when playing, so no
+                                             // score changes are possible.
       EventMap countInEvents;             // playlist of any metronome countin clicks
       QQueue<NPlayEvent> _liveEventQueue; // playlist for score editing and note entry (rendered live)
 
@@ -157,7 +165,8 @@ class Seq : public QObject, public Sequencer {
       QTimer* heartBeatTimer;
       QTimer* noteTimer;
 
-      void collectMeasureEvents(Measure*, int staffIdx);
+      void renderChunk(const MidiRenderer::Chunk&, EventMap*);
+      void updateEventsEnd();
 
       void setPos(int);
       void playEvent(const NPlayEvent&, unsigned framePos);
@@ -167,6 +176,8 @@ class Seq : public QObject, public Sequencer {
       void unmarkNotes();
       void updateSynthesizerState(int tick1, int tick2);
       void addCountInClicks();
+
+      int getPlayStartUtick();
 
       inline QQueue<NPlayEvent>* liveEventQueue() { return &_liveEventQueue; }
 
@@ -207,7 +218,8 @@ class Seq : public QObject, public Sequencer {
       void prevMeasure();
       void prevChord();
 
-      void collectEvents();
+      void collectEvents(int utick);
+      void ensureBufferAsync(int utick);
       void guiStop();
       void stopWait();
       void setLoopIn();

--- a/mtest/libmscore/midi/testGuitarTrem-ref.txt
+++ b/mtest/libmscore/midi/testGuitarTrem-ref.txt
@@ -547,9 +547,9 @@ Tick  =   9556   Type  =   224   Pitch  =   109   Velocity  =    64   Channel  =
 Tick  =   9572   Type  =   224   Pitch  =    68   Velocity  =    64   Channel  =     0    
 Tick  =   9588   Type  =   224   Pitch  =    27   Velocity  =    64   Channel  =     0    
 Tick  =   9599   Type  =   144   Pitch  =    60   Velocity  =     0   Channel  =     0    
+Tick  =   9600   Type  =   224   Pitch  =     0   Velocity  =    64   Channel  =     0    
 Tick  =   9600   Type  =   144   Pitch  =    60   Velocity  =    80   Channel  =     0    
 Tick  =   9600   Type  =   176   Pitch  =     2   Velocity  =    80   Channel  =     0    
-Tick  =   9600   Type  =   224   Pitch  =     0   Velocity  =    64   Channel  =     0    
 Tick  =   9600   Type  =   224   Pitch  =     0   Velocity  =    64   Channel  =     0    
 Tick  =   9600   Type  =     3   Pitch  =     0   Velocity  =   127   Channel  =     0    
 Tick  =   9616   Type  =   224   Pitch  =     0   Velocity  =    64   Channel  =     0    

--- a/mtest/libmscore/repeat/tst_repeat.cpp
+++ b/mtest/libmscore/repeat/tst_repeat.cpp
@@ -117,11 +117,11 @@ void TestRepeat::initTestCase()
 
 void TestRepeat::repeat(const char* f1, const QString & ref)
       {
-      Score* score = readScore(DIR + f1);
+      MasterScore* score = readScore(DIR + f1);
       QVERIFY(score);
-      score->updateRepeatList(true);
+      score->setExpandRepeats(true);
       QStringList sl;
-      for (const RepeatSegment* rs : *score->repeatList()) {
+      for (const RepeatSegment* rs : score->repeatList()) {
             int startTick  = rs->tick;
             int endTick    = startTick + rs->len();
             for (Measure* m = score->tick2measure(Fraction::fromTicks(startTick)); m; m = m->nextMeasure()) {


### PR DESCRIPTION
This pull request contains changes to MIDI rendering subsystem which allow:
- Avoid most of unnecessary recreation of MIDI events which were caused by extra updates of RepeatList.
- Do MIDI rendering of a score partially which allows a better playback experience of large scores (like [this one](https://musescore.com/openscore/scores/5271023)).

A part of playback rendering subsystem that relates directly to MIDI events was moved to a separate `MidiRenderer` class out of `Score`.

Known possible issues include the following:
- mtest shows that pitch bend events from vibrato get a bit reordered with respect to other events at rendering chunks borders (see the last commit of this PR). I didn't notice any audible effect from that, and it may be that this order does not matter but it would be great if someone could confirm or disprove that (maybe @jthistle could help with that?)
- Seeking playback position via Play Panel may lead to stopping a playback. Still I wasn't able to reproduce this with the latest versions of this patch after I took more caution about threads synchronization, so maybe it is not the case anymore.

There may be also other possible issues that I wasn't able to catch so it would be great to test this PR thoroughly if this is possible.