### PR TITLE
fix #21131: bad ledger line size with small notes

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -692,7 +692,7 @@ void Chord::addLedgerLines()
 
       // the extra length of a ledger line with respect to notehead (half of it on each side)
       qreal extraLen = score()->styleP(Sid::ledgerLineLength) * mag * 0.5;
-      qreal hw = _notes[0]->headWidth();
+      qreal hw;
       qreal minX, maxX;                         // note extrema in raster units
       int   minLine, maxLine;
       bool  visible = false;
@@ -706,6 +706,7 @@ void Chord::addLedgerLines()
       for (size_t j = 0; j < 2; j++) {             // notes are scanned twice...
             int from, delta;
             vector<LedgerLineData> vecLines;
+            hw = 0.0;
             minX  = maxX = 0;
             minLine = 0;
             maxLine = lineBelow;
@@ -732,6 +733,7 @@ void Chord::addLedgerLines()
 
                   if (note->visible())          // if one note is visible,
                         visible = true;         // all lines between it and the staff are visible
+                  hw = qMax(hw, note->headWidth());
 
                   //
                   // Experimental:


### PR DESCRIPTION
See https://musescore.org/en/node/21131.

It's a very old issue.  The original report about thickness of ledger lines on cue notes is actually not applicable - setting the *chord* small as opposed to the *note* accomplishes that goal.  But later the thread turned to the question of the *length* of the ledger lines in the case of chords with mixed note sizes, and we definitely don't do well.  This PR implements what seems the most sensible approach (supported by the examples shown): ledger lines are wide enough to support any note on that line *as well as* any note further from the staff.  See in particular https://musescore.org/en/node/21131#comment-928142