### PR TITLE
[WIP] fix #282246: "other" appearance in time signature properties does not work

### DIFF
--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -299,6 +299,20 @@ void TimeSig::layout()
             ds.clear();
             }
       else {
+            // "other" timesigs are placed at the middle of the staff too
+            if (sigType == TimeSigType::NORMAL && denominatorString().isEmpty()) {
+                  for (ProlatioTable pt : prolatioList) {
+                        if (numeratorString() == score()->scoreFont()->toString(pt.id)) {
+                              pz = QPointF(0.0, yoff);
+                              setbbox(symBbox(pt.id).translated(pz));
+                              ns.clear();
+                              ns.push_back(pt.id);
+                              ds.clear();
+                              return;
+                              }
+                        }
+                  }
+
             ns = toTimeSigString(_numeratorString.isEmpty()   ? QString::number(_sig.numerator())   : _numeratorString);
             ds = toTimeSigString(_denominatorString.isEmpty() ? QString::number(_sig.denominator()) : _denominatorString);
 
@@ -314,7 +328,7 @@ void TimeSig::layout()
 
             qreal displ = (numOfLines & 1) ? 0.0 : (0.05 * _spatium);
 
-            //align on the wider
+            // align on the wider
             qreal pzY = yoff - (denRect.width() < 0.01 ? 0.0 : (displ + numRect.height() * .5));
             qreal pnY = yoff + displ + denRect.height() * .5;
 
@@ -491,7 +505,7 @@ bool TimeSig::setProperty(Pid propertyId, const QVariant& v)
                         return false;
                   break;
             }
-      score()->setLayoutAll();      // TODO
+      triggerLayout();
       setGenerated(false);
       return true;
       }

--- a/libmscore/timesig.h
+++ b/libmscore/timesig.h
@@ -17,6 +17,8 @@
 #include "sig.h"
 #include "mscore.h"
 #include "groups.h"
+#include "sym.h"
+#include "mscore/icons.h"
 
 namespace Ms {
 
@@ -108,7 +110,6 @@ class TimeSig final : public Element {
 
       void setScale(const QSizeF& s)      { _scale = s; }
 
-
       void setFrom(const TimeSig*);
 
       virtual QVariant getProperty(Pid propertyId) const override;
@@ -129,6 +130,27 @@ class TimeSig final : public Element {
       virtual QString accessibleInfo() const override;
       };
 
+//---------------------------------------------------------
+//   ProlatioTable
+//    "Other" symbols
+//---------------------------------------------------------
+
+struct ProlatioTable {
+      SymId id;
+      Icons icon;
+      };
+
+const std::vector<ProlatioTable> prolatioList = {
+      { SymId::mensuralProlation1,  Icons::timesig_prolatio01_ICON },  // tempus perfectum, prol. perfecta
+      { SymId::mensuralProlation2,  Icons::timesig_prolatio02_ICON },  // tempus perfectum, prol. imperfecta
+      { SymId::mensuralProlation3,  Icons::timesig_prolatio03_ICON },  // tempus perfectum, prol. imperfecta, dimin.
+      { SymId::mensuralProlation4,  Icons::timesig_prolatio04_ICON },  // tempus perfectum, prol. perfecta, dimin.
+      { SymId::mensuralProlation5,  Icons::timesig_prolatio05_ICON },  // tempus imperf. prol. perfecta
+      { SymId::mensuralProlation7,  Icons::timesig_prolatio07_ICON },  // tempus imperf., prol. imperfecta, reversed
+      { SymId::mensuralProlation8,  Icons::timesig_prolatio08_ICON },  // tempus imperf., prol. perfecta, dimin.
+      { SymId::mensuralProlation10, Icons::timesig_prolatio10_ICON },  // tempus imperf., prol imperfecta, dimin., reversed
+      { SymId::mensuralProlation11, Icons::timesig_prolatio11_ICON },  // tempus inperf., prol. perfecta, reversed
+      };
+
 }     // namespace Ms
 #endif
-

--- a/mscore/timesigproperties.cpp
+++ b/mscore/timesigproperties.cpp
@@ -84,23 +84,6 @@ TimeSigProperties::TimeSigProperties(TimeSig* t, QWidget* parent)
                   break;
             }
 
