### PR TITLE
fix #291287: fingering jumps on drag +collect_artifacts

### DIFF
--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -112,7 +112,7 @@ void Fingering::layout()
 
             // update offset after drag
             qreal rebase = 0.0;
-            if (offsetChanged() != OffsetChange::NONE)
+            if (offsetChanged() != OffsetChange::NONE && !tight)
                   rebase = rebaseOffset();
 
             // temporarily exclude self from chord shape


### PR DESCRIPTION
See https://musescore.org/en/node/291287

The code I have to "rebase" offsets to prevent jumping on drag turns out to be unnecessary in one certain case, fingering on unbeamed single note in multi-voice context.  So this change simply skips the rebase in that case.

I set the build to collect artifacts so I can get feedback from our resident guitar fingerings expects to be sure this fixes it and doesn't break something else.