### PR TITLE
fix #284287: tab order in dialogs

### DIFF
--- a/mscore/editstaff.ui
+++ b/mscore/editstaff.ui
@@ -420,6 +420,9 @@
             <height>40</height>
            </size>
           </property>
+          <property name="tabChangesFocus">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
         <item row="1" column="1">
@@ -429,6 +432,9 @@
             <width>0</width>
             <height>40</height>
            </size>
+          </property>
+          <property name="tabChangesFocus">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -919,17 +925,18 @@
   <tabstop>spinExtraDistance</tabstop>
   <tabstop>mag</tabstop>
   <tabstop>hideMode</tabstop>
+  <tabstop>showIfEmpty</tabstop>
   <tabstop>showClef</tabstop>
   <tabstop>showTimesig</tabstop>
   <tabstop>showBarlines</tabstop>
   <tabstop>hideSystemBarLine</tabstop>
-  <tabstop>showIfEmpty</tabstop>
   <tabstop>small</tabstop>
   <tabstop>invisible</tabstop>
   <tabstop>color</tabstop>
   <tabstop>cutaway</tabstop>
   <tabstop>changeStaffType</tabstop>
   <tabstop>changeInstrument</tabstop>
+  <tabstop>partName</tabstop>
   <tabstop>longName</tabstop>
   <tabstop>shortName</tabstop>
   <tabstop>minPitchA</tabstop>
@@ -940,11 +947,15 @@
   <tabstop>minPitchPSelect</tabstop>
   <tabstop>maxPitchP</tabstop>
   <tabstop>maxPitchPSelect</tabstop>
+  <tabstop>octave</tabstop>
   <tabstop>iList</tabstop>
   <tabstop>up</tabstop>
   <tabstop>down</tabstop>
   <tabstop>numOfStrings</tabstop>
   <tabstop>editStringData</tabstop>
+  <tabstop>singleNoteDynamics</tabstop>
+  <tabstop>previousButton</tabstop>
+  <tabstop>nextButton</tabstop>
  </tabstops>
  <resources>
   <include location="musescore.qrc"/>

--- a/mscore/editstafftype.ui
+++ b/mscore/editstafftype.ui
@@ -215,7 +215,7 @@
         <number>0</number>
        </property>
        <property name="currentIndex">
-        <number>2</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="page">
         <layout class="QVBoxLayout" name="verticalLayout_7" stretch="0,0,0">
@@ -1410,6 +1410,7 @@
   <tabstop>genKeysigPitched</tabstop>
   <tabstop>showLedgerLinesPitched</tabstop>
   <tabstop>stemlessPitched</tabstop>
+  <tabstop>noteHeadScheme</tabstop>
   <tabstop>genKeysigPercussion</tabstop>
   <tabstop>showLedgerLinesPercussion</tabstop>
   <tabstop>stemlessPercussion</tabstop>
@@ -1425,6 +1426,7 @@
   <tabstop>linesThroughRadio</tabstop>
   <tabstop>linesBrokenRadio</tabstop>
   <tabstop>showBackTied</tabstop>
+  <tabstop>showTabFingering</tabstop>
   <tabstop>durFontName</tabstop>
   <tabstop>durFontSize</tabstop>
   <tabstop>durY</tabstop>

--- a/mscore/editstyle.ui
+++ b/mscore/editstyle.ui
@@ -1691,6 +1691,9 @@
                  <height>30</height>
                 </size>
                </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item row="0" column="2">
@@ -1711,6 +1714,9 @@
                  <height>30</height>
                 </size>
                </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item row="2" column="1">
@@ -1720,6 +1726,9 @@
                  <width>0</width>
                  <height>30</height>
                 </size>
+               </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -1754,6 +1763,9 @@
                  <height>30</height>
                 </size>
                </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item row="2" column="3">
@@ -1764,6 +1776,9 @@
                  <height>30</height>
                 </size>
                </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item row="1" column="3">
@@ -1773,6 +1788,9 @@
                  <width>0</width>
                  <height>30</height>
                 </size>
+               </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -1897,6 +1915,9 @@
                  <height>16777215</height>
                 </size>
                </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item row="1" column="2">
@@ -1912,6 +1933,9 @@
                  <width>16777215</width>
                  <height>16777215</height>
                 </size>
+               </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -1935,6 +1959,9 @@
                  <height>16777215</height>
                 </size>
                </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item row="2" column="1">
