### PR TITLE
fix #287528, fix #283258 & fix #289773: panels not dockable after undock & close

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -86,7 +86,7 @@ void MuseScore::showInspector(bool visible)
             addDockWidget(Qt::RightDockWidgetArea, _inspector);
             }
       if (_inspector)
-            _inspector->setVisible(visible);
+            reDisplayDockWidget(_inspector, visible);
       if (visible)
             updateInspector();
       }

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1173,7 +1173,7 @@ void MuseScore::showPalette(bool visible)
             updateIcons();
             }
       if (paletteBox)   // read failed?
-            paletteBox->setVisible(visible);
+            reDisplayDockWidget(paletteBox, visible);
       a->setChecked(visible);
       }
 

--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -76,10 +76,12 @@ Mixer::Mixer(QWidget* parent)
       showDetails(true),
       trackHolder(nullptr)
       {
-      setupUi(this);
 
-      setWindowFlags(Qt::Tool);
-      setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
+      // note: because of setupUi side-effects (generating a showEvent) it's critical
+      // that enablePlay is created first.
+      enablePlay = new EnablePlayForWidget(this);
+
+      setupUi(this);
       setAllowedAreas(Qt::DockWidgetAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea));
 
       trackAreaLayout = new QHBoxLayout;
@@ -88,7 +90,7 @@ Mixer::Mixer(QWidget* parent)
       trackArea->setLayout(trackAreaLayout);
 
       mixerDetails = new MixerDetails(this);
-      detailsLayout = new QGridLayout(this);
+      detailsLayout = new QGridLayout();
 
       detailsLayout->addWidget(mixerDetails);
       detailsLayout->setContentsMargins(0, 0, 0, 0);
@@ -120,8 +122,6 @@ Mixer::Mixer(QWidget* parent)
       connect(tracks_scrollArea->horizontalScrollBar(), SIGNAL(rangeChanged(int, int)), SLOT(adjustScrollPosition(int, int)));
       connect(tracks_scrollArea->horizontalScrollBar(), SIGNAL(valueChanged(int)), SLOT(checkKeptScrollValue(int)));
 
-      enablePlay = new EnablePlayForWidget(this);
-      readSettings();
       retranslate(true);
       }
 
@@ -200,7 +200,8 @@ void Mixer::masterVolumeChanged(double decibels)
 
 void Mixer::on_partOnlyCheckBox_toggled(bool checked)
       {
-      if (!_activeScore->excerpt())
+
+      if (!_activeScore || !_activeScore->excerpt())
             return;
 
       mscore->setPlayPartOnly(checked);
@@ -249,7 +250,20 @@ void Mixer::showEvent(QShowEvent* e)
       QWidget::showEvent(e);
       activateWindow();
       setFocus();
+      getAction("toggle-mixer")->setChecked(true);
       }
+
+
+//---------------------------------------------------------
+//   hideEvent
+//---------------------------------------------------------
+
+void Mixer::hideEvent(QHideEvent* e)
+      {
+      QWidget::hideEvent(e);
+      getAction("toggle-mixer")->setChecked(false);
+      }
+
 
 //---------------------------------------------------------
 //   eventFilter
@@ -463,45 +477,26 @@ void Mixer::notifyTrackSelected(MixerTrack* track)
 
 
 //---------------------------------------------------------
-//   writeSettings
-//---------------------------------------------------------
-
-void Mixer::writeSettings()
-      {
-      MuseScore::saveGeometry(this);
-      }
-
-//---------------------------------------------------------
-//   readSettings
-//---------------------------------------------------------
-
-void Mixer::readSettings()
-      {
-      resize(QSize(480, 600)); //ensure default size if no geometry in settings
-      MuseScore::restoreGeometry(this);
-      }
-
-
-//---------------------------------------------------------
 //   showMixer
 //---------------------------------------------------------
 
