### PR TITLE
Correct plugins documentation and plugins-related compiler warnings

### DIFF
--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -314,7 +314,7 @@ void PluginAPI::registerQmlTypes()
             qWarning("qmlRegisterType failed: MuseScore");
 
 //             qmlRegisterType<MScore>     ("MuseScore", 3, 0, "MScore");
-      qmlRegisterType<MsScoreView>("MuseScore", 3, 0, "ScoreView");
+      qmlRegisterType<ScoreView>("MuseScore", 3, 0, "ScoreView");
 
       qmlRegisterType<Cursor>("MuseScore", 3, 0, "Cursor");
       qmlRegisterType<ScoreElement>();

--- a/mscore/plugin/api/util.cpp
+++ b/mscore/plugin/api/util.cpp
@@ -135,8 +135,15 @@ int FileIO::modifiedTime()
 
 void MsScoreView::setScore(Ms::PluginAPI::Score* s)
       {
+      Ms::Score* newScore = s ? s->score() : nullptr;
+      setScore(newScore);
+      }
+
+void MsScoreView::setScore(Ms::Score* s)
+      {
+      MuseScoreView::setScore(s);
       _currentPage = 0;
-      score = s ? s->score() : nullptr;
+      score = s;
 
       if (score) {
             score->doLayout();

--- a/mscore/plugin/api/util.cpp
+++ b/mscore/plugin/api/util.cpp
@@ -32,10 +32,10 @@ namespace Ms {
 namespace PluginAPI {
 
 //---------------------------------------------------------
-//   MsScoreView
+//   ScoreView
 //---------------------------------------------------------
 
-MsScoreView::MsScoreView(QQuickItem* parent)
+ScoreView::ScoreView(QQuickItem* parent)
    : QQuickPaintedItem(parent)
       {
       setAcceptedMouseButtons(Qt::LeftButton);
@@ -133,13 +133,13 @@ int FileIO::modifiedTime()
 //   setScore
 //---------------------------------------------------------
 
-void MsScoreView::setScore(Ms::PluginAPI::Score* s)
+void ScoreView::setScore(Ms::PluginAPI::Score* s)
       {
       Ms::Score* newScore = s ? s->score() : nullptr;
       setScore(newScore);
       }
 
-void MsScoreView::setScore(Ms::Score* s)
+void ScoreView::setScore(Ms::Score* s)
       {
       MuseScoreView::setScore(s);
       _currentPage = 0;
@@ -166,7 +166,7 @@ void MsScoreView::setScore(Ms::Score* s)
 //   paint
 //---------------------------------------------------------
 
-void MsScoreView::paint(QPainter* p)
+void ScoreView::paint(QPainter* p)
       {
       p->setRenderHint(QPainter::Antialiasing, true);
       p->setRenderHint(QPainter::TextAntialiasing, true);
@@ -195,7 +195,7 @@ void MsScoreView::paint(QPainter* p)
 //   setCurrentPage
 //---------------------------------------------------------
 
-void MsScoreView::setCurrentPage(int n)
+void ScoreView::setCurrentPage(int n)
       {
       if (score == 0)
             return;
@@ -214,7 +214,7 @@ void MsScoreView::setCurrentPage(int n)
 //   nextPage
 //---------------------------------------------------------
 
-void MsScoreView::nextPage()
+void ScoreView::nextPage()
       {
       setCurrentPage(_currentPage + 1);
       }
@@ -223,7 +223,7 @@ void MsScoreView::nextPage()
 //   prevPage
 //---------------------------------------------------------
 
-void MsScoreView::prevPage()
+void ScoreView::prevPage()
       {
       setCurrentPage(_currentPage - 1);
       }

--- a/mscore/plugin/api/util.h
+++ b/mscore/plugin/api/util.h
@@ -127,11 +127,11 @@ class MsProcess : public QProcess {
       };
 
 //---------------------------------------------------------
-//   @@ ScoreView \since MuseScore 3.2
+//   @@ ScoreView
 ///    This is an GUI element to show a score. \since MuseScore 3.2
 //---------------------------------------------------------
 
-class MsScoreView : public QQuickPaintedItem, public MuseScoreView {
+class ScoreView : public QQuickPaintedItem, public MuseScoreView {
       Q_OBJECT
       /** Background color */
       Q_PROPERTY(QColor color READ color WRITE setColor)
@@ -169,8 +169,8 @@ class MsScoreView : public QQuickPaintedItem, public MuseScoreView {
 
    public:
       /// \cond MS_INTERNAL
-      MsScoreView(QQuickItem* parent = 0);
-      virtual ~MsScoreView() {}
+      ScoreView(QQuickItem* parent = 0);
+      virtual ~ScoreView() {}
       QColor color() const            { return _color;        }
       void setColor(const QColor& c)  { _color = c;           }
       qreal scale() const             { return mag;        }

--- a/mscore/plugin/api/util.h
+++ b/mscore/plugin/api/util.h
@@ -147,6 +147,8 @@ class MsScoreView : public QQuickPaintedItem, public MuseScoreView {
 
       QNetworkAccessManager* networkManager;
 
+      virtual void setScore(Ms::Score*) override;
+
       virtual void dataChanged(const QRectF&) override { update(); }
       virtual void updateAll() override                { update(); }
 

--- a/mscore/plugin/api/util.h
+++ b/mscore/plugin/api/util.h
@@ -107,8 +107,10 @@ class FileIO : public QObject {
 //---------------------------------------------------------
 //   MsProcess
 //   @@ QProcess
-///    Start an external program. Using this will most probably
-///    result in the plugin to be platform dependant. \since MuseScore 3.2
+///   \brief Start an external program.\ Available in QML
+///   as \p QProcess.
+///   \details Using this will most probably result in the
+///   plugin to be platform dependant. \since MuseScore 3.2
 //---------------------------------------------------------
 
 class MsProcess : public QProcess {


### PR DESCRIPTION
PR #5021 returns `QProcess` and `ScoreView` types to QML bindings available from plugins. However they appeared to be named incorrectly in the Doxygen-generated plugins documentation. This PR corrects this by renaming `MsScoreView` class to match the name available in QML and by adding the corresponding notice about exposing `MsProcess` under `QProcess` name (I was reluctant to introduce one more `QProcess` class to C++ code in order to avoid possible confusions).

Also the first commit of this PR corrects compiler warnings about MsScoreView class while compiling mtest, see [this Travis log](https://travis-ci.org/musescore/MuseScore/jobs/549931489#L3648) for the example of such warning.