### PR TITLE
Make undo/redo changes mark score playlist as dirty

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -153,6 +153,7 @@ void Score::undoRedo(bool undo, EditData* ed)
       else
             undoStack()->redo(ed);
       update();
+      masterScore()->setPlaylistDirty();  // TODO: flag all individual operations
       updateSelection();
       }
 


### PR DESCRIPTION
A fixup for #5059 that adds a general handling of the playlist change flag for undo/redo changes. As mentioned there, it would possibly be preferable to mark all the individual operations with `setPlaylistDirty()` calls but that would take much more effort and would leave much more errors right now.