### PR TITLE
Add adjusted bar numbers to the status bar, if they differ

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -4221,6 +4221,4 @@ void Measure::computeMinWidth()
 
       computeMinWidth(s, x, isSystemHeader);
       }
-
 }
-

--- a/libmscore/measurebase.cpp
+++ b/libmscore/measurebase.cpp
@@ -604,5 +604,22 @@ LayoutBreak* MeasureBase::sectionBreakElement() const
             }
       return 0;
       }
+
+//---------------------------------------------------------
+//   calculateAdjustedNo
+//    calculates the adjusted bar number, taking into
+//    account section breaks and manual adjustments.
+//---------------------------------------------------------
+
+int MeasureBase::calculateAdjustedNo()
+      {
+      int no = 0;
+      Measure* prev = this->findMeasure();
+      do {
+            no += prev->noOffset() + 1;
+            prev = prev->prevMeasure();
+            } while (prev != 0 && !prev->sectionBreak());
+      return no;
+      }
 }
 

--- a/libmscore/measurebase.h
+++ b/libmscore/measurebase.h
@@ -172,6 +172,8 @@ class MeasureBase : public Element {
 
       int index() const;
       int measureIndex() const;
+
+      int calculateAdjustedNo();
       };
 
 

--- a/mscore/scoreaccessibility.h
+++ b/mscore/scoreaccessibility.h
@@ -39,7 +39,7 @@ class ScoreAccessibility : public QObject {
       QMainWindow* mainWindow;
       QLabel* statusBarLabel;
       ScoreAccessibility(QMainWindow* statusBar);
-      std::pair<int, float>barbeat(Element* e);
+      std::tuple<int, int, float> barbeat(Element* e);
 
    public:
       ~ScoreAccessibility();


### PR DESCRIPTION
This implements some of the suggestions in https://musescore.org/en/node/288968. I haven't yet changed the find function to implement searching for these adjusted bar numbers, as I think there would have to be a significant rewrite of the parsing of that, in order to allow the user to specify bar numbers in a specific section, and I think that should have its own pull request. What this does do, though, is change the status bar text to include the adjusted bar number, if it differs from the absolute bar number. It does this in the format `adjusted bar number (absolute bar number)`.