### PR TITLE
fix #288528: After you change the pitch of a note that's tied, both tied notes end up selected.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1347,7 +1347,7 @@ static void setTpc(Note* oNote, int tpc, int& newTpc1, int& newTpc2)
 ///   Increment/decrement pitch of note by one or by an octave.
 //---------------------------------------------------------
 
-void Score::upDown(bool up, UpDownMode mode, bool updateSelection)
+void Score::upDown(bool up, UpDownMode mode)
       {
       QList<Note*> el = selection().uniqueNotes();
 
@@ -1515,12 +1515,6 @@ void Score::upDown(bool up, UpDownMode mode, bool updateSelection)
             // play new note with velocity 80 for 0.3 sec:
             setPlayNote(true);
             }
-
-      if (updateSelection) {
-            _selection.clear();
-            for (Note* note : el)
-                  _selection.add(note);
-            }
       }
 
 //---------------------------------------------------------
@@ -1528,15 +1522,15 @@ void Score::upDown(bool up, UpDownMode mode, bool updateSelection)
 ///   Add the delta to the pitch of note.
 //---------------------------------------------------------
 
-void Score::upDownDelta(int pitchDelta, bool updateSelection)
+void Score::upDownDelta(int pitchDelta)
       {
       while (pitchDelta > 0) {
-            upDown(true, UpDownMode::CHROMATIC, updateSelection);
+            upDown(true, UpDownMode::CHROMATIC);
             pitchDelta--;
             }
 
       while (pitchDelta < 0) {
-            upDown(false, UpDownMode::CHROMATIC, updateSelection);
+            upDown(false, UpDownMode::CHROMATIC);
             pitchDelta++;
             }
       }

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -673,8 +673,8 @@ class Score : public QObject, public ScoreElement {
       ChordRest* addClone(ChordRest* cr, const Fraction& tick, const TDuration& d);
       Rest* setRest(const Fraction& tick,  int track, const Fraction&, bool useDots, Tuplet* tuplet, bool useFullMeasureRest = true);
 
-      void upDown(bool up, UpDownMode, bool updateSelection = true);
-      void upDownDelta(int pitchDelta, bool updateSelection);
+      void upDown(bool up, UpDownMode);
+      void upDownDelta(int pitchDelta);
       ChordRest* searchNote(const Fraction& tick, int track) const;
 
       // undo/redo ops

--- a/mscore/pianoview.cpp
+++ b/mscore/pianoview.cpp
@@ -826,7 +826,7 @@ void PianoView::mouseMoveEvent(QMouseEvent* event)
                               }
 
                         score->startCmd();
-                        score->upDownDelta(pitchDelta, false);
+                        score->upDownDelta(pitchDelta);
                         score->endCmd();
 
                         inProgressUndoEvent = true;


### PR DESCRIPTION
See https://musescore.org/en/node/288528, and especially my comment there.