### PR TITLE
Fix #293460: Crash when loading file with orphan Segment tags

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -2368,7 +2368,7 @@ void Measure::readVoice(XmlReader& e, int staffIdx, bool irregular)
                         }
                   startingBeam = beam;
                   }
-            else if (tag == "Segment")
+            else if (tag == "Segment" && segment)
                   segment->read(e);
             else if (tag == "Ambitus") {
                   Ambitus* range = new Ambitus(score());

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -1287,7 +1287,8 @@ void Score::writeSegments(XmlWriter& xml, int strack, int etrack,
                         cr->writeTupletEnd(xml);
                         }
 
-                  segment->write(xml);    // write only once
+                  if (!(e->isRest() && toRest(e)->isGap()))
+                        segment->write(xml);    // write only once
                   if (forceTimeSig) {
                         if (segment->segmentType() == SegmentType::KeySig)
                               keySigWritten = true;


### PR DESCRIPTION
correct broken files on the fly and don't create them anymore.