### PR TITLE
fix #289502: system space keeps increasing

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -4176,11 +4176,24 @@ void LayoutContext::collectPage()
       {
       const qreal slb = score->styleP(Sid::staffLowerBorder);
       bool breakPages = score->layoutMode() != LayoutMode::SYSTEM;
-      qreal y         = prevSystem ? prevSystem->y() + prevSystem->height() : page->tm();
+      //qreal y         = prevSystem ? prevSystem->y() + prevSystem->height() : page->tm();
       qreal ey        = page->height() - page->bm();
 
       System* nextSystem = 0;
       int systemIdx = -1;
+
+      qreal y = page->systems().isEmpty() ? page->tm() : page->system(0)->y() + page->system(0)->height();
+      // re-calculate positions for systems before current
+      // (they may have been filled on previous layout)
+      int pSystems = page->systems().size();
+      for (int i = 1; i < pSystems; ++i) {
+            System* cs = page->system(i);
+            System* ps = page->system(i - 1);
+            qreal distance = ps->minDistance(cs);
+            y += distance;
+            cs->setPos(page->lm(), y);
+            y += cs->height();
+            }
 
       for (int k = 0;;++k) {
             //


### PR DESCRIPTION
See https://musescore.org/en/node/289502 for description of issue (critical regression) and analysis of why it's happening.  The short version is, when we collect pages on layout after an edit, we only recalculate y positions for systems starting with the first modified system (as per the range-based layout).  Meaning that we enter layoutPage, system distance are quite inconsistent, since the first few systems still have y positions based on the fill leftover from the last layout.

The code we formerly had that tried to enforce consistent system distance was actually necessary just to correct this error, independent of the wisdom of the code for its intended purpose.  My guess is there were other errors being masked - or not even masked, just not yet detect/reported/analyzed - due to this.  When I removed that code in #4949, it exposed this underlying flaw more obviously.

So, this PR fixes the problem at the source, in collectPage, making sure to recalculate the y position of the existing systems on the page that may have been filled.  This makes the code I removed unnecessary, thus fixing the issue at hand but probably also improving system consistency in other cases as well.