### PR TITLE
fix #291079: "Save online" fails as of Qt 5.12.4 on Windows

### DIFF
--- a/build/appveyor/before_build.bat
+++ b/build/appveyor/before_build.bat
@@ -3,13 +3,13 @@
 IF "%PLATFORM%" == "x64" (
   :: SET "QTURL=https://utils.musescore.org.s3.amazonaws.com/qt5120_msvc2017_64.7z"
   :: SET "QTDIR=%cd%\qt\msvc2017_64" & :: uncomment to use our Qt
-  SET "QTDIR=C:\Qt\5.12\msvc2017_64" & :: uncomment to use AppVeyor's Qt
+  SET "QTDIR=C:\Qt\5.12.4\msvc2017_64" & :: uncomment to use AppVeyor's Qt
   SET "TARGET_PROCESSOR_BITS=64"
   SET "TARGET_PROCESSOR_ARCH=x86_64"
 ) ELSE (
   :: SET "QTURL=https://utils.musescore.org.s3.amazonaws.com/qt5120_msvc2017_32.7z"
   :: SET "QTDIR=%cd%\qt\msvc2017" & :: uncomment to use our Qt
-  SET "QTDIR=C:\Qt\5.12\msvc2017" & :: uncomment to use AppVeyor's Qt
+  SET "QTDIR=C:\Qt\5.12.4\msvc2017" & :: uncomment to use AppVeyor's Qt
   SET "TARGET_PROCESSOR_BITS=32"
   SET "TARGET_PROCESSOR_ARCH=x86"
 )

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -644,6 +644,12 @@ if (MINGW)
       install( FILES
          ${MINGW_ROOT}/bin/libgcc_s_seh-1.dll
          DESTINATION bin)
+      if (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.12.4")
+         install( FILES
+            ${DEPENDENCIES_DIR}/libcrypto-1_1-x64.dll
+            ${DEPENDENCIES_DIR}/libssl-1_1-x64.dll
+            DESTINATION bin)
+      endif (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.12.4")
       install( FILES
          ${DEPENDENCIES_DIR}/portaudio.dll RENAME libportaudio-x86_64-w64-mingw32.static.dll
          DESTINATION bin)
@@ -652,6 +658,12 @@ if (MINGW)
          ${MINGW_ROOT}/bin/libgcc_s_dw2-1.dll
          ${DEPENDENCIES_DIR}/portaudio.dll
          DESTINATION bin)
+      if (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.12.4")
+         install( FILES
+            ${DEPENDENCIES_DIR}/libcrypto-1_1.dll
+            ${DEPENDENCIES_DIR}/libssl-1_1.dll
+            DESTINATION bin)
+      endif (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.12.4")
    endif (BUILD_64)
 
    install( FILES
@@ -659,16 +671,20 @@ if (MINGW)
       ${MINGW_ROOT}/bin/libwinpthread-1.dll
       ${DEPENDENCIES_DIR}/libogg.dll
       ${DEPENDENCIES_DIR}/libsndfile-1.dll
-      ${MINGW_ROOT}/opt/bin/libeay32.dll
       ${DEPENDENCIES_DIR}/libvorbis.dll
       ${DEPENDENCIES_DIR}/libvorbisfile.dll
-      ${MINGW_ROOT}/opt/bin/ssleay32.dll
       ${QT_INSTALL_BINS}/libEGL.dll
       ${QT_INSTALL_BINS}/libGLESv2.dll
       ${QT_INSTALL_BINS}/opengl32sw.dll
       ${QtInstallLibraries}
       ${PROJECT_SOURCE_DIR}/build/qt.conf
       DESTINATION bin)
+   if (Qt5Widgets_VERSION VERSION_LESS "5.12.4")
+      install( FILES
+         ${MINGW_ROOT}/opt/bin/libeay32.dll
+         ${MINGW_ROOT}/opt/bin/ssleay32.dll
+         DESTINATION bin)
+   endif (Qt5Widgets_VERSION VERSION_LESS "5.12.4")
 
    install (FILES
       ${DEPENDENCIES_DIR}/lame_enc.dll
@@ -916,8 +932,13 @@ else (MINGW)
       find_library( dll_vorbis      NAMES "libvorbis"      PATHS ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
       find_library( dll_vorbisfile  NAMES "libvorbisfile"  PATHS ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
       find_library( dll_portaudio   NAMES "portaudio"      PATHS ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
-      find_library( dll_ssl1        NAMES "libeay32"       PATHS ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
-      find_library( dll_ssl2        NAMES "ssleay32"       PATHS ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
+      if (Qt5Widgets_VERSION VERSION_LESS "5.12.4")
+         find_library( dll_ssl1        NAMES "libeay32"       PATHS ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
+         find_library( dll_ssl2        NAMES "ssleay32"       PATHS ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
+      else (Qt5Widgets_VERSION VERSION_LESS "5.12.4")
+         find_library( dll_ssl1        NAMES "libcrypto-1_1-x64" "libcrypto-1_1"  PATHS ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
+         find_library( dll_ssl2        NAMES "libssl-1_1-x64" "libssl-1_1"        PATHS ${DEPENDENCIES_DIR} NO_DEFAULT_PATH)
+      endif (Qt5Widgets_VERSION VERSION_LESS "5.12.4")
 
       list(APPEND dlls_to_copy ${dll_lame} ${dll_ogg} ${dll_sndfile} ${dll_vorbis} ${dll_vorbisfile} ${dll_portaudio} ${dll_ssl1} ${dll_ssl2} "$<TARGET_FILE_DIR:mscore>/${MSCORE_OUTPUT_NAME}.exe")
       set( output_dir_for_dlls "${PROJECT_BINARY_DIR}/../msvc.install${ARCH_TYPE}/bin")


### PR DESCRIPTION
As of Qt 5.12.4 (Open)SSL version 1.1 or later is needed.

Tested and working with MinGW 32-bit and MSVC 64-bit builds.

The 4 additionally needed DLLs (2 each for 32-but and 64-bit) need to get added to https://s3.amazonaws.com/utils.musescore.org/dependencies.7z
Attached to https://musescore.org/en/node/291079 (the "Light" versions from  https://slproweb.com/products/Win32OpenSSL.html) and https://musescore.org/en/node/291079#comment-940153 (taken from Qt' "OpenSSL 1.1.1c Toolkit")

Once 5.12.4 is the minimum required version, libeay32.dll and ssleay32.dll could get removed from that archive and CMakeLists.txt, but no real need, as they are not used and copied after Qt5.12.4.

AppVeyor fail expected, when using Qt 5.12.4 or later, as long as dependencies.7z hasn't been updated to include those libs.