### PR TITLE
Make it possible to place tremolo at stem center

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -1488,6 +1488,26 @@ void Beam::computeStemLen(const std::vector<ChordRest*>& cl, qreal& py1, int bea
             slope   = (bm.s * _spatium4) / dx;
       int dy = (c1->line(_up) - c1->line(!_up)) * 2;
 
+      // Ensure the resulting stem lengths are not less than a reasonable minimum
+      qreal firstStemLenPoints = bm.l * _spStaff4;
+      const qreal sgn = (firstStemLenPoints < 0 ? -1.0 : 1.0);
+      const QPointF p1 = cl[0]->stemPosBeam();
+      for (const ChordRest* cr : cl) {
+            if (cr->isChord()) {
+                  const qreal minAbsLen = toChord(cr)->minAbsStemLength();
+
+                  const QPointF p2 = cr->stemPosBeam();
+
+                  const qreal crStemAbsLen = std::abs((p2.x() - p1.x()) * slope - p2.y() + p1.y() + firstStemLenPoints);
+
+                  if (crStemAbsLen < minAbsLen) {
+                        const qreal dl = minAbsLen - crStemAbsLen;
+                        firstStemLenPoints += sgn * dl;
+                        bm.l += sgn * dl / _spStaff4;
+                        }
+                  }
+            }
+
       py1 += (dy + bm.l) * _spStaff4;
       }
 

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -116,7 +116,8 @@ class Chord final : public ChordRest {
 
       LedgerLine* ledgerLines()                  { return _ledgerLines; }
 
-      qreal defaultStemLength();
+      qreal defaultStemLength() const;
+      qreal minAbsStemLength() const;
 
       virtual void layoutStem1() override;
       void layoutStem();

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -327,6 +327,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::CHORD_LINE_TYPE,         true,  "subtype",               P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "chord line type")  },
       { Pid::CHORD_LINE_STRAIGHT,     true,  "straight",              P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "straight chord line") },
       { Pid::TREMOLO_TYPE,            true,  "subtype",               P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "tremolo type")     },
