### PR TITLE
fix #294126: cannot navigate to measure elements

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -3193,6 +3193,19 @@ Element* Measure::nextElementStaff(int staff)
       Element* e = score()->selection().element();
       if (!e && !score()->selection().elements().isEmpty())
             e = score()->selection().elements().first();
+
+      // handle measure elements
+      if (e->parent() == this) {
+            auto i = std::find(el().begin(), el().end(), e);
+            if (i != el().end()) {
+                  if (++i != el().end()) {
+                        Element* e = *i;
+                        if (e)
+                              return e;
+                        }
+                  }
+            }
+
       for (; e && e->type() != ElementType::SEGMENT; e = e->parent()) {
             ;
       }
@@ -3211,6 +3224,22 @@ Element* Measure::nextElementStaff(int staff)
 
 Element* Measure::prevElementStaff(int staff)
       {
+      Element* e = score()->selection().element();
+      if (!e && !score()->selection().elements().isEmpty())
+            e = score()->selection().elements().first();
+
+      // handle measure elements
+      if (e->parent() == this) {
+            auto i = std::find(el().rbegin(), el().rend(), e);
+            if (i != el().rend()) {
+                  if (++i != el().rend()) {
+                        Element* e = *i;
+                        if (e)
+                              return e;
+                        }
+                  }
+            }
+
       Measure* prevM = prevMeasureMM();
       if (prevM) {
             Segment* seg = prevM->last();

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1578,11 +1578,16 @@ Element* Segment::nextElement(int activeStaff)
                         return mb && mb->isBox() ? mb : score()->firstElement();
                         }
 
-                  // check for frame
-                  MeasureBase* nmb = measure()->next();
                   Measure* nsm = nextSegment->measure();
-                  if (nsm != measure() && nsm != nmb)
-                        return nmb;
+                  if (nsm != measure()) {
+                        // check for frame, measure elements
+                        MeasureBase* nmb = measure()->next();
+                        Element* nme = nsm->el().empty() ? nullptr : nsm->el().front();
+                        if (nsm != nmb)
+                              return nmb;
+                        else if (nme && nme->isTextBase() && nme->staffIdx() == e->staffIdx())
+                              return nme;
+                        }
 
                   while (nextSegment) {
                         nextEl = nextSegment->firstElementOfSegment(nextSegment, activeStaff);
@@ -1716,11 +1721,16 @@ Element* Segment::prevElement(int activeStaff)
                          return mb && mb->isBox() ? mb : score()->lastElement();
                          }
 
-                   // check for frame
-                   MeasureBase* pmb = measure()->prev();
                    Measure* psm = prevSeg->measure();
-                   if (psm != measure() && psm != pmb)
-                         return pmb;
+                   if (psm != measure()) {
+                         // check for frame, measure elements
+                         MeasureBase* pmb = measure()->prev();
+                         Element* me = measure()->el().empty() ? nullptr : measure()->el().back();
+                         if (me && me->isTextBase() && me->staffIdx() == e->staffIdx())
+                               return me;
+                         else if (psm != pmb)
+                              return pmb;
+                         }
 
                    prev = lastElementOfSegment(prevSeg, activeStaff);
                    while (!prev && prevSeg) {

--- a/mtest/testscript/scripts/accessible1.script
+++ b/mtest/testscript/scripts/accessible1.script
@@ -37,6 +37,7 @@ cmd next-element
 cmd toggle-visible
 cmd next-element
 cmd next-element
+cmd delete
 cmd next-element
 cmd next-element
 cmd next-element

--- a/mtest/testscript/scripts/init/twoStavesWithNotesAndMore.mscx
+++ b/mtest/testscript/scripts/init/twoStavesWithNotesAndMore.mscx
@@ -230,6 +230,11 @@
           </voice>
         </Measure>
       <Measure>
+        <Marker>
+          <style>Repeat Text Right</style>
+          <text>Fine</text>
+          <label>fine</label>
+          </Marker>
         <voice>
           <Chord>
             <durationType>half</durationType>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/294126

The navigation code for next-element and previous-elements ignores measure elements
(elements in the el() list for the measure).
This change adds handling for this
by checking for measure elements before moving to the next or previous measure
in Segment::nextElement() and Segment::previousElement(),
There is corresponding code in Measure::nextElementStaff()
and in Measure::previousElementStaff()
to iterate through multiple elements if present.

Testscript "accessible1" updated to check this.

This PR replaces the corresponding code in PR #5270 