### PR TITLE
[MU4] partially fix #290533: issues with articulations and the MusicXML exporter

### DIFF
--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -1982,43 +1982,61 @@ static QString symIdToArtic(const SymId sid)
       {
       switch (sid) {
             case SymId::articAccentAbove:
+                  return "accent placement=\"above\"";
+                  break;
+
             case SymId::articAccentBelow:
-                  return "accent";
+                  return "accent placement=\"below\"";
                   break;
 
             case SymId::articStaccatoAbove:
-            case SymId::articStaccatoBelow:
             case SymId::articAccentStaccatoAbove:
-            case SymId::articAccentStaccatoBelow:
             case SymId::articMarcatoStaccatoAbove:
+                  return "staccato placement=\"above\"";
+                  break;
+
+            case SymId::articStaccatoBelow:
+            case SymId::articAccentStaccatoBelow:
             case SymId::articMarcatoStaccatoBelow:
-                  return "staccato";
+                  return "staccato placement=\"below\"";
                   break;
 
             case SymId::articStaccatissimoAbove:
-            case SymId::articStaccatissimoBelow:
             case SymId::articStaccatissimoStrokeAbove:
-            case SymId::articStaccatissimoStrokeBelow:
             case SymId::articStaccatissimoWedgeAbove:
+                  return "staccatissimo placement=\"above\"";
+                  break;
+
+            case SymId::articStaccatissimoBelow:
+            case SymId::articStaccatissimoStrokeBelow:
             case SymId::articStaccatissimoWedgeBelow:
-                  return "staccatissimo";
+                  return "staccatissimo placement=\"below\"";
                   break;
 
             case SymId::articTenutoAbove:
-            case SymId::articTenutoBelow:
             case SymId::articMarcatoTenutoAbove:
+                  return "tenuto placement=\"above\"";
+                  break;
+
+            case SymId::articTenutoBelow:
             case SymId::articMarcatoTenutoBelow:
-                  return "tenuto";
+                  return "tenuto placement=\"below\"";
                   break;
 
             case SymId::articMarcatoAbove:
+                  return "strong-accent placement=\"above\"";
+                  break;
+
             case SymId::articMarcatoBelow:
-                  return "strong-accent";
+                  return "strong-accent placement=\"below\"";
                   break;
 
             case SymId::articTenutoStaccatoAbove:
+                  return "detached-legato placement=\"above\"";
+                  break;
+
             case SymId::articTenutoStaccatoBelow:
-                  return "detached-legato";
+                  return "detached-legato placement=\"below\"";
                   break;
 
             default:

--- a/mscore/exportxml.cpp
+++ b/mscore/exportxml.cpp
@@ -2006,6 +2006,8 @@ static QString symIdToArtic(const SymId sid)
 
             case SymId::articTenutoAbove:
             case SymId::articTenutoBelow:
+            case SymId::articMarcatoTenutoAbove:
+            case SymId::articMarcatoTenutoBelow:
                   return "tenuto";
                   break;
 
@@ -5781,4 +5783,3 @@ void ExportMusicXml::harmony(Harmony const* const h, FretDiagram const* const fd
       }
 
 }
-

--- a/mtest/musicxml/io/testMultipleNotations_ref.xml
+++ b/mtest/musicxml/io/testMultipleNotations_ref.xml
@@ -73,7 +73,7 @@
         <notations>
           <slur type="stop" number="1"/>
           <articulations>
-            <staccato/>
+            <staccato placement="below"/>
             </articulations>
           </notations>
         </note>

--- a/mtest/musicxml/io/testNoteAttributes1.xml
+++ b/mtest/musicxml/io/testNoteAttributes1.xml
@@ -85,7 +85,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <accent/>
+            <accent placement="below"/>
             </articulations>
           </notations>
         </note>
@@ -100,7 +100,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <staccato/>
+            <staccato placement="below"/>
             </articulations>
           </notations>
         </note>
@@ -117,7 +117,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <staccatissimo/>
+            <staccatissimo placement="below"/>
             </articulations>
           </notations>
         </note>
@@ -132,7 +132,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <tenuto/>
+            <tenuto placement="below"/>
             </articulations>
           </notations>
         </note>
@@ -147,7 +147,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <strong-accent type="up"/>
+            <strong-accent placement="above" type="up"/>
             </articulations>
           </notations>
         </note>
@@ -162,7 +162,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <strong-accent type="down"/>
+            <strong-accent placement="below" type="down"/>
             </articulations>
           </notations>
         </note>
@@ -253,7 +253,7 @@
         <notations>
           <slur type="start" placement="below" number="1"/>
           <articulations>
-            <staccato/>
+            <staccato placement="below"/>
             </articulations>
           </notations>
         </note>
@@ -269,7 +269,7 @@
         <notations>
           <slur type="start" placement="below" number="2"/>
           <articulations>
-            <staccato/>
+            <staccato placement="below"/>
             </articulations>
           </notations>
         </note>
@@ -285,8 +285,8 @@
         <notations>
           <slur type="stop" number="2"/>
           <articulations>
-            <staccato/>
-            <accent/>
+            <staccato placement="below"/>
+            <accent placement="below"/>
             </articulations>
           </notations>
         </note>
@@ -302,7 +302,7 @@
         <notations>
           <slur type="stop" number="1"/>
           <articulations>
-            <staccato/>
+            <staccato placement="below"/>
             </articulations>
           </notations>
         </note>

--- a/mtest/musicxml/io/testNoteAttributes2_ref.xml
+++ b/mtest/musicxml/io/testNoteAttributes2_ref.xml
@@ -96,7 +96,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <accent/>
+            <accent placement="below"/>
             </articulations>
           </notations>
         </note>
@@ -123,7 +123,7 @@
         <stem>down</stem>
         <notations>
           <articulations>
-            <staccato/>
+            <staccato placement="above"/>
             </articulations>
           </notations>
         </note>
@@ -138,7 +138,7 @@
         <stem>down</stem>
         <notations>
           <articulations>
-            <staccatissimo/>
+            <staccatissimo placement="above"/>
             </articulations>
           </notations>
         </note>
@@ -153,7 +153,7 @@
         <stem>down</stem>
         <notations>
           <articulations>
-            <staccatissimo/>
+            <staccatissimo placement="above"/>
             </articulations>
           </notations>
         </note>
@@ -170,7 +170,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <tenuto/>
+            <tenuto placement="below"/>
             </articulations>
           </notations>
         </note>
@@ -205,7 +205,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <strong-accent type="up"/>
+            <strong-accent placement="above" type="up"/>
             </articulations>
           </notations>
         </note>
@@ -222,7 +222,7 @@
         <stem>down</stem>
         <notations>
           <articulations>
-            <strong-accent type="down"/>
+            <strong-accent placement="below" type="down"/>
             </articulations>
           </notations>
         </note>
@@ -448,7 +448,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <detached-legato/>
+            <detached-legato placement="below"/>
             </articulations>
           </notations>
         </note>
@@ -465,7 +465,7 @@
         <stem>up</stem>
         <notations>
           <articulations>
-            <staccatissimo/>
+            <staccatissimo placement="below"/>
             </articulations>
           </notations>
         </note>


### PR DESCRIPTION
This PR addresses the following:

* the MusicXML exporter now exports the position of the articulations using the `placement` argument
* previously, the marcato-tenuto articulations was completely ignored. It is now exported as a tenuto

What is not fixed from the [original report](https://musescore.org/en/node/290533):
* marcato-staccato and marcato-tenuto export only a single staccato and a single tenuto instead of two articulations. This is because MuseScore considers the formers as single graphic object, while they would have to be exported as two separate articulations in the MusicXML. If anyone can guide me on how to tackle this, I will be happy to update this PR.

Note that the problem 1) reported in the [original report](https://musescore.org/en/node/290533) is actually not caused by the MusicXML exported and has since been reported as a [separate issue](https://musescore.org/en/node/290567). 