### PR TITLE
fix #289795: Local build of stable branch always displays "No Update Available" when launched

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -3882,7 +3882,7 @@ bool MuseScore::hasToCheckForExtensionsUpdate()
       }
 
 //---------------------------------------------------------
-//   checkForUpdate
+//   checkForUpdatesNoUI
 //         Doesn't show any messages if software is up to date
 //---------------------------------------------------------
 
@@ -3891,11 +3891,11 @@ void MuseScore::checkForUpdatesNoUI()
       if (autoUpdater)
             autoUpdater->checkUpdates();
       else if (ucheck)
-            ucheck->check(version(), sender() != 0);
+            ucheck->check(version(), false);
       }
 
 //---------------------------------------------------------
-//   checkForUpdateNow
+//   checkForUpdatesUI
 //          Show message like "Software is up to date" if software is up to date
 //---------------------------------------------------------
 void MuseScore::checkForUpdatesUI()
@@ -3903,7 +3903,7 @@ void MuseScore::checkForUpdatesUI()
       if (autoUpdater)
             autoUpdater->checkForUpdatesNow();
       else if (ucheck)
-            ucheck->check(version(), sender() != 0);
+            ucheck->check(version(), true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/289795

When `MuseScore::checkForUpdate()` was first written, it used the condition `sender() != 0` to determine whether or not the command was invoked manually by the user. If so, a message box would be displayed whether there was an update available or not. If this function was called automatically, then a message box would not be displayed if there was no update available. When this function was later split into `MuseScore::checkForUpdatesUI()` and `MuseScore::checkForUpdatesNoUI()`, the `sender() != 0` condition became obsolete, and yet it still remained in the code. This condition should have been replaced with `false` in `checkForUpdatesNoUI()` and `true` in `checkForUpdatesUI()`.

This does not cause problems in the official releases of MuseScore, because if Sparkle is enabled, then this condition is never evaluated. But it does cause problems on local builds of branches that have `UNSTABLE` set to `FALSE`. The result is that when `checkForUpdatesNoUI()` is called upon application load, it displays the message "No Update Available", even though the description of the function says "Doesn't show any messages if software is up to date".