### PR TITLE
Cross-staff beam regressions

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1624,6 +1624,7 @@ void Beam::layout2(std::vector<ChordRest*>crl, SpannerSegmentType, int frag)
                               // we should relayout entire measure
                               // this probably means starting over for beam as well
                               // see https://musescore.org/en/node/71901
+                              // also see https://musescore.org/en/node/289492
                               }
                         }
 

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -701,7 +701,7 @@ void Slur::slurPos(SlurPos* sp)
       if (scr->up() == _up && stem1 && sc->hook()) {
             sa1 = SlurAnchor::STEM;
             // if end chord is in same direction, link end of slur to stem too
-            if (ecr->up() == scr->up() && stem2)
+            if (ecr->up() == scr->up() && stem2 && (!ecr->beam() || !ecr->beam()->cross()))
                   sa2 = SlurAnchor::STEM;
             }
 
@@ -773,7 +773,11 @@ void Slur::slurPos(SlurPos* sp)
 
             if (stem1) { //sc not null
                   Beam* beam1 = sc->beam();
-                  if (beam1 && (beam1->elements().back() != sc) && (sc->up() == _up)) {
+                  if (beam1 && beam1->cross()) {
+                        // TODO: stem direction is not finalized, so we cannot use it here
+                        yo = fixArticulations(yo, sc, __up, false);
+                        }
+                  else if (beam1 && (beam1->elements().back() != sc) && (sc->up() == _up)) {
                         // start chord is beamed but not the last chord of beam group
                         // and slur direction is same as start chord (stem side)
 
@@ -873,7 +877,11 @@ void Slur::slurPos(SlurPos* sp)
 
                   if (stem2) { //ec can't be null
                         Beam* beam2 = ec->beam();
-                        if ((stemPos && (scr->up() == ec->up()))
+                        if (beam2 && beam2->cross()) {
+                              // TODO: stem direction is not finalized, so we cannot use it here
+                              yo = fixArticulations(yo, ec, __up, false);
+                              }
+                        else if ((stemPos && (scr->up() == ec->up()))
                            || (beam2
                              && (!beam2->elements().empty())
                              && (beam2->elements().front() != ec)
@@ -1072,6 +1080,12 @@ SpannerSegment* Slur::layoutSystem(System* system)
                               }
                         Chord* c1 = startCR()->isChord() ? toChord(startCR()) : 0;
                         Chord* c2 = endCR()->isChord()   ? toChord(endCR())   : 0;
+
+                        if (c1 && c1->beam() && c1->beam()->cross()) {
+                              // TODO: stem direction is not finalized, so we cannot use it here
+                              _up = true;
+                              break;
+                              }
 
                         _up = !(startCR()->up());
 


### PR DESCRIPTION
See https://musescore.org/en/node/289492 and https://musescore.org/en/node/289498.  The first issue contains a fairly thorough description of the underlying issue: bad layout resulting from the fact that with cross-staff beams, we make an initial guess as to stem direction, do some layout based on that, then correct the stem direction guess much later after it's too late to fix the layout based on the original guess.

We've fought some version of this for years and tried to address it by improving our guess, or being smarter about trying to correct things after realizing we guessed wrong.  for this PR, I took a simpler approach I think is both more likely to succeed and less likely to cause regressions elsewhere.  Instead of acting on the guess, instead I *recognize* that all we have is a guess, so I explicitly *don't* act on the guess, but only on things I know won't change during the course of the layout.

In the case of slurs, we were using stem direction to layout to either the notehead or the stem dpeneding on stem direction.  I've changed this so if the note is on a cross-staff beam, we always layout to the notehead.

In the case of beams, the issue was actually not so much about the beam layout as the layout of potentially overlapping chords (multiple voices on same segment), where changes of opinion about stem direction changes the horizontal offset of the chords.  So, again, in cases where a chord is on a cross-staff beam, I'm changing the algorithm to note base the offset on the guessed stem direction, but on things like, was it moved to another staff, what voice is it in, etc.  Some of the same things used in Chord::computeUp, but here I consider only the factors specifically relevant to cross-staff beams.

These changes should only affect cross-staff beams, so they are safe in that sense, but will no tdoubt mean some differences in layout compared to 3.0.5 and/or master without these changes.  There may be cases where the guess was actually right and produced the more correct result than my new code, but with my code we should actually produce good layout either way, no weird glitches liek the ones in the issues here.

I plan to inspect the vtests before going to bed, but need to deal with a couple of other last minute regressions first.
