### PR TITLE
fix #292024: chord symbols attached to fret diagrams in other staves

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4420,7 +4420,7 @@ void Score::undoAddElement(Element* element)
                         // make harmony child of fret diagram if possible
                         if (ne->isHarmony()) {
                               for (Element* segel : segment->annotations()) {
-                                    if (segel->isFretDiagram()) {
+                                    if (segel && segel->isFretDiagram() && segel->track() == ntrack) {
                                           ne->setTrack(segel->track());
                                           ne->setParent(segel);
                                           break;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/292024