### PR TITLE
fix #294121: navigation skips annotations entered out of order

### DIFF
--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1178,10 +1178,14 @@ Element* Segment::nextAnnotation(Element* e)
       {
       if (_annotations.empty() || e == _annotations.back())
             return nullptr;
-      auto i = std::find(_annotations.begin(), _annotations.end(), e);
-      Element* next = *(i+1);
-      if (next && next->staffIdx() == e->staffIdx())
-            return next;
+      auto ei = std::find(_annotations.begin(), _annotations.end(), e);
+      if (ei == _annotations.end())
+            return nullptr;               // element not found
+      for (auto i = ei + 1; i != _annotations.end(); i++) {
+            Element* next = *i;
+            if (next && next->staffIdx() == e->staffIdx())
+                  return next;
+            }
       return nullptr;
       }
 
@@ -1194,10 +1198,14 @@ Element* Segment::prevAnnotation(Element* e)
       {
       if (e == _annotations.front())
           return nullptr;
-      auto i = std::find(_annotations.begin(), _annotations.end(), e);
-            Element* prev = *(i-1);
-      if (prev && prev->staffIdx() == e->staffIdx())
-            return prev;
+      auto ei = std::find(_annotations.rbegin(), _annotations.rend(), e);
+      if (ei == _annotations.rend())
+            return nullptr;               // element not found
+      for (auto i = ei + 1; i != _annotations.rend(); i++) {
+            Element* prev = *i;
+            if (prev && prev->staffIdx() == e->staffIdx())
+                  return prev;
+            }
       return nullptr;
       }
 


### PR DESCRIPTION
Annotations are appended to the annotation list as they are entered.
This means they won't necessarily be sorted by track,
if you enter them onto staves in any order but top down.
The result is the navitgation code skips all annotations for a staff
after the first annotation it encounters on a different staff.

This commit fixes the issue by continuing to loop through the annotations,
looking for more on the same staff.