### PR TITLE
fix #290199: check box in Start Center to toggle showing Start Center on launch

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -460,6 +460,9 @@ void MuseScore::preferencesChanged(bool fromWorkspace)
       {
       updateExternalValuesFromPreferences();
 
+      if (startcenter)
+            startcenter->updateShowStartCenterCheckBox();
+            
       setPlayRepeats(MScore::playRepeats);
       getAction("pan")->setChecked(MScore::panPlayback);
       getAction("follow")->setChecked(preferences.getBool(PREF_APP_PLAYBACK_FOLLOWSONG));

--- a/mscore/startcenter.cpp
+++ b/mscore/startcenter.cpp
@@ -16,6 +16,7 @@
 #include "startcenter.h"
 #include "scoreBrowser.h"
 #include "tourhandler.h"
+#include "preferences.h"
 
 namespace Ms {
 
@@ -35,6 +36,8 @@ void MuseScore::showStartcenter(bool show)
             }
       if (!startcenter)
             return;
+
+      startcenter->updateShowStartCenterCheckBox();
       if (show)
             startcenter->setVisible(true);
       else
@@ -56,6 +59,7 @@ Startcenter::Startcenter(QWidget* parent)
       connect(recentPage,  &ScoreBrowser::scoreActivated, this, &Startcenter::loadScore);
       connect(openScore, SIGNAL(clicked()), this, SLOT(openScoreClicked()));
       connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
+      connect(showStartCenterCheckBox, SIGNAL(stateChanged(int)), this, SLOT(showStartCenterStateChanged()));
       setStyleSheet(QString("QPushButton { background-color: %1 }").arg(openScore->palette().color(QPalette::Base).name()));
 
 #ifdef USE_WEBENGINE
@@ -129,6 +133,25 @@ void Startcenter::newScore()
       mscore->tourHandler()->delayWelcomeTour();
       close();
       getAction("file-new")->trigger();
+      }
+
+//---------------------------------------------------------
+//   showStartCenterStateChanged
+//---------------------------------------------------------
+
+void Startcenter::showStartCenterStateChanged()
+      {
+      preferences.setPreference(PREF_UI_APP_STARTUP_SHOWSTARTCENTER, showStartCenterCheckBox->isChecked());
+      preferences.save();
+      }
+
+//---------------------------------------------------------
+//   updateShowStartCenterCheckBox
+//---------------------------------------------------------
+
+void Startcenter::updateShowStartCenterCheckBox()
+      {
+      showStartCenterCheckBox->setChecked(preferences.getBool(PREF_UI_APP_STARTUP_SHOWSTARTCENTER));
       }
 
 //---------------------------------------------------------

--- a/mscore/startcenter.h
+++ b/mscore/startcenter.h
@@ -81,7 +81,6 @@ class Startcenter : public AbstractDialog, public Ui::Startcenter {
       void loadScore(QString);
       void newScore();
       void openScoreClicked();
-
     protected:
       virtual void retranslate() { retranslateUi(this); }
 
@@ -92,10 +91,14 @@ class Startcenter : public AbstractDialog, public Ui::Startcenter {
       Startcenter(QWidget* parent);
       ~Startcenter();
       void updateRecentScores();
+      void updateShowStartCenterCheckBox();
       void writeSettings();
       void readSettings();
       void keyPressEvent(QKeyEvent*) override;
       void keyReleaseEvent(QKeyEvent*) override;
+
+    public slots:
+      void showStartCenterStateChanged();
       };
 }
 #endif //__STARTCENTER_H__

--- a/mscore/startcenter.ui
+++ b/mscore/startcenter.ui
@@ -77,6 +77,29 @@
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>10</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="showStartCenterCheckBox">
+         <property name="text">
+          <string>Show Start Center when opening MuseScore</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>40</width>


### PR DESCRIPTION
Wording next to check box reads: "Show this window when MuseScore launches". This is based on what Xcode uses in its equivalent of the Start Centre. People may have different / better ideas for the wording.

![Screenshot 2019-06-12 at 23 03 08](https://user-images.githubusercontent.com/3323784/59389491-52fcf180-8d66-11e9-8dee-19a47dbd18f8.png)
