### PR TITLE
add 'copy with link to score' command to foto mode

### DIFF
--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -266,7 +266,7 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       void normalCut();
       void normalCopy();
-      void fotoModeCopy();
+      void fotoModeCopy(bool includeLink = false);
       bool normalPaste(Fraction scale = Fraction(1, 1));
       void normalSwap();
 


### PR DESCRIPTION
See https://musescore.org/en/node/290194 for some background (and ignore #5099)

The "image capture" tool gives us the ability to insert MuseScore examples as images into other documents. I have an extension I developed for LibreOffice that provided some additional automation, most importantly, adding a link back to the original score so you can use that (via Ctrl+click in LibreOffice) to automatically open the source score in MuseScore. This is really nice for creating documents where you may need to go back and edit examples over time (eg, writing a textbook). But maintaining this extension is becoming a bit of a burden. As a possible substitute, I'd like to see this simply new feature added directly to MuseScore, it just adds a new command to the image capture tool that copies the image along with a link to the clipboard, so you can paste that directly into LibreOffice etc and get the same basic behavior: an image in your document you can Ctrl+click to edit in MuseScore.