### PR TITLE
fix #289668: crash on chord symbol navigation by duration

### DIFF
--- a/mscore/editfiguredbass.cpp
+++ b/mscore/editfiguredbass.cpp
@@ -142,6 +142,8 @@ void ScoreView::figuredBassTicksTab(const Fraction& ticks)
                   }
             }
 
+      changeState(ViewState::NORMAL);
+
       // look for a segment at this tick; if none, create one
       Segment * nextSegm = segm;
       while (nextSegm && nextSegm->tick() < nextSegTick)
@@ -156,8 +158,6 @@ void ScoreView::figuredBassTicksTab(const Fraction& ticks)
             _score->undoAddElement(nextSegm);
             _score->endCmd();
             }
-
-      changeState(ViewState::NORMAL);
 
       bool bNew;
       FiguredBass * fbNew = FiguredBass::addFiguredBassToSegment(nextSegm, track, ticks, &bNew);

--- a/mscore/editharmony.cpp
+++ b/mscore/editharmony.cpp
@@ -225,6 +225,8 @@ void ScoreView::harmonyTicksTab(const Fraction& ticks)
                   }
             }
 
+      changeState(ViewState::NORMAL);
+
       // look for a segment at this tick; if none, create one
       while (segment && segment->tick() < newTick)
             segment = segment->next1(SegmentType::ChordRest);
@@ -234,8 +236,6 @@ void ScoreView::harmonyTicksTab(const Fraction& ticks)
             _score->undoAddElement(segment);
             _score->endCmd();
             }
-
-      changeState(ViewState::NORMAL);
 
       // search for next chord name
       harmony = 0;


### PR DESCRIPTION
See https://musescore.org/en/node/289668

The crash itself happens a bit later on in the code than where my change is, but I've traced the cause to the segment we just created for the new chord symbol in ScoreView::harmonyTicksTab() getting clobbered when we call changeState().  This code didn't change recently (not in a relevant way, anyhow), but what *did* change was the handling of the undo stack within textBase::endEdit(), which is called during changeState().  That change was in #4921.  To the extent I understand that code, I think it's probably fine, and we just need to be careful not to start putting things on the undo stack we don't want rolled back when we call textBase::endEdit().

So far I have found that the other chord symbol navigation commands don't do this, but the equivalent command in figured bass does, and indeed crashes too.  So this PR fixes both.

It's possible there are other places in the code where there might still be problems - places where we placed some action on the undo stack prior to calling textBase::endEdit() and then bad things happen as that action is rolled back.  In some cases, that might just mean a surprising failure of some command to do what it is supposed to do.  The crash here only happened because we then tried to build upon that action by actually using the segment we created.