### PR TITLE
fix #289211: bad layout of lyrics dashes at end of system

### DIFF
--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -126,6 +126,8 @@ class LyricsLine final : public SLine {
 
       Lyrics* lyrics() const                          { return toLyrics(parent());   }
       Lyrics* nextLyrics() const                      { return _nextLyrics;         }
+      bool isEndMelisma() const                       { return lyrics()->ticks().isNotZero(); }
+      bool isDash() const                             { return !isEndMelisma(); }
       virtual bool setProperty(Pid propertyId, const QVariant& v) override;
       virtual SpannerSegment* layoutSystem(System*) override;
       };

--- a/libmscore/lyricsline.cpp
+++ b/libmscore/lyricsline.cpp
@@ -91,7 +91,7 @@ void LyricsLine::styleChanged()
 void LyricsLine::layout()
       {
       bool tempMelismaTicks = (lyrics()->ticks() == Fraction::fromTicks(Lyrics::TEMP_MELISMA_TICKS));
-      if (lyrics()->ticks().isNotZero()) {              // melisma
+      if (isEndMelisma()) {         // melisma
             setLineWidth(score()->styleP(Sid::lyricsLineThickness));
             // if lyrics has a temporary one-chord melisma, set to 0 ticks (just its own chord)
             if (tempMelismaTicks)
@@ -304,7 +304,7 @@ bool LyricsLine::setProperty(Pid propertyId, const QVariant& v)
                   {
                   // if parent lyrics has a melisma, change its length too
                   if (parent() && parent()->type() == ElementType::LYRICS
-                              && toLyrics(parent())->ticks() > Fraction(0,1)) {
+                              && isEndMelisma()) {
                         Fraction newTicks   = toLyrics(parent())->ticks() + v.value<Fraction>() - ticks();
                         parent()->undoChangeProperty(Pid::LYRIC_TICKS, newTicks);
                         }
@@ -339,7 +339,7 @@ void LyricsLineSegment::layout()
       ryoffset() = 0.0;
 
       bool        endOfSystem       = false;
-      bool        isEndMelisma      = lyricsLine()->lyrics()->ticks() > Fraction(0,1);
+      bool        isEndMelisma      = lyricsLine()->isEndMelisma();
       Lyrics*     lyr               = 0;
       Lyrics*     nextLyr           = 0;
       qreal       fromX             = 0;
@@ -464,7 +464,7 @@ void LyricsLineSegment::draw(QPainter* painter) const
       pen.setWidthF(lyricsLine()->lineWidth());
       pen.setCapStyle(Qt::FlatCap);
       painter->setPen(pen);
-      if (lyricsLine()->lyrics()->ticks() > Fraction(0,1))           // melisma
+      if (lyricsLine()->isEndMelisma())               // melisma
             painter->drawLine(QPointF(), pos2());
       else {                                          // dash(es)
             qreal step  = pos2().x() / _numOfDashes;

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -598,7 +598,7 @@ void Spanner::computeEndElement()
                   if (ticks().isZero() && isTextLine() && parent())   // special case palette
                         setTicks(score()->lastSegment()->tick() - _tick);
 
-                  if (isLyricsLine()) {
+                  if (isLyricsLine() && toLyricsLine(this)->isEndMelisma()) {
                         // lyrics endTick should already indicate the segment we want
                         // except for TEMP_MELISMA_TICKS case
                         Lyrics* l = toLyricsLine(this)->lyrics();


### PR DESCRIPTION
See https://musescore.org/en/node/289211

This code in my previous PR #4946 was meant to apply only to melisma lines - they are the only ones for which lyric ticks is relevant.  But I forgot we use the same data structure for dashes, distinguished only by this very value (zero ticks means dashes, non-zero means melisma).  So I've just added a check for that to reinstate the original behavior for dashes.