### PR TITLE
fix #283653: increase maximum value for frame radius in Inspector for text elements

### DIFF
--- a/mscore/inspector/inspector_text.ui
+++ b/mscore/inspector/inspector_text.ui
@@ -440,6 +440,9 @@
            <property name="accessibleName">
             <string>Corner radius</string>
            </property>
+           <property name="maximum">
+            <number>9999</number>
+           </property>
           </widget>
          </item>
         </layout>


### PR DESCRIPTION
This is the same PR as #5288, as that one is closed accidentally and cannot be restored.

See https://musescore.org/node/283653.

The default maximum value in Qt designer is 99, this remains unchanged for the corner radius setting for texts. #283653 suggests a bigger maximum value.