### PR TITLE
fix #289562: add missing blockSignals() calls on updating Mixer controls

### DIFF
--- a/mscore/mixerdetails.cpp
+++ b/mscore/mixerdetails.cpp
@@ -224,6 +224,9 @@ void MixerDetails::updateFromTrack()
       chorusSlider->blockSignals(true);
       chorusSpinBox->blockSignals(true);
 
+      portSpinBox->blockSignals(true);
+      channelSpinBox->blockSignals(true);
+
       trackColorLabel->setColor(QColor(_mti->color() | 0xff000000));
 
       volumeSlider->setValue((int)chan->volume());
@@ -247,6 +250,9 @@ void MixerDetails::updateFromTrack()
       reverbSpinBox->blockSignals(false);
       chorusSlider->blockSignals(false);
       chorusSpinBox->blockSignals(false);
+
+      portSpinBox->blockSignals(false);
+      channelSpinBox->blockSignals(false);
 
       //Set up mute per voice buttons
       mutePerVoiceHolder = new QWidget();


### PR DESCRIPTION
Fixes https://musescore.org/en/node/289562, or, at least, the symptoms of this issue.

#### Why this fix works
Not blocking signals from port and channel sliders on updating their values made `instrumentsChanged` flag in MasterScore be set to `true` every time these values were updated. `MuseScore::endCmd()` [triggers such an update](https://github.com/musescore/MuseScore/blob/13a720151231ef749e64107706652260ecf62660/mscore/musescore.cpp#L5835) every time if both Mixer exists and that flag is set to true. Fortunately a bit later `endCmd` sets this flag to false again but this doesn't manage to happen if the score has just been opened. The workaround by pressing Escape button before adding an instrument mentioned [here](https://musescore.org/en/node/289562#comment-921062) works exactly because it makes `endCmd()` be called and, thus, resets the mentioned flag to `false`.

#### Why the issue appeared only in 3.1-RC
The issue became much more visible after merging #5011 which caused Mixer object be created regardless of being actually displayed. In fact, the issue exists at least from 3.0.4 version (probably 3.0.3 but I tested it only on 3.0.4). In order to reproduce the issue on the versions before 3.1-RC one should open a Mixer window before executing steps 4-5 from [this comment](https://musescore.org/en/node/289562#comment-921062).

Although this fix works the more fundamental problem is probably having a somewhat invalid instruments and channels state at the moment when `MuseScore::endCmd()` gets executed on updating a score [here](https://github.com/musescore/MuseScore/blob/13a720151231ef749e64107706652260ecf62660/mscore/instrdialog.cpp#L538). Without that the signals blocking issue fixed here would cause only a small negative performance effect rather than a crash. This more fundamental issue should probably be addressed later but this patch should also be good to apply regardless of that.