### PR TITLE
Fix #290929: crash with negative number of dots for rests

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -430,8 +430,13 @@ void Rest::checkDots()
             score()->undoAddElement(dot);
             }
       if (n < 0) {
-            for (int i = 0; i < -n; ++i)
+            for (int i = 0; i < -n; ++i) {
+                  if (_dots.empty()) {
+                        qWarning("no dots at all or number mismatch");
+                        return;
+                        }
                   score()->undoRemoveElement(_dots.back());
+                  }
             }
       }
 


### PR DESCRIPTION
See also PR #5235, use either that (done) or this (no longer) or both (still possible).

This here avoids the crash in this particular case, and in that only.