### PR TITLE
fix #282246: "other" appearance in time signature properties does not work

### DIFF
--- a/libmscore/timesig.cpp
+++ b/libmscore/timesig.cpp
@@ -299,8 +299,14 @@ void TimeSig::layout()
             ds.clear();
             }
       else {
-            ns = toTimeSigString(_numeratorString.isEmpty()   ? QString::number(_sig.numerator())   : _numeratorString);
-            ds = toTimeSigString(_denominatorString.isEmpty() ? QString::number(_sig.denominator()) : _denominatorString);
+            if (_numeratorString.isEmpty()) {
+                  ns = toTimeSigString(_numeratorString.isEmpty()   ? QString::number(_sig.numerator())   : _numeratorString);
+                  ds = toTimeSigString(_denominatorString.isEmpty() ? QString::number(_sig.denominator()) : _denominatorString);
+                  }
+            else {
+                  ns = toTimeSigString(_numeratorString);
+                  ds = toTimeSigString(_denominatorString);
+                  }
 
             ScoreFont* font = score()->scoreFont();
             QSizeF mag(magS() * _scale);

--- a/mscore/timesigproperties.cpp
+++ b/mscore/timesigproperties.cpp
@@ -114,6 +114,10 @@ TimeSigProperties::TimeSigProperties(TimeSig* t, QWidget* parent)
                         textButton->setChecked(false);
                         otherButton->setChecked(true);
                         otherCombo->setCurrentIndex(idx);
+
+                        // set the custom text fields to empty
+                        zText->setText(QString());
+                        nText->setText(QString());
                         }
                   }
             idx++;
@@ -134,21 +138,12 @@ TimeSigProperties::TimeSigProperties(TimeSig* t, QWidget* parent)
 void TimeSigProperties::accept()
       {
       TimeSigType ts = TimeSigType::NORMAL;
-      if (textButton->isChecked())
+      if (textButton->isChecked() || otherButton->isChecked())
             ts = TimeSigType::NORMAL;
       else if (fourfourButton->isChecked())
             ts = TimeSigType::FOUR_FOUR;
       else if (allaBreveButton->isChecked())
             ts = TimeSigType::ALLA_BREVE;
-      else if (otherButton->isChecked()) {
-            // if other symbol, set as normal text...
-            ts = TimeSigType::NORMAL;
-            ScoreFont* scoreFont = timesig->score()->scoreFont();
-            SymId symId = (SymId)( otherCombo->itemData(otherCombo->currentIndex()).toInt() );
-            // ...and set numerator to font string for symbol and denominator to empty string
-            timesig->setNumeratorString(scoreFont->toString(symId));
-            timesig->setDenominatorString(QString());
-            }
 
       Fraction actual(zActual->value(), nActual->value());
       Fraction nominal(zNominal->value(), nNominal->value());
@@ -159,6 +154,14 @@ void TimeSigProperties::accept()
             timesig->setNumeratorString(zText->text());
       if (nText->text() != timesig->denominatorString())
             timesig->setDenominatorString(nText->text());
+
+      if (otherButton->isChecked()) {
+            ScoreFont* scoreFont = timesig->score()->scoreFont();
+            SymId symId = (SymId)( otherCombo->itemData(otherCombo->currentIndex()).toInt() );
+            // ...and set numerator to font string for symbol and denominator to empty string
+            timesig->setNumeratorString(scoreFont->toString(symId));
+            timesig->setDenominatorString(QString());
+            }
 
       Groups g = groups->groups();
       timesig->setGroups(g);


### PR DESCRIPTION
This commit fixes #282246. This fix works by changing the implementation closer to that of MuseScore 2. The issue is that "other" time signatures are created by changing the numerator string to the symbol, and the denominator string to empty, but during formatting, if the denominator is empty, it is replaced with the actual number of the time signature. The fix only replaces the denominator if the numerator and the denominator are empty. This way, the denominator will stay empty, and the formatting will be correct. This is how it was done in previous versions of MuseScore.