### PR TITLE
fix #289548: incorrect initial layout of added articulations

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1963,8 +1963,10 @@ void Chord::layoutPitched()
                   }
             }
 
+#if 0
       if (!_articulations.isEmpty()) {
             // TODO: allocate space to avoid "staircase" effect
+            // but we would need to determine direction in order to get correct symid & bbox
             // another alternative is to limit the width contribution of the articulation in layoutArticulations2()
             //qreal aWidth = 0.0;
             for (Articulation* a : articulations())
@@ -1974,6 +1976,7 @@ void Chord::layoutPitched()
             //lll = qMax(lll, aExtra);
             //rrr = qMax(rrr, aExtra);
             }
+#endif
 
       _spaceLw = lll;
       _spaceRw = rrr;
@@ -3278,6 +3281,7 @@ void Chord::layoutArticulations()
                   continue;
 
             bool bottom = !a->up();  // true: articulation is below chord;  false: articulation is above chord
+            a->layout();             // must be done after assigning direction, or else symId is not reliable
 
             bool headSide = bottom == up();
             qreal x = centerX();
@@ -3401,6 +3405,7 @@ void Chord::layoutArticulations2()
 
             if (a->up()) {
                   if (!a->layoutCloseToNote()) {
+                        a->layout();
                         a->setPos(x, chordTopY);
                         a->doAutoplace();
                         }
@@ -3408,6 +3413,7 @@ void Chord::layoutArticulations2()
                   }
             else {
                   if (!a->layoutCloseToNote()) {
+                        a->layout();
                         a->setPos(x, chordBotY);
                         a->doAutoplace();
                         }
@@ -3423,6 +3429,7 @@ void Chord::layoutArticulations2()
       for (Articulation* a : _articulations) {
             ArticulationAnchor aa = a->anchor();
             if (aa == ArticulationAnchor::TOP_STAFF || aa == ArticulationAnchor::BOTTOM_STAFF) {
+                  a->layout();
                   if (a->up()) {
                         a->setPos(x, staffTopY);
                         staffTopY -= distance0;

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2324,11 +2324,13 @@ void Chord::layoutTablature()
             rrr = qMax(rrr, x);
             }
 
+#if 0
       if (!_articulations.isEmpty()) {
             // TODO: allocate space? see layoutPitched()
             for (Articulation* a : articulations())
                   a->layout();
             }
+#endif
 
       _spaceLw = lll;
       _spaceRw = rrr;


### PR DESCRIPTION
See https://musescore.org/en/node/289548

This is a regression caused by my continuous view performance optimization.  Specifically, the change I made to articulation layout in order to fix an issue that was specific to continuous view.  But I didn't actually *need* all the code I actually added to fix that issue.  One bit I added - thinking it would be a nice little code simplification that would also help facilitate some future improvement - turns out to have caused this regression.  I had moved the articulation layout slightly earlier, but it turns out this doesn't work because we haven't yet assigned the direction (up/down) and thus haven't necessarily chosen the proper symId, which throws off the bbox.  Thus, the initial layout is bad, but later on we do calculate direction and assign the correct symID and so subsequent layouts are OK.  if lter the direction is fliped, then the same glitch happens and fixes itself again.

This PR fixes the issue by reverting that portion of my continuous view change - moving articulation layout back to Chord::layoutArticulations() instead of Chord::layoutPitched().  As I said, this change wasn't needed anyhow, and performance is the same either way - even though there are multiple call sites now, each articulation still gets laid out only once (and it's a very cheap operation anyhow).