### PR TITLE
fix #284002: Tablature: unexpected default behavior with tied fret mark and parenthesis

### DIFF
--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -267,7 +267,6 @@ class Note final : public Element {
       SymId _cachedSymNull; // additional symbol for some transparent notehead
 
       QString _fretString;
-      bool _fretHidden = false;
 
       virtual void startDrag(EditData&) override;
       virtual QRectF drag(EditData&) override;

--- a/libmscore/tie.cpp
+++ b/libmscore/tie.cpp
@@ -615,6 +615,13 @@ void Tie::calculateDirection()
 
 TieSegment* Tie::layoutFor(System* system)
       {
+      // do not layout ties in tablature if not showing back-tied fret marks
+      StaffType* st = staff()->staffType(startNote() ? startNote()->tick() : Fraction(0, 1));
+      if (st && st->isTabStaff() && !st->showBackTied()) {
+            if (!segmentsEmpty())
+                  eraseSpannerSegments();
+            return nullptr;
+            }
       //
       //    show short bow
       //
@@ -673,6 +680,14 @@ TieSegment* Tie::layoutFor(System* system)
 
 TieSegment* Tie::layoutBack(System* system)
       {
+      // do not layout ties in tablature if not showing back-tied fret marks
+      StaffType* st = staff()->staffType(startNote() ? startNote()->tick() : Fraction(0, 1));
+      if (st->isTabStaff() && !st->showBackTied()) {
+            if (!segmentsEmpty())
+                  eraseSpannerSegments();
+            return nullptr;
+            }
+
       SlurPos sPos;
       slurPos(&sPos);
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/284002.

The `_fretHidden` variable is often assigned the wrong value because `Note::layout()` and `Note::layout2()` are called before the measure is added to its system. This gets rid of the `_fretHidden` variable entirely, and now `Note::draw()` decides whether or not the fret should be hidden. Also, ties in tablature staves are now hidden if "Show back-tied fret marks" is OFF.