### PR TITLE
fix #291512: fix enumerations objects not available in qml with Qt 5.12.4

### DIFF
--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -315,6 +315,8 @@ void PluginAPI::registerQmlTypes()
       if (-1 == qmlRegisterType<PluginAPI>  ("MuseScore", 3, 0, "MuseScore"))
             qWarning("qmlRegisterType failed: MuseScore");
 
+      qmlRegisterUncreatableType<Enum>("MuseScore", 3, 0, "Ms::PluginAPI::Enum", "Cannot create an enumeration");
+
 //             qmlRegisterType<MScore>     ("MuseScore", 3, 0, "MScore");
       qmlRegisterType<ScoreView>("MuseScore", 3, 0, "ScoreView");
 


### PR DESCRIPTION
Fixes [this issue](https://musescore.org/en/node/291512). The reason why it worked previously may be related to Qt version but the solution should be correct regardless of that.