### PR TITLE
fix #289286: figured bass properties and autoplace

### DIFF
--- a/libmscore/figuredbass.h
+++ b/libmscore/figuredbass.h
@@ -239,6 +239,8 @@ class FiguredBass final : public TextBase {
       void              layoutLines();
       bool              hasParentheses() const; // read / write MusicXML support
 
+      virtual Sid getPropertyStyle(Pid) const override;
+
    public:
       FiguredBass(Score* s = 0);
       FiguredBass(const FiguredBass&);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3871,8 +3871,10 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                               dynamics.push_back(d);
                               }
                         }
-                  else if (e->isFiguredBass())
+                  else if (e->isFiguredBass()) {
                         e->layout();
+                        e->autoplaceSegmentElement();
+                        }
                   }
             }
 

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -1129,6 +1129,7 @@ static const StyleType styleTypes[] {
       { Sid::trillMinDistance,              "trillMinDistance",              Spatium(1.0)  },
       { Sid::vibratoMinDistance,            "vibratoMinDistance",            Spatium(1.0)  },
       { Sid::voltaMinDistance,              "voltaMinDistance",              Spatium(1.0)  },
+      { Sid::figuredBassMinDistance,        "figuredBassMinDistance",        Spatium(0.5)  },
 
       { Sid::autoplaceEnabled,              "autoplaceEnabled",              true },
 

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1104,6 +1104,7 @@ enum class Sid {
       trillMinDistance,
       vibratoMinDistance,
       voltaMinDistance,
+      figuredBassMinDistance,
 
       autoplaceEnabled,
 


### PR DESCRIPTION
See https://musescore.org/en/node/289286

Figured bass has always been treated very specially.  We made a point *not* to have a text style for it since most of the parameters will be ignored, and yet it does inherit from TextBase, so it does use a text style (the default text style).  This worked OK for 2.x but as we went through various changes in the text style implementation for 3.0, figured bass got left behind.  The most obvious of the problems that resulted is OFFSET never getting written because we were deliberately avoid TextBase::writeProperties, but there are a number of other less severe issues.

While it would be possible to revisit the decision not to have a text style for figured bass, we'd have to then deal with all the same problems that caused us to decide not to in the first place.  So instead, I'm addressing the problems by adjusting the list of styled properties for figured bass.  I'm making sure only what is relevant gets marked as styled, and that getPropertyStyle() also uses only the approved styled properties.

Beyond that, I also added autoplace support which was trivial in comparison (and that's what actually led me to discover the other issues) and some glitches with layout.

EDIT: originally I had some extraneous text after this that was probably confusing...