### PR TITLE
fix #289862: fix note input cursor moving to invalid position

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2182,7 +2182,7 @@ Element* Score::move(const QString& cmd)
                   Segment* s = _is.segment()->prev1(SegmentType::ChordRest);
                   int track = _is.track();
                   for (; s; s = s->prev1(SegmentType::ChordRest)) {
-                        if (s->element(track) || s->measure() != m) {
+                        if (s->element(track) || (s->measure() != m && s->rtick().isZero())) {
                               if (s->element(track)) {
                                     if (s->element(track)->isRest() && toRest(s->element(track))->isGap())
                                           continue;


### PR DESCRIPTION
Fixes https://musescore.org/en/node/289862 by fixing an incorrect cursor movement in situations like the one described in the issue.