### PR TITLE
fixes for layout of first measure of system, first system of page

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2658,6 +2658,9 @@ void Score::getNextMeasure(LayoutContext& lc)
             as.init(staff->keySigEvent(measure->tick()), staff->clef(measure->tick()));
 
             for (Segment& segment : measure->segments()) {
+                  // TODO? maybe we do need to process it here to make it possible to enable later
+                  //if (!segment.enabled())
+                  //      continue;
                   if (segment.isKeySigType()) {
                         KeySig* ks = toKeySig(segment.element(staffIdx * VOICES));
                         if (!ks)
@@ -2867,6 +2870,9 @@ void Score::getNextMeasure(LayoutContext& lc)
             score()->undoRemoveElement(seg);
 
       for (Segment& s : measure->segments()) {
+            // TODO? maybe we do need to process it here to make it possible to enable later
+            //if (!s.enabled())
+            //      continue;
             // DEBUG: relayout grace notes as beaming/flags may have changed
             if (s.isChordRestType()) {
                   for (Element* e : s.elist()) {
@@ -4237,7 +4243,6 @@ void LayoutContext::collectPage()
             //
             //  check for page break or if next system will fit on page
             //
-            const bool rangeWasDone = rangeDone;
             if (rangeDone) {
                   // take next system unchanged
                   if (systemIdx > 0) {
@@ -4312,9 +4317,6 @@ void LayoutContext::collectPage()
                   qreal dist = qMax(prevSystem->minBottom(), prevSystem->spacerDistance(false));
                   dist = qMax(dist, slb);
                   layoutPage(page, ey - (y + dist));
-                  // We don't accept current system to this page
-                  // so rollback rangeDone variable as well.
-                  rangeDone = rangeWasDone;
                   break;
                   }
             }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1726,10 +1726,12 @@ void LayoutContext::getNextPage()
             page = new Page(score);
             score->pages().push_back(page);
             prevSystem = nullptr;
+            pageOldMeasure = nullptr;
             }
       else {
             page = score->pages()[curPage];
             QList<System*>& systems = page->systems();
+            pageOldMeasure = systems.isEmpty() ? nullptr : systems.back()->measures().back();
             const int i = systems.indexOf(curSystem);
             if (i > 0 && systems[i-1]->page() == page) {
                   // Current and previous systems are on the current page.
@@ -4243,6 +4245,7 @@ void LayoutContext::collectPage()
             //
             //  check for page break or if next system will fit on page
             //
+            bool collected = false;
             if (rangeDone) {
                   // take next system unchanged
                   if (systemIdx > 0) {
@@ -4267,6 +4270,8 @@ void LayoutContext::collectPage()
                   }
             else {
                   nextSystem = score->collectSystem(*this);
+                  if (nextSystem)
+                        collected = true;
                   if (!nextSystem && score->isMaster()) {
                         MasterScore* ms = static_cast<MasterScore*>(score)->next();
                         if (ms) {
@@ -4317,6 +4322,10 @@ void LayoutContext::collectPage()
                   qreal dist = qMax(prevSystem->minBottom(), prevSystem->spacerDistance(false));
                   dist = qMax(dist, slb);
                   layoutPage(page, ey - (y + dist));
+                  // if we collected a system we cannot fit onto this page,
+                  // we need to collect next page in order to correctly set system positions
+                  if (collected)
+                        pageOldMeasure = nullptr;
                   break;
                   }
             }
@@ -4567,10 +4576,28 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
 
 void LayoutContext::layout()
       {
+      MeasureBase* lmb;
       do {
             getNextPage();
             collectPage();
-            } while (curSystem && !(rangeDone && page->system(0)->measures().back()->tick() > endTick)); // FIXME: perhaps the first measure was meant? Or last system?
+
+            if (page && !page->systems().isEmpty())
+                  lmb = page->systems().back()->measures().back();
+            else
+                  lmb = nullptr;
+
+            // we can stop collecting pages when:
+            // 1) we reach the end of score (curSystem is nullptr)
+            // or
+            // 2) we have fully processed the range and reached a point of stability:
+            //    a) we have completed layout for the range (rangeDone is true)
+            //    b) we haven't collected a system that will need to go on the next page
+            //    c) this page ends with the same measure as the previous layout
+            //    pageOldMeasure will be last measure from previous layout if range was completed on or before this page
+            //    it will be nullptr if this page was never laid out or if we collected a system for next page
+            } while (curSystem && !(rangeDone && lmb == pageOldMeasure));
+            // && page->system(0)->measures().back()->tick() > endTick // FIXME: perhaps the first measure was meant? Or last system?
+
       if (!curSystem) {
             // The end of the score. The remaining systems are not needed...
             qDeleteAll(systemList);

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3510,9 +3510,15 @@ System* Score::collectSystem(LayoutContext& lc)
 
             // preserve state of next measure (which is about to become current measure)
             if (lc.nextMeasure) {
-                  curWidth = lc.nextMeasure->width();
-                  curHeader = lc.nextMeasure->header();
-                  curTrailer = lc.nextMeasure->trailer();
+                  MeasureBase* nmb = lc.nextMeasure;
+                  if (nmb->isMeasure() && styleB(Sid::createMultiMeasureRests)) {
+                        Measure* nm = toMeasure(nmb);
+                        if (nm->hasMMRest())
+                              nmb = nm->mmRest();
+                        }
+                  curWidth = nmb->width();
+                  curHeader = nmb->header();
+                  curTrailer = nmb->trailer();
                   }
 
             getNextMeasure(lc);

--- a/libmscore/layout.h
+++ b/libmscore/layout.h
@@ -39,6 +39,7 @@ struct LayoutContext {
       System* curSystem        { 0 };
 
       MeasureBase* systemOldMeasure;
+      MeasureBase* pageOldMeasure;
       bool rangeDone           { false };
 
       MeasureBase* prevMeasure { 0 };

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -2009,6 +2009,10 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
       qreal ww = -1000000.0;        // can remain negative
       for (unsigned staffIdx = 0; staffIdx < _shapes.size(); ++staffIdx) {
             qreal d = staffShape(staffIdx).minHorizontalDistance(ns->staffShape(staffIdx));
+            // first chordrest of a staff should clear the widest header for any staff
+            // so make sure segment is as wide as it needs to be
+            if (systemHeaderGap)
+                  d = qMax(d, staffShape(staffIdx).right());
             ww      = qMax(ww, d);
             }
       qreal w = qMax(ww, 0.0);      // non-negative


### PR DESCRIPTION
See https://musescore.org/en/node/289892

The bug is triggered if, upon executing a command, we do a range layout, and the first system after the range starts with an mmrest.  In such cases, we incorrectly strip the header and zero the width of the mmrest that follows.  That's because the code I have to try to restore the correct attributes of the first measure of the next system (from #4866) is not seeing the mmrest but the underlying measure instead.  So the fix is simply to grab the mmrest attribues instead.