### PR TITLE
[MU4] fix #288937: Two voices each with an accidental

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -395,11 +395,6 @@ AccidentalVal Measure::findAccidental(Segment* s, int staffIdx, int line, bool &
       int startTrack = staffIdx * VOICES;
       int endTrack   = startTrack + VOICES;
       for (Segment* segment = first(st); segment; segment = segment->next(st)) {
-            if (segment == s && staff->isPitchedStaff(tick())) {
-                  ClefType clef = staff->clef(s->tick());
-                  int l = relStep(line, clef);
-                  return tversatz.accidentalVal(l, error);
-                  }
             for (int track = startTrack; track < endTrack; ++track) {
                   Element* e = segment->element(track);
                   if (!e || !e->isChord())
@@ -422,6 +417,11 @@ AccidentalVal Measure::findAccidental(Segment* s, int staffIdx, int line, bool &
                         int l      = absStep(tpc, note->epitch());
                         tversatz.setAccidentalVal(l, tpc2alter(tpc));
                         }
+                  }
+            if (segment == s && staff->isPitchedStaff(tick())) {
+                  ClefType clef = staff->clef(s->tick());
+                  int l = relStep(line, clef);
+                  return tversatz.accidentalVal(l, error);
                   }
             }
       qDebug("segment not found");


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/288937.

Moving this block to the end of the loop allows for taking into account accidentals in other voices at the specified segment, instead of ignoring them.