-void MuseScore::showMixer(bool val)
+void MuseScore::showMixer(bool visible)
       {
-      if (!cs)
-            return;
 
-      QAction* a = getAction("toggle-mixer");
+      QAction* toggleMixerAction = getAction("toggle-mixer");
       if (mixer == 0) {
             mixer = new Mixer(this);
             mscore->stackUnder(mixer);
             if (synthControl)
                   connect(synthControl, SIGNAL(soundFontChanged()), mixer, SLOT(updateTrack()));
             connect(synti, SIGNAL(soundFontChanged()), mixer, SLOT(updateTracks()));
-            connect(mixer, SIGNAL(closed(bool)), a, SLOT(setChecked(bool)));
+            connect(mixer, SIGNAL(closed(bool)), toggleMixerAction, SLOT(setChecked(bool)));
+            mixer->setFloating(false);
+            addDockWidget(Qt::RightDockWidgetArea, mixer);
             }
+      reDisplayDockWidget(mixer, visible);
+      toggleMixerAction->setChecked(visible);
       mixer->setScore(cs);
-      mixer->setVisible(val);
       }
 
 }

--- a/mscore/mixer.h
+++ b/mscore/mixer.h
@@ -81,9 +81,9 @@ class Mixer : public QDockWidget, public Ui::Mixer, public MixerTrackGroup
 
       virtual void closeEvent(QCloseEvent*) override;
       virtual void showEvent(QShowEvent*) override;
+      virtual void hideEvent(QHideEvent*) override;
       virtual bool eventFilter(QObject*, QEvent*) override;
       virtual void keyPressEvent(QKeyEvent*) override;
-      void readSettings();
       void keepScrollPosition();
       void setPlaybackScore(Score*);
 
@@ -109,7 +109,6 @@ class Mixer : public QDockWidget, public Ui::Mixer, public MixerTrackGroup
       Mixer(QWidget* parent);
       void setScore(Score*);
       PartEdit* getPartAtIndex(int index);
-      void writeSettings();
       void expandToggled(Part* part, bool expanded) override;
       void notifyTrackSelected(MixerTrack* track) override;
       void showDetailsToggled(bool shown);

--- a/mscore/mixer.ui
+++ b/mscore/mixer.ui
@@ -23,7 +23,7 @@
    <enum>Qt::ClickFocus</enum>
   </property>
   <property name="windowTitle">
-   <string/>
+   <string>Mixer</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2813,6 +2813,23 @@ void MuseScore::showElementContext(Element* el)
       }
 
 //---------------------------------------------------------
+//   reDisplayDockWidget
+//
+//   Helper function to ensure when un-docked widgets are
+//   re-displayed, they are also re-dockable
+//---------------------------------------------------------
+
+void MuseScore::reDisplayDockWidget(QDockWidget* widget, bool visible)
+      {
+      if (widget->isFloating() && !widget->isVisible()) {
+            // Ensure the widget is re-dockable if it has been closed and re-opened when un-docked. This is a workaround for a known QT bug. See QTBUG-69922.
+            widget->setFloating(false);
+            widget->setFloating(true);
+            }
+      widget->setVisible(visible);
+      }
+
+//---------------------------------------------------------
 //   showPlayPanel
 //---------------------------------------------------------
 
@@ -2840,7 +2857,7 @@ void MuseScore::showPlayPanel(bool visible)
             playPanel->setFloating(false);
             }
       else
-            playPanel->setVisible(visible);
+            reDisplayDockWidget(playPanel, visible);
       playId->setChecked(visible);
       }
 
@@ -4374,8 +4391,6 @@ void MuseScore::writeSettings()
       if (synthControl)
             synthControl->writeSettings();
       settings.setValue("synthControlVisible", synthControl && synthControl->isVisible());
