### PR TITLE
Fix #293008: Plugin: Provide Note.tieBack & Note.tieForward properties in QML.

### DIFF
--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -384,6 +384,7 @@ class Note final : public Element {
       void setTieBack(Tie* t)         { _tieBack = t;    }
       Note* firstTiedNote() const;
       const Note* lastTiedNote() const;
+      Note* lastTiedNote()            { return const_cast<Note*>(static_cast<const Note*>(this)->lastTiedNote()); }
       void disconnectTiedNotes();
       void connectTiedNotes();
 

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -59,6 +59,7 @@ if (SCRIPT_INTERFACE)
             plugin/api/excerpt.h
             plugin/api/util.h
             plugin/api/selection.h
+            plugin/api/tie.h
             plugin/api/playevent.h
 
             plugin/api/enums.cpp
@@ -69,6 +70,7 @@ if (SCRIPT_INTERFACE)
             plugin/api/excerpt.cpp
             plugin/api/util.cpp
             plugin/api/selection.cpp
+            plugin/api/tie.cpp
             plugin/api/playevent.cpp
             )
 

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -32,6 +32,8 @@ namespace Ms {
 namespace PluginAPI {
 
 class Element;
+class Tie;
+extern Tie* tieWrap(Ms::Tie* tie);
 
 //---------------------------------------------------------
 //   wrap
@@ -405,8 +407,20 @@ class Note : public Element {
 //       Q_PROPERTY(bool                           small             READ small              WRITE undoSetSmall)
 //       Q_PROPERTY(int                            string            READ string             WRITE undoSetString)
 //       Q_PROPERTY(int                            subchannel        READ subchannel)
-//       Q_PROPERTY(Ms::Tie*                       tieBack           READ tieBack)
-//       Q_PROPERTY(Ms::Tie*                       tieFor            READ tieFor)
+      /// Backward tie for this Note.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(Ms::PluginAPI::Tie*               tieBack           READ tieBack)
+      /// Forward tie for this Note.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(Ms::PluginAPI::Tie*               tieForward        READ tieForward)
+      /// The first note of a series of ties to this note.
+      /// This will return the calling note if there is not tieBack.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(Ms::PluginAPI::Note*              firstTiedNote     READ firstTiedNote)
+      /// The last note of a series of ties to this note.
+      /// This will return the calling note if there is not tieForward.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(Ms::PluginAPI::Note*              lastTiedNote      READ lastTiedNote)
       /// The NoteType of the note.
       /// \since MuseScore 3.2.1
       Q_PROPERTY(Ms::NoteType                      noteType          READ noteType)
@@ -446,6 +460,12 @@ class Note : public Element {
 
       int tpc() const { return note()->tpc(); }
       void setTpc(int val);
+
+      Ms::PluginAPI::Tie* tieBack()    const { return note()->tieBack() != nullptr ? tieWrap(note()->tieBack()) : nullptr; }
+      Ms::PluginAPI::Tie* tieForward() const { return note()->tieFor() != nullptr ? tieWrap(note()->tieFor()) : nullptr; }
+
+      Ms::PluginAPI::Note* firstTiedNote() { return wrap<Note>(note()->firstTiedNote()); }
+      Ms::PluginAPI::Note* lastTiedNote()  { return wrap<Note>(note()->lastTiedNote()); }
 
       QQmlListProperty<Element> dots() { return wrapContainerProperty<Element>(this, note()->dots()); }
       QQmlListProperty<Element> elements() { return wrapContainerProperty<Element>(this, note()->el());   }

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -18,6 +18,7 @@
 #include "part.h"
 #include "util.h"
 #include "selection.h"
+#include "tie.h"
 
 #ifndef TESTROOT
 #include "shortcut.h"
@@ -350,6 +351,7 @@ void PluginAPI::registerQmlTypes()
       qmlRegisterType<Part>();
       qmlRegisterType<Excerpt>();
       qmlRegisterType<Selection>();
+      qmlRegisterType<Tie>();
       qmlRegisterType<PlayEvent>("MuseScore", 3, 0, "PlayEvent");
       //qmlRegisterType<Hook>();
       //qmlRegisterType<Stem>();

--- a/mscore/plugin/api/tie.cpp
+++ b/mscore/plugin/api/tie.cpp
@@ -1,0 +1,37 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2019 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#include "tie.h"
+
+namespace Ms {
+namespace PluginAPI {
+
+//---------------------------------------------------------
+//   Tie::startNote
+//---------------------------------------------------------
+
+ Note* Tie::startNote() { return wrap<Note>(toTie(e)->startNote()); }
+
+//---------------------------------------------------------
+//   Tie::endNote
+//---------------------------------------------------------
+
+ Note* Tie::endNote()   { return wrap<Note>(toTie(e)->endNote()); }
+
+//---------------------------------------------------------
+//   tieWrap
+//---------------------------------------------------------
+
+Tie* tieWrap(Ms::Tie* tie) { return wrap<Tie>(tie); }
+
+}
+}

--- a/mscore/plugin/api/tie.h
+++ b/mscore/plugin/api/tie.h
@@ -1,0 +1,52 @@
+//=============================================================================
+//  MuseScore
+//  Music Composition & Notation
+//
+//  Copyright (C) 2019 Werner Schweer and others
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License version 2
+//  as published by the Free Software Foundation and appearing in
+//  the file LICENCE.GPL
+//=============================================================================
+
+#ifndef __PLUGIN_API_TIE_H__
+#define __PLUGIN_API_TIE_H__
+
+#include "elements.h"
+#include "libmscore/tie.h"
+
+namespace Ms {
+namespace PluginAPI {
+
+//---------------------------------------------------------
+//   Tie
+///  Provides access to internal Ms::Tie objects.
+///  \since MuseScore 3.3
+//---------------------------------------------------------
+
+class Tie : public Element {
+      Q_OBJECT
+      /// The starting note of the tie.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(Ms::PluginAPI::Note* startNote     READ startNote)
+      /// The ending note of the tie.
+      /// \since MuseScore 3.3
+      Q_PROPERTY(Ms::PluginAPI::Note* endNote       READ endNote)
+
+      /// \cond MS_INTERNAL
+
+   public:
+      Tie(Ms::Tie* tie, Ownership own = Ownership::PLUGIN) : Element(tie, own) {}
+
+      Note* startNote();
+      Note* endNote();
+
+      /// \endcond
+};
+
+extern Tie* tieWrap(Ms::Tie* tie);
+
+} // namespace PluginAPI
+} // namespace Ms
+#endif

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -109,6 +109,7 @@ set (SOURCE_LIB
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/excerpt.cpp
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/util.cpp
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/selection.cpp
+      ${PROJECT_SOURCE_DIR}/mscore/plugin/api/tie.cpp
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/playevent.cpp
       ${PROJECT_SOURCE_DIR}/mscore/preferences.cpp
       ${PROJECT_SOURCE_DIR}/mscore/shortcut.cpp


### PR DESCRIPTION
Provide Note.tieBack & Note.tieForward properties and their
associated Tie objects in QML. Also provides Note.firstTiedNote
and lastTiedNote methods to locate a tie range.