### PR TITLE
fix #291051: Crash on redo after deleting a key signature

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3813,7 +3813,7 @@ void Measure::addSystemHeader(bool isFirstSystem)
                                     // a transposing instrument using a different key sig.
                                     // To prevent this from making the wrong key sig display, remove any key
                                     // sigs on staves where the key in this measure is C.
-                                    score()->undo(new RemoveElement(e));
+                                    kSegment->remove(e);
                                     }
                               }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291051.