### PR TITLE
fix #291089: Leaving edit mode requires second click

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -1030,7 +1030,6 @@ void ScoreView::changeState(ViewState s)
             case ViewState::EDIT:
                   if ( !((mscoreState() & STATE_ALLTEXTUAL_EDIT) && state == ViewState::DRAG_EDIT) ) {
                         startEdit();
-                        setMouseTracking(true);
                         }
                   break;
             case ViewState::LASSO:
@@ -1047,6 +1046,8 @@ void ScoreView::changeState(ViewState s)
 
       state = s;
       mscore->changeState(mscoreState());
+      if (mscoreState() & STATE_ALLTEXTUAL_EDIT)
+            setMouseTracking(true);
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291089.

Switching to edit mode caused `mouseTracking` to be set to `true`, and a mouseMove event while in edit mode causes the state to switch to DRAG_EDIT. The first click switches from DRAG_EDIT to EDIT. The second click switches from EDIT to NORMAL.

When switching to edit mode, it is only necessary to set `mouseTracking` to `true` if we are editing text. This is so the mouse cursor will automatically update when it enters and leaves the text area.

If `mscoreState()` is called before the `state` variable is updated, the result will be based on the previous state.