### PR TITLE
Prevent crash with Qt 5.9 on Mac

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -1616,7 +1616,7 @@ MuseScore::MuseScore()
 
       menuFormat->addAction(getAction("add-remove-breaks"));
 
-      QMenu* menuStretch = new QMenu(tr("&Stretch"));
+      menuStretch = new QMenu(tr("&Stretch"));
       for (auto i : { "stretch+", "stretch-", "reset-stretch" })
             menuStretch->addAction(getAction(i));
       Workspace::addMenuAndString(menuStretch, "menu-stretch");
@@ -1702,7 +1702,7 @@ MuseScore::MuseScore()
       //---------------------
 
 #ifndef NDEBUG
-      QMenu* menuDebug = mb->addMenu("Debug");
+      menuDebug = mb->addMenu("Debug");
       menuDebug->setObjectName("Debug");
       a = getAction("no-horizontal-stretch");
       a->setCheckable(true);
@@ -1939,32 +1939,9 @@ void MuseScore::showError()
 
 void MuseScore::retranslate()
       {
+      setMenuTitles();
       _positionLabel->setToolTip(tr("Measure:Beat:Tick"));
-
-      // retranslate the menu
-      menuFile->setTitle(tr("&File"));
-      openRecent->setTitle(tr("Open &Recent"));
-      menuEdit->setTitle(tr("&Edit"));
-      menuView->setTitle(tr("&View"));
-      menuToolbars->setTitle(tr("&Toolbars"));
-      menuWorkspaces->setTitle(tr("W&orkspaces"));
       pref->setText(tr("&Preferences…"));
-      menuAdd->setTitle(tr("&Add"));
-      menuAddMeasures->setTitle(tr("&Measures"));
-      menuAddFrames->setTitle(tr("&Frames"));
-      menuAddText->setTitle(tr("&Text"));
-      menuAddLines->setTitle(tr("&Lines"));
-      menuAddPitch->setTitle(tr("N&otes"));
-      menuAddInterval->setTitle(tr("&Intervals"));
-      menuTuplet->setTitle(tr("T&uplets"));
-      menuFormat->setTitle(tr("F&ormat"));
-      menuTools->setTitle(tr("&Tools"));
-      menuVoices->setTitle(tr("&Voices"));
-      menuMeasure->setTitle(tr("&Measure"));
-      menuPlugins->setTitle(tr("&Plugins"));
-      menuHelp->setTitle(tr("&Help"));
-      menuTours->setTitle(tr("&Tours"));
-
       aboutAction->setText(tr("&About…"));
       aboutQtAction->setText(tr("About &Qt…"));
       aboutMusicXMLAction->setText(tr("About &MusicXML…"));
@@ -1993,7 +1970,91 @@ void MuseScore::retranslate()
       Shortcut::retranslate();
       Workspace::retranslate();
       }
+      
+//---------------------------------------------------------
+//   setMenuTitles
+//---------------------------------------------------------
 
