### PR TITLE
fix #294297: Cross-Measure Beam Custom Position Not Restored

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2445,22 +2445,11 @@ void Score::createBeams(Measure* measure)
             if (beam)
                   beam->layout1();
             else if (a1) {
-                  // is a1 the last chord/rest in the measure for its track?
-                  bool lastCR = true;
-                  for (Segment* s = a1->segment()->next(SegmentType::ChordRest); s; s = s->next(SegmentType::ChordRest)) {
-                        if (s->element(track)) {
-                              lastCR = false;
-                              break;
-                              }
-                        }
-                  if (lastCR) {
-                        const auto b = a1->beam();
-                        // if the second chord/rest in a1's beam (it must be in next measure) has forced MID beam mode
-                        if (b && b->elements().startsWith(a1) && b->elements().size()>=2 && b->elements()[1]->beamMode() == Beam::Mode::MID)
-                              // do not delete the origin beam
-                              continue;
-                        }
-                  a1->removeDeleteBeam(false);
+                  Fraction nextTick = a1->tick() + a1->actualTicks();
+                  Measure* m = (nextTick >= measure->endTick() ? measure->nextMeasure() : measure);
+                  ChordRest* nextCR = (m ? m->findChordRest(nextTick, track) : nullptr);
+                  if (!nextCR || !beamModeMid(nextCR->beamMode()))
+                        a1->removeDeleteBeam(false);
                   }
             }
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/294297.

When a beam is created in Measure::readVoice(), it will initially contain only one element. Later, during layout, Score::createBeams() will fill in the remaining elements of the beam. This commit basically reverts https://github.com/musescore/MuseScore/commit/932257f and https://github.com/musescore/MuseScore/commit/08c583f, and implements a slightly different take on a fix for https://musescore.org/en/node/285100 that looks at beamMode of the next ChordRest rather than the elements in a beam that may not yet have been filled.