@@ -1950,6 +1977,9 @@
                  <width>16777215</width>
                  <height>16777215</height>
                 </size>
+               </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -1974,6 +2004,9 @@
                  <height>16777215</height>
                 </size>
                </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item row="2" column="3">
@@ -1989,6 +2022,9 @@
                  <width>16777215</width>
                  <height>16777215</height>
                 </size>
+               </property>
+               <property name="tabChangesFocus">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -10370,13 +10406,37 @@
   <tabstop>resetAutoplaceVerticalAlignRange</tabstop>
   <tabstop>minVerticalDistance</tabstop>
   <tabstop>resetMinVerticalDistance</tabstop>
+  <tabstop>staffUpperBorder</tabstop>
+  <tabstop>resetStaffUpperBorder</tabstop>
   <tabstop>staffLowerBorder</tabstop>
+  <tabstop>resetStaffLowerBorder</tabstop>
+  <tabstop>staffDistance</tabstop>
+  <tabstop>resetStaffDistance</tabstop>
   <tabstop>akkoladeDistance</tabstop>
+  <tabstop>resetAkkoladeDistance</tabstop>
+  <tabstop>minSystemDistance</tabstop>
+  <tabstop>resetMinSystemDistance</tabstop>
   <tabstop>maxSystemDistance</tabstop>
+  <tabstop>resetMaxSystemDistance</tabstop>
+  <tabstop>systemFrameDistance</tabstop>
+  <tabstop>resetSystemFrameDistance</tabstop>
   <tabstop>frameSystemDistance</tabstop>
+  <tabstop>resetFrameSystemDistance</tabstop>
+  <tabstop>lastSystemFillThreshold</tabstop>
+  <tabstop>resetLastSystemFillThreshold</tabstop>
   <tabstop>genClef</tabstop>
   <tabstop>genKeysig</tabstop>
   <tabstop>genCourtesyClef</tabstop>
+  <tabstop>genCourtesyTimesig</tabstop>
+  <tabstop>genCourtesyKeysig</tabstop>
+  <tabstop>smallStaffSize</tabstop>
+  <tabstop>resetSmallStaffSize</tabstop>
+  <tabstop>smallNoteSize</tabstop>
+  <tabstop>resetSmallNoteSize</tabstop>
+  <tabstop>graceNoteSize</tabstop>
+  <tabstop>resetGraceNoteSize</tabstop>
+  <tabstop>smallClefSize</tabstop>
+  <tabstop>resetSmallClefSize</tabstop>
   <tabstop>showHeader</tabstop>
   <tabstop>showHeaderFirstPage</tabstop>
   <tabstop>headerOddEven</tabstop>
@@ -10395,8 +10455,30 @@
   <tabstop>evenFooterL</tabstop>
   <tabstop>evenFooterC</tabstop>
   <tabstop>evenFooterR</tabstop>
+  <tabstop>showMeasureNumber</tabstop>
+  <tabstop>showFirstMeasureNumber</tabstop>
+  <tabstop>showAllStaffsMeasureNumber</tabstop>
+  <tabstop>showEverySystemMeasureNumber</tabstop>
+  <tabstop>showIntervalMeasureNumber</tabstop>
+  <tabstop>intervalMeasureNumber</tabstop>
+  <tabstop>bracketWidth</tabstop>
+  <tabstop>akkoladeWidth</tabstop>
+  <tabstop>bracketDistance</tabstop>
+  <tabstop>akkoladeBarDistance</tabstop>
   <tabstop>dividerLeft</tabstop>
+  <tabstop>dividerLeftSym</tabstop>
+  <tabstop>dividerLeftX</tabstop>
+  <tabstop>dividerLeftY</tabstop>
   <tabstop>dividerRight</tabstop>
+  <tabstop>dividerRightSym</tabstop>
+  <tabstop>dividerRightX</tabstop>
+  <tabstop>dividerRightY</tabstop>
+  <tabstop>clefTab1</tabstop>
+  <tabstop>clefTab2</tabstop>
+  <tabstop>accidentalTable</tabstop>
+  <tabstop>radioKeySigNatNone</tabstop>
+  <tabstop>radioKeySigNatBefore</tabstop>
+  <tabstop>radioKeySigNatAfter</tabstop>
   <tabstop>minMeasureWidth_2</tabstop>
   <tabstop>resetMinMeasureWidth</tabstop>
   <tabstop>measureSpacing</tabstop>