-      if (mixer)
-            mixer->writeSettings();
       settings.setValue("mixerVisible", mixer && mixer->isVisible());
       if (seq) {
             seq->exit();
@@ -4424,6 +4439,12 @@ void MuseScore::readSettings()
 
       MuseScore::restoreGeometry(this);
 
+      // Grab the mixer visible state before the beginGroup.
+      // Previously the showMixer() call was made at the end of
+      // main(). Now it's made inside this beginGroup / endGroup.
+      // This code ensures user previous setting is respected when
+      // updating their version of MuseScore.
+      bool mixerVisible = settings.value("mixerVisible", "0").toBool();
       settings.beginGroup("MainWindow");
       mainWindow->restoreState(settings.value("debuggerSplitter").toByteArray());
       mainWindow->setOpaqueResize(false);
@@ -4438,6 +4459,7 @@ void MuseScore::readSettings()
       mscore->showInspector(settings.value("showInspector", "1").toBool());
       mscore->showPianoKeyboard(settings.value("showPianoKeyboard", "0").toBool());
       mscore->showSelectionWindow(settings.value("showSelectionWindow", "0").toBool());
+      mscore->showMixer(mixerVisible);
 
       restoreState(settings.value("state").toByteArray());
       //if we were in full screen mode, go to maximized mode
@@ -5239,7 +5261,7 @@ void MuseScore::editRaster()
 //   showPianoKeyboard
 //---------------------------------------------------------
 
-void MuseScore::showPianoKeyboard(bool on)
+void MuseScore::showPianoKeyboard(bool visible)
       {
       if (_pianoTools == 0) {
             QAction* a = getAction("toggle-piano");
@@ -5249,8 +5271,8 @@ void MuseScore::showPianoKeyboard(bool on)
             connect(_pianoTools, SIGNAL(keyReleased(int, bool, int)), SLOT(midiNoteReceived(int, bool, int)));
             connect(_pianoTools, SIGNAL(visibilityChanged(bool)), a, SLOT(setChecked(bool)));
             }
-      if (on) {
-            _pianoTools->show();
+      if (visible) {
+            reDisplayDockWidget(_pianoTools, visible);
             if (currentScore())
                   _pianoTools->changeSelection(currentScore()->selection());
             else
@@ -6065,7 +6087,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
       else if (cmd == "toggle-piano")
             showPianoKeyboard(a->isChecked());
       else if (cmd == "toggle-scorecmp-tool")
-            scoreCmpTool->setVisible(a->isChecked());
+            reDisplayDockWidget(scoreCmpTool, a->isChecked());
 #ifdef MSCORE_UNSTABLE
       else if (cmd == "toggle-script-recorder")
             scriptRecorder->setVisible(a->isChecked());
@@ -7663,8 +7685,6 @@ int main(int argc, char* av[])
       QSettings settings;
       if (settings.value("synthControlVisible", false).toBool())
             mscore->showSynthControl(true);
-      if (settings.value("mixerVisible", false).toBool())
-            mscore->showMixer(true);
 
       return qApp->exec();
       }

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -820,6 +820,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void unregisterPlugin(PluginDescription*);
 
       Q_INVOKABLE void showStartcenter(bool);
+      void reDisplayDockWidget(QDockWidget* widget, bool visible);
       void showPlayPanel(bool);
 
       QFileInfoList recentScores() const;

--- a/mscore/selectionwindow.cpp
+++ b/mscore/selectionwindow.cpp
@@ -178,7 +178,7 @@ void SelectionWindow::changeCheckbox(QListWidgetItem* item)
 //   showSelectionWindow
 //---------------------------------------------------------
 
-void MuseScore::showSelectionWindow(bool val)
+void MuseScore::showSelectionWindow(bool visible)
       {
       QAction* a = getAction("toggle-selection-window");
       if (selectionWindow == 0) {
@@ -189,8 +189,8 @@ void MuseScore::showSelectionWindow(bool val)
                   tabifyDockWidget(paletteBox, selectionWindow);
                   }
             }
-      selectionWindow->setVisible(val);
-      if (val) {
+      reDisplayDockWidget(selectionWindow, visible);
+      if (visible) {
             selectionWindow->raise();
             }
       }

--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -57,7 +57,7 @@ void MuseScore::showTimeline(bool visible)
             }
       connect(_timeline, SIGNAL(visibilityChanged(bool)), act, SLOT(setChecked(bool)));
       connect(_timeline, SIGNAL(closed(bool)), act, SLOT(setChecked(bool)));
-      _timeline->setVisible(visible);
+      reDisplayDockWidget(_timeline, visible);
 
       getAction("toggle-timeline")->setChecked(visible);
       if (visible)


### PR DESCRIPTION
1) Adds a function that tests if widget is both not-shown (!isVisible) AND
in the floating state. If so, it cycles the floating state through off
and on again to ensure widget is re-dockable. The !isVisible() test
avoids side effect of dock being resized, e.g. made wider, even when
the widget won't be landing on it (#289773). Function used to the fix
issue for:

- Play Panel
- Palettes
- Inspector
- Selection Filter
- Piano Keyboard (when dockable, only dockable in footer)
- Time Line (when dockable, only dockable in footer)
- Score Comparison Tool
- Mixer

2) Addresses some issues with the mixer (#283258) being converted from
an independent window to a dock widget:

- add code to ensure the show/hide menu is in sync with the mixer being
shown
- removed inappropriate widget configuration on setup