### PR TITLE
fix glissando regression

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -727,7 +727,8 @@ QPointF SLine::linePos(Grip grip, System** sys) const
 //                  QPointF     systPagePos = s->pagePos();
 //                  qreal       staffYPage  = s->staffYpage(e->staffIdx());
                   QPointF p = n->pagePos() - s->pagePos();
-                  p.rx() += n->width() * 0.5;
+                  if (!isGlissando())
+                        p.rx() += n->headWidth() * 0.5;
                   return p;
                   }
 


### PR DESCRIPTION
Fixes regression in glissando layout caused by #5041.  Glissando layout was apparently relying on the old behavior of note anchored lines.  So I've restriscted my previous change to "if (!isGlissando())" (and used headWidth() rather than width() for consistency with glissando layout, it's usually the same but almost certainly better if it ever isn't).