### PR TITLE
fix #294082: TAB - Mixing mensural value symbols and beaming in historic tablatures is broken.

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1671,6 +1671,8 @@ void Chord::layout2()
                   xOff -= minNoteDist + g->_spaceLw;    // move to left by grace note right space and inter-grace distance
                   }
             }
+      if (_tabDur)
+            _tabDur->layout2();
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/294082.

`TabDurationSymbol::layout2()` is responsible for setting the `_beamLength` for the tab duration symbol, which is used to determine the length of the line to draw. Problem is, `TabDurationSymbol::layout2()` is only ever called from `Chord::layoutStem()`, and `Chord::layoutStem()` is not being called at all, except from `ChordRest::removeDeleteBeam()`. Therefore, `_beamLength` is always equal to 0, which results in zero-length lines being drawn.

This adds a call to ~`Chord::layoutStem()`~ `TabDurationSymbol::layout2()` from ~`LayoutContext::collectPage()`~ `Chord::layout2()`, so that `_beamLength` can be set to the correct value.