### PR TITLE
fix #165621: Tremolo between 2 notes is copied even if unticked in selection filter

### DIFF
--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -339,6 +339,7 @@ void Selection::add(Element* el)
 
 //---------------------------------------------------------
 //   canSelect
+//   see also `static const char* labels[]` in selectionwindow.cpp
 //---------------------------------------------------------
 
 bool SelectionFilter::canSelect(const Element* e) const
@@ -373,7 +374,7 @@ bool SelectionFilter::canSelect(const Element* e) const
           return isFiltered(SelectionFilterType::OTHER_TEXT);
       if (e->isSLine()) // NoteLine, Volta
           return isFiltered(SelectionFilterType::OTHER_LINE);
-      if (e->isTremolo() && !toTremolo(e)->twoNotes())
+      if (e->isTremolo())
           return isFiltered(SelectionFilterType::TREMOLO);
       if (e->isChord() && toChord(e)->isGrace())
           return isFiltered(SelectionFilterType::GRACE_NOTE);

--- a/libmscore/select.h
+++ b/libmscore/select.h
@@ -76,6 +76,7 @@ enum class SelState : char {
 
 //---------------------------------------------------------
 //   SelectionFilterType
+//   see also `static const char* labels[]` in selectionwindow.cpp
 //---------------------------------------------------------
 
 enum class SelectionFilterType {

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -513,7 +513,7 @@ Palette* MuseScore::newFingeringPalette()
 Palette* MuseScore::newTremoloPalette()
       {
       Palette* sp = new Palette;
-      sp->setName(QT_TRANSLATE_NOOP("Palette", "Tremolo"));
+      sp->setName(QT_TRANSLATE_NOOP("Palette", "Tremolos"));
       sp->setGrid(27, 40);
       sp->setDrawGrid(true);
 

--- a/mscore/selectionwindow.cpp
+++ b/mscore/selectionwindow.cpp
@@ -26,32 +26,34 @@
 
 namespace Ms {
 
+// see `SelectionFilter::canSelect()` in select.cpp
+// and `enum class SelectionFilterType` in select.h
 static const char* labels[] = {
       QT_TRANSLATE_NOOP("selectionfilter", "All"),
       QT_TRANSLATE_NOOP("selectionfilter", "Voice 1"),
       QT_TRANSLATE_NOOP("selectionfilter", "Voice 2"),
       QT_TRANSLATE_NOOP("selectionfilter", "Voice 3"),
       QT_TRANSLATE_NOOP("selectionfilter", "Voice 4"),
-      QT_TRANSLATE_NOOP("selectionfilter", "Dynamics"),
-      QT_TRANSLATE_NOOP("selectionfilter", "Fingering"),
-      QT_TRANSLATE_NOOP("selectionfilter", "Lyrics"),
+      QT_TRANSLATE_NOOP("selectionfilter", "Dynamics & Hairpins"),
+      QT_TRANSLATE_NOOP("selectionfilter", "Fingerings"),
       QT_TRANSLATE_NOOP("selectionfilter", "Chord Symbols"),
+      QT_TRANSLATE_NOOP("selectionfilter", "Lyrics"),
       QT_TRANSLATE_NOOP("selectionfilter", "Other Text"),
       QT_TRANSLATE_NOOP("selectionfilter", "Articulations & Ornaments"),
-      QT_TRANSLATE_NOOP("selectionfilter", "Slurs"),
       QT_TRANSLATE_NOOP("selectionfilter", "Figured Bass"),
-      QT_TRANSLATE_NOOP("selectionfilter", "Ottava"),
+      QT_TRANSLATE_NOOP("selectionfilter", "Slurs"),
+      QT_TRANSLATE_NOOP("selectionfilter", "Ottavas"),
       QT_TRANSLATE_NOOP("selectionfilter", "Pedal Lines"),
       QT_TRANSLATE_NOOP("selectionfilter", "Other Lines"),
       QT_TRANSLATE_NOOP("selectionfilter", "Arpeggios"),
       QT_TRANSLATE_NOOP("selectionfilter", "Glissandi"),
       QT_TRANSLATE_NOOP("selectionfilter", "Fretboard Diagrams"),
       QT_TRANSLATE_NOOP("selectionfilter", "Breath Marks"),
-      QT_TRANSLATE_NOOP("selectionfilter", "Tremolo"),
+      QT_TRANSLATE_NOOP("selectionfilter", "Tremolos"),
       QT_TRANSLATE_NOOP("selectionfilter", "Grace Notes")
       };
 
-const int numLabels = sizeof(labels)/sizeof(labels[0]);
+static const size_t numLabels = sizeof(labels)/sizeof(labels[0]);
 
 SelectionListWidget::SelectionListWidget(QWidget *parent) : QListWidget(parent)
       {
@@ -62,7 +64,7 @@ SelectionListWidget::SelectionListWidget(QWidget *parent) : QListWidget(parent)
       setFocusPolicy(Qt::TabFocus);
       setTabKeyNavigation(true);
 
-      for (int row = 0; row < numLabels; row++) {
+      for (size_t row = 0; row < numLabels; row++) {
             QListWidgetItem *listItem = new QListWidgetItem(this);
             listItem->setData(Qt::UserRole, row == 0 ? QVariant(-1) : QVariant(1 << (row - 1)));
             listItem->setCheckState(Qt::Unchecked);
@@ -73,7 +75,7 @@ SelectionListWidget::SelectionListWidget(QWidget *parent) : QListWidget(parent)
 
 void SelectionListWidget::retranslate()
       {
-      for (int row = 0; row < numLabels; row++) {
+      for (size_t row = 0; row < numLabels; row++) {
             QListWidgetItem *listItem = item(row);
             listItem->setText(qApp->translate("selectionfilter", labels[row]));
             listItem->setData(Qt::AccessibleTextRole, qApp->translate("selectionfilter", labels[row]));
@@ -85,8 +87,7 @@ void SelectionListWidget::focusInEvent(QFocusEvent* e) {
       QListWidget::focusInEvent(e);
       }
 
-SelectionWindow::SelectionWindow(QWidget *parent, Score* score) :
-      QDockWidget(parent)
+SelectionWindow::SelectionWindow(QWidget *parent, Score* score) : QDockWidget(parent)
       {
       setObjectName("SelectionWindow");
       setAllowedAreas(Qt::DockWidgetAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea));
@@ -162,7 +163,7 @@ void SelectionWindow::changeCheckbox(QListWidgetItem* item)
             _score->selectionFilter().setFiltered(static_cast<SelectionFilterType>(type), set);
             }
       else {
-            for (int row = 1; row < numLabels; row++)
+            for (size_t row = 1; row < numLabels; row++)
                   _score->selectionFilter().setFiltered(static_cast<SelectionFilterType>(1 << (row - 1)), set);
             }
       _score->startCmd();
@@ -194,6 +195,7 @@ void MuseScore::showSelectionWindow(bool visible)
             selectionWindow->raise();
             }
       }
+
 void SelectionWindow::closeEvent(QCloseEvent* ev)
       {
       emit closed(false);

--- a/mtest/libmscore/selectionfilter/selectionfilter16-ref.xml
+++ b/mtest/libmscore/selectionfilter/selectionfilter16-ref.xml
@@ -25,9 +25,6 @@
         <pitch>76</pitch>
         <tpc>18</tpc>
         </Note>
-      <Tremolo>
-        <subtype>c8</subtype>
-        </Tremolo>
       </Chord>
     <Chord>
       <durationType>half</durationType>


### PR DESCRIPTION
also change labels to a) plural and b) reflect better what they really filter on