### PR TITLE
Plugins: add missing Part.instrumentId v2 property to v3.2

### DIFF
--- a/mscore/plugin/api/part.h
+++ b/mscore/plugin/api/part.h
@@ -27,6 +27,8 @@ class Part : public Ms::PluginAPI::ScoreElement {
       Q_OBJECT
       Q_PROPERTY(int                            startTrack          READ startTrack)
       Q_PROPERTY(int                            endTrack            READ endTrack)
+      /// The string identifier for the current instrument. \since MuseScore 3.2
+      Q_PROPERTY(QString                        instrumentId        READ instrumentId)
 
    public:
       /// \cond MS_INTERNAL
@@ -38,6 +40,7 @@ class Part : public Ms::PluginAPI::ScoreElement {
 
       int startTrack() const { return part()->startTrack(); }
       int endTrack()   const { return part()->endTrack(); }
+      QString instrumentId() const { return part()->instrument()->instrumentId(); }
       /// \endcond
       };
 } // namespace PluginAPI


### PR DESCRIPTION
This patch adds the 'Part.instrumentId' property which was lost when the plugin functionality was refactored into an api wrapper now living under the mscore folder.

This property was used by a tin whistle plugin that needs the property badly:

https://github.com/jgadsden/tin-whistle-tablature

The MuseScore plugin 2.0 version was much more functional. I'm also submitting a patch to that project to add back the lost functions.

-Dale