-      // set ID's of other symbols
-      struct ProlatioTable {
-            SymId id;
-            Icons icon;
-            };
-      static const std::vector<ProlatioTable> prolatioList = {
-            { SymId::mensuralProlation1,  Icons::timesig_prolatio01_ICON },  // tempus perfectum, prol. perfecta
-            { SymId::mensuralProlation2,  Icons::timesig_prolatio02_ICON },  // tempus perfectum, prol. imperfecta
-            { SymId::mensuralProlation3,  Icons::timesig_prolatio03_ICON },  // tempus perfectum, prol. imperfecta, dimin.
-            { SymId::mensuralProlation4,  Icons::timesig_prolatio04_ICON },  // tempus perfectum, prol. perfecta, dimin.
-            { SymId::mensuralProlation5,  Icons::timesig_prolatio05_ICON },  // tempus imperf. prol. perfecta
-            { SymId::mensuralProlation7,  Icons::timesig_prolatio07_ICON },  // tempus imperf., prol. imperfecta, reversed
-            { SymId::mensuralProlation8,  Icons::timesig_prolatio08_ICON },  // tempus imperf., prol. perfecta, dimin.
-            { SymId::mensuralProlation10, Icons::timesig_prolatio10_ICON },  // tempus imperf., prol imperfecta, dimin., reversed
-            { SymId::mensuralProlation11, Icons::timesig_prolatio11_ICON },  // tempus inperf., prol. perfecta, reversed
-            };
-
       ScoreFont* scoreFont = gscore->scoreFont();
       int idx = 0;
       otherCombo->clear();
@@ -134,31 +117,31 @@ TimeSigProperties::TimeSigProperties(TimeSig* t, QWidget* parent)
 void TimeSigProperties::accept()
       {
       TimeSigType ts = TimeSigType::NORMAL;
-      if (textButton->isChecked())
+      if (textButton->isChecked() || otherButton->isChecked())
             ts = TimeSigType::NORMAL;
       else if (fourfourButton->isChecked())
             ts = TimeSigType::FOUR_FOUR;
       else if (allaBreveButton->isChecked())
             ts = TimeSigType::ALLA_BREVE;
-      else if (otherButton->isChecked()) {
-            // if other symbol, set as normal text...
-            ts = TimeSigType::NORMAL;
-            ScoreFont* scoreFont = timesig->score()->scoreFont();
-            SymId symId = (SymId)( otherCombo->itemData(otherCombo->currentIndex()).toInt() );
-            // ...and set numerator to font string for symbol and denominator to empty string
-            timesig->setNumeratorString(scoreFont->toString(symId));
-            timesig->setDenominatorString(QString());
-            }
 
       Fraction actual(zActual->value(), nActual->value());
       Fraction nominal(zNominal->value(), nNominal->value());
       timesig->setSig(actual, ts);
       timesig->setStretch(nominal / actual);
 
-      if (zText->text() != timesig->numeratorString())
-            timesig->setNumeratorString(zText->text());
-      if (nText->text() != timesig->denominatorString())
-            timesig->setDenominatorString(nText->text());
+      if (!otherButton->isChecked()) {
+            if (zText->text() != timesig->numeratorString())
+                  timesig->setNumeratorString(zText->text());
+            if (nText->text() != timesig->denominatorString())
+                  timesig->setDenominatorString(nText->text());
+            }
+      else {
+            ScoreFont* scoreFont = timesig->score()->scoreFont();
+            SymId symId = (SymId)(otherCombo->itemData(otherCombo->currentIndex()).toInt());
+            // set numerator to font string for symbol and denominator to empty string
+            timesig->setNumeratorString(scoreFont->toString(symId));
+            timesig->setDenominatorString(QString());
+            }
 
       Groups g = groups->groups();
       timesig->setGroups(g);


### PR DESCRIPTION
See https://musescore.org/node/282246.

This bug happens because right after the numerator and denominator strings are set to the style of the chosen "other" timesig, they're both rewrote as numbers due to a logical flaw (this can work because "other" timesig also has a "NORMAL" TimeSigStyle).

Also, set the denominator string to empty won't work as simple as it is, because if the program finds a string empty it'll replace it with a number (like 4 in default). So this fix changes the layout rule of "other" timesig to the same as 4/4 and alla breve, which guarantees the timesig to be set at the middle of the staff.

**What is not fixed: switching from 4/4 or alla breve to an "other" timesig will instead switch to "text" timesig with empty strings.**