### PR TITLE
fix #294006: Symphony Orchestra template has wrong patches for pizzicato

### DIFF
--- a/mtest/importmidi/instrument_channels.mscx
+++ b/mtest/importmidi/instrument_channels.mscx
@@ -88,7 +88,7 @@
           </Channel>
         <Channel name="pizzicato">
           <controller ctrl="0" value="0"/>
-          <controller ctrl="32" value="21"/>
+          <controller ctrl="32" value="20"/>
           <program value="45"/>
           <midiPort>0</midiPort>
           <midiChannel>1</midiChannel>

--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -10700,7 +10700,7 @@
                         <program value="48"/> <!--String Ensemble 1-->
                   </Channel>
                   <Channel name="pizzicato">
-                        <controller ctrl="32" value="21"/> <!--Violins Pizzicato Expr.-->.
+                        <controller ctrl="32" value="20"/> <!--Violins Pizzicato-->.
                         <program value="45"/> <!--Pizzicato Strings-->
                   </Channel>
                   <Channel name="tremolo">
@@ -10745,7 +10745,7 @@
                         <program value="48"/> <!--String Ensemble 1-->
                   </Channel>
                   <Channel name="pizzicato">
-                        <controller ctrl="32" value="31"/> <!--Violas Pizzicato Expr.-->.
+                        <controller ctrl="32" value="30"/> <!--Violas Pizzicato-->.
                         <program value="45"/> <!--Pizzicato Strings-->
                   </Channel>
                   <Channel name="tremolo">
@@ -10791,7 +10791,7 @@
                         <program value="48"/> <!--String Ensemble 1-->
                   </Channel>
                   <Channel name="pizzicato">
-                        <controller ctrl="32" value="41"/> <!--Celli Pizzicato Expr.-->.
+                        <controller ctrl="32" value="40"/> <!--Celli Pizzicato-->.
                         <program value="45"/> <!--Pizzicato Strings-->
                   </Channel>
                   <Channel name="tremolo">
@@ -10843,7 +10843,7 @@
                         <program value="48"/> <!--String Ensemble 1-->
                   </Channel>
                   <Channel name="pizzicato">
-                        <controller ctrl="32" value="51"/> <!--Basses Pisszcato Expr.-->.
+                        <controller ctrl="32" value="50"/> <!--Basses Pizzicato-->.
                         <program value="45"/> <!--Pizzicato Strings-->
                   </Channel>
                   <Channel name="tremolo">

--- a/share/templates/08-Orchestral/02-Symphony_Orchestra.mscx
+++ b/share/templates/08-Orchestral/02-Symphony_Orchestra.mscx
@@ -1203,7 +1203,7 @@
           <synti>Fluid</synti>
           </Channel>
         <Channel name="pizzicato">
-          <controller ctrl="32" value="21"/>
+          <controller ctrl="32" value="20"/>
           <program value="45"/>
           <synti>Fluid</synti>
           </Channel>
@@ -1265,7 +1265,7 @@
           <synti>Fluid</synti>
           </Channel>
         <Channel name="pizzicato">
-          <controller ctrl="32" value="26"/>
+          <controller ctrl="32" value="25"/>
           <program value="45"/>
           <synti>Fluid</synti>
           </Channel>
@@ -1329,7 +1329,7 @@
           <synti>Fluid</synti>
           </Channel>
         <Channel name="pizzicato">
-          <controller ctrl="32" value="31"/>
+          <controller ctrl="32" value="30"/>
           <program value="45"/>
           <synti>Fluid</synti>
           </Channel>
@@ -1393,7 +1393,7 @@
           <synti>Fluid</synti>
           </Channel>
         <Channel name="pizzicato">
-          <controller ctrl="32" value="41"/>
+          <controller ctrl="32" value="40"/>
           <program value="45"/>
           <synti>Fluid</synti>
           </Channel>
@@ -1460,8 +1460,8 @@
           <synti>Fluid</synti>
           </Channel>
         <Channel name="pizzicato">
-          <controller ctrl="32" value="51"/>
-          <program value="32"/>
+          <controller ctrl="32" value="50"/>
+          <program value="45"/>
           <synti>Fluid</synti>
           </Channel>
         <Channel name="tremolo">


### PR DESCRIPTION
I broke it (or rather fixed it wrongly) with #5114