### PR TITLE
Vertical alignment support for fingering (sticking)

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -2206,9 +2206,12 @@ qreal Element::rebaseOffset(bool nox)
             p.rx() = 0.0;
       //OffsetChange saveChangedValue = _offsetChanged;
 
-      if (staff() && propertyFlags(Pid::PLACEMENT) != PropertyFlags::NOSTYLE) {
+      bool staffRelative = staff() && parent() && (parent()->isSegment() || parent()->isMeasure());
+      if (staffRelative && propertyFlags(Pid::PLACEMENT) != PropertyFlags::NOSTYLE) {
             // check if flipped
-            // TODO: elements that support PLACEMENT but not as a styled property
+            // TODO: elements that support PLACEMENT but not as a styled property (add supportsPlacement() method?)
+            // TODO: refactor to take advantage of existing cmdFlip() algorithms
+            // TODO: adjustPlacement() (from read206.cpp) on read for 3.0 as well
             QRectF r = bbox().translated(_changedPos);
             qreal staffHeight = staff()->height();
             Element* e = isSpannerSegment() ? toSpannerSegment(this)->spanner() : this;

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -492,6 +492,14 @@ Palette* MuseScore::newFingeringPalette()
             f->setXmlText(QString(finger[i]));
             sp->append(f, tr("String number %1").arg(finger[i]));
             }
+      finger = "RLrl";
+      for (unsigned i = 0; i < strlen(finger); ++i) {
+            Fingering* f = new Fingering(gscore, Tid::FINGERING);
+            f->setXmlText(QString(finger[i]));
+            f->setAlign(Align::HCENTER|Align::BASELINE);
+            f->setPropertyFlags(Pid::ALIGN, PropertyFlags::UNSTYLED);
+            sp->append(f, tr("Sticking %1").arg(finger[i]));
+            }
 
       static const std::vector<SymId> lute {
             SymId::stringsThumbPosition,

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -2039,6 +2039,30 @@
             <text>6</text>
             </Fingering>
           </Cell>
+        <Cell name="Sticking R">
+          <Fingering>
+            <align>center,baseline</align>
+            <text>R</text>
+            </Fingering>
+          </Cell>
+        <Cell name="Sticking L">
+          <Fingering>
+            <align>center,baseline</align>
+            <text>L</text>
+            </Fingering>
+          </Cell>
+        <Cell name="Sticking r">
+          <Fingering>
+            <align>center,baseline</align>
+            <text>r</text>
+            </Fingering>
+          </Cell>
+        <Cell name="Sticking l">
+          <Fingering>
+            <align>center,baseline</align>
+            <text>l</text>
+            </Fingering>
+          </Cell>
         <Cell name="Thumb position">
           <Articulation>
             <subtype>stringsThumbPosition</subtype>


### PR DESCRIPTION
Every so often we get requests for fingerings to honor vertical alignment (baseline or bottom, mostly) so they can be aligned from note to note.  See for instance https://musescore.org/en/node/287978#comment-919484, but I also recall it coming up in the context of accordion and other contexts.  The idea is to allow the baselines of the "R" and "r" to be aligned as I have it here, without the need to individual manual adjustments:

![image](https://user-images.githubusercontent.com/1799936/57986857-4e7b3c80-7a37-11e9-91d1-8c2afe64de61.png)

Currently, the default position of fingering - the "zero" point from which any offset is applied - is above/below the note.  But in order for vertical alignment of fingerings to work, the offset really needs to be applied consistently from the top/bottom of the staff.  So that's what this PR does - in the specific case of fingerings set to something other than the default of VCENTER alignment, I set the staff top/bottom as the origin rather than the note top/bottom.  In those cases, I also skip some of the special processing we use to stack fingerings more tightly.  So the result is layout that is basically the same as other types of text, but like other fingerings gets laid out early (eg, before dynamics), which is an important reason people want to use fingering for this rather than the staff text.

I could have introduced a new text style for this, but I elected not to for compatibility reasons (3.0 would not recognize it).  On the other hand, 3.0 won't lay out these fingerings correctly either, but at least it won't show additional bad effects specifically related to the text style not being recognized.

An advantage, however, would be that we could also introduce a vertical offset to keep the fingerings higher above the staff by default and thus less likely to be displaced by notes above the staff.