@@ -10439,75 +10521,41 @@
   <tabstop>resetMultiMeasureRestMargin</tabstop>
   <tabstop>staffLineWidth</tabstop>
   <tabstop>resetStaffLineWidth</tabstop>
+  <tabstop>showRepeatBarTips</tabstop>
+  <tabstop>resetShowRepeatBarTips</tabstop>
+  <tabstop>showStartBarlineSingle</tabstop>
+  <tabstop>resetShowStartBarlineSingle</tabstop>
+  <tabstop>showStartBarlineMultiple</tabstop>
+  <tabstop>resetShowStartBarlineMultiple</tabstop>
+  <tabstop>scaleBarlines</tabstop>
+  <tabstop>resetScaleBarlines</tabstop>
+  <tabstop>barWidth</tabstop>
+  <tabstop>resetBarWidth</tabstop>
+  <tabstop>endBarWidth</tabstop>
+  <tabstop>resetEndBarWidth</tabstop>
+  <tabstop>endBarDistance</tabstop>
+  <tabstop>resetEndBarDistance</tabstop>
+  <tabstop>doubleBarWidth</tabstop>
+  <tabstop>resetDoubleBarWidth</tabstop>
+  <tabstop>doubleBarDistance</tabstop>
+  <tabstop>resetDoubleBarDistance</tabstop>
+  <tabstop>repeatBarlineDotSeparation</tabstop>
+  <tabstop>resetRepeatBarlineDotSeparation</tabstop>
   <tabstop>shortenStem</tabstop>
-  <tabstop>clefTab1</tabstop>
-  <tabstop>clefTab2</tabstop>
+  <tabstop>shortStemProgression</tabstop>
+  <tabstop>shortestStem</tabstop>
+  <tabstop>accidentalNoteDistance</tabstop>
+  <tabstop>accidentalDistance</tabstop>
+  <tabstop>dotMag</tabstop>
+  <tabstop>noteDotDistance</tabstop>
+  <tabstop>dotDotDistance</tabstop>
+  <tabstop>stemWidth</tabstop>
+  <tabstop>ledgerLineWidth</tabstop>
+  <tabstop>ledgerLineLength</tabstop>
   <tabstop>beamWidth</tabstop>
+  <tabstop>beamDistance</tabstop>
   <tabstop>beamMinLen</tabstop>
   <tabstop>beamNoSlope</tabstop>
-  <tabstop>slurEndLineWidth</tabstop>
-  <tabstop>slurMidLineWidth</tabstop>
-  <tabstop>slurDottedLineWidth</tabstop>
-  <tabstop>minTieLength</tabstop>
-  <tabstop>smallStaffSize</tabstop>
-  <tabstop>smallNoteSize</tabstop>
-  <tabstop>graceNoteSize</tabstop>
-  <tabstop>smallClefSize</tabstop>
-  <tabstop>hairpinPlacement</tabstop>
-  <tabstop>resetHairpinPlacement</tabstop>
-  <tabstop>resetHairpinPosAbove</tabstop>
-  <tabstop>resetHairpinPosBelow</tabstop>
-  <tabstop>hairpinHeight</tabstop>
-  <tabstop>resetHairpinHeight</tabstop>
-  <tabstop>hairpinContinueHeight</tabstop>
-  <tabstop>resetHairpinContinueHeight</tabstop>
-  <tabstop>autoplaceHairpinDynamicsDistance</tabstop>
-  <tabstop>resetAutoplaceHairpinDynamicsDistance</tabstop>
-  <tabstop>pedalLinePlacement</tabstop>
-  <tabstop>resetPedalLinePlacement</tabstop>
-  <tabstop>resetPedalLinePosAbove</tabstop>
-  <tabstop>resetPedalLinePosBelow</tabstop>
-  <tabstop>pedalLineWidth</tabstop>
-  <tabstop>resetPedalLineWidth</tabstop>
-  <tabstop>pedalLineStyle</tabstop>
-  <tabstop>resetPedalLineStyle</tabstop>
-  <tabstop>textLinePlacement</tabstop>
-  <tabstop>resetTextLinePlacement</tabstop>
-  <tabstop>resetTextLinePosAbove</tabstop>
-  <tabstop>resetTextLinePosBelow</tabstop>
-  <tabstop>chordsStandard</tabstop>
-  <tabstop>chordsJazz</tabstop>
-  <tabstop>chordsCustom</tabstop>
-  <tabstop>chordDescriptionFile</tabstop>
-  <tabstop>chordDescriptionFileButton</tabstop>
-  <tabstop>chordsXmlFile</tabstop>
-  <tabstop>useStandardNoteNames</tabstop>
-  <tabstop>useGermanNoteNames</tabstop>
-  <tabstop>useFullGermanNoteNames</tabstop>
-  <tabstop>useSolfeggioNoteNames</tabstop>
-  <tabstop>useFrenchNoteNames</tabstop>
-  <tabstop>automaticCapitalization</tabstop>
-  <tabstop>lowerCaseMinorChords</tabstop>
-  <tabstop>lowerCaseBassNotes</tabstop>
-  <tabstop>allCapsNoteNames</tabstop>
-  <tabstop>harmonyFretDist</tabstop>
-  <tabstop>minHarmonyDistance</tabstop>
-  <tabstop>capoPosition</tabstop>
-  <tabstop>comboFBFont</tabstop>
-  <tabstop>doubleSpinFBSize</tabstop>
-  <tabstop>doubleSpinFBVertPos</tabstop>
-  <tabstop>spinFBLineHeight</tabstop>
-  <tabstop>radioFBTop</tabstop>
-  <tabstop>radioFBBottom</tabstop>
-  <tabstop>radioFBModern</tabstop>
-  <tabstop>radioFBHistoric</tabstop>
-  <tabstop>propertyDistanceHead</tabstop>
-  <tabstop>propertyDistanceStem</tabstop>
-  <tabstop>propertyDistance</tabstop>
-  <tabstop>accidentalTable</tabstop>
-  <tabstop>radioKeySigNatNone</tabstop>
-  <tabstop>radioKeySigNatBefore</tabstop>
-  <tabstop>radioKeySigNatAfter</tabstop>
   <tabstop>tupletMaxSlope</tabstop>
   <tabstop>resetTupletMaxSlope</tabstop>
   <tabstop>tupletVStemDistance</tabstop>
