### PR TITLE
Add style settings for articulations placement

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -32,6 +32,7 @@ namespace Ms {
 static const ElementStyle articulationStyle {
       { Sid::articulationMinDistance, Pid::MIN_DISTANCE },
 //      { Sid::articulationOffset, Pid::OFFSET },
+      { Sid::articulationAnchorDefault, Pid::ARTICULATION_ANCHOR },
       };
 
 //---------------------------------------------------------
@@ -127,8 +128,8 @@ bool Articulation::readProperties(XmlReader& e)
             _channelName = e.attribute("name");
             e.readNext();
             }
-      else if (tag == "anchor")
-            _anchor = ArticulationAnchor(e.readInt());
+      else if (readProperty(tag, e, Pid::ARTICULATION_ANCHOR))
+            ;
       else if (tag == "direction")
             readProperty(e, Pid::DIRECTION);
       else if ( tag == "ornamentStyle")
@@ -166,7 +167,6 @@ void Articulation::write(XmlWriter& xml) const
       for (const StyledProperty& spp : *styledProperties())
             writeProperty(xml, spp.pid);
       Element::writeProperties(xml);
-      writeProperty(xml, Pid::ARTICULATION_ANCHOR);
       xml.etag();
       }
 
@@ -336,68 +336,6 @@ QVariant Articulation::propertyDefault(Pid propertyId) const
             case Pid::DIRECTION:
                   return QVariant::fromValue<Direction>(Direction::AUTO);
 
-            case Pid::ARTICULATION_ANCHOR:
-                  switch (_symId) {
-                        case SymId::articAccentAbove:
-                        case SymId::articAccentBelow:
-                        case SymId::articStaccatoAbove:
-                        case SymId::articStaccatoBelow:
-                        case SymId::articStaccatissimoAbove:
-                        case SymId::articStaccatissimoBelow:
-                        case SymId::articTenutoAbove:
-                        case SymId::articTenutoBelow:
-                        case SymId::articTenutoStaccatoAbove:
-                        case SymId::articTenutoStaccatoBelow:
-                        case SymId::articMarcatoAbove:
-                        case SymId::articMarcatoBelow:
-
-                        case SymId::articAccentStaccatoAbove:
-                        case SymId::articAccentStaccatoBelow:
-                        case SymId::articLaissezVibrerAbove:
-                        case SymId::articLaissezVibrerBelow:
-                        case SymId::articMarcatoStaccatoAbove:
-                        case SymId::articMarcatoStaccatoBelow:
-                        case SymId::articMarcatoTenutoAbove:
-                        case SymId::articMarcatoTenutoBelow:
-                        case SymId::articStaccatissimoStrokeAbove:
-                        case SymId::articStaccatissimoStrokeBelow:
-                        case SymId::articStaccatissimoWedgeAbove:
-                        case SymId::articStaccatissimoWedgeBelow:
-                        case SymId::articStressAbove:
-                        case SymId::articStressBelow:
-                        case SymId::articTenutoAccentAbove:
-                        case SymId::articTenutoAccentBelow:
-                        case SymId::articUnstressAbove:
-                        case SymId::articUnstressBelow:
-
-                        case SymId::articSoftAccentAbove:
-                        case SymId::articSoftAccentBelow:
-                        case SymId::articSoftAccentStaccatoAbove:
-                        case SymId::articSoftAccentStaccatoBelow:
-                        case SymId::articSoftAccentTenutoAbove:
-                        case SymId::articSoftAccentTenutoBelow:
-                        case SymId::articSoftAccentTenutoStaccatoAbove:
-                        case SymId::articSoftAccentTenutoStaccatoBelow:
-
-                        case SymId::guitarFadeIn:
-                        case SymId::guitarFadeOut:
-                        case SymId::guitarVolumeSwell:
-                        case SymId::wiggleSawtooth:
-                        case SymId::wiggleSawtoothWide:
-                        case SymId::wiggleVibratoLargeFaster:
-                        case SymId::wiggleVibratoLargeSlowest:
-                              return int(ArticulationAnchor::CHORD);
-
-                        case SymId::luteFingeringRHThumb:
-                        case SymId::luteFingeringRHFirst:
-                        case SymId::luteFingeringRHSecond:
-                        case SymId::luteFingeringRHThird:
-                              return int(ArticulationAnchor::BOTTOM_CHORD);
-
-                        default:
-                              return int(ArticulationAnchor::TOP_STAFF);
-                        }
-
             case Pid::ORNAMENT_STYLE:
                   //return int(score()->style()->ornamentStyle(_ornamentStyle));
                   return int(MScore::OrnamentStyle::DEFAULT);
