### PR TITLE
fix #293228: accessibility for QML palettes

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -38,6 +38,7 @@
 #include "palette.h"
 #include "palettebox.h"
 #include "palette/palettemodel.h"
+#include "palette/palettewidget.h"
 #include "palette/paletteworkspace.h"
 #include "libmscore/part.h"
 #include "libmscore/drumset.h"
@@ -5870,13 +5871,10 @@ void MuseScore::cmd(QAction* a)
             return;
             }
       if (cmdn == "palette-search") {
-            PaletteBox* pb = getPaletteBox();
-            QLineEdit* sb = pb->searchBox();
-            sb->setFocus();
-            if (pb->noSelection())
-                  pb->setKeyboardNavigation(false);
-            else
-                  pb->setKeyboardNavigation(true);
+            // TODO: use new search box, or rename command to just "palette"
+            showPalette(true);
+            if (paletteWidget)
+                  paletteWidget->setFocus();
             return;
             }
       if (cmdn == "apply-current-palette-element") {

--- a/mscore/palette/palettemodel.cpp
+++ b/mscore/palette/palettemodel.cpp
@@ -25,6 +25,7 @@
 #include "libmscore/select.h"
 #include "palettetree.h"
 #include "preferences.h"
+#include "scoreaccessibility.h"
 
 namespace Ms {
 //---------------------------------------------------------
@@ -250,8 +251,12 @@ QVariant PaletteTreeModel::data(const QModelIndex& index, int role) const
             switch (role) {
                   case Qt::DisplayRole: // TODO don't display cell names in palettes
                   case Qt::ToolTipRole:
-                  case Qt::AccessibleTextRole:
                         return qApp->translate("Palette", cell->name.toUtf8());
+                  case Qt::AccessibleTextRole: {
+                        QString name = qApp->translate("Palette", cell->name.toUtf8());
+                        ScoreAccessibility::makeReadable(name);
+                        return name;
+                        }
                   case Qt::DecorationRole: {
                         qreal extraMag = 1.0;
                         if (const PalettePanel* pp = iptrToPalettePanel(index.internalPointer()))
@@ -455,6 +460,7 @@ QHash<int, QByteArray> PaletteTreeModel::roleNames() const
       roles[EditableRole] = "editable";
       roles[PaletteExpandedRole] = "expanded";
       roles[CellActiveRole] = "cellActive";
+      roles[Qt::AccessibleTextRole] = "accessibleText";
       return roles;
       }
 

--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -353,7 +353,10 @@ GridView {
             ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
             ToolTip.text: toolTip ? toolTip : ""
 
-            text: toolTip ? toolTip : ""
+            text: model.accessibleText
+            // TODO: these may be needed for support of other screenreaders
+            //Accessible.name: model.accessibleText
+            //Accessible.description: model.accessibleText
 
             onClicked: {
                 forceActiveFocus();

--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -46,6 +46,9 @@ Item {
         anchors.right: parent.right
 
         placeholderText: qsTr("Search")
+        //TODO: in the future we may wish these values to differ
+        //Accessible.name: qsTr("Search")
+        Accessible.name: placeholderText
         font: globalStyle.font
 
         color: globalStyle.text


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293228

The QML palette implementation is inherently much more accessible than the original,
but it needs a few small changes to work correctly:

1) the palette-search command was incorrectly still transferring focus to the old search box.
Fixed to transfer focus to the paletteWidget itself,
with a TODO noting that we really should be getting the search box within the palette.
I just don't know how to access individual QML widgets.

2) search box had no accessible text so it only read "edit",
fixed to inherit the placeholder text ("Search").

3) Names of key signatures and other palette cells that include unpronounceable Unicode characters
were not being read correctly (eg, Eb major reads as just "E major").
Fix is to call makeReadable() on the cell name for the AccessibleTextRole,
and to be sure that role name is exposed in the model.

I do not know a way to create automated tests for this.

This PR replaces the corresponding code in #5270.