### PR TITLE
[MU4] Fix #291349: Rename the labels for the markers "Coda" and "To Coda"

### DIFF
--- a/libmscore/jump.cpp
+++ b/libmscore/jump.cpp
@@ -33,9 +33,9 @@ const JumpTypeTable jumpTypeTable[] = {
     { Jump::Type::DC,         "D.C.",         "start", "end",  "",      QT_TRANSLATE_NOOP("jumpType", "Da Capo") },
     { Jump::Type::DC_AL_FINE, "D.C. al Fine", "start", "fine", "",
       QT_TRANSLATE_NOOP("jumpType", "Da Capo al Fine") },
-    { Jump::Type::DC_AL_CODA, "D.C. al Coda", "start", "coda", "codab",
+    { Jump::Type::DC_AL_CODA, "D.C. al Coda", "start", "tocoda", "coda",
       QT_TRANSLATE_NOOP("jumpType", "Da Capo al Coda") },
-    { Jump::Type::DS_AL_CODA, "D.S. al Coda", "segno", "coda", "codab", QT_TRANSLATE_NOOP("jumpType", "D.S. al Coda") },
+    { Jump::Type::DS_AL_CODA, "D.S. al Coda", "segno", "tocoda", "coda",QT_TRANSLATE_NOOP("jumpType", "D.S. al Coda") },
     { Jump::Type::DS_AL_FINE, "D.S. al Fine", "segno", "fine", "",      QT_TRANSLATE_NOOP("jumpType", "D.S. al Fine") },
     { Jump::Type::DS,         "D.S.",         "segno", "end",  "",      QT_TRANSLATE_NOOP("jumpType", "D.S.") }
 };

--- a/libmscore/marker.cpp
+++ b/libmscore/marker.cpp
@@ -82,7 +82,7 @@ void Marker::setMarkerType(Type t)
 
     case Type::CODA:
         txt = "<sym>coda</sym>";
-        setLabel("codab");
+        setLabel("coda");
         break;
 
     case Type::VARCODA:
@@ -104,13 +104,13 @@ void Marker::setMarkerType(Type t)
     case Type::TOCODA:
         txt = "To Coda";
         initTid(Tid::REPEAT_RIGHT, true);
-        setLabel("coda");
+        setLabel("tocoda");
         break;
 
     case Type::TOCODASYM:
         txt = "To <font size=\"20\"/><sym>coda</sym>";
         initTid(Tid::REPEAT_RIGHT, true);
-        setLabel("coda");
+        setLabel("tocoda");
         break;
 
     case Type::USER:
@@ -154,7 +154,7 @@ Marker::Type Marker::markerType(const QString& s) const
         return Type::SEGNO;
     } else if (s == "varsegno") {
         return Type::VARSEGNO;
-    } else if (s == "codab") {
+    } else if (s == "coda") {
         return Type::CODA;
     } else if (s == "varcoda") {
         return Type::VARCODA;
@@ -162,7 +162,7 @@ Marker::Type Marker::markerType(const QString& s) const
         return Type::CODETTA;
     } else if (s == "fine") {
         return Type::FINE;
-    } else if (s == "coda") {
+    } else if (s == "tocoda") {
         return Type::TOCODA;
     } else {
         return Type::USER;

--- a/mtest/musicxml/io/testDCalCoda.xml
+++ b/mtest/musicxml/io/testDCalCoda.xml
@@ -73,7 +73,7 @@
         <direction-type>
           <words>To Coda</words>
           </direction-type>
-        <sound tocoda="coda"/>
+        <sound tocoda="tocoda"/>
         </direction>
       </measure>
     <measure number="3">

--- a/mtest/testscript/scripts/palette.mscx
+++ b/mtest/testscript/scripts/palette.mscx
@@ -440,8 +440,8 @@
           <style>Repeat Text Right</style>
           <text>D.S. al Coda</text>
           <jumpTo>segno</jumpTo>
-          <playUntil>coda</playUntil>
-          <continueAt>codab</continueAt>
+          <playUntil>tocoda</playUntil>
+          <continueAt>coda</continueAt>
           </Jump>
         <voice>
           <Chord>

--- a/mtest/testscript/scripts/palette.script
+++ b/mtest/testscript/scripts/palette.script
@@ -89,7 +89,7 @@ cmd next-measure
 cmd note-b
 cmd escape
 cmd select-next-chord
-palette Jump jumpTo segno playUntil coda
+palette Jump jumpTo segno playUntil tocoda
 
 cmd note-input
 cmd next-measure

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -2187,7 +2187,7 @@
           <Marker>
             <style>Repeat Text Left</style>
             <text><sym>coda</sym></text>
-            <label>codab</label>
+            <label>coda</label>
             </Marker>
           </Cell>
         <Cell name="Varied coda">
@@ -2208,7 +2208,7 @@
           <Marker>
             <style>Repeat Text Left</style>
             <text>To Coda</text>
-            <label>coda</label>
+            <label>tocoda</label>
             </Marker>
           </Cell>
         <Cell name="Da Capo">
@@ -2234,8 +2234,8 @@
             <style>Repeat Text Right</style>
             <text>D.C. al Coda</text>
             <jumpTo>start</jumpTo>
-            <playUntil>coda</playUntil>
-            <continueAt>codab</continueAt>
+            <playUntil>tocoda</playUntil>
+            <continueAt>coda</continueAt>
             </Jump>
           </Cell>
         <Cell name="D.S. al Coda">
@@ -2243,8 +2243,8 @@
             <style>Repeat Text Right</style>
             <text>D.S. al Coda</text>
             <jumpTo>segno</jumpTo>
-            <playUntil>coda</playUntil>
-            <continueAt>codab</continueAt>
+            <playUntil>tocoda</playUntil>
+            <continueAt>coda</continueAt>
             </Jump>
           </Cell>
         <Cell name="D.S. al Fine">

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -708,7 +708,7 @@
           <Marker>
             <style>Repeat Text Left</style>
             <text><sym>coda</sym></text>
-            <label>codab</label>
+            <label>coda</label>
             </Marker>
           </Cell>
         <Cell name="Fine">
@@ -722,7 +722,7 @@
           <Marker>
             <style>Repeat Text Left</style>
             <text>To Coda</text>
-            <label>coda</label>
+            <label>tocoda</label>
             </Marker>
           </Cell>
         <Cell name="Da Capo">
@@ -748,8 +748,8 @@
             <style>Repeat Text Right</style>
             <text>D.C. al Coda</text>
             <jumpTo>start</jumpTo>
-            <playUntil>coda</playUntil>
-            <continueAt>codab</continueAt>
+            <playUntil>tocoda</playUntil>
+            <continueAt>coda</continueAt>
             </Jump>
           </Cell>
         <Cell name="D.S. al Coda">
@@ -757,8 +757,8 @@
             <style>Repeat Text Right</style>
             <text>D.S. al Coda</text>
             <jumpTo>segno</jumpTo>
-            <playUntil>coda</playUntil>
-            <continueAt>codab</continueAt>
+            <playUntil>tocoda</playUntil>
+            <continueAt>coda</continueAt>
             </Jump>
           </Cell>
         <Cell name="D.S. al Fine">


### PR DESCRIPTION
from "codab" to "coda" and from "coda" to tocoda", respectively, for their labels to better match their meaning.
See also https://musescore.org/en/node/290179