### PR TITLE
fix #293318: fix a crash on pasting grace note to a grace note

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1795,8 +1795,8 @@ Element* Note::drop(EditData& data)
                   n->setParent(ch);
                   score()->undoRemoveElement(this);
                   score()->undoAddElement(n);
+                  return n;
                   }
-                  break;
 
             case ElementType::GLISSANDO:
                   {
@@ -1827,6 +1827,7 @@ Element* Note::drop(EditData& data)
                               }
                         gliss->setParent(this);
                         score()->undoAddElement(e);
+                        return e;
                         }
                   else {
                         qDebug("no segment for second note of glissando found");

--- a/libmscore/paste.cpp
+++ b/libmscore/paste.cpp
@@ -986,13 +986,13 @@ void Score::cmdPaste(const QMimeData* ms, MuseScoreView* view, Fraction scale)
                               deselect(target);
 
                               // perform the drop
-                              target->drop(ddata);
+                              Element* pastedElement = target->drop(ddata);
 
                               // if the target is a rest rather than a note,
                               // a new note is generated, and nel becomes invalid as well
                               // (ChordRest::drop() will select it for us)
-                              if (targetType == ElementType::NOTE)
-                                    select(nel);
+                              if (pastedElement && targetType == ElementType::NOTE)
+                                    select(pastedElement);
                               }
                         else {
                               target->drop(ddata);


### PR DESCRIPTION
Fixes https://musescore.org/en/node/293318.

The fix makes use of the fact that `Element::drop` is expected to return the dropped element (and does so in most cases):
https://github.com/dmitrio95/MuseScore/blob/c3f76efd9d16447c1fdd4e9ad08f6062d66baf0d/libmscore/element.h#L358

This allows us to check whether the element was actually pasted or rejected in order to make a correct decision on selecting it after that. In order to retain the effect of #5014 `Note::drop()` had also to be corrected to comply with the mentioned requirement for `Element::drop()` return value.