### PR TITLE
Fixes for ties at start of system

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3711,7 +3711,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
                         clef->parent()->remove(clef);
                         delete clef;
                         }
-                  cSegment->createShape(staffIdx);
+                  //cSegment->createShape(staffIdx);
                   cSegment->setEnabled(true);
                   }
             else {
@@ -3769,7 +3769,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
                         }
                   keysig->setKeySigEvent(keyIdx);
                   keysig->layout();
-                  kSegment->createShape(staffIdx);
+                  //kSegment->createShape(staffIdx);
                   kSegment->setEnabled(true);
                   }
             else {
@@ -3805,6 +3805,11 @@ void Measure::addSystemHeader(bool isFirstSystem)
 
             ++staffIdx;
             }
+      if (cSegment)
+            cSegment->createShapes();
+      if (kSegment)
+            kSegment->createShapes();
+
       //
       // create systemic barline
       //
@@ -3826,9 +3831,9 @@ void Measure::addSystemHeader(bool isFirstSystem)
                         bl->setSpanStaff(true);
                         bl->layout();
                         s->add(bl);
-                        s->createShapes();
                         }
                   }
+            s->createShapes();
             s->setEnabled(true);
             s->setHeader(true);
             setHeader(true);
@@ -3880,8 +3885,9 @@ void Measure::addSystemTrailer(Measure* nm)
                                     }
                               ts->setFrom(nts);
                               ts->layout();
-                              s->createShape(track / VOICES);
+                              //s->createShape(track / VOICES);
                               }
+                        s->createShapes();
                         }
                   }
             }
@@ -3923,7 +3929,7 @@ void Measure::addSystemTrailer(Measure* nm)
                   //      }
                   ks->setKeySigEvent(key2);
                   ks->layout();
-                  s->createShape(track / VOICES);
+                  //s->createShape(track / VOICES);
                   s->setEnabled(true);
                   }
             else {
@@ -3940,6 +3946,10 @@ void Measure::addSystemTrailer(Measure* nm)
                         }
                   }
             }
+      if (s)
+            s->createShapes();
+      if (clefSegment)
+            clefSegment->createShapes();
 
       checkTrailer();
       }

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -490,8 +490,8 @@ void Tie::slurPos(SlurPos* sp)
       sp->p2    = ec->pos() + ec->segment()->pos() + ec->measure()->pos();
       sp->system2 = ec->measure()->system();
 
-      // force tie to be horizontal except for cross-staff or if there is a difference of enharmonic spelling
-      bool horizontal = startNote()->tpc() == endNote()->tpc() && sc->vStaffIdx() == ec->vStaffIdx();
+      // force tie to be horizontal except for cross-staff or if there is a difference of line (tpc, clef, tpc)
+      bool horizontal = startNote()->line() == endNote()->line() && sc->vStaffIdx() == ec->vStaffIdx();
 
       hw = endNote()->tabHeadWidth(stt);
       if ((ec->notes().size() > 1) || (ec->stem() && !ec->up() && !_up)) {

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -488,10 +488,7 @@ void Tie::slurPos(SlurPos* sp)
             }
       Chord* ec = endNote()->chord();
       sp->p2    = ec->pos() + ec->segment()->pos() + ec->measure()->pos();
-      if (sp->system1 && (sc->measure() == sp->system1->lastMeasure()) && (ec->measure() != sc->measure()))
-            sp->system2 = nullptr;
-      else
-            sp->system2 = ec->measure()->system();
+      sp->system2 = ec->measure()->system();
 
       // force tie to be horizontal except for cross-staff or if there is a difference of enharmonic spelling
       bool horizontal = startNote()->tpc() == endNote()->tpc() && sc->vStaffIdx() == ec->vStaffIdx();

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -681,7 +681,7 @@ TieSegment* Tie::layoutBack(System* system)
       segment->setSystem(system);
 
       qreal x;
-      Segment* seg = endNote()->chord()->segment()->prevEnabled();
+      Segment* seg = endNote()->chord()->segment()->prevActive();
       if (seg) {
             // find maximum width
             qreal width = 0.0;
@@ -690,8 +690,8 @@ TieSegment* Tie::layoutBack(System* system)
                   if (!system->staff(i)->show())
                         continue;
                   Element* e = seg->element(i * VOICES);
-                  if (e)
-                        width = qMax(width, e->width());
+                  if (e && e->addToSkyline())
+                        width = qMax(width, e->pos().x() + e->bbox().right());
                   }
             x = seg->measure()->pos().x() + seg->pos().x() + width;
             }


### PR DESCRIPTION
There are several different but somewhat issues issues fixed in this PR, all relating to the layout of ties at the start of a system.

The original issue submitted by a user is https://musescore.org/en/node/289605.  Cross-staff ties work better in 3.1 than 3.0.5, but they still fail at the start of a system, despite code I put in place to handle that case.  The code doesn't work because of a previous fix #3960.  This was a fine fix at the time, but it turns out to not be needed any more, because it was really more of a workaround for the fact we were doing tie layout too early.  Now that tie layout happens later, we don't need that #3960 fix any more.  So my first commit reverts it.

In my testing to be sure I didn't break the issue that #3960 was trying to fix, though, I disocvered two other issues with the layout of ties at the start of a system.  https://musescore.org/en/node/289605 is actually about ties displaying incorrectly across clef changes, not necessarily system changes, but that's how I discovered it.  Here it turns out I had fixed this then broke it again in my cross-staff work.  The second commit here fixes it again.

The third commit is for https://musescore.org/en/node/289616, which is a regression compared to 3.0.5.  Again, there were issues here in the past, I fixed them, but then I inadvertently broke it for some cases with #4769.  I found this also testing that my first fix didn't break what the code I reverted was fixing.  It turns out a quirk in that particular score illustrates another issue, where a key signature segment that has nothing in the visible staves but does have elements in invisible staves was affecting layout.  The change from prevEnabled(0 to prevActive() in tie.cpp *mostly* solves this, but this is a glitch where the tie still displays somewhat poorly on first load, then fixes itself on the next layout.  This turns out to be because Measure::addSystemHeader is calling Segment::createShape() for each staff one at a time rather than for the whole segment, and is thus missing the code to initialize "visble" to false.  So I found all the calls to createShape() within loops per staff, and replaced them with calls to createShapes() (plural) after the loop.  I guess that's the scariest change in any of this, but I haven't found anything it breaks, and actually, it's just as likely it fixes some other issues.

The three commits are completely independent, but I've mostly tested them together, and I think ti probably makes sense to merge them together.  The last is the only true regression against 3.0.5 here.  All three cases are likely to be fairly rare, but the first - the originally reported one - is frankly the only one that would make me want to at least consider this for 3.1.  Otherwise it can all wait for 3.1.x as far as I'm concerned.