### PR TITLE
fix #294156: Incorrect segment type for fermata

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1,4 +1,4 @@
-﻿//=============================================================================
+//=============================================================================
 //  MuseScore
 //  Music Composition & Notation
 //
@@ -2396,7 +2396,8 @@ void Measure::readVoice(XmlReader& e, int staffIdx, bool irregular)
                   }
             }
       if (fermata) {
-            segment = getSegment(SegmentType::EndBarLine, e.tick());
+            SegmentType st = (e.tick() == endTick() ? SegmentType::EndBarLine : SegmentType::ChordRest);
+            segment = getSegment(st, e.tick());
             segment->add(fermata);
             fermata = nullptr;
             }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/294156.