### PR TITLE
fix #289581: Fermata loses assignment to voice and direction

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1055,7 +1055,7 @@ static void readChord(Measure* m, Chord* chord, XmlReader& e)
                   chord->add(note);
                   }
             else if (tag == "Attribute" || tag == "Articulation") {
-                  Element* el = readArticulation(chord->score(), e);
+                  Element* el = readArticulation(chord, e);
                   if (el->isFermata()) {
                         if (!chord->segment())
                               chord->setParent(m->getSegment(SegmentType::ChordRest, e.tick()));
@@ -1088,7 +1088,7 @@ static void readRest(Measure* m, Rest* rest, XmlReader& e)
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "Attribute" || tag == "Articulation") {
-                  Element* el = readArticulation(rest->score(), e);
+                  Element* el = readArticulation(rest, e);
                   if (el->isFermata()) {
                         if (!rest->segment())
                               rest->setParent(m->getSegment(SegmentType::ChordRest, e.tick()));

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1934,7 +1934,7 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
             ch->setBeamMode(bm);
             }
       else if (tag == "Articulation") {
-            Element* el = readArticulation(ch->score(), e);
+            Element* el = readArticulation(ch, e);
             if (el->isFermata())
                   ch->segment()->add(el);
             else
@@ -2538,13 +2538,14 @@ static void setFermataPlacement(Element* el, ArticulationAnchor anchor, Directio
 //   readArticulation
 //---------------------------------------------------------
 
-Element* readArticulation(Score* score, XmlReader& e)
+Element* readArticulation(Element* parent, XmlReader& e)
       {
       Element* el = 0;
       SymId sym = SymId::fermataAbove;          // default -- backward compatibility (no type = ufermata in 1.2)
       ArticulationAnchor anchor  = ArticulationAnchor::TOP_STAFF;
       Direction direction = Direction::AUTO;
-      int track = e.track();
+      Score* score = parent->score();
+      int track = parent->track();
       double timeStretch = 0.0;
       bool useDefaultPlacement = true;
 
@@ -2811,7 +2812,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                         else if (t == "spanToOffset")
                               bl->setSpanTo(e.readInt());
                         else if (t == "Articulation") {
-                              Element* el = readArticulation(score, e);
+                              Element* el = readArticulation(bl, e);
                               if (el->isFermata()) {
                                     if (el->placement() == Placement::ABOVE)
                                           fermataAbove = toFermata(el);

--- a/libmscore/read206.h
+++ b/libmscore/read206.h
@@ -65,7 +65,7 @@ class PageFormat {
       qreal oddRightMargin() const        { return _size.width() - _printableWidth - _oddLeftMargin;  }
       };
 
-extern Element* readArticulation(Score*, XmlReader&);
+extern Element* readArticulation(Element*, XmlReader&);
 extern void readAccidental206(Accidental*, XmlReader&);
 extern void setPageFormat(MStyle*, const PageFormat&);
 extern void initPageFormat(MStyle*, PageFormat*);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/289581

This was broken with #3595 when the first parameter to `readArticulation()` was changed from a `ChordRest*` to a `Score*`. This change was made so that `readArticulation()` could be called from `readMeasure()` where there is no appropriate `ChordRest*` to use. But the `ChordRest`'s track was being used to determine the fermata's track, and as it turns out this is not the same as `e.track()`. This fixes the problem by passing the fermata's parent to readArticulation as an `Element*`, and using the parent's track to determine the fermata's track as before.