### PR TITLE
Autoplace cleanup

### DIFF
--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -52,6 +52,16 @@ enum class Grip {
       };
 
 //---------------------------------------------------------
+//   OffsetChange
+//---------------------------------------------------------
+
+enum class OffsetChange {
+      RELATIVE_OFFSET   = -1,
+      NONE              =  0,
+      ABSOLUTE_OFFSET   =  1
+      };
+
+//---------------------------------------------------------
 //   ElementFlag
 //---------------------------------------------------------
 
@@ -155,8 +165,8 @@ class Element : public ScoreElement {
       qreal _mag;                 ///< standard magnification (derived value)
       QPointF _pos;               ///< Reference position, relative to _parent, set by autoplace
       QPointF _offset;            ///< offset from reference position, set by autoplace or user
-      int _offsetChanged;         ///< set by user actions that change offset, used by autoplace
-      QPointF _changedPos;        ///< position set when changing offset (valid when _offsetChanged)
+      OffsetChange  _offsetChanged; ///< set by user actions that change offset, used by autoplace
+      QPointF _changedPos;        ///< position set when changing offset
       Spatium _minDistance;       ///< autoplace min distance
       int _track;                 ///< staffIdx * VOICES + voice
       mutable ElementFlags _flags;
@@ -211,7 +221,7 @@ class Element : public ScoreElement {
 
       Spatium minDistance() const             { return _minDistance;    }
       void setMinDistance(Spatium v)          { _minDistance = v;       }
-      int offsetChanged() const               { return _offsetChanged;  }
+      OffsetChange offsetChanged() const      { return _offsetChanged;  }
       void setOffsetChanged(bool v, bool absolute = true, const QPointF& diff = QPointF());
 
       const QPointF& ipos() const             { return _pos;                    }

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -112,7 +112,7 @@ void Fingering::layout()
 
             // update offset after drag
             qreal rebase = 0.0;
-            if (offsetChanged())
+            if (offsetChanged() != OffsetChange::NONE)
                   rebase = rebaseOffset();
 
             // temporarily exclude self from chord shape
@@ -157,7 +157,7 @@ void Fingering::layout()
                               qreal diff = (bbox().bottom() + ipos().y() + yd + n->y()) - top;
                               if (diff > 0.0)
                                     yd -= diff;
-                              if (offsetChanged()) {
+                              if (offsetChanged() != OffsetChange::NONE) {
                                     // user moved element within the skyline
                                     // we may need to adjust minDistance, yd, and/or offset
                                     bool inStaff = placeAbove() ? r.bottom() + rebase > 0.0 : r.top() + rebase < staff()->height();
@@ -193,7 +193,7 @@ void Fingering::layout()
                               qreal diff = bottom - (bbox().top() + ipos().y() + yd + n->y());
                               if (diff > 0.0)
                                     yd += diff;
-                              if (offsetChanged()) {
+                              if (offsetChanged() != OffsetChange::NONE) {
                                     // user moved element within the skyline
                                     // we may need to adjust minDistance, yd, and/or offset
                                     bool inStaff = placeAbove() ? r.bottom() + rebase > 0.0 : r.top() + rebase < staff()->height();
@@ -216,7 +216,7 @@ void Fingering::layout()
             // restore autoplace
             setAutoplace(true);
             }
-      else if (offsetChanged()) {
+      else if (offsetChanged() != OffsetChange::NONE) {
             // rebase horizontally too, as autoplace may have adjusted it
             rebaseOffset(false);
             }

--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -252,7 +252,7 @@ void HairpinSegment::layout()
 
       // rebase vertical offset on drag
       qreal rebase = 0.0;
-      if (offsetChanged())
+      if (offsetChanged() != OffsetChange::NONE)
             rebase = rebaseOffset();
 
       if (autoplace()) {
@@ -283,7 +283,7 @@ void HairpinSegment::layout()
                   }
             qreal yd = ymax - pos().y();
             if (yd != 0.0) {
-                  if (offsetChanged()) {
+                  if (offsetChanged() != OffsetChange::NONE) {
                         // user moved element within the skyline
                         // we may need to adjust minDistance, yd, and/or offset
                         qreal adj = pos().y() + rebase;

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3130,6 +3130,17 @@ void Score::layoutLyrics(System* system)
                                     if (cr) {
                                           int nA = 0;
                                           for (Lyrics* l : cr->lyrics()) {
+                                                // user adjusted offset can possibly change placement
+                                                if (l->offsetChanged() != OffsetChange::NONE) {
+                                                      Placement p = l->placement();
+                                                      l->rebaseOffset();
+                                                      if (l->placement() != p) {
+                                                            l->undoResetProperty(Pid::AUTOPLACE);
+                                                            //l->undoResetProperty(Pid::OFFSET);
+                                                            //l->layout();
+                                                            }
+                                                      }
+                                                l->setOffsetChanged(false);
                                                 if (l->placeAbove())
                                                       ++nA;
                                                 }

--- a/libmscore/lyrics.cpp
+++ b/libmscore/lyrics.cpp
@@ -557,6 +557,17 @@ QVariant Lyrics::propertyDefault(Pid id) const
       }
 
 //---------------------------------------------------------
+//   getPropertyStyle
+//---------------------------------------------------------
+
+Sid Lyrics::getPropertyStyle(Pid pid) const
+      {
+      if (pid == Pid::OFFSET)
+            return placeAbove() ? Sid::lyricsPosAbove : Sid::lyricsPosBelow;
+      return TextBase::getPropertyStyle(pid);
+      }
+
+//---------------------------------------------------------
 //   forAllLyrics
 //---------------------------------------------------------
 

--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -101,6 +101,7 @@ class Lyrics final : public TextBase {
       virtual QVariant getProperty(Pid propertyId) const override;
       virtual bool setProperty(Pid propertyId, const QVariant&) override;
       virtual QVariant propertyDefault(Pid id) const override;
+      virtual Sid getPropertyStyle(Pid) const override;
       };
 
 //---------------------------------------------------------

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -1354,7 +1354,7 @@ void SpannerSegment::autoplaceSpannerSegment()
 
       // rebase vertical offset on drag
       qreal rebase = 0.0;
-      if (offsetChanged())
+      if (offsetChanged() != OffsetChange::NONE)
             rebase = rebaseOffset();
 
       if (autoplace()) {
@@ -1377,7 +1377,7 @@ void SpannerSegment::autoplaceSpannerSegment()
                         yd = d + md;
                   }
             if (yd != 0.0) {
-                  if (offsetChanged()) {
+                  if (offsetChanged() != OffsetChange::NONE) {
                         // user moved element within the skyline
                         // we may need to adjust minDistance, yd, and/or offset
                         qreal adj = pos().y() + rebase;


### PR DESCRIPTION
Addresses review by @dmitrio95 from https://github.com/musescore/MuseScore/pull/4982#pullrequestreview-237124019.  Based on his comments, I have made the following changes for now:

- created an enum for offsetChanged()
- allowed autoplace to manage min distance even when moving elements away from the staff
- added articulations to the list of "liberated" elements

I acknowledge there are still improvements that could be made to the automatic flipping mechanism, but that can be done separately, and incrementally over time.

My lyrics PR #5017 also remains an important followup.