### PR TITLE
fix #288679 and #269262: ensure support of set QStandardKey

### DIFF
--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -18,7 +18,7 @@
     </SC>
   <SC>
     <key>file-save-as</key>
-    <std>63</std>
+    <seq>Ctrl+Shift+S</seq>
     </SC>
   <SC>
     <key>file-close</key>

--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -18,7 +18,7 @@
     </SC>
   <SC>
     <key>file-save-as</key>
-    <std>63</std>
+    <seq>Ctrl+Shift+S</seq>
     </SC>
   <SC>
     <key>file-close</key>

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -3812,6 +3812,9 @@ void Shortcut::setKeys(const QList<QKeySequence>& ks)
 
 void Shortcut::setStandardKey(QKeySequence::StandardKey k)
       {
+      if (QKeySequence::keyBindings(k).empty()) // make sure key binding is set for OS
+            return;
+
       _standardKey = k;
       if (_action && k != QKeySequence::UnknownKey)
             _action->setShortcuts(_standardKey);
@@ -4109,8 +4112,11 @@ void Shortcut::read(XmlReader& e)
             const QStringRef& tag(e.name());
             if (tag == "key")
                   _key = e.readElementText().toLocal8Bit();
-            else if (tag == "std")
-                  _standardKey = QKeySequence::StandardKey(e.readInt());
+            else if (tag == "std") {
+                  int i = e.readInt();
+                  if (!QKeySequence::keyBindings((QKeySequence::StandardKey(i))).empty()) // make sure key binding is set for OS
+                        _standardKey = QKeySequence::StandardKey(i);
+                  }
             else if (tag == "seq") {
                   QKeySequence seq  = Shortcut::keySeqFromString(e.readElementText(), QKeySequence::PortableText);
 #ifndef NDEBUG
@@ -4163,7 +4169,7 @@ void Shortcut::load()
                                           }
                                     else if (tag == "std") {
                                           int i = e.readInt();
-                                          if(sc)
+                                          if(sc && !QKeySequence::keyBindings((QKeySequence::StandardKey(i))).empty()) // make sure key binding is set for OS
                                                 sc->_standardKey = QKeySequence::StandardKey(i);
                                           }
                                     else if (tag == "seq") {
@@ -4220,8 +4226,11 @@ static QList<Shortcut1> loadShortcuts(QString fileLocation)
                                     const QStringRef& tag(e.name());
                                     if (tag == "key")
                                           sc.key = e.readElementText().toLocal8Bit();
-                                    else if (tag == "std")
-                                          sc.standardKey = QKeySequence::StandardKey(e.readInt());
+                                    else if (tag == "std") {
+                                          int i = e.readInt();
+                                          if (!QKeySequence::keyBindings(QKeySequence::StandardKey(i)).empty()) // make sure key binding is set for OS
+                                                sc.standardKey = QKeySequence::StandardKey(i);
+                                          }
                                     else if (tag == "seq")
                                           sc.keys.append(Shortcut::keySeqFromString(e.readElementText(), QKeySequence::PortableText));
                                     else


### PR DESCRIPTION
The used QKeySequence::StandardKey may not be set on all Platforms, as described here (and in table above given link): https://doc.qt.io/archives/qt-4.8/qkeysequence.html#StandardKey-enum

This way the UI has an unsupported StandardKey as a shortcut (in the reported bug, it is Save-As, which has number 63). When now adding a manual shortcut, the Ms::Shortcut object has two shortcuts, the (unsupported) StandardKey and the manual entry. As a result, `QAction* Shortcut::action() const` will return the StandardKey and the added shortcut is never applied.

This commit double checks that the OS supports the defined StandardKey, and if not, it blocks setting it as a shortcut. 

Note: This also applies when clicking on "Reset All Preferences to Default", as the default shortcuts.xml contains the StandardKey causing these issues. 