### PR TITLE
Fix #291708 Plugin: Expose NoteEvent's via QML Note interface.

### DIFF
--- a/libmscore/accidental.h
+++ b/libmscore/accidental.h
@@ -127,7 +127,6 @@ extern AccidentalVal sym2accidentalVal(SymId id);
 }     // namespace Ms
 
 Q_DECLARE_METATYPE(Ms::AccidentalRole);
-Q_DECLARE_METATYPE(Ms::AccidentalType);
 
 
 #endif

--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3542,4 +3542,38 @@ void Chord::layoutArticulations3(Slur* slur)
             }
       }
 
+//---------------------------------------------------------
+//   getNoteEventLists
+//    Get contents of all NoteEventLists for all notes in
+//    the chord.
+//---------------------------------------------------------
+
+QList<NoteEventList> Chord::getNoteEventLists()
+      {
+      QList<NoteEventList> ell;
+      if (notes().empty())
+            return ell;
+      for (size_t i = 0; i < notes().size(); ++i) {
+            ell.append(NoteEventList(notes()[i]->playEvents()));
+            }
+      return ell;
+      }
+
+   //---------------------------------------------------------
+   //   setNoteEventLists
+   //    Set contents of all NoteEventLists for all notes in
+   //    the chord.
+   //---------------------------------------------------------
+
+void Chord::setNoteEventLists(QList<NoteEventList>& ell)
+      {
+      if (notes().empty())
+            return;
+      Q_ASSERT(ell.size() == notes().size());
+      for (size_t i = 0; i < ell.size(); i++) {
+            notes()[i]->setPlayEvents(ell[int(i)]);
+            }
+
+      }
+
 }

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -36,12 +36,6 @@ class LedgerLine;
 class AccidentalState;
 
 enum class TremoloChordType : char { TremoloSingle, TremoloFirstNote, TremoloSecondNote };
-enum class PlayEventType : char    {
-      Auto,       // Play events for all notes are calculated by MuseScore.
-      User,       // Some play events are modified by user. The events must be written into the mscx file.
-      InvalidUser // The user modified play events must be replaced by MuseScore generated ones on
-                  // next recalculation. The actual play events must be saved on the undo stack.
-      };
 
 //---------------------------------------------------------
 //   @@ Chord
@@ -194,6 +188,8 @@ class Chord final : public ChordRest {
 
       PlayEventType playEventType() const           { return _playEventType; }
       void setPlayEventType(PlayEventType v)        { _playEventType = v;    }
+      QList<NoteEventList> getNoteEventLists();
+      void setNoteEventLists(QList<NoteEventList>& nel);
 
       TremoloChordType tremoloChordType() const;
 

--- a/libmscore/rendermidi.cpp
+++ b/libmscore/rendermidi.cpp
@@ -2305,12 +2305,8 @@ void Score::createGraceNotesPlayEvents(const Fraction& tick, Chord* chord, int& 
                   el.append(nel);
                   }
 
-            if (gc->playEventType() == PlayEventType::InvalidUser)
-                  gc->score()->undo(new ChangeEventList(gc, el));
-            else if (gc->playEventType() == PlayEventType::Auto) {
-                  for (int ii = 0; ii < int(nn); ++ii)
-                        gc->notes()[ii]->setPlayEvents(el[ii]);
-                  }
+            if (gc->playEventType() == PlayEventType::Auto)
+                  gc->setNoteEventLists(el);
             on += graceDuration;
             }
       if (na) {
@@ -2332,12 +2328,8 @@ void Score::createGraceNotesPlayEvents(const Fraction& tick, Chord* chord, int& 
                         el.append(nel);
                         }
 
-                  if (gc->playEventType() == PlayEventType::InvalidUser)
-                        gc->score()->undo(new ChangeEventList(gc, el));
-                  else if (gc->playEventType() == PlayEventType::Auto) {
-                        for (int ii = 0; ii < int(nn); ++ii)
-                              gc->notes()[ii]->setPlayEvents(el[ii]);
-                        }
+                  if (gc->playEventType() == PlayEventType::Auto)
+                        gc->setNoteEventLists(el);
                   on += graceDuration1;
                   }
             }
