### PR TITLE
fix #289423: correct origin for note anchored lines

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -715,9 +715,10 @@ QPointF SLine::linePos(Grip grip, System** sys) const
                   Element* e = grip == Grip::START ? startElement() : endElement();
                   if (!e)
                         return QPointF();
-                  System* s = toNote(e)->chord()->segment()->system();
+                  Note* n = toNote(e);
+                  System* s = n->chord()->segment()->system();
                   if (s == 0) {
-                        qDebug("no system: %s  start %s chord parent %s\n", name(), e->name(), toNote(e)->chord()->parent()->name());
+                        qDebug("no system: %s  start %s chord parent %s\n", name(), n->name(), n->chord()->parent()->name());
                         return QPointF();
                         }
                   *sys = s;
@@ -725,7 +726,9 @@ QPointF SLine::linePos(Grip grip, System** sys) const
 //                  QPointF     elemPagePos = e->pagePos();                   // DEBUG
 //                  QPointF     systPagePos = s->pagePos();
 //                  qreal       staffYPage  = s->staffYpage(e->staffIdx());
-                  return e->pagePos() - s->pagePos();
+                  QPointF p = n->pagePos() - s->pagePos();
+                  p.rx() += n->width() * 0.5;
+                  return p;
                   }
 
             case Spanner::Anchor::CHORD:

--- a/libmscore/textline.cpp
+++ b/libmscore/textline.cpp
@@ -133,15 +133,23 @@ LineSegment* TextLine::createLineSegment()
 
 Sid TextLineSegment::getPropertyStyle(Pid pid) const
       {
-      if (pid == Pid::OFFSET)
-            return spanner()->placeAbove() ? Sid::textLinePosAbove : Sid::textLinePosBelow;
+      if (pid == Pid::OFFSET) {
+            if (spanner()->anchor() == Spanner::Anchor::NOTE)
+                  return Sid::NOSTYLE;
+            else
+                  return spanner()->placeAbove() ? Sid::textLinePosAbove : Sid::textLinePosBelow;
+            }
       return TextLineBaseSegment::getPropertyStyle(pid);
       }
 
 Sid TextLine::getPropertyStyle(Pid pid) const
       {
-      if (pid == Pid::OFFSET)
-            return placeAbove() ? Sid::textLinePosAbove : Sid::textLinePosBelow;
+      if (pid == Pid::OFFSET) {
+            if (anchor() == Spanner::Anchor::NOTE)
+                  return Sid::NOSTYLE;
+            else
+                  return placeAbove() ? Sid::textLinePosAbove : Sid::textLinePosBelow;
+            }
       return TextLineBase::getPropertyStyle(pid);
       }
 


### PR DESCRIPTION
See https://musescore.org/en/node/289423

This was originally reported as a request to improve the horizontal alignment of note anchored lines - and have long been bothered by this too, just not enough to fix it.  But then it was observed that I caused a regression in the *vertical* alignment with a fix for text lines in #4894.  See in particular my comment https://github.com/musescore/MuseScore/pull/4894#issuecomment-481970618, where I discussed the tradeoffs involved in allowing text lines to honor their style setting, which they previously weren't.  I neglected to take into account the fact that note anchored lines would be affected as well.

Since there no particular reason why most people would need to customize a style setting for the offset of note anchored lines, I didn't introduce one - I just made them stop honoring the textline one, so they are back to zero vertical offset.  And fixed the horizontal position to connect centers as originally requested and I agree with.