+void MuseScore::setMenuTitles()
+      {
+      menuFile->setTitle(tr("&File"));
+      openRecent->setTitle(tr("Open &Recent"));
+      menuEdit->setTitle(tr("&Edit"));
+      menuView->setTitle(tr("&View"));
+      menuToolbars->setTitle(tr("&Toolbars"));
+      menuWorkspaces->setTitle(tr("W&orkspaces"));
+      menuAdd->setTitle(tr("&Add"));
+      menuAddMeasures->setTitle(tr("&Measures"));
+      menuAddFrames->setTitle(tr("&Frames"));
+      menuAddText->setTitle(tr("&Text"));
+      menuAddLines->setTitle(tr("&Lines"));
+      menuAddPitch->setTitle(tr("N&otes"));
+      menuAddInterval->setTitle(tr("&Intervals"));
+      menuTuplet->setTitle(tr("T&uplets"));
+      menuFormat->setTitle(tr("F&ormat"));
+      menuStretch->setTitle(tr("&Stretch"));
+      menuTools->setTitle(tr("&Tools"));
+      menuVoices->setTitle(tr("&Voices"));
+      menuMeasure->setTitle(tr("&Measure"));
+      menuPlugins->setTitle(tr("&Plugins"));
+      menuHelp->setTitle(tr("&Help"));
+      menuTours->setTitle(tr("&Tours"));
+#ifndef NDEBUG
+      menuDebug->setTitle("Debug");  // not translated
+#endif
+      }
+
+//---------------------------------------------------------
+//   updateMenu
+//---------------------------------------------------------
+
+void MuseScore::updateMenu(QMenu*& menu, QString menu_id, QString name)
+      {
+      QMenu* m = Workspace::findMenuFromString(menu_id);
+      if (m) {
+            menu = m;
+            if (name != "")
+                  menu->setObjectName(name);
+            }
+      }
+
+//---------------------------------------------------------
+//   updateMenus
+//---------------------------------------------------------
+
+void MuseScore::updateMenus()
+      {
+      updateMenu(menuFile,        "menu-file",         "File");
+      updateMenu(openRecent,      "menu-open-recent",  "");
+      updateMenu(menuEdit,        "menu-edit",         "Edit");
+      updateMenu(menuView,        "menu-view",         "View");
+      updateMenu(menuToolbars,    "menu-toolbars",     "");
+      updateMenu(menuWorkspaces,  "menu-workspaces",   "");
+      updateMenu(menuAdd,         "menu-add",          "Add");
+      updateMenu(menuAddMeasures, "menu-add-measures", "");
+      updateMenu(menuAddFrames,   "menu-add-frames",   "");
+      updateMenu(menuAddText,     "menu-add-text",     "");
+      updateMenu(menuAddLines,    "menu-add-lines",    "");
+      updateMenu(menuAddPitch,    "menu-add-pitch",    "");
+      updateMenu(menuAddInterval, "menu-add-interval", "");
+      updateMenu(menuTuplet,      "menu-tuplet",       "");
+      updateMenu(menuFormat,      "menu-format",       "Format");
+      updateMenu(menuStretch,     "menu-stretch",      "");
+      updateMenu(menuTools,       "menu-tools",        "Tools");
+      updateMenu(menuVoices,      "menu-voices",       "");
+      updateMenu(menuMeasure,     "menu-measure",      "");
+      updateMenu(menuPlugins,     "menu-plugins",      "Plugins");
+      updateMenu(menuHelp,        "menu-help",         "Help");
+      updateMenu(menuTours,       "menu-tours",        "");
+#ifndef NDEBUG
+      updateMenu(menuDebug,       "menu-debug",        "Debug");
+#endif
+      connect(openRecent,     SIGNAL(aboutToShow()),       SLOT(openRecentMenu()));
+      connect(openRecent,     SIGNAL(triggered(QAction*)), SLOT(selectScore(QAction*)));
+      connect(menuWorkspaces, SIGNAL(aboutToShow()),       SLOT(showWorkspaceMenu()));
+      setMenuTitles();
+      }
+      
 //---------------------------------------------------------
 //   resizeEvent
 //---------------------------------------------------------

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -310,6 +310,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QMenu* menuTuplet;
 
       QMenu* menuFormat;
+      QMenu* menuStretch;
       QMenu* menuTools;
       QMenu* menuVoices;
       QMenu* menuMeasure;
@@ -317,6 +318,9 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       QMenu* menuPlugins;
       QMenu* menuHelp;
       QMenu* menuTours;
+#ifndef NDEBUG
+      QMenu* menuDebug;
+#endif
       AlbumManager* albumManager           { 0 };
 
       QWidget* _searchDialog               { 0 };
@@ -442,6 +446,8 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       virtual void showEvent(QShowEvent *event);
 
       void retranslate();
+      void setMenuTitles();
+      void updateMenu(QMenu*& menu, QString menu_id, QString objectName);
 
       void playVisible(bool flag);
       void launchBrowser(const QString whereTo);
@@ -803,6 +809,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       WorkspaceDialog* workspaceDialog() { return _workspaceDialog; }
       void updateIcons();
+      void updateMenus();
 
       Inspector* inspector()           { return _inspector; }
       PluginCreator* pluginCreator()   { return _pluginCreator; }

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -694,20 +694,13 @@ void Workspace::read(XmlReader& e)
                   saveMenuBar = true;
                   QMenuBar* mb = mscore->menuBar();
                   mb->clear();
