### PR TITLE
fix #164571: UNDO does not remove instrument from mixer

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2413,15 +2413,20 @@ void Score::cmdRemovePart(Part* part)
 
 void Score::insertPart(Part* part, int idx)
       {
+      bool inserted = false;
       int staff = 0;
       for (QList<Part*>::iterator i = _parts.begin(); i != _parts.end(); ++i) {
             if (staff >= idx) {
                   _parts.insert(i, part);
-                  return;
+                  inserted = true;
+                  break;
                   }
             staff += (*i)->nstaves();
             }
-      _parts.push_back(part);
+      if (!inserted)
+            _parts.push_back(part);
+      masterScore()->rebuildMidiMapping();
+      setInstrumentsChanged(true);
       }
 
 //---------------------------------------------------------
@@ -2431,6 +2436,8 @@ void Score::insertPart(Part* part, int idx)
 void Score::removePart(Part* part)
       {
       _parts.removeAt(_parts.indexOf(part));
+      masterScore()->rebuildMidiMapping();
+      setInstrumentsChanged(true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/164571

In addition to resolving the above issue, this also addresses the "more fundamental problem" that @dmitrio95 mentioned in #5060.