### PR TITLE
Fix #293837: Plugin: WIP: Add ability to compare sameness of MuseScore QML elements.

### DIFF
--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -141,6 +141,9 @@ static const ElementName elementNames[] = {
 
 ScoreElement::ScoreElement(const ScoreElement& se)
       {
+#ifdef SCRIPT_INTERFACE
+      _plugInWrapper = nullptr;
+#endif
       _score        = se._score;
       _elementStyle = se._elementStyle;
       if (_elementStyle) {

--- a/libmscore/scoreElement.cpp
+++ b/libmscore/scoreElement.cpp
@@ -169,6 +169,10 @@ ScoreElement::~ScoreElement()
                   }
             }
       delete[] _propertyFlagsList;
+      if (_plugInWrapper != nullptr)
+            {
+            QMetaObject::invokeMethod(_plugInWrapper, "symbiantDestroyed");
+            }
       }
 
 //---------------------------------------------------------

--- a/libmscore/scoreElement.h
+++ b/libmscore/scoreElement.h
@@ -171,6 +171,9 @@ struct ElementName {
 
 class ScoreElement {
       Score* _score;
+#ifdef SCRIPT_INTERFACE
+      QObject* _plugInWrapper = nullptr;
+#endif
       static ElementStyle const emptyStyle;
 
    protected:
@@ -180,11 +183,14 @@ class ScoreElement {
       virtual int getPropertyFlagsIdx(Pid id) const;
 
    public:
-      ScoreElement(Score* s) : _score(s)   {}
+      ScoreElement(Score* s) : _score(s) {}
       ScoreElement(const ScoreElement& se);
 
       virtual ~ScoreElement();
-
+#ifdef SCRIPT_INTERFACE
+      QObject* getPlugInWrapper() const         { return _plugInWrapper; }
+      void setPlugInWrapper(QObject* wrapper)   { _plugInWrapper = wrapper; }
+#endif
       Score* score() const                 { return _score;      }
       MasterScore* masterScore() const;
       virtual void setScore(Score* s)      { _score = s;         }

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -580,6 +580,9 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
 
       void onFocusWindowChanged(QWindow*);
 
+#ifdef SCRIPT_INTERFACE
+      void closePlugin();
+#endif
       virtual QMenu* createPopupMenu() override;
 
       QByteArray exportPdfAsJSON(Score*);

--- a/mscore/plugin/api/excerpt.cpp
+++ b/mscore/plugin/api/excerpt.cpp
@@ -17,23 +17,43 @@
 namespace Ms {
 namespace PluginAPI {
 
+QHash<Ms::Excerpt*, Excerpt*> Excerpt::_wrapMap;
+
 //---------------------------------------------------------
 //   Excerpt::partScore
 //---------------------------------------------------------
 
 Score* Excerpt::partScore()
       {
-      return wrap<Score>(e->partScore(), Ownership::SCORE);
+      return Ms::PluginAPI::wrap<Score>(e->partScore(), Ownership::SCORE);
       }
 
 //---------------------------------------------------------
-//   wrap
+//   Excerpt::wrap
+///   \cond PLUGIN_API \private \endcond
+//---------------------------------------------------------
+
+Excerpt* Excerpt::wrap(Ms::Excerpt* excerpt)
+      {
+      // Use the existing wrapper for this object if it exists.
+      if (_wrapMap.contains(excerpt))
+            return _wrapMap.value(excerpt);
+      // Create a new wrapper.
+      Excerpt* w = new Excerpt(excerpt);
+      _wrapMap[excerpt] = w;
+      // All wrapper objects should belong to JavaScript code.
+      QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
+      return w;
+      }
+
+//---------------------------------------------------------
+//   excerptWrap
 ///   \cond PLUGIN_API \private \endcond
 //---------------------------------------------------------
 
 Excerpt* excerptWrap(Ms::Excerpt* e)
       {
-      return excerptWrap<Excerpt>(e);
+      return Excerpt::wrap(e);
       }
 
 }

--- a/mscore/plugin/api/playevent.cpp
+++ b/mscore/plugin/api/playevent.cpp
@@ -19,6 +19,27 @@
 namespace Ms {
 namespace PluginAPI {
 
+QHash<Ms::NoteEvent*, PlayEvent*> PlayEvent::_wrapMap;
+
+//---------------------------------------------------------
+//   PlayEvent::wrap
+//---------------------------------------------------------
+
+PlayEvent* PlayEvent::wrap(Ms::NoteEvent* ne, Note* parent)
+      {
+      if (!ne)
+            return nullptr;
+      // Use the existing wrapper for this object if it exists.
+      if (_wrapMap.contains(ne))
+            return _wrapMap.value(ne);
+      // Create a new wrapper.
+      PlayEvent* w = new PlayEvent(ne, parent);
+      _wrapMap[ne] = w;
+      // All wrapper objects should belong to JavaScript code.
+      QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
+      return w;
+      }
+
 //---------------------------------------------------------
 //   PlayEvent::setPitch
 //---------------------------------------------------------

--- a/mscore/plugin/api/playevent.h
+++ b/mscore/plugin/api/playevent.h
@@ -50,16 +50,20 @@ class PlayEvent : public QObject {
       Q_PROPERTY(int offtime READ offtime)
       /// \cond MS_INTERNAL
 
+   // Map of existing PlayEvent wrappers.
+   static QHash<Ms::NoteEvent*, PlayEvent*> _wrapMap;
+
    protected:
       Ms::NoteEvent* ne;
       Note* parentNote;
 
    public:
+      static PlayEvent* wrap(Ms::NoteEvent* t, Note* parent);
 
       PlayEvent(Ms::NoteEvent* _ne = new Ms::NoteEvent(), Note* _parent = nullptr)
          : QObject(), ne(_ne), parentNote(_parent) {}
       // Delete the NoteEvent if parentless.
-      virtual ~PlayEvent() { if (parentNote == nullptr) delete ne; }
+      virtual ~PlayEvent() { _wrapMap.remove(ne); if (parentNote == nullptr) delete ne; }
 
       const Ms::NoteEvent& getNoteEvent() { return *ne; }
       void setParentNote(Note* parent) { this->parentNote = parent; }
@@ -81,12 +85,9 @@ class PlayEvent : public QObject {
 ///   \relates Ms::NoteEvent
 //---------------------------------------------------------
 
-inline PlayEvent* playEventWrap(Ms::NoteEvent* t, Note* parent)
+inline PlayEvent* playEventWrap(Ms::NoteEvent* ne, Note* parent)
       {
-      PlayEvent* w = t ? new PlayEvent(t, parent) : nullptr;
-      // All wrapper objects should belong to JavaScript code.
-      QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
-      return w;
+      return PlayEvent::wrap(ne, parent);
       }
 
 //---------------------------------------------------------

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -103,7 +103,9 @@ PluginAPI::PluginAPI(QQuickItem* parent)
 
 Score* PluginAPI::curScore() const
       {
-      return wrap<Score>(msc()->currentScore(), Ownership::SCORE);
+      Score* pscore = wrap<Score>(msc()->currentScore(), Ownership::SCORE);
+      QQmlEngine::setObjectOwnership(pscore, QQmlEngine::CppOwnership);
+      return pscore;
       }
 
 //---------------------------------------------------------

--- a/mscore/plugin/api/score.h
+++ b/mscore/plugin/api/score.h
@@ -180,7 +180,7 @@ class Score : public Ms::PluginAPI::ScoreElement {
       QString mscoreRevision() { return QString::number(score()->mscoreRevision(), /* base */ 16); }
 
       QQmlListProperty<Part> parts() { return wrapContainerProperty<Part>(this, score()->parts());   }
-      QQmlListProperty<Excerpt> excerpts() { return wrapExcerptsContainerProperty<Excerpt>(this, score()->excerpts());   }
+      QQmlListProperty<Excerpt> excerpts() { return wrapExcerptsContainerProperty(this, score()->excerpts());   }
       /// \endcond
       };
 } // namespace PluginAPI

--- a/mscore/plugin/api/scoreelement.cpp
+++ b/mscore/plugin/api/scoreelement.cpp
@@ -21,25 +21,44 @@ namespace Ms {
 namespace PluginAPI {
 
 //---------------------------------------------------------
-//   ScoreElement
+//   ScoreElement::~ScoreElement
 //---------------------------------------------------------
 
 ScoreElement::~ScoreElement()
       {
       if (_ownership == Ownership::PLUGIN)
             delete e;
-      else
+      else if (e)
             e->setPlugInWrapper(nullptr);
       }
 
+//---------------------------------------------------------
+//   ScoreElement::symbiantDestroyed
+//---------------------------------------------------------
+
+void ScoreElement::symbiantDestroyed()
+      {
+      QQmlEngine::setObjectOwnership(this, QQmlEngine::JavaScriptOwnership);
+      // Wipe out our pointer to the wrapped object.
+      e = nullptr;
+      }
+
+//---------------------------------------------------------
+//   ScoreElement::name
+//---------------------------------------------------------
+
 QString ScoreElement::name() const
       {
-      return QString(e->name());
+      return QString(e ? e->name() : "");
       }
+
+//---------------------------------------------------------
+//   ScoreElement::type
+//---------------------------------------------------------
 
 int ScoreElement::type() const
       {
-      return int(e->type());
+      return int(e ? e->type() : Ms::ElementType::ELEMENT);
       }
 
 //---------------------------------------------------------
@@ -51,7 +70,7 @@ int ScoreElement::type() const
 
 QString ScoreElement::userName() const
       {
-      return e->userName();
+      return e ? e->userName() : QString("No Score");
       }
 
 //---------------------------------------------------------
@@ -82,7 +101,7 @@ void ScoreElement::set(Ms::Pid pid, QVariant val)
       if (propertyType(pid) == P_TYPE::FRACTION) {
             FractionWrapper* f = val.value<FractionWrapper*>();
             if (!f) {
-                  qWarning("ScoreElement::set: trying to assing value of wrong type to fractional property");
+                  qWarning("ScoreElement::set: trying to assign value of wrong type to fractional property");
                   return;
                   }
             val = QVariant::fromValue(f->fraction());

--- a/mscore/plugin/api/scoreelement.cpp
+++ b/mscore/plugin/api/scoreelement.cpp
@@ -28,6 +28,8 @@ ScoreElement::~ScoreElement()
       {
       if (_ownership == Ownership::PLUGIN)
             delete e;
+      else
+            e->setPlugInWrapper(nullptr);
       }
 
 QString ScoreElement::name() const

--- a/mscore/plugin/api/scoreelement.h
+++ b/mscore/plugin/api/scoreelement.h
@@ -129,14 +129,8 @@ Wrapper* wrap(T* t, Ownership own = Ownership::SCORE)
                   {
                   w = new Wrapper(t, own);
                   t->setPlugInWrapper(w);
-                  //@@@@@@ // All wrapper objects should belong to JavaScript code.
-                  //@@@@@@ QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
-
-				  // All ScoreElement based wrapper objects should belong to Cpp code.
-				  // When the associated MuseScore object is destroyed it will call
-                  // slot "symbiantDestroyed". That handler will set object ownership back to
-                  // the Javascript Engine.
-                  QQmlEngine::setObjectOwnership(w, QQmlEngine::CppOwnership);
+                  // All wrapper objects should belong to JavaScript code.
+                  QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
                   }
             else
                   w = static_cast<Wrapper*>(t->getPlugInWrapper());

--- a/mscore/plugin/api/scoreelement.h
+++ b/mscore/plugin/api/scoreelement.h
@@ -119,9 +119,19 @@ class ScoreElement : public QObject {
 template <class Wrapper, class T>
 Wrapper* wrap(T* t, Ownership own = Ownership::SCORE)
       {
-      Wrapper* w = t ? new Wrapper(t, own) : nullptr;
-      // All wrapper objects should belong to JavaScript code.
-      QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
+      Wrapper* w = nullptr;
+      if (t != nullptr)
+            {
+            if (t->getPlugInWrapper() == nullptr)
+                  {
+                  w = new Wrapper(t, own);
+                  t->setPlugInWrapper(w);
+                  // All wrapper objects should belong to JavaScript code.
+                  QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
+                  }
+            else
+                  w = static_cast<Wrapper*>(t->getPlugInWrapper());
+            }
       return w;
       }
 

--- a/mscore/plugin/api/scoreelement.h
+++ b/mscore/plugin/api/scoreelement.h
@@ -52,6 +52,26 @@ class ScoreElement : public QObject {
        * element name suitable for usage in a user interface.
        */
       Q_PROPERTY(QString   name READ name)
+      /**
+       * Unique element identifier for comparing MuseScore object equality.
+       *
+       * elementId is available for all elements so that QML scripting can
+       * compare two different QML elements to see if they are accessing the
+       * same MuseScore object beneath the plugin wrappers. This is needed
+       * because there may be more than one wrapper object for the same
+       * MuseScore object because that are provided in many different ways.
+       *
+       * \code{.js}
+       * var note = cursor.element.notes[0];
+       * if (note.elementId == note.firstTiedNote.elementId)
+       *    console.log("Both wrappers point to the same Note object.")
+       * else
+       *    console.log("Both wrappers point to different Note objects.")
+       * \endcode
+       *
+       * \since MuseScore 3.3
+       */
+      Q_PROPERTY(qint64 elementId READ elementId)
 
       Ownership _ownership;
 
@@ -76,6 +96,9 @@ class ScoreElement : public QObject {
 
       QString name() const;
       int type() const;
+
+      qint64 elementId() const { return qint64((void*)e); }
+
 
       QVariant get(Ms::Pid pid) const;
       void set(Ms::Pid pid, QVariant val);

--- a/mscore/plugin/api/scoreelement.h
+++ b/mscore/plugin/api/scoreelement.h
@@ -77,8 +77,11 @@ class ScoreElement : public QObject {
 
    protected:
       /// \cond MS_INTERNAL
-      Ms::ScoreElement* const e;
+      Ms::ScoreElement* e;
       /// \endcond
+
+   public slots:
+      void symbiantDestroyed();
 
    public:
       /// \cond MS_INTERNAL
@@ -126,8 +129,14 @@ Wrapper* wrap(T* t, Ownership own = Ownership::SCORE)
                   {
                   w = new Wrapper(t, own);
                   t->setPlugInWrapper(w);
-                  // All wrapper objects should belong to JavaScript code.
-                  QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
+                  //@@@@@@ // All wrapper objects should belong to JavaScript code.
+                  //@@@@@@ QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
+
+				  // All ScoreElement based wrapper objects should belong to Cpp code.
+				  // When the associated MuseScore object is destroyed it will call
+                  // slot "symbiantDestroyed". That handler will set object ownership back to
+                  // the Javascript Engine.
+                  QQmlEngine::setObjectOwnership(w, QQmlEngine::CppOwnership);
                   }
             else
                   w = static_cast<Wrapper*>(t->getPlugInWrapper());

--- a/mscore/plugin/api/selection.cpp
+++ b/mscore/plugin/api/selection.cpp
@@ -11,21 +11,36 @@
 //=============================================================================
 
 #include "selection.h"
-#include "score.h"
 
 namespace Ms {
 namespace PluginAPI {
 
+QHash<Ms::Selection*, Selection*> Selection::_wrapMap;
+
 //---------------------------------------------------------
-//   QmlPlayEventsListAccess::append
+//   Selection::wrap
+//---------------------------------------------------------
+
+Selection* Selection::wrap(Ms::Selection* select)
+      {
+      // Use the existing wrapper for this object if it exists.
+      if (_wrapMap.contains(select))
+            return _wrapMap.value(select);
+      // Create a new wrapper.
+      Selection* w = new Selection(select);
+      _wrapMap[select] = w;
+      // All wrapper objects should belong to JavaScript code.
+      QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
+      return w;
+      }
+
+//---------------------------------------------------------
+//   selectionWrap
 //---------------------------------------------------------
 
 Selection* selectionWrap(Ms::Selection* select)
       {
-      Selection* w = new Selection(select);
-      // All wrapper objects should belong to JavaScript code.
-      QQmlEngine::setObjectOwnership(w, QQmlEngine::JavaScriptOwnership);
-      return w;
+      return Selection::wrap(select);
       }
 
 }

--- a/mscore/plugin/api/selection.h
+++ b/mscore/plugin/api/selection.h
@@ -33,13 +33,17 @@ class Selection : public QObject {
 
       /// \cond MS_INTERNAL
 
+      // Map of existing Selection wrappers.
+      static QHash<Ms::Selection*, Selection*> _wrapMap;
+
    protected:
       Ms::Selection* _select;
 
    public:
+      static Selection* wrap(Ms::Selection* select);
 
       Selection(Ms::Selection* select) : QObject(), _select(select) {}
-      virtual ~Selection() { }
+      virtual ~Selection() { _wrapMap.remove(_select); }
 
       QQmlListProperty<Element> elements()
             { return wrapContainerProperty<Element>(this, _select->elements()); }

--- a/mscore/plugin/mscorePlugins.cpp
+++ b/mscore/plugin/mscorePlugins.cpp
@@ -390,6 +390,14 @@ bool MuseScore::loadPlugin(const QString& filename)
       }
 
 //---------------------------------------------------------
+//   closePlugin
+//---------------------------------------------------------
+void MuseScore::closePlugin()
+      {
+      getPluginEngine()->collectGarbage();
+      }
+
+//---------------------------------------------------------
 //   pluginTriggered
 //---------------------------------------------------------
 
@@ -469,12 +477,25 @@ void MuseScore::pluginTriggered(QString pp)
 
       p->setFilePath(pp.section('/', 0, -2));
 
-      // don’t call startCmd for non modal dialog
+      connect(engine, SIGNAL(quit()), SLOT(closePlugin()));
+
+      // don't call startCmd for non modal dialog
       if (cs && p->pluginType() != "dock")
             cs->startCmd();
       p->runPlugin();
       if (cs && p->pluginType() != "dock")
             cs->endCmd();
+
+      disconnect(engine, SIGNAL(quit()), this, SLOT(closePlugin()));
+
+      if (p->pluginType() != "dock" && p->pluginType() != "dialog")
+            {
+            // Since this plugin has no UI elements all work happens on the
+            // onRun event. Therefore, rather than rely on the "quit" or 
+            // "destroyed" events, just force a clean up now.
+            closePlugin();    // Ensure unused objects are garbage collected.
+            }
+
 //      endCmd();
       }
 


### PR DESCRIPTION
This PR is a work in progress to test ideas for comparing objects in QML scripts.

Note that there may be several patches using different solutions. When the PR is ready to go it will be reduced down to the final approach.

-Dale