### PR TITLE
fix #288976: stems too long on staves with scaled line distance

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1418,7 +1418,10 @@ qreal Chord::defaultStemLength()
             int n = tab1[hookIdx ? 1 : 0][up() ? 1 : 0][odd][_tremolo->lines()-1];
             stemLen += n * .5;
             }
-      return stemLen * _spatium * lineDistance;
+
+      if (tab)
+            stemLen *= lineDistance;
+      return stemLen * _spatium;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/288976

I had done a bit of work on staves with scale line distances some years ago, much of it seems still in place but some has been lost over time. One thing that is lost is that stems on standard & percussion staves should not scale with line distance. I had this working but it seems it was reverted in musescore@337e885#diff-428e0bb12d899d2d494b3cc99e75e22fL1334. There didn't seem to be any compelling reason for the change then, and it's simple enough to put it back, so here it is.