### PR TITLE
fix some more translatable strings

### DIFF
--- a/build/travis/job_macos_lupdate/script.sh
+++ b/build/travis/job_macos_lupdate/script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -9,12 +9,15 @@ fi
 
 # Translation routines
 # update translation on transifex
+# remove obsolete strings
+OBSOLETE=-no-obsolete # '-noobsolete' in older QT versions
+
 ./build/gen-qt-projectfile . > mscore.pro
-lupdate mscore.pro
+lupdate ${OBSOLETE} mscore.pro
 ./build/gen-instruments-projectfile ./share/instruments > instruments.pro
-lupdate instruments.pro
+lupdate ${OBSOLETE} instruments.pro
 ./build/gen-tours-projectfile ./share/tours > tours.pro
-lupdate tours.pro
+lupdate ${OBSOLETE} tours.pro
 
 rm mscore.pro
 rm instruments.pro

--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -575,8 +575,11 @@
        <layout class="QHBoxLayout" name="hLayout_Transposition">
         <item>
          <widget class="QLabel" name="labelTransp">
+          <property name="toolTip">
+           <string>Interval from written to sounding pitch</string>
+          </property>
           <property name="text">
-           <string>Transposition against concert/sounding pitch:</string>
+           <string>Transposition:</string>
           </property>
           <property name="buddy">
            <cstring>iList</cstring>
@@ -585,6 +588,9 @@
         </item>
         <item>
          <widget class="QSpinBox" name="octave">
+          <property name="accessibleName">
+           <string>Octave</string>
+          </property>
           <property name="maximum">
            <number>10</number>
           </property>
@@ -607,6 +613,9 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="accessibleName">
+           <string>Interval</string>
           </property>
           <item>
            <property name="text">

--- a/mscore/mixerdetails.ui
+++ b/mscore/mixerdetails.ui
@@ -331,7 +331,7 @@
        <item row="2" column="0" rowspan="2">
         <widget class="QLabel" name="labelPatch">
          <property name="text">
-          <string>Patch:</string>
+          <string>Sound:</string>
          </property>
         </widget>
        </item>
@@ -466,7 +466,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Patch voice</string>
+          <string>Sound name</string>
          </property>
         </widget>
        </item>

--- a/mscore/mixertrackchannel.cpp
+++ b/mscore/mixertrackchannel.cpp
@@ -161,13 +161,13 @@ void MixerTrackChannel::updateNameLabel()
                            "Channel: %3\n"
                            "Bank: %4\n"
                            "Program: %5\n"
-                           "Patch: %6")
+                           "Sound: %6")
                   .arg(part->partName(),
                        instr->trackName(),
                        qApp->translate("InstrumentsXML", chan->name().toUtf8().data()),
                        QString::number(chan->bank()),
                        QString::number(chan->program()),
-                       mp ? mp->name : tr("~no patch~"));
+                       mp ? mp->name : tr("~no sound~"));
 
       trackLabel->setToolTip(tooltip);
 

--- a/mscore/mixertrackpart.cpp
+++ b/mscore/mixertrackpart.cpp
@@ -177,12 +177,12 @@ void MixerTrackPart::updateNameLabel()
                                 "Primary Instrument: %2\n"
                                 "Bank: %3\n"
                                 "Program: %4\n"
-                                "Patch: %5")
+                                "Sound: %5")
                   .arg(part->partName(),
                        part->longName(),
                        QString::number(chan->bank()),
                        QString::number(chan->program()),
-                       mp ? mp->name : tr("~no patch~"));
+                       mp ? mp->name : tr("~no sound~"));
 
       trackLabel->setToolTip(tooltip);
 

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -186,7 +186,7 @@ void Palette::setMoreElements(bool val)
       _moreElements = val;
       if (val && (cells.isEmpty() || cells.back()->tag != "ShowMore")) {
             PaletteCell* cell = new PaletteCell;
-            cell->name      = "Show More";
+            cell->name      = tr("Show More");
             cell->tag       = "ShowMore";
             cells.append(cell);
             }

--- a/mscore/synthcontrol.ui
+++ b/mscore/synthcontrol.ui
@@ -380,7 +380,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_6">
             <property name="text">
-             <string>Switch all patches:</string>
+             <string>Switch all sounds:</string>
             </property>
            </widget>
           </item>
@@ -400,7 +400,7 @@
           <item row="0" column="1">
            <widget class="QPushButton" name="switchExpr">
             <property name="accessibleName">
-             <string>Switch all patches to expressive</string>
+             <string>Switch all sounds to expressive</string>
             </property>
             <property name="text">
              <string>To Expressive</string>
@@ -410,7 +410,7 @@
           <item row="0" column="2">
            <widget class="QPushButton" name="switchNonExpr">
             <property name="accessibleName">
-             <string>Switch all patches to non-expressive</string>
+             <string>Switch all sounds to non-expressive</string>
             </property>
             <property name="text">
              <string>To Non-Expressive</string>
@@ -420,7 +420,7 @@
           <item row="0" column="3">
            <widget class="QPushButton" name="resetExpr">
             <property name="accessibleName">
-             <string>Reset all patches to defaults</string>
+             <string>Reset all sounds to defaults</string>
             </property>
             <property name="text">
              <string>Reset All</string>


### PR DESCRIPTION
* Change "Transposition against concert/sounding pitch:" to just "Transposition:" and add a toolTip to it, also add accessibilty text for the 2 input fields next to it.
* Take care of removing obsolete strings once again.
* Change "Patch" to "Sound", see https://musescore.org/node/292204