### PR TITLE
Fix QML palettes on Windows

### DIFF
--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -489,6 +489,7 @@ add_executable ( ${ExecutableName}
       extension.cpp extension.h
       tourhandler.cpp
       script/script.cpp script/scriptentry.cpp script/testscript.cpp script/recorderwidget.cpp
+      qml/msqmlengine.cpp
       qmldockwidget.cpp
 
       ${WIDGETS_SOURCE_FILES}

--- a/mscore/CMakeLists.txt
+++ b/mscore/CMakeLists.txt
@@ -926,6 +926,7 @@ else (MINGW)
                   "${QT_INSTALL_BINS}/Qt5Core.dll"  "${QT_INSTALL_BINS}/Qt5Gui.dll"  "${QT_INSTALL_BINS}/Qt5Help.dll"
                   "${QT_INSTALL_BINS}/Qt5Network.dll"  "${QT_INSTALL_BINS}/Qt5PrintSupport.dll"
                   "${QT_INSTALL_BINS}/Qt5Qml.dll"  "${QT_INSTALL_BINS}/Qt5Quick.dll"  "${QT_INSTALL_BINS}/Qt5Sql.dll"
+                  "${QT_INSTALL_BINS}/Qt5QuickControls2.dll" "${QT_INSTALL_BINS}/Qt5QuickTemplates2.dll"
                   "${QT_INSTALL_BINS}/Qt5Svg.dll"  "${QT_INSTALL_BINS}/Qt5Widgets.dll"  "${QT_INSTALL_BINS}/Qt5Xml.dll"
                   "${QT_INSTALL_BINS}/Qt5XmlPatterns.dll"
                   "${QT_INSTALL_BINS}/Qt5WebChannel.dll"

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -87,6 +87,7 @@
 
 #include "palette/palettetree.h"
 #include "palette/palettewidget.h"
+#include "qml/msqmlengine.h"
 
 namespace Ms {
 
@@ -1185,7 +1186,7 @@ void MuseScore::showPalette(bool visible)
             preferencesChanged();
             updateIcons();
 
-            paletteWidget = new PaletteWidget(getPaletteWorkspace(), this);
+            paletteWidget = new PaletteWidget(getPaletteWorkspace(), getQmlUiEngine(), this);
             QAction* a = getAction("toggle-palette");
             connect(paletteWidget, &PaletteWidget::visibilityChanged, a, &QAction::setChecked);
             addDockWidget(Qt::LeftDockWidgetArea, paletteWidget);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -7940,6 +7940,17 @@ bool MuseScore::exportPartsPdfsToJSON(const QString& inFilePath, const QString& 
       }
 
 //---------------------------------------------------------
+//   getQmlEngine
+//---------------------------------------------------------
+
+MsQmlEngine* MuseScore::getQmlUiEngine()
+      {
+      if (!_qmlUiEngine)
+            _qmlUiEngine = new MsQmlEngine(this);
+      return _qmlUiEngine;
+      }
+
+//---------------------------------------------------------
 //   getPluginEngine
 //---------------------------------------------------------
 

--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -88,6 +88,7 @@ class TDockWidget;
 class Sym;
 class MasterPalette;
 class PluginCreator;
+class MsQmlEngine;
 #ifdef SCRIPT_INTERFACE
 class PluginManager;
 class QmlPluginEngine;
@@ -297,6 +298,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       PluginManager* pluginManager         { 0 };
       QmlPluginEngine* _qmlEngine          { 0 };
 #endif
+      MsQmlEngine* _qmlUiEngine            { 0 };
       SelectionWindow* selectionWindow     { 0 };
 
       QMenu* menuFile;
@@ -661,6 +663,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       PluginManager* getPluginManager() const     { return pluginManager; }
       QmlPluginEngine* getPluginEngine();
 #endif
+      MsQmlEngine* getQmlUiEngine();
       void writeSessionFile(bool);
       bool restoreSession(bool);
       bool splitScreen() const { return _splitScreen; }

--- a/mscore/plugin/qmlpluginengine.cpp
+++ b/mscore/plugin/qmlpluginengine.cpp
@@ -18,33 +18,17 @@
 //=============================================================================
 
 #include "qmlpluginengine.h"
-#include "api/cursor.h"
 #include "api/qmlpluginapi.h"
 
 namespace Ms {
-
-extern QString mscoreGlobalShare;
 
 //---------------------------------------------------------
 //   QmlPluginEngine
 //---------------------------------------------------------
 
 QmlPluginEngine::QmlPluginEngine(QObject* parent)
-   : QQmlEngine(parent)
+   : MsQmlEngine(parent)
       {
-#ifdef Q_OS_WIN
-      QStringList importPaths;
-      QDir dir(QCoreApplication::applicationDirPath() + QString("/../qml"));
-      importPaths.append(dir.absolutePath());
-      setImportPathList(importPaths);
-#endif
-#ifdef Q_OS_MAC
-      QStringList importPaths;
-      QDir dir(mscoreGlobalShare + QString("/qml"));
-      importPaths.append(dir.absolutePath());
-      setImportPathList(importPaths);
-#endif
-
       PluginAPI::PluginAPI::registerQmlTypes();
       }
 }

--- a/mscore/qml/msqmlengine.cpp
+++ b/mscore/qml/msqmlengine.cpp
@@ -17,21 +17,30 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-#ifndef __QMLPLUGINENGINE_H__
-#define __QMLPLUGINENGINE_H__
-
-#include "../qml/msqmlengine.h"
+#include "msqmlengine.h"
 
 namespace Ms {
 
+extern QString mscoreGlobalShare;
+
 //---------------------------------------------------------
-//   QmlPluginEngine
+//   MsQmlEngine
 //---------------------------------------------------------
 
-class QmlPluginEngine : public MsQmlEngine {
-   public:
-      QmlPluginEngine(QObject* parent = nullptr);
-      };
-
-} // namespace Ms
+MsQmlEngine::MsQmlEngine(QObject* parent)
+   : QQmlEngine(parent)
+      {
+#ifdef Q_OS_WIN
+      QStringList importPaths;
+      QDir dir(QCoreApplication::applicationDirPath() + QString("/../qml"));
+      importPaths.append(dir.absolutePath());
+      setImportPathList(importPaths);
 #endif
+#ifdef Q_OS_MAC
+      QStringList importPaths;
+      QDir dir(mscoreGlobalShare + QString("/qml"));
+      importPaths.append(dir.absolutePath());
+      setImportPathList(importPaths);
+#endif
+      }
+}

--- a/mscore/qml/msqmlengine.h
+++ b/mscore/qml/msqmlengine.h
@@ -17,20 +17,18 @@
 //  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 //=============================================================================
 
-#ifndef __QMLPLUGINENGINE_H__
-#define __QMLPLUGINENGINE_H__
-
-#include "../qml/msqmlengine.h"
+#ifndef __MSQMLENGINE_H__
+#define __MSQMLENGINE_H__
 
 namespace Ms {
 
 //---------------------------------------------------------
-//   QmlPluginEngine
+//   MsQmlEngine
 //---------------------------------------------------------
 
-class QmlPluginEngine : public MsQmlEngine {
+class MsQmlEngine : public QQmlEngine {
    public:
-      QmlPluginEngine(QObject* parent = nullptr);
+      MsQmlEngine(QObject* parent = nullptr);
       };
 
 } // namespace Ms

--- a/mtest/CMakeLists.txt
+++ b/mtest/CMakeLists.txt
@@ -96,6 +96,7 @@ set (SOURCE_LIB
       ${PROJECT_SOURCE_DIR}/mscore/importxmlfirstpass.cpp
       ${PROJECT_SOURCE_DIR}/mscore/musicxmlfonthandler.cpp
       ${PROJECT_SOURCE_DIR}/mscore/musicxmlsupport.cpp
+      ${PROJECT_SOURCE_DIR}/mscore/qml/msqmlengine.cpp
       ${PROJECT_SOURCE_DIR}/mscore/plugin/qmlplugin.cpp
       ${PROJECT_SOURCE_DIR}/mscore/plugin/qmlpluginengine.cpp
       ${PROJECT_SOURCE_DIR}/mscore/plugin/api/enums.cpp


### PR DESCRIPTION
A follow-up to #5289 which resulted in palettes being not displayed in Windows builds.