### PR TITLE
fix #290323: synthesizer state duplicated when changing score with saved state

### DIFF
--- a/libmscore/synthesizerstate.cpp
+++ b/libmscore/synthesizerstate.cpp
@@ -42,6 +42,7 @@ void SynthesizerState::write(XmlWriter& xml, bool force /* = false */) const
 
 void SynthesizerState::read(XmlReader& e)
       {
+      std::list<SynthesizerGroup> tempGroups;
       while (e.readNextStartElement()) {
             SynthesizerGroup group;
             group.setName(e.name().toString());
@@ -54,7 +55,12 @@ void SynthesizerState::read(XmlReader& e)
                   else
                         e.unknown();
                   }
-            push_back(group);
+            tempGroups.push_back(group);
+            }
+
+      if (!tempGroups.empty()) {
+            // Replace any previously set state if we have read a new state
+            swap(tempGroups);
             setIsDefault(false);
             }
       }
@@ -128,7 +134,7 @@ int SynthesizerState::ccToUse() const
       if (method == 0)        // velocity only
             return -1;
 
-      return cc;  
+      return cc;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves (again): https://musescore.org/en/node/290323

Pretty simple and self-explanatory fix, I think. I've tested it and it produces the desired behaviour.