### PR TITLE
fix #276084: fix a crash on importing .ove file with no pedal end denoted

### DIFF
--- a/mscore/importove.cpp
+++ b/mscore/importove.cpp
@@ -1948,7 +1948,6 @@ void OveToMScore::convertArticulation(
                         pedal_->setTrack(track);
                         Segment* seg = measure->getSegment(SegmentType::ChordRest, Fraction::fromTicks(absTick));
                         pedal_->setTick(seg->tick());
-                        score_->addSpanner(pedal_);
                         }
                   break;
                   }
@@ -1956,6 +1955,7 @@ void OveToMScore::convertArticulation(
                   if(pedal_){
                         Segment* seg = measure->getSegment(SegmentType::ChordRest, Fraction::fromTicks(absTick));
                         pedal_->setTick2(seg->tick());
+                        score_->addSpanner(pedal_);
                         pedal_ = 0;
                         }
                   break;


### PR DESCRIPTION
Fixes https://musescore.org/en/node/276084.

The .ove file referenced in the issue contains a marking for "pedal down" event but there is no corresponding "pedal up" sign there (or at least MuseScore doesn't see it). This produces a crash since the `Pedal` object that has been created and added to a score on "pedal down" event gets deleted [here](https://github.com/dmitrio95/MuseScore/blob/ddfd5d834131879feb8e0b38565260591043a732/mscore/importove.cpp#L310). I am not familiar with .ove format and I don't know whether it is a correct situation for that format and whether some reasonable suggestions about pedal length can be applied here, but here I propose to add pedal to a score *after* its end is met for two reasons:
1) Since an old pedal object is deleted if its end has not been met yet, the original intention behind this code was probably to ignore such unfinished pedals;
2) This is consistent to how `Ottava` is handled in importove: see [this line](https://github.com/dmitrio95/MuseScore/blob/ddfd5d834131879feb8e0b38565260591043a732/mscore/importove.cpp#L708).

So this patch causes unfinished pedals be ignored (as it might have been intended before) but allows opening .ove scores containing them with no crash.