### PR TITLE
Plugins: Add remainder of v2.0 Part object properties to v3.2.1

### DIFF
--- a/libmscore/part.cpp
+++ b/libmscore/part.cpp
@@ -504,7 +504,7 @@ void Part::insertTime(const Fraction& tick, const Fraction& len)
 //   lyricCount
 //---------------------------------------------------------
 
-int Part::lyricCount()
+int Part::lyricCount() const
       {
       if (!score())
             return 0;
@@ -524,7 +524,7 @@ int Part::lyricCount()
 //   harmonyCount
 //---------------------------------------------------------
 
-int Part::harmonyCount()
+int Part::harmonyCount() const
       {
       if (!score())
             return 0;
@@ -543,7 +543,7 @@ int Part::harmonyCount()
 //   hasPitchedStaff
 //---------------------------------------------------------
 
-bool Part::hasPitchedStaff()
+bool Part::hasPitchedStaff() const
       {
       if (!staves())
             return false;
@@ -558,7 +558,7 @@ bool Part::hasPitchedStaff()
 //   hasTabStaff
 //---------------------------------------------------------
 
-bool Part::hasTabStaff()
+bool Part::hasTabStaff() const
       {
       if (!staves())
             return false;
@@ -573,7 +573,7 @@ bool Part::hasTabStaff()
 //   hasDrumStaff
 //---------------------------------------------------------
 
-bool Part::hasDrumStaff()
+bool Part::hasDrumStaff() const
       {
       if (!staves())
             return false;

--- a/libmscore/part.h
+++ b/libmscore/part.h
@@ -122,11 +122,11 @@ class Part final : public ScoreElement {
       QVariant getProperty(Pid) const override;
       bool setProperty(Pid, const QVariant&) override;
 
-      int lyricCount();
-      int harmonyCount();
-      bool hasPitchedStaff();
-      bool hasTabStaff();
-      bool hasDrumStaff();
+      int lyricCount() const;
+      int harmonyCount() const;
+      bool hasPitchedStaff() const;
+      bool hasTabStaff() const;
+      bool hasDrumStaff() const;
 
       const Part* masterPart() const;
       Part* masterPart();

--- a/mscore/plugin/api/part.h
+++ b/mscore/plugin/api/part.h
@@ -25,10 +25,42 @@ namespace PluginAPI {
 
 class Part : public Ms::PluginAPI::ScoreElement {
       Q_OBJECT
-      Q_PROPERTY(int                            startTrack          READ startTrack)
-      Q_PROPERTY(int                            endTrack            READ endTrack)
+      Q_PROPERTY(int                            startTrack           READ startTrack)
+      Q_PROPERTY(int                            endTrack             READ endTrack)
       /// The string identifier for the current instrument. \since MuseScore 3.2
-      Q_PROPERTY(QString                        instrumentId        READ instrumentId)
+      Q_PROPERTY(QString                        instrumentId         READ instrumentId)
+      /// The number of Chord Symbols. \since MuseScore 3.2.1
+      Q_PROPERTY(int                            harmonyCount         READ harmonyCount)
+      /// Whether it is a percussion staff. \since MuseScore 3.2.1
+      Q_PROPERTY(bool                           hasDrumStaff         READ hasDrumStaff)
+      /// Whether it is a 'normal' staff with notes. \since MuseScore 3.2.1
+      Q_PROPERTY(bool                           hasPitchedStaff      READ hasPitchedStaff)
+      /// Whether it is a tablature staff. \since MuseScore 3.2.1
+      Q_PROPERTY(bool                           hasTabStaff          READ hasTabStaff)
+      /// The number of lyrics syllables. \since MuseScore 3.2.1
+      Q_PROPERTY(int                            lyricCount           READ lyricCount)
+      /// One of 16 music channels that can be assigned an instrument. \since MuseScore 3.2.1
+      Q_PROPERTY(int                            midiChannel          READ midiChannel)
+      /// One of the 128 different instruments in General MIDI. \since MuseScore 3.2.1
+      Q_PROPERTY(int                            midiProgram          READ midiProgram)
+      /// The long name for the current instrument.
+      /// Note that this property was writeable in MuseScore v2.x
+      /// \since MuseScore 3.2.1
+      Q_PROPERTY(QString                        longName             READ longName)
+      /// The short name for the current instrument.
+      /// Note that this property was writeable in MuseScore v2.x
+      /// \since MuseScore 3.2.1
+      Q_PROPERTY(QString                        shortName            READ shortName)
+      /// The name of the current part of music.
+      /// It is shown in Mixer.
+      ///
+      /// Note that this property was writeable in MuseScore v2.x
+      /// \since MuseScore 3.2.1
+      Q_PROPERTY(QString                        partName             READ partName)
+      /// Whether part is shown or hidden.
+      /// Note that this property was writeable in MuseScore v2.x
+      /// \since MuseScore 3.2.1
+      Q_PROPERTY(bool                           show                 READ show)
 
    public:
       /// \cond MS_INTERNAL
@@ -41,6 +73,17 @@ class Part : public Ms::PluginAPI::ScoreElement {
       int startTrack() const { return part()->startTrack(); }
       int endTrack()   const { return part()->endTrack(); }
       QString instrumentId() const { return part()->instrument()->instrumentId(); }
+      int harmonyCount() const { return part()->harmonyCount(); }
+      bool hasPitchedStaff() const { return part()->hasPitchedStaff(); }
+      bool hasTabStaff() const { return part()->hasTabStaff(); }
+      bool hasDrumStaff() const { return part()->hasDrumStaff(); }
+      int lyricCount() const { return part()->lyricCount(); }
+      int midiChannel() const { return part()->midiChannel(); }
+      int midiProgram() const { return part()->midiProgram(); }
+      QString longName() const { return part()->longName(); }
+      QString shortName() const { return part()->shortName(); }
+      QString partName() const { return part()->partName(); }
+      bool show() const { return part()->show(); }
       /// \endcond
       };
 } // namespace PluginAPI


### PR DESCRIPTION
The v3.0 release lost many properties for the Part
object when it released. This commit restores them.

A preemptive comment...

I know I'm missing the documentation of the restored properties (I added a "TBD" for them) as I don't know precisely what they are. If someone could point me to some documentation I'd be happy to add them as well. As a minimum I thought the restoration of properties would be still useful since I was in this area of the code for fixing the missing instrumentId property anyway. No reason to leave some new knowledge go to waste. :)

I see also that the properties "volume" and "mute" seem to be missing from v3.0 libmscore Part definition so obviously these didn't make the cut.

-Dale
