### PR TITLE
improve text editing appearance on score

### DIFF
--- a/libmscore/textbase.cpp
+++ b/libmscore/textbase.cpp
@@ -127,7 +127,7 @@ QRectF TextCursor::cursorRect() const
       qreal h = ascent;
       qreal x = tline.xpos(column(), _text);
       qreal y = tline.y() - ascent * .9;
-      return QRectF(x, y, 4.0, h);
+      return QRectF(x, y, 2.0, h);
       }
 
 //---------------------------------------------------------
@@ -1121,12 +1121,10 @@ TextBase::TextBase(const TextBase& st)
 
 void TextBase::drawSelection(QPainter* p, const QRectF& r) const
       {
-      QBrush bg(QColor("steelblue"));
-      p->setCompositionMode(QPainter::CompositionMode_HardLight);
+      QBrush bg = QBrush(QPalette(QApplication::palette()).color(QPalette::Active, QPalette::Highlight));
       p->setBrush(bg);
       p->setPen(Qt::NoPen);
-      p->drawRect(r);
-      p->setCompositionMode(QPainter::CompositionMode_SourceOver);
+      p->drawRect(r.marginsAdded(QMargins(6, 10, 10, 6)));
       p->setPen(textColor());
       }
 

--- a/share/themes/palette_light_fusion.json
+++ b/share/themes/palette_light_fusion.json
@@ -7,6 +7,7 @@
 "Button":        "#c9c9c9",
 "ButtonText":    "#333333",
 "BrightText":    "#000000",
+"Highlight":     "#b3d7ff",
 "ToolTipBase":   "#fefac2",
 "ToolTipText":   "#000000",
 "Link":          "#3a80c6",


### PR DESCRIPTION
- make cursor narrower - more in line with non-score text editing UI
- make highlight larger - more in line with non-score text editing UI
- make highlight color match highlight color in the theme

Complements (but is independent of) PR #5101

![text-edit-highlight](https://user-images.githubusercontent.com/3323784/59337526-adf7ff80-8cf8-11e9-8170-c0ddb506cbc3.png)
