### PR TITLE
fix some compiler warnings differently/cleaner

### DIFF
--- a/fluid/voice.cpp
+++ b/fluid/voice.cpp
@@ -1805,7 +1805,6 @@ void Sample::optimize()
       signed short peak;
       float normalized_amplitude_during_loop;
       double result;
-      int i;
 
       /* ignore ROM and other(?) invalid samples */
       if (!s->valid())
@@ -1813,7 +1812,7 @@ void Sample::optimize()
 
       if (!s->amplitude_that_reaches_noise_floor_is_valid) { /* Only once */
             /* Scan the loop */
-            for (i = (int)s->loopstart; i < (int) s->loopend; i ++) {
+            for (size_t i = s->loopstart; i < s->loopend; i++) {
                   signed short val = s->data[i];
                   if (val > peak_max)
                         peak_max = val;

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -993,14 +993,14 @@ Fraction Score::makeGap(Segment* segment, int track, const Fraction& _sd, Tuplet
                               }
                         }
                   else {
-                        for (int i = int(dList.size()) - 1; i >= 0; --i) {
+                        for (size_t i = dList.size(); i > 0; --i) { // loop needs to be in this reverse order
                               if (ltuplet) {
                                     // take care not to recreate tuplet we just deleted
-                                    Rest* r = setRest(tick, track, dList[i].fraction(), false, 0, false);
+                                    Rest* r = setRest(tick, track, dList[i-1].fraction(), false, 0, false);
                                     tick += r->actualTicks();
                                     }
                               else {
-                                    tick += addClone(cr, tick, dList[i])->actualTicks();
+                                    tick += addClone(cr, tick, dList[i-1])->actualTicks();
                                     }
                               }
                         }
@@ -1371,18 +1371,18 @@ void Score::changeCRlen(ChordRest* cr, const Fraction& dstF, bool fillWithRest)
                               }
                         }
                   else {
-                        for (int i = int(dList.size()) - 1; i >= 0; --i) {
+                        for (size_t i = dList.size(); i > 0; --i) { // loop probably needs to be in this reverse order
                               bool genTie;
                               Chord* cc;
                               if (oc) {
                                     genTie = true;
                                     cc = oc;
-                                    oc = addChord(tick, dList[i], cc, genTie, tuplet);
+                                    oc = addChord(tick, dList[i-1], cc, genTie, tuplet);
                                     }
                               else {
                                     genTie = false;
                                     cc = toChord(cr);
-                                    undoChangeChordRestLen(cr, dList[i]);
+                                    undoChangeChordRestLen(cr, dList[i-1]);
                                     oc = cc;
                                     }
                               if (first) {

--- a/libmscore/dynamic.h
+++ b/libmscore/dynamic.h
@@ -104,7 +104,7 @@ class Dynamic final : public TextBase {
       static QString dynamicTypeName(Dynamic::Type type);
       QString dynamicTypeName() const { return dynamicTypeName(_dynamicType); }
       Type dynamicType() const                     { return _dynamicType; }
-      virtual int subtype() const override         { return (int) _dynamicType; }
+      virtual int subtype() const override         { return static_cast<int>(_dynamicType); }
       virtual QString subtypeName() const override { return dynamicTypeName(); }
 
       virtual void layout() override;

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -347,8 +347,8 @@ Rest* Score::setRest(const Fraction& _tick, int track, const Fraction& _l, bool 
                               }
                         }
                   else {
-                        for (int i = int(dList.size()) - 1; i >= 0; --i) {
-                              rest = addRest(tick, track, dList[i], tuplet);
+                        for (size_t i = dList.size(); i > 0; --i) { // loop needs to be in this reverse order
+                              rest = addRest(tick, track, dList[i-1], tuplet);
                               if (r == 0)
                                     r = rest;
                               tick += rest->actualTicks();

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -300,7 +300,7 @@ void Glissando::layout()
       // interpolate y-coord of intermediate points across total width and height
       qreal xCurr = 0.0;
       qreal yCurr;
-      for (int i = 0; i < int(spannerSegments().size()-1); i++) {
+      for (unsigned i = 0; i + 1 < spannerSegments().size(); i++) {
             SpannerSegment* segm = segmentAt(i);
             xCurr += segm->ipos2().x();
             yCurr = y0 + ratio * xCurr;

--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -92,7 +92,7 @@ void GlissandoSegment::draw(QPainter* painter) const
       else if (glissando()->glissandoType() == GlissandoType::WAVY) {
             QRectF b = symBbox(SymId::wiggleTrill);
             qreal a  = symAdvance(SymId::wiggleTrill);
-            int n    = (int)(l / a);      // always round down (truncate) to avoid overlap
+            int n    = static_cast<int>(l / a);      // always round down (truncate) to avoid overlap
             qreal x  = (l - n*a) * 0.5;   // centre line in available space
             std::vector<SymId> ids;
             for (int i = 0; i < n; ++i)

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -341,9 +341,9 @@ void Score::layoutChords1(Segment* segment, int staffIdx)
                               else
                                     break;
                               }
-                        for (int i = int(downStemNotes.size()) - 1; i >= 0; --i) {
-                              if (downStemNotes[i]->line() <= bottomUpNote->line() + 1)
-                                    overlapNotes.append(downStemNotes[i]);
+                        for (size_t i = downStemNotes.size(); i > 0; --i) { // loop most probably needs to be in this reverse order
+                              if (downStemNotes[i-1]->line() <= bottomUpNote->line() + 1)
+                                    overlapNotes.append(downStemNotes[i-1]);
                               else
                                     break;
                               }

--- a/libmscore/location.cpp
+++ b/libmscore/location.cpp
@@ -241,12 +241,12 @@ int Location::note(const Element* e)
             const std::vector<Note*>& notes = n->chord()->notes();
             if (notes.size() == 1)
                   return 0;
-            int noteIdx;
-            for (noteIdx = 0; noteIdx < int(notes.size()); ++noteIdx) {
+            size_t noteIdx;
+            for (noteIdx = 0; noteIdx < notes.size(); ++noteIdx) {
                   if (n == notes.at(noteIdx))
                         break;
                   }
-            return noteIdx;
+            return static_cast<int>(noteIdx);
             }
       return absDefaults.note();
       }

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -496,7 +496,7 @@ void Measure::layoutMeasureNumber()
       QString s;
       if (smn)
             s = QString("%1").arg(no() + 1);
-      int nn = 1;
+      unsigned nn = 1;
       bool nas = score()->styleB(Sid::measureNumberAllStaffs);
 
       if (!nas) {
@@ -511,7 +511,7 @@ void Measure::layoutMeasureNumber()
                         }
                   }
             }
-      for (int staffIdx = 0; staffIdx < int(_mstaves.size()); ++staffIdx) {
+      for (unsigned staffIdx = 0; staffIdx < _mstaves.size(); ++staffIdx) {
             MStaff* ms       = _mstaves[staffIdx];
             MeasureNumber* t = ms->noText();
             if (t)
@@ -611,7 +611,7 @@ void Measure::layout2()
                         }
                   }
             }
-      for (int staffIdx = 0; staffIdx < int(_mstaves.size()); ++staffIdx) {
+      for (unsigned staffIdx = 0; staffIdx < _mstaves.size(); ++staffIdx) {
             MStaff* ms       = _mstaves[staffIdx];
             MeasureNumber* t = ms->noText();
             if (t)

--- a/libmscore/midimapping.cpp
+++ b/libmscore/midimapping.cpp
@@ -253,7 +253,7 @@ int MasterScore::updateMidiMapping()
       for (const MidiMapping& mm :_midiMapping) {
             if (mm.port() == -1 || mm.channel() == -1)
                   continue;
-            occupiedMidiChannels.insert((int)(mm.port())*16+(int)mm.channel());
+            occupiedMidiChannels.insert(static_cast<int>(mm.port())*16+(int)mm.channel());
             if (maxport < mm.port())
                   maxport = mm.port();
             }

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -763,7 +763,7 @@ int Note::tpc() const
 QString Note::tpcUserName(bool explicitAccidental) const
       {
       QString pitchName = tpc2name(tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
-      QString octaveName = QString::number(((epitch() + ottaveCapoFret() - int(tpc2alter(tpc()))) / 12) - 1);
+      QString octaveName = QString::number(((epitch() + ottaveCapoFret() - static_cast<int>(tpc2alter(tpc()))) / 12) - 1);
       return pitchName + (explicitAccidental ? " " : "") + octaveName;
       }
 

--- a/libmscore/pitchspelling.cpp
+++ b/libmscore/pitchspelling.cpp
@@ -586,13 +586,13 @@ int computeWindow(const std::vector<Note*>& notes, int start, int end)
             int pa    = 0;
             int pb    = 0;
             int l     = pitch[0] * 2 + (i & 1);
-            Q_ASSERT(l >= 0 && l <= (int)(sizeof(tab1)/sizeof(*tab1)));
+            Q_ASSERT(l >= 0 && l <= static_cast<int>(sizeof(tab1)/sizeof(*tab1)));
             int lof1a = tab1[l];
             int lof1b = tab2[l];
 
             for (k = 1; k < 10; ++k) {
                   int l1 = pitch[k] * 2 + ((i & (1 << k)) >> k);
-                  Q_ASSERT(l1 >= 0 && l1 <= (int)(sizeof(tab1)/sizeof(*tab1)));
+                  Q_ASSERT(l1 >= 0 && l1 <= static_cast<int>(sizeof(tab1)/sizeof(*tab1)));
                   int lof2a = tab1[l1];
                   int lof2b = tab2[l1];
                   pa += penalty(lof1a, lof2a, key[k]);

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -1804,7 +1804,7 @@ static QList<NoteEventList> renderChord(Chord* chord, int gateTime, int ontime, 
             renderChordArticulation(chord, ell, gateTime);
 
       // Check each note and apply gateTime
-      for (int i = 0; i < int(notes); ++i) {
+      for (unsigned i = 0; i < notes; ++i) {
             NoteEventList* el = &ell[i];
             if (!shouldRenderNote(chord->notes()[i])) {
                   el->clear();
@@ -1897,7 +1897,7 @@ void Score::createGraceNotesPlayEvents(const Fraction& tick, Chord* chord, int& 
             QList<NoteEventList> el;
             Chord* gc = gnb.at(i);
             size_t nn = gc->notes().size();
-            for (size_t ii = 0; ii < nn; ++ii) {
+            for (unsigned ii = 0; ii < nn; ++ii) {
                   NoteEventList nel;
                   nel.append(NoteEvent(0, on, graceDuration));
                   el.append(nel);

--- a/libmscore/scorediff.cpp
+++ b/libmscore/scorediff.cpp
@@ -196,7 +196,7 @@ std::vector<TextDiff> MscxModeDiff::mscxModeDiff(const QString& s1, const QStrin
 
 void MscxModeDiff::adjustSemanticsMscx(std::vector<TextDiff>& diffs)
       {
-      for (int i = 0; i < int(diffs.size()); ++i)
+      for (unsigned i = 0; i < diffs.size(); ++i)
             i = adjustSemanticsMscxOneDiff(diffs, i);
       }
 

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -996,13 +996,13 @@ Enabling copying of more element types requires enabling pasting in Score::paste
       int   currTrack = -1;
       for (auto iter = map.cbegin(); iter != map.cend(); ++iter) {
             int   numSegs;
-            int   track = (int)(iter->first >> 32);
+            int   track = static_cast<int>(iter->first >> 32);
             if (currTrack != track) {
                   xml.tag("trackOffset", track - topTrack);
                   currTrack = track;
                   seg       = firstSeg;
                   }
-            xml.tag("tickOffset", (int)(iter->first & 0xFFFFFFFF) - firstTick.ticks());
+            xml.tag("tickOffset", static_cast<int>(iter->first & 0xFFFFFFFF) - firstTick.ticks());
             numSegs = 0;
             // with figured bass, we need to look for the proper segment
             // not only according to ChordRest elements, but also annotations

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -665,7 +665,7 @@ void Staff::write(XmlWriter& xml) const
             int b = i->bracketSpan();
             int c = i->column();
             if (a != BracketType::NO_BRACKET || b > 0)
-                  xml.tagE(QString("bracket type=\"%1\" span=\"%2\" col=\"%3\"").arg((int)(a)).arg(b).arg(c));
+                  xml.tagE(QString("bracket type=\"%1\" span=\"%2\" col=\"%3\"").arg(static_cast<int>(a)).arg(b).arg(c));
             }
 
       writeProperty(xml, Pid::STAFF_BARLINE_SPAN);

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -1294,7 +1294,7 @@ const StaffType* StaffType::preset(StaffTypes idx)
 
 const StaffType* StaffType::presetFromXmlName(QString& xmlName)
       {
-      for (int i = 0; i < int(_presets.size()); ++i) {
+      for (size_t i = 0; i < _presets.size(); ++i) {
             if (_presets[i].xmlName() == xmlName)
                   return &_presets[i];
             }
@@ -1303,7 +1303,7 @@ const StaffType* StaffType::presetFromXmlName(QString& xmlName)
 #if 0
 const StaffType* StaffType::presetFromName(QString& name)
       {
-      for (int i = 0; i < (int)_presets.size(); ++i) {
+      for (size_t i = 0; i < _presets.size(); ++i) {
             if (_presets[i].name() == name)
                   return &_presets[i];
             }

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -903,7 +903,7 @@ void TabDurationSymbol::layout()
                   _beamLength = 0.0;
                   }
             else if (chord->beamMode() == Beam::Mode::MID || chord->beamMode() == Beam::Mode::END) {
-                  _beamLevel  = (int)(chord->durationType().type()) - (int)(font.zeroBeamLevel);
+                  _beamLevel  = static_cast<int>(chord->durationType().type()) - static_cast<int>(font.zeroBeamLevel);
                   _beamGrid   = (_beamLevel < 1 ? TabBeamGrid::INITIAL : TabBeamGrid::MEDIALFINAL);
                   // _beamLength and bbox x and width will be set in layout2(),
                   // once horiz. positions of chords are known

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -5760,10 +5760,10 @@ void ScoreFont::draw(SymId id, QPainter* painter, const QSizeF& mag, const QPoin
             QImage img(QSize(bm->width, bm->rows), QImage::Format_ARGB32);
             img.fill(Qt::transparent);
 
-            for (int y = 0; y < int(bm->rows); ++y) {
+            for (unsigned y = 0; y < bm->rows; ++y) {
                   unsigned* dst      = (unsigned*)img.scanLine(y);
                   unsigned char* src = (unsigned char*)(bm->buffer) + bm->pitch * y;
-                  for (int x = 0; x < int(bm->width); ++x) {
+                  for (unsigned x = 0; x < bm->width; ++x) {
                         unsigned val = *src++;
                         color.setAlpha(val);
                         *dst++ = color.rgba();

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -57,7 +57,7 @@ class Tremolo final : public Element {
       Tremolo &operator=(const Tremolo&) = delete;
       virtual Tremolo* clone() const       { return new Tremolo(*this); }
       virtual ElementType type() const     { return ElementType::TREMOLO; }
-      virtual int subtype() const override { return (int) _tremoloType; }
+      virtual int subtype() const override { return static_cast<int>(_tremoloType); }
       virtual QString subtypeName() const override;
 
       QString tremoloTypeName() const;

--- a/libmscore/xmlreader.cpp
+++ b/libmscore/xmlreader.cpp
@@ -638,8 +638,8 @@ void XmlReader::reconnectBrokenConnectors()
             return;
       qDebug("Reconnecting broken connectors (%d nodes)", int(_connectors.size()));
       QList<QPair<int, QPair<ConnectorInfoReader*, ConnectorInfoReader*>>> brokenPairs;
-      for (int i = 1; i < int(_connectors.size()); ++i) {
-            for (int j = 0; j < i; ++j) {
+      for (size_t i = 1; i < _connectors.size(); ++i) {
+            for (size_t j = 0; j < i; ++j) {
                   ConnectorInfoReader* c1 = _connectors[i].get();
                   ConnectorInfoReader* c2 = _connectors[j].get();
                   int d = c1->connectionDistance(*c2);

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -827,7 +827,7 @@ void EditStyle::on_comboFBFont_currentIndexChanged(int index)
 
       if (FiguredBass::fontData(index, 0, 0, &size, &lineHeight)) {
             doubleSpinFBSize->setValue(size);
-            spinFBLineHeight->setValue((int)(lineHeight * 100.0));
+            spinFBLineHeight->setValue(static_cast<int>(lineHeight * 100.0));
             }
       }
 

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -158,7 +158,7 @@ void ScoreView::wheelEvent(QWheelEvent* event)
             nReal = static_cast<qreal>(stepsScrolled.y()) / 120;
             }
 
-      n = (int) nReal;
+      n = static_cast<int>(nReal);
 
       //this functionality seems currently blocked by the context menu
       if (event->buttons() & Qt::RightButton) {

--- a/mscore/fretcanvas.cpp
+++ b/mscore/fretcanvas.cpp
@@ -290,7 +290,7 @@ void FretCanvas::mousePressEvent(QMouseEvent* ev)
                               };
 
                               // Find the lowest dot type that doesn't already exist on the string
-                              for (int i = 0; i < int(dtypes.size()); i++) {
+                              for (size_t i = 0; i < dtypes.size(); i++) {
                                     FretDotType t = dtypes[i];
 
                                     bool hasThisType = false;

--- a/mscore/importmidi/importmidi_beat.cpp
+++ b/mscore/importmidi/importmidi_beat.cpp
@@ -207,9 +207,9 @@ double findMatchRank(const std::set<ReducedFraction> &beatSet,
                   beatCount = 0;
                   int relationCount = 0;
                   int relationMatches = 0;
-                  for (int i = 0; i != (int)beatsOfBar.size() - 1; ++i) {
+                  for (size_t i = 0; i != beatsOfBar.size() - 1; ++i) {
                         const auto s1 = saliences.find(beatsOfBar[i]);
-                        for (int j = i + 1; j != (int)beatsOfBar.size(); ++j) {
+                        for (size_t j = i + 1; j != beatsOfBar.size(); ++j) {
                               ++relationCount;    // before s1 search check
                               if (s1 == saliences.end())
                                     continue;

--- a/mscore/importmidi/importmidi_lrhand.cpp
+++ b/mscore/importmidi/importmidi_lrhand.cpp
@@ -69,10 +69,10 @@ int findLastSplitPoint(const std::vector<ChordSplitData> &splits)
       int minPenalty = std::numeric_limits<int>::max();
       const auto &possibleSplits = splits[splits.size() - 1].possibleSplits;
 
-      for (int i = 0; i != (int)possibleSplits.size(); ++i) {
+      for (size_t i = 0; i != possibleSplits.size(); ++i) {
             if (possibleSplits[i].penalty < minPenalty) {
                   minPenalty = possibleSplits[i].penalty;
-                  splitPoint = i;
+                  splitPoint = static_cast<int>(i);
                   }
             }
 

--- a/mscore/importmidi/importmidi_quant.cpp
+++ b/mscore/importmidi/importmidi_quant.cpp
@@ -1000,10 +1000,10 @@ int findLastChordPosition(const std::vector<QuantData> &quantData)
       int posIndex = -1;
       double minPenalty = std::numeric_limits<double>::max();
       const auto &lastPositions = quantData[quantData.size() - 1].positions;
-      for (int i = 0; i != (int)lastPositions.size(); ++i) {
+      for (size_t i = 0; i != lastPositions.size(); ++i) {
             if (lastPositions[i].penalty < minPenalty) {
                   minPenalty = lastPositions[i].penalty;
-                  posIndex = i;
+                  posIndex = static_cast<int>(i);
                   }
             }
 
@@ -1019,9 +1019,9 @@ void applyDynamicProgramming(std::vector<QuantData> &quantData)
       const bool isHuman = opers.isHumanPerformance.value();
       const double MERGE_PENALTY_COEFF = 5.0;
 
-      for (int chordIndex = 0; chordIndex != (int)quantData.size(); ++chordIndex) {
+      for (size_t chordIndex = 0; chordIndex != quantData.size(); ++chordIndex) {
             QuantData &d = quantData[chordIndex];
-            for (int pos = 0; pos != (int)d.positions.size(); ++pos) {
+            for (size_t pos = 0; pos != d.positions.size(); ++pos) {
                   QuantPos &p = d.positions[pos];
 
                   const auto timePenalty = (d.chord->first - p.time).absValue().toDouble();
@@ -1047,7 +1047,7 @@ void applyDynamicProgramming(std::vector<QuantData> &quantData)
                   double minPenalty = std::numeric_limits<double>::max();
                   int minPos = -1;
 
-                  for (int posPrev = 0; posPrev != (int)dPrev.positions.size(); ++posPrev) {
+                  for (size_t posPrev = 0; posPrev != dPrev.positions.size(); ++posPrev) {
                         const QuantPos &pPrev = dPrev.positions[posPrev];
                         if (pPrev.time > p.time)
                               continue;
@@ -1061,7 +1061,7 @@ void applyDynamicProgramming(std::vector<QuantData> &quantData)
 
                         if (penalty < minPenalty) {
                               minPenalty = penalty;
-                              minPos = posPrev;
+                              minPos = static_cast<int>(posPrev);
                               }
                         }
 

--- a/mscore/importmidi/importmidi_tuplet.cpp
+++ b/mscore/importmidi/importmidi_tuplet.cpp
@@ -813,7 +813,7 @@ void addTupletEvents(std::multimap<ReducedFraction, TupletData> &tupletEvents,
                      const std::vector<TupletInfo> &tuplets,
                      const std::list<TiedTuplet> &backTiedTuplets)
       {
-      for (int i = 0; i != (int)tuplets.size(); ++i) {
+      for (size_t i = 0; i != tuplets.size(); ++i) {
             const auto &tupletInfo = tuplets[i];
             TupletData tupletData = {
                   tupletInfo.chords.begin()->second->second.voice,

--- a/mscore/importmidi/importmidi_tuplet_filter.cpp
+++ b/mscore/importmidi/importmidi_tuplet_filter.cpp
@@ -141,10 +141,10 @@ std::set<int> findLongestUncommonGroup(
             };
 
       std::vector<TInfo> info;
-      for (int i = 0; i != (int)tuplets.size(); ++i) {
+      for (size_t i = 0; i != tuplets.size(); ++i) {
             const auto &tuplet = tuplets[i];
             const auto interval = tupletInterval(tuplet, basicQuant);
-            info.push_back({interval.first, interval.second, i});
+            info.push_back({interval.first, interval.second, static_cast<int>(i)});
             }
 
       std::sort(info.begin(), info.end());
@@ -155,8 +155,8 @@ std::set<int> findLongestUncommonGroup(
       // non-overlapping tuplets can have common chords
 
       std::set<int> indexes;
-      int lastSelected = 0;
-      for (int i = 0; i != (int)info.size(); ++i) {
+      size_t lastSelected = 0;
+      for (size_t i = 0; i != info.size(); ++i) {
             if (i > 0 && info[i].onTime < info[lastSelected].offTime)
                   continue;
             if (haveCommonChords(info[lastSelected].index, info[i].index, tuplets))
@@ -511,7 +511,7 @@ class ValidTuplets
       std::vector<std::pair<int, int>> save()
             {
             std::vector<std::pair<int, int>> indexes(indexes_.size() - first_);
-            for (int i = first_; i != (int)indexes_.size(); ++i)
+            for (size_t i = first_; i != indexes_.size(); ++i)
                   indexes[i - first_] = indexes_[i];
             return indexes;
             }
@@ -519,7 +519,7 @@ class ValidTuplets
       void restore(const std::vector<std::pair<int, int>> &indexes)
             {
             first_ = int(indexes_.size() - indexes.size());
-            for (int i = 0; i != int(indexes.size()); ++i)
+            for (size_t i = 0; i < indexes.size(); ++i)
                   indexes_[i + first_] = indexes[i];
             }
 

--- a/mscore/importmidi/importmidi_tuplet_voice.cpp
+++ b/mscore/importmidi/importmidi_tuplet_voice.cpp
@@ -49,10 +49,10 @@ chordInterval(const std::pair<const ReducedFraction, MidiChord> &chord,
 int findTupletWithChord(const MidiChord &midiChord,
                         const std::vector<TupletInfo> &tuplets)
       {
-      for (int i = 0; i != (int)tuplets.size(); ++i) {
+      for (size_t i = 0; i != tuplets.size(); ++i) {
             for (const auto &chord: tuplets[i].chords) {
                   if (&(chord.second->second) == &midiChord)
-                        return i;
+                        return static_cast<int>(i);
                   }
             }
       return -1;
@@ -389,7 +389,7 @@ void removeUnusedTuplets(
             return;
 
       std::vector<TupletInfo> newTuplets;
-      for (int i = 0; i != (int)tuplets.size(); ++i) {
+      for (size_t i = 0; i != tuplets.size(); ++i) {
             if (pendingTuplets.find(tuplets[i].id) == pendingTuplets.end()) {
                   newTuplets.push_back(tuplets[i]);
                   }
@@ -410,7 +410,7 @@ void removeUnusedTuplets(
 std::set<int> findPendingTuplets(const std::vector<TupletInfo> &tuplets)
       {
       std::set<int> pendingTuplets;       // tuplet indexes
-      for (int i = 0; i != (int)tuplets.size(); ++i) {
+      for (size_t i = 0; i != tuplets.size(); ++i) {
             pendingTuplets.insert(tuplets[i].id);
             }
       return pendingTuplets;
@@ -683,12 +683,12 @@ void setBackTiedVoices(
             }
       }
 
-std::map<std::pair<const ReducedFraction, MidiChord> *, int>
+std::map<std::pair<const ReducedFraction, MidiChord> *, size_t>
 findMappedTupletChords(const std::vector<TupletInfo> &tuplets)
       {
                   // <chord address, tupletIndex>
-      std::map<std::pair<const ReducedFraction, MidiChord> *, int> tupletChords;
-      for (int i = 0; i != (int)tuplets.size(); ++i) {
+      std::map<std::pair<const ReducedFraction, MidiChord> *, size_t> tupletChords;
+      for (size_t i = 0; i != tuplets.size(); ++i) {
             for (const auto &tupletChord: tuplets[i].chords) {
                   auto tupletIt = tupletChord.second;
                   tupletChords.insert({&*tupletIt, i});
@@ -776,7 +776,7 @@ findBackTiedTuplets(
       std::set<std::pair<const ReducedFraction, MidiChord> *> usedChords;
       const auto tupletChords = findMappedTupletChords(tuplets);
 
-      for (int i = 0; i != (int)tuplets.size(); ++i) {
+      for (size_t i = 0; i != tuplets.size(); ++i) {
 
             Q_ASSERT_X(!tuplets[i].chords.empty(),
                        "MidiTuplets::findBackTiedTuplets", "Tuplet chords are empty");

--- a/mscore/importmidi/importmidi_voice.cpp
+++ b/mscore/importmidi/importmidi_voice.cpp
@@ -51,7 +51,7 @@ bool areNotesSortedByOffTimeInAscOrder(
             const QList<MidiNote>& notes,
             const std::vector<int> &groupOfIndexes)
       {
-      for (int i = 0; i != (int)groupOfIndexes.size() - 1; ++i) {
+      for (size_t i = 0; i != groupOfIndexes.size() - 1; ++i) {
             if (notes[groupOfIndexes[i]].offTime > notes[groupOfIndexes[i + 1]].offTime)
                   return false;
             }
@@ -490,7 +490,7 @@ VoiceSplit findBestSplit(
                                    std::numeric_limits<int>::max()};
       int bestSplit = -1;
 
-      for (int i = 0; i != (int)possibleSplits.size(); ++i) {
+      for (size_t i = 0; i != possibleSplits.size(); ++i) {
             const int voice = possibleSplits[i].voice;
             const auto &notes = chordIt->second.notes;
             int totalPitchDist = 0;
@@ -513,7 +513,7 @@ VoiceSplit findBestSplit(
 
             if (error < minError) {
                   minError = error;
-                  bestSplit = i;
+                  bestSplit = static_cast<int>(i);
                   }
             }
 

--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -893,7 +893,7 @@ void MusicXMLParserPass1::scorePartwise()
 
       // handle the explicit brackets
       const QList<Part*>& il = _score->parts();
-      for (int i = 0; i < (int) partGroupList.size(); i++) {
+      for (size_t i = 0; i < partGroupList.size(); i++) {
             MusicXmlPartGroup* pg = partGroupList[i];
             // add part to set
             if (pg->span == 1)

--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -879,7 +879,7 @@ void MusicXMLParserPass1::scorePartwise()
 
       /*
        qDebug("partGroupList");
-       for (int i = 0; i < (int) partGroupList.size(); i++) {
+       for (size_t i = 0; i < partGroupList.size(); i++) {
        MusicXmlPartGroup* pg = partGroupList[i];
        qDebug("part-group span %d start %d type %hhd barlinespan %d",
        pg->span, pg->start, pg->type, pg->barlineSpan);

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -223,7 +223,7 @@ static void xmlSetPitch(Note* n, int step, int alter, int octave, const int octa
       const Interval intval = instr->transpose();     // TODO: tick
 
       //qDebug("  staff=%p instr=%p dia=%d chro=%d",
-      //       staff, instr, (int) intval.diatonic, (int) intval.chromatic);
+      //       staff, instr, static_cast<int>(intval.diatonic), static_cast<int>(intval.chromatic));
 
       int pitch = MusicXMLStepAltOct2Pitch(step, alter, octave);
       pitch += intval.chromatic; // assume not in concert pitch

--- a/mscore/importove.cpp
+++ b/mscore/importove.cpp
@@ -1295,9 +1295,9 @@ void OveToMScore::convertMeasureMisc(Measure* measure, int part, int staff, int 
             t->setTempo(tpo);
             QString durationTempoL;
             QString durationTempoR;
-            if ((int)(tempoPtr->getLeftNoteType()))
+            if (static_cast<int>(tempoPtr->getLeftNoteType()))
                   durationTempoL = TempoText::duration2tempoTextString(OveNoteType_To_Duration(tempoPtr->getLeftNoteType()));
-            if ((int)(tempoPtr->getRightNoteType()))
+            if (static_cast<int>(tempoPtr->getRightNoteType()))
                   durationTempoR = TempoText::duration2tempoTextString(OveNoteType_To_Duration(tempoPtr->getRightNoteType()));
             QString textTempo;
             if (tempoPtr->getShowBeforeText())
@@ -1563,7 +1563,7 @@ void OveToMScore::convertNotes(Measure* measure, int part, int staff, int track)
                               OVE::ToneType clefMiddleTone;
                               int clefMiddleOctave;
                               getMiddleToneOctave(clefType, clefMiddleTone, clefMiddleOctave);
-                              int absLine = (int) clefMiddleTone + clefMiddleOctave * OCTAVE + oveNote->getLine();
+                              int absLine = static_cast<int>(clefMiddleTone) + clefMiddleOctave * OCTAVE + oveNote->getLine();
                               if ((partStaffCount == 2) && oveNote->getOffsetStaff())
                                     absLine += 2 * (oveNote->getOffsetStaff());
                               int tone = absLine % OCTAVE;
@@ -1575,7 +1575,7 @@ void OveToMScore::convertNotes(Measure* measure, int part, int staff, int track)
                               note->setTpc(step2tpc(tone, AccidentalVal(alter)));
                               if (oveNote->getShowAccidental()) {
                                     Ms::Accidental* a = new Accidental(score_);
-                                    bool bracket = (int)(oveNote->getAccidental()) & 0x8;
+                                    bool bracket = static_cast<int>(oveNote->getAccidental()) & 0x8;
                                     AccidentalType at = Ms::AccidentalType::NONE;
                                     switch(alter) {
                                           case 0: at = Ms::AccidentalType::NATURAL; break;

--- a/mscore/inspector/inspectorAmbitus.cpp
+++ b/mscore/inspector/inspectorAmbitus.cpp
@@ -66,13 +66,13 @@ InspectorAmbitus::InspectorAmbitus(QWidget* parent)
       //
       // fix order of noteheads and tpc's
       //
-      for (int i = 0; i < int(sizeof(heads)/sizeof(*heads)); ++i)
+      for (unsigned i = 0; i < sizeof(heads)/sizeof(*heads); ++i)
             r.noteHeadGroup->setItemData(i, int(heads[i]));
       // noteHeadType starts at -1
       for (int i = 0; i < 5; ++i)
             r.noteHeadType->setItemData(i, i-1);
       // set proper itemdata for TPC combos
-      for (int i = 0; i < int(sizeof(tpcs)/sizeof(*tpcs)); ++i) {
+      for (unsigned i = 0; i < sizeof(tpcs)/sizeof(*tpcs); ++i) {
             r.topTpc->   setItemData(i, tpcs[i]);
             r.bottomTpc->setItemData(i, tpcs[i]);
             }

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -57,13 +57,13 @@ double chorusToUserRange(char v) { return v * 100.0 / 128.0; }
 double reverbToUserRange(char v) { return v * 100.0 / 128.0; }
 
 //0 to 100
-char userRangeToVolume(double v) { return (char)qBound(0, (int)(v / 100.0 * 128.0), 127); }
+char userRangeToVolume(double v) { return (char)qBound(0, static_cast<int>(v / 100.0 * 128.0), 127); }
 //-180 to 180
-char userRangeToPan(double v) { return (char)qBound(0, (int)((v / 360.0) * 128.0), 127); }
+char userRangeToPan(double v) { return (char)qBound(0, static_cast<int>((v / 360.0) * 128.0), 127); }
 //0 to 100
-char userRangeToChorus(double v) { return (char)qBound(0, (int)(v / 100.0 * 128.0), 127); }
+char userRangeToChorus(double v) { return (char)qBound(0, static_cast<int>(v / 100.0 * 128.0), 127); }
 //0 to 100
-char userRangeToReverb(double v) { return (char)qBound(0, (int)(v / 100.0 * 128.0), 127); }
+char userRangeToReverb(double v) { return (char)qBound(0, static_cast<int>(v / 100.0 * 128.0), 127); }
 
 //---------------------------------------------------------
 //   Mixer

--- a/mscore/mixertrackitem.cpp
+++ b/mscore/mixertrackitem.cpp
@@ -77,7 +77,7 @@ int MixerTrackItem::color()
 
 void MixerTrackItem::setVolume(char value)
       {
-//      char v = (char)qBound(0, (int)(value * 128.0 / 100.0), 127);
+//      char v = (char)qBound(0, static_cast<int>(value * 128.0 / 100.0), 127);
 
       if (_trackType == TrackType::PART) {
             const InstrumentList* il = _part->instruments();
@@ -106,7 +106,7 @@ void MixerTrackItem::setVolume(char value)
 
 void MixerTrackItem::setPan(char value)
       {
-//      char v = (char)qBound(0, (int)((value + 180.0) / 360.0 * 128.0), 127);
+//      char v = (char)qBound(0, static_cast<int>((value + 180.0) / 360.0 * 128.0), 127);
 
       if (_trackType == TrackType::PART) {
             const InstrumentList* il = _part->instruments();
@@ -135,7 +135,7 @@ void MixerTrackItem::setPan(char value)
 
 void MixerTrackItem::setChorus(char value)
       {
-//      char v = (char)qBound(0, (int)(value * 128.0 / 100.0), 127);
+//      char v = (char)qBound(0, static_cast<int>(value * 128.0 / 100.0), 127);
 
       if (_trackType == TrackType::PART) {
             const InstrumentList* il = _part->instruments();
@@ -164,7 +164,7 @@ void MixerTrackItem::setChorus(char value)
 
 void MixerTrackItem::setReverb(char value)
       {
-//      char v = (char)qBound(0, (int)(value * 128.0 / 100.0), 127);
+//      char v = (char)qBound(0, static_cast<int>(value * 128.0 / 100.0), 127);
 
       if (_trackType == TrackType::PART) {
             const InstrumentList* il = _part->instruments();

--- a/mscore/ove.cpp
+++ b/mscore/ove.cpp
@@ -1180,7 +1180,7 @@ int Line::getStaffCount() const {
       }
 
 Staff* Line::getStaff(int idx) const {
-      if (idx >= 0 && idx < (int) staffs_.size()) {
+      if (idx >= 0 && idx < static_cast<int>(staffs_.size())) {
             return staffs_[idx];
             }
 
@@ -1892,47 +1892,47 @@ int NoteContainer::getOffsetStaff() const {
       }
 
 int NoteContainer::getDuration() const {
-      int duration = (int) NoteDuration::D_4;
+      int duration = static_cast<int>(NoteDuration::D_4);
 
       switch (noteType_) {
             case NoteType::Note_DoubleWhole: {
-                  duration = (int) NoteDuration::D_Double_Whole;
+                  duration = static_cast<int>(NoteDuration::D_Double_Whole);
                   break;
                   }
             case NoteType::Note_Whole: {
-                  duration = (int) NoteDuration::D_Whole;
+                  duration = static_cast<int>(NoteDuration::D_Whole);
                   break;
                   }
             case NoteType::Note_Half: {
-                  duration = (int) NoteDuration::D_2;
+                  duration = static_cast<int>(NoteDuration::D_2);
                   break;
                   }
             case NoteType::Note_Quarter: {
-                  duration = (int) NoteDuration::D_4;
+                  duration = static_cast<int>(NoteDuration::D_4);
                   break;
                   }
             case NoteType::Note_Eight: {
-                  duration = (int) NoteDuration::D_8;
+                  duration = static_cast<int>(NoteDuration::D_8);
                   break;
                   }
             case NoteType::Note_Sixteen: {
-                  duration = (int) NoteDuration::D_16;
+                  duration = static_cast<int>(NoteDuration::D_16);
                   break;
                   }
             case NoteType::Note_32: {
-                  duration = (int) NoteDuration::D_32;
+                  duration = static_cast<int>(NoteDuration::D_32);
                   break;
                   }
             case NoteType::Note_64: {
-                  duration = (int) NoteDuration::D_64;
+                  duration = static_cast<int>(NoteDuration::D_64);
                   break;
                   }
             case NoteType::Note_128: {
-                  duration = (int) NoteDuration::D_128;
+                  duration = static_cast<int>(NoteDuration::D_128);
                   break;
                   }
             case NoteType::Note_256: {
-                  duration = (int) NoteDuration::D_256;
+                  duration = static_cast<int>(NoteDuration::D_256);
                   break;
                   }
             default:
@@ -3470,7 +3470,7 @@ int Block::toInt() const {
       int num = 0;
 
       for (i = 0; i < (int)sizeof(int) && i < size(); ++i) {
-            num = (num << 8) + (int) *(data() + i);
+            num = (num << 8) + static_cast<int>(*(data()) + i);
             }
 
       std::size_t minSize = sizeof(int);
@@ -3479,7 +3479,7 @@ int Block::toInt() const {
             }
 
       if ((*(data()) & 0x80) == 0x80) {
-            int maxNum = int(pow(2.0, (int) minSize * 8));
+            int maxNum = static_cast<int>(pow(2.0, static_cast<int>(minSize) * 8));
             num -= maxNum;
             //num *= -1;
             }
@@ -4825,7 +4825,7 @@ bool BarsParse::parseTempo(MeasureData* measureData, int /*length*/) {
       // right note dot
       tempo->setRightNoteDot((getHighNibble(thisByte) & 0x1 ) == 0x1 );
       // compatibility with v3 files ?
-      tempo->setRightSideType((int)(getHighNibble(thisByte) & 0x2));
+      tempo->setRightSideType(static_cast<int>(getHighNibble(thisByte) & 0x2));
       // right note type
       tempo->setRightNoteType(getLowNibble(thisByte));
       // right text

--- a/mscore/ove.cpp
+++ b/mscore/ove.cpp
@@ -4340,28 +4340,28 @@ bool BarsParse::parse() {
       QList<Measure*> measures;
       QList<MeasureData*> measureDatas;
 
-      if( measureChunks_.isEmpty() ||
+      if (measureChunks_.isEmpty() ||
           measureChunks_.size() != conductChunks_.size() ||
-          (int)bdatChunks_.size() != measureDataCount ) {
+          bdatChunks_.size() != measureDataCount) {
             return false;
             }
 
       // add to ove
-      for ( i=0; i<(int)measureChunks_.size(); ++i ) {
+      for ( i = 0; i < measureChunks_.size(); ++i ) {
             Measure* measure = new Measure(i);
 
             measures.push_back(measure);
             ove_->addMeasure(measure);
             }
 
-      for ( i=0; i<measureDataCount; ++i ) {
+      for ( i = 0; i < measureDataCount; ++i ) {
             MeasureData* oveMeasureData = new MeasureData();
 
             measureDatas.push_back(oveMeasureData);
             ove_->addMeasureData(oveMeasureData);
             }
 
-      for( i=0; i<(int)measureChunks_.size(); ++i ) {
+      for ( i = 0; i < measureChunks_.size(); ++i ) {
             Measure* measure = measures[i];
 
             // MEAS
@@ -4373,7 +4373,7 @@ bool BarsParse::parse() {
                   }
             }
 
-      for( i=0; i<(int)conductChunks_.size(); ++i ) {
+      for ( i = 0; i < conductChunks_.size(); ++i ) {
             // COND
             if( !parseCond(measures[i], measureDatas[i], conductChunks_[i]) ) {
                   QString ss = QString("failed in parse COND %1\n").arg(i);
@@ -4383,7 +4383,7 @@ bool BarsParse::parse() {
                   }
             }
 
-      for( i=0; i<(int)bdatChunks_.size(); ++i ) {
+      for ( i = 0; i < bdatChunks_.size(); ++i ) {
             int measId = i % trackMeasureCount;
 
             // BDAT
@@ -8419,15 +8419,15 @@ bool OveSerialize::readBarsData() {
       // parse bars
       BarsParse barsParse(ove_);
 
-      for (i = 0; i < (int) measureChunks.size(); ++i) {
+      for (i = 0; i < measureChunks.size(); ++i) {
             barsParse.addMeasure(measureChunks[i]);
             }
 
-      for (i = 0; i < (int) conductChunks.size(); ++i) {
+      for (i = 0; i < conductChunks.size(); ++i) {
             barsParse.addConduct(conductChunks[i]);
             }
 
-      for (i = 0; i < (int) bdatChunks.size(); ++i) {
+      for (i = 0; i < bdatChunks.size(); ++i) {
             barsParse.addBdat(bdatChunks[i]);
             }
 

--- a/mscore/pianolevels.cpp
+++ b/mscore/pianolevels.cpp
@@ -95,7 +95,7 @@ void PianoLevels::setXpos(int val)
 //---------------------------------------------------------
 
 int PianoLevels::pixelXToTick(int pixX) {
-      return (int)((pixX + _xpos) / _xZoom) - MAP_OFFSET;
+      return static_cast<int>((pixX + _xpos) / _xZoom) - MAP_OFFSET;
       }
 
 
@@ -104,7 +104,7 @@ int PianoLevels::pixelXToTick(int pixX) {
 //---------------------------------------------------------
 
 int PianoLevels::tickToPixelX(int tick) {
-      return (int)(tick + MAP_OFFSET) * _xZoom - _xpos;
+      return static_cast<int>(tick + MAP_OFFSET) * _xZoom - _xpos;
       }
 
 
@@ -303,7 +303,7 @@ int PianoLevels::valToPixelY(int value) {
       int range = filter->maxRange() - filter->minRange();
       qreal frac = (value - filter->minRange()) / (qreal)range;
 
-      return (int)(height() - vMargin * 2) * (1 - frac) + vMargin;
+      return static_cast<int>(height() - vMargin * 2) * (1 - frac) + vMargin;
       }
 
 
@@ -316,7 +316,7 @@ int PianoLevels::pixelYToVal(int pix) {
 
       PianoLevelsFilter* filter = PianoLevelsFilter::FILTER_LIST[_levelsIndex];
       int range = filter->maxRange() - filter->minRange();
-      return (int)(frac * range + filter->minRange());
+      return static_cast<int>(frac * range + filter->minRange());
       }
 
 //---------------------------------------------------------

--- a/mscore/pianolevelsfilter.cpp
+++ b/mscore/pianolevelsfilter.cpp
@@ -76,7 +76,7 @@ int PianoLevelFilterVeloOffset::value(Staff* staff, Note* note, NoteEvent* /*evt
       switch (Note::ValueType(note->veloType())) {
             case Note::ValueType::USER_VAL: {
                   int dynamicsVel = staff->velocities().val(note->tick());
-                  return (int)((note->veloOffset() / (qreal)dynamicsVel - 1) * 100);
+                  return static_cast<int>((note->veloOffset() / (qreal)dynamicsVel - 1) * 100);
                   }
             default:
             case Note::ValueType::OFFSET_VAL:
@@ -97,7 +97,7 @@ void PianoLevelFilterVeloOffset::setValue(Staff* staff, Note* note, NoteEvent* /
       switch (Note::ValueType(note->veloType())) {
             case Note::ValueType::USER_VAL: {
                   int dynamicsVel = staff->velocities().val(note->tick());
-                  int newVelocity = (int)(dynamicsVel * (1 + value / 100.0));
+                  int newVelocity = static_cast<int>(dynamicsVel * (1 + value / 100.0));
 
                   score->undo(new ChangeVelocity(note, Note::ValueType::USER_VAL, newVelocity));
 
@@ -127,7 +127,7 @@ int PianoLevelFilterVeloUser::value(Staff* staff, Note* note, NoteEvent* /*evt*/
             default:
             case Note::ValueType::OFFSET_VAL: {
                   int dynamicsVel = staff->velocities().val(note->tick());
-                  return (int)(dynamicsVel * (1 + note->veloOffset() / 100.0));
+                  return static_cast<int>(dynamicsVel * (1 + note->veloOffset() / 100.0));
                   }
             }
       }
@@ -149,7 +149,7 @@ void PianoLevelFilterVeloUser::setValue(Staff* staff, Note* note, NoteEvent* /*e
             default:
             case Note::ValueType::OFFSET_VAL: {
                   int dynamicsVel = staff->velocities().val(note->tick());
-                  int newVelocity = (int)((value / (qreal)dynamicsVel - 1) * 100);
+                  int newVelocity = static_cast<int>((value / (qreal)dynamicsVel - 1) * 100);
 
                   score->undo(new ChangeVelocity(note, Note::ValueType::OFFSET_VAL, newVelocity));
                   break;

--- a/mscore/pianoroll.cpp
+++ b/mscore/pianoroll.cpp
@@ -506,10 +506,10 @@ void PianorollEditor::veloTypeChanged(int val)
       //Change velocity to equivalent in new metric
       switch (Note::ValueType(val)) {
             case Note::ValueType::USER_VAL:
-                  newVelocity = (int)(dynamicsVel * (1 + newVelocity / 100.0));
+                  newVelocity = static_cast<int>(dynamicsVel * (1 + newVelocity / 100.0));
                   break;
             case Note::ValueType::OFFSET_VAL:
-                  newVelocity = (int)((newVelocity / (qreal)dynamicsVel - 1) * 100);
+                  newVelocity = static_cast<int>((newVelocity / (qreal)dynamicsVel - 1) * 100);
                   break;
             }
 

--- a/mscore/pianoview.cpp
+++ b/mscore/pianoview.cpp
@@ -491,7 +491,7 @@ void PianoView::moveLocator(int /*i*/)
 //---------------------------------------------------------
 
 int PianoView::pixelXToTick(int pixX) {
-      return (int)(pixX / _xZoom) - MAP_OFFSET;
+      return static_cast<int>(pixX / _xZoom) - MAP_OFFSET;
       }
 
 
@@ -500,7 +500,7 @@ int PianoView::pixelXToTick(int pixX) {
 //---------------------------------------------------------
 
 int PianoView::tickToPixelX(int tick) {
-      return (int)(tick + MAP_OFFSET) * _xZoom;
+      return static_cast<int>(tick + MAP_OFFSET) * _xZoom;
       }
 
 //---------------------------------------------------------
@@ -531,7 +531,7 @@ void PianoView::wheelEvent(QWheelEvent* event)
             updateBoundingSize();
             updateNotes();
 
-            int mousePixY = (int)(mouseYNote * _noteHeight);
+            int mousePixY = static_cast<int>(mouseYNote * _noteHeight);
             verticalScrollBar()->setValue(mousePixY - event->y());
 
             scene()->update();
@@ -840,7 +840,7 @@ void PianoView::mouseMoveEvent(QMouseEvent* event)
 
       //Update mouse tracker
       QPointF p(mapToScene(event->pos()));
-      int pitch = (int)((_noteHeight * 128 - p.y()) / _noteHeight);
+      int pitch = static_cast<int>((_noteHeight * 128 - p.y()) / _noteHeight);
       emit pitchChanged(pitch);
 
       int tick = pixelXToTick(p.x());

--- a/mscore/plugin/api/cursor.cpp
+++ b/mscore/plugin/api/cursor.cpp
@@ -511,7 +511,7 @@ void Cursor::nextInTrack()
 int Cursor::qmlKeySignature()
       {
       Staff* staff = _score->staves()[staffIdx()];
-      return (int) staff->key(Fraction::fromTicks(tick()));
+      return static_cast<int>(staff->key(Fraction::fromTicks(tick())));
       }
 }
 }

--- a/mscore/plugin/qmledit.cpp
+++ b/mscore/plugin/qmledit.cpp
@@ -508,8 +508,8 @@ void QmlEdit::lineNumberAreaPaintEvent(QPaintEvent *event)
 
       QTextBlock block = firstVisibleBlock();
       int blockNumber = block.blockNumber();
-      int top = (int) blockBoundingGeometry(block).translated(contentOffset()).top();
-      int bottom = top + (int) blockBoundingRect(block).height();
+      int top = static_cast<int>(blockBoundingGeometry(block).translated(contentOffset()).top());
+      int bottom = top + static_cast<int>(blockBoundingRect(block).height());
 
       int w = lineNumberArea->width();
       int h = fontMetrics().height();
@@ -522,7 +522,7 @@ void QmlEdit::lineNumberAreaPaintEvent(QPaintEvent *event)
 
             block = block.next();
             top   = bottom;
-            bottom = top + (int) blockBoundingRect(block).height();
+            bottom = top + static_cast<int>(blockBoundingRect(block).height());
             ++blockNumber;
             }
       }

--- a/mscore/scorecmp/scorelistmodel.cpp
+++ b/mscore/scorecmp/scorelistmodel.cpp
@@ -193,9 +193,9 @@ QVariant ScoreVersionListModel::data(const QModelIndex& index, int role) const
 
 int ScoreVersionListModel::getPosition(ScoreVersionIndex index) const
       {
-      for (int i = 0; i < int(_versions.size()); ++i) {
+      for (size_t i = 0; i < _versions.size(); ++i) {
             if (_versions[i].index == index)
-                  return i;
+                  return static_cast<int>(i);
             }
       return -1;
       }

--- a/mscore/script/scriptentry.cpp
+++ b/mscore/script/scriptentry.cpp
@@ -345,7 +345,7 @@ bool InspectorScriptEntry::execute(ScriptContext& ctx) const
             return false;
 
       const auto iiList = ib->iList;
-      for (int idx = 0; idx < int(iiList.size()); ++idx) {
+      for (unsigned idx = 0; idx < iiList.size(); ++idx) {
             const InspectorItem& ii = iiList[idx];
             if (ii.t == _pid && ii.parent == _parentLevel) {
                   const Score* score = ctx.mscore()->currentScore();

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1317,7 +1317,7 @@ void Seq::stopNotes(int channel, bool realTime)
       };
       // Stop notes in all channels
       if (channel == -1) {
-            for(int ch = 0; ch < int(cs->midiMapping().size()); ch++) {
+            for(unsigned ch = 0; ch < cs->midiMapping().size(); ch++) {
                   send(NPlayEvent(ME_CONTROLLER, ch, CTRL_SUSTAIN, 0));
                   send(NPlayEvent(ME_CONTROLLER, ch, CTRL_ALL_NOTES_OFF, 0));
                   if (cs->midiChannel(ch) != 9)

--- a/mscore/tourhandler.cpp
+++ b/mscore/tourhandler.cpp
@@ -374,7 +374,7 @@ void TourHandler::positionMessage(QList<QWidget*> widgets, QMessageBox* mbox)
             else
                   displayPoint.setY(widgetsBox.bottom() + mboxFrameTopThickness);
 
-            int x = (int) (widgetsBox.width() - mbox->size().width()) / 2 + widgetsBox.left();
+            int x = static_cast<int>(widgetsBox.width() - mbox->size().width()) / 2 + widgetsBox.left();
             displayPoint.setX(x);
             }
       else {


### PR DESCRIPTION
as requested/discussed in PR #4989, by using size_t or at least unsigned instead of casting to int when using the size() method of stl containers (vectors etc.) in for loops.
Doesn't work everywhere though, not without either adding more casts elsewhere or with massive code changes or with different compiler(s') warnings.
Tested with MinGW 32-bit and 64-bit and with MSVC 64-bit.