### PR TITLE
fix #287397: unable to select bottom staves in single page view

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4227,11 +4227,9 @@ void LayoutContext::collectPage()
                   }
             }
 
-      qreal height = 0;
       Fraction stick = Fraction(-1,1);
       for (System* s : page->systems()) {
             Score* currentScore = s->score();
-            height += s->rypos();
             for (MeasureBase* mb : s->measures()) {
                   if (!mb->isMeasure())
                         continue;
@@ -4302,8 +4300,11 @@ void LayoutContext::collectPage()
                   }
             }
 
-      if (score->systemMode())
-            page->bbox().setRect(0.0, 0.0, score->loWidth(), height);
+      if (score->systemMode()) {
+            System* s = page->systems().last();
+            qreal height = s ? s->pos().y() + s->height() + s->minBottom() : page->tm();
+            page->bbox().setRect(0.0, 0.0, score->loWidth(), height + page->bm());
+            }
 
       page->rebuildBspTree();
       }


### PR DESCRIPTION
See https://musescore.org/en/node/287397

It's been reported that it's impossible to select anything after the first staff or so in single page view on a score with only a single system.  The trigger is actually not about the number of staves or systems, although it should correlate pretty well with that description.  It's really just a matter of us setting a totally bogus page height in single page (system) mode.  The calculation was adding together Y positions of systems, which produces too short a page at first then gradually becoming too large by a larger and larger margin.

I corrected the algorithm, should work much better now.