### PR TITLE
Fix #293017: Plugin: Enable elements selection from plugins

### DIFF
--- a/mscore/plugin/api/selection.cpp
+++ b/mscore/plugin/api/selection.cpp
@@ -10,6 +10,7 @@
 //  the file LICENCE.GPL
 //=============================================================================
 
+#include "libmscore/select.h"
 #include "selection.h"
 #include "score.h"
 
@@ -26,6 +27,46 @@ Selection* selectionWrap(Ms::Selection* select)
       // All wrapper objects should belong to JavaScript code.
       QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
       return w;
+      }
+
+//---------------------------------------------------------
+//   QmlSelElementsListAccess::at
+//---------------------------------------------------------
+
+Element* QmlSelElementsListAccess::at(QQmlListProperty<Element>* l, int i)
+      {
+      Ms::Selection* sel = static_cast<Ms::Selection*>(l->data);
+      return wrap(sel->elements()[i]);
+      }
+
+//---------------------------------------------------------
+//   QmlSelElementsListAccess::count
+//---------------------------------------------------------
+
+int QmlSelElementsListAccess::count(QQmlListProperty<Element>* l)
+      {
+      Ms::Selection* sel = static_cast<Ms::Selection*>(l->data);
+      return sel->elements().length();
+      }
+
+//---------------------------------------------------------
+//   QmlSelElementsListAccess::clear
+//---------------------------------------------------------
+
+void QmlSelElementsListAccess::clear(QQmlListProperty<Element>* l)
+      {
+      Ms::Selection* sel = static_cast<Ms::Selection*>(l->data);
+      sel->clear();
+      }
+
+//---------------------------------------------------------
+//   QmlSelElementsListAccess::append
+//---------------------------------------------------------
+
+void QmlSelElementsListAccess::append(QQmlListProperty<Element>* l, Element *e)
+      {
+      Ms::Selection* sel = static_cast<Ms::Selection*>(l->data);
+      sel->add(e->element());
       }
 
 }

--- a/mscore/plugin/api/selection.h
+++ b/mscore/plugin/api/selection.h
@@ -20,15 +20,40 @@ namespace Ms {
 namespace PluginAPI {
 
 //---------------------------------------------------------
+//   QML R/W access to container of selected Elements
+//
+//   QmlSelElementsListAccess provides a convenience interface
+//   for QQmlListProperty providing access to plugins for to
+//   selected elements.
+//---------------------------------------------------------
+
+class QmlSelElementsListAccess : public QQmlListProperty<Element> {
+   public:
+   QmlSelElementsListAccess(QObject* obj, Ms::Selection& sel)
+         : QQmlListProperty<Element>(obj, &sel, &append, &count, &at, &clear) {};
+
+   static int count(QQmlListProperty<Element>* l);
+   static Element* at(QQmlListProperty<Element>* l, int i);
+   static void clear(QQmlListProperty<Element>* l);
+   static void append(QQmlListProperty<Element>* l, Element *v);
+};
+
+/** \cond PLUGIN_API \private \endcond */
+inline QmlSelElementsListAccess wrapSelElementsContainerProperty(QObject* obj, Ms::Selection& sel)
+      {
+      return QmlSelElementsListAccess(obj, sel);
+      }
+
+//---------------------------------------------------------
 //   Selection
 //    Wrapper class for internal Ms::Selection
-///  \since MuseScore 3.3 
+///  \since MuseScore 3.3.1
 //---------------------------------------------------------
 
 class Selection : public QObject {
       Q_OBJECT
       /// Current GUI selections for the score.
-      /// \since MuseScore 3.3
+      /// \since MuseScore 3.3.1
       Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element> elements READ elements)
 
       /// \cond MS_INTERNAL
@@ -42,12 +67,13 @@ class Selection : public QObject {
       virtual ~Selection() { }
 
       QQmlListProperty<Element> elements()
-            { return wrapContainerProperty<Element>(this, _select->elements()); }
+            { return wrapSelElementsContainerProperty(this, *_select); }
 
       /// \endcond
 };
 
 extern Selection* selectionWrap(Ms::Selection* select);
+
 
 } // namespace PluginAPI
 } // namespace Ms


### PR DESCRIPTION
Extends the Score.selection.elements list implementation to allow modifications
so that plugin scripts can programatically select any element that can be selected 
from the GUI.