### PR TITLE
fix #290187: crash on paste clef/key/time signature

### DIFF
--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -980,14 +980,24 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
                               ddata.dropElement = nel;
                               ddata.duration    = duration;
                               if (target->acceptDrop(ddata)) {
-                                    // dropping an element of the same type is likely to replace it
-                                    // thus invaldiating the selection
-                                    ElementType targetType = target->type();
-                                    if (targetType == type)
+                                    if (type == ElementType::NOTE) {
+                                          // dropping a note replaces and invalidates the target,
+                                          // so we need to deselect it
+                                          ElementType targetType = target->type();
                                           deselect(target);
-                                    target->drop(ddata);
-                                    if (targetType == type)
-                                          select(nel);
+
+                                          // perform the drop
+                                          target->drop(ddata);
+
+                                          // if the target is a rest rather than a note,
+                                          // a new note is generated, and nel becomes invalid as well
+                                          // (ChordRest::drop() will select it for us)
+                                          if (targetType == ElementType::NOTE)
+                                                select(nel);
+                                          }
+                                    else {
+                                          target->drop(ddata);
+                                          }
                                     if (_selection.element())
                                           addRefresh(_selection.element()->abbox());
                                     }


### PR DESCRIPTION
See https://musescore.org/en/node/290187

Crash comes from my code to re-establish the selection upon pasting an element onto another of the same type.  Turns out my assumption that this resulted in replacing the target with the new element is wrong elements other than notes.  So, I've adjusted this code to be more specific: we do the special handling only when dropping notes.  In that case, we deselect the target because we know it is being replaced, then select the new note when dropping a note onto a nother note.  We don't select anything here when dropping a note onto a rest because it turns out both the original rest and the dropped note are invalid here because a new note is generated (and, luckily, selected for us) in ChordRest::drop().

Tested now with combinations or notes, rests, clefs, key & time signatures, and also pasting other elements (text, articuations, etc) onto notes.