### PR TITLE
fix #290047: require Shift to adjust segment with cursor keys in edit…

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2367,7 +2367,11 @@ void Note::editDrag(EditData& ed)
       {
       Chord* ch = chord();
       Segment* seg = ch->segment();
-      if (seg) {
+      // adjust segment on plain drag or Shift+cursor,
+      // adjust note/chord for Ctrl+drag or plain cursor
+      if (seg &&
+          (((ed.buttons & Qt::LeftButton) && !(ed.modifiers & Qt::ControlModifier))
+           || (ed.modifiers & Qt::ShiftModifier))) {
             const Spatium deltaSp = Spatium(ed.delta.x() / spatium());
             seg->undoChangeProperty(Pid::LEADING_SPACE, seg->extraLeadingSpace() + deltaSp);
             }


### PR DESCRIPTION
… mode

See https://musescore.org/en/node/290047.  Also a couple of forum threads, and my comment in https://github.com/musescore/MuseScore/pull/4930#issuecomment-509024634.  People definitely miss the ability to adjust note offset with cursor keys, this was lost when editDrag() was changed to adjust segment leading space instead.

So, this PR makes keyboard adjustment (left/right, Ctrl+left/right) revert to the old behavior of adjusting the note or chord.  I also allowed Ctrl+drag to revert to the old behavior.  Shift with keyboard will now use the new behavior.