### PR TITLE
fix #291314 Volta Palette DClick default 1st staff

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -680,8 +680,10 @@ void Palette::applyPaletteElement(PaletteCell* cell, Qt::KeyboardModifiers modif
             else if (element->isSLine() && element->type() != ElementType::GLISSANDO) {
                   Segment* startSegment = sel.startSegment();
                   Segment* endSegment = sel.endSegment();
-                  int endStaff = sel.staffEnd();
-                  for (int i = sel.staffStart(); i < endStaff; ++i) {
+                  bool firstStaffOnly = element->isVolta() && !(modifiers & Qt::ControlModifier);
+                  int startStaff = firstStaffOnly ? 0 : sel.staffStart();
+                  int endStaff   = firstStaffOnly ? 1 : sel.staffEnd();
+                  for (int i = startStaff; i < endStaff; ++i) {
                         Spanner* spanner = static_cast<Spanner*>(element->clone());
                         spanner->setScore(score);
                         spanner->styleChanged();


### PR DESCRIPTION
Previous behavior when double-clicking a volta from the palette when a range was selected was to always apply the volta to *all* staves in the range.  However this causes problems because MuseScore assumes when creating and editing part scores that the first staff is the authority on the voltas.  Therefore I think better to make sure that voltas only get applied to the first staff, unless user explicity desires to apply to other staves.

This fix keeps the previous behavior if the user holds Control while double-clicking on a volta from the palette.  But the new default behavior is that the volta only gets applied to the very first staff (even if the first staff isn't even in the selected range).