### PR TITLE
fix compiler warnings reg. comparing signed and unsigned and some unused parameters

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -3577,8 +3577,8 @@ void Chord::setNoteEventLists(QList<NoteEventList>& ell)
       {
       if (notes().empty())
             return;
-      Q_ASSERT(ell.size() == notes().size());
-      for (size_t i = 0; i < ell.size(); i++) {
+      Q_ASSERT(ell.size() == int(notes().size()));
+      for (size_t i = 0; int(i) < ell.size(); i++) {
             notes()[i]->setPlayEvents(ell[int(i)]);
             }
 

--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1041,10 +1041,10 @@ Element* ChordRest::prevArticulationOrLyric(Element* e)
             }
       else if (isChord() && e->isArticulation()) {
             Chord* c = toChord(this);
-            auto i = std::find(c->articulations().begin(), c->articulations().end(), e);
-            if (i != c->articulations().end()) {
-                  if (i != c->articulations().begin())
-                        return *(i-1);
+            auto j = std::find(c->articulations().begin(), c->articulations().end(), e);
+            if (j != c->articulations().end()) {
+                  if (j != c->articulations().begin())
+                        return *(j-1);
                   }
             }
       return 0;

--- a/mscore/importmxmlpass1.cpp
+++ b/mscore/importmxmlpass1.cpp
@@ -2708,6 +2708,7 @@ void determineTupletFractionAndFullDuration(const Fraction duration, Fraction& f
 
 static bool isTupletFilled(const MxmlTupletState& state, const TDuration normalType, const Fraction timeMod)
       {
+      Q_UNUSED(timeMod);
       bool res { false };
       const auto actualNotes = state.m_actualNotes;
       /*

--- a/mscore/importmxmlpass2.cpp
+++ b/mscore/importmxmlpass2.cpp
@@ -1328,6 +1328,7 @@ static void resetTuplets(Tuplets& tuplets)
 
 void MusicXMLParserPass2::initPartState(const QString& partId)
       {
+      Q_UNUSED(partId);
       _timeSigDura = Fraction(0, 0);             // invalid
       _tie    = 0;
       _lastVolta = 0;
@@ -4463,8 +4464,7 @@ Note* MusicXMLParserPass2::note(const QString& partId,
             if (cue) cr->setSmall(cue);  // only once per chord
             }
 
-      auto part = _pass1.getPart(partId);
-      Q_ASSERT(part);
+      Q_ASSERT(_pass1.getPart(partId));
 
       // handle notations
       if (cr) {

--- a/mscore/selectionwindow.cpp
+++ b/mscore/selectionwindow.cpp
@@ -76,7 +76,7 @@ SelectionListWidget::SelectionListWidget(QWidget *parent) : QListWidget(parent)
 void SelectionListWidget::retranslate()
       {
       for (size_t row = 0; row < numLabels; row++) {
-            QListWidgetItem *listItem = item(row);
+            QListWidgetItem *listItem = item(int(row));
             listItem->setText(qApp->translate("selectionfilter", labels[row]));
             listItem->setData(Qt::AccessibleTextRole, qApp->translate("selectionfilter", labels[row]));
             }


### PR DESCRIPTION
for some strange reason `QList::size()` returns `int` rather than `size_t`, IMHO a bug in Qt, as even a `QList` can't have a negative number of members.
That warning (well, the code causing it) got introduced by PR #5224 
And fix another warning reg. shadowing a local variable as well as reg.
some unused parameters