### PR TITLE
fix #289552: [Regression] Crash splitting multimeasure rest

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2859,10 +2859,11 @@ void Score::padToggle(Pad n)
             if (cr && cr->isRest() && cr->measure()->isMMRest()) {
                   Measure* m = cr->measure()->mmRestFirst();
                   if (m)
-                        cr = m->findChordRest(Fraction(0,1), 0);
+                        cr = m->findChordRest(m->tick(), 0);
                   }
 
-            crs.push_back(cr);
+            if (cr)
+                  crs.push_back(cr);
             }
       else {
             const auto elements = selection().uniqueElements();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/289552