### PR TITLE
fix #291089: Leaving edit mode requires second click

### DIFF
--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -844,6 +844,7 @@ void ScoreView::contextMenuEvent(QContextMenuEvent* ev)
             }
       QPoint gp          = ev->globalPos();
       editData.startMove = toLogical(ev->pos());
+      editData.buttons   = Qt::NoButton;
       Element* e         = elementNear(editData.startMove);
       if (e) {
             if (!e->selected()) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291089.

On macOS and Linux, Qt never sends a mouse release event to the ScoreView for the right mouse button, and so `editData.buttons` is not reset to `Qt::NoButton`. Changing to text edit mode causes mouse tracking to be turned on, and `editData.buttons` is still equal to `Qt::RightMouseButton`, and so any subsequent mouse movement registers as a drag. This fixes the problem by setting `editData.buttons` to `Qt::NoButton` in `ScoreView::contextMenuEvent()`.