### PR TITLE
fix #288693: Disappearing key signature in all but first stave

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -245,10 +245,8 @@ void Score::writeMovement(XmlWriter& xml, bool selectionOnly)
             xml.tag("name", excerpt()->title());
       xml.etag();
 
-      if (unhide) {
-            endCmd();
-            undoRedo(true, 0);   // undo
-            }
+      if (unhide)
+            endCmd(true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/288693.