### PR TITLE
fix #290060: improving dark theme

### DIFF
--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -1055,7 +1055,7 @@ static void readChord(Measure* m, Chord* chord, XmlReader& e)
                   chord->add(note);
                   }
             else if (tag == "Attribute" || tag == "Articulation") {
-                  Element* el = readArticulation(chord->score(), e);
+                  Element* el = readArticulation(chord, e);
                   if (el->isFermata()) {
                         if (!chord->segment())
                               chord->setParent(m->getSegment(SegmentType::ChordRest, e.tick()));
@@ -1088,7 +1088,7 @@ static void readRest(Measure* m, Rest* rest, XmlReader& e)
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "Attribute" || tag == "Articulation") {
-                  Element* el = readArticulation(rest->score(), e);
+                  Element* el = readArticulation(rest, e);
                   if (el->isFermata()) {
                         if (!rest->segment())
                               rest->setParent(m->getSegment(SegmentType::ChordRest, e.tick()));

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -1934,7 +1934,7 @@ bool readChordRestProperties206(XmlReader& e, ChordRest* ch)
             ch->setBeamMode(bm);
             }
       else if (tag == "Articulation") {
-            Element* el = readArticulation(ch->score(), e);
+            Element* el = readArticulation(ch, e);
             if (el->isFermata())
                   ch->segment()->add(el);
             else
@@ -2538,13 +2538,14 @@ static void setFermataPlacement(Element* el, ArticulationAnchor anchor, Directio
 //   readArticulation
 //---------------------------------------------------------
 
-Element* readArticulation(Score* score, XmlReader& e)
+Element* readArticulation(Element* parent, XmlReader& e)
       {
       Element* el = 0;
       SymId sym = SymId::fermataAbove;          // default -- backward compatibility (no type = ufermata in 1.2)
       ArticulationAnchor anchor  = ArticulationAnchor::TOP_STAFF;
       Direction direction = Direction::AUTO;
-      int track = e.track();
+      Score* score = parent->score();
+      int track = parent->track();
       double timeStretch = 0.0;
       bool useDefaultPlacement = true;
 
@@ -2811,7 +2812,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                         else if (t == "spanToOffset")
                               bl->setSpanTo(e.readInt());
                         else if (t == "Articulation") {
-                              Element* el = readArticulation(score, e);
+                              Element* el = readArticulation(bl, e);
                               if (el->isFermata()) {
                                     if (el->placement() == Placement::ABOVE)
                                           fermataAbove = toFermata(el);

--- a/libmscore/read206.h
+++ b/libmscore/read206.h
@@ -65,7 +65,7 @@ class PageFormat {
       qreal oddRightMargin() const        { return _size.width() - _printableWidth - _oddLeftMargin;  }
       };
 
-extern Element* readArticulation(Score*, XmlReader&);
+extern Element* readArticulation(Element*, XmlReader&);
 extern void readAccidental206(Accidental*, XmlReader&);
 extern void setPageFormat(MStyle*, const PageFormat&);
 extern void initPageFormat(MStyle*, PageFormat*);


### PR DESCRIPTION
This PR improves the dark theme. The main modifications made were:
* backgrounds are substantially darker, in line with how dark themes work in other software (GIMP, Darktable, etc.)
* blue highlight colour has been darkened a bit as it did not work well with the white text of the dark theme
* tooltip text has been changed from black to white as to match the rest of the theme

For the initial report, see: https://musescore.org/en/node/290060