@@ -409,6 +347,75 @@ QVariant Articulation::propertyDefault(Pid propertyId) const
                   break;
             }
       return Element::propertyDefault(propertyId);
+      }
+
+//---------------------------------------------------------
+//   anchorGroup
+//---------------------------------------------------------
+
+Articulation::AnchorGroup Articulation::anchorGroup(SymId symId)
+      {
+      switch (symId) {
+            case SymId::articAccentAbove:
+            case SymId::articAccentBelow:
+            case SymId::articStaccatoAbove:
+            case SymId::articStaccatoBelow:
+            case SymId::articStaccatissimoAbove:
+            case SymId::articStaccatissimoBelow:
+            case SymId::articTenutoAbove:
+            case SymId::articTenutoBelow:
+            case SymId::articTenutoStaccatoAbove:
+            case SymId::articTenutoStaccatoBelow:
+            case SymId::articMarcatoAbove:
+            case SymId::articMarcatoBelow:
+
+            case SymId::articAccentStaccatoAbove:
+            case SymId::articAccentStaccatoBelow:
+            case SymId::articLaissezVibrerAbove:
+            case SymId::articLaissezVibrerBelow:
+            case SymId::articMarcatoStaccatoAbove:
+            case SymId::articMarcatoStaccatoBelow:
+            case SymId::articMarcatoTenutoAbove:
+            case SymId::articMarcatoTenutoBelow:
+            case SymId::articStaccatissimoStrokeAbove:
+            case SymId::articStaccatissimoStrokeBelow:
+            case SymId::articStaccatissimoWedgeAbove:
+            case SymId::articStaccatissimoWedgeBelow:
+            case SymId::articStressAbove:
+            case SymId::articStressBelow:
+            case SymId::articTenutoAccentAbove:
+            case SymId::articTenutoAccentBelow:
+            case SymId::articUnstressAbove:
+            case SymId::articUnstressBelow:
+
+            case SymId::articSoftAccentAbove:
+            case SymId::articSoftAccentBelow:
+            case SymId::articSoftAccentStaccatoAbove:
+            case SymId::articSoftAccentStaccatoBelow:
+            case SymId::articSoftAccentTenutoAbove:
+            case SymId::articSoftAccentTenutoBelow:
+            case SymId::articSoftAccentTenutoStaccatoAbove:
+            case SymId::articSoftAccentTenutoStaccatoBelow:
+
+            case SymId::guitarFadeIn:
+            case SymId::guitarFadeOut:
+            case SymId::guitarVolumeSwell:
+            case SymId::wiggleSawtooth:
+            case SymId::wiggleSawtoothWide:
+            case SymId::wiggleVibratoLargeFaster:
+            case SymId::wiggleVibratoLargeSlowest:
+                  return AnchorGroup::ARTICULATION;
+
+            case SymId::luteFingeringRHThumb:
+            case SymId::luteFingeringRHFirst:
+            case SymId::luteFingeringRHSecond:
+            case SymId::luteFingeringRHThird:
+                  return AnchorGroup::LUTE_FINGERING;
+
+            default:
+                  break;
+            }
+      return AnchorGroup::OTHER;
       }
 
 //---------------------------------------------------------
@@ -504,6 +511,17 @@ Sid Articulation::getPropertyStyle(Pid id) const
       switch (id) {
             case Pid::MIN_DISTANCE:
                   return Element::getPropertyStyle(id);
+
+            case Pid::ARTICULATION_ANCHOR: {
+                  switch (anchorGroup(_symId)) {
+                        case AnchorGroup::ARTICULATION:
+                              return Sid::articulationAnchorDefault;
+                        case AnchorGroup::LUTE_FINGERING:
+                              return Sid::articulationAnchorLuteFingering;
+                        case AnchorGroup::OTHER:
+                              return Sid::articulationAnchorOther;
+                        }
+                  }
             default:
                   return Sid::NOSTYLE;
             }

