### PR TITLE
fix #289501: saving with autoplace disabled, disables it for all elements

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -514,7 +514,16 @@ bool Element::intersects(const QRectF& rr) const
 
 void Element::writeProperties(XmlWriter& xml) const
       {
-      writeProperty(xml, Pid::AUTOPLACE);
+      bool autoplaceEnabled = score()->styleB(Sid::autoplaceEnabled);
+      if (!autoplaceEnabled) {
+            score()->setStyleValue(Sid::autoplaceEnabled, true);
+            writeProperty(xml, Pid::AUTOPLACE);
+            score()->setStyleValue(Sid::autoplaceEnabled, autoplaceEnabled);
+            }
+      else {
+            writeProperty(xml, Pid::AUTOPLACE);
+            }
+
       // copy paste should not keep links
       if (_links && (_links->size() > 1) && !xml.clipboardmode()) {
             if (MScore::debugMode)


### PR DESCRIPTION
See https://musescore.org/en/node/289501.  Critical issue where saving a score with the new "disable automatic placement for all elements" style setting doesn't just save the style setting, it causes all elements to save with autoplace turned off individually, resulting in completely messed up layout on read.

There are no doubt more efficient ways to solve this than what I have here.  Turning the option back on temporarily in Score::writeMovement() would work, but it missed the copy/paste case, which laso use writeProperties and thus presumably suffers the same problem.  Or, if there was an easy way from within Element::autoplace() to check if we were in the middle of a writeProperties() call before checking the style setting, even better.  But as it is, this is the best I can think of right now.

It means two extra style setting operations per element per write, but only if it's currently off, which will never happen for most users.