+                  menuToStringList.clear();
                   while (e.readNextStartElement()) {
                         if (e.hasAttribute("name")) { // is a menu
                               QString menu_id = e.attribute("name");
-                              QMenu* menu = findMenuFromString(menu_id);
-                              if (menu) {
-                                    menu->clear();
-                                    mb->addMenu(menu);
-                                    readMenu(e, menu);
-                                    }
-                              else {
-                                    menu = new QMenu(menu_id);
-                                    mb->addMenu(menu);
-                                    readMenu(e, menu);
-                                    }
+                              QMenu* menu = mb->addMenu(menu_id);
+                              addMenuAndString(menu, menu_id);
+                              readMenu(e, menu);
                               }
                         else { // is an action
                               QString action_id = e.readXml();
@@ -719,6 +712,7 @@ void Workspace::read(XmlReader& e)
                                     }
                               }
                         }
+                  mscore->updateMenus();
                   }
             else if (tag == "State") {
                   saveComponents = true;
@@ -762,17 +756,9 @@ void Workspace::readMenu(XmlReader& e, QMenu* menu)
       while (e.readNextStartElement()) {
             if (e.hasAttribute("name")) { // is a menu
                   QString menu_id = e.attribute("name");
-                  QMenu* new_menu = findMenuFromString(menu_id);
-                  if (new_menu) {
-                        new_menu->clear();
-                        menu->addMenu(new_menu);
-                        readMenu(e, new_menu);
-                        }
-                  else {
-                        new_menu = new QMenu(menu_id);
-                        menu->addMenu(new_menu);
-                        readMenu(e, new_menu);
-                        }
+                  QMenu* new_menu = menu->addMenu(menu_id);
+                  addMenuAndString(new_menu, menu_id);
+                  readMenu(e, new_menu);
                   }
             else { // is an action
                   QString action_id = e.readXml();
@@ -806,20 +792,13 @@ void Workspace::readGlobalMenuBar()
                         if (e.name() == "MenuBar") {
                               QMenuBar* mb = mscore->menuBar();
                               mb->clear();
+                              menuToStringList.clear();
                               while (e.readNextStartElement()) {
                                     if (e.hasAttribute("name")) { // is a menu
                                           QString menu_id = e.attribute("name");
-                                          QMenu* menu = findMenuFromString(menu_id);
-                                          if (menu) {
-                                                menu->clear();
-                                                mb->addMenu(menu);
-                                                readMenu(e, menu);
-                                                }
-                                          else {
-                                                menu = new QMenu(menu_id);
-                                                mb->addMenu(menu);
-                                                readMenu(e, menu);
-                                                }
+                                          QMenu* menu = mb->addMenu(menu_id);
+                                          addMenuAndString(menu, menu_id);
+                                          readMenu(e, menu);
                                           }
                                     else { // is an action
                                           QString action_id = e.readXml();
@@ -831,6 +810,7 @@ void Workspace::readGlobalMenuBar()
                                                 }
                                           }
                                     }
+                              mscore->updateMenus();
                               }
                         else
                               e.unknown();

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -49,7 +49,6 @@ class Workspace : public QObject {
 
       static QString findStringFromAction(QAction* action);
       static QAction* findActionFromString(QString string);
-      static QMenu* findMenuFromString(QString string);
       static QString findStringFromMenu(QMenu* menu);
 
       QString _name;
@@ -100,6 +99,7 @@ class Workspace : public QObject {
       static void addActionAndString(QAction* action, QString string);
       static void addRemainingFromMenuBar(QMenuBar* mb);
       static void addMenuAndString(QMenu* menu, QString string);
+      static QMenu* findMenuFromString(QString string);
 
       bool getSaveComponents()       { return saveComponents; }
       void setSaveComponents(bool s) { saveComponents = s;    }


### PR DESCRIPTION
See https://musescore.org/en/node/278772.

This is basically the same as #4808, but without the changes to Travis files or CMakeLists.txt. In other words, it only contains the changes that are necessary to prevent workspaces from triggering the Qt bug that causes a crash when menus that have been added to the menu bar are later reused. The bug was supposed to have been fixed in Qt 5.9.8, but I seem to recall that when I tested it, I found that it was still there.