### PR TITLE
fix #293897: [Tablature] Note value repeat section: setting "Never" broken

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -2286,7 +2286,9 @@ void Chord::layoutTablature()
                         || prevCR->type() == ElementType::REST)
                         needTabDur = true;
                   else if (tab->symRepeat() == TablatureSymbolRepeat::ALWAYS
-                        || measure() != prevCR->measure()) {
+                        || ((tab->symRepeat() == TablatureSymbolRepeat::MEASURE ||
+                              tab->symRepeat() == TablatureSymbolRepeat::SYSTEM)
+                              && measure() != prevCR->measure())) {
                         needTabDur = true;
                         repeat = true;
                         }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293897.

This followup to 3cd5154 makes sure not to repeat tablature duration symbols when "Repeat" is set to "Never".