### PR TITLE
fix #290323: synthesizer tag always written

### DIFF
--- a/libmscore/synthesizerstate.cpp
+++ b/libmscore/synthesizerstate.cpp
@@ -19,8 +19,11 @@ namespace Ms {
 //   write
 //---------------------------------------------------------
 
-void SynthesizerState::write(XmlWriter& xml) const
+void SynthesizerState::write(XmlWriter& xml, bool force /* = false */) const
       {
+      if (isDefault() && !force)
+            return;
+
       xml.stag("Synthesizer");
       for (const SynthesizerGroup& g : *this) {
             if (!g.name().isEmpty()) {
@@ -52,6 +55,7 @@ void SynthesizerState::read(XmlReader& e)
                         e.unknown();
                   }
             push_back(group);
+            setIsDefault(false);
             }
       }
 

--- a/libmscore/synthesizerstate.h
+++ b/libmscore/synthesizerstate.h
@@ -53,6 +53,7 @@ class SynthesizerGroup : public std::list<IdValue> {
 //---------------------------------------------------------
 
 class SynthesizerState : public std::list<SynthesizerGroup> {
+      bool _isDefault        { true };
 
    public:
       SynthesizerState(std::initializer_list<SynthesizerGroup> l) {
@@ -60,12 +61,14 @@ class SynthesizerState : public std::list<SynthesizerGroup> {
             }
       SynthesizerState() : std::list<SynthesizerGroup>() {}
 
-      void write(XmlWriter&) const;
+      void write(XmlWriter&, bool force = false) const;
       void read(XmlReader&);
       SynthesizerGroup group(const QString& name) const;
       bool isDefaultSynthSoundfont();
       int ccToUse() const;
       int method() const;
+      bool isDefault() const        { return _isDefault; }
+      void setIsDefault(bool val)   { _isDefault = val; }
       };
 
 //---------------------------------------------------------

--- a/mscore/synthcontrol.cpp
+++ b/mscore/synthcontrol.cpp
@@ -355,7 +355,10 @@ void SynthControl::saveButtonClicked()
       if (!_score)
             return;
       _score->startCmd();
-      _score->undo(new ChangeSynthesizerState(_score, synti->state()));
+      SynthesizerState ss = synti->state();
+      if (_dirty || !_score->synthesizerState().isDefault())
+            ss.setIsDefault(false);
+      _score->undo(new ChangeSynthesizerState(_score, ss));
       _score->endCmd();
 
       updateExpressivePatches();
@@ -363,6 +366,7 @@ void SynthControl::saveButtonClicked()
       saveButton->setEnabled(false);
       storeButton->setEnabled(true);
       recallButton->setEnabled(true);
+      _dirty = false;
       }
 
 //---------------------------------------------------------
@@ -391,6 +395,7 @@ void SynthControl::recallButtonClicked()
             else
                   e.unknown();
             }
+      state.setIsDefault(true);
       synti->setState(state);
       updateGui();
 
@@ -417,6 +422,7 @@ void SynthControl::storeButtonClicked()
       updateExpressivePatches();
       storeButton->setEnabled(false);
       recallButton->setEnabled(false);
+      _dirty = false;
       }
 
 //---------------------------------------------------------
@@ -479,6 +485,7 @@ void SynthControl::updateMixer()
 
 void SynthControl::setDirty()
       {
+      _dirty = true;
       loadButton->setEnabled(true);
       saveButton->setEnabled(true);
       storeButton->setEnabled(true);

--- a/mscore/synthcontrol.h
+++ b/mscore/synthcontrol.h
@@ -36,6 +36,7 @@ class SynthControl : public QWidget, Ui::SynthControl {
 
       Score* _score;
       EnablePlayForWidget* enablePlay;
+      bool _dirty    { false };
 
       virtual void closeEvent(QCloseEvent*);
       virtual void showEvent(QShowEvent*);

--- a/synthesizer/msynthesizer.cpp
+++ b/synthesizer/msynthesizer.cpp
@@ -408,7 +408,9 @@ bool MasterSynthesizer::storeState()
             }
       XmlWriter xml(0, &f);
       xml.header();
-      state().write(xml);
+      // force the write, since the msynth state is created when state() is called and so will
+      // automatically have _isDefault = true, when in fact we need to write the state here, default or not
+      state().write(xml, true);
       return true;
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/290323

This adds a member for the synthesizer state, `_isDefault`. This holds whether the synth state has been loaded from the MasterSynthesizer state, or if it has in fact been read from the score.

If the state is the MasterSynth default, `_isDefault` is true and we don't have to write it, since the expected action is for any score to have its state loaded from master score unless otherwise specified. If it's not, `_isDefault` will be false we need to write it, since the user has pressed 'Save state to score' in the synth control.

_isDefault is set:

- to false when a synth state is read
- to false when a synth state is changed via the synthesizer control and then saved to the score
- just before the master synth state is written (applied to a copy of the state) so that it is actually written

The new `_dirty` member of SynthControl is to allow a check for whether the synth state has been changed before it is saved to score. If it is true, then the SynthState being saved to the score is set to have `_isDefault = false` because it's different.