--- a/libmscore/articulation.h
+++ b/libmscore/articulation.h
@@ -67,6 +67,13 @@ class Articulation final : public Element {
 
       virtual void draw(QPainter*) const;
 
+      enum class AnchorGroup {
+            ARTICULATION,
+            LUTE_FINGERING,
+            OTHER
+            };
+      static AnchorGroup anchorGroup(SymId);
+
    public:
       Articulation(Score*);
       Articulation(SymId, Score*);

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -207,6 +207,9 @@ static const StyleType styleTypes[] {
 
       { Sid::articulationMag,         "articulationMag",         QVariant(1.0) },
       { Sid::articulationPosAbove,    "articulationPosAbove",    QPointF(0.0, 0.0) },
+      { Sid::articulationAnchorDefault, "articulationAnchorDefault", int(ArticulationAnchor::CHORD) },
+      { Sid::articulationAnchorLuteFingering, "articulationAnchorLuteFingering", int(ArticulationAnchor::BOTTOM_CHORD) },
+      { Sid::articulationAnchorOther, "articulationAnchorOther", int(ArticulationAnchor::TOP_STAFF) },
       { Sid::lastSystemFillLimit,     "lastSystemFillLimit",     QVariant(0.3) },
 
       { Sid::hairpinPlacement,        "hairpinPlacement",        int(Placement::BELOW)  },

--- a/libmscore/style.h
+++ b/libmscore/style.h
@@ -179,6 +179,9 @@ enum class Sid {
       propertyDistance,
       articulationMag,
       articulationPosAbove,
+      articulationAnchorDefault,
+      articulationAnchorLuteFingering,
+      articulationAnchorOther,
       lastSystemFillLimit,
 
       hairpinPlacement,

--- a/mscore/importgtp-gp6.cpp
+++ b/mscore/importgtp-gp6.cpp
@@ -1525,6 +1525,7 @@ Fraction GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* mea
                                                 else if (str == "VolumeSwell")
                                                       art->setSymId(SymId::guitarVolumeSwell);
                                                 art->setAnchor(ArticulationAnchor::TOP_STAFF);
+                                                art->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
                                                 if (!note->score()->addArticulation(note, art))
                                                       delete art;
                                                 }
@@ -1803,6 +1804,7 @@ Fraction GuitarPro6::readBeats(QString beats, GPPartInfo* partInfo, Measure* mea
                               art->setSymId(SymId::fermataLongAbove);
                         art->setUp(true);
                         art->setAnchor(ArticulationAnchor::TOP_STAFF);
+                        art->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
                         auto seg = cr->segment()->prev1(SegmentType::ChordRest);
                         if (seg && seg->cr(track)->isChord()) {
                               seg->cr(track)->add(art);

--- a/mscore/importgtp.cpp
+++ b/mscore/importgtp.cpp
@@ -1015,6 +1015,7 @@ void GuitarPro::applyBeatEffects(Chord* chord, int beatEffect)
                   Articulation* a = new Articulation(chord->score());
                   a->setSymId(SymId::guitarFadeIn);
                   a->setAnchor(ArticulationAnchor::TOP_STAFF);
+                  a->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
                   chord->add(a);
                   }
             //TODO-ws		else for (auto n : chord->notes())
@@ -2483,6 +2484,7 @@ bool GuitarPro3::read(QFile* fp)
                                     Articulation* art = new Articulation(score);
                                     art->setSymId(SymId::guitarFadeOut);
                                     art->setAnchor(ArticulationAnchor::TOP_STAFF);
+                                    art->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
                                     if (!score->addArticulation(cr, art)) {
                                           delete art;
                                           }
@@ -2637,6 +2639,7 @@ int GuitarPro3::readBeatEffects(int track, Segment* segment)
             // art->setArticulationType(ArticulationType::FadeOut);
             art->setSym(SymId::guitarFadeOut);
             art->setAnchor(ArticulationAnchor::TOP_STAFF);
+            art->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
             if (!score->addArticulation(segment->cr(track), art)) {
                   delete art;
                   }

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -1166,10 +1166,12 @@ static void addArticulationToChord(ChordRest* cr, SymId articSym, QString dir)
       if (dir == "up") {
             na->setUp(true);
             na->setAnchor(ArticulationAnchor::TOP_STAFF);
+            na->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
             }
       else if (dir == "down") {
             na->setUp(false);
             na->setAnchor(ArticulationAnchor::BOTTOM_STAFF);
+            na->setPropertyFlags(Pid::ARTICULATION_ANCHOR, PropertyFlags::UNSTYLED);
             }
       cr->add(na);
       }

--- a/mtest/guitarpro/fade-in.gp4-ref.mscx
+++ b/mtest/guitarpro/fade-in.gp4-ref.mscx
@@ -94,8 +94,8 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>guitarFadeIn</subtype>
-              <linkedMain/>
               <anchor>0</anchor>
+              <linkedMain/>
               </Articulation>
             <Note>
               <linkedMain/>
@@ -234,9 +234,9 @@
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>guitarFadeIn</subtype>
+                <anchor>0</anchor>
                 <linked>
                   </linked>
-                <anchor>0</anchor>
                 </Articulation>
               <Note>
                 <linked>
@@ -282,10 +282,10 @@
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>guitarFadeIn</subtype>
+                <anchor>0</anchor>
                 <linked>
                   <indexDiff>1</indexDiff>
                   </linked>
-                <anchor>0</anchor>
                 </Articulation>
               <Note>
                 <linked>

--- a/mtest/guitarpro/fade-in.gp5-ref.mscx
+++ b/mtest/guitarpro/fade-in.gp5-ref.mscx
@@ -89,8 +89,8 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>guitarFadeIn</subtype>
-              <linkedMain/>
               <anchor>0</anchor>
+              <linkedMain/>
               </Articulation>
             <Note>
               <linkedMain/>
@@ -241,9 +241,9 @@
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>guitarFadeIn</subtype>
+                <anchor>0</anchor>
                 <linked>
                   </linked>
-                <anchor>0</anchor>
                 </Articulation>
               <Note>
                 <linked>
@@ -311,10 +311,10 @@
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>guitarFadeIn</subtype>
+                <anchor>0</anchor>
                 <linked>
                   <indexDiff>1</indexDiff>
                   </linked>
-                <anchor>0</anchor>
                 </Articulation>
               <Note>
                 <linked>

--- a/mtest/guitarpro/volume-swell.gpx-ref.mscx
+++ b/mtest/guitarpro/volume-swell.gpx-ref.mscx
@@ -142,8 +142,8 @@
             <durationType>quarter</durationType>
             <Articulation>
               <subtype>guitarVolumeSwell</subtype>
-              <linkedMain/>
               <anchor>0</anchor>
+              <linkedMain/>
               </Articulation>
             <Note>
               <linkedMain/>
@@ -348,9 +348,9 @@
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>guitarVolumeSwell</subtype>
+                <anchor>0</anchor>
                 <linked>
                   </linked>
-                <anchor>0</anchor>
                 </Articulation>
               <Note>
                 <linked>
@@ -418,10 +418,10 @@
               <durationType>quarter</durationType>
               <Articulation>
                 <subtype>guitarVolumeSwell</subtype>
+                <anchor>0</anchor>
                 <linked>
                   <indexDiff>1</indexDiff>
                   </linked>
-                <anchor>0</anchor>
                 </Articulation>
               <Note>
                 <linked>

--- a/mtest/libmscore/compat206/articulations-double-ref.mscx
+++ b/mtest/libmscore/compat206/articulations-double-ref.mscx
@@ -498,8 +498,8 @@
               <direction>down</direction>
               <subtype>articAccentStaccatoBelow</subtype>
               <ornamentStyle>baroque</ornamentStyle>
-              <linkedMain/>
               <anchor>4</anchor>
+              <linkedMain/>
               </Articulation>
             <Note>
               <linkedMain/>
@@ -2313,9 +2313,9 @@
                 <direction>down</direction>
                 <subtype>articAccentStaccatoBelow</subtype>
                 <ornamentStyle>baroque</ornamentStyle>
+                <anchor>4</anchor>
                 <linked>
                   </linked>
-                <anchor>4</anchor>
                 </Articulation>
               <Note>
                 <linked>


### PR DESCRIPTION
Allows controlling the default articulation placement, e.g. allows to place all common articulations above the staff.