### PR TITLE
fix #224451: Mismatch between "To Coda" and "Fine" when the first is deleted before enable mmrests

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -1913,6 +1913,52 @@ void Score::deleteItem(Element* el)
                   }
                   break;
 
+            case ElementType::MARKER:
+                  {
+                  Measure* m = toMeasure(el->parent());
+                  if (m->isMMRest()) {
+                        // find corresponding marker in underlying measure
+                        bool found = false;
+                        // the marker may be in the first measure...
+                        for (Element* e : m->mmRestFirst()->el()) {
+                              if (e->isMarker() && e->subtype() == el->subtype()) {
+                                    undoRemoveElement(e);
+                                    found = true;
+                                    break;
+                                    }
+                              }
+                        if (!found) {
+                              // ...or it may be in the last measure
+                              for (Element* e : m->mmRestLast()->el()) {
+                                    if (e->isMarker() && e->subtype() == el->subtype()) {
+                                          undoRemoveElement(e);
+                                          break;
+                                          }
+                                    }
+                              }
+                        }
+                  // whether m is an mmrest or not, we still need to remove el
+                  undoRemoveElement(el);
+                  }
+                  break;
+
+            case ElementType::JUMP:
+                  {
+                  Measure* m = toMeasure(el->parent());
+                  if (m->isMMRest()) {
+                        // find corresponding jump in underlying measure
+                        for (Element* e : m->mmRestLast()->el()) {
+                              if (e->isJump() && e->subtype() == el->subtype()) {
+                                    undoRemoveElement(e);
+                                    break;
+                                    }
+                              }
+                        }
+                  // whether m is an mmrest or not, we still need to remove el
+                  undoRemoveElement(el);
+                  }
+                  break;
+
             default:
                   undoRemoveElement(el);
                   break;

--- a/libmscore/jump.h
+++ b/libmscore/jump.h
@@ -53,6 +53,7 @@ class Jump final : public TextBase {
 
       virtual Jump* clone() const override      { return new Jump(*this);   }
       virtual ElementType type() const override { return ElementType::JUMP; }
+      virtual int subtype() const override      { return int(jumpType());   }
 
       Measure* measure() const                  { return toMeasure(parent()); }
 

--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1897,7 +1897,7 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
       for (Element* e : newList) {
             bool found = false;
             for (Element* ee : oldList) {
-                  if (ee->type() == e->type()) {
+                  if (ee->type() == e->type() && ee->subtype() == e->subtype()) {
                         mmr->add(ee);
                         auto i = std::find(oldList.begin(), oldList.end(), ee);
                         if (i != oldList.end())
@@ -1906,11 +1906,8 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                         break;
                         }
                   }
-            if (!found) {
-                  Element* e1 = e->clone();
-                  e1->setParent(mmr);
-                  undo(new AddElement(e1));
-                  }
+            if (!found)
+                  mmr->add(e->clone());
             }
       for (Element* e : oldList)
             delete e;

--- a/libmscore/marker.h
+++ b/libmscore/marker.h
@@ -52,6 +52,7 @@ class Marker final : public TextBase {
 
       virtual Marker* clone() const override    { return new Marker(*this); }
       virtual ElementType type() const override { return ElementType::MARKER; }
+      virtual int subtype() const override      { return int(_markerType); }
 
       Measure* measure() const         { return (Measure*)parent(); }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/224451.