### PR TITLE
fix #290058 translate palette drag painter coords

### DIFF
--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -1195,8 +1195,9 @@ QPixmap Palette::pixmap(int paletteIdx) const
             toIcon(e)->setExtent(w < h ? w : h);
       p.scale(cellMag, cellMag);
 
+      p.translate(-r.topLeft());
       QPointF pos = e->ipos();
-      e->setPos(-r.topLeft());
+      e->setPos(0, 0);
 
       QColor color;
        // show voice colors for notes


### PR DESCRIPTION
If the default layout of a palette element resulted in a boundary box with negative x & y coordinates for the top-left corner, the deleted lines of this commit would attempt to ensure that the entire element's pixelmap would be rendered in positive coordinate space only by adjusting accoring to the top-left corner.  Unfortunately, that code don't seem to work, since vertically-cenetered elements like hairpins (which have a negative y coordinate for the top of its boundary box) only display the elements bottom-half when dragged from palette.

This fix uses alternate code which I think more properly does what the deleted lines *intended* to do, but uses Qt's QPainter function for translate instead to offset the painting by the top-left coordinate.