### PR TITLE
fix #291941: Changing spacer length with a mouse is not undoable

### DIFF
--- a/libmscore/spacer.cpp
+++ b/libmscore/spacer.cpp
@@ -128,6 +128,16 @@ void Spacer::startEdit(EditData& ed)
       }
 
 //---------------------------------------------------------
+//   startEditDrag
+//---------------------------------------------------------
+
+void Spacer::startEditDrag(EditData& ed)
+      {
+      ElementEditData* eed = ed.getData(this);
+      eed->pushProperty(Pid::SPACE);
+      }
+
+//---------------------------------------------------------
 //   editDrag
 //---------------------------------------------------------
 

--- a/libmscore/spacer.h
+++ b/libmscore/spacer.h
@@ -51,6 +51,7 @@ class Spacer final : public Element {
       virtual void draw(QPainter*) const;
       virtual bool isEditable() const { return true; }
       virtual void startEdit(EditData&) override;
+      virtual void startEditDrag(EditData&) override;
       virtual void editDrag(EditData&) override;
       virtual void updateGrips(EditData&) const override;
       virtual void spatiumChanged(qreal, qreal);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291941.