### PR TITLE
fix #285651, #283120: swap chord symbols and instrument change positions with X

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1480,7 +1480,9 @@ void Score::cmdFlip()
                || e->isPedalSegment()
                || e->isFermata()
                || e->isLyrics()
-               || e->isTrillSegment()) {
+               || e->isTrillSegment()
+               || e->isHarmony()
+               || e->isInstrumentChange()) {
                   e->undoChangeProperty(Pid::AUTOPLACE, true);
                   // getProperty() delegates call from spannerSegment to Spanner:
                   Placement p = Placement(e->getProperty(Pid::PLACEMENT).toInt());


### PR DESCRIPTION
Simple changes to allow swapping the position of a couple more elements with the X shortcut.