### PR TITLE
fix #281362: allow shift+drag to rearrange palette

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -873,7 +873,7 @@ void Palette::leaveEvent(QEvent*)
       if (currentIdx != -1) {
             QRect r = idxRect(currentIdx);
             PaletteBox* pb = mscore->getPaletteBox();
-            if (!pb->getKeyboardNavigation())
+            if (!pb->getKeyboardNavigation() && !(QGuiApplication::keyboardModifiers() & Qt::ShiftModifier))
                   currentIdx = -1;
             update(r);
             }


### PR DESCRIPTION
See https://musescore.org/en/node/281362

In 2.x it was possible to rearrange elements in custom palettes by dragging them around, but somehow this abiity was lost in MuseScore 3.  After some investigation, I found the code for this restructured significantly at https://github.com/musescore/MuseScore/commit/292a8d9cd139fe3cf373007ea175f8a78ba90eeb.  I can see the *intent* was that Shift+drag would do the job now, but that doesn't work either, because currentIdx is always -1 when the following code executes:

https://github.com/MarcSabatella/MuseScore/blob/309611ca65ab3d9b1d23c4e6b7e0131f36c33db8/mscore/palette.cpp#L1825-L1834

currentIdx is originally set to the dragged element, but it gets cleared (set to -1) in Palette::leaveEvent().  That code has been there since day one and presumably serves a useful purpose.  So I'm not sure how this ever worked, but apparently it did, on macOS at least - see https://musescore.org/en/node/283590.

So while I'm not totally sure what's going on here, I *can* say that simply disabling this clearing if Shift is pressed works: now Shift+drag allows rearranging the palette as I believe was intended.

I can't swear there are no side effects (what about Shift while moving the mouse and *not* dragging?) and I also can't swear this works on all platforms or all versions of Qt.  But it's worth considering.  I welcome further review / testing!