### PR TITLE
fix #292883: Using the "Repeat selection" shortcut to notes within a tuplet crashes MuseScore.

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4223,6 +4223,9 @@ void ScoreView::cmdRepeatSelection()
             return;
             }
 
+      if (!checkCopyOrCut())
+            return;
+
       QString mimeType = selection.mimeType();
       if (mimeType.isEmpty()) {
             qDebug("mime type is empty");


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/292883.