### PR TITLE
disable autoflip for fingering

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -2210,9 +2210,12 @@ qreal Element::rebaseOffset(bool nox)
             p.rx() = 0.0;
       //OffsetChange saveChangedValue = _offsetChanged;
 
-      if (staff() && propertyFlags(Pid::PLACEMENT) != PropertyFlags::NOSTYLE) {
+      bool staffRelative = staff() && parent() && !(parent()->isNote() || parent()->isRest());
+      if (staffRelative && propertyFlags(Pid::PLACEMENT) != PropertyFlags::NOSTYLE) {
             // check if flipped
-            // TODO: elements that support PLACEMENT but not as a styled property
+            // TODO: elements that support PLACEMENT but not as a styled property (add supportsPlacement() method?)
+            // TODO: refactor to take advantage of existing cmdFlip() algorithms
+            // TODO: adjustPlacement() (from read206.cpp) on read for 3.0 as well
             QRectF r = bbox().translated(_changedPos);
             qreal staffHeight = staff()->height();
             Element* e = isSpannerSegment() ? toSpannerSegment(this)->spanner() : this;


### PR DESCRIPTION
The autoflip code (automatically change placement when user manually moves an element to opposite side of staff) was only designed to work for elements that are actually placed relative to the staff.  Fingerings are placed relative to the note, so the detection of when we have flipped is wrong, so is the adjustment to the offset, resulting in cases where we set placement to below even though you're actually above or vice versa, and a sudden jump in the offset too.

In principle this is fixable, but the right way to do so is to rearchitect things a bit as discussed in the thread #4982.  So for now I'm just disabling the autoflip code for elements attached to notes or rests.  This also includes lyrics attached to rests, which have the same issue.  Most lyrics are attached to *chords*, not notes, and this still works.