### PR TITLE
Copy image with link

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2658,6 +2658,9 @@ void Score::getNextMeasure(LayoutContext& lc)
             as.init(staff->keySigEvent(measure->tick()), staff->clef(measure->tick()));
 
             for (Segment& segment : measure->segments()) {
+                  // TODO? maybe we do need to process it here to make it possible to enable later
+                  //if (!segment.enabled())
+                  //      continue;
                   if (segment.isKeySigType()) {
                         KeySig* ks = toKeySig(segment.element(staffIdx * VOICES));
                         if (!ks)
@@ -2867,6 +2870,9 @@ void Score::getNextMeasure(LayoutContext& lc)
             score()->undoRemoveElement(seg);
 
       for (Segment& s : measure->segments()) {
+            // TODO? maybe we do need to process it here to make it possible to enable later
+            //if (!s.enabled())
+            //      continue;
             // DEBUG: relayout grace notes as beaming/flags may have changed
             if (s.isChordRestType()) {
                   for (Element* e : s.elist()) {
@@ -4237,7 +4243,6 @@ void LayoutContext::collectPage()
             //
             //  check for page break or if next system will fit on page
             //
-            const bool rangeWasDone = rangeDone;
             if (rangeDone) {
                   // take next system unchanged
                   if (systemIdx > 0) {
@@ -4312,9 +4317,6 @@ void LayoutContext::collectPage()
                   qreal dist = qMax(prevSystem->minBottom(), prevSystem->spacerDistance(false));
                   dist = qMax(dist, slb);
                   layoutPage(page, ey - (y + dist));
-                  // We don't accept current system to this page
-                  // so rollback rangeDone variable as well.
-                  rangeDone = rangeWasDone;
                   break;
                   }
             }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3510,9 +3510,15 @@ System* Score::collectSystem(LayoutContext& lc)
 
             // preserve state of next measure (which is about to become current measure)
             if (lc.nextMeasure) {
-                  curWidth = lc.nextMeasure->width();
-                  curHeader = lc.nextMeasure->header();
-                  curTrailer = lc.nextMeasure->trailer();
+                  MeasureBase* nmb = lc.nextMeasure;
+                  if (nmb->isMeasure() && styleB(Sid::createMultiMeasureRests)) {
+                        Measure* nm = toMeasure(nmb);
+                        if (nm->hasMMRest())
+                              nmb = nm->mmRest();
+                        }
+                  curWidth = nmb->width();
+                  curHeader = nmb->header();
+                  curTrailer = nmb->trailer();
                   }
 
             getNextMeasure(lc);

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -2009,6 +2009,10 @@ qreal Segment::minHorizontalDistance(Segment* ns, bool systemHeaderGap) const
       qreal ww = -1000000.0;        // can remain negative
       for (unsigned staffIdx = 0; staffIdx < _shapes.size(); ++staffIdx) {
             qreal d = staffShape(staffIdx).minHorizontalDistance(ns->staffShape(staffIdx));
+            // first chordrest of a staff should clear the widest header for any staff
+            // so make sure segment is as wide as it needs to be
+            if (systemHeaderGap)
+                  d = qMax(d, staffShape(staffIdx).right());
             ww      = qMax(ww, d);
             }
       qreal w = qMax(ww, 0.0);      // non-negative

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -266,7 +266,7 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       void normalCut();
       void normalCopy();
-      void fotoModeCopy();
+      void fotoModeCopy(bool includeLink = false);
       bool normalPaste(Fraction scale = Fraction(1, 1));
       void normalSwap();
 


### PR DESCRIPTION
See https://musescore.org/en/node/290194 for some background.

The "image capture" tool gives us the insert MuseScore examples as images into other documents.  I have an extension I developed for LibreOffice that provided some additional automation, most importantly, adding a link back to the original score so you can use that (via Ctrl+click in LibreOffice) to automtically open the source score in MuseScore.  This is really nice for creating documents where you may need to go back and edit examples over time (eg, writing a textbook).  But maintaining this extension is becoming a bit of a burden.  As a possible substitute, I'd like to see this simply new feature added directly to MuseScore, it just adds a new command to the image capture tool that copies the image along with a link to the clipboard, so you can paste that directly into LibreOffice etc and get the same basic behavior: an image in your document you can Ctrl+click to edit in MuseScore.