### PR TITLE
fix #289877: fingering affects layout with autoplace off

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3222,6 +3222,8 @@ Shape Chord::shape() const
       for (Note* note : _notes) {
             shape.add(note->shape().translated(note->pos()));
             for (Element* e : note->el()) {
+                  if (!e->addToSkyline())
+                        continue;
                   if (e->isFingering() && toFingering(e)->layoutType() == ElementType::CHORD && e->bbox().isValid())
                         shape.add(e->bbox().translated(e->pos() + note->pos()));
                   }


### PR DESCRIPTION
Another case where disabling autoplace doesn't completely remove an element from the layout equation.  Especially troublesome here because fingering layout is done in a couple of passes, so rather than disabling autoplace having *no* effect, it sometimes does and sometimes doesn't, producing erratic-seemingly layut shifts.

Fix is simple, just checking addToSklyine() like we do pretty much everywhere else.
