### PR TITLE
fix #289453: [Regression] Unable to start slur mode (within note input) in voice > 1 at end of measure

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3366,7 +3366,7 @@ void ScoreView::cmdAddSlur(ChordRest* cr1, ChordRest* cr2)
       if (cr2 == 0) {
             cr2 = nextChordRest(cr1);
             if (cr2 == 0)
-                  return;
+                  cr2 = cr1;
             startEditMode = true;      // start slur in edit mode if last chord is not given
             }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/289453.

This reverts one line of code to the way it was before #4077. 