### PR TITLE
fix #292310: Crash when adjusting Absolute Velocity in piano roll editor

### DIFF
--- a/mscore/pianolevels.cpp
+++ b/mscore/pianolevels.cpp
@@ -416,7 +416,8 @@ void PianoLevels::adjustLevelLerp(int tick0, int value0, int tick1, int value1, 
             else {
                   int tick = noteStartTick(note, 0);
                   if (tick0 <= tick && tick <= tick1) {
-                        int value = (value1 - value0) * (tick - tick0) / (tick1 - tick0) + value0;
+                        int value = tick0 == tick1 ? value0
+                              : (value1 - value0) * (tick - tick0) / (tick1 - tick0) + value0;
                         filter->setValue(_staff, note, 0, value);
                         hitNote = true;
                         }


### PR DESCRIPTION
See https://musescore.org/en/node/292310.

The calculation in line 419 will result in a divide-by-zero exception if tick0 is equal to tick1. In lines 408 and 409, the same calculation is made, but only if tick 0 is not equal to tick1. This modifies line 419 to match lines 408 and 409.