### PR TITLE
fix compiler warnings

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3759,7 +3759,6 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "relayout",                   [this]{ cmdRelayout();                                              }},
             { "toggle-autoplace",           [this]{ cmdToggleAutoplace(false);                                  }},
             { "autoplace-enabled",          [this]{ cmdToggleAutoplace(true);                                   }},
-            { "",                           [this]{                                                             }},
             };
 
       for (const auto& c : cmdList) {

--- a/libmscore/connector.cpp
+++ b/libmscore/connector.cpp
@@ -277,7 +277,7 @@ ConnectorInfo* ConnectorInfo::end()
 //---------------------------------------------------------
 
 ConnectorInfoReader::ConnectorInfoReader(XmlReader& e, Element* current, int track)
-   : ConnectorInfo(current, track), _reader(&e), _connector(nullptr), _currentElement(current), _connectorReceiver(current)
+   : ConnectorInfo(current, track), _reader(&e), _connector(nullptr), _connectorReceiver(current)
       {}
 
 //---------------------------------------------------------
@@ -295,7 +295,7 @@ static Location readPositionInfo(const XmlReader& e, int track) {
 //---------------------------------------------------------
 
 ConnectorInfoReader::ConnectorInfoReader(XmlReader& e, Score* current, int track)
-   : ConnectorInfo(current, readPositionInfo(e, track)), _reader(&e), _connector(nullptr), _currentElement(nullptr), _connectorReceiver(current)
+   : ConnectorInfo(current, readPositionInfo(e, track)), _reader(&e), _connector(nullptr), _connectorReceiver(current)
       {
       setCurrentUpdated(true);
       }

--- a/libmscore/connector.h
+++ b/libmscore/connector.h
@@ -96,7 +96,6 @@ class ConnectorInfo {
 class ConnectorInfoReader final : public ConnectorInfo {
       XmlReader* _reader;
       Element* _connector;
-      Element* _currentElement;
       ScoreElement* _connectorReceiver;
 
       void readEndpointLocation(Location& l);

--- a/libmscore/line.h
+++ b/libmscore/line.h
@@ -71,10 +71,6 @@ class SLine : public Spanner {
       qreal _dashGapLen       { 5.0   };
       bool _diagonal          { false };
 
-      PropertyFlags lineWidthStyle;
-      PropertyFlags lineStyleStyle;
-      PropertyFlags lineColorStyle;
-
    protected:
       virtual QPointF linePos(Grip, System** system) const;
 

--- a/libmscore/lyricsline.cpp
+++ b/libmscore/lyricsline.cpp
@@ -25,10 +25,6 @@
 
 namespace Ms {
 
-// metrics for dashes and melisma; all in sp. units:
-static constexpr qreal  LYRICS_DASH_Y_POS_RATIO             = 0.67;     // the fraction of lyrics font x-height to
-                                                                        //    raise the dashes above text base line;
-
 //---------------------------------------------------------
 //   searchNextLyrics
 //---------------------------------------------------------

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -428,9 +428,6 @@ void Score::fixTicks()
       for (Staff* staff : _staves)
             staff->clearTimeSig();
 
-      Fraction sig(fm->ticks());
-      Fraction nomSig(fm->timesig());
-
       if (isMaster()) {
             tempomap()->clear();
             sigmap()->clear();

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -832,7 +832,7 @@ class Score : public QObject, public ScoreElement {
       virtual const MStyle& style() const  { return _style;                  }
 
       void setStyle(const MStyle& s);
-      bool loadStyle(const QString&, bool ignore = false);
+      bool loadStyle(const QString&, bool ign = false);
       bool saveStyle(const QString&);
 
       QVariant styleV(Sid idx) const  { return style().value(idx);   }

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -655,12 +655,12 @@ bool Score::saveFile(QFileInfo& info)
 //   loadStyle
 //---------------------------------------------------------
 
-bool Score::loadStyle(const QString& fn, bool ignore)
+bool Score::loadStyle(const QString& fn, bool ign)
       {
       QFile f(fn);
       if (f.open(QIODevice::ReadOnly)) {
             MStyle st = style();
-            if (st.load(&f, ignore)) {
+            if (st.load(&f, ign)) {
                   undo(new ChangeStyle(this, st));
                   return true;
                   }

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -394,26 +394,6 @@ void SlurSegment::computeBezier(QPointF p6o)
       }
 
 //---------------------------------------------------------
-//   slurDistance
-//---------------------------------------------------------
-
-inline static qreal slurDistance(const Shape& shape, const QPointF& pt, qreal sdist, bool up)
-      {
-      qreal ddy;
-      if (up) {
-            ddy = -shape.bottomDistance(pt) + sdist;
-            if (ddy <= 0.0)   // assume no more collisions
-                  ddy = 0.0;
-            }
-      else {
-            ddy = shape.topDistance(pt) - sdist;
-            if (ddy >= 0.0)
-                  ddy = 0.0;
-            }
-      return ddy;
-      }
-
-//---------------------------------------------------------
 //   layoutSegment
 //---------------------------------------------------------
 

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -2422,7 +2422,7 @@ bool MStyle::readTextStyleValCompat(XmlReader& e)
 //   load
 //---------------------------------------------------------
 
-bool MStyle::load(QFile* qf, bool ignore)
+bool MStyle::load(QFile* qf, bool ign)
       {
       XmlReader e(qf);
       while (e.readNextStartElement()) {
@@ -2430,7 +2430,7 @@ bool MStyle::load(QFile* qf, bool ignore)
                   QString version = e.attribute("version");
                   QStringList sl  = version.split('.');
                   int mscVersion  = sl[0].toInt() * 100 + sl[1].toInt();
-                  if (mscVersion != MSCVERSION && !ignore)
+                  if (mscVersion != MSCVERSION && !ign)
                         return false;
                   while (e.readNextStartElement()) {
                         if (e.name() == "Style")

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -1167,7 +1167,7 @@ class MStyle {
       void setCustomChordList(bool t) { _customChordList = t; }
       void checkChordList();
 
-      bool load(QFile* qf, bool ignore = false);
+      bool load(QFile* qf, bool ign = false);
       void load(XmlReader& e);
       void save(XmlWriter& xml, bool optimize);
       bool readProperties(XmlReader&);

--- a/libmscore/sym.cpp
+++ b/libmscore/sym.cpp
@@ -40,7 +40,7 @@ QVector<ScoreFont> ScoreFont::_scoreFonts {
       ScoreFont("MuseJazz",   "MuseJazz",     ":/fonts/musejazz/", "MuseJazz.otf" ),
       };
 
-std::array<uint, size_t(SymId::lastSym)+1> ScoreFont::_mainSymCodeTable { 0 };
+std::array<uint, size_t(SymId::lastSym)+1> ScoreFont::_mainSymCodeTable { {0} };
 
 //---------------------------------------------------------
 //   table of symbol names

--- a/libmscore/symbol.cpp
+++ b/libmscore/symbol.cpp
@@ -59,7 +59,6 @@ void Symbol::layout()
       // foreach(Element* e, leafs())     done in BSymbol::layout() ?
       //      e->layout();
       setbbox(_scoreFont ? _scoreFont->bbox(_sym, magS()) : symBbox(_sym));
-      QPointF o(offset());
       qreal w = width();
       QPointF p;
       if (align() & Align::BOTTOM)

--- a/libmscore/tremolo.cpp
+++ b/libmscore/tremolo.cpp
@@ -186,11 +186,11 @@ QPainterPath Tremolo::basePath() const
       qreal lw  = _spatium * score()->styleS(Sid::tremoloStrokeWidth).val();
       qreal td  = _spatium * score()->styleS(Sid::tremoloDistance).val();
 
-      QPainterPath path;
+      QPainterPath ppath;
       qreal ty  = 0.0;
 
       for (int i = 0; i < _lines; i++) {
-            path.addRect(-w2, ty, 2.0 * w2, lw);
+            ppath.addRect(-w2, ty, 2.0 * w2, lw);
             ty += td;
             }
 
@@ -198,15 +198,15 @@ QPainterPath Tremolo::basePath() const
             // just for the palette
             QTransform shearTransform;
             shearTransform.shear(0.0, -(lw / 2.0) / w2);
-            path = shearTransform.map(path);
+            ppath = shearTransform.map(ppath);
             }
       else if (!twoNotes()) {
             QTransform shearTransform;
             shearTransform.shear(0.0, -(lw / 2.0) / w2);
-            path = shearTransform.map(path);
+            ppath = shearTransform.map(ppath);
             }
 
-      return path;
+      return ppath;
       }
 
 //---------------------------------------------------------

--- a/mscore/fotomode.cpp
+++ b/mscore/fotomode.cpp
@@ -467,9 +467,9 @@ void ScoreView::fotoModeCopy(bool includeLink)
             printer.save(&buffer, "PNG");
             buffer.close();
             QString html = "<a href=\"" + url.toString() + "\"><img src=\"data:image/png," + imageData.toPercentEncoding() + "\" /></a>";
-            QMimeData *data = new QMimeData;
-            data->setHtml(html);
-            QApplication::clipboard()->setMimeData(data);
+            QMimeData *mdata = new QMimeData;
+            mdata->setHtml(html);
+            QApplication::clipboard()->setMimeData(mdata);
             // TODO: add both, with priority to html
             //QApplication::clipboard()->setImage(printer);
             }

--- a/mscore/inspector/inspectorBarline.cpp
+++ b/mscore/inspector/inspectorBarline.cpp
@@ -74,10 +74,10 @@ void InspectorBarLine::setAsStaffDefault()
 
       Score* score = ebl->score();
       score->startCmd();
-      for (Element* e : *inspector->el()) {
-            if (!e || !e->isBarLine())
+      for (Element* el : *inspector->el()) {
+            if (!el || !el->isBarLine())
                   continue;
-            BarLine* bl = toBarLine(e);
+            BarLine* bl = toBarLine(el);
             Staff* staff = bl->staff();
             if (std::find(staffList.begin(), staffList.end(), staff) == staffList.end()) {
                   staff->undoChangeProperty(Pid::STAFF_BARLINE_SPAN,      span);

--- a/mscore/ove.cpp
+++ b/mscore/ove.cpp
@@ -592,7 +592,6 @@ int OveSong::getPartBarCount() const {
       }
 
 QPair<int, int> OveSong::trackToPartStaff(int track) const {
-      QPair<int, int> partStaff;
       int i;
       int staffCount = 0;
 

--- a/mscore/updatechecker.cpp
+++ b/mscore/updatechecker.cpp
@@ -27,6 +27,7 @@
 
 namespace Ms {
 
+#if !defined(Q_OS_MAC) && (!defined(Q_OS_WIN) || defined(MSCORE_UNSTABLE))
 //---------------------------------------------------------
 //   default period
 //---------------------------------------------------------
@@ -42,6 +43,7 @@ static int defaultPeriod()
             }
       return result;
       }
+#endif
 
 UpdateChecker::UpdateChecker(QObject* parent)
       : UpdateCheckerBase(parent)

--- a/thirdparty/portmidi/CMakeLists.txt
+++ b/thirdparty/portmidi/CMakeLists.txt
@@ -20,6 +20,7 @@
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNEWBUFFER -DPMNULL")
 
 if (APPLE)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations -Wno-macro-redefined")
   file(GLOB_RECURSE INCS "*.h")
 
   add_library (

--- a/zerberus/zerberus.cpp
+++ b/zerberus/zerberus.cpp
@@ -49,7 +49,7 @@ Zerberus::Zerberus()
             }
       
       freeVoices.init(this);
-      for (int i = 0; i < MAX_CHANNEL; ++i)
+      for (int i = 0; i < MAX_CHANNELS; ++i)
             _channel[i] = new Channel(this, i);
       busy = true;      // no sf loaded yet
       }
@@ -178,9 +178,10 @@ void Zerberus::play(const Ms::PlayEvent& event)
       {
       if (busy)
             return;
-      if (event.channel() >= MAX_CHANNEL)
-            return;
-      Channel* cp = _channel[int(event.channel())];
+      static_assert(MAX_CHANNELS - 1 >= std::numeric_limits<decltype(event.channel())>::max(), "need to add a check for a channel number range");
+      //if (event.channel() >= MAX_CHANNELS)
+      //      return;
+      Channel* cp = _channel[event.channel()];
       if (cp->instrument() == 0) {
             // qDebug("Zerberus::play(): no instrument for channel %d", event.channel());
             return;
@@ -363,12 +364,12 @@ bool Zerberus::removeSoundFont(const QString& s)
                   if (it == instruments.end())
                         return false;
                   instruments.erase(it);
-                  for (int k = 0; k < MAX_CHANNEL; ++k) {
+                  for (int k = 0; k < MAX_CHANNELS; ++k) {
                         if (_channel[k]->instrument() == i)
                               _channel[k]->setInstrument(0);
                         }
                   if (!instruments.empty()) {
-                        for (int ii = 0; ii < MAX_CHANNEL; ++ii) {
+                        for (int ii = 0; ii < MAX_CHANNELS; ++ii) {
                               if (_channel[ii]->instrument() == 0)
                                     _channel[ii]->setInstrument(instruments.front());
                               }
@@ -454,7 +455,7 @@ bool Zerberus::loadInstrument(const QString& s)
                   instruments.push_back(instr);
                   instr->setRefCount(instr->refCount() + 1);
                   if (instruments.size() == 1) {
-                        for (int i = 0; i < MAX_CHANNEL; ++i)
+                        for (int i = 0; i < MAX_CHANNELS; ++i)
                               _channel[i]->setInstrument(instr);
                         }
                   busy = false;
@@ -482,7 +483,7 @@ bool Zerberus::loadInstrument(const QString& s)
                   // set default instrument for all channels:
                   //
                   if (instruments.size() == 1) {
-                        for (int i = 0; i < MAX_CHANNEL; ++i)
+                        for (int i = 0; i < MAX_CHANNELS; ++i)
                               _channel[i]->setInstrument(instr);
                         }
                   busy = false;

--- a/zerberus/zerberus.h
+++ b/zerberus/zerberus.h
@@ -30,9 +30,9 @@ class Channel;
 class ZInstrument;
 enum class Trigger : char;
 
-static const int MAX_VOICES  = 512;
-static const int MAX_CHANNEL = 256;
-static const int MAX_TRIGGER = 512;
+static const int MAX_VOICES   = 512;
+static const int MAX_CHANNELS = 256;
+static const int MAX_TRIGGER  = 512;
 
 //---------------------------------------------------------
 //   VoiceFifo
@@ -81,7 +81,7 @@ class Zerberus : public Ms::Synthesizer {
       std::atomic<bool> busy;
 
       std::list<ZInstrument*> instruments;
-      Channel* _channel[MAX_CHANNEL];
+      Channel* _channel[MAX_CHANNELS];
 
       int allocatedVoices = 0;
       VoiceFifo freeVoices;


### PR DESCRIPTION
all for Windows (MSVC and MinGW), the only for Linux and all but those those I don't understand* for Mac (XCode). Mac changes not verfied though, Travis doesn't run the Mac builds on PRs, so a review is needed.

*) Esp. those on XCode 10.2, about non-virtual destructors are beyond my pay grade I'm affraid. But now as we're back on XCode 9.4, those are gone anyhow.