### PR TITLE
fix #291992 and fix #291991: “Play Panel” and "Mixer" is untranslated

### DIFF
--- a/mscore/mixer.cpp
+++ b/mscore/mixer.cpp
@@ -72,7 +72,7 @@ char userRangeToReverb(double v) { return (char)qBound(0, (int)(v / 100.0 * 128.
 //---------------------------------------------------------
 
 Mixer::Mixer(QWidget* parent)
-    : QDockWidget("Mixer", parent),
+    : QDockWidget(qApp->translate("Mixer", "Mixer"), parent),
       showDetails(true),
       trackHolder(nullptr)
       {
@@ -221,7 +221,7 @@ void Mixer::on_partOnlyCheckBox_toggled(bool checked)
 
 void Mixer::retranslate(bool firstTime)
       {
-      setWindowTitle(tr("Mixer"));
+      setWindowTitle(qApp->translate("Mixer", "Mixer"));
       if (!firstTime) {
             for (int i = 0; i < trackAreaLayout->count(); i++) {
                   PartEdit* p = getPartAtIndex(i);

--- a/mscore/playpanel.cpp
+++ b/mscore/playpanel.cpp
@@ -34,7 +34,7 @@ namespace Ms {
 //---------------------------------------------------------
 
 PlayPanel::PlayPanel(QWidget* parent)
-    : QDockWidget("Play Panel", parent)
+    : QDockWidget(qApp->translate("PlayPanelBase", "Play Panel"), parent)
       {
       cachedTickPosition = -1;
       cachedTimePosition = -1;

--- a/mscore/plugin/mscorePlugins.cpp
+++ b/mscore/plugin/mscorePlugins.cpp
@@ -434,7 +434,7 @@ void MuseScore::pluginTriggered(QString pp)
             //view->setHeight(p->height());
             view->setResizeMode(QQuickView::SizeRootObjectToView);
             if (p->pluginType() == "dock") {
-                  QDockWidget* dock = new QDockWidget("Plugin", 0);
+                  QDockWidget* dock = new QDockWidget(view->title(), 0);
                   dock->setAttribute(Qt::WA_DeleteOnClose);
                   Qt::DockWidgetArea area = Qt::RightDockWidgetArea;
                   if (p->dockArea() == "left")

--- a/mscore/plugin/pluginCreator.cpp
+++ b/mscore/plugin/pluginCreator.cpp
@@ -342,7 +342,7 @@ void PluginCreator::runClicked()
             item->setParentItem(view->contentItem());
 
             if (item->pluginType() == "dock") {
-                  dock = new QDockWidget("Plugin", 0);
+                  dock = new QDockWidget(view->title(), 0);
                   dock->setAttribute(Qt::WA_DeleteOnClose);
                   dock->setWidget(QWidget::createWindowContainer(view));
                   dock->widget()->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));


### PR DESCRIPTION
and setting the windowTitle of docked plugins to their name in the menu rather than to "Plugin".

Unrelated to the isues in one way, but related in another: these are only other occurence where the 1st paramenter to `QDockWidget()` is an untranslatable string literal. Here no need for a translation, as the Plugin's name is the better alternative anyhow.
The other changes just recycle already existing strings and their translations, so this PR works right away, no work for the translator.