### PR TITLE
Layout range optimization for continuous view

### DIFF
--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -45,6 +45,7 @@ struct LayoutContext {
       MeasureBase* curMeasure  { 0 };
       MeasureBase* nextMeasure { 0 };
       int measureNo            { 0 };
+      Fraction startTick;
       Fraction endTick;
 
       LayoutContext() = default;


### PR DESCRIPTION
This is my attempt at applying layout range optimizations for continuous view.  That is, only laying out the measures that have actually changed.  I have it working pretty well, actually, although there is a glitch where sometimes an otherwise unchanged measure gets wider after the initial calculation, and this throws off the beams in those measures.  I need to sort that out.  And no doubt I am being too aggressive in skipping layout and something else will turn up.  But unfortunately, it seems there was no one "silver bullet" here - I needed to go through a bunch of different places and see where we could apply it to the range and where we could not, and no single one of them produced a big enough win to make it all worthwhile.  And still, the results are not as impressive as I had hoped, but they aren't insignificant either.  I'm guessinging rebuilding the entire bsp tree is going to be a limiting factor.

So, for now, this is for testing purposes, hopefully I sort out the occasional measure-resizing glitch (seems to be measures starting with a note containing a wide articulation).