### PR TITLE
fix #290040: line min distance not saved, so won't stay within skyline

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -997,7 +997,7 @@ void SLine::writeProperties(XmlWriter& xml) const
             return;
 
       //
-      // write user modified layout
+      // write user modified layout and other segment properties
       //
       qreal _spatium = score()->spatium();
       for (const SpannerSegment* seg : spannerSegments()) {
@@ -1010,6 +1010,7 @@ void SLine::writeProperties(XmlWriter& xml) const
             //if (seg->propertyFlags(Pid::OFFSET) & PropertyFlags::UNSTYLED)
             xml.tag("offset", seg->offset() / _spatium);
             xml.tag("off2", seg->userOff2() / _spatium);
+            seg->writeProperty(xml, Pid::MIN_DISTANCE);
             seg->Element::writeProperties(xml);
             xml.etag();
             }


### PR DESCRIPTION
See https://musescore.org/en/node/290040.  This is another one of those "how could I possibly have missed this" bugs - whil you can move a line into the skyline, the adjusted min distance property that makes this possible doesn't get saved.

Apparently, while line segments may have styled properties, these are never actually written as such - there is no loop to write styled properties as there is for most other element types.  There is code in SLine::writeProperties() that special-cases OFFSET (and this isn't really good, as the comment indicates) so it gets written, but if anything else is listed in the element style for the segment, too bad.  Right now, we're quite consistent about giving all line segments OFFSET and MIN_DISTANCE as styled properties, but only OFFSET gets written.

In this PR, I am simply writing MIN_DISTANCE explicitly in the same place we write OFFSET.  Really, we *could* loop through the styled properties and write them, or even call ScoreElement::writeStyledProperties() to do it for us.  But I'm a little reluctant to make a change like that, as it could potentially have other ramifications in the future, and management of properties on spanners and spanner segments has been problematic and fragile for years as it is.