### PR TITLE
fix #285688: width of repeat measure keeps increasing

### DIFF
--- a/libmscore/repeat.cpp
+++ b/libmscore/repeat.cpp
@@ -48,6 +48,7 @@ void RepeatMeasure::layout()
       for (Element* e : el())
             e->layout();
 
+      rxpos() = 0.0;
       qreal sp  = spatium();
 
       qreal y   = sp;


### PR DESCRIPTION
See https://musescore.org/en/node/285688

Kept getting annoyed by this - width of repeat measure increasing on every layout - while investigating https://musescore.org/en/node/289721.  I can't say I got anywhere understanding the latter but the width thing is a simple fix.  We do the same thing - resetting position to 0 on layout - for measure rests and indeed most elements, sees to have just been an oversight here.