### PR TITLE
fix #119101: Wrong undo visibility change for dotted note, where note and dot have different visibilities

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3520,7 +3520,7 @@ void Score::cmdToggleVisible()
             if (e->isBracket())     // ignore
                   continue;
             if (e->isNoteDot() && selection().elements().contains(e->parent()))
-                  // already handled in Note::setProperty() and Rest::setProperty(); don't toggle twice
+                  // already handled in ScoreElement::undoChangeProperty(); don't toggle twice
                   continue;
             bool spannerSegment = e->isSpannerSegment();
             if (!spannerSegment || !spanners.contains(toSpannerSegment(e)->spanner()))

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2648,13 +2648,8 @@ bool Note::setProperty(Pid propertyId, const QVariant& v)
                   setVeloType(ValueType(v.toInt()));
                   score()->setPlaylistDirty();
                   break;
-            case Pid::VISIBLE: {                     // Pid::VISIBLE requires reflecting property on dots
+            case Pid::VISIBLE: {
                   setVisible(v.toBool());
-                  int dots = chord()->dots();
-                  for (int i = 0; i < dots; ++i) {
-                        if (_dots[i])
-                              _dots[i]->setVisible(visible());
-                        }
                   if (m)
                         m->checkMultiVoices(chord()->staffIdx());
                   break;
@@ -2676,6 +2671,16 @@ bool Note::setProperty(Pid propertyId, const QVariant& v)
             }
       triggerLayout();
       return true;
+      }
+
+//---------------------------------------------------------
+//   undoChangeDotsVisible
+//---------------------------------------------------------
+
+void Note::undoChangeDotsVisible(bool v)
+      {
+      for (NoteDot* dot : _dots)
+            dot->undoChangeProperty(Pid::VISIBLE, QVariant(v));
       }
 
 //---------------------------------------------------------

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -458,6 +458,7 @@ class Note final : public Element {
 
       virtual QVariant getProperty(Pid propertyId) const override;
       virtual bool setProperty(Pid propertyId, const QVariant&) override;
+      void undoChangeDotsVisible(bool v);
       virtual QVariant propertyDefault(Pid) const override;
       virtual QString propertyUserValue(Pid) const override;
 

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -947,8 +947,6 @@ bool Rest::setProperty(Pid propertyId, const QVariant& v)
                   break;
             case Pid::VISIBLE:
                   setVisible(v.toBool());
-                  for (NoteDot* dot : _dots)
-                        dot->setVisible(visible());
                   score()->setLayout(tick());
                   break;
             case Pid::OFFSET:
@@ -964,6 +962,16 @@ bool Rest::setProperty(Pid propertyId, const QVariant& v)
                   return ChordRest::setProperty(propertyId, v);
             }
       return true;
+      }
+
+//---------------------------------------------------------
+//   undoChangeDotsVisible
+//---------------------------------------------------------
+
+void Rest::undoChangeDotsVisible(bool v)
+      {
+      for (NoteDot* dot : _dots)
+            dot->undoChangeProperty(Pid::VISIBLE, QVariant(v));
       }
 
 //---------------------------------------------------------

--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -93,6 +93,7 @@ class Rest : public ChordRest {
       virtual QPointF stemPosBeam() const;
 
       virtual bool setProperty(Pid propertyId, const QVariant& v) override;
+      void undoChangeDotsVisible(bool v);
       virtual QVariant getProperty(Pid propertyId) const override;
       virtual QVariant propertyDefault(Pid) const override;
 

--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -320,6 +320,12 @@ void ScoreElement::undoChangeProperty(Pid id, const QVariant& v, PropertyFlags p
                   }
             }
       changeProperties(this, id, v, ps);
+      if (id == Pid::VISIBLE) {
+            if (isNote())
+                  toNote(this)->undoChangeDotsVisible(v.toBool());
+            else if (isRest())
+                  toRest(this)->undoChangeDotsVisible(v.toBool());
+            }
       if (id != Pid::GENERATED)
             changeProperties(this, Pid::GENERATED, QVariant(false), PropertyFlags::NOSTYLE);
       if (doUpdateInspector)


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/119101.