### PR TITLE
fix #289293: articulation min distance not written

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -163,6 +163,8 @@ void Articulation::write(XmlWriter& xml) const
       xml.tag("subtype", Sym::id2name(_symId));
       writeProperty(xml, Pid::PLAY);
       writeProperty(xml, Pid::ORNAMENT_STYLE);
+      for (const StyledProperty& spp : *styledProperties())
+            writeProperty(xml, spp.pid);
       Element::writeProperties(xml);
       writeProperty(xml, Pid::ARTICULATION_ANCHOR);
       xml.etag();


### PR DESCRIPTION
See https://musescore.org/en/node/289293.  Just a matter of making sure we write the properties.  And in the case of fret diagrams, I needed to make it a styled property, as it was also not being initialized correctly.