### PR TITLE
fix #289254: Beam in edit mode always switches to right grab handle

### DIFF
--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -2140,8 +2140,10 @@ void Beam::editDrag(EditData& ed)
             y1 += dy;
 
       qreal _spatium = spatium();
-      undoChangeProperty(Pid::BEAM_POS, QPointF(y1 / _spatium, y2 / _spatium));
+      // Because of the logic in Beam::setProperty(),
+      // changing Pid::BEAM_POS only has an effect if Pid::USER_MODIFIED is true.
       undoChangeProperty(Pid::USER_MODIFIED, true);
+      undoChangeProperty(Pid::BEAM_POS, QPointF(y1 / _spatium, y2 / _spatium));
       undoChangeProperty(Pid::GENERATED, false);
 
       triggerLayout();

--- a/mscore/editelement.cpp
+++ b/mscore/editelement.cpp
@@ -111,7 +111,7 @@ void ScoreView::startEdit(Element* element, Grip startGrip)
       editData.element = element;
       if (forceStartEdit) // call startEdit() forcibly to reinitialize edit mode.
             startEdit();
-      else
+      else if (state != ViewState::DRAG_EDIT)
             changeState(ViewState::EDIT);
 
       if (startGrip != Grip::NO_GRIP)

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -1036,9 +1036,8 @@ void ScoreView::changeState(ViewState s)
                         startEdit();
                   break;
             case ViewState::EDIT:
-                  if ( !((mscoreState() & STATE_ALLTEXTUAL_EDIT) && state == ViewState::DRAG_EDIT) ) {
+                  if (state != ViewState::DRAG_EDIT)
                         startEdit();
-                        }
                   break;
             case ViewState::LASSO:
                   break;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/289254.