### PR TITLE
Fix Jack library heuristics for portable build

### DIFF
--- a/build/Linux+BSD/mscore.1.in
+++ b/build/Linux+BSD/mscore.1.in
@@ -63,13 +63,14 @@
 is a Free and Open Source WYSIWYG cross-platform multi-lingual
 music composition and notation software, released under the
 GNU General Public Licence (GPLv2).
-@MAN_PORTABLE@.Ss Special options for the AppImage
+@MAN_PORTABLE@.Ss Special arguments, options & environment variables for the AppImage
 @MAN_PORTABLE@This portable version of MuseScore has all of MuseScore's
 @MAN_PORTABLE@usual features, but it runs on a wider range of distributions
 @MAN_PORTABLE@and does not need to be installed.
 @MAN_PORTABLE@There is an option to install it for full integration with
 @MAN_PORTABLE@other applications and the desktop environment, though.
 .Pp
+@MAN_PORTABLE@.Ss AppImage sole arguments
 @MAN_PORTABLE@.Bl -tag -width Ds
 @MAN_PORTABLE@.It Cm man , Cm manual , Cm manpage
 @MAN_PORTABLE@Displays this manual.
@@ -124,6 +125,26 @@ GNU General Public Licence (GPLv2).
 @MAN_PORTABLE@are not available from the system and so must be packaged
 @MAN_PORTABLE@alongside the MuseScore portable version.
 @MAN_PORTABLE@.El
+@MAN_PORTABLE@.Pp
+@MAN_PORTABLE@.Ss AppImage Jack options
+@MAN_PORTABLE@.Bl -tag -width Ds
+@MAN_PORTABLE@.It Fl \-dummy\-jack , Fl \-no\-dummy\-jack
+@MAN_PORTABLE@Force use either of dummy or of system's Jack client library.
+@MAN_PORTABLE@These options override the value of
+@MAN_PORTABLE@.Ev APPIMAGE_DUMMY_JACK
+@MAN_PORTABLE@environment variable.
+@MAN_PORTABLE@.El
+@MAN_PORTABLE@.Pp
+@MAN_PORTABLE@.Ss AppImage environment variables
+@MAN_PORTABLE@.Bl -tag -width Ds
+@MAN_PORTABLE@.It Ev APPIMAGE_LIBRARY_PATH
+@MAN_PORTABLE@It's value is prepended to
+@MAN_PORTABLE@.Ev LD_LIBRARY_PATH.
+@MAN_PORTABLE@.It Ev APPIMAGE_DUMMY_JACK
+@MAN_PORTABLE@Set to 1 to force use of dummy version of Jack client library or
+@MAN_PORTABLE@0 to use system's. May be overridden by AppImage Jack options.
+@MAN_PORTABLE@.El
+@MAN_PORTABLE@.Pp
 @MAN_PORTABLE@.Ss Normal MuseScore options
 Running
 .Nm
@@ -359,6 +380,17 @@ uncompressed MusicXML file
 .Pp
 See below for an example.
 .Sh ENVIRONMENT
+@MAN_PORTABLE@.Ss AppImage environment variables
+@MAN_PORTABLE@.Bl -tag -width Ds
+@MAN_PORTABLE@.It Ev APPIMAGE_LIBRARY_PATH
+@MAN_PORTABLE@It's value is prepended to
+@MAN_PORTABLE@.Ev LD_LIBRARY_PATH.
+@MAN_PORTABLE@.It Ev APPIMAGE_DUMMY_JACK
+@MAN_PORTABLE@Set to 1 to force use of dummy version of Jack client library or
+@MAN_PORTABLE@0 to use system's. May be overridden by AppImage Jack options.
+@MAN_PORTABLE@.El
+@MAN_PORTABLE@.Pp
+@MAN_PORTABLE@.Ss Normal MuseScore environment variables
 .Bl -tag -width Ds
 .It Ev SKIP_LIBJACK
 Set this (the value does not matter) to skip initialisation

--- a/build/Linux+BSD/portable/AppRun.in
+++ b/build/Linux+BSD/portable/AppRun.in
@@ -11,26 +11,51 @@
 libs="${APPDIR}/lib"
 
 # Workaround for Jack library