@@ -10525,13 +10573,110 @@
   <tabstop>resetTupletNoteRightDistance</tabstop>
   <tabstop>tupletBracketWidth</tabstop>
   <tabstop>resetTupletBracketWidth</tabstop>
+  <tabstop>tupletBracketHookHeight</tabstop>
+  <tabstop>resetTupletBracketHookHeight</tabstop>
   <tabstop>tupletDirection</tabstop>
   <tabstop>resetTupletDirection</tabstop>
+  <tabstop>tupletNumberType</tabstop>
+  <tabstop>resetTupletNumberType</tabstop>
+  <tabstop>tupletBracketType</tabstop>
+  <tabstop>resetTupletBracketType</tabstop>
+  <tabstop>arpeggioNoteDistance</tabstop>
+  <tabstop>arpeggioLineWidth</tabstop>
+  <tabstop>arpeggioHookLen</tabstop>
+  <tabstop>arpeggioHiddenInStdIfTab</tabstop>
+  <tabstop>slurEndLineWidth</tabstop>
+  <tabstop>resetSlurEndLineWidth</tabstop>
+  <tabstop>slurMidLineWidth</tabstop>
+  <tabstop>resetSlurMidLineWidth</tabstop>
+  <tabstop>slurDottedLineWidth</tabstop>
+  <tabstop>resetSlurDottedLineWidth</tabstop>
+  <tabstop>minTieLength</tabstop>
+  <tabstop>resetMinTieLength</tabstop>
+  <tabstop>slurMinDistance</tabstop>
+  <tabstop>resetSlurMinDistance</tabstop>
+  <tabstop>hairpinPlacement</tabstop>
+  <tabstop>resetHairpinPlacement</tabstop>
+  <tabstop>resetHairpinPosAbove</tabstop>
+  <tabstop>resetHairpinPosBelow</tabstop>
+  <tabstop>hairpinHeight</tabstop>
+  <tabstop>resetHairpinHeight</tabstop>
+  <tabstop>hairpinContinueHeight</tabstop>
+  <tabstop>resetHairpinContinueHeight</tabstop>
+  <tabstop>autoplaceHairpinDynamicsDistance</tabstop>
+  <tabstop>resetAutoplaceHairpinDynamicsDistance</tabstop>
+  <tabstop>hairpinLineWidth</tabstop>
+  <tabstop>resetHairpinLineWidth</tabstop>
+  <tabstop>resetVoltaPosAbove</tabstop>
+  <tabstop>voltaHook</tabstop>
+  <tabstop>resetVoltaHook</tabstop>
+  <tabstop>voltaLineWidth</tabstop>
+  <tabstop>resetVoltaLineWidth</tabstop>
+  <tabstop>voltaLineStyle</tabstop>
+  <tabstop>resetVoltaLineStyle</tabstop>
+  <tabstop>ottavaNumbersOnly</tabstop>
+  <tabstop>resetOttavaNumbersOnly</tabstop>
+  <tabstop>resetOttavaPosAbove</tabstop>
+  <tabstop>ottavaHookAbove</tabstop>
+  <tabstop>resetOttavaHookAbove</tabstop>
+  <tabstop>resetOttavaPosBelow</tabstop>
+  <tabstop>ottavaHookBelow</tabstop>
+  <tabstop>resetOttavaHookBelow</tabstop>
+  <tabstop>ottavaLineWidth</tabstop>
+  <tabstop>resetOttavaLineWidth</tabstop>
+  <tabstop>ottavaLineStyle</tabstop>
+  <tabstop>resetOttavaLineStyle</tabstop>
+  <tabstop>pedalLinePlacement</tabstop>
+  <tabstop>resetPedalLinePlacement</tabstop>
+  <tabstop>resetPedalLinePosAbove</tabstop>
+  <tabstop>resetPedalLinePosBelow</tabstop>
+  <tabstop>pedalLineWidth</tabstop>
+  <tabstop>resetPedalLineWidth</tabstop>
+  <tabstop>pedalLineStyle</tabstop>
+  <tabstop>resetPedalLineStyle</tabstop>
+  <tabstop>trillLinePlacement</tabstop>
+  <tabstop>resetTrillLinePlacement</tabstop>
+  <tabstop>resetTrillLinePosAbove</tabstop>
+  <tabstop>resetTrillLinePosBelow</tabstop>
+  <tabstop>vibratoLinePlacement</tabstop>
+  <tabstop>resetVibratoLinePlacement</tabstop>
+  <tabstop>resetVibratoLinePosAbove</tabstop>
+  <tabstop>resetVibratoLinePosBelow</tabstop>
+  <tabstop>bendLineWidth</tabstop>
+  <tabstop>resetBendLineWidth</tabstop>
+  <tabstop>bendArrowWidth</tabstop>
+  <tabstop>resetBendArrowWidth</tabstop>
+  <tabstop>textLinePlacement</tabstop>
+  <tabstop>resetTextLinePlacement</tabstop>
+  <tabstop>resetTextLinePosAbove</tabstop>
+  <tabstop>resetTextLinePosBelow</tabstop>
+  <tabstop>propertyDistanceHead</tabstop>
+  <tabstop>resetPropertyDistanceHead</tabstop>
+  <tabstop>propertyDistanceStem</tabstop>
+  <tabstop>resetPropertyDistanceStem</tabstop>
+  <tabstop>propertyDistance</tabstop>
+  <tabstop>resetPropertyDistance</tabstop>
+  <tabstop>articulationMag</tabstop>
+  <tabstop>resetArticulationMag</tabstop>
+  <tabstop>resetFermataPosAbove</tabstop>
+  <tabstop>resetFermataPosBelow</tabstop>
+  <tabstop>fermataMinDistance</tabstop>
+  <tabstop>resetFermataMinDistance</tabstop>
+  <tabstop>staffTextPlacement</tabstop>
+  <tabstop>resetStaffTextPlacement</tabstop>
+  <tabstop>resetStaffTextPosAbove</tabstop>
+  <tabstop>resetStaffTextPosBelow</tabstop>
+  <tabstop>staffTextMinDistance</tabstop>
+  <tabstop>resetStaffTextMinDistance</tabstop>
+  <tabstop>tempoTextPlacement</tabstop>
+  <tabstop>resetTempoTextPlacement</tabstop>
+  <tabstop>resetTempoTextPosAbove</tabstop>
+  <tabstop>resetTempoTextPosBelow</tabstop>
+  <tabstop>tempoTextMinDistance</tabstop>
+  <tabstop>resetTempoTextMinDistance</tabstop>
   <tabstop>lyricsPlacement</tabstop>
   <tabstop>resetLyricsPlacement</tabstop>
