### PR TITLE
Fix #293113: Number instruments when using New Score Wizard

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -1029,6 +1029,7 @@ void InstrumentsWidget::createInstruments(Score* cs)
                   m->cmdAddStaves(sidx, eidx, true);
             staffIdx += rstaff;
             }
+            numberInstrumentNames(cs);
 #if 0 // TODO
       //
       // check for bar lines
@@ -1050,6 +1051,44 @@ void InstrumentsWidget::createInstruments(Score* cs)
             }
 #endif
       cs->setLayoutAll();
+      }
+
+//---------------------------------------------------------
+//   numberInstrumentNames
+//---------------------------------------------------------
+
+void InstrumentsWidget::numberInstrumentNames(Score* cs)
+      {
+      vector<QString> names;
+      vector<QString> firsts;
+
+      for (auto i = cs->parts().begin(); i != cs->parts().end(); ++i) {
+            auto p = *i;
+
+            QString name = p->partName();
+
+            names.push_back(name);
+            int n = 1;
+
+            for (auto j = i + 1; j != cs->parts().end(); ++j) {
+                  auto part = *j;
+                  // number 2nd and subsequent instances of instrument
+                  if (std::find(names.begin(), names.end(), part->partName()) != names.end())  {
+                        firsts.push_back(name);
+                        n++;
+                        part->setPartName((part->partName() + QStringLiteral(" %1").arg(n)));
+                        part->setLongName((part->longName() + QStringLiteral(" %1").arg(n)));
+                        part->setShortName((part->shortName() + QStringLiteral(" %1").arg(n)));
+                        }
+                  }
+
+            // now finish by adding first instances
+            if (std::find(firsts.begin(), firsts.end(), p->partName()) != firsts.end()) {
+                  p->setPartName(p->partName() + " 1");
+                  p->setLongName(p->longName() + " 1");
+                  p->setShortName(p->shortName() + " 1");
+                  }
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -154,6 +154,7 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
       void genPartList(Score*);
       void init();
       void createInstruments(Score*);
+      void numberInstrumentNames(Score*);
       QTreeWidget* getPartiturList();
       };
 


### PR DESCRIPTION
When creating a new score and choosing instruments, all duplicates will be automatically numbered (e.g., "Violin" and "Violin" will be "Violin 1" and "Violin 2". Algorithm is probably wasteful; help requested.

The format "[default text] [digit]" may not be correct in all languages, but at the moment I don't know any way around that. The similar PR #2953 (for part names) did not address translations.