### PR TITLE
fix #166116: Slurs terminate in wrong spot in voices other than 1

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -783,6 +783,11 @@ Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction 
             connectTies();
       if (nr) {
             if (_is.slur() && nr->type() == ElementType::NOTE) {
+                  // If the start element was the same as the end element when the slur was created,
+                  // the end grip of the front slur segment was given an x-offset of 3.0 * spatium().
+                  // Now that the slur is about to be given a new end element, this should be reset.
+                  if (_is.slur()->endElement() == _is.slur()->startElement())
+                        _is.slur()->frontSegment()->reset();
                   //
                   // extend slur
                   //

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3442,8 +3442,11 @@ void ScoreView::addSlur()
       InputState& is = _score->inputState();
       if (noteEntryMode() && is.slur()) {
             const std::vector<SpannerSegment*>& el = is.slur()->spannerSegments();
-            if (!el.empty())
+            if (!el.empty()) {
                   el.front()->setSelected(false);
+                  // Now make sure that the slur segment is redrawn so that it does not *look* selected
+                  update();
+                  }
             is.setSlur(nullptr);
             return;
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/166116