### PR TITLE
fix #291491: support tuplets in rebaseMinDistance

### DIFF
--- a/libmscore/articulation.cpp
+++ b/libmscore/articulation.cpp
@@ -653,7 +653,7 @@ void Articulation::doAutoplace()
                         // user moved element within the skyline
                         // we may need to adjust minDistance, yd, and/or offset
                         //bool inStaff = placeAbove() ? r.bottom() + rebase > 0.0 : r.top() + rebase < staff()->height();
-                        if (rebaseMinDistance(md, yd, sp, rebase, true))
+                        if (rebaseMinDistance(md, yd, sp, rebase, above, true))
                               r.translate(0.0, rebase);
                         }
                   rypos() += yd;

--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -478,7 +478,7 @@ class Element : public ScoreElement {
       void autoplaceMeasureElement(bool add = true) { autoplaceMeasureElement(placeAbove(), add); }
       void autoplaceCalculateOffset(QRectF& r, qreal minDistance);
       qreal rebaseOffset(bool nox = true);
-      bool rebaseMinDistance(qreal& md, qreal& yd, qreal sp, qreal rebase, bool fix);
+      bool rebaseMinDistance(qreal& md, qreal& yd, qreal sp, qreal rebase, bool above, bool fix);
 
       qreal styleP(Sid idx) const;
       };

