### PR TITLE
fix #289749: all annotations disappear when pasting segment into measure rest

### DIFF
--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -245,7 +245,7 @@ Segment* Score::tick2rightSegment(const Fraction& tick) const
             return 0;
             }
       // loop over all segments
-      for (Segment* s = m->first(SegmentType::ChordRest); s; s = s->next(SegmentType::ChordRest)) {
+      for (Segment* s = m->first(SegmentType::ChordRest); s; s = s->next1(SegmentType::ChordRest)) {
             if (tick <= s->tick())
                   return s;
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/289749

We probably shouldn't stop at a measure end when searching for the next segment to the right of a tick, hence the `next1` instead of just `next`. I've checked usage of the `tick2rightSegment` function and can't find anywhere that this change would break.