### PR TITLE
Fix #290929: crash with negative number of dots for rests

### DIFF
--- a/libmscore/durationtype.cpp
+++ b/libmscore/durationtype.cpp
@@ -56,6 +56,8 @@ void TDuration::setDots(int v)
       {
       if (v > MAX_DOTS)
             v = MAX_DOTS;
+      if (v < 0)
+            v = 0;
       _dots = v;
       }
 


### PR DESCRIPTION
Split off of PR #5226, use either that or this here or both.

This here prevents the issue from happening in the general case, for chords and rests, on read and write.