### PR TITLE
fix #294010: properly calculate dash lengths to stop hanging

### DIFF
--- a/libmscore/textlinebase.cpp
+++ b/libmscore/textlinebase.cpp
@@ -156,7 +156,7 @@ void TextLineBaseSegment::draw(QPainter* painter) const
                         painter->drawLines(&points[end-1], 1);
                         end--;
                         }
-                  numPairs = adjustedLineLength / (dash + gap);
+                  numPairs = max(qreal(1), adjustedLineLength / (dash + gap));
                   nDashes[1] = (adjustedLineLength - dash * (numPairs + 1)) / numPairs;
                   pen.setDashPattern(nDashes);
                   }


### PR DESCRIPTION
Custom dashes for lines are drawn so that they start and stop on a dash. This requires some calculations to adjust the dash spacing and allow for this. One of the calculations is wrapped in a `max()` function to make sure that we don't divide by 0 and end up in an infinite loop once Qt tries to draw the dashes. This was previously not an issue since the missing `max()` was for calculating the adjustment for the bulk of the line which was never small enough to create the division by 0 until the updated palettes revealed the missing code. 