### PR TITLE
fix #288333: different dynamics on piano staves don't work

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -768,8 +768,22 @@ static void collectMeasureEventsDefault(EventMap* events, Measure* m, Staff* sta
                                     continue;
                                     }
 
-                              if (s->isHairpin() && s->staff() == st1) {
+                              if (s->isHairpin()) {
                                     h = toHairpin(s);
+                                    switch (h->dynRange()) {
+                                          case Dynamic::Range::STAFF:
+                                                if (h->staff() != st1)
+                                                      continue;
+                                                break;
+                                          case Dynamic::Range::PART:
+                                                if (h->part() != st1->part())
+                                                      continue;
+                                                break;
+                                          case Dynamic::Range::SYSTEM:
+                                          default:
+                                                break;
+                                          }
+
                                     singleNoteDynamics = h->singleNoteDynamics() || singleNoteDynamics;
                                     if (singleNoteDynamics) {
                                           hairpinStartTick = Fraction::fromTicks(it.start);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/288333

This is a fix that doesn't involve reworking the whole channel structure of an `Instrument` (see #4990). That feature shouldn't be needed anymore, by the way, because looking through the lists of instruments, I can't see any that would benefit from separate dynamics on staves (i.e. none of them seem capable of that).