### PR TITLE
fix #147031: Note symbols are truncated in Tab Preview

### DIFF
--- a/mscore/editstafftype.ui
+++ b/mscore/editstafftype.ui
@@ -280,7 +280,7 @@
            <property name="minimumSize">
             <size>
              <width>0</width>
-             <height>80</height>
+             <height>150</height>
             </size>
            </property>
            <property name="title">
@@ -1269,7 +1269,7 @@
            <property name="minimumSize">
             <size>
              <width>0</width>
-             <height>80</height>
+             <height>170</height>
             </size>
            </property>
            <property name="title">

--- a/mscore/exampleview.cpp
+++ b/mscore/exampleview.cpp
@@ -85,8 +85,7 @@ void ExampleView::resetMatrix()
       double mag = 0.9 * guiScaling * (DPI_DISPLAY / DPI);  // 90% of nominal
       qreal _spatium = SPATIUM20 * mag;
       // example would normally be 10sp from top of page; this leaves 3sp margin above
-//      _matrix  = QTransform(mag, 0.0, 0.0, mag, _spatium, -_spatium * 7.0);
-      _matrix  = QTransform(mag, 0.0, 0.0, mag, _spatium, -_spatium * 10.0);
+      _matrix  = QTransform(mag, 0.0, 0.0, mag, _spatium, -_spatium * 7.0);
       imatrix  = _matrix.inverted();
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/147031.