### PR TITLE
fix #290011: [Tablature] Note value repeat section: "At new system" renders the same as "At new measure"

### DIFF
--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -13,6 +13,7 @@
 #include "stafftype.h"
 
 #include "chord.h"
+#include "measure.h"
 #include "mscore.h"
 #include "navigate.h"
 #include "staff.h"
@@ -982,6 +983,14 @@ void TabDurationSymbol::draw(QPainter* painter) const
       {
       if (!_tab)
             return;
+
+      if (_repeat && (_tab->symRepeat() == TablatureSymbolRepeat::SYSTEM)) {
+            Chord* chord = toChord(parent());
+            ChordRest* prevCR = prevChordRest(chord);
+            if (prevCR && (chord->measure()->system() == prevCR->measure()->system()))
+                  return;
+            }
+
       qreal mag = magS();
       qreal imag = 1.0 / mag;
 

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -423,6 +423,7 @@ class TabDurationSymbol final : public Element {
       TabBeamGrid _beamGrid;        // value for special 'English' grid display
       const StaffType*  _tab;
       QString     _text;
+      bool        _repeat;
 
    public:
       TabDurationSymbol(Score* s);
@@ -440,6 +441,8 @@ class TabDurationSymbol final : public Element {
             _tab = tab;
             _text = tab->durationString(type, dots);
             }
+      bool isRepeat() const                     { return _repeat; }
+      void setRepeat(bool val)                  { _repeat = val;  }
       };
 
 }     // namespace Ms


### PR DESCRIPTION
See https://musescore.org/en/node/290011.