-# Based on the solution https://github.com/LMMS/lmms/pull/3958/files
-if ldconfig -p | grep libjack.so.0 > /dev/null 2>&1; then
-   echo "Jack appears to be installed on this system, so we'll use it."
+useDummyJack() {
+   export LD_LIBRARY_PATH="${APPDIR}/optional${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+}
+args=("$@")
+for i in "${!args[@]}"; do
+    if [ "${args[${i}]}" = "--dummy-jack" ]; then
+        APPIMAGE_DUMMY_JACK=1
+        unset args[$i]
+    elif [ "${args[${i}]}" = "--no-dummy-jack" ]; then
+        APPIMAGE_DUMMY_JACK=0
+        unset args[${i}]
+    fi
+done
+args=("${args[@]}")
+if [ "${APPIMAGE_DUMMY_JACK}" = 1 ]; then
+   useDummyJack
+   echo "Forcing use of dummy Jack client library."
+elif [ "${APPIMAGE_DUMMY_JACK}" = 0 ]; then
+   echo "Forcing use of system's Jack client library."
 else
-   echo "Jack does not appear to be installed.  That's OK, we'll use a dummy version instead."
-   export LD_LIBRARY_PATH="${APPDIR}/optional:${LD_LIBRARY_PATH}"
+   # For the record, old workaround was
+   # # Based on the solution https://github.com/LMMS/lmms/pull/3958/files
+   # if ! ldconfig -p | grep libjack.so.0 > /dev/null 2>&1; then
+   if LC_ALL=C ldd "${APPDIR}/bin/mscore@MSCORE_INSTALL_SUFFIX@" \
+   | grep "libjack.*not found" >/dev/null; then
+      echo "Jack does not appear to be installed."
+      echo "That's OK, we'll use a dummy Jack client library version instead."
+      useDummyJack
+   else
+      echo "Jack appears to be installed on this system, so we'll use it."
+   fi
 fi
 
 # Setting LD_LIBRARY_PATH won't override AppImage libraries, but advanced users
 # can do that with APPIMAGE_LIBRARY_PATH if they really want to.
-export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH}:${libs}:${libs}/qt5/lib:${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="${APPIMAGE_LIBRARY_PATH:+${APPIMAGE_LIBRARY_PATH}:}${libs}:${libs}/qt5/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 export QT_STYLE_OVERRIDE="GTK+" # use system font size
 
-case "$1" in
+case "${args[0]}" in
   -h|--help|install|uninstall|remove|man|manual|manpage|check-depends|check-dependencies )
-    "${APPDIR}/bin/portable-utils" "$@"
+    "${APPDIR}/bin/portable-utils" "${args[@]}"
     ;;
   * )
-    "${APPDIR}/bin/mscore@MSCORE_INSTALL_SUFFIX@" "$@"
+    "${APPDIR}/bin/mscore@MSCORE_INSTALL_SUFFIX@" "${args[@]}"
     ;;
 esac
 

--- a/build/Linux+BSD/portable/portable-utils.in
+++ b/build/Linux+BSD/portable/portable-utils.in
@@ -36,14 +36,29 @@ like full integration with other applications and the desktop environment.
 
 Usage: $(basename "${APPIMAGE}") [options] [scorefile]
 
-Special options for MuseScore Portable AppImage:
+Special arguments, options & environment vars for MuseScore Portable AppImage:
+
+AppImage sole arguments:
   -h, --help                    Displays this help and the normal help (below).
   man, manual, manpage          Displays MuseScore's man page.
   install [-i] [PREFIX]         Installs resources for desktop integration.
   remove, uninstall [PREFIX]    Removes resources from desktop environment.
   check-depends [exes-only]     Displays system information for developers.
 
+AppImage Jack options
+  --dummy-jack, --no-dummy-jack Force use either of dummy or of system's Jack
+                                client library. These options override the
+                                value of APPIMAGE_DUMMY_JACK environment
+                                variable.
+
+AppImage environment variables:
+  APPIMAGE_LIBRARY_PATH         It's value is prepended to LD_LIBRARY_PATH
+  APPIMAGE_DUMMY_JACK           Set to 1 to force use of dummy version of Jack
+                                client library or 0 to use system's. May be
+                                overridden by AppImage Jack options.
+
 Ordinary MuseScore options:
+
 $("${APPDIR}/bin/mscore@MSCORE_INSTALL_SUFFIX@" --help | tail -n +5)
 EOF
 }


### PR DESCRIPTION
- Make ldconfig available for non-root users.

  TODO: ldconfig should find a library matching the architecture of the
        build. CMakeLists.txt must be modified.

- Support command line arguments to force (non) usage of dummy version.