### PR TITLE
fix #288609: Crash when creating parts if a rest on a wrong staff after using cross-staff notation

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -282,8 +282,11 @@ bool ChordRest::readProperties(XmlReader& e)
             }
       else if (tag == "dots")
             setDots(e.readInt());
-      else if (tag == "staffMove")
+      else if (tag == "staffMove") {
             _staffMove = e.readInt();
+            if (vStaffIdx() < part()->staves()->first()->idx() || vStaffIdx() > part()->staves()->last()->idx())
+                  _staffMove = 0;
+            }
       else if (tag == "Spanner")
             Spanner::readSpanner(e, this, track());
       else if (tag == "Lyrics") {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/288609.

This prevents a cross-staff ChordRest from crossing over into another part when pasted into another staff. And it fixes existing scores that contain ChordRests which have crossed over into another part.