### PR TITLE
trial PR: automatically space staves in continuous view

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3712,8 +3712,8 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
             m->layoutMeasureNumber();
             // in continuous view, entire score is one system
             // but we only need to process the range
-            if (lineMode() && (m->tick() < lc.startTick || m->tick() > lc.endTick))
-                  continue;
+            //if (lineMode() && (m->tick() < lc.startTick || m->tick() > lc.endTick))
+            //      continue;
             for (Segment* s = m->first(); s; s = s->next()) {
                   if (s->isChordRestType() || !s->annotations().empty())
                         sl.push_back(s);
@@ -3734,8 +3734,8 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                   Measure* m = toMeasure(mb);
                   MeasureNumber* mno = m->noText(staffIdx);
                   // no need to build skyline outside of range in continuous view
-                  if (lineMode() && (m->tick() < lc.startTick || m->tick() > lc.endTick))
-                        continue;
+                  //if (lineMode() && (m->tick() < lc.startTick || m->tick() > lc.endTick))
+                  //      continue;
                   if (mno && mno->addToSkyline())
                         ss->skyline().add(mno->bbox().translated(m->pos() + mno->pos()));
                   if (m->staffLines(staffIdx)->addToSkyline())
@@ -3823,6 +3823,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                   // layout beam
                   if (isTopBeam(cr)) {
                         Beam* b = cr->beam();
+                        //if (!lineMode() || (s->tick() >= lc.startTick && s->tick() <= lc.endTick))
                         b->layout();
                         b->addSkyline(system->staff(b->staffIdx())->skyline());
                         }

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -582,7 +582,7 @@ void System::layout2()
                         dist = qMax(dist, sp->gap() + h);
                   }
             if (!fixedSpace) {
-                  qreal d = score()->lineMode() ? 0.0 : ss->skyline().minDistance(System::staff(si2)->skyline());
+                  qreal d = /*score()->lineMode() ? 0.0 :*/ ss->skyline().minDistance(System::staff(si2)->skyline());
                   dist = qMax(dist, d + minVerticalDistance);
                   }
 #endif
@@ -1250,8 +1250,8 @@ qreal System::topDistance(int staffIdx, const SkylineLine& s) const
       {
       Q_ASSERT(!vbox());
       Q_ASSERT(!s.isNorth());
-      if (score()->lineMode())
-            return 0.0;
+      //if (score()->lineMode())
+      //      return 0.0;
       return s.minDistance(staff(staffIdx)->skyline().north());
       }
 
@@ -1263,8 +1263,8 @@ qreal System::bottomDistance(int staffIdx, const SkylineLine& s) const
       {
       Q_ASSERT(!vbox());
       Q_ASSERT(s.isNorth());
-      if (score()->lineMode())
-            return 0.0;
+      //if (score()->lineMode())
+      //      return 0.0;
       return staff(staffIdx)->skyline().south().minDistance(s);
       }
 


### PR DESCRIPTION
Trial code only - submitting to get an AppVeyor artifact for further testing.

Right now, we do not automatically space staves to avoid collisions in continuous view.  It's an expensive operation to have to do this for the entire score rather than just the systems that have changed.  But with the rest of performance improvements in place for 3.1, I thought it would be worth seeing just what it would cost.  I expect the result will be faster than 3.0.5 but slower than 3.1; the question is by how much?