### PR TITLE
fix some 'red underline' warnings in/for QtCreator

### DIFF
--- a/libmscore/beam.h
+++ b/libmscore/beam.h
@@ -74,7 +74,7 @@ class Beam final : public Element {
             AUTO, BEGIN, MID, END, NONE, BEGIN32, BEGIN64, INVALID = -1
             ///\}
             };
-      Q_ENUM(Mode)
+      Q_ENUM(Mode);
 
       Beam(Score* = 0);
       Beam(const Beam&);

--- a/libmscore/layoutbreak.h
+++ b/libmscore/layoutbreak.h
@@ -33,7 +33,7 @@ class LayoutBreak final : public Element {
             ///\}
             };
    private:
-      Q_ENUM(Type)
+      Q_ENUM(Type);
 
       qreal lw;
       QPainterPath path;

--- a/libmscore/lyrics.h
+++ b/libmscore/lyrics.h
@@ -32,7 +32,7 @@ class Lyrics final : public TextBase {
             SINGLE, BEGIN, END, MIDDLE
             ///\}
             };
-      Q_ENUM(Syllabic)
+      Q_ENUM(Syllabic);
 
       // MELISMA FIRST UNDERSCORE:
       // used as_ticks value to mark a melisma for which only the first chord has been spanned so far

--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -296,8 +296,8 @@ class MScore {
    public:
       enum class DirectionH : char { /**.\{*/ AUTO, LEFT, RIGHT /**\}*/ };
       enum class OrnamentStyle : char { /**.\{*/ DEFAULT, BAROQUE /**\}*/ };
-      Q_ENUM(DirectionH)
-      Q_ENUM(OrnamentStyle)
+      Q_ENUM(DirectionH);
+      Q_ENUM(OrnamentStyle);
 
       static MsError _error;
       static std::vector<MScoreError> errorList;

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -136,8 +136,8 @@ class NoteHead final : public Symbol {
             ///\}
             };
 
-      Q_ENUM(Group)
-      Q_ENUM(Type)
+      Q_ENUM(Group);
+      Q_ENUM(Type);
 
       NoteHead(Score* s = 0) : Symbol(s) {}
       NoteHead &operator=(const NoteHead&) = delete;
@@ -212,7 +212,7 @@ class Note final : public Element {
       Q_GADGET
    public:
       enum class ValueType : char { OFFSET_VAL, USER_VAL };
-      Q_ENUM(ValueType)
+      Q_ENUM(ValueType);
 
    private:
       bool _ghost         { false };      ///< ghost note (guitar: death note)

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -138,7 +138,7 @@ class Spanner : public Element {
       enum class Anchor {
             SEGMENT, MEASURE, CHORD, NOTE
             };
-      Q_ENUM(Anchor)
+      Q_ENUM(Anchor);
    private:
 
       Element* _startElement { 0  };

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -491,17 +491,17 @@ enum class TupletNumberType  : char { SHOW_NUMBER, SHOW_RELATION, NO_TEXT       
 enum class TupletBracketType : char { AUTO_BRACKET, SHOW_BRACKET, SHOW_NO_BRACKET };
 
 #ifdef SCRIPT_INTERFACE
-Q_ENUM_NS(ElementType)
-Q_ENUM_NS(Direction)
-Q_ENUM_NS(GlissandoType)
-Q_ENUM_NS(GlissandoStyle)
-Q_ENUM_NS(Placement)
-Q_ENUM_NS(SegmentType)
-Q_ENUM_NS(Tid)
-Q_ENUM_NS(Align)
-Q_ENUM_NS(NoteType)
-Q_ENUM_NS(PlayEventType)
-Q_ENUM_NS(AccidentalType)
+Q_ENUM_NS(ElementType);
+Q_ENUM_NS(Direction);
+Q_ENUM_NS(GlissandoType);
+Q_ENUM_NS(GlissandoStyle);
+Q_ENUM_NS(Placement);
+Q_ENUM_NS(SegmentType);
+Q_ENUM_NS(Tid);
+Q_ENUM_NS(Align);
+Q_ENUM_NS(NoteType);
+Q_ENUM_NS(PlayEventType);
+Q_ENUM_NS(AccidentalType);
 #endif
 
 //hack: to force the build system to run moc on this file

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -42,7 +42,7 @@
 #include "rest.h"
 #include "fret.h"
 
-Q_DECLARE_LOGGING_CATEGORY(undoRedo)
+Q_DECLARE_LOGGING_CATEGORY(undoRedo);
 
 namespace Ms {
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -146,10 +146,10 @@ extern Ms::Synthesizer* createZerberus();
 #endif
 
 #ifdef QT_NO_DEBUG
-      Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtCriticalMsg)
+      Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtCriticalMsg);
 #else
-      Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtCriticalMsg)
-//      Q_LOGGING_CATEGORY(undoRedo, "undoRedo")
+      Q_LOGGING_CATEGORY(undoRedo, "undoRedo", QtCriticalMsg);
+//      Q_LOGGING_CATEGORY(undoRedo, "undoRedo");
 #endif
 
 #ifdef BUILD_CRASH_REPORTER


### PR DESCRIPTION
by adding some otherwise unneeded but harmless semicolons