### PR TITLE
[MU4] partial fix #283283: fingerings on beamed notes can collide with slurs

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3221,12 +3221,14 @@ Shape Chord::shape() const
 //            shape.add(_tremolo->shape().translated(_tremolo->pos()));
       for (Note* note : _notes) {
             shape.add(note->shape().translated(note->pos()));
+#if 0
             for (Element* e : note->el()) {
                   if (!e->addToSkyline())
                         continue;
                   if (e->isFingering() && toFingering(e)->layoutType() == ElementType::CHORD && e->bbox().isValid())
                         shape.add(e->bbox().translated(e->pos() + note->pos()));
                   }
+#endif
             }
       for (Element* e : el()) {
             if (e->addToSkyline())

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3845,7 +3845,13 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                               f->layout();
                               if (f->addToSkyline()) {
                                     Note* n = f->note();
-                                    QRectF r = f->bbox().translated(f->pos() + n->pos() + n->chord()->pos() + s->pos() + s->measure()->pos());
+                                    QRectF r = f->bbox().translated(f->pos() + n->pos() + n->chord()->pos());
+                                    // segment shapes were regenerated for beamed notes
+                                    // fingering shape was lost since it was cleared above
+                                    // so add it back now
+                                    if (n->chord()->beam())
+                                          n->chord()->segment()->staffShape(n->chord()->vStaffIdx()).add(r);
+                                    r.translate(s->pos() + s->measure()->pos());
                                     system->staff(f->note()->chord()->vStaffIdx())->skyline().add(r);
                                     }
                               }

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3750,7 +3750,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                     int effectiveTrack = e->vStaffIdx() * VOICES + e->voice();
                                     if (effectiveTrack < strack || effectiveTrack >= etrack)
                                           continue;
-
+#if 0
                                     // clear layout for chord-based fingerings
                                     // do this before adding chord to skyline
                                     if (e->isChord()) {
@@ -3774,7 +3774,7 @@ void Score::layoutSystemElements(System* system, LayoutContext& lc)
                                                       }
                                                 }
                                           }
-
+#endif
                                     // add element to skyline
                                     if (e->addToSkyline())
                                           skyline.add(e->shape().translated(e->pos() + p));


### PR DESCRIPTION
See https://musescore.org/en/node/283283

Chord-based fingerings are part of the chord shape and are thus added to the segment shape early in layout, but this is lost when the segment shape is re-created during beam layout.  This PR simply adds them back to the segment shape.  It's only a partial fix to the issue because the segments at the endpoints are deliberately skipped during slur autoplace, to avoid bad effects trying to avoid collisions with accidentals etc.  In theory we could have a fixFingerings() function akin to fixArticulation() in slur.cpp to avoid these collisions.  The reality is this is probably easier said than done, depending on what the desired result is (placing the slur outside the fingerings is probably easier but less desirable).