### PR TITLE
remove bogus accessibilty string

### DIFF
--- a/mscore/prefsdialog.ui
+++ b/mscore/prefsdialog.ui
@@ -65,9 +65,6 @@
        <property name="focusPolicy">
         <enum>Qt::StrongFocus</enum>
        </property>
-       <property name="accessibleName">
-        <string>Apply</string>
-       </property>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>


### PR DESCRIPTION
not suitable for a QDialogButtonBox, which this is now (it use to be 3 separate QPushButton, one of which was labeled "Apply")