### PR TITLE
fix #291326 ShowMore Key&Time Sigs

### DIFF
--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -181,7 +181,7 @@
         <gridWidth>56</gridWidth>
         <gridHeight>55</gridHeight>
         <mag>1</mag>
-        <moreElements>0</moreElements>
+        <moreElements>1</moreElements>
         <yoffset>1</yoffset>
         <Cell name="G major, E minor">
           <staff>1</staff>
@@ -285,7 +285,7 @@
         <gridWidth>42</gridWidth>
         <gridHeight>38</gridHeight>
         <mag>0.8</mag>
-        <moreElements>0</moreElements>
+        <moreElements>1</moreElements>
         <Cell name="2/4">
           <staff>1</staff>
           <TimeSig>

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -138,7 +138,7 @@
         <gridWidth>42</gridWidth>
         <gridHeight>38</gridHeight>
         <mag>0.8</mag>
-        <moreElements>0</moreElements>
+        <moreElements>1</moreElements>
         <Cell name="2/4">
           <staff>1</staff>
           <TimeSig>


### PR DESCRIPTION
This adds an entry to the Advanced Workspace palettes for Key sigs and Time sigs which looks like "???" which when clicked will open the Master Palette for Key and Time sigs.  Note that the Clef palette already has this feature.  This will help faciliate adding custom key sigs and time sigs, since can access the Master Palette when you have your hand on your mouse in the palette.