### PR TITLE
fix #290546: corruption on copy/paste end final mmrest

### DIFF
--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -1016,7 +1016,7 @@ class Score : public QObject, public ScoreElement {
       MasterScore* masterScore() const    { return _masterScore; }
       void setMasterScore(MasterScore* s) { _masterScore = s;    }
       void createRevision();
-      void writeSegments(XmlWriter& xml, int strack, int etrack, Segment* first, Segment* last, bool, bool);
+      void writeSegments(XmlWriter& xml, int strack, int etrack, Segment* sseg, Segment* eseg, bool, bool);
 
       const QMap<QString, QString>& metaTags() const   { return _metaTags; }
       QMap<QString, QString>& metaTags()               { return _metaTags; }


### PR DESCRIPTION
See https://musescore.org/en/node/290546

Problem is simple: when selecting to the end of a score that ends in an mmrest, we are setting "ls" to the last segment of the score, but that's not right - if there hadn't been an mmrest, ls would have been nullptr.  That's the usual convention - the "last segment" pointer is supposed to be the segment *after* the selection, or to nullkptr, so that loops can stop *before* that specified segment.  And that's where the corruption comes in - we're stopping before the last segment of the score, which in this case is the measure rest in the underlying piece (there's no barline in the underlying measure if it hasn't been laid out yet).

Anyhow, that's the fix - setting "ls" to nullptr rather than lastSegment().  Potentially this change could have been made in the selection code rather than here, but that would have greater impact on other things and risk regressions.