### PR TITLE
Plugins menu issues

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2053,6 +2053,7 @@ void MuseScore::updateMenus()
       connect(openRecent,     SIGNAL(triggered(QAction*)), SLOT(selectScore(QAction*)));
       connect(menuWorkspaces, SIGNAL(aboutToShow()),       SLOT(showWorkspaceMenu()));
       setMenuTitles();
+      addPluginMenuEntries();
       }
       
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6644,6 +6644,7 @@ void MuseScore::showSearchDialog()
 
 #ifndef SCRIPT_INTERFACE
 void MuseScore::pluginTriggered(int) {}
+void MuseScore::pluginTriggered(QString path) {}
 void MuseScore::loadPlugins() {}
 bool MuseScore::loadPlugin(const QString&) { return false;}
 void MuseScore::unloadPlugins() {}

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -654,6 +654,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       virtual void setCurrentView(int tabIdx, int idx);
       void loadPlugins();
       void unloadPlugins();
+      void addPluginMenuEntries();
 
       ScoreState state() const { return _sstate; }
       void changeState(ScoreState);

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -363,7 +363,6 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       QTimer* autoSaveTimer;
       QList<QAction*> pluginActions;
-      QSignalMapper* pluginMapper        { 0 };
 
       PianorollEditor* pianorollEditor   { 0 };
       DrumrollEditor* drumrollEditor     { 0 };
@@ -572,6 +571,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void dirtyChanged(Score*);
       void setPos(const Fraction& tick);
       void pluginTriggered(int);
+      void pluginTriggered(QString path);
       void handleMessage(const QString& message);
       void setCurrentScoreView(ScoreView*);
       void setCurrentScoreView(int);

--- a/mscore/plugin/mscorePlugins.cpp
+++ b/mscore/plugin/mscorePlugins.cpp
@@ -250,6 +250,18 @@ void MuseScore::createMenuEntry(PluginDescription* plugin)
             }
       }
 
+//---------------------------------------------------------
+//   addPluginMenuEntries
+//---------------------------------------------------------
+
+void MuseScore::addPluginMenuEntries()
+      {
+      for (int i = 0; i < pluginManager->pluginCount(); ++i) {
+            PluginDescription* d = pluginManager->getPluginDescription(i);
+            if (d->load)
+                  createMenuEntry(d);
+            }
+      }
 
 void MuseScore::removeMenuEntry(PluginDescription* plugin)
       {

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -501,12 +501,18 @@ void Workspace::writeMenuBar(XmlWriter& xml, QMenuBar* mb)
             if (action->isSeparator())
                   xml.tag("action", "");
             else if (action->menu()) {
-                  xml.stag("Menu name=\"" + findStringFromMenu(action->menu()) + "\"");
-                  writeMenu(xml, action->menu());
-                  xml.etag();
+                  const QString menuString = findStringFromMenu(action->menu());
+                  if (!menuString.isEmpty()) {
+                        xml.stag("Menu name=\"" + menuString + "\"");
+                        writeMenu(xml, action->menu());
+                        xml.etag();
+                        }
                   }
-            else
-                  xml.tag("action", findStringFromAction(action));
+            else {
+                  const QString actionString = findStringFromAction(action);
+                  if (!actionString.isEmpty())
+                        xml.tag("action", actionString);
+                  }
 
             }
       xml.etag();
@@ -523,12 +529,17 @@ void Workspace::writeMenu(XmlWriter& xml, QMenu* menu)
             if (action->isSeparator())
                   xml.tag("action", "");
             else if (action->menu()) {
-                  xml.stag("Menu name=\"" + findStringFromMenu(action->menu()) + "\"");
-                  writeMenu(xml, action->menu());
-                  xml.etag();
+                  const QString menuString = findStringFromMenu(action->menu());
+                  if (!menuString.isEmpty()) {
+                        xml.stag("Menu name=\"" + menuString + "\"");
+                        writeMenu(xml, action->menu());
+                        xml.etag();
+                        }
                   }
             else {
-                  xml.tag("action", findStringFromAction(action));
+                  const QString actionString = findStringFromAction(action);
+                  if (!actionString.isEmpty())
+                        xml.tag("action", actionString);
                   }
             }
       }

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -693,6 +693,11 @@ void Workspace::read(XmlReader& e)
             else if (tag == "MenuBar") {
                   saveMenuBar = true;
                   QMenuBar* mb = mscore->menuBar();
+                  const QObjectList menus(mb->children()); // need a copy
+                  for (QObject* m : menus) {
+                        if (qobject_cast<QMenu*>(m))
+                              delete m;
+                        }
                   mb->clear();
                   menuToStringList.clear();
                   while (e.readNextStartElement()) {
@@ -791,6 +796,11 @@ void Workspace::readGlobalMenuBar()
                   while (e.readNextStartElement()) {
                         if (e.name() == "MenuBar") {
                               QMenuBar* mb = mscore->menuBar();
+                              const QObjectList menus(mb->children()); // need a copy
+                              for (QObject* m : menus) {
+                                    if (qobject_cast<QMenu*>(m))
+                                          delete m;
+                                    }
                               mb->clear();
                               menuToStringList.clear();
                               while (e.readNextStartElement()) {


### PR DESCRIPTION
This pull request contains fixes for the recently discussed plugins menu issues.

The first two commits (to fix [291460](https://musescore.org/en/node/291460) and [291583](https://musescore.org/en/node/291583)) are slightly modified versions of the @mattmcclinch's PR #5185. The other two commits are to fix the issue with wrong plugins being activated by menu entries after disabling and enabling multiple plugins (as far as I know it is not reported in the issue tracker yet, and it is somewhat random to reproduce) and the issue [286727](https://musescore.org/en/node/286727).