### PR TITLE
[MU4] fix#15513 Enable pedals to take the whole part into consideration when extending

### DIFF
--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -159,7 +159,10 @@ class EditData {
 ///     score layout elements.
 //-------------------------------------------------------------------
 
+enum class ElementScope { VOICE, STAFF, PART, SYSTEM };
+
 class Element : public ScoreElement {
+      ElementScope _scope { ElementScope::STAFF };
       Element* _parent { 0 };
       mutable QRectF _bbox;       ///< Bounding box relative to _pos + _offset
       qreal _mag;                 ///< standard magnification (derived value)
@@ -187,6 +190,8 @@ class Element : public ScoreElement {
       Q_INVOKABLE virtual Ms::Element* clone() const = 0;
       virtual Element* linkedClone();
 
+      ElementScope scope() const              { return _scope; }
+      void setScope(ElementScope s)           { _scope = s; }
       Element* parent() const                 { return _parent;     }
       void setParent(Element* e)              { _parent = e;        }
       Measure* findMeasure();

--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -22,6 +22,9 @@
 
 namespace Ms {
 
+extern int computeStartTrack(int track, ElementScope scope, const Score* const score);
+extern int computeEndTrack(int track, ElementScope scope, const Score* const score);
+
 static const ElementStyle pedalStyle {
       { Sid::pedalFontFace,                      Pid::BEGIN_FONT_FACE         },
       { Sid::pedalFontFace,                      Pid::CONTINUE_FONT_FACE      },
@@ -94,6 +97,8 @@ Pedal::Pedal(Score* s)
 
       resetProperty(Pid::BEGIN_TEXT_PLACE);
       resetProperty(Pid::LINE_VISIBLE);
+
+      setScope(ElementScope::PART);
       }
 
 //---------------------------------------------------------
@@ -230,9 +235,10 @@ QPointF Pedal::linePos(Grip grip, System** sys) const
                               if (seg->segmentType() == SegmentType::ChordRest) {
                                     // look for a chord/rest in any voice on this staff
                                     bool crFound = false;
-                                    int track = staffIdx() * VOICES;
-                                    for (int i = 0; i < VOICES; ++i) {
-                                          if (seg->element(track + i)) {
+                                    int strack { computeStartTrack(track(), scope(), score()) };
+                                    int etrack { computeEndTrack(track2(), scope(), score()) };
+                                    for (int i = strack; i < etrack; ++i) {
+                                          if (seg->element(i)) {
                                                 crFound = true;
                                                 break;
                                                 }

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3819,7 +3819,7 @@ ChordRest* Score::findCR(Fraction tick, int track) const
 //    find last chord/rest on staff that ends before tick
 //---------------------------------------------------------
 
-ChordRest* Score::findCRinStaff(const Fraction& tick, int staffIdx) const
+ChordRest* Score::findCRinScope(const Fraction& tick, int track, ElementScope scope) const
       {
       Fraction ptick = tick - Fraction::fromTicks(1);
       Measure* m = tick2measureMM(ptick);
@@ -3832,8 +3832,8 @@ ChordRest* Score::findCRinStaff(const Fraction& tick, int staffIdx) const
             ptick = m->tick();
 
       Segment* s      = m->first(SegmentType::ChordRest);
-      int strack      = staffIdx * VOICES;
-      int etrack      = strack + VOICES;
+      int strack      = computeStartTrack(track, scope, this);
+      int etrack      = computeEndTrack(track, scope, this);
       int actualTrack = strack;
 
       Fraction lastTick = Fraction(-1,1);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1094,7 +1094,7 @@ class Score : public QObject, public ScoreElement {
       Hairpin* addHairpin(HairpinType, ChordRest* cr1, ChordRest* cr2 = nullptr, bool toCr2End = true);
 
       ChordRest* findCR(Fraction tick, int track) const;
-      ChordRest* findCRinStaff(const Fraction& tick, int staffIdx) const;
+      ChordRest* findCRinScope(const Fraction& tick, int track, ElementScope scope) const;
       void insertTime(const Fraction& tickPos, const Fraction&tickLen);
 
       ScoreFont* scoreFont() const            { return _scoreFont;     }

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -25,6 +25,9 @@
 
 namespace Ms {
 
+extern int computeStartTrack(int track, ElementScope scope, const Score* const score);
+extern int computeEndTrack(int track, ElementScope scope, const Score* const score);
+
 //-----------------------------------------------------------------------------
 //   @@ SpannerWriter
 ///   Helper class for writing Spanners
@@ -48,6 +51,7 @@ SpannerSegment::SpannerSegment(Spanner* sp, Score* s, ElementFlags f)
       {
       _spanner = sp;
       setSpannerSegmentType(SpannerSegmentType::SINGLE);
+      setScope(sp->scope());
       }
 
 SpannerSegment::SpannerSegment(Score* s, ElementFlags f)
@@ -561,8 +565,8 @@ void Spanner::computeStartElement()
       switch (_anchor) {
             case Anchor::SEGMENT: {
                   Segment* seg = score()->tick2segmentMM(tick(), false, SegmentType::ChordRest);
-                  int strack = (track() / VOICES) * VOICES;
-                  int etrack = strack + VOICES;
+                  int strack { computeStartTrack(track(), scope(), score()) };
+                  int etrack { computeEndTrack(track2(), scope(), score()) };
                   _startElement = 0;
                   if (seg) {
                         for (int t = strack; t < etrack; ++t) {
@@ -618,8 +622,8 @@ void Spanner::computeEndElement()
                               }
                         }
                   else {
-                        // find last cr on this staff that ends before tick2
-                        _endElement = score()->findCRinStaff(tick2(), track2() / VOICES);
+                        // find last cr in this scope that ends before tick2
+                        _endElement = score()->findCRinScope(tick2(), track2(), scope());
                         }
                   if (!_endElement) {
                         qDebug("%s no end element for tick %d", name(), tick2().ticks());

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -304,14 +304,52 @@ Fraction Score::nextSeg(const Fraction& tick, int track)
       }
 
 //---------------------------------------------------------
+//   computeStartTrack()
+//---------------------------------------------------------
+
+int computeStartTrack(int track, ElementScope scope, const Score* const score)
+      {
+      switch (scope) {
+            case ElementScope::VOICE: return track;
+            case ElementScope::STAFF: return (track / VOICES) * VOICES;
+            case ElementScope::SYSTEM: return 0;
+            case ElementScope::PART:
+                  for (auto part : score->parts()) {
+                        if (part->endTrack() > track)
+                              return part->startTrack();
+                        }
+            default: return -1;
+            }
+      }
+
+//---------------------------------------------------------
+//   computeEndTrack()
+//---------------------------------------------------------
+
+int computeEndTrack(int track, ElementScope scope, const Score* const score)
+      {
+      switch (scope) {
+            case ElementScope::VOICE: return track + 1;
+            case ElementScope::STAFF: return (track / VOICES + 1) * VOICES;
+            case ElementScope::SYSTEM: return score->ntracks();
+            case ElementScope::PART:
+                  for (auto part : score->parts()) {
+                        if (part->endTrack() > track)
+                              return part->endTrack();
+                  }
+            default: return -1;
+            }
+      }
+
+//---------------------------------------------------------
 //   nextSeg1
 //---------------------------------------------------------
 
-Segment* nextSeg1(Segment* seg, int& track)
+Segment* nextSeg1(Segment* seg, int& track, int startTrack, int endTrack)
       {
-      int staffIdx   = track / VOICES;
-      int startTrack = staffIdx * VOICES;
-      int endTrack   = startTrack + VOICES;
+      if (startTrack == -1 || endTrack == -1)
+            return nullptr;
+
       while ((seg = seg->next1(SegmentType::ChordRest))) {
             for (int t = startTrack; t < endTrack; ++t) {
                   if (seg->element(t)) {
@@ -327,11 +365,11 @@ Segment* nextSeg1(Segment* seg, int& track)
 //   prevSeg1
 //---------------------------------------------------------
 
-Segment* prevSeg1(Segment* seg, int& track)
+Segment* prevSeg1(Segment* seg, int& track, int startTrack, int endTrack)
       {
-      int staffIdx   = track / VOICES;
-      int startTrack = staffIdx * VOICES;
-      int endTrack   = startTrack + VOICES;
+      if (startTrack == -1 || endTrack == -1)
+            return nullptr;
+
       while ((seg = seg->prev1(SegmentType::ChordRest))) {
             for (int t = startTrack; t < endTrack; ++t) {
                   if (seg->element(t)) {

--- a/libmscore/utils.h
+++ b/libmscore/utils.h
@@ -36,12 +36,12 @@ enum class SymId;
 class Measure;
 class Segment;
 class System;
-class Element;
 class Note;
 class Tuplet;
 class BarLine;
 
 enum class ClefType : signed char;
+enum class ElementScope;
 
 extern QRectF handleRect(const QPointF& pos);
 
@@ -69,8 +69,10 @@ extern bool compareVersion(QString v1, QString v2);
 
 extern Note* nextChordNote(Note* note);
 extern Note* prevChordNote(Note* note);
-extern Segment* nextSeg1(Segment* s, int& track);
-extern Segment* prevSeg1(Segment* seg, int& track);
+extern int computeStartTrack(int track, ElementScope scope, const Score* const score);
+extern int computeEndTrack(int track, ElementScope scope, const Score* const score);
+extern Segment* nextSeg1(Segment* seg, int& track, int startTrack, int endTrack);
+extern Segment* prevSeg1(Segment* seg, int& track, int startTrack, int endTrack);
 
 extern Note* searchTieNote(Note* note);
 extern Note* searchTieNote114(Note* note);


### PR DESCRIPTION
Pedal lines can now extend to notes in another staff of the same part too. To enable that, I added an `enum class` named `ElementScope` in `element.h`. This enum has basically an identical function to the `DynRange` enum in `dynamic.h`, but only adds one more range: `VOICE`. This lays the groundwork for making the "Range" concept applicable to a broader range of different elements. Those which doesn't need it doesn't need to use it anywhere else than setting it to an appropriate default in its constructor.