### PR TITLE
fix #289148: lyrics offset issues

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -745,6 +745,8 @@ void ChordRest::add(Element* e)
                   qDebug("ChordRest::add: unknown element %s", e->name());
                   break;
             case ElementType::LYRICS:
+                  if (e->isStyled(Pid::OFFSET))
+                        e->setOffset(e->propertyDefault(Pid::OFFSET).toPointF());
                   _lyrics.push_back(toLyrics(e));
                   break;
             default:

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1795,8 +1795,16 @@ static void readLyrics(Lyrics* lyrics, XmlReader& e)
             delete _verseNumber;
             }
       lyrics->setAutoplace(true);
-      lyrics->setOffset(QPointF());
-//TODO-offset      lyrics->setOffset(QPointF());
+      if (!lyrics->isStyled(Pid::OFFSET) && !e.pasteMode()) {
+            // fix offset for pre-3.1 scores
+            // 2.x and earlier: y offset was relative to staff; x offset was relative to center of notehead
+            lyrics->rxoffset() -= lyrics->symWidth(SymId::noteheadBlack) * 0.5;
+            //lyrics->ryoffset() -= lyrics->placeBelow() && lyrics->staff() ? lyrics->staff()->height() : 0.0;
+            // temporarily set placement to above, since the original offset is relative to top of staff
+            // depend on adjustPlacement() to change the placement if appropriate
+            lyrics->setPlacement(Placement::ABOVE);
+            adjustPlacement(lyrics);
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/289148

After the merge of #4982, the one element that has a compatibility issue with respect to 3.0 is lyrics, because the way we represent offsets.  But the good news is, this also gives us an opportunity to greatly improve the import from 2.x.  We had been throwing away offset information because there was no way for autoplace to use it, but now there is.

So this PR fixes the offset lyrics offset issue on import of 3.0 scores via the change to Lyrics::read(), plus the addition of Lyrics::getPropertyStyle().  It also allows 2.x lyrics to retain offset via the change to readLyrics() in read206.cpp.  The change to Lyrics::undoChangeProperty() also helps with compatiblity, but isn't actually as crucial, it just allows turning off autoplace for lyrics to rebase and thus preserve the offset, as it did in 3.0, and thus avoids the lyric "jumping".

This fix is important; without it any 3.0 score with manual adjustments to lyrics that don't turn off autoplace will look wrong.