@@ -2384,15 +2376,9 @@ void Score::createPlayEvents(Chord* chord)
       //    render normal (and articulated) chords
       //
       QList<NoteEventList> el = renderChord(chord, gateTime, ontime, trailtime);
-      if (chord->playEventType() == PlayEventType::InvalidUser) {
-            chord->score()->undo(new ChangeEventList(chord, el));
-            }
-      else if (chord->playEventType() == PlayEventType::Auto) {
-            int n = int(chord->notes().size());
-            for (int i = 0; i < n; ++i)
-                  chord->notes()[i]->setPlayEvents(el[i]);
-            }
-      // don’t change event list if type is PlayEventType::User
+      if (chord->playEventType() == PlayEventType::Auto)
+            chord->setNoteEventLists(el);
+      // don't change event list if type is PlayEventType::User
       }
 
 void Score::createPlayEvents(Measure* start, Measure* end)

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -148,6 +148,7 @@ enum class ElementType {
 //   AccidentalType
 //---------------------------------------------------------
 // NOTE: keep this in sync with with accList array
+
 enum class AccidentalType : char {
       ///.\{
       NONE,
@@ -469,6 +470,20 @@ constexpr bool operator& (FontStyle a1, FontStyle a2) {
       }
 
 //---------------------------------------------------------
+//   PlayEventType
+/// Determines whether oranaments are automatically generated
+/// when playing a score and whether the PlayEvents are saved
+/// in the score file.
+//---------------------------------------------------------
+
+enum class PlayEventType : char {
+      ///.\{
+      Auto,       ///< Play events for all notes are calculated by MuseScore.
+      User,       ///< Some play events are modified by user. Those events are written into the mscx file.
+      ///.\}
+      };
+
+//---------------------------------------------------------
 //   Tuplets
 //---------------------------------------------------------
 
@@ -477,7 +492,6 @@ enum class TupletBracketType : char { AUTO_BRACKET, SHOW_BRACKET, SHOW_NO_BRACKE
 
 #ifdef SCRIPT_INTERFACE
 Q_ENUM_NS(ElementType)
-Q_ENUM_NS(AccidentalType)
 Q_ENUM_NS(Direction)
 Q_ENUM_NS(GlissandoType)
 Q_ENUM_NS(GlissandoStyle)
@@ -486,6 +500,8 @@ Q_ENUM_NS(SegmentType)
 Q_ENUM_NS(Tid)
 Q_ENUM_NS(Align)
 Q_ENUM_NS(NoteType)
+Q_ENUM_NS(PlayEventType)
+Q_ENUM_NS(AccidentalType)
 #endif
 
 //hack: to force the build system to run moc on this file
@@ -502,10 +518,14 @@ extern void fillComboBoxDirection(QComboBox*);
 
 } // namespace Ms
 
-Q_DECLARE_METATYPE(Ms::Align)
+Q_DECLARE_METATYPE(Ms::Align);
 
 Q_DECLARE_METATYPE(Ms::Direction);
 
 Q_DECLARE_METATYPE(Ms::NoteType);
+
+Q_DECLARE_METATYPE(Ms::PlayEventType);
+
+Q_DECLARE_METATYPE(Ms::AccidentalType);
 
 #endif

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -1900,6 +1900,46 @@ void ChangeNoteEvents::flip(EditData*)
       }
 
 //---------------------------------------------------------
+//   ChangeNoteEventList::flip
+//---------------------------------------------------------
+
+void ChangeNoteEventList::flip(EditData*)
+      {
+      note->score()->setPlaylistDirty();
+      // Get copy of current list.
+      NoteEventList nel = note->playEvents();
+      // Replace current copy with new list.
+      note->setPlayEvents(newEvents);
+      // Save copy of replaced list.
+      newEvents = nel;
+      // Get a copy of the current playEventType.
+      PlayEventType petval = note->chord()->playEventType();
+      // Replace current setting with new setting.
+      note->chord()->setPlayEventType(newPetype);
+      // Save copy of old setting.
+      newPetype = petval;
+      }
+
+//---------------------------------------------------------
+//   ChangeNoteEventList::flip
+//---------------------------------------------------------
+
+void ChangeChordPlayEventType::flip(EditData*)
+      {
+      chord->score()->setPlaylistDirty();
+      // Flips data between NoteEventList's.
+      size_t n = chord->notes().size();
+      for (size_t i = 0; i < n; ++i) {
+            Note* note = chord->notes()[i];
+            note->playEvents().swap(events[int(i)]);
+            }
+      // Flips PlayEventType between chord and undo.
+      PlayEventType curPetype = chord->playEventType();
+      chord->setPlayEventType(petype);
+      petype = curPetype;
+      }
+
+//---------------------------------------------------------
 //   ChangeInstrument::flip
 //---------------------------------------------------------
 
@@ -2212,9 +2252,12 @@ void ChangeNoteEvent::flip(EditData*)
       NoteEvent e = *oldEvent;
       *oldEvent   = newEvent;
       newEvent    = e;
-
-      // TODO:
-      note->chord()->setPlayEventType(PlayEventType::User);
+      // Get a copy of the current playEventType.
+      PlayEventType petval = note->chord()->playEventType();
+      // Replace current setting with new setting.
+      note->chord()->setPlayEventType(newPetype);
+      // Save copy of old setting.
+      newPetype = petval;
       }
 
 //---------------------------------------------------------

