### PR TITLE
Fix #289957: wrong string in Advanced palette

### DIFF
--- a/mscore/debugger/text.ui
+++ b/mscore/debugger/text.ui
@@ -26,7 +26,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
-         <string>Align:</string>
+         <string notr="true">Align:</string>
         </property>
        </widget>
       </item>
@@ -40,9 +40,6 @@
         </property>
         <property name="text">
          <string notr="true">Text:</string>
-        </property>
-        <property name="textFormat">
-         <enum>Qt::PlainText</enum>
         </property>
        </widget>
       </item>
@@ -105,7 +102,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>H:</string>
+            <string notr="true">H:</string>
            </property>
           </widget>
          </item>
@@ -119,7 +116,7 @@
          <item>
           <widget class="QLabel" name="label_11">
            <property name="text">
-            <string>V:</string>
+            <string notr="true">V:</string>
            </property>
           </widget>
          </item>

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -1336,7 +1336,7 @@
             </BarLine>
           </Cell>
         </Palette>
-      <Palette name="Arpeggios &amp;&amp; Glissandos">
+      <Palette name="Arpeggios &amp;&amp; Glissandi">
         <gridWidth>27</gridWidth>
         <gridHeight>50</gridHeight>
         <mag>1</mag>


### PR DESCRIPTION
results in it not getting translated (ommission from #5016).
Also removing translatability of 3 strings of debugger.