### PR TITLE
fix #289651: show courtesy checkbox not working in clef inspector

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -954,7 +954,8 @@ void InspectorClef::setElement()
 void InspectorClef::valueChanged(int idx)
       {
       // copy into 'other clef' the ShowCouretsy ser of this clef
-      if (idx == 6 && otherClef)
+      Pid pid = iList[idx].t;
+      if (pid == Pid::SHOW_COURTESY && otherClef)
             otherClef->setShowCourtesy(c.showCourtesy->isChecked());
       InspectorBase::valueChanged(idx);
       }


### PR DESCRIPTION
See https://musescore.org/en/node/289651

The way we were checking to see if the user pressed the "show courtesy" button was flawed, it depended on the numeric index of the control.  Amazing to me this worked for six years before my new "minimum distance" control broke it.  Anyhow, changed to actually check the Pid.