### PR TITLE
fix #291791: letter landscape score exported as A4 in score+parts PDF

### DIFF
--- a/mscore/file.cpp
+++ b/mscore/file.cpp
@@ -2126,7 +2126,7 @@ bool MuseScore::savePdf(QList<Score*> cs_, const QString& saveName)
       printer.setOutputFileName(saveName);
       printer.setResolution(preferences.getInt(PREF_EXPORT_PDF_DPI));
       QSizeF size(firstScore->styleD(Sid::pageWidth), firstScore->styleD(Sid::pageHeight));
-      QPageSize ps(QPageSize::id(size, QPageSize::Inch));
+      QPageSize ps(QPageSize::id(size, QPageSize::Inch, QPageSize::FuzzyOrientationMatch));
       printer.setPageSize(ps);
       printer.setPageOrientation(size.width() > size.height() ? QPageLayout::Landscape : QPageLayout::Portrait);
       printer.setFullPage(true);
@@ -2170,7 +2170,7 @@ bool MuseScore::savePdf(QList<Score*> cs_, const QString& saveName)
             MScore::pdfPrinting = true;
 
             QSizeF size1(s->styleD(Sid::pageWidth), s->styleD(Sid::pageHeight));
-            QPageSize ps1(QPageSize::id(size1, QPageSize::Inch));
+            QPageSize ps1(QPageSize::id(size1, QPageSize::Inch, QPageSize::FuzzyOrientationMatch));
             printer.setPageSize(ps1);
             printer.setPageOrientation(size1.width() > size1.height() ? QPageLayout::Landscape : QPageLayout::Portrait);
             p.setViewport(QRect(0.0, 0.0, size1.width() * printer.logicalDpiX(),


### PR DESCRIPTION
See https://musescore.org/en/node/291791.  We use width > height as our indicatio of landscape, but Qt/PDF wants otherwise - Letter is only recognized is width = 8.5.  Fix (as per @sidewayss ) is to use FuzzyOrientationMatch.