### PR TITLE
Plugin: Expose Ms:Align enum to plugins.

### DIFF
--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -426,6 +426,7 @@ enum class Tid {
 //---------------------------------------------------------
 
 enum class Align : char {
+      ///.\{
       LEFT     = 0,
       RIGHT    = 1,
       HCENTER  = 2,
@@ -436,6 +437,7 @@ enum class Align : char {
       CENTER = Align::HCENTER | Align::VCENTER,
       HMASK  = Align::LEFT    | Align::RIGHT    | Align::HCENTER,
       VMASK  = Align::TOP     | Align::BOTTOM   | Align::VCENTER | Align::BASELINE
+      ///.\}
       };
 
 constexpr Align operator| (Align a1, Align a2) {
@@ -482,6 +484,7 @@ Q_ENUM_NS(GlissandoStyle)
 Q_ENUM_NS(Placement)
 Q_ENUM_NS(SegmentType)
 Q_ENUM_NS(Tid)
+Q_ENUM_NS(Align)
 Q_ENUM_NS(NoteType)
 #endif
 

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -40,6 +40,7 @@ Enum* PluginAPI::directionHEnum;
 Enum* PluginAPI::ornamentStyleEnum;
 Enum* PluginAPI::glissandoStyleEnum;
 Enum* PluginAPI::tidEnum;
+Enum* PluginAPI::alignEnum;
 Enum* PluginAPI::noteTypeEnum;
 Enum* PluginAPI::noteHeadTypeEnum;
 Enum* PluginAPI::noteHeadGroupEnum;
@@ -68,6 +69,7 @@ void PluginAPI::initEnums() {
       PluginAPI::ornamentStyleEnum = wrapEnum<Ms::MScore::OrnamentStyle>();
       PluginAPI::glissandoStyleEnum = wrapEnum<Ms::GlissandoStyle>();
       PluginAPI::tidEnum = wrapEnum<Ms::Tid>();
+      PluginAPI::alignEnum = wrapEnum<Ms::Align>();
       PluginAPI::noteTypeEnum = wrapEnum<Ms::NoteType>();
       PluginAPI::noteHeadTypeEnum = wrapEnum<Ms::NoteHead::Type>();
       PluginAPI::noteHeadGroupEnum = wrapEnum<Ms::NoteHead::Group>();

--- a/mscore/plugin/api/qmlpluginapi.h
+++ b/mscore/plugin/api/qmlpluginapi.h
@@ -123,7 +123,10 @@ class PluginAPI : public Ms::QmlPlugin {
       /// \note In MuseScore 2.X this enumeration was available as
       /// TextStyleType (TextStyleType.TITLE etc.)
       DECLARE_API_ENUM( Tid,              tidEnum                 )
-      /// Contains Ms::NoteType enumeration values 
+      /// Contains Ms::Align enumeration values
+      /// \since MuseScore 3.3
+      DECLARE_API_ENUM( Align,            alignEnum               )
+      /// Contains Ms::NoteType enumeration values
       /// \since MuseScore 3.2.1
       DECLARE_API_ENUM( NoteType,         noteTypeEnum            )
       /// Contains Ms::NoteHead::Type enumeration values


### PR DESCRIPTION
Exposes the Ms:Align enum values to a plugin's
QML script. Used to set text alignment rather than
looking up numerical values in the source code.