### PR TITLE
fix #293311: changing Part Properties changes violin patch in the mixer

### DIFF
--- a/libmscore/instrument.cpp
+++ b/libmscore/instrument.cpp
@@ -812,6 +812,10 @@ void Channel::switchExpressive(Synthesizer* synth, bool expressive, bool force /
       if ((_userBankController && !force) || !synth)
             return;
 
+      // Don't try to switch if we already have done so
+      if (expressive == _switchedToExpressive)
+            return;
+
       // Check that we're actually changing the MuseScore General soundfont
       const auto fontsInfo = synth->soundFontsInfo();
       if (fontsInfo.empty())
@@ -836,6 +840,7 @@ void Channel::switchExpressive(Synthesizer* synth, bool expressive, bool force /
                   newBankNum = 18;
             else
                   newBankNum = relativeBank + 1;
+            _switchedToExpressive = true;
             }
       else {
             int relativeBank = bank() % 129;
@@ -845,6 +850,7 @@ void Channel::switchExpressive(Synthesizer* synth, bool expressive, bool force /
                   newBankNum = 8;
             else
                   newBankNum = relativeBank - 1;
+            _switchedToExpressive = false;
             }
 
       // Floor bank num to multiple of 129 and add new num to get bank num of new patch

--- a/libmscore/instrument.h
+++ b/libmscore/instrument.h
@@ -122,8 +122,9 @@ class Channel {
       bool _mute;
       bool _solo;
 
-      // flags whether the user has changed the bank controller as opposed to switchExpressive
-      bool _userBankController = false;
+      // MuseScore General-specific SND flags:
+      bool _userBankController = false;   // if the user has changed the bank controller as opposed to switchExpressive
+      bool _switchedToExpressive = false; // if the patch has been automatically switched to and expr variant
 
       mutable std::vector<MidiCoreEvent> _init;
       mutable bool _mustUpdateInit = true;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293311