### PR TITLE
fix #290019: Piano keyboard display does not update when changing note by using arrow keys.

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1516,6 +1516,7 @@ void Score::upDown(bool up, UpDownMode mode)
             // play new note with velocity 80 for 0.3 sec:
             setPlayNote(true);
             }
+      setSelectionChanged(true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/290019

This was working until #4979 removed the code that updated the selection. All that is needed is to call `setSelectionChanged(true)` at the end of `Score::upDown()`.