### PR TITLE
fix #290415: crash when moving a formerly cross-system-break tied note

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -1492,7 +1492,7 @@ void Score::addElement(Element* element)
 void Score::removeElement(Element* element)
       {
       Element* parent = element->parent();
-      setLayout(element->tick());
+      element->triggerLayout();
 
 //      qDebug("Score(%p) Element(%p)(%s) parent %p(%s)",
 //         this, element, element->name(), parent, parent ? parent->name() : "");


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/290415.