### PR TITLE
fix #290967: Crash on right-click / Edit Element with a different element selected

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -319,7 +319,9 @@ void ScoreView::objectPopup(const QPoint& pos, Element* obj)
       popup->addAction("Debugger")->setData("list");
 #endif
 
+      popupActive = true;
       a = popup->exec(pos);
+      popupActive = false;
       if (a == 0)
             return;
       const QByteArray& cmd(a->data().toByteArray());
@@ -1902,7 +1904,7 @@ void ScoreView::cmd(const char* s)
 
       else if (cmd == "edit-element") {
             Element* e = _score->selection().element();
-            if (e && e->isEditable()) {
+            if (e && e->isEditable() && !popupActive) {
                   startEditMode(e);
                   }
             }

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -121,6 +121,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       bool allowRealtimeRests; // Allow entering rests in realtime mode? (See note above)
 
       bool tripleClickPending = false;
+      bool popupActive = false;
 
       // Loop In/Out marks in the score
       PositionCursor* _curLoopIn;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/290967.