### PR TITLE
fix #291261 Volta Mouse Drop default first staff

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -280,7 +280,7 @@ void Score::deletePostponed()
 //        HAIRPIN, LET_RING, VIBRATO and TEXTLINE
 //---------------------------------------------------------
 
-void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos)
+void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos, bool firstStaffOnly)
       {
       int staffIdx;
       Segment* segment;
@@ -292,6 +292,8 @@ void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos)
             return;
             }
 
+      if (firstStaffOnly)
+            staffIdx = 0;
       // all spanners live in voice 0 (except slurs/ties)
       int track = staffIdx == -1 ? -1 : staffIdx * VOICES;
 
@@ -308,7 +310,7 @@ void Score::cmdAddSpanner(Spanner* spanner, const QPointF& pos)
             Measure* m = toMeasure(mb);
             QRectF b(m->canvasBoundingRect());
 
-            if (pos.x() >= (b.x() + b.width() * .5) && m != lastMeasureMM())
+            if (!spanner->isVolta() && pos.x() >= (b.x() + b.width() * .5) && m != lastMeasureMM())
                   m = m->nextMeasure();
             spanner->setTick(m->tick());
             spanner->setTick2(m->endTick());

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1086,7 +1086,7 @@ class Score : public QObject, public ScoreElement {
       bool isSpannerStartEnd(const Fraction& tick, int track) const;
       void removeSpanner(Spanner*);
       void addSpanner(Spanner*);
-      void cmdAddSpanner(Spanner* spanner, const QPointF& pos);
+      void cmdAddSpanner(Spanner* spanner, const QPointF& pos, bool firstStaffOnly = false);
       void cmdAddSpanner(Spanner* spanner, int staffIdx, Segment* startSegment, Segment* endSegment);
       void checkSpanner(const Fraction& startTick, const Fraction& lastTick);
       const std::set<Spanner*> unmanagedSpanners() { return _unmanagedSpanner; }

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -183,7 +183,7 @@ class ScoreView : public QWidget, public MuseScoreView {
 
       void setShadowNote(const QPointF&);
       void drawElements(QPainter& p,QList<Element*>& el, Element* editElement);
-      bool dragTimeAnchorElement(const QPointF& pos);
+      bool dragTimeAnchorElement(const QPointF& pos, bool firstStaffOnly = false);
       bool dragMeasureAnchorElement(const QPointF& pos);
       virtual void lyricsTab(bool back, bool end, bool moveOnly) override;
       virtual void lyricsReturn() override;


### PR DESCRIPTION
Previously, dragging a volta from the palette and dropping onto a measure would cause the volta to only be applied to the particular staff under the mouse. However this causes problems because MuseScore generally assumes that first staff is the authority on voltas when creating and dealing with part scores.

This PR makes volta drops only be applied to the first staff, unless the user holds control while dropping, in which case the previous behavior of the volta gets applied to the particular staff will occur.