### PR TITLE
fix #293531: clef&key appear on second system with gen clef&key disabled

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -3437,8 +3437,9 @@ System* Score::collectSystem(LayoutContext& lc)
                               if (!s->enabled())
                                     s->setEnabled(true);
                               }
+                        bool firstSystem = lc.prevMeasure->sectionBreak() && _layoutMode != LayoutMode::FLOAT;
                         if (curHeader)
-                              m->addSystemHeader(lc.firstSystem);
+                              m->addSystemHeader(firstSystem);
                         else
                               m->removeSystemHeader();
                         if (curTrailer)


### PR DESCRIPTION
See https://musescore.org/en/node/293531

In https://github.com/musescore/MuseScore/pull/4866 I added code
to better handle the detection of the end of the layout range.
Part of this was to re-establish the header in the first measure after the end of the range.
But my code mistakenly passed in lc.firstSystem as the firstSystem parameter.
Thus it treated the *second* system as if it was the first,
since lc.firstSystem was set based on the system we just completed,
not the system we are about to consider.
Fix is to calculate when this new system is actually the first system of a section or not.
I calculate this the same way lc.firstMeasure itself is calculated.