### PR TITLE
Fix #287528 - Side panels not dockable after undock and close

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -86,7 +86,7 @@ void MuseScore::showInspector(bool visible)
             addDockWidget(Qt::RightDockWidgetArea, _inspector);
             }
       if (_inspector)
-            _inspector->setVisible(visible);
+            reDisplayDockWidget(_inspector, visible);
       if (visible)
             updateInspector();
       }

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1173,7 +1173,7 @@ void MuseScore::showPalette(bool visible)
             updateIcons();
             }
       if (paletteBox)   // read failed?
-            paletteBox->setVisible(visible);
+            reDisplayDockWidget(paletteBox, visible);
       a->setChecked(visible);
       }
 

--- a/mscore/mixer.h
+++ b/mscore/mixer.h
@@ -81,9 +81,9 @@ class Mixer : public QDockWidget, public Ui::Mixer, public MixerTrackGroup
 
       virtual void closeEvent(QCloseEvent*) override;
       virtual void showEvent(QShowEvent*) override;
+      virtual void hideEvent(QHideEvent*) override;
       virtual bool eventFilter(QObject*, QEvent*) override;
       virtual void keyPressEvent(QKeyEvent*) override;
-      void readSettings();
       void keepScrollPosition();
       void setPlaybackScore(Score*);
 
@@ -109,7 +109,6 @@ class Mixer : public QDockWidget, public Ui::Mixer, public MixerTrackGroup
       Mixer(QWidget* parent);
       void setScore(Score*);
       PartEdit* getPartAtIndex(int index);
-      void writeSettings();
       void expandToggled(Part* part, bool expanded) override;
       void notifyTrackSelected(MixerTrack* track) override;
       void showDetailsToggled(bool shown);

--- a/mscore/mixer.ui
+++ b/mscore/mixer.ui
@@ -5,25 +5,28 @@
   <property name="enabled">
    <bool>true</bool>
   </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>648</width>
+    <height>495</height>
+   </rect>
+  </property>
+  <property name="focusPolicy">
+   <enum>Qt::ClickFocus</enum>
+  </property>
   <property name="floating">
    <bool>false</bool>
   </property>
   <property name="features">
    <set>QDockWidget::AllDockWidgetFeatures</set>
   </property>
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>648</width>
-    <height>431</height>
-   </rect>
-  </property>
-  <property name="focusPolicy">
-   <enum>Qt::ClickFocus</enum>
+  <property name="allowedAreas">
+   <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea</set>
   </property>
   <property name="windowTitle">
-   <string/>
+   <string>Mixer</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -142,8 +145,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>554</width>
-           <height>371</height>
+           <width>528</width>
+           <height>368</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_2">

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2812,6 +2812,24 @@ void MuseScore::showElementContext(Element* el)
       debugger->setElement(el);
       }
 
+    
+//---------------------------------------------------------
+//   reDisplayDockWidget
+//
+//   Helper function to ensure when un-docked widgets are
+//   re-displayed, they are also re-dockable
+//---------------------------------------------------------
+
+void MuseScore::reDisplayDockWidget(QDockWidget* widget, bool visible)
+     {
+      widget->setVisible(visible);
+      if (widget->isFloating()) {
+            // Ensure the widget is re-dockable if it has been closed and re-opened when un-docked
+            widget->setFloating(false);
+            widget->setFloating(true);
+            }
+     }
+
 //---------------------------------------------------------
 //   showPlayPanel
 //---------------------------------------------------------
@@ -2840,7 +2858,7 @@ void MuseScore::showPlayPanel(bool visible)
             playPanel->setFloating(false);
             }
       else
-            playPanel->setVisible(visible);
+            reDisplayDockWidget(playPanel, visible);
       playId->setChecked(visible);
       }
 
@@ -4374,8 +4392,6 @@ void MuseScore::writeSettings()
       if (synthControl)
             synthControl->writeSettings();
       settings.setValue("synthControlVisible", synthControl && synthControl->isVisible());
-      if (mixer)
-            mixer->writeSettings();
       settings.setValue("mixerVisible", mixer && mixer->isVisible());
       if (seq) {
             seq->exit();
@@ -4423,7 +4439,12 @@ void MuseScore::readSettings()
             }
 
       MuseScore::restoreGeometry(this);
-
+      
+      // grab the visible state before the beginGroup
+      // this awkwardness to ensure state saved before code changes should
+      // still work OK.
+      bool mixerVisibleFlag = settings.value("mixerVisible", "0").toBool();
+          
       settings.beginGroup("MainWindow");
       mainWindow->restoreState(settings.value("debuggerSplitter").toByteArray());
       mainWindow->setOpaqueResize(false);
