### PR TITLE
fix #291233: make disabled menu entries more distinguishable in dark theme

### DIFF
--- a/share/themes/palette_dark_fusion.json
+++ b/share/themes/palette_dark_fusion.json
@@ -7,9 +7,9 @@
 "Button":        "#2C2C2C",
 "ButtonText":    "#EFF0F1",
 "BrightText":    "#000000",
-"Highlight":     "#88bff6",
+"ToolTipBase":   "#808080",
+"ToolTipText":   "#000000",
 "Link":          "#00ffff",
 "LinkVisited":   "#00ffff",
-"ToolTipBase":   "#808080",
-"ToolTipText":   "#000000"
+"Highlight":     "#88bff6"
 }

--- a/share/themes/palette_light_fusion.json
+++ b/share/themes/palette_light_fusion.json
@@ -10,5 +10,6 @@
 "ToolTipBase":   "#fefac2",
 "ToolTipText":   "#000000",
 "Link":          "#3a80c6",
-"LinkVisited":   "#3a80c6"
+"LinkVisited":   "#3a80c6",
+"Highlight":     "#000080"
 }

--- a/share/themes/style_dark_fusion.css
+++ b/share/themes/style_dark_fusion.css
@@ -1,5 +1,9 @@
 *:disabled {
- color: gray
+ color: gray;
+}
+
+QMenu::disabled {
+ background-color: palette(base);
 }
 
 QGroupBox {
@@ -26,7 +30,7 @@ QTabBar::close-button:hover {
 
 /* Inspector buttons */
 QPushButton:flat:hover {
- border: 1px solid gray;
+ border: 1px solid dimgray;
  border-radius: 3px;
 }
 QPushButton:flat:hover:checked {
@@ -58,3 +62,14 @@ QToolButton[iconic-text="true"]:disabled:checked { color: $buttonHighlightDisabl
 
 /* Mainly in midi import */
 QTableView { border: none; }
+
+/* dock and main area separator */
+QMainWindow::separator {
+    background: #C8C8C8;
+    width: 1px; /* when vertical */
+    height: 1px; /* when horizontal */
+}
+
+QMainWindow::separator:hover {
+    background: gray;
+}

--- a/share/themes/style_light_fusion.css
+++ b/share/themes/style_light_fusion.css
@@ -1,5 +1,9 @@
 *:disabled {
- color: gray
+ color: gray;
+}
+
+QMenu::disabled {
+ background-color: palette(base);
 }
 
 QGroupBox {


### PR DESCRIPTION
"#444444" seems a pretty close match to the color the menus background has without that change, but with it also for disabled menu entries.