### PR TITLE
Change the shortcut for sforzato to accent

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3661,7 +3661,7 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "add-staccato",               [this]{ addArticulation(SymId::articStaccatoAbove);                 }},
             { "add-tenuto",                 [this]{ addArticulation(SymId::articTenutoAbove);                   }},
             { "add-marcato",                [this]{ addArticulation(SymId::articMarcatoAbove);                  }},
-            { "add-sforzato",               [this]{ addArticulation(SymId::articAccentAbove);                   }},
+            { "add-accent",                 [this]{ addArticulation(SymId::articAccentAbove);                   }},
             { "add-trill",                  [this]{ addArticulation(SymId::ornamentTrill);                      }},
             { "add-up-bow",                 [this]{ addArticulation(SymId::stringsUpBow);                       }},
             { "add-down-bow",               [this]{ addArticulation(SymId::stringsDownBow);                     }},

--- a/mscore/data/shortcuts-Mac.xml
+++ b/mscore/data/shortcuts-Mac.xml
@@ -209,7 +209,7 @@
     <seq>Shift+O</seq>
     </SC>
   <SC>
-    <key>add-sforzato</key>
+    <key>add-accent</key>
     <seq>Shift+V</seq>
     </SC>
   <SC>

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -221,7 +221,7 @@
     <seq>Shift+O</seq>
     </SC>
   <SC>
-    <key>add-sforzato</key>
+    <key>add-accent</key>
     <seq>Shift+V</seq>
     </SC>
   <SC>

--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -219,7 +219,7 @@
     <seq>Shift+O</seq>
     </SC>
   <SC>
-    <key>add-sforzato</key>
+    <key>add-accent</key>
     <seq>Shift+V</seq>
     </SC>
   <SC>

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -701,7 +701,7 @@ Shortcut Shortcut::_sc[] = {
       {
          MsWidget::SCORE_TAB,
          STATE_NORMAL | STATE_NOTE_ENTRY,
-         "add-sforzato",
+         "add-accent",
          QT_TRANSLATE_NOOP("action","Accent"),
          QT_TRANSLATE_NOOP("action","Toggle accent"),
          0,


### PR DESCRIPTION
Follow up to PR #5063
Not sure we really want this though, as it invalidates an existing shortcut settings. We may get away with this by documenting in the release notes that this shortcut gets lost during an upgrade and needs to get reinstated manually (or via a factory reset).