### PR TITLE
Plugins: Expose the NoteType enum and Chord/Note.noteType properties.

### DIFF
--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -141,31 +141,6 @@ enum class SelectType : char {
       };
 
 //---------------------------------------------------------
-//   NoteType
-//---------------------------------------------------------
-
-enum class NoteType : unsigned char {
-      NORMAL        = 0,
-      ACCIACCATURA  = 0x1,
-      APPOGGIATURA  = 0x2,       // grace notes
-      GRACE4        = 0x4,
-      GRACE16       = 0x8,
-      GRACE32       = 0x10,
-      GRACE8_AFTER  = 0x20,
-      GRACE16_AFTER = 0x40,
-      GRACE32_AFTER = 0x80,
-      INVALID       = 0xFF
-      };
-// Q_ENUM_NS(NoteType);
-
-constexpr NoteType operator| (NoteType t1, NoteType t2) {
-      return static_cast<NoteType>(static_cast<int>(t1) | static_cast<int>(t2));
-      }
-constexpr bool operator& (NoteType t1, NoteType t2) {
-      return static_cast<int>(t1) & static_cast<int>(t2);
-      }
-
-//---------------------------------------------------------
 //    AccidentalVal
 //---------------------------------------------------------
 

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -248,6 +248,33 @@ enum class AccidentalType : char {
       };
 
 //---------------------------------------------------------
+//   NoteType
+//---------------------------------------------------------
+
+enum class NoteType {
+      ///.\{
+      NORMAL        = 0,
+      ACCIACCATURA  = 0x1,
+      APPOGGIATURA  = 0x2,       // grace notes
+      GRACE4        = 0x4,
+      GRACE16       = 0x8,
+      GRACE32       = 0x10,
+      GRACE8_AFTER  = 0x20,
+      GRACE16_AFTER = 0x40,
+      GRACE32_AFTER = 0x80,
+      INVALID       = 0xFF
+      ///\}
+      };
+
+constexpr NoteType operator| (NoteType t1, NoteType t2) {
+      return static_cast<NoteType>(static_cast<int>(t1) | static_cast<int>(t2));
+      }
+constexpr bool operator& (NoteType t1, NoteType t2) {
+      return static_cast<int>(t1) & static_cast<int>(t2);
+      }
+
+
+//---------------------------------------------------------
 //   Direction
 //---------------------------------------------------------
 
@@ -455,6 +482,7 @@ Q_ENUM_NS(GlissandoStyle)
 Q_ENUM_NS(Placement)
 Q_ENUM_NS(SegmentType)
 Q_ENUM_NS(Tid)
+Q_ENUM_NS(NoteType)
 #endif
 
 //hack: to force the build system to run moc on this file
@@ -474,5 +502,7 @@ extern void fillComboBoxDirection(QComboBox*);
 Q_DECLARE_METATYPE(Ms::Align)
 
 Q_DECLARE_METATYPE(Ms::Direction);
+
+Q_DECLARE_METATYPE(Ms::NoteType);
 
 #endif

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -363,6 +363,10 @@ class Note : public Element {
 //       Q_PROPERTY(int                            subchannel        READ subchannel)
 //       Q_PROPERTY(Ms::Tie*                       tieBack           READ tieBack)
 //       Q_PROPERTY(Ms::Tie*                       tieFor            READ tieFor)
+      /// The NoteType of the note.
+      /// \since MuseScore 3.2.1
+      Q_PROPERTY(Ms::NoteType                      noteType          READ noteType)
+
       /** MIDI pitch of this note */
       API_PROPERTY_T( int, pitch,                   PITCH                     )
       /**
@@ -406,6 +410,7 @@ class Note : public Element {
 
       Ms::AccidentalType accidentalType() { return note()->accidentalType(); }
       void setAccidentalType(Ms::AccidentalType t) { note()->setAccidentalType(t); }
+      Ms::NoteType noteType() { return note()->noteType(); }
       /// \endcond
       };
 
@@ -423,6 +428,9 @@ class Chord : public Element {
       //Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element>  stemSlash  READ stemSlash )
       //Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element>  beam       READ beam      )
       //Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element>  hook       READ hook      )
+      /// The NoteType of the chord.
+      /// \since MuseScore 3.2.1
+      Q_PROPERTY(Ms::NoteType                              noteType   READ noteType)
 
    public:
       /// \cond MS_INTERNAL
@@ -439,6 +447,7 @@ class Chord : public Element {
       //QQmlListProperty<Element> stemSlash()    { return wrapContainerProperty<Element>(this, chord()->stemSlash()); }
       //QQmlListProperty<Element> beam()         { return wrapContainerProperty<Element>(this, chord()->beam());      }
       //QQmlListProperty<Element> hook()         { return wrapContainerProperty<Element>(this, chord()->hook());      }
+      Ms::NoteType noteType()                  { return chord()->noteType(); }
       /// \endcond
       };
 

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -40,6 +40,7 @@ Enum* PluginAPI::directionHEnum;
 Enum* PluginAPI::ornamentStyleEnum;
 Enum* PluginAPI::glissandoStyleEnum;
 Enum* PluginAPI::tidEnum;
+Enum* PluginAPI::noteTypeEnum;
 Enum* PluginAPI::noteHeadTypeEnum;
 Enum* PluginAPI::noteHeadGroupEnum;
 Enum* PluginAPI::noteValueTypeEnum;
@@ -67,6 +68,7 @@ void PluginAPI::initEnums() {
       PluginAPI::ornamentStyleEnum = wrapEnum<Ms::MScore::OrnamentStyle>();
       PluginAPI::glissandoStyleEnum = wrapEnum<Ms::GlissandoStyle>();
       PluginAPI::tidEnum = wrapEnum<Ms::Tid>();
+      PluginAPI::noteTypeEnum = wrapEnum<Ms::NoteType>();
       PluginAPI::noteHeadTypeEnum = wrapEnum<Ms::NoteHead::Type>();
       PluginAPI::noteHeadGroupEnum = wrapEnum<Ms::NoteHead::Group>();
       PluginAPI::noteValueTypeEnum = wrapEnum<Ms::Note::ValueType>();

--- a/mscore/plugin/api/qmlpluginapi.h
+++ b/mscore/plugin/api/qmlpluginapi.h
@@ -123,6 +123,9 @@ class PluginAPI : public Ms::QmlPlugin {
       /// \note In MuseScore 2.X this enumeration was available as
       /// TextStyleType (TextStyleType.TITLE etc.)
       DECLARE_API_ENUM( Tid,              tidEnum                 )
+      /// Contains Ms::NoteType enumeration values 
+      /// \since MuseScore 3.2.1
+      DECLARE_API_ENUM( NoteType,         noteTypeEnum            )
       /// Contains Ms::NoteHead::Type enumeration values
       /// \note In MuseScore 2.X this enumeration was available in
       /// NoteHead class (e.g. NoteHead.HEAD_QUARTER).


### PR DESCRIPTION
This patch exposes the Note.noteType read only property to
QML so plugins can determine where a graceNote lies with
respect to its parent note.

This work is related to a discussion on the musescore.org forum:

https://musescore.org/en/node/291248

The following repository and branch makes use of the new exposure:

https://github.com/DLLarson/tin-whistle-tablature/blob/lead-trail-grace-working/tin_whistle_tablature.qml

-Dale
