### PR TITLE
fix #75626, fix #287520, restructure ChangeSpannerElements

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -260,7 +260,7 @@ bool LineSegment::edit(EditData& ed)
                      != note2->chord()->staff()->part()->instrument(note2->chord()->tick()) )
                         return true;
                   if (note1 != oldNote1 || note2 != oldNote2)
-                        spanner()->setNoteSpan(note1, note2);          // set new spanner span
+                        score()->undoChangeSpannerElements(spanner(), note1, note2);
                   }
                   break;
             case Spanner::Anchor::MEASURE:
@@ -368,9 +368,7 @@ void LineSegment::editDrag(EditData& ed)
                         Note* sNote   = toNote(l->startElement());
                         // do not change anchor if new note is before start note
                         if (sNote && sNote->chord() && noteNew->chord() && sNote->chord()->tick() < noteNew->chord()->tick()) {
-                              noteOld->removeSpannerBack(l);
-                              noteNew->addSpannerBack(l);
-                              l->setEndElement(noteNew);
+                              score()->undoChangeSpannerElements(l, sNote, noteNew);
 
                               _offset2 += noteOld->canvasPos() - noteNew->canvasPos();
                               }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -56,6 +56,7 @@
 #include "tempotext.h"
 #include "articulation.h"
 #include "revisions.h"
+#include "tie.h"
 #include "tiemap.h"
 #include "layoutbreak.h"
 #include "harmony.h"
@@ -4196,10 +4197,6 @@ void Score::changeVoice(int voice)
                   Note* note   = toNote(e);
                   Chord* chord = note->chord();
 
-                  // TODO - handle ties; for now we skip tied notes
-                  if (note->tieFor() || note->tieBack())
-                        continue;
-
                   // move grace notes with main chord only
                   if (chord->isGrace())
                         continue;
@@ -4284,6 +4281,14 @@ void Score::changeVoice(int voice)
                               // add new chord if one was created
                               if (dstChord != dstCR)
                                     undoAddCR(dstChord, m, s->tick());
+                              // reconnect the tie to this note, if any
+                              Tie* tie = note->tieBack();
+                              if (tie)
+                                    undoChangeSpannerElements(tie, tie->startNote(), newNote);
+                              // reconnect the tie from this note, if any
+                              tie = note->tieFor();
+                              if (tie)
+                                    undoChangeSpannerElements(tie, newNote, tie->endNote());
                               // remove original note
                               if (notes > 1) {
                                     undoRemoveElement(note);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -621,6 +621,7 @@ class Score : public QObject, public ScoreElement {
       void undoAddElement(Element* element);
       void undoAddCR(ChordRest* element, Measure*, const Fraction& tick);
       void undoRemoveElement(Element* element);
+      void undoChangeSpannerElements(Spanner* spanner, Element* startElement, Element* endElement);
       void undoChangeElement(Element* oldElement, Element* newElement);
       void undoChangePitch(Note* note, int pitch, int tpc1, int tpc2);
       void undoChangeFretting(Note* note, int pitch, int string, int fret, int tpc1, int tpc2);

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -2113,56 +2113,20 @@ void ChangeSpannerElements::flip(EditData*)
             // be sure new spanner elements are of the right type
             if (!startElement->isNote() || !endElement->isNote())
                   return;
-            Note* newStartNote;
-            Note* newEndNote;
-            Note* oldStartNote;
-            Note* oldEndNote;
-            int   startDeltaTrack   = oldStartElement->track() - startElement->track();
-            int   endDeltaTrack     = oldEndElement->track() - endElement->track();
-            // scan all spanners linked to this one
-            for (ScoreElement* el : spanner->linkList()) {
-                  Spanner*    sp    = static_cast<Spanner*>(el);
-                  newStartNote      = newEndNote = nullptr;
-                  oldStartNote      = toNote(sp->startElement());
-                  oldEndNote        = toNote(sp->endElement());
-                  // if not the current spanner, but one linked to it, determine its new start and end notes
-                  // as modifications 'parallel' to the modifications of the current spanner's start and end notes
-                  if (sp != spanner) {
-                        // determine the track where to expect the 'parallel' start element
-                        int   newTrack    = sp->startElement()->track() + startDeltaTrack;
-                        // look in notes linked to new start note for a note with
-                        // same score as linked spanner and appropriate track
-                        for (ScoreElement* newEl : startElement->linkList())
-                              if (static_cast<Note*>(newEl)->score() == sp->score()
-                                          && static_cast<Note*>(newEl)->track() == newTrack) {
-                                    newStartNote = static_cast<Note*>(newEl);
-                                    break;
-                                    }
-                        // similarly to determine the 'parallel' end element
-                        newTrack    = sp->endElement()->track() + endDeltaTrack;
-                        for (ScoreElement* newEl : endElement->linkList())
-                              if (static_cast<Note*>(newEl)->score() == sp->score()
-                                          && static_cast<Note*>(newEl)->track() == newTrack) {
-                                    newEndNote = static_cast<Note*>(newEl);
-                                    break;
-                                    }
-                        }
-                  // if current spanner, just use stored start and end elements
-                  else {
-                        newStartNote = toNote(startElement);
-                        newEndNote   = toNote(endElement);
-                        }
-                  // update spanner's start and end notes
-                  if (newStartNote && newEndNote) {
-                        oldStartNote->removeSpannerFor(sp);
-                        oldEndNote->removeSpannerBack(sp);
-                        sp->setNoteSpan(newStartNote, newEndNote);
-                        newStartNote->addSpannerFor(sp);
-                        newEndNote->addSpannerBack(sp);
+            Note* oldStartNote = toNote(oldStartElement);
+            Note* oldEndNote = toNote(oldEndElement);
+            Note* newStartNote = toNote(startElement);
+            Note* newEndNote = toNote(endElement);
+            // update spanner's start and end notes
+            if (newStartNote && newEndNote) {
+                  oldStartNote->removeSpannerFor(spanner);
+                  oldEndNote->removeSpannerBack(spanner);
+                  spanner->setNoteSpan(newStartNote, newEndNote);
+                  newStartNote->addSpannerFor(spanner);
+                  newEndNote->addSpannerBack(spanner);
 
-                        if (sp->isGlissando())
-                              oldEndNote->chord()->updateEndsGlissando();
-                        }
+                  if (spanner->isGlissando())
+                        oldEndNote->chord()->updateEndsGlissando();
                   }
             }
       else {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/75626.
Also resolves: https://musescore.org/en/node/287520.

This moves the code for handling linked parts in ChangeSpannerElements::flip() into a new method Score::undoChangeSpannerElements() where it belongs. This new method is then used to fix a bug pertaining to changing the anchor of a glissando, and also to allow the changeVoice feature to work on tied notes.