### PR TITLE
fix #291969: Crash on load of score with staff type change on measure 1

### DIFF
--- a/libmscore/staff.cpp
+++ b/libmscore/staff.cpp
@@ -999,7 +999,7 @@ void Staff::staffTypeListChanged(const Fraction& tick)
             ++i;
             if (i != _staffTypeList.end())
                   score()->setLayout(Fraction::fromTicks(i->first));
-            else
+            else if (score()->lastMeasure())
                   score()->setLayout(score()->lastMeasure()->endTick());
             }
       }


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/291969.

If a staff type change occurs on the first measure, Staff::staffTypeListChanged() will be called on a score that does not have any measures yet. In this case, we do not have to update the layout range at this time, because there is not yet anything to layout.