--- a/libmscore/undo.h
+++ b/libmscore/undo.h
@@ -37,6 +37,7 @@
 #include "stafftype.h"
 #include "cleflist.h"
 #include "note.h"
+#include "chord.h"
 #include "drumset.h"
 #include "rest.h"
 #include "fret.h"
@@ -899,6 +900,39 @@ class ChangeNoteEvents : public UndoCommand {
       };
 
 //---------------------------------------------------------
+//   ChangeNoteEventList
+//---------------------------------------------------------
+
+class ChangeNoteEventList : public UndoCommand {
+      Ms::Note*      note;
+      NoteEventList  newEvents;
+      PlayEventType  newPetype;
+
+      void flip(EditData*) override;
+
+   public:
+      ChangeNoteEventList(Ms::Note* n, NoteEventList& ne) :
+         note(n), newEvents(ne), newPetype(PlayEventType::User) {}
+      UNDO_NAME("ChangeNoteEventList")
+      };
+
+//---------------------------------------------------------
+//   ChangeChordPlayEventType
+//---------------------------------------------------------
+
+class ChangeChordPlayEventType : public UndoCommand {
+      Ms::Chord* chord;
+      Ms::PlayEventType petype;
+      QList<NoteEventList> events;
+
+      void flip(EditData*) override;
+
+   public:
+      ChangeChordPlayEventType(Chord* c, Ms::PlayEventType pet) : chord(c), petype(pet) { events = c->getNoteEventLists(); }
+      UNDO_NAME("ChangeChordPlayEventType")
+      };
+
+//---------------------------------------------------------
 //   ChangeInstrument
 //    change instrument in an InstrumentChange element
 //---------------------------------------------------------
