### PR TITLE
"Concert Pitch" button styling to better show state - option to address #283120

### DIFF
--- a/mscore/miconengine.cpp
+++ b/mscore/miconengine.cpp
@@ -159,6 +159,10 @@ void MIconEnginePrivate::loadDataForModeAndState(QSvgRenderer* renderer, QIcon::
                                     auto colorName = Ms::preferences.getColor(PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_LIGHT_ON).name().toLatin1();
                                     ba.replace("#3b3f45", colorName).replace("#3B3F45", colorName).replace("rgb(59,63,69)", colorName);
                                     }
+                              else {
+                                    auto colorName = Ms::preferences.getColor(PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_LIGHT_OFF).name().toLatin1();
+                                    ba.replace("#3b3f45", colorName).replace("#3B3F45", colorName).replace("rgb(59,63,69)", colorName);
+                              }
                               }
                         }
                   renderer->load(ba);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1213,7 +1213,9 @@ MuseScore::MuseScore()
       cpitchTools->setObjectName("pitch-tools");
       a = getAction("concert-pitch");
       a->setCheckable(true);
-      cpitchTools->addWidget(new AccessibleToolButton(cpitchTools, a));
+      AccessibleToolButton* concertPitchButton = new AccessibleToolButton(cpitchTools, a);
+      concertPitchButton->setProperty("iconic-text", true);
+      cpitchTools->addWidget(concertPitchButton);
 
       //-------------------------------
       //    Image Capture Tool Bar
@@ -7043,6 +7045,19 @@ void MuseScore::updateUiStyleAndTheme()
       css.replace("$voice2-bgcolor", MScore::selectColor[1].name(QColor::HexRgb));
       css.replace("$voice3-bgcolor", MScore::selectColor[2].name(QColor::HexRgb));
       css.replace("$voice4-bgcolor", MScore::selectColor[3].name(QColor::HexRgb));
+
+      if (preferences.isThemeDark()) {
+            css.replace("$buttonHighlightDisabledOff", Ms::preferences.getColor(PREF_UI_BUTTON_HIGHLIGHT_COLOR_DISABLED_DARK_OFF).name().toLatin1());
+            css.replace("$buttonHighlightDisabledOn", Ms::preferences.getColor(PREF_UI_BUTTON_HIGHLIGHT_COLOR_DISABLED_DARK_ON).name().toLatin1());
+            css.replace("$buttonHighlightEnabledOff", Ms::preferences.getColor(PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_DARK_OFF).name().toLatin1());
+            css.replace("$buttonHighlightEnabledOn", Ms::preferences.getColor(PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_DARK_ON).name().toLatin1());
+      } else {
+            css.replace("$buttonHighlightDisabledOff", Ms::preferences.getColor(PREF_UI_BUTTON_HIGHLIGHT_COLOR_DISABLED_LIGHT_OFF).name().toLatin1());
+            css.replace("$buttonHighlightDisabledOn", Ms::preferences.getColor(PREF_UI_BUTTON_HIGHLIGHT_COLOR_DISABLED_LIGHT_ON).name().toLatin1());
+            css.replace("$buttonHighlightEnabledOff", Ms::preferences.getColor(PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_LIGHT_OFF).name().toLatin1());
+            css.replace("$buttonHighlightEnabledOn", Ms::preferences.getColor(PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_LIGHT_ON).name().toLatin1());
+      }
+
       qApp->setStyleSheet(css);
 
       QString style = QString("*, QSpinBox { font: %1pt \"%2\" } ")

--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -209,7 +209,8 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_BUTTON_HIGHLIGHT_COLOR_DISABLED_LIGHT_OFF,    new ColorPreference(QColor("#a0a0a0"))},
             {PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_DARK_ON,       new ColorPreference(QColor("#43C1F7"))},
             {PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_DARK_OFF,      new ColorPreference(QColor("#eff0f1"))},
