### PR TITLE
fix #291292: Add 3/2 time signature to advanced workspace and master palette

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -1359,7 +1359,10 @@ Palette* MuseScore::newTimePalette()
             { 9,  8, TimeSigType::NORMAL, "9/8" },
             { 12, 8, TimeSigType::NORMAL, "12/8" },
             { 4,  4, TimeSigType::FOUR_FOUR,  tr("4/4 common time") },
-            { 2,  2, TimeSigType::ALLA_BREVE, tr("2/2 alla breve") }
+            { 2,  2, TimeSigType::ALLA_BREVE, tr("2/2 alla breve") },
+            { 2,  2, TimeSigType::NORMAL, "2/2" },
+            { 3,  2, TimeSigType::NORMAL, "3/2" },
+            { 4,  2, TimeSigType::NORMAL, "4/2" },
             };
 
       Palette* sp = new Palette;

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -285,7 +285,7 @@
         <gridWidth>42</gridWidth>
         <gridHeight>38</gridHeight>
         <mag>0.8</mag>
-        <moreElements>0</moreElements>
+        <moreElements>1</moreElements>
         <Cell name="2/4">
           <staff>1</staff>
           <TimeSig>
@@ -369,6 +369,13 @@
           <TimeSig>
             <subtype>2</subtype>
             <sigN>2</sigN>
+            <sigD>2</sigD>
+            </TimeSig>
+          </Cell>
+        <Cell name="3/2">
+          <staff>1</staff>
+          <TimeSig>
+            <sigN>3</sigN>
             <sigD>2</sigD>
             </TimeSig>
           </Cell>

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -138,7 +138,7 @@
         <gridWidth>42</gridWidth>
         <gridHeight>38</gridHeight>
         <mag>0.8</mag>
-        <moreElements>0</moreElements>
+        <moreElements>1</moreElements>
         <Cell name="2/4">
           <staff>1</staff>
           <TimeSig>


### PR DESCRIPTION
while at it add 2/2 and 4/2 too, but only to master palette and a 'more' element to the workspaces (shamelessly stolen from #5170)