### PR TITLE
fix #291104: fix articulations not playing properly in MDL instruments

### DIFF
--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -939,6 +939,7 @@ static void collectMeasureEventsDefault(EventMap* events, Measure* m, Staff* sta
                               int staticTick = seg->tick().ticks();
                               changeCCBetween(renderData.tempPlayEvents, staticTick, staticTick, exprVal, exprVal, channel, controller, defaultChangeMethod, tickOffset, staffIdx);
                               }
+                        velocity = velocityStart; // update the velocity value that will be used in note events
                         } // if instr->singleNoteDynamics()
                   else {
                         if (chord != 0) {


### PR DESCRIPTION
Fixes https://musescore.org/en/node/291104.

The issue applies not only to MDL instruments but to any instruments that use soundfonts not compatible with single-note dynamics (SND) but still have SND enabled. This fix makes correct velocities be assigned to the MIDI events being generated so articulations are played back properly regardless of SND support.

@jthistle, I would be grateful for your review on this patch, the fix looks trivial but it would be good to ensure that I am not missing something else with it.