-  <tabstop>lyricsPosAbove</tabstop>
   <tabstop>resetLyricsPosAbove</tabstop>
-  <tabstop>lyricsPosBelow</tabstop>
   <tabstop>resetLyricsPosBelow</tabstop>
   <tabstop>lyricsLineHeight</tabstop>
   <tabstop>resetLyricsLineHeight</tabstop>
@@ -10561,8 +10706,79 @@
   <tabstop>resetLyricsLineThickness</tabstop>
   <tabstop>lyricsMelismaPad</tabstop>
   <tabstop>resetLyricsMelismaPad</tabstop>
-  <tabstop>lyricsMelismaAlign</tabstop>
   <tabstop>resetLyricsMelismaAlign</tabstop>
+  <tabstop>dynamicsPlacement</tabstop>
+  <tabstop>resetDynamicsPlacement</tabstop>
+  <tabstop>resetDynamicsPosAbove</tabstop>
+  <tabstop>resetDynamicsPosBelow</tabstop>
+  <tabstop>dynamicsMinDistance</tabstop>
+  <tabstop>resetDynamicsMinDistance</tabstop>
+  <tabstop>rehearsalMarkPlacement</tabstop>
+  <tabstop>resetRehearsalMarkPlacement</tabstop>
+  <tabstop>resetRehearsalMarkPosAbove</tabstop>
+  <tabstop>resetRehearsalMarkPosBelow</tabstop>
+  <tabstop>rehearsalMarkMinDistance</tabstop>
+  <tabstop>resetRehearsalMarkMinDistance</tabstop>
+  <tabstop>comboFBFont</tabstop>
+  <tabstop>doubleSpinFBSize</tabstop>
+  <tabstop>doubleSpinFBVertPos</tabstop>
+  <tabstop>spinFBLineHeight</tabstop>
+  <tabstop>radioFBTop</tabstop>
+  <tabstop>radioFBBottom</tabstop>
+  <tabstop>radioFBModern</tabstop>
+  <tabstop>radioFBHistoric</tabstop>
+  <tabstop>chordsStandard</tabstop>
+  <tabstop>chordsJazz</tabstop>
+  <tabstop>chordsCustom</tabstop>
+  <tabstop>chordDescriptionFile</tabstop>
+  <tabstop>chordDescriptionFileButton</tabstop>
+  <tabstop>chordsXmlFile</tabstop>
+  <tabstop>useStandardNoteNames</tabstop>
+  <tabstop>useGermanNoteNames</tabstop>
+  <tabstop>useFullGermanNoteNames</tabstop>
+  <tabstop>useSolfeggioNoteNames</tabstop>
+  <tabstop>useFrenchNoteNames</tabstop>
+  <tabstop>automaticCapitalization</tabstop>
+  <tabstop>lowerCaseMinorChords</tabstop>
+  <tabstop>lowerCaseBassNotes</tabstop>
+  <tabstop>allCapsNoteNames</tabstop>
+  <tabstop>harmonyFretDist</tabstop>
+  <tabstop>minHarmonyDistance</tabstop>
+  <tabstop>maxHarmonyBarDistance</tabstop>
+  <tabstop>capoPosition</tabstop>
+  <tabstop>fretY</tabstop>
+  <tabstop>fretMag</tabstop>
+  <tabstop>fretNumMag</tabstop>
+  <tabstop>radioFretNumLeft</tabstop>
+  <tabstop>radioFretNumRight</tabstop>
+  <tabstop>barreLineWidth</tabstop>
+  <tabstop>fretDotSize</tabstop>
+  <tabstop>fretStringSpacing</tabstop>
+  <tabstop>fretFretSpacing</tabstop>
+  <tabstop>textStyles</tabstop>
+  <tabstop>styleName</tabstop>
+  <tabstop>resetTextStyleName</tabstop>
+  <tabstop>textStyleFontFace</tabstop>
+  <tabstop>resetTextStyleFontFace</tabstop>
+  <tabstop>textStyleFontSize</tabstop>
+  <tabstop>resetTextStyleFontSize</tabstop>
+  <tabstop>textStyleSpatiumDependent</tabstop>
+  <tabstop>resetTextStyleSpatiumDependent</tabstop>
+  <tabstop>resetTextStyleFontStyle</tabstop>
+  <tabstop>resetTextStyleAlign</tabstop>
+  <tabstop>resetTextStyleColor</tabstop>
+  <tabstop>resetTextStyleOffset</tabstop>
+  <tabstop>textStyleFrameType</tabstop>
+  <tabstop>resetTextStyleFrameType</tabstop>
+  <tabstop>resetTextStyleFrameForeground</tabstop>
+  <tabstop>resetTextStyleFrameBackground</tabstop>
+  <tabstop>textStyleFrameBorder</tabstop>
+  <tabstop>resetTextStyleFrameBorder</tabstop>
+  <tabstop>textStyleFramePadding</tabstop>
+  <tabstop>resetTextStyleFramePadding</tabstop>
+  <tabstop>textStyleFrameBorderRadius</tabstop>
+  <tabstop>resetTextStyleFrameBorderRadius</tabstop>
+  <tabstop>buttonTogglePagelist</tabstop>
  </tabstops>
  <resources>
   <include location="musescore.qrc"/>

