### PR TITLE
fix #290121: changes to non-expr patches aren't saved

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -637,6 +637,18 @@ void Channel::setSolo(bool value)
       }
 
 //---------------------------------------------------------
+//   setUserBankController
+//---------------------------------------------------------
+
+void Channel::setUserBankController(bool val)
+      {
+      if (_userBankController != val) {
+            _userBankController = val;
+            firePropertyChanged(Prop::USER_BANK_CONTROL);
+            }
+      }
+
+//---------------------------------------------------------
 //   write
 //---------------------------------------------------------
 
@@ -655,12 +667,10 @@ void Channel::write(XmlWriter& xml, const Part* part) const
             if (e.type() == ME_INVALID)
                   continue;
             if (e.type() == ME_CONTROLLER) {
-                  // don't write if automatically switched
-                  if ((e.dataA() == CTRL_HBANK || e.dataA() == CTRL_LBANK) &&  !_userBankController)
+                  // Don't write bank if automatically switched, but always write if switched by the user
+                  if (e.dataA() == CTRL_HBANK && e.dataB() == 0 && !_userBankController)
                         continue;
-                  if (e.dataA() == CTRL_HBANK && e.dataB() == 0)
-                        continue;
-                  if (e.dataA() == CTRL_LBANK && e.dataB() == 0)
+                  if (e.dataA() == CTRL_LBANK && e.dataB() == 0 && !_userBankController)
                         continue;
                   if (e.dataA() == CTRL_VOLUME && e.dataB() == 100)
                         continue;
@@ -1004,6 +1014,9 @@ void PartChannelSettingsLink::applyProperty(Channel::Prop p, const Channel* from
                   break;
             case Channel::Prop::CHANNEL:
                   to->setChannel(from->channel());
+                  break;
+            case Channel::Prop::USER_BANK_CONTROL:
+                  to->setUserBankController(from->userBankController());
                   break;
             };
       }

--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -138,7 +138,7 @@ public:
 
       enum class Prop : char {
             VOLUME, PAN, CHORUS, REVERB, NAME, DESCR, PROGRAM, BANK, COLOR,
-            SOLOMUTE, SOLO, MUTE, SYNTI, CHANNEL
+            SOLOMUTE, SOLO, MUTE, SYNTI, CHANNEL, USER_BANK_CONTROL
             };
 
 private:
@@ -182,7 +182,7 @@ public:
 
       // If the bank controller is set by the user or not
       bool userBankController() const           { return _userBankController; }
-      void setUserBankController(bool val)      { _userBankController = val; }
+      void setUserBankController(bool val);
 
       QList<NamedEventList> midiActions;
       QList<MidiArticulation> articulation;

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2479,9 +2479,6 @@ static void readInstrument(Instrument *i, Part* p, XmlReader& e)
                  e.unknown();
             }
 
-      // Read single-note dynamics from template
-      i->setSingleNoteDynamicsFromTemplate();
-
       if (i->channel().empty()) {      // for backward compatibility
             Channel* a = new Channel;
             a->setName(Channel::DEFAULT_NAME);
@@ -2497,6 +2494,15 @@ static void readInstrument(Instrument *i, Part* p, XmlReader& e)
             if (i->channel()[0]->bank() == 0)
                   i->channel()[0]->setBank(128);
             }
+
+      // Fix user bank controller read
+      for (Channel* c : i->channel()) {
+            if (c->bank() == 0)
+                  c->setUserBankController(false);
+            }
+
+      // Read single-note dynamics from template
+      i->setSingleNoteDynamicsFromTemplate();
       }
 
 //---------------------------------------------------------

--- a/mtest/importmidi/perc_drums.mscx
+++ b/mtest/importmidi/perc_drums.mscx
@@ -262,6 +262,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/importmidi/perc_no_grand_staff.mscx
+++ b/mtest/importmidi/perc_no_grand_staff.mscx
@@ -89,6 +89,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           </Channel>
         </Instrument>
@@ -333,6 +334,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="16"/>
           </Channel>
         </Instrument>

--- a/mtest/importmidi/perc_remove_ties.mscx
+++ b/mtest/importmidi/perc_remove_ties.mscx
@@ -262,6 +262,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           <controller ctrl="7" value="105"/>
           </Channel>

--- a/mtest/importmidi/perc_respect_beat.mscx
+++ b/mtest/importmidi/perc_respect_beat.mscx
@@ -98,6 +98,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="51"/>
           </Channel>
         </Instrument>

--- a/mtest/importmidi/perc_short_notes.mscx
+++ b/mtest/importmidi/perc_short_notes.mscx
@@ -262,6 +262,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           <controller ctrl="7" value="127"/>
           </Channel>

--- a/mtest/importmidi/perc_triplet.mscx
+++ b/mtest/importmidi/perc_triplet.mscx
@@ -98,6 +98,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="51"/>
           </Channel>
         </Instrument>

--- a/mtest/importmidi/perc_tuplet_simplify.mscx
+++ b/mtest/importmidi/perc_tuplet_simplify.mscx
@@ -262,6 +262,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/importmidi/perc_tuplet_simplify2.mscx
+++ b/mtest/importmidi/perc_tuplet_simplify2.mscx
@@ -262,6 +262,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="21"/>
           </Channel>
         </Instrument>

--- a/mtest/importmidi/perc_tuplet_voice.mscx
+++ b/mtest/importmidi/perc_tuplet_voice.mscx
@@ -262,6 +262,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/compat114/drumset-ref.mscx
+++ b/mtest/libmscore/compat114/drumset-ref.mscx
@@ -252,6 +252,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           <controller ctrl="93" value="30"/>
           <controller ctrl="91" value="30"/>

--- a/mtest/libmscore/compat114/tamtam-ref.mscx
+++ b/mtest/libmscore/compat114/tamtam-ref.mscx
@@ -85,6 +85,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           <controller ctrl="93" value="30"/>
           <controller ctrl="91" value="30"/>

--- a/mtest/libmscore/compat206/drumset-ref.mscx
+++ b/mtest/libmscore/compat206/drumset-ref.mscx
@@ -301,6 +301,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           </Channel>
         </Instrument>
@@ -433,6 +434,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="56"/>
           </Channel>
         </Instrument>
@@ -641,6 +643,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="95"/>
           </Channel>
         </Instrument>
@@ -765,6 +768,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="57"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/tools/undoSlashFill01-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashFill01-ref.mscx
@@ -297,6 +297,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/tools/undoSlashFill02-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashFill02-ref.mscx
@@ -297,6 +297,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/tools/undoSlashRhythm01-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashRhythm01-ref.mscx
@@ -297,6 +297,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           </Channel>
         </Instrument>

--- a/mtest/libmscore/tools/undoSlashRhythm02-ref.mscx
+++ b/mtest/libmscore/tools/undoSlashRhythm02-ref.mscx
@@ -297,6 +297,7 @@
           </Articulation>
         <Channel>
           <controller ctrl="0" value="1"/>
+          <controller ctrl="32" value="0"/>
           <program value="0"/>
           </Channel>
         </Instrument>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/290121