### PR TITLE
fix #289561: playback continues to repeat after end repeat barline has been deleted

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -183,8 +183,8 @@ void Score::endCmd(bool rollback)
       undoStack()->endMacro(noUndo);
 
       if (dirty()) {
-            masterScore()->_playlistDirty = true;  // TODO: flag individual operations
-            masterScore()->_autosaveDirty = true;
+            masterScore()->setPlaylistDirty();  // TODO: flag individual operations
+            masterScore()->setAutosaveDirty(true);
             }
       MuseScoreCore::mscoreCore->endCmd();
       cmdState().reset();
@@ -243,9 +243,9 @@ void Score::update()
             if (is.noteEntryMode() && is.segment()) {
                   setPlayPos(is.segment()->tick());
                   }
-            if (_playlistDirty) {
+            if (playlistDirty()) {
                   emit playlistChanged();
-                  _playlistDirty = false;
+                  masterScore()->setPlaylistClean();
                   }
             cs.reset();
             }

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -369,6 +369,7 @@ bool MeasureBase::setProperty(Pid id, const QVariant& value)
                   break;
             }
       score()->setLayoutAll();
+      score()->setPlaylistDirty();
       return true;
       }
 

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -803,12 +803,21 @@ ScoreContentState Score::state() const
       }
 
 //---------------------------------------------------------
+//   playlistDirty
+//---------------------------------------------------------
+
+bool Score::playlistDirty() const
+      {
+      return masterScore()->playlistDirty();
+      }
+
+//---------------------------------------------------------
 //   setPlaylistDirty
 //---------------------------------------------------------
 
 void Score::setPlaylistDirty()
       {
-      _playlistDirty = true;
+      masterScore()->setPlaylistDirty();
       }
 
 //---------------------------------------------------------
@@ -817,7 +826,7 @@ void Score::setPlaylistDirty()
 
 void MasterScore::setPlaylistDirty()
       {
-      Score::setPlaylistDirty();
+      _playlistDirty = true;
       _repeatList->setScoreChanged();
       }
 
@@ -1412,13 +1421,13 @@ void Score::addElement(Element* element)
                         }
                   cmdState().layoutFlags |= LayoutFlag::FIX_PITCH_VELO;
                   o->staff()->updateOttava();
-                  _playlistDirty = true;
+                  setPlaylistDirty();
                   }
                   break;
 
             case ElementType::DYNAMIC:
                   cmdState().layoutFlags |= LayoutFlag::FIX_PITCH_VELO;
-                  _playlistDirty = true;
+                  setPlaylistDirty();
                   break;
 
             case ElementType::TEMPO_TEXT:
@@ -1575,13 +1584,13 @@ void Score::removeElement(Element* element)
                   removeSpanner(o);
                   o->staff()->updateOttava();
                   cmdState().layoutFlags |= LayoutFlag::FIX_PITCH_VELO;
-                  _playlistDirty = true;
+                  setPlaylistDirty();
                   }
                   break;
 
             case ElementType::DYNAMIC:
                   cmdState().layoutFlags |= LayoutFlag::FIX_PITCH_VELO;
-                  _playlistDirty = true;
+                  setPlaylistDirty();
                   break;
 
             case ElementType::CHORD:
@@ -3422,7 +3431,7 @@ void Score::setTempo(Segment* segment, qreal tempo)
 void Score::setTempo(const Fraction& tick, qreal tempo)
       {
       tempomap()->setTempo(tick.ticks(), tempo);
-      _playlistDirty = true;
+      setPlaylistDirty();
       }
 
 //---------------------------------------------------------
@@ -3432,7 +3441,7 @@ void Score::setTempo(const Fraction& tick, qreal tempo)
 void Score::removeTempo(const Fraction& tick)
       {
       tempomap()->delTempo(tick.ticks());
-      _playlistDirty = true;
+      setPlaylistDirty();
       }
 
 //---------------------------------------------------------
@@ -3471,7 +3480,7 @@ void Score::resetTempoRange(const Fraction& tick1, const Fraction& tick2)
 void Score::setPause(const Fraction& tick, qreal seconds)
       {
       tempomap()->setPause(tick.ticks(), seconds);
-      _playlistDirty = true;
+      setPlaylistDirty();
       }
 
 //---------------------------------------------------------

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -428,7 +428,6 @@ class Score : public QObject, public ScoreElement {
       bool _showInstrumentNames   { true  };
       bool _showVBox              { true  };
       bool _printing              { false };      ///< True if we are drawing to a printer
-      bool _playlistDirty         { true  };
       bool _autosaveDirty         { true  };
       bool _savedCapture          { false };      ///< True if we saved an image capture
       bool _saved                 { false };    ///< True if project was already saved; only on first
@@ -819,7 +818,7 @@ class Score : public QObject, public ScoreElement {
       void setPrinting(bool val)     { _printing = val;      }
       void setAutosaveDirty(bool v)  { _autosaveDirty = v;    }
       bool autosaveDirty() const     { return _autosaveDirty; }
-      bool playlistDirty()           { return _playlistDirty; }
+      virtual bool playlistDirty() const;
       virtual void setPlaylistDirty();
 
       void spell();
@@ -1204,7 +1203,8 @@ class MasterScore : public Score {
       TimeSigMap* _sigmap;
       TempoMap* _tempomap;
       RepeatList* _repeatList;
-      bool _expandRepeats = true;
+      bool _expandRepeats     { true };
+      bool _playlistDirty     { true };
       QList<Excerpt*> _excerpts;
       std::vector<PartChannelSettingsLink> _playbackSettingsLinks;
       Score* _playbackScore = nullptr;
@@ -1255,10 +1255,13 @@ class MasterScore : public Score {
       virtual TimeSigMap* sigmap() const override                     { return _sigmap;     }
       virtual TempoMap* tempomap() const override                     { return _tempomap;   }
 
+      virtual bool playlistDirty() const override                     { return _playlistDirty; }
+      virtual void setPlaylistDirty() override;
+      void setPlaylistClean()                                         { _playlistDirty = false; }
+
       void setExpandRepeats(bool expandRepeats);
       void updateRepeatListTempo();
       virtual const RepeatList& repeatList() const override;
-      void setPlaylistDirty() override;
 
       virtual QList<Excerpt*>& excerpts() override                    { return _excerpts;   }
       virtual const QList<Excerpt*>& excerpts() const override        { return _excerpts;   }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/289561

The change needed is to make a call to `Score::setPlaylistDirty` update the master score `repeatList`. To do this, I've removed the `MasterScore::setPlaylistDirty` override, and made the score version of the function call a new `setRepeatListDirty` function of the master score. So, all calls to `MasterScore::setPlaylistDirty` invoke `Score::setPlaylistDirty`, which updates the master score repeat list as well as setting the score `_playlistDirty` variable.