### PR TITLE
fix #293894: crash on Space when editing custom fingering

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2419,6 +2419,7 @@ void ScoreView::textTab(bool back)
             return;
 
       TextBase* ot = toTextBase(oe);
+      Tid defaultTid = Tid(ot->propertyDefault(Pid::SUB_STYLE).toInt());
       Tid tid = ot->tid();
       ElementType type = ot->type();
       int staffIdx = ot->staffIdx();
@@ -2496,6 +2497,7 @@ void ScoreView::textTab(bool back)
       if (el) {
             // edit existing text
             score()->select(el);
+            mscore->updateInspector();    // needed for Space with fingering
             startEditMode(el);
             }
       else {
@@ -2504,7 +2506,7 @@ void ScoreView::textTab(bool back)
             // but it pre-fills the text
             // would be better to create empty tempo element
             if (type != ElementType::TEMPO_TEXT)
-                  cmdAddText(tid);
+                  cmdAddText(defaultTid, tid);
             }
       }
 
@@ -4030,7 +4032,7 @@ void ScoreView::cmdAddChordName(HarmonyType ht)
 //   cmdAddText
 //---------------------------------------------------------
 
-void ScoreView::cmdAddText(Tid tid)
+void ScoreView::cmdAddText(Tid tid, Tid customTid)
       {
       if (!_score->checkHasMeasures())
             return;
@@ -4136,6 +4138,8 @@ void ScoreView::cmdAddText(Tid tid)
             }
 
       if (s) {
+            if (customTid != Tid::DEFAULT && customTid != tid)
+                  s->initTid(customTid);
             _score->select(s, SelectType::SINGLE, 0);
             _score->endCmd();
             Measure* m = s->findMeasure();

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -203,7 +203,7 @@ class ScoreView : public QWidget, public MuseScoreView {
       void realtimeAdvance(bool allowRests);
       void cmdAddFret(int fret);
       void cmdAddChordName(HarmonyType ht);
-      void cmdAddText(Tid tid);
+      void cmdAddText(Tid tid, Tid customTid = Tid::DEFAULT);
       void cmdEnterRest(const TDuration&);
       void cmdEnterRest();
       void cmdTuplet(int n, ChordRest*);


### PR DESCRIPTION
When editing fingering with a "User" text style applied and then hitting Space,
we try to create a new text element on the next note,
but the attempt fails because we cmdAddText() keys off the text style,
and there is no handling for user styles (not clear what element type should be created).
Unfortunately there are no further checks for this and eventually there is a crash
as we attempt to update the text toolbar on the non-existent text element.
I should note that Alt+Right does not crash, but the operation still fails for the same reason.

This commit addresses the underlying problem directly
by making sure we create the element correctly:
passing in the *default* Tid for the desired element type in cmdAddText(),
and then overriding the Tid afterwards if necessary.
Thus, we never fail to create the text and thereby avoid any ill effects.
As a bonus, we gain the ability to add texts with a style different from the default.