### PR TITLE
fix #290827: barline not added to mmrest

### DIFF
--- a/libmscore/barline.cpp
+++ b/libmscore/barline.cpp
@@ -78,7 +78,7 @@ static void undoChangeBarLineType(BarLine* bl, BarLineType barType, bool allStav
                               m2 = bl->masterScore()->tick2measure(m2->tick());
                               if (!m2)
                                     return;     // should never happen
-                              segment = m2->undoGetSegmentR(segment->segmentType(), segment->rtick());
+                              segment = m2->undoGetSegment(segment->segmentType(), segment->tick());
                               }
                         const std::vector<Element*>& elist = allStaves ? segment->elist() : std::vector<Element*> { bl };
                         for (Element* e : elist) {


### PR DESCRIPTION
See https://musescore.org/en/node/290827

I had fixed barlines pretty well for the early 3.1 builds, but then later broke one important aspect of it (ability to change barlines on mmrests) with my change in #4914 to allow adding barlines in one part to affect the other parts.  Silly mistake: after getting the correponding measure in the master score, I try to get the barline segment, but I use the rtick() of the original barline segment rather than the tick().  I do use the right function for this, so it works in the normal case.  But it fails in the case of mmrests, since the rtick of the barline in the mmrest is different from the rtick in the measure.

Simple fix, just change from looking up by using undoGetSegmentR() and rtick() to undoGetSegment() and tick().