### PR TITLE
fix #279117: allow custom spacers to be added to palette

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -555,9 +555,10 @@ void Measure::layout2()
             Spacer* sp = ms->vspacerDown();
             if (sp) {
                   sp->layout();
-                  int n = score()->staff(staffIdx)->lines(tick()) - 1;
+                  Staff* staff = score()->staff(staffIdx);
+                  int n = staff->lines(tick()) - 1;
                   qreal y = system()->staff(staffIdx)->y();
-                  sp->setPos(_spatium * .5, y + n * _spatium);
+                  sp->setPos(_spatium * .5, y + n * _spatium * staff->mag(tick()));
                   }
             sp = ms->vspacerUp();
             if (sp) {
@@ -864,6 +865,7 @@ void Measure::add(Element* e)
                               _mstaves[e->staffIdx()]->setVspacerDown(sp);
                               break;
                         }
+                  sp->setGap(sp->gap());  // trigger relayout
                   }
                   break;
             case ElementType::JUMP:

--- a/libmscore/spacer.cpp
+++ b/libmscore/spacer.cpp
@@ -62,7 +62,7 @@ void Spacer::layout0()
       path    = QPainterPath();
       qreal w = _spatium;
       qreal b = w * .5;
-      qreal h = _gap;
+      qreal h = parent() ? _gap : qMin(_gap, spatium() * 4.0);    // limit length for palette
 
       switch (spacerType()) {
             case SpacerType::DOWN:

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3584,7 +3584,7 @@ void ScoreView::cmdChangeEnharmonic(bool both)
 
 void ScoreView::cloneElement(Element* e)
       {
-      if (e->isMeasure() || e->isNote() || e->isVBox() || e->isSpacer())
+      if (e->isMeasure() || e->isNote() || e->isVBox())
             return;
       QDrag* drag = new QDrag(this);
       QMimeData* mimeData = new QMimeData;


### PR DESCRIPTION
See https://musescore.org/en/node/279117

It was possible to add spacers to custom palettes in 2.x.  This ability was removed - inadvertently, I am pretty sure - in https://github.com/musescore/MuseScore/commit/9f12f2aa7ca0d8ecf6bc4c4fc9b336ccfd34ac50.  The line changed was originally disallowing elements that are not movable from being cloned and added to the palette, *except* for spacers and vboxes.  The new code excludes spacers, I think because of a simple error in use of "!".  vboxes are excluded as well when they weren't before, but this is probably just as well, because while it was possible to add on to a custom palette, it doesn't seem to work to add one to the score that way.

Anyhow, all I had to do to get this working was change that one line.  But I saw some issues with how spacers are laid out and elected to fix those as well.  Custom spacers added to the palette are likely to be more than just the 3sp default spacer, and they protrude from their cells in the palette.  So I limit the length of spacers in the palette (and then have to force them to be laid out again when adding them to the score).  Also, they are displayed incorrectly on small staves, because we aren't scaling for the staff height, so I fixed that.  This was a visual glitch only, they actually behave correctly either way.

BTW, it was in testing this fix I discovered https://musescore.org/en/node/289693, which is a pretty major regression from 3.0.5, so I'm glad I chose to look at this when I did!