### PR TITLE
[MU4] fix #289501: don't disable autoplace for each on write when disabled …

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -209,6 +209,11 @@ void Score::writeMovement(XmlWriter& xml, bool selectionOnly)
       xml.setCurTrack(0);
       xml.setTrackDiff(-staffStart * VOICES);
       if (measureStart) {
+            // don't write with autoplace disabled, or all elements will have it disabled individually
+            bool autoplaceEnabled = score()->styleB(Sid::autoplaceEnabled);
+            if (!autoplaceEnabled)
+                  score()->setStyleValue(Sid::autoplaceEnabled, true);
+
             for (int staffIdx = staffStart; staffIdx < staffEnd; ++staffIdx) {
                   xml.stag(staff(staffIdx), QString("id=\"%1\"").arg(staffIdx + 1 - staffStart));
                   xml.setCurTick(measureStart->tick());
@@ -231,6 +236,8 @@ void Score::writeMovement(XmlWriter& xml, bool selectionOnly)
                         }
                   xml.etag();
                   }
+            if (!autoplaceEnabled)
+                  score()->setStyleValue(Sid::autoplaceEnabled, false);
             }
       xml.setCurTrack(-1);
       if (isMaster()) {

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -675,6 +675,11 @@ QString Selection::mimeType() const
 
 QByteArray Selection::mimeData() const
       {
+      // don't write with autoplace disabled, or all elements will have it disabled individually
+      bool autoplaceEnabled = score()->styleB(Sid::autoplaceEnabled);
+      if (!autoplaceEnabled)
+            score()->setStyleValue(Sid::autoplaceEnabled, true);
+
       QByteArray a;
       switch (_state) {
             case SelState::LIST:
@@ -689,6 +694,8 @@ QByteArray Selection::mimeData() const
                   a = staffMimeData();
                   break;
             }
+      if (!autoplaceEnabled)
+            score()->setStyleValue(Sid::autoplaceEnabled, false);
       return a;
       }
 


### PR DESCRIPTION
…globally

See https://musescore.org/en/node/289501.  This is a critical flaw in the new command to disable autoplace globally.  I have a previous PR #5047 that fixes this by turning autoplace back on (and then off) for each element write, in Element::writeProperties.  That one works but seems clumsy and inefficient.  This version does the toggling of the option at a much higher level - when writing the score, or when copying the selection to the clipboard (which also involves write operations).  It works also, both for regular writes and for copies. I tested single element copy as well as range copy, with autoplace enabled and disabled.  So far I don't see anything I missed.

If it does turn out I missed something, worst case is that command is unreliable and we don't document it, but I'm sure if problems are found before release they can be fixed.

So, I think I recommend this PR over the other, but one or the other needs to be in place.