### PR TITLE
fix #294054: enable direction change in stem's inspector UI

### DIFF
--- a/libmscore/stem.cpp
+++ b/libmscore/stem.cpp
@@ -342,6 +342,8 @@ QVariant Stem::getProperty(Pid propertyId) const
                   return lineWidth();
             case Pid::USER_LEN:
                   return userLen();
+            case Pid::STEM_DIRECTION:
+                  return QVariant::fromValue<Direction>(chord()->stemDirection());
             default:
                   return Element::getProperty(propertyId);
             }
@@ -359,6 +361,9 @@ bool Stem::setProperty(Pid propertyId, const QVariant& v)
                   break;
             case Pid::USER_LEN:
                   setUserLen(v.toDouble());
+                  break;
+            case Pid::STEM_DIRECTION:
+                  chord()->setStemDirection(v.value<Direction>());
                   break;
             default:
                   return Element::setProperty(propertyId, v);
@@ -378,6 +383,8 @@ QVariant Stem::propertyDefault(Pid id) const
                   return 0.0;
 //            case Pid::LINE_WIDTH:
 //                  return score()->styleP(Sid::stemWidth);
+            case Pid::STEM_DIRECTION:
+                  return QVariant::fromValue<Direction>(Direction::AUTO);
             default:
                   return Element::propertyDefault(id);
             }

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -1009,8 +1009,9 @@ InspectorStem::InspectorStem(QWidget* parent)
       s.setupUi(addWidget());
 
       const std::vector<InspectorItem> iiList = {
-            { Pid::LINE_WIDTH, 0, s.lineWidth,  s.resetLineWidth  },
-            { Pid::USER_LEN,   0, s.userLength, s.resetUserLength },
+            { Pid::LINE_WIDTH,     0, s.lineWidth,     s.resetLineWidth     },
+            { Pid::USER_LEN,       0, s.userLength,    s.resetUserLength    },
+            { Pid::STEM_DIRECTION, 0, s.stemDirection, s.resetStemDirection }
             };
       const std::vector<InspectorPanel> ppList = { { s.title, s.panel } };
       mapSignals(iiList, ppList);

--- a/mscore/inspector/inspector_stem.ui
+++ b/mscore/inspector/inspector_stem.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>218</width>
+    <width>220</width>
     <height>106</height>
    </rect>
   </property>
@@ -73,38 +73,6 @@
       <property name="spacing">
        <number>3</number>
       </property>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="lineWidth">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string>Line thickness</string>
-        </property>
-        <property name="suffix">
-         <string>sp</string>
-        </property>
-        <property name="singleStep">
-         <double>0.010000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Line thickness:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="buddy">
-         <cstring>lineWidth</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
@@ -140,6 +108,19 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Line thickness:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>lineWidth</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="2">
        <widget class="Ms::ResetButton" name="resetLineWidth" native="true">
         <property name="sizePolicy">
@@ -153,6 +134,22 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="2">
+       <widget class="Ms::ResetButton" name="resetStemDirection" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Stem direction' value</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="2">
        <widget class="Ms::ResetButton" name="resetUserLength" native="true">
         <property name="sizePolicy">
@@ -163,6 +160,60 @@
         </property>
         <property name="accessibleName">
          <string>Reset 'Length change' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="stemDirection">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <item>
+         <property name="text">
+          <string>Auto</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Up</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Down</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="lineWidth">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Line thickness</string>
+        </property>
+        <property name="suffix">
+         <string>sp</string>
+        </property>
+        <property name="singleStep">
+         <double>0.010000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="stemDirection">
+        <property name="text">
+         <string>Direction:</string>
+        </property>
+        <property name="buddy">
+         <cstring>stemDirection</cstring>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Implements https://musescore.org/node/294054.

In 3.2.3, you can change the stem direction in chord's UI, but not in stem's. This commit fixes it.