### PR TITLE
fix #293229, fix #66961: incorrect screenreader feedback on score change

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6268,7 +6268,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
       else if (cmd == "next-score")
             changeScore(1);
       else if (cmd == "previous-score")
-            changeScore(1);
+            changeScore(-1);
       else if (cmd == "transpose")
             transpose();
       else if (cmd == "save-style") {

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -60,8 +60,7 @@ QString AccessibleScoreView::text(QAccessible::Text t) const
       {
       switch (t) {
             case QAccessible::Name:
-//TODO                  return tr("Score %1").arg(s->score()->name());
-                  return "Score ???";
+                  return s->score()->title();
             case QAccessible::Value:
                   return s->score()->accessibleInfo();
             default:


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293229, https://musescore.org/en/node/66961

In AccessibleScoreView::text() where we should be returning the name of the score,
we were returning "???" with a "TODO" that shows an attempt to get the name() of the score.
It didn't work because we really need to get title().

In addition, the previous-score command was not working correctly,
instead getting the next score.
Combined with the lack of screenreader feedback
this made it difficult to track which score you are editing.
The fix was just a matter of changing "1" to "-1" in the call to changeScore().

I'm not aware of any way to automatically test this, but I have verified it on my machine and another.

This PR replaces the corresponding code in #5270 