+      { Pid::TREMOLO_PLACEMENT,       false, "tremoloPlacement",      P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "tremolo placement") },
 
       { Pid::END, false, "++end++", P_TYPE::INT, DUMMY_QT_TRANSLATE_NOOP("propertyName", "<invalid property>") }
       };

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -337,6 +337,7 @@ enum class Pid {
       CHORD_LINE_TYPE,
       CHORD_LINE_STRAIGHT,
       TREMOLO_TYPE,
+      TREMOLO_PLACEMENT,
 
       END
       };

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -462,6 +462,7 @@ static const StyleType styleTypes[] {
       { Sid::tremoloBoxHeight,        "tremoloBoxHeight",        Spatium(0.65) },
       { Sid::tremoloStrokeWidth,      "tremoloLineWidth",        Spatium(0.5) },  // was 0.35
       { Sid::tremoloDistance,         "tremoloDistance",         Spatium(0.8) },
+      { Sid::tremoloPlacement,        "tremoloPlacement",        int(TremoloPlacement::DEFAULT) },
 
       { Sid::linearStretch,           "linearStretch",           QVariant(qreal(1.5)) },
       { Sid::crossMeasureValues,      "crossMeasureValues",      QVariant(false) },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -434,6 +434,7 @@ enum class Sid {
       tremoloBoxHeight,
       tremoloStrokeWidth,
       tremoloDistance,
+      tremoloPlacement,
       // TODO tremoloBeamLengthMultiplier,
       // TODO tremoloMaxBeamLength,
 

--- a/libmscore/tremolo.cpp
+++ b/libmscore/tremolo.cpp
@@ -24,6 +24,14 @@
 namespace Ms {
 
 //---------------------------------------------------------
+//   tremoloStyle
+//---------------------------------------------------------
+
+static const ElementStyle tremoloStyle {
+      { Sid::tremoloPlacement, Pid::TREMOLO_PLACEMENT },
+      };
+
+//---------------------------------------------------------
 //   Tremolo
 //---------------------------------------------------------
 
@@ -42,6 +50,7 @@ static const char* tremoloName[] = {
 Tremolo::Tremolo(Score* score)
    : Element(score, ElementFlag::MOVABLE)
       {
+      initElementStyle(&tremoloStyle);
       setTremoloType(TremoloType::R8);
       _chord1  = 0;
       _chord2  = 0;
@@ -127,8 +136,7 @@ void Tremolo::setTremoloType(TremoloType t)
 
 bool Tremolo::placeMidStem() const
       {
-      const bool placeAllTremoloMidStem = true; // TODO: style setting
-      return tremoloType() == TremoloType::BUZZ_ROLL || placeAllTremoloMidStem;
+      return _tremoloPlacement == TremoloPlacement::STEM_CENTER;
       }
 
 //---------------------------------------------------------
@@ -637,6 +645,8 @@ QVariant Tremolo::getProperty(Pid propertyId) const
       switch(propertyId) {
             case Pid::TREMOLO_TYPE:
                   return int(_tremoloType);
+            case Pid::TREMOLO_PLACEMENT:
+                  return int (_tremoloPlacement);
             default:
                   break;
             }
@@ -653,10 +663,14 @@ bool Tremolo::setProperty(Pid propertyId, const QVariant& val)
             case Pid::TREMOLO_TYPE:
                   setTremoloType(TremoloType(val.toInt()));
                   break;
-            default:
+            case Pid::TREMOLO_PLACEMENT:
+                  _tremoloPlacement = TremoloPlacement(val.toInt());
                   break;
+            default:
+                  return Element::setProperty(propertyId, val);
             }
-      return Element::setProperty(propertyId, val);
+      triggerLayout();
+      return true;
       }
 
 //---------------------------------------------------------

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -40,6 +40,11 @@ class Tremolo final : public Element {
 
       int _lines;       // derived from _subtype
 
+      QPainterPath basePath() const;
+      void computeShape();
+      void layoutOneNoteTremolo(qreal x, qreal y, qreal spatium);
+      void layoutTwoNotesTremolo(qreal x, qreal y, qreal h, qreal spatium);
+
    public:
       Tremolo(Score*);
       Tremolo(const Tremolo&);
@@ -79,6 +84,12 @@ class Tremolo final : public Element {
       Fraction tremoloLen() const;
       bool twoNotes() const { return tremoloType() >= TremoloType::C8; } // is it a two note tremolo?
       int lines() const { return _lines; }
+
+      bool placeMidStem() const;
+
+      virtual void spatiumChanged(qreal oldValue, qreal newValue) override;
+      virtual void localSpatiumChanged(qreal oldValue, qreal newValue) override;
+      virtual void styleChanged() override;
 
       virtual QString accessibleInfo() const override;
 

--- a/libmscore/tremolo.h
+++ b/libmscore/tremolo.h
@@ -27,6 +27,11 @@ enum class TremoloType : signed char {
       C8, C16, C32, C64     // two note tremolo (change)
       };
 
+enum class TremoloPlacement : signed char {
+      DEFAULT = 0,
+      STEM_CENTER
+      };
+
 //---------------------------------------------------------
 //   @@ Tremolo
 //---------------------------------------------------------
@@ -39,6 +44,7 @@ class Tremolo final : public Element {
       QPainterPath path;
 
       int _lines;       // derived from _subtype
+      TremoloPlacement _tremoloPlacement = TremoloPlacement::DEFAULT;
 
       QPainterPath basePath() const;
       void computeShape();

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -183,6 +183,7 @@ QT5_WRAP_UI (ui_headers
       inspector/inspector_bend.ui
       inspector/inspector_arpeggio.ui
       inspector/inspector_tremolo.ui
+      inspector/inspector_tremolobar.ui
       inspector/inspector_caesura.ui
       inspector/inspector_bracket.ui
       inspector/inspector_iname.ui

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -304,6 +304,9 @@ void Inspector::update(Score* s)
                         case ElementType::BEND:
                               ie = new InspectorBend(this);
                               break;
+                        case ElementType::TREMOLO:
+                              ie = new InspectorTremolo(this);
+                              break;
                         case ElementType::TREMOLOBAR:
                               ie = new InspectorTremoloBar(this);
                               break;
@@ -918,6 +921,23 @@ void InspectorTremoloBar::propertiesClicked()
       mscore->currentScoreView()->editTremoloBarProperties(b);
       score->setLayoutAll();
       score->endCmd();
+      }
+
+//---------------------------------------------------------
+//   InspectorTremoloBar
+//---------------------------------------------------------
+
+InspectorTremolo::InspectorTremolo(QWidget* parent)
+   : InspectorElementBase(parent)
+      {
+      g.setupUi(addWidget());
+
+      const std::vector<InspectorItem> iiList = {
+            { Pid::TREMOLO_PLACEMENT, 0, g.tremoloPlacement, g.resetTremoloPlacement },
+            };
+      const std::vector<InspectorPanel> ppList = { { g.title, g.panel } };
+
+      mapSignals(iiList, ppList);
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -42,6 +42,7 @@
 #include "ui_inspector_text.h"
 // #include "ui_inspector_fret.h"
 #include "ui_inspector_tremolo.h"
+#include "ui_inspector_tremolobar.h"
 #include "ui_inspector_caesura.h"
 #include "ui_inspector_bracket.h"
 #include "ui_inspector_iname.h"
@@ -315,6 +316,19 @@ class InspectorTremoloBar : public InspectorElementBase {
 
    public:
       InspectorTremoloBar(QWidget* parent);
+      };
+
+//---------------------------------------------------------
+//   InspectorTremolo
+//---------------------------------------------------------
+
+class InspectorTremolo : public InspectorElementBase {
+      Q_OBJECT
+
+      Ui::InspectorTremolo g;
+
+   public:
+      InspectorTremolo(QWidget* parent);
       };
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspector_tremolo.ui
+++ b/mscore/inspector/inspector_tremolo.ui
@@ -1,24 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>InspectorTremoloBar</class>
- <widget class="QWidget" name="InspectorTremoloBar">
+ <class>InspectorTremolo</class>
+ <widget class="QWidget" name="InspectorTremolo">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>188</width>
-    <height>155</height>
+    <width>229</width>
+    <height>221</height>
    </rect>
   </property>
   <property name="accessibleName">
-   <string>Tremolo Bar Inspector</string>
+   <string>Tremolo Inspector</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
     <number>0</number>
-   </property>
-   <property name="sizeConstraint">
-    <enum>QLayout::SetNoConstraint</enum>
    </property>
    <property name="leftMargin">
     <number>0</number>
@@ -57,7 +54,7 @@
       </font>
      </property>
      <property name="text">
-      <string>Tremolo Bar</string>
+      <string>Tremolo</string>
      </property>
     </widget>
    </item>
@@ -80,112 +77,37 @@
        <number>3</number>
       </property>
       <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="lineWidth">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
+       <widget class="QComboBox" name="tremoloPlacement">
         <property name="accessibleName">
-         <string>Line thickness</string>
+         <string>Tremolo range</string>
         </property>
-        <property name="suffix">
-         <string>sp</string>
-        </property>
-        <property name="minimum">
-         <double>0.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>5.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
+        <item>
+         <property name="text">
+          <string>Default</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Stem center</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Line thickness:</string>
+         <string>Placement:</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
         <property name="buddy">
-         <cstring>lineWidth</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="play">
-        <property name="focusPolicy">
-         <enum>Qt::TabFocus</enum>
-        </property>
-        <property name="text">
-         <string>Play</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Scale:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>mag</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="mag">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Scale</string>
-        </property>
-        <property name="minimum">
-         <double>0.200000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>50.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.200000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
+         <cstring>tremoloPlacement</cstring>
         </property>
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="Ms::ResetButton" name="resetLineWidth" native="true">
+       <widget class="Ms::ResetButton" name="resetTremoloPlacement" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -193,40 +115,7 @@
          </sizepolicy>
         </property>
         <property name="accessibleName">
-         <string>Reset 'Line thickness' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="Ms::ResetButton" name="resetMag" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Scale' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="Ms::ResetButton" name="resetPlay" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Reset 'Play' value</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="3">
-       <widget class="QPushButton" name="properties">
-        <property name="text">
-         <string>Properties</string>
+         <string>Reset 'Tremolo range' value</string>
         </property>
        </widget>
       </item>
@@ -245,10 +134,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>title</tabstop>
-  <tabstop>lineWidth</tabstop>
-  <tabstop>mag</tabstop>
-  <tabstop>play</tabstop>
-  <tabstop>properties</tabstop>
+  <tabstop>tremoloPlacement</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/mscore/inspector/inspector_tremolobar.ui
+++ b/mscore/inspector/inspector_tremolobar.ui
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>InspectorTremoloBar</class>
+ <widget class="QWidget" name="InspectorTremoloBar">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>188</width>
+    <height>155</height>
+   </rect>
+  </property>
+  <property name="accessibleName">
+   <string>Tremolo Bar Inspector</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="sizeConstraint">
+    <enum>QLayout::SetNoConstraint</enum>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::HLine</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="title">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Tremolo Bar</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="panel" native="true">
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>3</number>
+      </property>
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <property name="spacing">
+       <number>3</number>
+      </property>
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="lineWidth">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Line thickness</string>
+        </property>
+        <property name="suffix">
+         <string>sp</string>
+        </property>
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>5.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Line thickness:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>lineWidth</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="play">
+        <property name="focusPolicy">
+         <enum>Qt::TabFocus</enum>
+        </property>
+        <property name="text">
+         <string>Play</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Scale:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>mag</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="mag">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Scale</string>
+        </property>
+        <property name="minimum">
+         <double>0.200000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>50.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.200000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="Ms::ResetButton" name="resetLineWidth" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Line thickness' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="Ms::ResetButton" name="resetMag" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Scale' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="Ms::ResetButton" name="resetPlay" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Play' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="3">
+       <widget class="QPushButton" name="properties">
+        <property name="text">
+         <string>Properties</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Ms::ResetButton</class>
+   <extends>QWidget</extends>
+   <header>inspector/resetButton.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>title</tabstop>
+  <tabstop>lineWidth</tabstop>
+  <tabstop>mag</tabstop>
+  <tabstop>play</tabstop>
+  <tabstop>properties</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Implements one-note tremolo placement at stem center which should be useful for the notation used in drumline scores.

The following changes are included:
 - Corrected bounding box for buzzroll tremolo.
 - Added a possibility to place tremolo at stem center.
 - Reworked one-note tremolo layout to make it possible
   to know its dimensions before performing its layout
   on a stem.
 - Implemented padding around one-note tremolo to make it
   clearly separated from beams and noteheads.
 - Added a style property to control tremolo placement
 - Added an inspector for tremolo.