### PR TITLE
fix #288343: don't lose selection on paste element

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -967,7 +967,6 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
             else
                   els.append(_selection.elements());
 
-            deselectAll();
             if (type != ElementType::INVALID) {
                   Element* el = Element::create(type, this);
                   if (el) {
@@ -981,7 +980,14 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
                               ddata.dropElement = nel;
                               ddata.duration    = duration;
                               if (target->acceptDrop(ddata)) {
+                                    // dropping an element of the same type is likely to replace it
+                                    // thus invaldiating the selection
+                                    ElementType targetType = target->type();
+                                    if (targetType == type)
+                                          deselect(target);
                                     target->drop(ddata);
+                                    if (targetType == type)
+                                          select(nel);
                                     if (_selection.element())
                                           addRefresh(_selection.element()->abbox());
                                     }


### PR DESCRIPTION
See https://musescore.org/en/node/288343.

There was a crash fixed in https://github.com/musescore/MuseScore/commit/807d2825fb7387632ac3e0c2e3099866b4984201, but the fix is too harsh, losing the selection completely on all pastes of a single element onto a single element.  So for example, pasting a text onto a note loses the selection, which is not good.

This fix reverts the previous one and manages the selection more conservatively, checking if the pasted element is the same type as the target and fixing up the selection if so.  This actually doesn't handle the case of pasting a note onto a rest, but the code in ChordRest::drop() was already selecting the note.  We could certainly consider doing that for safety in Note::drop() as well.  But I like having the code I added to cmdPaste because it will handle other cases where we replace the target element or might consider doing so in the future (eg, pasting a dynamic on top of another dynamic).