### PR TITLE
fix #290053: don't trigger layout for elements not yet added to score

### DIFF
--- a/libmscore/element.cpp
+++ b/libmscore/element.cpp
@@ -1784,7 +1784,8 @@ bool Element::isUserModified() const
 
 void Element::triggerLayout() const
       {
-      score()->setLayout(tick());
+      if (parent())
+            score()->setLayout(tick());
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/290053

Currently, adding an element to the score often causes a layout of the whole score from the start to that point.  That's because the act of constructing the new element often involves some setProperty() calls, and Eement::setProperty() as well as many of its overrides call triggerLayout().  That would be fine, but the element being constructed does not yet have a parent, so when triggerLayout() goes to get a tick, it comes up with 0.  Thus, we end up setting the start tick for the layout range to 0 unnecessarily.  The result is that adding elements to the score gets progressively slower the deeper into the score you go.

My PR here is very simple, I simply have triggerLayout() do nothing for elements with no parent.  Once the element is fully constructed, and given a parent, there is an explicit triggerLayout() call right at the top of Score::addElement() as well, so that we are able to set the correct tick and perform the proper layout.