### PR TITLE
Fix #291708 Plugin: Expose Score.selection object to access to GUI selected elements.

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -58,6 +58,7 @@ if (SCRIPT_INTERFACE)
             plugin/api/fraction.h
             plugin/api/excerpt.h
             plugin/api/util.h
+            plugin/api/selection.h
 
             plugin/api/enums.cpp
             plugin/mscorePlugins.cpp plugin/pluginCreator.cpp plugin/pluginManager.cpp plugin/qmledit.cpp
@@ -66,6 +67,7 @@ if (SCRIPT_INTERFACE)
             plugin/api/score.cpp
             plugin/api/excerpt.cpp
             plugin/api/util.cpp
+            plugin/api/selection.cpp
             )
 
       set (SCRIPT_UI

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -17,6 +17,8 @@
 #include "score.h"
 #include "part.h"
 #include "util.h"
+#include "selection.h"
+
 #ifndef TESTROOT
 #include "shortcut.h"
 #endif
@@ -332,6 +334,7 @@ void PluginAPI::registerQmlTypes()
       qmlRegisterType<Measure>();
       qmlRegisterType<Part>();
       qmlRegisterType<Excerpt>();
+      qmlRegisterType<Selection>();
       //qmlRegisterType<Hook>();
       //qmlRegisterType<Stem>();
       //qmlRegisterType<StemSlash>();

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -24,6 +24,10 @@ namespace PluginAPI {
 class Cursor;
 class Segment;
 class Measure;
+class Selection;
+class Score;
+
+extern Selection* selectionWrap(Ms::Selection* select);
 
 //---------------------------------------------------------
 //   Score
@@ -80,6 +84,8 @@ class Score : public Ms::PluginAPI::ScoreElement {
       Q_PROPERTY(QString                        mscoreVersion     READ mscoreVersion)
       /** MuseScore revision the score has been last saved with (includes autosave) (read only) */
       Q_PROPERTY(QString                        mscoreRevision    READ mscoreRevision)
+      /** Current selections for the score. \since MuseScore 3.3 */
+      Q_PROPERTY(Ms::PluginAPI::Selection*      selection         READ selection)
 
    public:
       /// \cond MS_INTERNAL
@@ -98,6 +104,8 @@ class Score : public Ms::PluginAPI::ScoreElement {
       int lyricCount() { return score()->lyricCount(); }
       QString lyricist() { return score()->metaTag("lyricist"); } // not the meanwhile obsolete "poet"
       QString title() { return score()->metaTag("workTitle"); }
+      Ms::PluginAPI::Selection* selection() { return selectionWrap(&score()->selection()); }
+
       /// \endcond
 
       /// Returns as a string the metatag named \p tag

--- a/mscore/plugin/api/scoreelement.h
+++ b/mscore/plugin/api/scoreelement.h
@@ -114,7 +114,16 @@ public:
             : QQmlListProperty<T>(obj, const_cast<void*>(static_cast<const void*>(&container)), &count, &at) {};
 
       static int count(QQmlListProperty<T>* l)     { return int(static_cast<Container*>(l->data)->size()); }
-      static T* at(QQmlListProperty<T>* l, int i)  { return wrap<T>(static_cast<Container*>(l->data)->at(i), Ownership::SCORE); }
+      static T* at(QQmlListProperty<T>* l, int i)
+            {
+            auto el = static_cast<Container*>(l->data)->at(i);
+            // If a polymorphic wrap() function is available
+            // for the requested type, use it for wrapping.
+            if (std::is_same<T*, decltype(wrap(el, Ownership::SCORE))>::value)
+                  return static_cast<T*>(wrap(el, Ownership::SCORE));
+            // Otherwise, wrap directly to the requested wrapper type.
+            return wrap<T>(el, Ownership::SCORE);
+            }
       /// \endcond
       };
 

--- a/mscore/plugin/api/selection.cpp
+++ b/mscore/plugin/api/selection.cpp
@@ -1,0 +1,32 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2019 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "selection.h"
+#include "score.h"
+
+namespace Ms {
+namespace PluginAPI {
+
+//---------------------------------------------------------
+//   QmlPlayEventsListAccess::append
+//---------------------------------------------------------
+
+Selection* selectionWrap(Ms::Selection* select)
+      {
+      Selection* w = new Selection(select);
+      // All wrapper objects should belong to JavaScript code.
+      QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
+      return w;
+      }
+
+}
+}

--- a/mscore/plugin/api/selection.h
+++ b/mscore/plugin/api/selection.h
@@ -1,0 +1,54 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2019 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __PLUGIN_API_SELECTION_H__
+#define __PLUGIN_API_SELECTION_H__
+
+#include "elements.h"
+#include "score.h"
+
+namespace Ms {
+namespace PluginAPI {
+
+//---------------------------------------------------------
+//   Selection
+//    Wrapper class for internal Ms::Selection
+///  \since MuseScore 3.3 
+//---------------------------------------------------------
+
+class Selection : public QObject {
+      Q_OBJECT
+      /// Current GUI selections for the score.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element> elements READ elements)
+
+      /// \cond MS_INTERNAL
+
+   protected:
+      Ms::Selection* _select;
+
+   public:
+
+      Selection(Ms::Selection* select) : QObject(), _select(select) {}
+      virtual ~Selection() { }
+
+      QQmlListProperty<Element> elements()
+            { return wrapContainerProperty<Element>(this, _select->elements()); }
+
+      /// \endcond
+};
+
+extern Selection* selectionWrap(Ms::Selection* select);
+
+} // namespace PluginAPI
+} // namespace Ms
+#endif

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -108,6 +108,7 @@ set (SOURCE_LIB
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/part.h
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/excerpt.cpp
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/util.cpp
+      ${PROJECT_SOURCE_DIR}/mscore/plugin/api/selection.cpp
       ${PROJECT_SOURCE_DIR}/mscore/preferences.cpp
       ${PROJECT_SOURCE_DIR}/mscore/shortcut.cpp
       ${PROJECT_SOURCE_DIR}/mscore/stringutils.cpp


### PR DESCRIPTION
This commit exposes the Score.selection.elements list
enabling QML scripts to manipulate on user selected score elements.
The expectation is that additional selection information will be
provided on this object in the future.