### PR TITLE
fix #291261 Volta Mouse Drop default first staff

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1317,6 +1317,7 @@ bool Measure::acceptDrop(EditData& data) const
                   viewer->setDropRectangle(canvasBoundingRect());
                   return true;
 
+            case ElementType::VOLTA:
             case ElementType::KEYSIG:
             case ElementType::TIMESIG:
                   if (data.modifiers & Qt::ControlModifier)
@@ -1436,6 +1437,14 @@ Element* Measure::drop(EditData& data)
                   score()->undoChangeClef(staff, first(), toClef(e)->clefType());
                   delete e;
                   break;
+
+            case ElementType::VOLTA:
+                  {
+                  Spanner* volta = static_cast<Spanner*>(e->clone());
+                  volta->setScore(score());
+                  score()->cmdAddSpanner(volta, staffIdx, first(), last());
+                  break;
+                  }
 
             case ElementType::KEYSIG:
                   {

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -332,7 +332,6 @@ void ScoreView::dragMoveEvent(QDragMoveEvent* event)
       editData.modifiers = event->keyboardModifiers();
 
       switch (editData.dropElement->type()) {
-            case ElementType::VOLTA:
             case ElementType::PEDAL:
             case ElementType::LET_RING:
             case ElementType::VIBRATO:
@@ -346,6 +345,7 @@ void ScoreView::dragMoveEvent(QDragMoveEvent* event)
             case ElementType::IMAGE:
             case ElementType::SYMBOL:
             case ElementType::DYNAMIC:
+            case ElementType::VOLTA:
             case ElementType::KEYSIG:
             case ElementType::CLEF:
             case ElementType::TIMESIG:
@@ -417,7 +417,6 @@ void ScoreView::dropEvent(QDropEvent* event)
             Q_ASSERT(editData.dropElement->score() == score());
             _score->addRefresh(editData.dropElement->canvasBoundingRect());
             switch (editData.dropElement->type()) {
-                  case ElementType::VOLTA:
                   case ElementType::OTTAVA:
                   case ElementType::TRILL:
                   case ElementType::PEDAL:
@@ -477,6 +476,9 @@ void ScoreView::dropEvent(QDropEvent* event)
                         }
                         event->acceptProposedAction();
                         break;
+                  case ElementType::VOLTA:
+                        if (editData.modifiers & Qt::ControlModifier)
+                              editData.dropElement->setSystemFlag(false);
                   case ElementType::HBOX:
                   case ElementType::VBOX:
                   case ElementType::KEYSIG:


### PR DESCRIPTION
Previously, dragging a volta from the palette and dropping onto a measure would cause the volta to only be applied to the particular staff under the mouse.  However this causes problems because MuseScore generally assumes that first staff is the authority on voltas when creating and dealing with part scores.

This PR makes volta drops only be applied to the first staff, unless the user holds control while dropping, in which case the previous behavior of the volta gets applied to the particular staff will occur.