### PR TITLE
make build scripts more Qt version independent

### DIFF
--- a/build/Linux+BSD/portable/x86_32/Recipe
+++ b/build/Linux+BSD/portable/x86_32/Recipe
@@ -54,7 +54,7 @@ yum -y install \
 # get Qt
 if [ ! -d "qt5" ]; then
   mkdir qt5
-  wget -q -O qt5.zip http://utils.musescore.org.s3.amazonaws.com/qt542-x86.zip
+  wget -q -O qt5.zip https://s3.amazonaws.com/utils.musescore.org/qt542-x86.zip
   unzip -qq qt5.zip -d qt5
   rm -f qt5.zip
 fi

--- a/build/travis/job_macos/install.sh
+++ b/build/travis/job_macos/install.sh
@@ -79,10 +79,10 @@ rvm uninstall 2.0.0-p643
 rvm uninstall 2.0.0
 rvm get head
 
-wget -nv https://s3.amazonaws.com/utils.musescore.org/qt598_mac.zip
+wget -nv -O qt5.zip https://s3.amazonaws.com/utils.musescore.org/qt598_mac.zip
 mkdir -p $QT_MACOS
-unzip -qq qt598_mac.zip -d $QT_MACOS
-rm qt598_mac.zip
+unzip -qq qt5.zip -d $QT_MACOS
+rm qt5.zip
 
 #install sparkle
 export SPARKLE_VERSION=1.20.0

--- a/build/travis/job_macos_lupdate/install.sh
+++ b/build/travis/job_macos_lupdate/install.sh
@@ -5,7 +5,7 @@ if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   exit 0
 fi
 
-wget -nv https://s3.amazonaws.com/utils.musescore.org/qt5124_mac.zip
+wget -nv -O qt5.zip https://s3.amazonaws.com/utils.musescore.org/qt5124_mac.zip
 mkdir -p $QT_MACOS
-unzip -qq qt5124_mac.zip -d $QT_MACOS
-rm qt5124_mac.zip
+unzip -qq qt5.zip -d $QT_MACOS
+rm qt5.zip


### PR DESCRIPTION
and switch the (currently disabled) 32bit AppImage build to use the same site as the others to fetch Qt.