--- a/mscore/excerptsdialog.ui
+++ b/mscore/excerptsdialog.ui
@@ -386,6 +386,16 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>excerptList</tabstop>
+  <tabstop>moveUpButton</tabstop>
+  <tabstop>moveDownButton</tabstop>
+  <tabstop>newAllButton</tabstop>
+  <tabstop>newButton</tabstop>
+  <tabstop>deleteButton</tabstop>
+  <tabstop>title</tabstop>
+  <tabstop>instrumentList</tabstop>
+  <tabstop>addButton</tabstop>
+  <tabstop>removeButton</tabstop>
   <tabstop>partList</tabstop>
  </tabstops>
  <resources>

--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -4174,6 +4174,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>showStartcenter</tabstop>
   <tabstop>playPanelShow</tabstop>
   <tabstop>navigatorShow</tabstop>
+  <tabstop>showTours</tabstop>
   <tabstop>myScores</tabstop>
   <tabstop>myScoresButton</tabstop>
   <tabstop>myStyles</tabstop>
@@ -4209,10 +4210,17 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>fgWallpaperButton</tabstop>
   <tabstop>fgWallpaper</tabstop>
   <tabstop>fgWallpaperSelect</tabstop>
+  <tabstop>pageHorizontal</tabstop>
+  <tabstop>pageVertical</tabstop>
+  <tabstop>limitScrollArea</tabstop>
+  <tabstop>drawAntialiased</tabstop>
+  <tabstop>proximity</tabstop>
   <tabstop>enableMidiInput</tabstop>
