### PR TITLE
fix #289241: hairpin above won't stay in staff

### DIFF
--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -101,7 +101,7 @@ void HairpinSegment::layout()
       const int _trck = track();
       Dynamic* sd = nullptr;
       Dynamic* ed = nullptr;
-      qreal dymax = 0.0;
+      qreal dymax = hairpin()->placeBelow() ? -10000.0 : 10000.0;
       if (autoplace() && !score()->isPalette()) {
             // Try to fit between adjacent dynamics
             qreal minDynamicsDistance = score()->styleP(Sid::autoplaceHairpinDynamicsDistance) * staff()->mag(tick());
@@ -123,7 +123,7 @@ void HairpinSegment::layout()
             if (isSingleType() || isEndType()) {
                   Segment* end = hairpin()->endSegment();
                   if (end && end->tick() < sys->endTick()) {
-                        // checking ticks rather than systems since latter
+                        // checking ticks rather than systems
                         // systems may be unknown at layout stage.
                         ed = toDynamic(end->findAnnotation(ElementType::DYNAMIC, _trck, _trck));
                         }
@@ -271,7 +271,8 @@ void HairpinSegment::layout()
                   if (d > -md)
                         ymax -= d + md;
                   // align hairpin with dynamics
-                  ymax = qMin(ymax, dymax - ddiff);
+                  if (!hairpin()->diagonal())
+                        ymax = qMin(ymax, dymax - ddiff);
                   }
             else {
                   d  = system()->bottomDistance(staffIdx(), sl);


### PR DESCRIPTION
See https://musescore.org/en/node/289241.  Hairpins that have been placed "above" the staff, once moved onto the staff using the new skyline-crossing facility, won't stay there.

The bug was not actually "caused" by my recent change, more like "exposed" by it.  It was *caused* by a flaw in my previous code for vertically aligning hairpins with dynamics.  We're trying to align the hairpin with a non-existent dynamic, and trying to compute the Y position furthest from the staff.  That should mean treating the nonexistent dynamic as having a large positive position for the purpose of alignment when above staff, a large negative position when below, but we were just using 0.  Worked OK when the hairpin position itself would not be greater than 0 with above placement, but fails as soon as you allow autoplaced hairpins on the staff.

Main fix is just to change the default value of dymax.  However, the originally reported case actually shouldn't have triggered this at all, since the hairpin is diagonal and we should be disabling this alignment for diagonal hairpins.  But this happened only for hairpins placed below.  So that's now fixed to.  I also borrowed the hairpin-specific code borrowed from #4894, which addressed some issues with the calculation of default position values for hairpins, to make sure that didn't compound this issue.