### PR TITLE
Add channel and polyphonic aftertouch support to fluid

### DIFF
--- a/fluid/chan.cpp
+++ b/fluid/chan.cpp
@@ -67,7 +67,6 @@ void Channel::init()
 
 void Channel::initCtrl()
       {
-      key_pressure     = 0;
       channel_pressure = 0;
       pitch_bend       = 0x2000; // Range is 0x4000, pitch bend wheel starts in centered position
       pitch_wheel_sensitivity = PITCH_BEND_SENSITIVITY; /* four semi-tones, default for many DAWs */
@@ -77,8 +76,13 @@ void Channel::initCtrl()
             gen[i]     = 0.0f;
             gen_abs[i] = 0;
             }
-      for (int i = 0; i < 128; i++)
+
+      /* Reset key pressure and CCs for all possible values */
+      for (int i = 0; i < 128; i++) {
+            // For MuseScore purposes, default to 80 for poly aftertouch
+            setKeyPressure(i, 80);
             setCC(i, 0);
+            }
 
       /* Volume / initial attenuation (MSB & LSB) */
       setCC(VOLUME_MSB, 127);
@@ -202,6 +206,26 @@ void Channel::pitchBend(int val)
       {
       pitch_bend = val;
       synth->modulate_voices(channum, false, FLUID_MOD_PITCHWHEEL);
+      }
+
+//---------------------------------------------------------
+//   setChannelPressure
+//---------------------------------------------------------
+
+void Channel::setChannelPressure(int val)
+      {
+      channel_pressure = val;
+      synth->modulate_voices(channum, false, FLUID_MOD_CHANNELPRESSURE);
+      }
+
+//---------------------------------------------------------
+//   setKeyPressure
+//---------------------------------------------------------
+
+void Channel::setKeyPressure(int key, int val)
+      {
+      key_pressure[key] = val;
+      synth->modulate_voices(channum, false, FLUID_MOD_KEYPRESSURE);
       }
 
 //---------------------------------------------------------

--- a/fluid/fluid.cpp
+++ b/fluid/fluid.cpp
@@ -194,6 +194,22 @@ void Fluid::play(const PlayEvent& event)
             int midiPitch = event.dataB() * 128 + event.dataA();  // msb * 128 + lsb
             cp->pitchBend(midiPitch);
             }
+      /*
+       *    MIDI spec.: One data byte follows the Status. It is the pressure amount, a value
+       *    from 0 to 127 (where 127 is the most pressure).
+       */
+      else if (type == ME_AFTERTOUCH){
+            cp->setChannelPressure(event.dataA());
+            }
+      /*
+       *    MIDI spec.: Two data bytes follow the Status. The first data is the note number.
+       *    This indicates to which note the pressure is being applied. The second data byte is the
+       *    pressure amount, a value from 0 to 127 (where 127 is the most pressure).
+       */
+      else if (type == ME_POLYAFTER){
+            cp->setKeyPressure(event.dataA(), event.dataB());
+            }
+
       if (err) {
             // TODO: distinguish between types of error code.
             // Lack of a soundfont should not produce qDebug messages, because user could deliberately be using MIDI out only.

--- a/fluid/fluid.h
+++ b/fluid/fluid.h
@@ -223,12 +223,12 @@ class Channel {
 
    public:
       int channum;
-      short key_pressure;
       short channel_pressure;
       short pitch_bend;
       short pitch_wheel_sensitivity;
 
-      short cc[128];          // controller values
+      short cc[128];                // controller values
+      short key_pressure[128];      // MIDI polyphonic key pressure from [0;127]
 
       /* cached values of last MSB values of MSB/LSB controllers */
       unsigned char bank_msb;
@@ -283,6 +283,10 @@ class Channel {
       int getNum() const                  { return channum;    }
       void setInterpMethod(int m)         { interp_method = m; }
       int getInterpMethod() const         { return interp_method; }
+      void setChannelPressure(int val);
+      int channelPressure() const         { return channel_pressure; }
+      void setKeyPressure(int key, int val);
+      int keyPressure(int key) const      { return key_pressure[key]; }
       };
 
 // subsystems:
@@ -599,8 +603,8 @@ enum fluid_mod_src {
       FLUID_MOD_NONE             = 0,
       FLUID_MOD_VELOCITY         = 2,
       FLUID_MOD_KEY              = 3,
-      FLUID_MOD_KEYPRESSURE      = 10,
-      FLUID_MOD_CHANNELPRESSURE  = 13,
+      FLUID_MOD_KEYPRESSURE      = 10,          // polyphonic aftertouch
+      FLUID_MOD_CHANNELPRESSURE  = 13,          // channel aftertouch
       FLUID_MOD_PITCHWHEEL       = 14,
       FLUID_MOD_PITCHWHEELSENS   = 16
       };

--- a/fluid/mod.cpp
+++ b/fluid/mod.cpp
@@ -129,7 +129,7 @@ float Mod::get_value(Channel* chan, Voice* voice)
                               v1 = voice->key;
                               break;
                         case FLUID_MOD_KEYPRESSURE:
-                              v1 = chan->key_pressure;
+                              v1 = chan->keyPressure(voice->key);
                               break;
                         case FLUID_MOD_CHANNELPRESSURE:
                               v1 = chan->channel_pressure;
@@ -222,7 +222,7 @@ float Mod::get_value(Channel* chan, Voice* voice)
                               v2 = voice->key;
                               break;
                         case FLUID_MOD_KEYPRESSURE:
-                              v2 = chan->key_pressure;
+                              v2 = chan->keyPressure(voice->key);
                               break;
                         case FLUID_MOD_CHANNELPRESSURE:
                               v2 = chan->channel_pressure;

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -531,7 +531,7 @@ void Seq::playEvent(const NPlayEvent& event, unsigned framePos)
                   putEvent(event, framePos);
                   }
             }
-      else if (type == ME_CONTROLLER || type == ME_PITCHBEND)
+      else if (type == ME_CONTROLLER || type == ME_PITCHBEND || type == ME_AFTERTOUCH || type == ME_POLYAFTER)
             putEvent(event, framePos);
       }
 


### PR DESCRIPTION
This is in preparation for a possible switch of single note dynamics from using CC events to polyphonic aftertouch, allowing per staff dynamics and other cool things.