### PR TITLE
Scale offsets with staff

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2567,6 +2567,31 @@ qreal Chord::dotPosX() const
       }
 
 //---------------------------------------------------------
+//   localSpatiumChanged
+//---------------------------------------------------------
+
+void Chord::localSpatiumChanged(qreal oldValue, qreal newValue)
+      {
+      ChordRest::localSpatiumChanged(oldValue, newValue);
+      for (Element* e : graceNotes())
+            e->localSpatiumChanged(oldValue, newValue);
+      if (_hook)
+            _hook->localSpatiumChanged(oldValue, newValue);
+      if (_stem)
+            _stem->localSpatiumChanged(oldValue, newValue);
+      if (_stemSlash)
+            _stemSlash->localSpatiumChanged(oldValue, newValue);
+      if (arpeggio())
+            arpeggio()->localSpatiumChanged(oldValue, newValue);
+      if (_tremolo && (tremoloChordType() != TremoloChordType::TremoloSecondNote))
+            _tremolo->localSpatiumChanged(oldValue, newValue);
+      for (Element* e : articulations())
+            e->localSpatiumChanged(oldValue, newValue);
+      for (Note* note : notes())
+            note->localSpatiumChanged(oldValue, newValue);
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -207,6 +207,7 @@ class Chord final : public ChordRest {
 
       virtual void crossMeasureSetup(bool on);
 
+      virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
       virtual QVariant getProperty(Pid propertyId) const override;
       virtual bool setProperty(Pid propertyId, const QVariant&) override;
       virtual QVariant propertyDefault(Pid) const override;

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -745,6 +745,8 @@ void ChordRest::add(Element* e)
                   qDebug("ChordRest::add: unknown element %s", e->name());
                   break;
             case ElementType::LYRICS:
+                  if (e->isStyled(Pid::OFFSET))
+                        e->setOffset(e->propertyDefault(Pid::OFFSET).toPointF());
                   _lyrics.push_back(toLyrics(e));
                   break;
             default:
@@ -800,6 +802,19 @@ void ChordRest::removeDeleteBeam(bool beamed)
 void ChordRest::undoSetBeamMode(Beam::Mode mode)
       {
       undoChangeProperty(Pid::BEAM_MODE, int(mode));
+      }
+
+//---------------------------------------------------------
+//   localSpatiumChanged
+//---------------------------------------------------------
+
+void ChordRest::localSpatiumChanged(qreal oldValue, qreal newValue)
+      {
+      DurationElement::localSpatiumChanged(oldValue, newValue);
+      for (Element* e : lyrics())
+            e->localSpatiumChanged(oldValue, newValue);
+      for (Element* e : el())
+            e->localSpatiumChanged(oldValue, newValue);
       }
 
 //---------------------------------------------------------

--- a/libmscore/chordrest.h
+++ b/libmscore/chordrest.h
@@ -151,6 +151,7 @@ class ChordRest : public DurationElement {
       TDuration crossMeasureDurationType() const      { return _crossMeasureTDur;   }
       void setCrossMeasureDurationType(TDuration v)   { _crossMeasureTDur = v;      }
 
+      virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
       virtual QVariant getProperty(Pid propertyId) const override;
       virtual bool setProperty(Pid propertyId, const QVariant&) override;
       virtual QVariant propertyDefault(Pid) const override;

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2547,6 +2547,23 @@ void Note::setNval(const NoteVal& nval, Fraction tick)
       }
 
 //---------------------------------------------------------
+//   localSpatiumChanged
+//---------------------------------------------------------
+
+void Note::localSpatiumChanged(qreal oldValue, qreal newValue)
+      {
+      Element::localSpatiumChanged(oldValue, newValue);
+      for (Element* e : dots())
+            e->localSpatiumChanged(oldValue, newValue);
+      for (Element* e : el())
+            e->localSpatiumChanged(oldValue, newValue);
+      for (Spanner* spanner : spannerBack()) {
+            for (auto k : spanner->spannerSegments())
+                  k->localSpatiumChanged(oldValue, newValue);
+            }
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -456,6 +456,7 @@ class Note final : public Element {
 
       void transposeDiatonic(int interval, bool keepAlterations, bool useDoubleAccidentals);
 
+      virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
       virtual QVariant getProperty(Pid propertyId) const override;
       virtual bool setProperty(Pid propertyId, const QVariant&) override;
       virtual QVariant propertyDefault(Pid) const override;

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -907,6 +907,19 @@ void Rest::read(XmlReader& e)
       }
 
 //---------------------------------------------------------
+//   localSpatiumChanged
+//---------------------------------------------------------
+
+void Rest::localSpatiumChanged(qreal oldValue, qreal newValue)
+      {
+      ChordRest::localSpatiumChanged(oldValue, newValue);
+      for (Element* e : _dots)
+            e->localSpatiumChanged(oldValue, newValue);
+      for (Element* e : el())
+            e->localSpatiumChanged(oldValue, newValue);
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 

--- a/libmscore/rest.h
+++ b/libmscore/rest.h
@@ -92,6 +92,7 @@ class Rest : public ChordRest {
       virtual qreal stemPosX() const;
       virtual QPointF stemPosBeam() const;
 
+      virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
       virtual bool setProperty(Pid propertyId, const QVariant& v) override;
       virtual QVariant getProperty(Pid propertyId) const override;
       virtual QVariant propertyDefault(Pid) const override;

--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -1413,8 +1413,10 @@ void Staff::localSpatiumChanged(double oldVal, double newVal, Fraction tick)
       int startTrack = staffIdx * VOICES;
       int endTrack = startTrack + VOICES;
       for (Segment* s = score()->tick2rightSegment(tick); s && s->tick() < etick; s = s->next1()) {
-            for (Element* e : s->annotations())
-                  e->localSpatiumChanged(oldVal, newVal);
+            for (Element* e : s->annotations()) {
+                  if (e->track() >= startTrack && e->track() < endTrack)
+                        e->localSpatiumChanged(oldVal, newVal);
+                  }
             for (int track = startTrack; track < endTrack; ++track) {
                   if (s->element(track))
                         s->element(track)->localSpatiumChanged(oldVal, newVal);

--- a/libmscore/tremolo.cpp
+++ b/libmscore/tremolo.cpp
@@ -121,7 +121,7 @@ void Tremolo::setTremoloType(TremoloType t)
 
 void Tremolo::layout()
       {
-      qreal _spatium  = spatium() * mag();
+      qreal _spatium  = score()->spatium() * mag();
 
       qreal w2  = _spatium * score()->styleS(Sid::tremoloWidth).val() * .5;
       qreal lw  = _spatium * score()->styleS(Sid::tremoloStrokeWidth).val();
@@ -228,7 +228,7 @@ void Tremolo::layout()
                      },
                   };
             int idx = _chord1->hook() ? 1 : (_chord1->beam() ? 2 : 0);
-            y = (line + t[idx][up][_lines-1][line & 1]) * spatium() * .5 / mag();
+            y = (line + t[idx][up][_lines-1][line & 1]) * .5 * _spatium;
 
             QTransform shearTransform;
             shearTransform.shear(0.0, -(lw / 2.0) / w2);


### PR DESCRIPTION
Further testing of my autoplace changes revealed already-existing flaws in the scaling of manual offsets for small staves, including a regression over 3.0.5 that I introduced with my improvements for small staves in #4935 where setting one staff to "small" affects the offsets of staff text on other staves.

So I have three commits here for the three separate issues fixed:

https://musescore.org/en/node/287839: the aforementioned issue with changes on one staff affecting staff text on another, fixed by making sure we only call localSpatiumChanged() for annotations in the correct track range

https://musescore.org/en/node/278314: an issue with scaling of tremolo that also affects chords made small, also affects the scaling of the tremolo bars themselves, we were not correctly dealing with the staff magnification vs the chord magnification in the layout calculations

https://musescore.org/en/node/289312: there was no localSpatiumChanged() override for chords or rests, so the staff size change was not being propagated to elements attached to them.  I added these, also reproduced one of my fixes from #5017 that turns out to be necessary for the default position of lyrics to scale correctly (although the fix was originally for a very a recent regression in layout of lyrics above staff, it turns out to also fix this scaling issue that was present in 3.0.5 as well).