### PR TITLE
fix #272892: properly reset arpeggio

### DIFF
--- a/libmscore/arpeggio.cpp
+++ b/libmscore/arpeggio.cpp
@@ -414,6 +414,17 @@ Element* Arpeggio::drop(EditData& data)
       }
 
 //---------------------------------------------------------
+//   reset
+//---------------------------------------------------------
+
+void Arpeggio::reset()
+      {
+      undoChangeProperty(Pid::ARP_USER_LEN1, 0.0);
+      undoChangeProperty(Pid::ARP_USER_LEN2, 0.0);
+      Element::reset();
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 

--- a/libmscore/arpeggio.h
+++ b/libmscore/arpeggio.h
@@ -69,6 +69,7 @@ class Arpeggio final : public Element {
 
       virtual void read(XmlReader& e) override;
       virtual void write(XmlWriter& xml) const override;
+      virtual void reset() override;
 
       int span() const      { return _span; }
       void setSpan(int val) { _span = val; }


### PR DESCRIPTION
Arpeggios have some of their own properties that aren't covered by Element::reset() and so arpeggio length doesn't get properly reset with Ctrl+R or Format/Reset Style and Layout. This fix just overrides the reset function to properly reset these two properties. 