### PR TITLE
fix #283120: concert pitch button now toggles text also

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2560,6 +2560,7 @@ void MuseScore::setCurrentScoreView(ScoreView* view)
 
       QAction* a = getAction("concert-pitch");
       a->setChecked(cs->styleB(Sid::concertPitch));
+      a->setText(a->isChecked() ? tr("Concert Pitch") : tr("Transposed"));
 
       setPos(cs->inputPos());
       //showMessage(cs->filePath(), 2000);
@@ -5818,7 +5819,9 @@ void MuseScore::endCmd()
                   SelState ss = cs->selection().state();
                   selectionChanged(ss);
                   }
-            getAction("concert-pitch")->setChecked(cs->styleB(Sid::concertPitch));
+            QAction* a = getAction("concert-pitch");
+            a->setChecked(cs->styleB(Sid::concertPitch));
+            a->setText(a->isChecked() ? tr("Concert Pitch") : tr("Transposed"));
 
             if (e == 0 && cs->noteEntryMode())
                   e = cs->inputState().cr();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -2309,7 +2309,7 @@ Shortcut Shortcut::_sc[] = {
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "concert-pitch",
          QT_TRANSLATE_NOOP("action","Concert Pitch"),
-         QT_TRANSLATE_NOOP("action","Display in concert pitch"),
+         QT_TRANSLATE_NOOP("action","Toggle between 'Concert Pitch' and 'Transposed'"),
          0,
          Icons::Invalid_ICON,
          Qt::WindowShortcut


### PR DESCRIPTION
The concert pitch button is a little confusing as is. With this change the button will also cycle between "Concert Pitch" and "Transposed" while still keeping the toggle button. This way it's still easy to see if something is Concert Pitch at first glace (using the shading), but for newer users the text is there to make the button more intuitive.