### PR TITLE
fix #290061: no space between header and clef change

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -4106,7 +4106,8 @@ void Measure::computeMinWidth(Segment* s, qreal x, bool isSystemHeader)
             qreal w;
 
             if (ns) {
-                  if (isSystemHeader && ns->isChordRestType()) {        // this is the system header gap
+                  if (isSystemHeader && (ns->isChordRestType() || (ns->isClefType() && !ns->header()))) {
+                        // this is the system header gap
                         w = s->minHorizontalDistance(ns, true);
                         isSystemHeader = false;
                         }

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -2079,6 +2079,14 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
             // d = qMax(d, spatium());       // minimum distance is one spatium
             // w = qMax(w, minRight()) + d;
             }
+      else if (systemHeaderGap) {
+            // first segment after header is *not* a chordrest
+            // could be a clef
+            if (st == SegmentType::TimeSig)
+                  w += score()->styleP(Sid::systemHeaderTimeSigDistance);
+            else
+                  w += score()->styleP(Sid::systemHeaderDistance);
+            }
       else if (st & (SegmentType::Clef | SegmentType::HeaderClef)) {
             if (nst == SegmentType::KeySig || nst == SegmentType::KeySigAnnounce)
                   w += score()->styleP(Sid::clefKeyDistance);


### PR DESCRIPTION
See https://musescore.org/en/node/290061

We have lots of checks in Segment::minDistance() to pply the various different settings from Format / Style / Measure ("Key signature left marign", etc).  But nowhere were we checking for the case of a header followed immediately by a clef change, so none of these settings were being applied.  This PR simply adds that check.  I had to set the systemHeaderGap parameter in Measure::computeMinWidth() because it was only considering setting it for the chordrest segment (and thus also putting too much space after a clef change at the start of a system), but then also put code in Segment::minHorizontalDistance to handle this.

Pretty straightforward, but like any change of this nature, it warrants review!