### PR TITLE
fix #287520: Glissando with anchor change via Shift+Down lost on save/reload

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -25,6 +25,7 @@
 #include "system.h"
 #include "textline.h"
 #include "utils.h"
+#include "undo.h"
 #include "xml.h"
 
 namespace Ms {
@@ -257,7 +258,7 @@ bool LineSegment::edit(EditData& ed)
                      != note2->chord()->staff()->part()->instrument(note2->chord()->tick()) )
                         return true;
                   if (note1 != oldNote1 || note2 != oldNote2)
-                        spanner()->setNoteSpan(note1, note2);          // set new spanner span
+                        score()->undo(new ChangeSpannerElements(spanner(), note1, note2));
                   }
                   break;
             case Spanner::Anchor::MEASURE:
@@ -364,10 +365,7 @@ void LineSegment::editDrag(EditData& ed)
                         Note* sNote   = toNote(l->startElement());
                         // do not change anchor if new note is before start note
                         if (sNote && sNote->chord() && noteNew->chord() && sNote->chord()->tick() < noteNew->chord()->tick()) {
-                              noteOld->removeSpannerBack(l);
-                              noteNew->addSpannerBack(l);
-                              l->setEndElement(noteNew);
-
+                              score()->undo(new ChangeSpannerElements(l, sNote, noteNew));
                               _offset2 += noteOld->canvasPos() - noteNew->canvasPos();
                               }
                         }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/287520.