@@ -4438,7 +4459,8 @@ void MuseScore::readSettings()
       mscore->showInspector(settings.value("showInspector", "1").toBool());
       mscore->showPianoKeyboard(settings.value("showPianoKeyboard", "0").toBool());
       mscore->showSelectionWindow(settings.value("showSelectionWindow", "0").toBool());
-
+      mscore->showMixer(mixerVisibleFlag);
+          
       restoreState(settings.value("state").toByteArray());
       //if we were in full screen mode, go to maximized mode
       if (isFullScreen()) {
@@ -5239,7 +5261,7 @@ void MuseScore::editRaster()
 //   showPianoKeyboard
 //---------------------------------------------------------
 
-void MuseScore::showPianoKeyboard(bool on)
+void MuseScore::showPianoKeyboard(bool visible)
       {
       if (_pianoTools == 0) {
             QAction* a = getAction("toggle-piano");
@@ -5249,8 +5271,8 @@ void MuseScore::showPianoKeyboard(bool on)
             connect(_pianoTools, SIGNAL(keyReleased(int, bool, int)), SLOT(midiNoteReceived(int, bool, int)));
             connect(_pianoTools, SIGNAL(visibilityChanged(bool)), a, SLOT(setChecked(bool)));
             }
-      if (on) {
-            _pianoTools->show();
+      if (visible) {
+            reDisplayDockWidget(_pianoTools, visible);
             if (currentScore())
                   _pianoTools->changeSelection(currentScore()->selection());
             else
@@ -6065,7 +6087,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
       else if (cmd == "toggle-piano")
             showPianoKeyboard(a->isChecked());
       else if (cmd == "toggle-scorecmp-tool")
-            scoreCmpTool->setVisible(a->isChecked());
+            reDisplayDockWidget(scoreCmpTool, a->isChecked());
 #ifdef MSCORE_UNSTABLE
       else if (cmd == "toggle-script-recorder")
             scriptRecorder->setVisible(a->isChecked());
@@ -7660,8 +7682,6 @@ int main(int argc, char* av[])
       QSettings settings;
       if (settings.value("synthControlVisible", false).toBool())
             mscore->showSynthControl(true);
-      if (settings.value("mixerVisible", false).toBool())
-            mscore->showMixer(true);
 
       return qApp->exec();
       }

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -820,6 +820,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void unregisterPlugin(PluginDescription*);
 
       Q_INVOKABLE void showStartcenter(bool);
+      void reDisplayDockWidget(QDockWidget* widget, bool visible);
       void showPlayPanel(bool);
 
       QFileInfoList recentScores() const;

--- a/mscore/selectionwindow.cpp
+++ b/mscore/selectionwindow.cpp
@@ -178,7 +178,7 @@ void SelectionWindow::changeCheckbox(QListWidgetItem* item)
 //   showSelectionWindow
 //---------------------------------------------------------
 
-void MuseScore::showSelectionWindow(bool val)
+void MuseScore::showSelectionWindow(bool visible)
       {
       QAction* a = getAction("toggle-selection-window");
       if (selectionWindow == 0) {
@@ -189,8 +189,8 @@ void MuseScore::showSelectionWindow(bool val)
                   tabifyDockWidget(paletteBox, selectionWindow);
                   }
             }
-      selectionWindow->setVisible(val);
-      if (val) {
+      reDisplayDockWidget(selectionWindow, visible);
+      if (visible) {
             selectionWindow->raise();
             }
       }

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -57,7 +57,7 @@ void MuseScore::showTimeline(bool visible)
             }
       connect(_timeline, SIGNAL(visibilityChanged(bool)), act, SLOT(setChecked(bool)));
       connect(_timeline, SIGNAL(closed(bool)), act, SLOT(setChecked(bool)));
-      _timeline->setVisible(visible);
+      reDisplayDockWidget(_timeline, visible);
 
       getAction("toggle-timeline")->setChecked(visible);
       if (visible)


### PR DESCRIPTION
Adds a function that tests if widget is in the floating state and,
if so, cycles the floating state through off and on again to ensure
widget is re-dockable. Function used to the fix issue for:
* Play Panel
* Palettes
* Inspector
* Selection Filter
* Piano Keyboard (when dockable, only dockable in footer)
* Time Line (when dockable, only dockable in footer)
* Score Comparison Tool

Can confirm I've signed the CLA (as Matthew Elton). This is first pull request on MuseScore and I'm not used to C++, so any guidance on anything I've not got right / conventions not adhered to appreciated.