### PR TITLE
fix #287432: Key signature appears in multimeasure rest after being deleted from underlying measure

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1820,15 +1820,16 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                   if (s)
                         s->setRtick(len);
                   }
+            mmr->removeSystemTrailer();
             }
       else {
             mmr = new Measure(this);
             mmr->setTicks(len);
             mmr->setTick(m->tick());
-            mmr->setPageBreak(lm->pageBreak());
-            mmr->setLineBreak(lm->lineBreak());
             undo(new ChangeMMRest(m, mmr));
             }
+      mmr->setPageBreak(lm->pageBreak());
+      mmr->setLineBreak(lm->lineBreak());
       mmr->setMMRestCount(n);
       mmr->setNo(m->no());
 

--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -4011,7 +4011,7 @@ void Measure::removeSystemTrailer()
             changed = true;
             }
       setTrailer(false);
-      if (changed)
+      if (system() && changed)
             computeMinWidth();
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/287432.

This is a follow-up to #4884.

When an existing mmrest is reused upon reenabling multimeasure rests, the old system trailer should be removed. It will be added back if needed. Also, the mmrest should take on the layout break properties of the last underlying measure, whether an existing mmrest was reused or not.