@@ -1190,12 +1224,13 @@ class ChangeNoteEvent : public UndoCommand {
       Note* note;
       NoteEvent* oldEvent;
       NoteEvent newEvent;
+      PlayEventType  newPetype;
 
       void flip(EditData*) override;
 
    public:
       ChangeNoteEvent(Note* n, NoteEvent* oe, const NoteEvent& ne)
-         : note(n), oldEvent(oe), newEvent(ne) {}
+         : note(n), oldEvent(oe), newEvent(ne), newPetype(PlayEventType::User) {}
       UNDO_NAME("ChangeNoteEvent")
       };
 

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -59,6 +59,7 @@ if (SCRIPT_INTERFACE)
             plugin/api/excerpt.h
             plugin/api/util.h
             plugin/api/selection.h
+            plugin/api/playevent.h
 
             plugin/api/enums.cpp
             plugin/mscorePlugins.cpp plugin/pluginCreator.cpp plugin/pluginManager.cpp plugin/qmledit.cpp
@@ -68,6 +69,7 @@ if (SCRIPT_INTERFACE)
             plugin/api/excerpt.cpp
             plugin/api/util.cpp
             plugin/api/selection.cpp
+            plugin/api/playevent.cpp
             )
 
       set (SCRIPT_UI

--- a/mscore/plugin/api/elements.cpp
+++ b/mscore/plugin/api/elements.cpp
@@ -12,6 +12,7 @@
 
 #include "elements.h"
 #include "libmscore/property.h"
+#include "libmscore/undo.h"
 
 namespace Ms {
 namespace PluginAPI {
@@ -67,6 +68,20 @@ void Note::setTpc(int val)
             set(Pid::TPC1, val);
       else
             set(Pid::TPC2, val);
+      }
+
+//---------------------------------------------------------
+//   Chord::setPlayEventType
+//---------------------------------------------------------
+
+void Chord::setPlayEventType(Ms::PlayEventType v)
+      {
+      // Only create undo operation if the value has changed.
+      if (v != chord()->playEventType())
+            {
+            chord()->score()->setPlaylistDirty();
+            chord()->score()->undo(new ChangeChordPlayEventType(chord(), v));
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -22,6 +22,10 @@
 #include "libmscore/notedot.h"
 #include "libmscore/segment.h"
 #include "libmscore/accidental.h"
+#include "libmscore/musescoreCore.h"
+#include "libmscore/score.h"
+#include "libmscore/undo.h"
+#include "playevent.h"
 
 namespace Ms {
 namespace PluginAPI {
@@ -348,6 +352,11 @@ class Note : public Element {
       Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element>  dots              READ dots)
 //       Q_PROPERTY(int                            dotsCount         READ qmlDotsCount)
       Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element>  elements          READ elements)
+      /// List of PlayEvents associated with this note.
+      /// Important: You must call Score.createPlayEvents()
+      /// to see meaningful data in the PlayEvent lists.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::PlayEvent> playEvents READ playEvents)
 //       Q_PROPERTY(int                            fret              READ fret               WRITE undoSetFret)
 //       Q_PROPERTY(bool                           ghost             READ ghost              WRITE undoSetGhost)
 //       Q_PROPERTY(Ms::NoteHead::Group            headGroup         READ headGroup          WRITE undoSetHeadGroup)
@@ -403,8 +412,9 @@ class Note : public Element {
       int tpc() const { return note()->tpc(); }
       void setTpc(int val);
 
-      QQmlListProperty<Element> dots()     { return wrapContainerProperty<Element>(this, note()->dots()); }
+      QQmlListProperty<Element> dots() { return wrapContainerProperty<Element>(this, note()->dots()); }
       QQmlListProperty<Element> elements() { return wrapContainerProperty<Element>(this, note()->el());   }
+      QQmlListProperty<PlayEvent> playEvents() { return wrapPlayEventsContainerProperty(this, note()->playEvents()); }
 
       Element* accidental() { return wrap<Element>(note()->accidental()); }
 
@@ -412,6 +422,10 @@ class Note : public Element {
       void setAccidentalType(Ms::AccidentalType t) { note()->setAccidentalType(t); }
       Ms::NoteType noteType() { return note()->noteType(); }
       /// \endcond
+
+      /// Creates a PlayEvent object for use in Javascript.
+      /// \since MuseScore 3.3
+      Q_INVOKABLE Ms::PluginAPI::PlayEvent* createPlayEvent() { return playEventWrap(new NoteEvent(), nullptr); }
       };
 
 //---------------------------------------------------------
@@ -431,6 +445,9 @@ class Chord : public Element {
       /// The NoteType of the chord.
       /// \since MuseScore 3.2.1
       Q_PROPERTY(Ms::NoteType                              noteType   READ noteType)
+      /// The PlayEventType of the chord.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(Ms::PlayEventType                    playEventType   READ playEventType WRITE setPlayEventType)
 
    public:
       /// \cond MS_INTERNAL
@@ -448,6 +465,8 @@ class Chord : public Element {
       //QQmlListProperty<Element> beam()         { return wrapContainerProperty<Element>(this, chord()->beam());      }
       //QQmlListProperty<Element> hook()         { return wrapContainerProperty<Element>(this, chord()->hook());      }
       Ms::NoteType noteType()                  { return chord()->noteType(); }
+      Ms::PlayEventType playEventType()        { return chord()->playEventType(); }
+      void setPlayEventType(Ms::PlayEventType v);
       /// \endcond
       };
 

--- a/mscore/plugin/api/playevent.cpp
+++ b/mscore/plugin/api/playevent.cpp
@@ -1,0 +1,168 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2019 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "libmscore/score.h"
+#include "libmscore/note.h"
+#include "libmscore/undo.h"
+#include "elements.h"
+#include "playevent.h"
+
+namespace Ms {
+namespace PluginAPI {
+
+//---------------------------------------------------------
+//   PlayEvent::setPitch
+//---------------------------------------------------------
+
+void PlayEvent::setPitch(int v)
+      {
+      if (!ne || ne->pitch() == v)
+            return;                                   // Value hasn't changed so no need to do more.
+
+      if (parentNote == nullptr)
+            {
+            // We can't check against a parent note we don't have so
+            // we check against the absolute range. When this NoteEvent
+            // is added to an actual note the range should be checked
+            // again.
+            if (pitchIsValid(abs(v))) {
+                  ne->setPitch(v);                    // Set new ontTime value
+                  }
+            else
+                  {
+                  qWarning("PluginAPI::PlayEvent::setPitch: Invalid relative pitch value when added to parent note pitch.");
+                  return;
+                  }
+            }
+      else
+            {
+            Ms::Score* score = parentNote->note()->score();
+            if (!score) {
+                  qWarning("PluginAPI::PlayEvent::setOntime: A score is required.");
+                  return;
+                  }
+            int parentPitch = parentNote->note()->pitch();
+            // A NoteEvent's pitch is actually summed with the parent pitch. This
+            // check ensures that it doesn't result with an illegal pitch.
+            if (!pitchIsValid(v + parentPitch)) {
+                  qWarning("PluginAPI::PlayEvent::setPitch: Invalid relative pitch value when added to parent note pitch.");
+                  return;
+                  }
+            Ms::NoteEvent e = *ne;                    // Make copy of NoteEvent value
+            e.setPitch(v);                            // Set new ontTime value
+            score->undo(new ChangeNoteEvent(parentNote->note(), ne, e));
+            }
+      }
+
+//---------------------------------------------------------
+//   PlayEvent::setOntime
+//---------------------------------------------------------
+
+void PlayEvent::setOntime(int v)
+      {
+      if (!ne || ne->ontime() == v)
+            return;                                   // Value hasn't changed so no need to do more.
+      // Note that onTime can be negative so a note can play earlier.
+      // See: https://musescore.org/en/node/74651
+      if (v < -2 * Ms::NoteEvent::NOTE_LENGTH || v > 2 * Ms::NoteEvent::NOTE_LENGTH) {
+            qWarning("PluginAPI::PlayEvent::setOntime: Invalid value.");
+            return;
+            }
+      if (parentNote == nullptr)
+            {
+            // Unowned floating value in QML context.
+            ne->setOntime(v);                         // Set new ontTime value
+            }
+      else
+            {
+            Ms::Score* score = parentNote->note()->score();
+            if (!score) {
+                  qWarning("PluginAPI::PlayEvent::setOntime: A score is required.");
+                  return;
+                  }
+            Ms::NoteEvent e = *ne;                    // Make copy of NoteEvent value
+            e.setOntime(v);                           // Set new ontTime value
+            score->undo(new ChangeNoteEvent(parentNote->note(), ne, e));
+            }
+      }
+
+//---------------------------------------------------------
+//   PlayEvent::setLen
+//---------------------------------------------------------
+
+void PlayEvent::setLen(int v)
+      {
+      if (!ne || ne->len() == v)
+            return;                                   // Value hasn't changed so no need to do more.
+      if (v <= 0 || v > 2 * Ms::NoteEvent::NOTE_LENGTH) {
+            qWarning("PluginAPI::PlayEvent::setLen: Invalid value.");
+            return;
+            }
+      if (parentNote == nullptr)
+            {
+            ne->setLen(v);                            // Set new length value
+            }
+      else
+            {
+            Ms::Score* score = parentNote->note()->score();
+            if (!score) {
+                  qWarning("PluginAPI::PlayEvent::setLen: A score is required.");
+                  return;
+                  }
+            Ms::NoteEvent e = *ne;                    // Make copy of NoteEvent value
+            e.setLen(v);                              // Set new length value
+            score->undo(new ChangeNoteEvent(parentNote->note(), ne, e));
+            }
+      }
+
+//---------------------------------------------------------
+//   QmlPlayEventsListAccess::clear
+//---------------------------------------------------------
+
+void QmlPlayEventsListAccess::clear(QQmlListProperty<PlayEvent>* l)
+      {
+      NoteEventList* plist = static_cast<NoteEventList*>(l->data);
+      Note* papinote = static_cast<Note*>(l->object);
+
+      // Get a copy of the current list contents.
+      NoteEventList nel = *plist;
+
+      // Modify the list copy.
+      nel.clear();
+
+      // Set up the undo operation for the change.
+      Ms::Score* score = papinote->note()->score();
+      score->undo(new ChangeNoteEventList(papinote->note(), nel));
+      }
+
+//---------------------------------------------------------
+//   QmlPlayEventsListAccess::append
+//---------------------------------------------------------
+
+void QmlPlayEventsListAccess::append(QQmlListProperty<PlayEvent>* l, PlayEvent *v)
+      {
+      NoteEventList* plist = static_cast<NoteEventList*>(l->data);
+      Note* papinote = static_cast<Note*>(l->object);
+
+      // Get a copy of the current list contents.
+      NoteEventList nel = *plist;
+
+      // Modify the list copy.
+      nel.append(v->getNoteEvent());
+
+      // Set up the undo operation for the change.
+      Ms::Score* score = papinote->note()->score();
+      score->undo(new ChangeNoteEventList(papinote->note(), nel));
+      }
+
+}
+}

--- a/mscore/plugin/api/playevent.h
+++ b/mscore/plugin/api/playevent.h
@@ -1,0 +1,122 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2019 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __PLUGIN_API_PLAYEVENT_H__
+#define __PLUGIN_API_PLAYEVENT_H__
+
+#include "libmscore/noteevent.h"
+#include "elements.h"
+
+namespace Ms {
+namespace PluginAPI {
+
+class Note;
+
+//---------------------------------------------------------
+//   PlayEvent
+//    Wrapper class for internal Ms::NoteEvent
+//
+//   This is based on the wrapper in excerpt.h.
+///  \since MuseScore 3.3
+//---------------------------------------------------------
+
+class PlayEvent : public QObject {
+      Q_OBJECT
+      /// The relative pitch to the note pitch.
+      /// This is added to the parent note's actual pitch.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(int pitch READ pitch WRITE setPitch)
+      /// Time to turn on the note event.
+      /// This value is expressed in 1/1000 of the nominal note length.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(int ontime READ ontime WRITE setOntime)
+      /// The length of time for the event.
+      /// This value is expressed in 1/1000 of the nominal note length.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(int len READ len WRITE setLen)
+      /// Time note will turn off.
+      /// This value derived from onTime and len. This value is expressed
+      /// in 1/1000 of the nominal note length.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(int offtime READ offtime)
+      /// \cond MS_INTERNAL
+
+   protected:
+      Ms::NoteEvent* ne;
+      Note* parentNote;
+
+   public:
+
+      PlayEvent(Ms::NoteEvent* _ne = new Ms::NoteEvent(), Note* _parent = nullptr)
+         : QObject(), ne(_ne), parentNote(_parent) {}
+      // Delete the NoteEvent if parentless.
+      virtual ~PlayEvent() { if (parentNote == nullptr) delete ne; }
+
+      const Ms::NoteEvent& getNoteEvent() { return *ne; }
+      void setParentNote(Note* parent) { this->parentNote = parent; }
+      Note* note() { return parentNote; }
+
+      int pitch() const { return ne->pitch(); }
+      int ontime() const { return ne->ontime(); }
+      int offtime() const { return ne->offtime(); }
+      int len() const { return ne->len(); }
+      void setPitch(int v);
+      void setOntime(int v);
+      void setLen(int v);
+      /// \endcond
+};
+
+//---------------------------------------------------------
+//   wrap
+///   \cond PLUGIN_API \private \endcond
+///   \relates Ms::NoteEvent
+//---------------------------------------------------------
+
+inline PlayEvent* playEventWrap(Ms::NoteEvent* t, Note* parent)
+      {
+      PlayEvent* w = t ? new PlayEvent(t, parent) : nullptr;
+      // All wrapper objects should belong to JavaScript code.
+      QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
+      return w;
+      }
+
+//---------------------------------------------------------
+//   QML access to containers of NoteEvent
+//
+//   QmlNoteEventsListAccess provides a convenience interface
+//   for QQmlListProperty providing access to plugins for NoteEvent
+//   Containers.
+//
+//   Based on QmlListAccess in excerpt.h
+//---------------------------------------------------------
+
+
+class QmlPlayEventsListAccess : public QQmlListProperty<PlayEvent> {
+   public:
+   QmlPlayEventsListAccess(QObject* obj, NoteEventList& container)
+         : QQmlListProperty<PlayEvent>(obj, &container, &append, &count, &at, &clear) {};
+
+   static int count(QQmlListProperty<PlayEvent>* l)  { return int(static_cast<NoteEventList*>(l->data)->size()); }
+   static PlayEvent* at(QQmlListProperty<PlayEvent>* l, int i) { return playEventWrap(&(*(static_cast<NoteEventList*>(l->data)))[i], reinterpret_cast<Note*>(l->object)); }
+   static void clear(QQmlListProperty<PlayEvent>* l);
+   static void append(QQmlListProperty<PlayEvent>* l, PlayEvent *v);
+};
+
+/** \cond PLUGIN_API \private \endcond */
+inline QmlPlayEventsListAccess wrapPlayEventsContainerProperty(QObject* obj, NoteEventList& c)
+      {
+      return QmlPlayEventsListAccess(obj, c);
+      }
+
+} // namespace PluginAPI
+} // namespace Ms
+#endif

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -44,6 +44,7 @@ Enum* PluginAPI::glissandoStyleEnum;
 Enum* PluginAPI::tidEnum;
 Enum* PluginAPI::alignEnum;
 Enum* PluginAPI::noteTypeEnum;
+Enum* PluginAPI::playEventTypeEnum;
 Enum* PluginAPI::noteHeadTypeEnum;
 Enum* PluginAPI::noteHeadGroupEnum;
 Enum* PluginAPI::noteValueTypeEnum;
@@ -73,6 +74,7 @@ void PluginAPI::initEnums() {
       PluginAPI::tidEnum = wrapEnum<Ms::Tid>();
       PluginAPI::alignEnum = wrapEnum<Ms::Align>();
       PluginAPI::noteTypeEnum = wrapEnum<Ms::NoteType>();
+      PluginAPI::playEventTypeEnum = wrapEnum<Ms::PlayEventType>();
       PluginAPI::noteHeadTypeEnum = wrapEnum<Ms::NoteHead::Type>();
       PluginAPI::noteHeadGroupEnum = wrapEnum<Ms::NoteHead::Group>();
       PluginAPI::noteValueTypeEnum = wrapEnum<Ms::Note::ValueType>();
@@ -335,6 +337,7 @@ void PluginAPI::registerQmlTypes()
       qmlRegisterType<Part>();
       qmlRegisterType<Excerpt>();
       qmlRegisterType<Selection>();
+      qmlRegisterType<PlayEvent>("MuseScore", 3, 0, "PlayEvent");
       //qmlRegisterType<Hook>();
       //qmlRegisterType<Stem>();
       //qmlRegisterType<StemSlash>();

--- a/mscore/plugin/api/qmlpluginapi.h
+++ b/mscore/plugin/api/qmlpluginapi.h
@@ -14,7 +14,6 @@
 #define __QMLPLUGINAPI_H__
 
 #include "config.h"
-
 #include "../qmlplugin.h"
 #include "enums.h"
 #include "libmscore/mscore.h"
@@ -129,6 +128,9 @@ class PluginAPI : public Ms::QmlPlugin {
       /// Contains Ms::NoteType enumeration values
       /// \since MuseScore 3.2.1
       DECLARE_API_ENUM( NoteType,         noteTypeEnum            )
+      /// Contains Ms::PlayEventType enumeration values
+      /// \since MuseScore 3.3
+      DECLARE_API_ENUM( PlayEventType,    playEventTypeEnum       )
       /// Contains Ms::NoteHead::Type enumeration values
       /// \note In MuseScore 2.X this enumeration was available in
       /// NoteHead class (e.g. NoteHead.HEAD_QUARTER).

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -166,6 +166,15 @@ class Score : public Ms::PluginAPI::ScoreElement {
        */
       Q_INVOKABLE void endCmd(bool rollback = false) { score()->endCmd(rollback); }
 
+      /**
+       * Create PlayEvents for all notes based on ornamentation.
+       * You need to call this if you are manipulating PlayEvent's
+       * so that all ornamentations are populated into Note's
+       * PlayEvent lists.
+       * \since 3.3
+       */
+      Q_INVOKABLE void createPlayEvents() { score()->createPlayEvents(); }
+
       /// \cond MS_INTERNAL
       QString mscoreVersion() { return score()->mscoreVersion(); }
       QString mscoreRevision() { return QString::number(score()->mscoreRevision(), /* base */ 16); }

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -109,6 +109,7 @@ set (SOURCE_LIB
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/excerpt.cpp
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/util.cpp
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/selection.cpp
+      ${PROJECT_SOURCE_DIR}/mscore/plugin/api/playevent.cpp
       ${PROJECT_SOURCE_DIR}/mscore/preferences.cpp
       ${PROJECT_SOURCE_DIR}/mscore/shortcut.cpp
       ${PROJECT_SOURCE_DIR}/mscore/stringutils.cpp


### PR DESCRIPTION
Adds capablity to examine and modify PlayEvent's.
PlayEvent's are wrappers for an internal object called a NoteEvent.
The name PlayEvent better reflects what it's role is and what
you are really affecting from the QML plugin. Any changes made
with this feature also creates undo frames so they can be removed from
the user interface.