+  <tabstop>warnPitchRange</tabstop>
+  <tabstop>realtimeDelay</tabstop>
+  <tabstop>playNotes</tabstop>
   <tabstop>defaultPlayDuration</tabstop>
   <tabstop>playChordOnAddNote</tabstop>
-  <tabstop>warnPitchRange</tabstop>
   <tabstop>rcGroup</tabstop>
   <tabstop>rewindActive</tabstop>
   <tabstop>recordRewind</tabstop>
@@ -4242,12 +4250,12 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>recordUndo</tabstop>
   <tabstop>rca9</tabstop>
   <tabstop>rcr9</tabstop>
+  <tabstop>rca12</tabstop>
+  <tabstop>rcr12</tabstop>
   <tabstop>rca10</tabstop>
   <tabstop>rcr10</tabstop>
   <tabstop>rca11</tabstop>
   <tabstop>rcr11</tabstop>
-  <tabstop>rca12</tabstop>
-  <tabstop>rcr12</tabstop>
   <tabstop>realtimeAdvanceActive</tabstop>
   <tabstop>recordRealtimeAdvance</tabstop>
   <tabstop>advanceOnRelease</tabstop>
@@ -4261,6 +4269,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>partStyle</tabstop>
   <tabstop>partStyleButton</tabstop>
   <tabstop>scale</tabstop>
+  <tabstop>showMidiControls</tabstop>
   <tabstop>pulseaudioDriver</tabstop>
   <tabstop>portaudioDriver</tabstop>
   <tabstop>portaudioApi</tabstop>
@@ -4279,6 +4288,7 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>rememberLastMidiConnections</tabstop>
   <tabstop>useJackTransport</tabstop>
   <tabstop>becomeTimebaseMaster</tabstop>
+  <tabstop>rescanDrivers</tabstop>
   <tabstop>useImportBuiltinStyle</tabstop>
   <tabstop>useImportStyleFile</tabstop>
   <tabstop>importStyleFile</tabstop>
@@ -4290,7 +4300,12 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>shortestNote</tabstop>
   <tabstop>pngResolution</tabstop>
   <tabstop>pngTransparent</tabstop>