--- a/libmscore/fingering.cpp
+++ b/libmscore/fingering.cpp
@@ -119,6 +119,7 @@ void Fingering::layout()
             setAutoplace(false);
 
             if (layoutType() == ElementType::CHORD) {
+                  bool above = placeAbove();
                   Stem* stem = chord->stem();
                   Segment* s = chord->segment();
                   Measure* m = s->measure();
@@ -130,7 +131,7 @@ void Fingering::layout()
                   if (n->mirror())
                         rxpos() -= n->ipos().x();
                   rxpos() += headWidth * .5;
-                  if (placeAbove()) {
+                  if (above) {
                         if (tight) {
                               if (chord->stem())
                                     rxpos() -= 0.8 * sp;
@@ -160,8 +161,8 @@ void Fingering::layout()
                               if (offsetChanged() != OffsetChange::NONE) {
                                     // user moved element within the skyline
                                     // we may need to adjust minDistance, yd, and/or offset
-                                    bool inStaff = placeAbove() ? r.bottom() + rebase > 0.0 : r.top() + rebase < staff()->height();
-                                    rebaseMinDistance(md, yd, sp, rebase, inStaff);
+                                    bool inStaff = above ? r.bottom() + rebase > 0.0 : r.top() + rebase < staff()->height();
+                                    rebaseMinDistance(md, yd, sp, rebase, above, inStaff);
                                     }
                               rypos() += yd;
                               }
@@ -196,8 +197,8 @@ void Fingering::layout()
                               if (offsetChanged() != OffsetChange::NONE) {
                                     // user moved element within the skyline
                                     // we may need to adjust minDistance, yd, and/or offset
-                                    bool inStaff = placeAbove() ? r.bottom() + rebase > 0.0 : r.top() + rebase < staff()->height();
-                                    rebaseMinDistance(md, yd, sp, rebase, inStaff);
+                                    bool inStaff = above ? r.bottom() + rebase > 0.0 : r.top() + rebase < staff()->height();
+                                    rebaseMinDistance(md, yd, sp, rebase, above, inStaff);
                                     }
                               rypos() += yd;
                               }

--- a/libmscore/hairpin.cpp
+++ b/libmscore/hairpin.cpp
@@ -275,10 +275,11 @@ void HairpinSegment::layout()
             qreal sp = spatium();
             qreal md = minDistance().val() * sp;
 
-            SkylineLine sl(!hairpin()->placeAbove());
+            bool above = spanner()->placeAbove();
+            SkylineLine sl(!above);
             Shape sh = shape();
             sl.add(sh.translated(pos()));
-            if (hairpin()->placeAbove()) {
+            if (above) {
                   d  = system()->topDistance(staffIdx(), sl);
                   if (d > -md)
                         ymax -= d + md;
@@ -300,8 +301,8 @@ void HairpinSegment::layout()
                         // user moved element within the skyline
                         // we may need to adjust minDistance, yd, and/or offset
                         qreal adj = pos().y() + rebase;
-                        bool inStaff = spanner()->placeAbove() ? sh.bottom() + adj > 0.0 : sh.top() + adj < staff()->height();
-                        rebaseMinDistance(md, yd, sp, rebase, inStaff);
+                        bool inStaff = above ? sh.bottom() + adj > 0.0 : sh.top() + adj < staff()->height();
+                        rebaseMinDistance(md, yd, sp, rebase, above, inStaff);
                         }
                   rypos() += yd;
                   }

--- a/libmscore/shape.cpp
+++ b/libmscore/shape.cpp
@@ -160,7 +160,7 @@ qreal Shape::right() const
 
 qreal Shape::top() const
       {
-      qreal dist = 0.0;
+      qreal dist = 1000000.0;
       for (const QRectF& r : *this) {
             if (r.top() < dist)
                   dist = r.top();
@@ -174,7 +174,7 @@ qreal Shape::top() const
 
 qreal Shape::bottom() const
       {
-      qreal dist = 0.0;
+      qreal dist = -1000000.0;
       for (const QRectF& r : *this) {
             if (r.bottom() > dist)
                   dist = r.bottom();

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -1362,11 +1362,12 @@ void SpannerSegment::autoplaceSpannerSegment()
             if (!systemFlag() && !spanner()->systemFlag())
                   sp *= staff()->mag(spanner()->tick());
             qreal md = minDistance().val() * sp;
-            SkylineLine sl(!spanner()->placeAbove());
+            bool above = spanner()->placeAbove();
+            SkylineLine sl(!above);
             Shape sh = shape();
             sl.add(sh.translated(pos()));
             qreal yd = 0.0;
-            if (spanner()->placeAbove()) {
+            if (above) {
                   qreal d  = system()->topDistance(staffIdx(), sl);
                   if (d > -md)
                         yd = -(d + md);
@@ -1381,8 +1382,8 @@ void SpannerSegment::autoplaceSpannerSegment()
                         // user moved element within the skyline
                         // we may need to adjust minDistance, yd, and/or offset
                         qreal adj = pos().y() + rebase;
-                        bool inStaff = spanner()->placeAbove() ? sh.bottom() + adj > 0.0 : sh.top() + adj < staff()->height();
-                        rebaseMinDistance(md, yd, sp, rebase, inStaff);
+                        bool inStaff = above ? sh.bottom() + adj > 0.0 : sh.top() + adj < staff()->height();
+                        rebaseMinDistance(md, yd, sp, rebase, above, inStaff);
                         }
                   rypos() += yd;
                   }

--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -1156,7 +1156,7 @@ static const StyleType styleTypes[] {
       { Sid::vibratoMinDistance,            "vibratoMinDistance",            Spatium(1.0)  },
       { Sid::voltaMinDistance,              "voltaMinDistance",              Spatium(1.0)  },
       { Sid::figuredBassMinDistance,        "figuredBassMinDistance",        Spatium(0.5)  },
-      { Sid::tupletMinDistance,             "tupletMinDistance",             Spatium(1.0)  },
+      { Sid::tupletMinDistance,             "tupletMinDistance",             Spatium(0.5)  },
 
       { Sid::autoplaceEnabled,              "autoplaceEnabled",              true },
 

--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -656,7 +656,7 @@ void Tuplet::layout()
             }
       setbbox(r);
 
-      if (!cross())
+      if (outOfStaff && !cross())
             autoplaceMeasureElement(_isUp, /* add to skyline */ true);
       }
 
@@ -934,8 +934,9 @@ void Tuplet::editDrag(EditData& ed)
       else
             _p2 += ed.delta;
       setGenerated(false);
-      layout();
-      score()->setUpdateAll();
+      //layout();
+      //score()->setUpdateAll();
+      triggerLayout();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
See https://musescore.org/en/node/291491.  Support for autoplace of tuplets was added recently and is mostly good from what I can tell, but unfortunately min distance isn't being managed correctly, because the code currently relies on placement() which is not defined for tuplets.  I discuss several possible solutions in the issue thread, but this one is the simplest for now, we can always revisit this later to make things more general.