### PR TITLE
fix #288865: Moving a key signature with Ctrl + Shift crashes the program

### DIFF
--- a/libmscore/keysig.cpp
+++ b/libmscore/keysig.cpp
@@ -109,9 +109,11 @@ void KeySig::layout()
       if (staff()) {
             // Look for a clef before the key signature at the same tick
             Clef* c = nullptr;
-            for (Segment* seg = segment()->prev1(); !c && seg && seg->tick() == tick(); seg = seg->prev1())
-                  if (seg->isClefType() || seg->isHeaderClefType())
-                        c = toClef(seg->element(track()));
+            if (segment()) {
+                  for (Segment* seg = segment()->prev1(); !c && seg && seg->tick() == tick(); seg = seg->prev1())
+                        if (seg->isClefType() || seg->isHeaderClefType())
+                              c = toClef(seg->element(track()));
+                  }
             if (c)
                   clef = c->clefType();
             else


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/288865.