### PR TITLE
fix #294085: all elements set to normal position if all rests in voices other than voice 1 are deleted

### DIFF
--- a/libmscore/beam.h
+++ b/libmscore/beam.h
@@ -93,6 +93,7 @@ class Beam final : public Element {
 
       virtual Fraction tick() const override;
       virtual Fraction rtick() const override;
+      Fraction ticks() const;
 
       virtual void write(XmlWriter& xml) const override;
       virtual void read(XmlReader&) override;
@@ -110,7 +111,7 @@ class Beam final : public Element {
       void clear()                        { _elements.clear(); }
       bool empty() const                { return _elements.empty(); }
       bool contains(const ChordRest* cr) const { return std::find(_elements.begin(), _elements.end(), cr) != _elements.end(); }
-
+      
       virtual void add(Element*) override;
       virtual void remove(Element*) override;
 

--- a/libmscore/slur.cpp
+++ b/libmscore/slur.cpp
@@ -1013,6 +1013,25 @@ static bool isDirectionMixture(Chord* c1, Chord* c2)
       }
 
 //---------------------------------------------------------
+//   restsDeletedInOtherVoices
+//    returns true if the track we're checking is the first one in its staff
+//    and the rests in other tracks are deleted for the spanned time period
+//---------------------------------------------------------
+
+static bool restsDeletedInOtherVoices(int track, Measure* m, Fraction tick, Fraction ticks)
+      {
+      if (track & 3 != 0)
+            return false;
+      else {
+            for (int i = 1; i <= 3; ++i) {
+                  if (!m->isOnlyDeletedRests(track + i, tick, tick + ticks))
+                        return false;
+                  }
+            return true;
+            }
+      }
+
+//---------------------------------------------------------
 //   layoutSystem
 //    layout slurSegment for system
 //---------------------------------------------------------
@@ -1080,7 +1099,8 @@ SpannerSegment* Slur::layoutSystem(System* system)
                               // but grace notes are exceptions
                               _up = true;
                               }
-                        else if (m1->hasVoices(startCR()->staffIdx()) && c1 && !c1->isGrace()) {
+                        else if (m1->hasVoices(startCR()->staffIdx()) && c1 && !c1->isGrace()
+                           && !restsDeletedInOtherVoices(track(), m1, tick(), ticks())) {
                               // in polyphonic passage, slurs go on the stem side
                               _up = startCR()->up();
                               }
@@ -1202,7 +1222,8 @@ void Slur::layout()
                         // but grace notes are exceptions
                         _up = true;
                         }
-                  else if (m1->hasVoices(startCR()->staffIdx()) && c1 && c1->noteType() == NoteType::NORMAL) {
+                  else if (m1->hasVoices(startCR()->staffIdx()) && c1 && c1->noteType() == NoteType::NORMAL
+                     && !restsDeletedInOtherVoices(track(), m1, tick(), ticks())){
                         // in polyphonic passage, slurs go on the stem side
                         _up = startCR()->up();
                         }


### PR DESCRIPTION
Implements https://musescore.org/node/294085.

The added code tracks down the staff's first voice. If the measure has multiple voices but the rests in other voices which have the same stick and etick of the specific chord (or a group of chords and rests beamed together) are all deleted:

- Stem/beam direction
- Articulation anchor
- Slur/tie position

should all be the same as if there're no other voices. This has been witnessed in almost every standard orchestral score.