### PR TITLE
fix #291053: Bad key change after undoing the enabling of multimeasure rests

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2034,6 +2034,7 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
                         if (!nks) {
                               nks = ks->generated() ? ks->clone() : toKeySig(ks->linkedClone());
                               nks->setParent(ns);
+                              nks->setGenerated(true);
                               undo(new AddElement(nks));
                               }
                         else {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291053.