### PR TITLE
Fix #289190 - Toolbar customization refinements & fixes

### DIFF
--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -835,6 +835,8 @@ public:
     std::list<const char*>* fileOperationEntries() { return &_fileOperationEntries; }
     void setFileOperationEntries(std::list<const char*> l) { _fileOperationEntries = l; }
     void populateFileOperations();
+    void addViewModeWidget();
+    void addZoomOptionsWidget();
 
     static const std::list<const char*>& allPlaybackControlEntries() { return _allPlaybackControlEntries; }
     std::list<const char*>* playbackControlEntries() { return &_playbackControlEntries; }

--- a/mscore/toolbarEditor.h
+++ b/mscore/toolbarEditor.h
@@ -28,6 +28,9 @@ class ToolbarEditor : public QDialog, public Ui::ToolbarEditor
     void updateNewToolbar(int toolbar_to_update);
 
     void populateLists(const std::list<const char*>&, std::list<const char*>*);
+    void refreshAvailableList(const std::list<const char*>&, std::list<const char*>*);
+    QListWidgetItem* listItem(const char* id);
+    QListWidgetItem* _listItem(const char* id);
     bool isSpacer(QListWidgetItem*) const;
 
     virtual void hideEvent(QHideEvent*);

--- a/mscore/toolbarEditor.ui
+++ b/mscore/toolbarEditor.ui
@@ -11,11 +11,11 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Edit Toolbar</string>
+   <string>Customize Toolbars</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QLabel" name="toolbarLabel">
+   <item row="0" column="2">
+    <widget class="QLabel" name="availableActionsLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -23,11 +23,21 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Toolbar</string>
+      <string>Available actions</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="3" column="0" colspan="5">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
     <widget class="QLabel" name="actionsLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -40,71 +50,20 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="4">
-    <widget class="QLabel" name="availableActionsLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Available Actions</string>
+   <item row="1" column="2" rowspan="2">
+    <widget class="QListWidget" name="availableList">
+     <property name="toolTip">
+      <string>Actions available to show on toolbar</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" rowspan="2" colspan="2">
-    <widget class="QListWidget" name="toolbarList">
-     <property name="currentRow">
-      <number>-1</number>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2" rowspan="2">
-    <widget class="QListWidget" name="actionList"/>
-   </item>
-   <item row="2" column="4" rowspan="2">
-    <widget class="QListWidget" name="availableList"/>
-   </item>
-   <item row="0" column="0" colspan="5">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="workspaceLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Workspace:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="workspaceName">
-       <property name="readOnly">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="3">
+   <item row="1" column="3">
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
       <widget class="QToolButton" name="add">
-       <property name="text">
-        <string notr="true"/>
+       <property name="toolTip">
+        <string>Add action to toolbar</string>
        </property>
-       <property name="icon">
-        <iconset resource="musescore.qrc">
-         <normaloff>:/data/icons/go-previous.svg</normaloff>:/data/icons/go-previous.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="remove">
        <property name="text">
         <string notr="true"/>
        </property>
@@ -115,7 +74,24 @@
       </widget>
      </item>
      <item>
+      <widget class="QToolButton" name="remove">
+       <property name="toolTip">
+        <string>Remove action from toolbar</string>
+       </property>
+       <property name="text">
+        <string notr="true"/>
+       </property>
+       <property name="icon">
+        <iconset resource="musescore.qrc">
+         <normaloff>:/data/icons/go-previous.svg</normaloff>:/data/icons/go-previous.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QToolButton" name="up">
+       <property name="toolTip">
+        <string>Move action up</string>
+       </property>
        <property name="text">
         <string notr="true"/>
        </property>
@@ -127,6 +103,9 @@
      </item>
      <item>
       <widget class="QToolButton" name="down">
+       <property name="toolTip">
+        <string>Move action down</string>
+       </property>
        <property name="text">
         <string/>
        </property>
@@ -138,20 +117,39 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="0" colspan="5">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="1" column="0" rowspan="2" colspan="2">
+    <widget class="QListWidget" name="toolbarList">
+     <property name="toolTip">
+      <string>Toolbar to customize</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     <property name="currentRow">
+      <number>-1</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="toolbarLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Toolbar</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4" rowspan="2">
+    <widget class="QListWidget" name="actionList">
+     <property name="toolTip">
+      <string>Actions shown on toolbar</string>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>workspaceName</tabstop>
   <tabstop>toolbarList</tabstop>
   <tabstop>actionList</tabstop>
   <tabstop>add</tabstop>

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -240,6 +240,8 @@ void MuseScore::changeWorkspace(Workspace* p, bool first)
         preferencesChanged(true);
     }
 
+    getAction("edit-toolbars")->setEnabled(WorkspacesManager::currentWorkspace()->canCustomizeToolbars());
+
     connect(getPaletteWorkspace(), &PaletteWorkspace::userPaletteChanged,
             WorkspacesManager::currentWorkspace(), QOverload<>::of(&Workspace::setDirty), Qt::UniqueConnection);
 
@@ -1137,6 +1139,11 @@ void Workspace::setDirty(bool val)
 {
     _dirty = val;
     _saveTimer.start();
+}
+
+bool Workspace::canCustomizeToolbars()
+{
+    return saveToolbars && !_readOnly;
 }
 
 //---------------------------------------------------------

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -90,6 +90,7 @@ public:
     void read(XmlReader&);
     void read();
     bool readOnly() const { return _readOnly; }
+    bool canCustomizeToolbars();
     void setReadOnly(bool val) { _readOnly = val; }
     void reset();
 

--- a/mscore/workspacedialog.cpp
+++ b/mscore/workspacedialog.cpp
@@ -149,6 +149,9 @@ void WorkspaceDialog::accepted()
     newWorkspace->setSaveMenuBar(menubarCheck->isChecked());
     preferences.setUseLocalPreferences(prefsCheck->isChecked());
 
+    //enable or disable customize toolbars menu to reflect current status
+    getAction("edit-toolbars")->setEnabled(newWorkspace->canCustomizeToolbars());
+
     //save newly created/edited workspace
     newWorkspace->save();
 

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -3334,6 +3334,9 @@
       <action>print</action>
       <action>undo</action>
       <action>redo</action>
+      <action></action>
+      <action>zoom-options</action>
+      <action>view-mode</action>
       </Toolbar>
     <Toolbar name="playbackControl">
       <action>midi-on</action>

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -926,7 +926,10 @@
       <action>print</action>
       <action>undo</action>
       <action>redo</action>
-      </Toolbar>
+      <action></action>
+      <action>zoom-options</action>
+      <action>view-mode</action>
+    </Toolbar>
     <Toolbar name="playbackControl">
       <action>midi-on</action>
       <action></action>


### PR DESCRIPTION
- made dialogue show the proper names for customisable actions / item
  previously it was showing the internal tags/ids (which won't translate)

- allow for the view mode / view zoom to be customised like other items

- fixed title of dialogue box

- removed text box showing workspace name from dialogue box - it's an
  edit box showing information that can never be edited - unhelpful UI

- added name of workspace being edited to the dialogue box title

- re-ordered the available and chosen lists in the dialogue box to make
  more sense - most specific is at the right and not in the middle

- added tooltips to various items in dialogue box

- menu is greyed out / disabled when toolbars are not customisable,
  i.e. because we're in advanced or basic mode

- available actions now maintain STANDARD order when items are removed
  from the current toolbar