### PR TITLE
fix #291326 X/X Create Custom Time Sig

### DIFF
--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -104,7 +104,7 @@ Element* TimeSig::drop(EditData& data)
 
 void TimeSig::setNumeratorString(const QString& a)
       {
-      if (_timeSigType == TimeSigType::NORMAL)
+      if (_timeSigType == TimeSigType::NORMAL || _timeSigType == TimeSigType::CREATE_CUSTOM)
             _numeratorString = a;
       }
 
@@ -115,7 +115,7 @@ void TimeSig::setNumeratorString(const QString& a)
 
 void TimeSig::setDenominatorString(const QString& a)
       {
-      if (_timeSigType ==  TimeSigType::NORMAL)
+      if (_timeSigType == TimeSigType::NORMAL || _timeSigType == TimeSigType::CREATE_CUSTOM)
             _denominatorString = a;
       }
 

--- a/libmscore/timesig.h
+++ b/libmscore/timesig.h
@@ -31,6 +31,7 @@ enum class TimeSigType : char {
       NORMAL,            // use sz/sn text
       FOUR_FOUR,         // common time (4/4)
       ALLA_BREVE,        // cut time (2/2)
+      CREATE_CUSTOM,     // shortcut to open master palette create time signature dialog, appears like X/X
       };
 
 //---------------------------------------------------------------------------------------

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -1042,6 +1042,7 @@ std::vector<SymId> toTimeSigString(const QString& s)
             { 67,    SymId::timeSigCommon           },  // 'C'
             { 40,    SymId::timeSigParensLeftSmall  },  // '('
             { 41,    SymId::timeSigParensRightSmall },  // ')'
+            { 88,    SymId::timeSigX                },  // 'X'
             { 162,   SymId::timeSigCutCommon        },  // '¢'
             { 59664, SymId::mensuralProlation1      },
             { 79,    SymId::mensuralProlation2      },  // 'O'

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -361,6 +361,11 @@ void Palette::mousePressEvent(QMouseEvent* ev)
       PaletteCell* cell = cellAt(dragIdx);
       if (cell && (cell->tag == "ShowMore"))
             emit displayMore(_name);
+      if (cell && (cell->name == "create custom time signature")) {
+            dragIdx = -1; // disable dragging
+            mscore->showMasterPalette(qApp->translate("Palette", "Time Signatures"));
+            return;
+            }
       if (mscore->getPaletteBox()->getKeyboardNavigation()) {
             PaletteBox* pb = mscore->getPaletteBox();
             pb->mousePressEvent(ev, this);

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -372,6 +372,13 @@
             <sigD>2</sigD>
             </TimeSig>
           </Cell>
+        <Cell name="create custom time signature">
+          <staff>1</staff>
+          <TimeSig>
+            <textN>X</textN>
+            <textD>X</textD>
+            </TimeSig>
+          </Cell>
         </Palette>
       <Palette name="Brackets">
         <gridWidth>40</gridWidth>


### PR DESCRIPTION
This is a feature request to facilitate creating new time signatures. Currently in order to open the master palette you can use shortcut "Shift->T" or by "View"->"Master Palette"->"Time Signatures". But just wanted an easy way for when your hand is on your mouse hovering in the palette looking for the particular time sig, such that can click to open the dialog with your mouse in the area without having to switch hand to keyboard or mouse to the top menu.