### PR TITLE
fix #292571 and fix #292583: improvements for dark/light theme

### DIFF
--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -328,7 +328,7 @@ void InspectorBase::setElement()
 void InspectorBase::checkDifferentValues(const InspectorItem& ii)
       {
       bool valuesAreDifferent = false;
-      QColor c(preferences.isThemeDark() ? Qt::yellow : Qt::darkCyan);
+      QColor c(Ms::preferences.getColor(preferences.isThemeDark() ? PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_DARK_ON : PREF_UI_BUTTON_HIGHLIGHT_COLOR_ENABLED_LIGHT_ON));
 
       if (inspector->el()->size() > 1) {
             Pid id      = ii.t;

--- a/mscore/inspector/inspectorBase.cpp
+++ b/mscore/inspector/inspectorBase.cpp
@@ -344,7 +344,7 @@ void InspectorBase::checkDifferentValues(const InspectorItem& ii)
                   if (valuesAreDifferent)
                         break;
                   }
-            ii.w->setStyleSheet(valuesAreDifferent ? QString("* { color: %1 }").arg(c.name()) : "");
+            ii.w->setStyleSheet(valuesAreDifferent ? QString("* { color: %1; } QToolTip { color: palette(tooltiptext); }").arg(c.name()) : "");
             }
 
       //deal with reset if only one element, or if values are the same
@@ -355,7 +355,7 @@ void InspectorBase::checkDifferentValues(const InspectorItem& ii)
 
             switch (styledValue) {
                   case PropertyFlags::STYLED:
-                        ii.w->setStyleSheet(QString("* { color: %1 }").arg(c.name()));
+                        ii.w->setStyleSheet(QString("* { color: %1; } QToolTip { color: palette(tooltiptext); }").arg(c.name()));
                         enableReset = false;
                         break;
                   case PropertyFlags::UNSTYLED:

--- a/share/themes/palette_dark_fusion.json
+++ b/share/themes/palette_dark_fusion.json
@@ -7,7 +7,7 @@
 "Button":        "#2C2C2C",
 "ButtonText":    "#EFF0F1",
 "BrightText":    "#000000",
-"ToolTipBase":   "#808080",
+"ToolTipBase":   "#fefac2",
 "ToolTipText":   "#000000",
 "Link":          "#00ffff",
 "LinkVisited":   "#00ffff",

--- a/share/themes/palette_light_fusion.json
+++ b/share/themes/palette_light_fusion.json
@@ -11,5 +11,5 @@
 "ToolTipText":   "#000000",
 "Link":          "#3a80c6",
 "LinkVisited":   "#3a80c6",
-"Highlight":     "#000080"
+"Highlight":     "#88bff6"
 }


### PR DESCRIPTION
* fix #292571: In dark theme toolTips in Inspector are basically unreadable and inconsistent between styled and non-styled and also different from other tooltips in toolbar or palette. Also toolTip's colors they are inconsistent between Windows and macOS/Linux.
* fix #292583: the color for styled settings in Inspector can't get configured, instead they are hard coded