### PR TITLE
Fix# 291708 Plugin: Add Note.onTimeOffset and Note.offTimeOffset properties

### DIFF
--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -428,7 +428,9 @@ class Note final : public Element {
       void setVeloOffset(int v)             { _veloOffset = v;           }
 
       void setOnTimeOffset(int v);
+      int getOnTimeOffset() const           { return _playEvents[0].ontime(); }
       void setOffTimeOffset(int v);
+      int getOffTimeOffset() const          { return _playEvents[0].offtime(); }
 
       int customizeVelocity(int velo) const;
       NoteDot* dot(int n)                         { return _dots[n];          }

--- a/mscore/plugin/api/elements.cpp
+++ b/mscore/plugin/api/elements.cpp
@@ -69,6 +69,55 @@ void Note::setTpc(int val)
             set(Pid::TPC2, val);
       }
 
+
+//---------------------------------------------------------
+//   Note::setOnTimeOffset
+//---------------------------------------------------------
+
+void Note::setOnTimeOffset(int v)
+      {
+      //Ms::Score* score = Ms::MuseScoreCore::mscoreCore->currentScore();
+      Ms::Score* score = note()->score();
+      if (!score) {
+            qWarning("PluginAPI::Note::setOnTimeOffset: A score is required.");
+            return;
+            }
+      NoteEvent* event = note()->noteEvent(0);
+      if (v < 0 || v > 2*NoteEvent::NOTE_LENGTH || v >= event->offtime()) {
+            qWarning("PluginAPI::Note::setOnTimeOffset: Invalid value.");
+            return;
+            }
+      if (!event || event->ontime() == v)
+            return;                             // Value hasn't changed so no need for undo
+      NoteEvent ne = *event;                    // Make copy of NoteEvent value
+      ne.setOntime(v);                          // Set new ontTime value
+      score->undo(new ChangeNoteEvent(note(), event, ne));
+      }
+
+//---------------------------------------------------------
+//   Note::setOffTimeOffset
+//---------------------------------------------------------
+
+void Note::setOffTimeOffset(int v) 
+      { 
+      //Ms::Score* score = Ms::MuseScoreCore::mscoreCore->currentScore();
+      Ms::Score* score = note()->score();
+      if (!score) {
+            qWarning("PluginAPI::Note::setOffTimeOffset: A score is required.");
+            return;
+            }
+      NoteEvent* event = note()->noteEvent(0);
+      if (v < 0 || v > 2*NoteEvent::NOTE_LENGTH || v <= event->ontime()) {
+            qWarning("PluginAPI::Note::setOffTimeOffset: Invalid value.");
+            return;
+            }
+      if (!event || event->offtime() == v)
+            return;                             // Value hasn't changed so no need for undo
+      NoteEvent ne = *event;                    // Make copy of NoteEvent value
+      ne.setLen(v - ne.ontime());               // Set new length value
+      score->undo(new ChangeNoteEvent(note(), event, ne));
+      }
+
 //---------------------------------------------------------
 //   wrap
 ///   \cond PLUGIN_API \private \endcond

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -22,6 +22,9 @@
 #include "libmscore/notedot.h"
 #include "libmscore/segment.h"
 #include "libmscore/accidental.h"
+#include "libmscore/musescoreCore.h"
+#include "libmscore/score.h"
+#include "libmscore/undo.h"
 
 namespace Ms {
 namespace PluginAPI {
@@ -365,7 +368,13 @@ class Note : public Element {
 //       Q_PROPERTY(Ms::Tie*                       tieFor            READ tieFor)
       /// The NoteType of the note.
       /// \since MuseScore 3.2.1
-      Q_PROPERTY(Ms::NoteType                      noteType          READ noteType)
+      Q_PROPERTY(Ms::NoteType                     noteType          READ noteType)
+      /// Set NoteEvent onTimeOffset value.
+      /// \since MuseScore 3.2.4
+      Q_PROPERTY(int                              onTimeOffset      READ onTimeOffset       WRITE setOnTimeOffset)
+      /// Set NoteEvent offTimeOffset value.
+      /// \since MuseScore 3.2.4
+      Q_PROPERTY(int                              offTimeOffset     READ offTimeOffset      WRITE setOffTimeOffset)
 
       /** MIDI pitch of this note */
       API_PROPERTY_T( int, pitch,                   PITCH                     )
@@ -410,7 +419,13 @@ class Note : public Element {
 
       Ms::AccidentalType accidentalType() { return note()->accidentalType(); }
       void setAccidentalType(Ms::AccidentalType t) { note()->setAccidentalType(t); }
+
       Ms::NoteType noteType() { return note()->noteType(); }
+
+      int onTimeOffset() const { return note()->getOnTimeOffset(); }
+      void setOnTimeOffset(int v);
+      int offTimeOffset() const { return note()->getOffTimeOffset(); }
+      void setOffTimeOffset(int v);
       /// \endcond
       };
 


### PR DESCRIPTION
Expose Note.onTimeOffset and Note.offTimeOffset properties
for use by plugins.

This addition was motivate by the following discussion threads on the MuseScore Forum:

https://musescore.org/en/node/291414
https://musescore.org/en/node/291519

-Dale