### PR TITLE
fix #283360: show dots on rests in tab

### DIFF
--- a/libmscore/notedot.cpp
+++ b/libmscore/notedot.cpp
@@ -38,8 +38,13 @@ void NoteDot::draw(QPainter* p) const
       {
       if (note() && note()->dotsHidden())     // don't draw dot if note is hidden
             return;
-      Fraction tick = note() ? note()->chord()->tick() : rest()->tick();
-      if (!staff()->isTabStaff(tick) || staff()->staffType(tick)->stemThrough()) {
+      Note* n = note();
+      Fraction tick = n ? n->chord()->tick() : rest()->tick();
+      // always draw dot for non-tab
+      // for tab, draw if on a note and stems through staff or on a rest and rests shown
+      if (!staff()->isTabStaff(tick)
+          || (n && staff()->staffType(tick)->stemThrough())
+          || (!n && staff()->staffType(tick)->showRests())) {
             p->setPen(curColor());
             drawSymbol(SymId::augmentationDot, p);
             }


### PR DESCRIPTION
See https://musescore.org/en/node/283360, in particular my analysis in https://musescore.org/en/node/283360#comment-934709.

Bug is that for tab, we draw dots if and only if "stems through staff" is set.  This leads to two problems involving dots on rests.  If stems through staff is not set, dots are not drawn on rests.  And if stems through staff *is* set, the dots for rests are shown even when rests themselves are not.

Fix is simple enough, just be sure to check if we are on a note or rest when drawing, and do the right thing accordingly.