### PR TITLE
fix #285535, fix #284613: spacing of mid-measure clefs

### DIFF
--- a/libmscore/clef.cpp
+++ b/libmscore/clef.cpp
@@ -198,9 +198,11 @@ void Clef::layout()
             default:
                   break;
             }
-      // clefs are right aligned to Segment
+      // clefs on palette or at start of system/measure are left aligned
+      // other clefs are right aligned
       QRectF r(symBbox(symId));
-      setPos(0.0, yoff * _spatium + (stepOffset * -_spatium));
+      qreal x = segment() && segment()->rtick().isNotZero() ? -r.right() : 0.0;
+      setPos(x, yoff * _spatium + (stepOffset * -_spatium));
 
       setbbox(r);
       }

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -2002,11 +2002,12 @@ qreal Segment::minHorizontalCollidingDistance(Segment* ns) const
 
 qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
       {
-      qreal w = 0.0;
+      qreal ww = -1000000.0;        // can remain negative
       for (unsigned staffIdx = 0; staffIdx < _shapes.size(); ++staffIdx) {
             qreal d = staffShape(staffIdx).minHorizontalDistance(ns->staffShape(staffIdx));
-            w       = qMax(w, d);
+            ww      = qMax(ww, d);
             }
+      qreal w = qMax(ww, 0.0);      // non-negative
 
       SegmentType st  = segmentType();
       SegmentType nst = ns ? ns->segmentType() : SegmentType::Invalid;
@@ -2017,7 +2018,10 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
                   w += score()->styleP(Sid::noteBarDistance);
                   }
             else if (nst == SegmentType::Clef) {
-                  w = qMax(w, score()->styleP(Sid::clefLeftMargin));
+                  // clef likely does not exist on all staves
+                  // and can cause very uneven spacing
+                  // so use ww to avoid forcing margin except as necessary
+                  w = ww + score()->styleP(Sid::clefLeftMargin);
                   }
             else {
                   bool isGap = false;
@@ -2050,7 +2054,13 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
 //                  qreal d = score()->styleP(Sid::barNoteDistance);
 //                  qreal dd = minRight() + ns->minLeft() + spatium();
 //                  w = qMax(d, dd);
-                  w += score()->styleP(Sid::barNoteDistance);
+                  // not header
+                  if (st == SegmentType::Clef)
+                        w = ww + score()->styleP(Sid::midClefKeyRightMargin);
+                  else if (st == SegmentType::KeySig)
+                        w += score()->styleP(Sid::midClefKeyRightMargin);
+                  else
+                        w += score()->styleP(Sid::barNoteDistance);
 
                   if (st == SegmentType::StartRepeatBarLine) {
                         if (Element* barLine = element(0)) {

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -163,6 +163,7 @@ static const StyleType styleTypes[] {
 
       { Sid::timesigLeftMargin,       "timesigLeftMargin",       Spatium(0.5) },
       { Sid::timesigScale,            "timesigScale",            QVariant(QSizeF(1.0, 1.0)) },
+      { Sid::midClefKeyRightMargin,   "midClefKeyRightMargin",   Spatium(1.0) },
       { Sid::clefKeyRightMargin,      "clefKeyRightMargin",      Spatium(0.8) },
       { Sid::clefKeyDistance,         "clefKeyDistance",         Spatium(1.0) },   // gould: 1 - 1.25
       { Sid::clefTimesigDistance,     "clefTimesigDistance",     Spatium(1.0) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -136,6 +136,7 @@ enum class Sid {
       timesigLeftMargin,
       timesigScale,
 
+      midClefKeyRightMargin,
       clefKeyRightMargin,
       clefKeyDistance,
       clefTimesigDistance,

--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -184,7 +184,7 @@ EditStyle::EditStyle(Score* s, QWidget* parent)
       { Sid::clefLeftMargin,          false, clefLeftMargin,          resetClefLeftMargin },
       { Sid::keysigLeftMargin,        false, keysigLeftMargin,        resetKeysigLeftMargin },
       { Sid::timesigLeftMargin,       false, timesigLeftMargin,       resetTimesigLeftMargin },
-      { Sid::clefKeyRightMargin,      false, clefKeyRightMargin,      resetClefKeyRightMargin },
+      { Sid::midClefKeyRightMargin,   false, clefKeyRightMargin,      resetClefKeyRightMargin },
       { Sid::clefKeyDistance,         false, clefKeyDistance,         resetClefKeyDistance },
       { Sid::clefTimesigDistance,     false, clefTimesigDistance,     resetClefTimesigDistance },
       { Sid::keyTimesigDistance,      false, keyTimesigDistance,      resetKeyTimesigDistance },


### PR DESCRIPTION
See https://musescore.org/en/node/285535

The main issue here was a seemingly innocuous change to the alignment of clefs within their segment for the sake of palette display, but it ended up breaking mid-measure clef layout for scores with multiple staves.  That's because previously clefs had negative positions and hence could overlap notes on other staves just as accidentals can - the segment shapes don't collide.  But after that change, we ended up with bad spacing because layout would not allow the clefs to overlap the notes on other staves:

![image](https://user-images.githubusercontent.com/1799936/57803170-fed60180-7714-11e9-8a0a-a29cc11f6410.png)

Fixing this in clef.cpp, however, uncovered another problem, where clefs would not longer tuck in over notes on the same staff:

![image](https://user-images.githubusercontent.com/1799936/57803207-144b2b80-7715-11e9-9d1e-29d98a681fa8.png)

versus the expected (in 3.0.5, anyhow, and ignore the collision with the beam in both cases, which is unrelated):

![image](https://user-images.githubusercontent.com/1799936/57803229-24fba180-7715-11e9-87e6-839de61910f7.png)

It's not as big a deal - and it was essentially the same in 2.3.2 - but since the whole "shape" scheme was supposed to allow for this, it did seem worth addressing.  It turns out to have an interesting solution - Segment::minHorizontalDistance needs to be allowed to return negative values.  It fixes this case, and I'm hoping it might turn out to also allow tighter spacing in other similar cases.  So far I don't see any regressions from this, but more testing it definitely in order. [EDIT: see below, breaths needed to not return negative values, fixed now]

Here is how the original example now looks (more or less same as 2.3.2):

![image](https://user-images.githubusercontent.com/1799936/57807662-d8b55f00-771e-11e9-8b2d-3658b7586f57.png)