+  <tabstop>exportPdfDpi</tabstop>
+  <tabstop>expandRepeats</tabstop>
+  <tabstop>exportRPNs</tabstop>
+  <tabstop>normalize</tabstop>
   <tabstop>exportAudioSampleRate</tabstop>
+  <tabstop>exportMp3BitRate</tabstop>
   <tabstop>exportLayout</tabstop>
   <tabstop>exportAllBreaks</tabstop>
   <tabstop>exportManualBreaks</tabstop>
@@ -4301,25 +4316,14 @@ Adjusting latency can help synchronize your MIDI hardware with MuseScore's inter
   <tabstop>loadShortcutList</tabstop>
   <tabstop>clearShortcut</tabstop>
   <tabstop>defineShortcut</tabstop>
-  <tabstop>printShortcuts</tabstop>
-  <tabstop>resetToDefault</tabstop>
-  <tabstop>buttonBox</tabstop>
-  <tabstop>limitScrollArea</tabstop>
-  <tabstop>drawAntialiased</tabstop>
-  <tabstop>proximity</tabstop>
-  <tabstop>pageHorizontal</tabstop>
-  <tabstop>pageVertical</tabstop>
-  <tabstop>realtimeDelay</tabstop>
-  <tabstop>playNotes</tabstop>
-  <tabstop>showMidiControls</tabstop>
-  <tabstop>expandRepeats</tabstop>
-  <tabstop>exportRPNs</tabstop>
-  <tabstop>exportPdfDpi</tabstop>
-  <tabstop>exportMp3BitRate</tabstop>
   <tabstop>filterShortcuts</tabstop>
+  <tabstop>printShortcuts</tabstop>
   <tabstop>checkUpdateStartup</tabstop>
+  <tabstop>checkExtensionsUpdateStartup</tabstop>
   <tabstop>resetPreference</tabstop>
   <tabstop>advancedSearch</tabstop>
+  <tabstop>resetToDefault</tabstop>
+  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
   <include location="musescore.qrc"/>

--- a/mscore/selectdialog.ui
+++ b/mscore/selectdialog.ui
@@ -171,6 +171,7 @@
   <tabstop>inSelection</tabstop>
   <tabstop>sameVoice</tabstop>
   <tabstop>sameSystem</tabstop>
+  <tabstop>sameDuration</tabstop>
   <tabstop>replace</tabstop>
   <tabstop>add</tabstop>
   <tabstop>fromSelection</tabstop>

--- a/mscore/selectnotedialog.ui
+++ b/mscore/selectnotedialog.ui
@@ -214,6 +214,11 @@
  </widget>
  <tabstops>
   <tabstop>sameNotehead</tabstop>
+  <tabstop>samePitch</tabstop>
+  <tabstop>sameString</tabstop>
+  <tabstop>sameType</tabstop>
+  <tabstop>sameDuration</tabstop>
+  <tabstop>sameName</tabstop>
   <tabstop>sameStaff</tabstop>
   <tabstop>inSelection</tabstop>
   <tabstop>sameVoice</tabstop>

--- a/mscore/transposedialog.ui
+++ b/mscore/transposedialog.ui
@@ -490,8 +490,8 @@
   <tabstop>keyList</tabstop>
   <tabstop>upKey</tabstop>
   <tabstop>downKey</tabstop>
-  <tabstop>upInterval</tabstop>
   <tabstop>transposeByInterval</tabstop>
+  <tabstop>upInterval</tabstop>
   <tabstop>intervalList</tabstop>
   <tabstop>downInterval</tabstop>
   <tabstop>transposeKeys</tabstop>

--- a/mscore/uploadscoredialog.ui
+++ b/mscore/uploadscoredialog.ui
@@ -119,6 +119,9 @@
          <property name="sizeAdjustPolicy">
           <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
          </property>
+         <property name="tabChangesFocus">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
       </layout>
@@ -321,6 +324,9 @@ p, li { white-space: pre-wrap; }
         <widget class="QPlainTextEdit" name="changes">
          <property name="sizeAdjustPolicy">
           <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="tabChangesFocus">
+          <bool>true</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
I made a fairly thorough pass through the basic dialogs and fixed all the tab order issues I could find, including cases where we were processng tab as input for no good reason when we should have treated it as navigation (eg, long/short instrument names in staff properties).

I didn't touch the mixer, inspector, or any other top level windows, as there is generally more going on there and just tweaking the tabstop tags in the UI files may or may not do the job, plus its often less clear what an expected tab order is in some of these.