### PR TITLE
fix #293459: Tie command does not properly handle chords with unisons

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -502,7 +502,7 @@ void Chord::add(Element* e)
 
                   for (unsigned idx = 0; idx < _notes.size(); ++idx) {
                         if (note->pitch() <= _notes[idx]->pitch()) {
-                              if (note->pitch() == _notes[idx]->pitch() && note->line() > _notes[idx]->line())
+                              if (note->pitch() == _notes[idx]->pitch() && note->line() >= _notes[idx]->line())
                                     _notes.insert(_notes.begin()+idx+1, note);
                               else
                                     _notes.insert(_notes.begin()+idx, note);
@@ -2530,13 +2530,17 @@ void Chord::layoutArpeggio2()
 //   findNote
 //---------------------------------------------------------
 
-Note* Chord::findNote(int pitch) const
+Note* Chord::findNote(int pitch, int skip) const
       {
       size_t ns = _notes.size();
       for (size_t i = 0; i < ns; ++i) {
             Note* n = _notes.at(i);
-            if (n->pitch() == pitch)
-                  return n;
+            if (n->pitch() == pitch) {
+                  if (skip == 0)
+                        return n;
+                  else
+                        --skip;
+                  }
             }
       return 0;
       }

--- a/libmscore/chord.h
+++ b/libmscore/chord.h
@@ -128,7 +128,7 @@ class Chord final : public ChordRest {
 
       qreal maxHeadWidth() const;
 
-      Note* findNote(int pitch) const;
+      Note* findNote(int pitch, int skip = 0) const;
 
       Stem* stem() const                     { return _stem; }
       Arpeggio* arpeggio() const             { return _arpeggio;  }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4607,8 +4607,8 @@ void Score::undoAddElement(Element* element)
                               sm = cr2->staffIdx() - cr1->staffIdx();
                         Chord* c1 = findLinkedChord(cr1, score->staff(staffIdx));
                         Chord* c2 = findLinkedChord(cr2, score->staff(staffIdx + sm));
-                        Note* nn1 = c1->findNote(n1->pitch());
-                        Note* nn2 = c2 ? c2->findNote(n2->pitch()) : 0;
+                        Note* nn1 = c1->findNote(n1->pitch(), n1->unisonIndex());
+                        Note* nn2 = c2 ? c2->findNote(n2->pitch(), n2->unisonIndex()) : 0;
 
                         // create tie
                         Tie* ntie = toTie(ne);

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -3110,6 +3110,27 @@ std::vector<Note*> Note::tiedNotes() const
       }
 
 //---------------------------------------------------------
+//   unisonIndex
+//---------------------------------------------------------
+
+int Note::unisonIndex() const
+      {
+      int index = 0;
+      auto notes = chord()->notes();
+      size_t ns = notes.size();
+      for (size_t i = 0; i < ns; ++i) {
+            Note* n = notes.at(i);
+            if (n->pitch() == pitch()) {
+                  if (n == this)
+                        return index;
+                  else
+                        ++index;
+                  }
+            }
+      return 0;
+      }
+
+//---------------------------------------------------------
 //   disconnectTiedNotes
 //---------------------------------------------------------
 

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -385,6 +385,7 @@ class Note final : public Element {
       Note* firstTiedNote() const;
       const Note* lastTiedNote() const;
       Note* lastTiedNote()            { return const_cast<Note*>(static_cast<const Note*>(this)->lastTiedNote()); }
+      int unisonIndex() const;
       void disconnectTiedNotes();
       void connectTiedNotes();
 

--- a/libmscore/utils.cpp
+++ b/libmscore/utils.cpp
@@ -847,9 +847,11 @@ Note* searchTieNote(Note* note)
                               return gn2;
                         }
                   for (Note* n : c->notes()) {
-                        if (n->pitch() == note->pitch()) {
-                              if (note2 == 0 || c->track() == chord->track())
+                        if (n->pitch() == note->pitch() && !n->tieBack()) {
+                              if (note2 == 0 || c->track() == chord->track()) {
                                     note2 = n;
+                                    break;
+                                    }
                               }
                         }
                   }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293459.

This provides a way to tell `Chord::findNote()` that we are looking for a specific occurrence of a note at the given pitch within the chord. This could potentially be useful in other situations, but the changes here are focused specifically on properly creating tied unisons.