### PR TITLE
fix #294120: Insert measures in mmrest mode leads to corruption/crash

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1828,6 +1828,7 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
             mmr->setTick(m->tick());
             undo(new ChangeMMRest(m, mmr));
             }
+      mmr->setTimesig(m->timesig());
       mmr->setPageBreak(lm->pageBreak());
       mmr->setLineBreak(lm->lineBreak());
       mmr->setMMRestCount(n);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/294120.

When creating a multimeasure rest, it is important to set the `_timesig` property of the mmrest to that of the underlying measures in order to preserve the integrity of the TimeSigMap.