-            {PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_LIGHT_ON,      new ColorPreference(QColor("#205E78"))}
+            {PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_LIGHT_ON,      new ColorPreference(QColor("#205E78"))},
+            {PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_LIGHT_OFF,     new ColorPreference(QColor("#3b3f45"))}
       });
 
       _initialized = true;

--- a/mscore/preferences.h
+++ b/mscore/preferences.h
@@ -208,6 +208,7 @@ enum class MusicxmlExportBreaks : char {
 #define PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_DARK_ON      "ui/button/highlight/color/enabled/dark/on"
 #define PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_DARK_OFF     "ui/button/highlight/color/enabled/dark/off"
 #define PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_LIGHT_ON     "ui/button/highlight/color/enabled/light/on"
+#define PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_LIGHT_OFF    "ui/button/highlight/color/enabled/light/off"
 
 
 

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -195,6 +195,13 @@ void MuseScore::updateIcons()
                   widget->setFixedHeight(preferences.getInt(PREF_UI_THEME_ICONHEIGHT) + 8);  // hack
                   // apparently needed for viewModeCombo, see MuseScore::populateFileOperations
             }
+      for (QAction* a : cpitchTools->actions()) {
+            QWidget* widget = cpitchTools->widgetForAction(a);
+            if (widget->property("iconic-text") == true)
+                  widget->setFixedHeight(preferences.getInt(PREF_UI_THEME_ICONHEIGHT) + 8);  // hack
+                  // so that toolbar buttons with text but no icon can match
+                  // the height of other toolbar buttons
+            }
       }
 
 //---------------------------------------------------------

--- a/share/themes/style_dark_fusion.css
+++ b/share/themes/style_dark_fusion.css
@@ -50,5 +50,11 @@ QToolButton[voice4="true"]:checked, QToolButton[voice4="true"]:pressed { color: 
 /* Toolbar voice selector */
 QToolButton#voice:checked, QToolButton#voice:pressed { color: white; }
 
+/* ToolbarButton text to match ToolbarButton icons */
+QToolButton[iconic-text="true"] { color: $buttonHighlightEnabledOff; }
+QToolButton[iconic-text="true"]:enabled:checked { color: $buttonHighlightEnabledOn; }
+QToolButton[iconic-text="true"]:disabled { color: $buttonHighlightDisabledOff; }
+QToolButton[iconic-text="true"]:disabled:checked { color: $buttonHighlightDisabledOn; }
+
 /* Mainly in midi import */
 QTableView { border: none; }

--- a/share/themes/style_light_fusion.css
+++ b/share/themes/style_light_fusion.css
@@ -50,6 +50,12 @@ QToolButton[voice4="true"]:checked, QToolButton[voice4="true"]:pressed { color: 
 /* Toolbar voice selector */
 QToolButton#voice:checked, QToolButton#voice:pressed { color: white; }
 
+/* ToolbarButton text to match ToolbarButton icons */
+QToolButton[iconic-text="true"] { color: $buttonHighlightEnabledOff; }
+QToolButton[iconic-text="true"]:enabled:checked { color: $buttonHighlightEnabledOn; }
+QToolButton[iconic-text="true"]:disabled { color: $buttonHighlightDisabledOff; }
+QToolButton[iconic-text="true"]:disabled:checked { color: $buttonHighlightDisabledOn; }
+
 /* Mainly in midi import */
 QTableView { border: none; }
 


### PR DESCRIPTION
Add code to both theme stylesheets to style toolbar text so that it matches the
colors of the toolbar icons. Currently colouring of icons relies on hard coded numbers in
the miconeninge.cpp. This fix gets button text working right away. A follow
on fix will get miconengine.cpp to pull values out of  palette_light.json and
palette_dark.json so that colouring of toolbar icons and text is always
consistent and controlled entirely by those json files.

This would provide some partial intermediate relief for the "Concert Pitch" 
toolbar button state not being easy to recognise. Just now the "Concert
Pitch" button is the only toolbar button with text.

![concert ptich](https://user-images.githubusercontent.com/3323784/58136501-2c93dc80-7c26-11e9-956f-e187fc4d3e7f.png)