### PR TITLE
clean up and remove unnecessary tasks from msvc_build.bat

### DIFF
--- a/msvc_build.bat
+++ b/msvc_build.bat
@@ -32,19 +32,22 @@ REM    "msvc_build.bat clean" remove all files in msvc.* folders and the folders
 
 REM BUILD_64 and BUILD_FOR_WINSTORE are used in CMakeLists.txt
 SET BUILD_FOR_WINSTORE=OFF
-SET BUILD_64=ON
-
-SET BUILD_FOLDER=msvc.build
-SET INSTALL_FOLDER=msvc.install
-SET ARCH=x64
-SET GENERATOR_NAME="Visual Studio 15 2017 Win64"
+SET "BUILD_FOLDER=msvc.build"
+SET "INSTALL_FOLDER=msvc.install"
 
 IF NOT "%2"=="" (
    IF "%2"=="32" (
-       SET ARCH=x86
+       SET "ARCH=x86"
        SET GENERATOR_NAME="Visual Studio 15 2017"
        SET BUILD_64=OFF
+       ) ELSE (
+           echo Invalid second argument
+           GOTO :END
        )
+   ) ELSE (
+       SET "ARCH=x64"
+       SET GENERATOR_NAME="Visual Studio 15 2017 Win64"
+       SET BUILD_64=ON
    )
 
 IF NOT "%3"=="" (
@@ -68,25 +71,25 @@ IF /I "%1"=="relwithdebinfo" (
    )
 
 IF /I "%1"=="install" (
-   SET BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%
+   SET "BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%"
    SET CONFIGURATION_STR="release"
    GOTO :INSTALL
    )
 
 IF /I "%1"=="installdebug" (
-   SET BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%
+   SET "BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%"
    SET CONFIGURATION_STR="debug"
    GOTO :INSTALL
    )
 
 IF /I "%1"=="installrelwithdebinfo" (
-   SET BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%
+   SET "BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%"
    SET CONFIGURATION_STR="relwithdebinfo"
    GOTO :INSTALL
    )
 
 IF /I "%1"=="package" (
-   cd %BUILD_FOLDER%_%ARCH%
+   cd "%BUILD_FOLDER%_%ARCH%"
    cmake --build . --config RelWithDebInfo --target package
    GOTO :END
    )
@@ -101,50 +104,34 @@ IF /I "%1"=="clean" (
    for /d %%G in ("msvc.*") do rd /s /q "%%~G"
    GOTO :END
    ) ELSE (
-@echo on
-   echo "No valid parameters are set"
-@echo off
+   echo No valid parameters are set
    GOTO :END
    )
 
 :BUILD
-   SET BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%
-@echo on
-   echo "Build forlder is: %BUILD_FOLDER%"
-@echo off
-   SET INSTALL_FOLDER=%INSTALL_FOLDER%_%ARCH%
-@echo on
-   echo "Install forlder is: %INSTALL_FOLDER%"
-@echo off
-   if not exist %BUILD_FOLDER%\nul mkdir %BUILD_FOLDER%
-   if not exist %INSTALL_FOLDER%\nul mkdir %INSTALL_FOLDER%
-@echo on
-   echo "Building CMake configuration..."
-@echo off
+   SET "BUILD_FOLDER=%BUILD_FOLDER%_%ARCH%"
+   echo Build folder is: %BUILD_FOLDER%
+   SET "INSTALL_FOLDER=%INSTALL_FOLDER%_%ARCH%"
+   echo Install folder is: %INSTALL_FOLDER%
+   if not exist "%BUILD_FOLDER%\nul" mkdir "%BUILD_FOLDER%"
+   if not exist "%INSTALL_FOLDER%\nul" mkdir "%INSTALL_FOLDER%"
+   echo Building CMake configuration...
 
 IF NOT "%CRASH_LOG_SERVER_URL%" == "" (
     SET CRASH_REPORT_URL_OPT=-DCRASH_REPORT_URL=%CRASH_LOG_SERVER_URL%
     )
 
 REM -DCMAKE_BUILD_NUMBER=%BUILD_NUMBER% -DCMAKE_BUILD_AUTOUPDATE=%BUILD_AUTOUPDATE% %CRASH_REPORT_URL_OPT% are used for CI only
-   cd %BUILD_FOLDER% & cmake -G %GENERATOR_NAME% -DCMAKE_INSTALL_PREFIX=../%INSTALL_FOLDER% -DCMAKE_BUILD_TYPE=%CONFIGURATION_STR% -DBUILD_FOR_WINSTORE=%BUILD_FOR_WINSTORE% -DBUILD_64=%BUILD_64% -DCMAKE_BUILD_NUMBER=%BUILD_NUMBER% -DBUILD_AUTOUPDATE=%BUILD_AUTOUPDATE% %CRASH_REPORT_URL_OPT% ..
+   cd "%BUILD_FOLDER%" & cmake -G %GENERATOR_NAME% -DCMAKE_INSTALL_PREFIX=../%INSTALL_FOLDER% -DCMAKE_BUILD_TYPE=%CONFIGURATION_STR% -DBUILD_FOR_WINSTORE=%BUILD_FOR_WINSTORE% -DBUILD_64=%BUILD_64% -DCMAKE_BUILD_NUMBER=%BUILD_NUMBER% -DBUILD_AUTOUPDATE=%BUILD_AUTOUPDATE% %CRASH_REPORT_URL_OPT% ..
 
-@echo on
-   echo "Running lrelease..."
-@echo off
-   cmake --build . --target lrelease
-@echo on
-   echo "Building MuseScore..."
-@echo off
-   cd %BUILD_FOLDER% & cmake --build . --config %CONFIGURATION_STR% --target mscore
+   echo Building MuseScore...
+   cd "%BUILD_FOLDER%" & cmake --build . --config %CONFIGURATION_STR% --target mscore
    GOTO :END
    )
 
 :INSTALL
-   cd %BUILD_FOLDER%
-@echo on
-   echo "Installing MuseScore files..."
-@echo off
+   cd "%BUILD_FOLDER%"
+   echo Installing MuseScore files...
    cmake --build . --config %CONFIGURATION_STR% --target install
    GOTO :END
 


### PR DESCRIPTION
Mostly, I removed this:
```bat
@echo on
echo whatever
@echo off
```
because it caused the following to show up in the console, and it bugged me a bit:
```cmd
C:\Users\User\Documents\MuseScore> echo whatever
whatever
```
I also corrected the spelling of "folder" (was "forlder") in two places.

I then also removed the `lrelease` step, since it is built as part of the `mscore` target and thus is redundant. That should speed up build times a little bit (but every little bit helps for me ;-) )