### PR TITLE
fix #179251: Select all glissandos in Range Selection fails

### DIFF
--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -444,6 +444,14 @@ void Selection::appendChord(Chord* chord)
                               _el.append(note->tieFor());
                         }
                   }
+            for (Spanner* sp : note->spannerFor()) {
+                  if (sp->endElement()->isNote()) {
+                        Note* endNote = toNote(sp->endElement());
+                        Segment* s = endNote->chord()->segment();
+                        if (s->tick() < tickEnd())
+                              _el.append(sp);
+                        }
+                  }
             }
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/179251

This will make sure that glissandos are added to the range selection if their beginning and end notes are both inside the range. This uses the same logic as is used for selecting ties (handled just above). Both blocks of code are needed, because ties are not included in the `Note::spannerFor()` list.