### PR TITLE
Build AppImage with Qt 5.12.4 in Ubuntu 18.04 environment

### DIFF
--- a/build/Linux+BSD/portable/x86_64/Dockerfile
+++ b/build/Linux+BSD/portable/x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/ubuntu:14.04
+FROM library/ubuntu:18.04
 ADD Recipe /Recipe
 RUN bash -ex Recipe && apt-get clean autoclean
 RUN apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/*

--- a/build/Linux+BSD/portable/x86_64/Recipe
+++ b/build/Linux+BSD/portable/x86_64/Recipe
@@ -24,7 +24,7 @@ apt-get -y install \
   libdrm-dev \
   libgl1-mesa-dev \
   libopenal1 \
-  gstreamer0.10-plugins-base \
+  gstreamer1.0-plugins-base \
   software-properties-common # installs `add-apt-repository`
 
 # get newer compiler
@@ -35,8 +35,9 @@ fi
 
 # MuseScore dependencies (same as on Travis)
 apt-get -y install \
-  g++-4.9 \
+  g++-7 \
   wget \
+  cmake \
   make \
   curl \
   alsa \
@@ -59,12 +60,12 @@ apt-get -y install \
   libxtst-dev
 
 
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 40 --slave /usr/bin/g++ g++ /usr/bin/g++-7
 
 # get Qt
 if [ ! -d "qt5" ]; then
   mkdir qt5
-  wget -q -O qt5.zip http://utils.musescore.org.s3.amazonaws.com/qt598.zip
+  wget -q -O qt5.zip https://s3.amazonaws.com/utils.musescore.org/qt5124.zip
   unzip -qq qt5.zip -d qt5
   rm -f qt5.zip
 fi
@@ -72,18 +73,6 @@ export PATH="${PWD}/qt5/bin:$PATH"
 export QT_PLUGIN_PATH="${PWD}/qt5/plugins"
 export QML2_IMPORT_PATH="${PWD}/qt5/qml"
 export LD_LIBRARY_PATH="${PWD}/qt5/lib:$LD_LIBRARY_PATH"
-
-# install cmake
-if [ ! -d cmake ]; then
-  if [ "$(arch)" = "i686" ]; then
-    CMAKE_URL="http://www.cmake.org/files/v3.10/cmake-3.10.1-Linux-i386.tar.gz"
-  else
-    CMAKE_URL="http://www.cmake.org/files/v3.5/cmake-3.5.1-Linux-$(arch).tar.gz"
-  fi
-  mkdir cmake
-  wget --no-check-certificate --quiet -O - "${CMAKE_URL}" | tar --strip-components=1 -xz -C cmake
-fi
-export PATH="${PWD}/cmake/bin:${PATH}"
 
 # build AppImageKit
 if [ ! -d "AppImageKit" ]; then


### PR DESCRIPTION
The upgrade should also fix [284164](https://musescore.org/en/node/284164) and, possibly, [288662](https://musescore.org/en/node/288662).