### PR TITLE
fix #289721: disallow breaking MIDI rendering chunk at repeat measure

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2722,7 +2722,7 @@ bool Measure::isFullMeasureRest() const
 //   isRepeatMeasure
 //---------------------------------------------------------
 
-bool Measure::isRepeatMeasure(Staff* staff) const
+bool Measure::isRepeatMeasure(const Staff* staff) const
       {
       int staffIdx = staff->idx();
       int strack   = staffIdx * VOICES;

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -212,7 +212,7 @@ class Measure final : public MeasureBase {
       bool hasVoice(int track) const;
       bool isEmpty(int staffIdx) const;
       bool isFullMeasureRest() const;
-      bool isRepeatMeasure(Staff* staff) const;
+      bool isRepeatMeasure(const Staff* staff) const;
       bool visible(int staffIdx) const;
       bool slashStyle(int staffIdx) const;
       bool isFinalMeasureOfSection() const;

--- a/libmscore/rendermidi.h
+++ b/libmscore/rendermidi.h
@@ -92,6 +92,7 @@ class MidiRenderer {
       std::vector<Chunk> chunks;
 
       void updateChunksPartition();
+      static bool canBreakChunk(const Measure* last);
       void updateState();
 
       void renderStaffChunk(const Chunk&, EventMap* events, Staff*, DynamicsRenderMethod method, int cc);


### PR DESCRIPTION
Fixes https://musescore.org/en/node/289721 which happens to be a regression after #4978. The issue happened because measure repeat happened to go right after the partial MIDI rendering chunk border. As measure repeats depend on previous measures being properly rendered I believe the most robust solution would be to disallow breaking MIDI rendering chunks at measure repeats (at least for now). This is what is implemented by this patch.