### PR TITLE
fix #284481: Automatic placement of single rests in multiple voice areas

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2806,6 +2806,27 @@ bool Measure::isOnlyDeletedRests(int track) const
       }
 
 //---------------------------------------------------------
+//   isOnlyDeletedRests
+//---------------------------------------------------------
+
+bool Measure::isOnlyDeletedRests(int track, const Fraction& stick, const Fraction& etick) const
+      {
+      static const SegmentType st { SegmentType::ChordRest };
+      for (const Segment* s = first(st); s; s = s->next(st)) {
+            if (s->segmentType() != st || !s->element(track))
+                  continue;
+            ChordRest* cr = toChordRest(s->element(track));
+            if (cr->tick() + cr->globalTicks() <= stick)
+                  continue;
+            if (cr->tick() >= etick)
+                  return true;
+            if (!cr->isRest() || !toRest(cr)->isGap())
+                  return false;
+            }
+      return true;
+      }
+
+//---------------------------------------------------------
 //   stretchedLen
 //---------------------------------------------------------
 

--- a/libmscore/measure.h
+++ b/libmscore/measure.h
@@ -224,6 +224,7 @@ class Measure final : public MeasureBase {
       bool empty() const;
       bool isOnlyRests(int track) const;
       bool isOnlyDeletedRests(int track) const;
+      bool isOnlyDeletedRests(int track, const Fraction& stick, const Fraction& etick) const;
 
       int playbackCount() const      { return _playbackCount; }
       void setPlaybackCount(int val) { _playbackCount = val; }

--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -482,12 +482,14 @@ int Rest::computeLineOffset(int lines)
       if (offsetVoices && voice() == 0) {
             // do not offset voice 1 rest if there exists a matching invisible rest in voice 2;
             Element* e = s->element(track() + 1);
-            if (e && e->isRest() && (!e->visible() || toRest(e)->isGap())) {
+            if (e && e->isRest() && !e->visible() && !toRest(e)->isGap()) {
                   Rest* r = toRest(e);
                   if (r->globalTicks() == globalTicks()) {
                         offsetVoices = false;
                         }
                   }
+            else if (measure()->isOnlyDeletedRests(track() + 1, tick(), tick() + globalTicks()))
+                  offsetVoices = false;
             }
 #if 0
       if (offsetVoices && staff()->mergeMatchingRests()) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/284481.