### PR TITLE
Fix #290987 B# and Cb octave change

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -760,7 +760,9 @@ int Note::tpc() const
 QString Note::tpcUserName(bool explicitAccidental) const
       {
       QString pitchName = tpc2name(tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
-      QString octaveName = QString::number((epitch() / 12) - 1);
+      QString octaveName = QString::number((epitch() / 12) - 1);QString octaveName = QString::number((epitch() / 12) - 1);
+      int alter = tpc2alterByKey(tpc(), Key::C);
+      octaveName = QString::number(((epitch() - alter) / 12) - 1);
       return pitchName + (explicitAccidental ? " " : "") + octaveName;
       }
 

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -761,6 +761,8 @@ QString Note::tpcUserName(bool explicitAccidental) const
       {
       QString pitchName = tpc2name(tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
       QString octaveName = QString::number((epitch() / 12) - 1);
+      int alter = tpc2alterByKey(tpc(), Key::C);
+      octaveName = QString::number(((epitch() - alter) / 12) - 1);
       return pitchName + (explicitAccidental ? " " : "") + octaveName;
       }
 

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -759,11 +759,11 @@ int Note::tpc() const
 
 QString Note::tpcUserName(bool explicitAccidental) const
       {
-      QString pitchName = tpc2name(tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
-      QString octaveName = QString::number((epitch() / 12) - 1);QString octaveName = QString::number((epitch() / 12) - 1);
-      int alter = tpc2alterByKey(tpc(), Key::C);
-      octaveName = QString::number(((epitch() - alter) / 12) - 1);
-      return pitchName + (explicitAccidental ? " " : "") + octaveName;
+    QString pitchName = tpc2name(tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
+          QString octaveName = QString::number((epitch() / 12) - 1);
+          int alter = tpc2alterByKey(tpc(), Key::C);
+          QString octaveName = QString::number(((epitch() - alter) / 12) - 1);
+          return pitchName + (explicitAccidental ? " " : "") + octaveName;
       }
 
 //---------------------------------------------------------

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -760,9 +760,7 @@ int Note::tpc() const
 QString Note::tpcUserName(bool explicitAccidental) const
       {
       QString pitchName = tpc2name(tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
-      QString octaveName = QString::number((epitch() / 12) - 1);QString octaveName = QString::number((epitch() / 12) - 1);
-      int alter = tpc2alterByKey(tpc(), Key::C);
-      octaveName = QString::number(((epitch() - alter) / 12) - 1);
+      QString octaveName = QString::number((epitch() / 12) - 1);
       return pitchName + (explicitAccidental ? " " : "") + octaveName;
       }
 

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -759,11 +759,11 @@ int Note::tpc() const
 
 QString Note::tpcUserName(bool explicitAccidental) const
       {
-    QString pitchName = tpc2name(tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
-          QString octaveName = QString::number((epitch() / 12) - 1);
-          int alter = tpc2alterByKey(tpc(), Key::C);
-          QString octaveName = QString::number(((epitch() - alter) / 12) - 1);
-          return pitchName + (explicitAccidental ? " " : "") + octaveName;
+      QString pitchName = tpc2name(tpc(), NoteSpellingType::STANDARD, NoteCaseType::AUTO, explicitAccidental);
+      QString octaveName = QString::number((epitch() / 12) - 1);QString octaveName = QString::number((epitch() / 12) - 1);
+      int alter = tpc2alterByKey(tpc(), Key::C);
+      octaveName = QString::number(((epitch() - alter) / 12) - 1);
+      return pitchName + (explicitAccidental ? " " : "") + octaveName;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
This is basically the fix suggested by mattmcclinch.

Displays B# & Cb in the correct octaves