### PR TITLE
Palette translations

### DIFF
--- a/libmscore/xmlwriter.cpp
+++ b/libmscore/xmlwriter.cpp
@@ -334,6 +334,8 @@ QString XmlWriter::xmlString(ushort c)
                   return QLatin1String("&amp;");
             case '\"':
                   return QLatin1String("&quot;");
+            case '%':
+                  return QLatin1String("&#37;");
             default:
                   // ignore invalid characters in xml 1.0
                   if ((c < 0x20 && c != 0x09 && c != 0x0A && c != 0x0D))

--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -233,16 +233,16 @@ Palette* MuseScore::newKeySigPalette()
       for (int i = 0; i < 7; ++i) {
             KeySig* k = new KeySig(gscore);
             k->setKey(Key(i + 1));
-            sp->append(k, qApp->translate("MuseScore", keyNames[i*2]));
+            sp->append(k, keyNames[i*2]);
             }
       for (int i = -7; i < 0; ++i) {
             KeySig* k = new KeySig(gscore);
             k->setKey(Key(i));
-            sp->append(k, qApp->translate("MuseScore", keyNames[(7 + i) * 2 + 1]));
+            sp->append(k, keyNames[(7 + i) * 2 + 1]);
             }
       KeySig* k = new KeySig(gscore);
       k->setKey(Key::C);
-      sp->append(k, qApp->translate("MuseScore", keyNames[14]));
+      sp->append(k, keyNames[14]);
 
       // atonal key signature
       KeySigEvent nke;
@@ -251,7 +251,7 @@ Palette* MuseScore::newKeySigPalette()
       nke.setMode(KeyMode::NONE);
       KeySig* nk = new KeySig(gscore);
       nk->setKeySigEvent(nke);
-      sp->append(nk, qApp->translate("MuseScore", keyNames[15]));
+      sp->append(nk, keyNames[15]);
 
       return sp;
       }
@@ -343,7 +343,7 @@ Palette* MuseScore::newBarLinePalette()
             b->setBarLineType(BarLineType::NORMAL);
             b->setSpanFrom(span.from);
             b->setSpanTo(span.to);
-            sp->append(b, qApp->translate("Palette", span.userName));
+            sp->append(b, span.userName);
             }
       return sp;
       }
@@ -361,7 +361,7 @@ Palette* MuseScore::newRepeatsPalette()
       sp->setDrawGrid(true);
 
       RepeatMeasure* rm = new RepeatMeasure(gscore);
-      sp->append(rm, tr("Repeat measure sign"));
+      sp->append(rm, QT_TRANSLATE_NOOP("Palette", "Repeat measure sign"));
 
       for (int i = 0; i < markerTypeTableSize(); i++) {
             if (markerTypeTable[i].type == Marker::Type::CODETTA) //not in smufl
@@ -370,13 +370,13 @@ Palette* MuseScore::newRepeatsPalette()
             Marker* mk = new Marker(gscore);
             mk->setMarkerType(markerTypeTable[i].type);
             mk->styleChanged();
-            sp->append(mk, qApp->translate("markerType", markerTypeTable[i].name.toUtf8().constData()));
+            sp->append(mk, markerTypeTable[i].name);
             }
 
       for (int i = 0; i < jumpTypeTableSize(); i++) {
             Jump* jp = new Jump(gscore);
             jp->setJumpType(jumpTypeTable[i].type);
-            sp->append(jp, qApp->translate("jumpType", jumpTypeTable[i].userText.toUtf8().constData()));
+            sp->append(jp, jumpTypeTable[i].userText);
             }
 
       for (unsigned i = 0;; ++i) {
@@ -419,42 +419,42 @@ Palette* MuseScore::newBreaksPalette()
             };
       LayoutBreak* lb = new LayoutBreak(gscore);
       lb->setLayoutBreakType(LayoutBreak::Type::LINE);
-      PaletteCell* cell = sp->append(lb, tr("System break"));
+      PaletteCell* cell = sp->append(lb, QT_TRANSLATE_NOOP("Palette", "System break"));
       cell->mag = 1.2;
 
       lb = new LayoutBreak(gscore);
       lb->setLayoutBreakType(LayoutBreak::Type::PAGE);
-      cell = sp->append(lb, tr("Page break"));
+      cell = sp->append(lb, QT_TRANSLATE_NOOP("Palette", "Page break"));
       cell->mag = 1.2;
 
       lb = new LayoutBreak(gscore);
       lb->setLayoutBreakType(LayoutBreak::Type::SECTION);
-      cell = sp->append(lb, tr("Section break"));
+      cell = sp->append(lb, QT_TRANSLATE_NOOP("Palette", "Section break"));
       cell->mag = 1.2;
 
 #if 0
       lb = new LayoutBreak(gscore);
       lb->setLayoutBreakType(LayoutBreak::Type::NOBREAK);
-      cell = sp->append(lb, tr("Don't break"));
+      cell = sp->append(lb, QT_TRANSLATE_NOOP("Palette", "Don't break"));
       cell->mag = 1.2;
 #endif
 
       Spacer* spacer = new Spacer(gscore);
       spacer->setSpacerType(SpacerType::DOWN);
       spacer->setGap(3 * _spatium);
-      cell = sp->append(spacer, tr("Staff spacer down"));
+      cell = sp->append(spacer, QT_TRANSLATE_NOOP("Palette", "Staff spacer down"));
       cell->mag = .7;
 
       spacer = new Spacer(gscore);
       spacer->setSpacerType(SpacerType::UP);
       spacer->setGap(3 * _spatium);
-      cell = sp->append(spacer, tr("Staff spacer up"));
+      cell = sp->append(spacer, QT_TRANSLATE_NOOP("Palette", "Staff spacer up"));
       cell->mag = .7;
 
       spacer = new Spacer(gscore);
       spacer->setSpacerType(SpacerType::FIXED);
       spacer->setGap(3 * _spatium);
-      cell = sp->append(spacer, tr("Staff spacer fixed down"));
+      cell = sp->append(spacer, QT_TRANSLATE_NOOP("Palette", "Staff spacer fixed down"));
       cell->mag = .7;
 
       return sp;
@@ -476,25 +476,25 @@ Palette* MuseScore::newFingeringPalette()
       for (unsigned i = 0; i < strlen(finger); ++i) {
             Fingering* f = new Fingering(gscore);
             f->setXmlText(QString(finger[i]));
-            sp->append(f, tr("Fingering %1").arg(finger[i]));
+            sp->append(f, QT_TRANSLATE_NOOP("Palette", "Fingering %1"));
             }
       finger = "pimac";
       for (unsigned i = 0; i < strlen(finger); ++i) {
             Fingering* f = new Fingering(gscore, Tid::RH_GUITAR_FINGERING);
             f->setXmlText(QString(finger[i]));
-            sp->append(f, tr("RH Guitar Fingering %1").arg(finger[i]));
+            sp->append(f, QT_TRANSLATE_NOOP("Palette", "RH Guitar Fingering %1"));
             }
       finger = "012345T";
       for (unsigned i = 0; i < strlen(finger); ++i) {
             Fingering* f = new Fingering(gscore, Tid::LH_GUITAR_FINGERING);
             f->setXmlText(QString(finger[i]));
-            sp->append(f, tr("LH Guitar Fingering %1").arg(finger[i]));
+            sp->append(f, QT_TRANSLATE_NOOP("Palette", "LH Guitar Fingering %1"));
             }
       finger = "0123456";
       for (unsigned i = 0; i < strlen(finger); ++i) {
             Fingering* f = new Fingering(gscore, Tid::STRING_NUMBER);
             f->setXmlText(QString(finger[i]));
-            sp->append(f, tr("String number %1").arg(finger[i]));
+            sp->append(f, QT_TRANSLATE_NOOP("Palette", "String number %1"));
             }
 
       static const std::vector<SymId> lute {
@@ -524,7 +524,7 @@ Palette* MuseScore::newTremoloPalette()
       for (int i = int(TremoloType::R8); i <= int(TremoloType::C64); ++i) {
             Tremolo* tremolo = new Tremolo(gscore);
             tremolo->setTremoloType(TremoloType(i));
-            sp->append(tremolo, qApp->translate("Tremolo", tremolo->subtypeName().toUtf8().constData()));
+            sp->append(tremolo, tremolo->subtypeName());
             }
       return sp;
       }
@@ -634,13 +634,13 @@ Palette* MuseScore::newArticulationsPalette()
       bend->points().append(PitchValue(0,    0, false));
       bend->points().append(PitchValue(15, 100, false));
       bend->points().append(PitchValue(60, 100, false));
-      sp->append(bend, qApp->translate("articulation", "Bend"));
+      sp->append(bend, QT_TRANSLATE_NOOP("Palette", "Bend"));
 
       TremoloBar* tb = new TremoloBar(gscore);
       tb->points().append(PitchValue(0,     0, false));     // "Dip"
       tb->points().append(PitchValue(30, -100, false));
       tb->points().append(PitchValue(60,    0, false));
-      sp->append(tb, qApp->translate("articulation", "Tremolo bar"));
+      sp->append(tb, QT_TRANSLATE_NOOP("Palette", "Tremolo bar"));
 
       return sp;
       }
@@ -786,7 +786,7 @@ Palette* MuseScore::newBracketsPalette()
             BracketItem* bi1 = new BracketItem(gscore);
             bi1->setBracketType(t.first);
             b1->setBracketItem(bi1);
-            sp->append(b1, qApp->translate("Palette", t.second));      // Bracket, Brace, Square, Line
+            sp->append(b1, t.second);      // Bracket, Brace, Square, Line
             }
       return sp;
       }
@@ -826,51 +826,51 @@ Palette* MuseScore::newArpeggioPalette()
       for (int i = 0; i < 6; ++i) {
             Arpeggio* a = new Arpeggio(gscore);
             a->setArpeggioType(ArpeggioType(i));
-            sp->append(a, tr("Arpeggio"));
+            sp->append(a, QT_TRANSLATE_NOOP("Palette", "Arpeggio"));
             }
       for (int i = 0; i < 2; ++i) {
             Glissando* a = new Glissando(gscore);
             a->setGlissandoType(GlissandoType(i));
-            sp->append(a, tr("Glissando"));
+            sp->append(a, QT_TRANSLATE_NOOP("Palette", "Glissando"));
             }
 
       //fall and doits
 
       ChordLine* cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::FALL);
-      sp->append(cl, tr(scorelineNames[0]));
+      sp->append(cl, scorelineNames[0]);
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::DOIT);
-      sp->append(cl, tr(scorelineNames[1]));
+      sp->append(cl, scorelineNames[1]);
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::PLOP);
-      sp->append(cl, tr(scorelineNames[2]));
+      sp->append(cl, scorelineNames[2]);
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::SCOOP);
-      sp->append(cl, tr(scorelineNames[3]));
+      sp->append(cl, scorelineNames[3]);
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::FALL);
       cl->setStraight(true);
-      sp->append(cl, qApp->translate("articulation", "Slide out down"));
+      sp->append(cl, QT_TRANSLATE_NOOP("Ms", "Slide out down"));
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::DOIT);
       cl->setStraight(true);
-      sp->append(cl, qApp->translate("articulation", "Slide out up"));
+      sp->append(cl, QT_TRANSLATE_NOOP("Ms", "Slide out up"));
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::PLOP);
       cl->setStraight(true);
-      sp->append(cl, qApp->translate("articulation", "Slide in above"));
+      sp->append(cl, QT_TRANSLATE_NOOP("Ms", "Slide in above"));
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::SCOOP);
       cl->setStraight(true);
-      sp->append(cl, qApp->translate("articulation", "Slide in below"));
+      sp->append(cl, QT_TRANSLATE_NOOP("Ms", "Slide in below"));
 
       return sp;
       }
@@ -917,7 +917,7 @@ Palette* MuseScore::newClefsPalette(bool defaultPalette)
       for (ClefType j : *items) {
             Clef* k = new Ms::Clef(gscore);
             k->setClefType(ClefTypeList(j, j));
-            sp->append(k, qApp->translate("clefTable", ClefInfo::name(j)));
+            sp->append(k, ClefInfo::name(j));
             }
       return sp;
       }
@@ -961,7 +961,7 @@ Palette* MuseScore::newBagpipeEmbellishmentPalette()
       for (int i = 0; i < BagpipeEmbellishment::nEmbellishments(); ++i) {
             BagpipeEmbellishment* b  = new BagpipeEmbellishment(gscore);
             b->setEmbelType(i);
-            sp->append(b, qApp->translate("bagpipe", BagpipeEmbellishment::BagpipeEmbellishmentList[i].name));
+            sp->append(b, BagpipeEmbellishment::BagpipeEmbellishmentList[i].name);
             }
 
       return sp;
@@ -982,12 +982,12 @@ Palette* MuseScore::newLinesPalette()
       qreal w = gscore->spatium() * 8;
 
       Slur* slur = new Slur(gscore);
-      sp->append(slur, qApp->translate("lines", "Slur"));
+      sp->append(slur, QT_TRANSLATE_NOOP("Palette", "Slur"));
 
       Hairpin* gabel0 = new Hairpin(gscore);
       gabel0->setHairpinType(HairpinType::CRESC_HAIRPIN);
       gabel0->setLen(w);
-      sp->append(gabel0, qApp->translate("lines", "Crescendo hairpin"));
+      sp->append(gabel0, QT_TRANSLATE_NOOP("Palette", "Crescendo hairpin"));
 
       Hairpin* gabel1 = new Hairpin(gscore);
       gabel1->setHairpinType(HairpinType::DECRESC_HAIRPIN);
@@ -997,7 +997,7 @@ Palette* MuseScore::newLinesPalette()
       Hairpin* gabel2 = new Hairpin(gscore);
       gabel2->setHairpinType(HairpinType::CRESC_LINE);
       gabel2->setLen(w);
-      sp->append(gabel2, qApp->translate("lines", "Crescendo line"));
+      sp->append(gabel2, QT_TRANSLATE_NOOP("Palette", "Crescendo line"));
 
       Hairpin* gabel3 = new Hairpin(gscore);
       gabel3->setHairpinType(HairpinType::DECRESC_LINE);
@@ -1009,7 +1009,7 @@ Palette* MuseScore::newLinesPalette()
       gabel4->setBeginText("<sym>dynamicMezzo</sym><sym>dynamicForte</sym>");
       gabel4->setBeginTextAlign(Align::VCENTER);
       gabel4->setLen(w);
-      sp->append(gabel4, qApp->translate("lines", "Dynamic + hairpin"));
+      sp->append(gabel4, QT_TRANSLATE_NOOP("Palette", "Dynamic + hairpin"));
 
       Volta* volta = new Volta(gscore);
       volta->setVoltaType(Volta::Type::CLOSED);
@@ -1129,7 +1129,7 @@ Palette* MuseScore::newLinesPalette()
             Trill* trill = new Trill(gscore);
             trill->setTrillType(trillTable[i].type);
             trill->setLen(w);
-            sp->append(trill, qApp->translate("trillType", trillTable[i].userName.toUtf8().constData()));
+            sp->append(trill, trillTable[i].userName);
             }
 
       TextLine* textLine = new TextLine(gscore);
@@ -1154,7 +1154,7 @@ Palette* MuseScore::newLinesPalette()
             Vibrato* vibrato = new Vibrato(gscore);
             vibrato->setVibratoType(vibratoTable[i].type);
             vibrato->setLen(w);
-            sp->append(vibrato, qApp->translate("vibratoType", vibratoTable[i].userName.toUtf8().constData()));
+            sp->append(vibrato, vibratoTable[i].userName);
             }
 
       PalmMute* pm = new PalmMute(gscore);
@@ -1262,15 +1262,15 @@ Palette* MuseScore::newTempoPalette(bool defaultPalette)
             tt->setXmlText(tp.pattern);
             if (tp.relative) {
                   tt->setRelative(tp.f);
-                  sp->append(tt, tr("Metric modulation"), QString(), 1.5);
+                  sp->append(tt, QT_TRANSLATE_NOOP("Palette", "Metric modulation"), QString(), 1.5);
                   }
             else if (tp.italian) {
                   tt->setTempo(tp.f);
-                  sp->append(tt, tr("Tempo text"), QString(), 1.3);
+                  sp->append(tt, QT_TRANSLATE_NOOP("Palette", "Tempo text"), QString(), 1.3);
                   }
             else {
                   tt->setTempo(tp.f);
-                  sp->append(tt, tr("Tempo text"), QString(), 1.5);
+                  sp->append(tt, QT_TRANSLATE_NOOP("Palette", "Tempo text"), QString(), 1.5);
                   }
             }
       sp->setMoreElements(false);
@@ -1292,60 +1292,64 @@ Palette* MuseScore::newTextPalette(bool defaultPalette)
       sp->setDrawGrid(true);
 
       StaffText* st = new StaffText(gscore);
-      st->setXmlText(tr("Staff Text"));
-      sp->append(st, tr("Staff text"));
+      st->setXmlText(QT_TRANSLATE_NOOP("Palette", "Staff Text"));
+      sp->append(st, QT_TRANSLATE_NOOP("Palette", "Staff text"))->setElementTranslated(true);
 
       st = new StaffText(gscore, Tid::EXPRESSION);
-      st->setXmlText(tr("Expression"));
+      st->setXmlText(QT_TRANSLATE_NOOP("Palette", "Expression"));
       st->setPlacement(Placement::BELOW);
       st->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
-      sp->append(st, tr("Expression text"));
+      sp->append(st, QT_TRANSLATE_NOOP("Palette", "Expression text"))->setElementTranslated(true);
 
       InstrumentChange* is = new InstrumentChange(gscore);
-      is->setXmlText(tr("Change Instr."));
-      sp->append(is, tr("Instrument change"));
+      is->setXmlText(QT_TRANSLATE_NOOP("Palette", "Change Instr."));
+      sp->append(is, QT_TRANSLATE_NOOP("Palette", "Instrument change"))->setElementTranslated(true);
 
       StaffTypeChange* stc = new StaffTypeChange(gscore);
-      sp->append(stc, tr("Staff type change"));
+      sp->append(stc, QT_TRANSLATE_NOOP("Palette", "Staff type change"));
 
       RehearsalMark* rhm = new RehearsalMark(gscore);
       rhm->setXmlText("B1");
-      sp->append(rhm, tr("Rehearsal mark"));
+      sp->append(rhm, QT_TRANSLATE_NOOP("Palette", "Rehearsal mark"));
 
       SystemText* stxt = new SystemText(gscore, Tid::TEMPO);
-      stxt->setXmlText(tr("Swing"));
+      stxt->setXmlText(QT_TRANSLATE_NOOP("Palette", "Swing"));
       stxt->setSwing(true);
-      sp->append(stxt, tr("Swing"));
+      sp->append(stxt, QT_TRANSLATE_NOOP("Palette", "Swing"))->setElementTranslated(true);
 
       stxt = new SystemText(gscore);
-      stxt->setXmlText(tr("System Text"));
-      sp->append(stxt, tr("System text"));
+      stxt->setXmlText(QT_TRANSLATE_NOOP("Palette", "System Text"));
+      sp->append(stxt, QT_TRANSLATE_NOOP("Palette", "System text"))->setElementTranslated(true);
 
       if (!defaultPalette) {
             StaffText* pz = new StaffText(gscore);
-            pz->setXmlText(tr("pizz."));
+            pz->setXmlText(QT_TRANSLATE_NOOP("Palette", "pizz."));
             pz->setChannelName(0, "pizzicato");
-            sp->append(pz, tr("pizz."));
+            sp->append(pz, QT_TRANSLATE_NOOP("Palette", "Pizzicato"))->setElementTranslated(true);
 
             StaffText* ar = new StaffText(gscore);
-            ar->setXmlText(tr("arco"));
+            ar->setXmlText(QT_TRANSLATE_NOOP("Palette", "arco"));
             ar->setChannelName(0, "arco");
-            sp->append(ar, tr("arco"));
+            sp->append(ar, QT_TRANSLATE_NOOP("Palette", "Arco"))->setElementTranslated(true);
 
             StaffText* tm = new StaffText(gscore, Tid::EXPRESSION);
-            tm->setXmlText(tr("tremolo"));
+            tm->setXmlText(QT_TRANSLATE_NOOP("Palette", "tremolo"));
             tm->setChannelName(0, "tremolo");
-            sp->append(tm, tr("tremolo"));
+            sp->append(tm, QT_TRANSLATE_NOOP("Palette", "Tremolo"))->setElementTranslated(true);
 
             StaffText* mu = new StaffText(gscore);
-            mu->setXmlText(tr("mute"));
+            /*: For brass instruments: staff text that prescribes to use mute while playing, see https://en.wikipedia.org/wiki/Mute_(music) */
+            mu->setXmlText(QT_TRANSLATE_NOOP("Palette", "mute"));
             mu->setChannelName(0, "mute");
-            sp->append(mu, tr("mute"));
+            /*: For brass instruments: staff text that prescribes to use mute while playing, see https://en.wikipedia.org/wiki/Mute_(music) */
+            sp->append(mu, QT_TRANSLATE_NOOP("Palette", "Mute"))->setElementTranslated(true);
 
             StaffText* no = new StaffText(gscore);
-            no->setXmlText(tr("open"));
+            /*: For brass instruments: staff text that prescribes to play without mute, see https://en.wikipedia.org/wiki/Mute_(music) */
+            no->setXmlText(QT_TRANSLATE_NOOP("Palette", "open"));
             no->setChannelName(0, "open");
-            sp->append(no, tr("open"));
+            /*: For brass instruments: staff text that prescribes to play without mute, see https://en.wikipedia.org/wiki/Mute_(music) */
+            sp->append(no, QT_TRANSLATE_NOOP("Palette", "Open"))->setElementTranslated(true);
             }
 
       return sp;
@@ -1376,8 +1380,8 @@ Palette* MuseScore::newTimePalette()
             { 7,  8, TimeSigType::NORMAL, "7/8" },
             { 9,  8, TimeSigType::NORMAL, "9/8" },
             { 12, 8, TimeSigType::NORMAL, "12/8" },
-            { 4,  4, TimeSigType::FOUR_FOUR,  tr("4/4 common time") },
-            { 2,  2, TimeSigType::ALLA_BREVE, tr("2/2 alla breve") },
+            { 4,  4, TimeSigType::FOUR_FOUR,  QT_TRANSLATE_NOOP("Palette", "4/4 common time") },
+            { 2,  2, TimeSigType::ALLA_BREVE, QT_TRANSLATE_NOOP("Palette", "2/2 alla breve") },
             { 2,  2, TimeSigType::NORMAL, "2/2" },
             { 3,  2, TimeSigType::NORMAL, "3/2" },
             { 4,  2, TimeSigType::NORMAL, "4/2" },
@@ -1662,16 +1666,16 @@ PalettePanel* MuseScore::newKeySigPalettePanel()
       for (int i = 0; i < 7; ++i) {
             KeySig* k = new KeySig(gscore);
             k->setKey(Key(i + 1));
-            sp->append(k, qApp->translate("MuseScore", keyNames[i*2]));
+            sp->append(k, keyNames[i*2]);
             }
       for (int i = -7; i < 0; ++i) {
             KeySig* k = new KeySig(gscore);
             k->setKey(Key(i));
-            sp->append(k, qApp->translate("MuseScore", keyNames[(7 + i) * 2 + 1]));
+            sp->append(k, keyNames[(7 + i) * 2 + 1]);
             }
       KeySig* k = new KeySig(gscore);
       k->setKey(Key::C);
-      sp->append(k, qApp->translate("MuseScore", keyNames[14]));
+      sp->append(k, keyNames[14]);
 
       // atonal key signature
       KeySigEvent nke;
@@ -1680,7 +1684,7 @@ PalettePanel* MuseScore::newKeySigPalettePanel()
       nke.setMode(KeyMode::NONE);
       KeySig* nk = new KeySig(gscore);
       nk->setKeySigEvent(nke);
-      sp->append(nk, qApp->translate("MuseScore", keyNames[15]));
+      sp->append(nk, keyNames[15]);
 
       return sp;
       }
@@ -1772,7 +1776,7 @@ PalettePanel* MuseScore::newBarLinePalettePanel()
             b->setBarLineType(BarLineType::NORMAL);
             b->setSpanFrom(span.from);
             b->setSpanTo(span.to);
-            sp->append(b, qApp->translate("Palette", span.userName));
+            sp->append(b, span.userName);
             }
       return sp;
       }
@@ -1790,7 +1794,7 @@ PalettePanel* MuseScore::newRepeatsPalettePanel()
       sp->setDrawGrid(true);
 
       RepeatMeasure* rm = new RepeatMeasure(gscore);
-      sp->append(rm, tr("Repeat measure sign"));
+      sp->append(rm, QT_TRANSLATE_NOOP("Palette", "Repeat measure sign"));
 
       for (int i = 0; i < markerTypeTableSize(); i++) {
             if (markerTypeTable[i].type == Marker::Type::CODETTA) //not in smufl
@@ -1799,13 +1803,13 @@ PalettePanel* MuseScore::newRepeatsPalettePanel()
             Marker* mk = new Marker(gscore);
             mk->setMarkerType(markerTypeTable[i].type);
             mk->styleChanged();
-            sp->append(mk, qApp->translate("markerType", markerTypeTable[i].name.toUtf8().constData()));
+            sp->append(mk, markerTypeTable[i].name);
             }
 
       for (int i = 0; i < jumpTypeTableSize(); i++) {
             Jump* jp = new Jump(gscore);
             jp->setJumpType(jumpTypeTable[i].type);
-            sp->append(jp, qApp->translate("jumpType", jumpTypeTable[i].userText.toUtf8().constData()));
+            sp->append(jp, jumpTypeTable[i].userText);
             }
 
       for (unsigned i = 0;; ++i) {
@@ -1848,42 +1852,42 @@ PalettePanel* MuseScore::newBreaksPalettePanel()
             };
       LayoutBreak* lb = new LayoutBreak(gscore);
       lb->setLayoutBreakType(LayoutBreak::Type::LINE);
-      PaletteCell* cell = sp->append(lb, tr("System break"));
+      PaletteCell* cell = sp->append(lb, QT_TRANSLATE_NOOP("Palette", "System break"));
       cell->mag = 1.2;
 
       lb = new LayoutBreak(gscore);
       lb->setLayoutBreakType(LayoutBreak::Type::PAGE);
-      cell = sp->append(lb, tr("Page break"));
+      cell = sp->append(lb, QT_TRANSLATE_NOOP("Palette", "Page break"));
       cell->mag = 1.2;
 
       lb = new LayoutBreak(gscore);
       lb->setLayoutBreakType(LayoutBreak::Type::SECTION);
-      cell = sp->append(lb, tr("Section break"));
+      cell = sp->append(lb, QT_TRANSLATE_NOOP("Palette", "Section break"));
       cell->mag = 1.2;
 
 #if 0
       lb = new LayoutBreak(gscore);
       lb->setLayoutBreakType(LayoutBreak::Type::NOBREAK);
-      cell = sp->append(lb, tr("Don't break"));
+      cell = sp->append(lb, QT_TRANSLATE_NOOP("Palette", "Don't break"));
       cell->mag = 1.2;
 #endif
 
       Spacer* spacer = new Spacer(gscore);
       spacer->setSpacerType(SpacerType::DOWN);
       spacer->setGap(3 * _spatium);
-      cell = sp->append(spacer, tr("Staff spacer down"));
+      cell = sp->append(spacer, QT_TRANSLATE_NOOP("Palette", "Staff spacer down"));
       cell->mag = .7;
 
       spacer = new Spacer(gscore);
       spacer->setSpacerType(SpacerType::UP);
       spacer->setGap(3 * _spatium);
-      cell = sp->append(spacer, tr("Staff spacer up"));
+      cell = sp->append(spacer, QT_TRANSLATE_NOOP("Palette", "Staff spacer up"));
       cell->mag = .7;
 
       spacer = new Spacer(gscore);
       spacer->setSpacerType(SpacerType::FIXED);
       spacer->setGap(3 * _spatium);
-      cell = sp->append(spacer, tr("Staff spacer fixed down"));
+      cell = sp->append(spacer, QT_TRANSLATE_NOOP("Palette", "Staff spacer fixed down"));
       cell->mag = .7;
 
       return sp;
@@ -1905,25 +1909,25 @@ PalettePanel* MuseScore::newFingeringPalettePanel()
       for (unsigned i = 0; i < strlen(finger); ++i) {
             Fingering* f = new Fingering(gscore);
             f->setXmlText(QString(finger[i]));
-            sp->append(f, tr("Fingering %1").arg(finger[i]));
+            sp->append(f, QT_TRANSLATE_NOOP("Palette", "Fingering %1"));
             }
       finger = "pimac";
       for (unsigned i = 0; i < strlen(finger); ++i) {
             Fingering* f = new Fingering(gscore, Tid::RH_GUITAR_FINGERING);
             f->setXmlText(QString(finger[i]));
-            sp->append(f, tr("RH Guitar Fingering %1").arg(finger[i]));
+            sp->append(f, QT_TRANSLATE_NOOP("Palette", "RH Guitar Fingering %1"));
             }
       finger = "012345T";
       for (unsigned i = 0; i < strlen(finger); ++i) {
             Fingering* f = new Fingering(gscore, Tid::LH_GUITAR_FINGERING);
             f->setXmlText(QString(finger[i]));
-            sp->append(f, tr("LH Guitar Fingering %1").arg(finger[i]));
+            sp->append(f, QT_TRANSLATE_NOOP("Palette", "LH Guitar Fingering %1"));
             }
       finger = "0123456";
       for (unsigned i = 0; i < strlen(finger); ++i) {
             Fingering* f = new Fingering(gscore, Tid::STRING_NUMBER);
             f->setXmlText(QString(finger[i]));
-            sp->append(f, tr("String number %1").arg(finger[i]));
+            sp->append(f, QT_TRANSLATE_NOOP("Palette", "String number %1"));
             }
 
       static const std::vector<SymId> lute {
@@ -1953,7 +1957,7 @@ PalettePanel* MuseScore::newTremoloPalettePanel()
       for (int i = int(TremoloType::R8); i <= int(TremoloType::C64); ++i) {
             Tremolo* tremolo = new Tremolo(gscore);
             tremolo->setTremoloType(TremoloType(i));
-            sp->append(tremolo, qApp->translate("Tremolo", tremolo->subtypeName().toUtf8().constData()));
+            sp->append(tremolo, tremolo->subtypeName());
             }
       return sp;
       }
@@ -2063,13 +2067,13 @@ PalettePanel* MuseScore::newArticulationsPalettePanel()
       bend->points().append(PitchValue(0,    0, false));
       bend->points().append(PitchValue(15, 100, false));
       bend->points().append(PitchValue(60, 100, false));
-      sp->append(bend, qApp->translate("articulation", "Bend"));
+      sp->append(bend, QT_TRANSLATE_NOOP("Palette", "Bend"));
 
       TremoloBar* tb = new TremoloBar(gscore);
       tb->points().append(PitchValue(0,     0, false));     // "Dip"
       tb->points().append(PitchValue(30, -100, false));
       tb->points().append(PitchValue(60,    0, false));
-      sp->append(tb, qApp->translate("articulation", "Tremolo bar"));
+      sp->append(tb, QT_TRANSLATE_NOOP("Palette", "Tremolo bar"));
 
       return sp;
       }
@@ -2215,7 +2219,7 @@ PalettePanel* MuseScore::newBracketsPalettePanel()
             BracketItem* bi1 = new BracketItem(gscore);
             bi1->setBracketType(t.first);
             b1->setBracketItem(bi1);
-            sp->append(b1, qApp->translate("Palette", t.second));      // Bracket, Brace, Square, Line
+            sp->append(b1, t.second);      // Bracket, Brace, Square, Line
             }
       return sp;
       }
@@ -2255,51 +2259,51 @@ PalettePanel* MuseScore::newArpeggioPalettePanel()
       for (int i = 0; i < 6; ++i) {
             Arpeggio* a = new Arpeggio(gscore);
             a->setArpeggioType(ArpeggioType(i));
-            sp->append(a, tr("Arpeggio"));
+            sp->append(a, QT_TRANSLATE_NOOP("Palette", "Arpeggio"));
             }
       for (int i = 0; i < 2; ++i) {
             Glissando* a = new Glissando(gscore);
             a->setGlissandoType(GlissandoType(i));
-            sp->append(a, tr("Glissando"));
+            sp->append(a, QT_TRANSLATE_NOOP("Palette", "Glissando"));
             }
 
       //fall and doits
 
       ChordLine* cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::FALL);
-      sp->append(cl, tr(scorelineNames[0]));
+      sp->append(cl, scorelineNames[0]);
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::DOIT);
-      sp->append(cl, tr(scorelineNames[1]));
+      sp->append(cl, scorelineNames[1]);
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::PLOP);
-      sp->append(cl, tr(scorelineNames[2]));
+      sp->append(cl, scorelineNames[2]);
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::SCOOP);
-      sp->append(cl, tr(scorelineNames[3]));
+      sp->append(cl, scorelineNames[3]);
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::FALL);
       cl->setStraight(true);
-      sp->append(cl, qApp->translate("articulation", "Slide out down"));
+      sp->append(cl, QT_TRANSLATE_NOOP("Ms", "Slide out down"));
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::DOIT);
       cl->setStraight(true);
-      sp->append(cl, qApp->translate("articulation", "Slide out up"));
+      sp->append(cl, QT_TRANSLATE_NOOP("Ms", "Slide out up"));
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::PLOP);
       cl->setStraight(true);
-      sp->append(cl, qApp->translate("articulation", "Slide in above"));
+      sp->append(cl, QT_TRANSLATE_NOOP("Ms", "Slide in above"));
 
       cl = new ChordLine(gscore);
       cl->setChordLineType(ChordLineType::SCOOP);
       cl->setStraight(true);
-      sp->append(cl, qApp->translate("articulation", "Slide in below"));
+      sp->append(cl, QT_TRANSLATE_NOOP("Ms", "Slide in below"));
 
       return sp;
       }
@@ -2346,7 +2350,7 @@ PalettePanel* MuseScore::newClefsPalettePanel(bool defaultPalettePanel)
       for (ClefType j : *items) {
             Clef* k = new Ms::Clef(gscore);
             k->setClefType(ClefTypeList(j, j));
-            sp->append(k, qApp->translate("clefTable", ClefInfo::name(j)));
+            sp->append(k, ClefInfo::name(j));
             }
       return sp;
       }
@@ -2390,7 +2394,7 @@ PalettePanel* MuseScore::newBagpipeEmbellishmentPalettePanel()
       for (int i = 0; i < BagpipeEmbellishment::nEmbellishments(); ++i) {
             BagpipeEmbellishment* b  = new BagpipeEmbellishment(gscore);
             b->setEmbelType(i);
-            sp->append(b, qApp->translate("bagpipe", BagpipeEmbellishment::BagpipeEmbellishmentList[i].name));
+            sp->append(b, BagpipeEmbellishment::BagpipeEmbellishmentList[i].name);
             }
 
       return sp;
@@ -2411,12 +2415,12 @@ PalettePanel* MuseScore::newLinesPalettePanel()
       qreal w = gscore->spatium() * 8;
 
       Slur* slur = new Slur(gscore);
-      sp->append(slur, qApp->translate("lines", "Slur"));
+      sp->append(slur, QT_TRANSLATE_NOOP("Palette", "Slur"));
 
       Hairpin* gabel0 = new Hairpin(gscore);
       gabel0->setHairpinType(HairpinType::CRESC_HAIRPIN);
       gabel0->setLen(w);
-      sp->append(gabel0, qApp->translate("lines", "Crescendo hairpin"));
+      sp->append(gabel0, QT_TRANSLATE_NOOP("Palette", "Crescendo hairpin"));
 
       Hairpin* gabel1 = new Hairpin(gscore);
       gabel1->setHairpinType(HairpinType::DECRESC_HAIRPIN);
@@ -2426,7 +2430,7 @@ PalettePanel* MuseScore::newLinesPalettePanel()
       Hairpin* gabel2 = new Hairpin(gscore);
       gabel2->setHairpinType(HairpinType::CRESC_LINE);
       gabel2->setLen(w);
-      sp->append(gabel2, qApp->translate("lines", "Crescendo line"));
+      sp->append(gabel2, QT_TRANSLATE_NOOP("Palette", "Crescendo line"));
 
       Hairpin* gabel3 = new Hairpin(gscore);
       gabel3->setHairpinType(HairpinType::DECRESC_LINE);
@@ -2440,7 +2444,7 @@ PalettePanel* MuseScore::newLinesPalettePanel()
       gabel4->setBeginTextAlign(Align::VCENTER);
       gabel4->setPropertyFlags(Pid::BEGIN_TEXT_ALIGN, PropertyFlags::UNSTYLED);
       gabel4->setLen(w);
-      sp->append(gabel4, qApp->translate("lines", "Dynamic + hairpin"));
+      sp->append(gabel4, QT_TRANSLATE_NOOP("Palette", "Dynamic + hairpin"));
 
       Volta* volta = new Volta(gscore);
       volta->setVoltaType(Volta::Type::CLOSED);
@@ -2560,7 +2564,7 @@ PalettePanel* MuseScore::newLinesPalettePanel()
             Trill* trill = new Trill(gscore);
             trill->setTrillType(trillTable[i].type);
             trill->setLen(w);
-            sp->append(trill, qApp->translate("trillType", trillTable[i].userName.toUtf8().constData()));
+            sp->append(trill, trillTable[i].userName);
             }
 
       TextLine* textLine = new TextLine(gscore);
@@ -2585,7 +2589,7 @@ PalettePanel* MuseScore::newLinesPalettePanel()
             Vibrato* vibrato = new Vibrato(gscore);
             vibrato->setVibratoType(vibratoTable[i].type);
             vibrato->setLen(w);
-            sp->append(vibrato, qApp->translate("vibratoType", vibratoTable[i].userName.toUtf8().constData()));
+            sp->append(vibrato, vibratoTable[i].userName);
             }
 
       PalmMute* pm = new PalmMute(gscore);
@@ -2646,15 +2650,15 @@ PalettePanel* MuseScore::newTempoPalettePanel(bool defaultPalettePanel)
             tt->setXmlText(tp.pattern);
             if (tp.relative) {
                   tt->setRelative(tp.f);
-                  sp->append(tt, tr("Metric modulation"), QString(), 1.5);
+                  sp->append(tt, QT_TRANSLATE_NOOP("Palette", "Metric modulation"), QString(), 1.5);
                   }
             else if (tp.italian) {
                   tt->setTempo(tp.f);
-                  sp->append(tt, tr("Tempo text"), QString(), 1.3);
+                  sp->append(tt, QT_TRANSLATE_NOOP("Palette", "Tempo text"), QString(), 1.3);
                   }
             else {
                   tt->setTempo(tp.f);
-                  sp->append(tt, tr("Tempo text"), QString(), 1.5);
+                  sp->append(tt, QT_TRANSLATE_NOOP("Palette", "Tempo text"), QString(), 1.5);
                   }
             }
       sp->setMoreElements(false);
@@ -2676,60 +2680,64 @@ PalettePanel* MuseScore::newTextPalettePanel(bool defaultPalettePanel)
       sp->setDrawGrid(true);
 
       StaffText* st = new StaffText(gscore);
-      st->setXmlText(tr("Staff Text"));
-      sp->append(st, tr("Staff text"));
+      st->setXmlText(QT_TRANSLATE_NOOP("Palette", "Staff Text"));
+      sp->append(st, QT_TRANSLATE_NOOP("Palette", "Staff text"))->setElementTranslated(true);
 
       st = new StaffText(gscore, Tid::EXPRESSION);
-      st->setXmlText(tr("Expression"));
+      st->setXmlText(QT_TRANSLATE_NOOP("Palette", "Expression"));
       st->setPlacement(Placement::BELOW);
       st->setPropertyFlags(Pid::PLACEMENT, PropertyFlags::UNSTYLED);
-      sp->append(st, tr("Expression text"));
+      sp->append(st, QT_TRANSLATE_NOOP("Palette", "Expression text"))->setElementTranslated(true);
 
       InstrumentChange* is = new InstrumentChange(gscore);
-      is->setXmlText(tr("Change Instr."));
-      sp->append(is, tr("Instrument change"));
+      is->setXmlText(QT_TRANSLATE_NOOP("Palette", "Change Instr."));
+      sp->append(is, QT_TRANSLATE_NOOP("Palette", "Instrument change"))->setElementTranslated(true);
 
       StaffTypeChange* stc = new StaffTypeChange(gscore);
-      sp->append(stc, tr("Staff type change"));
+      sp->append(stc, QT_TRANSLATE_NOOP("Palette", "Staff type change"));
 
       RehearsalMark* rhm = new RehearsalMark(gscore);
       rhm->setXmlText("B1");
-      sp->append(rhm, tr("Rehearsal mark"));
+      sp->append(rhm, QT_TRANSLATE_NOOP("Palette", "Rehearsal mark"));
 
       SystemText* stxt = new SystemText(gscore, Tid::TEMPO);
-      stxt->setXmlText(tr("Swing"));
+      stxt->setXmlText(QT_TRANSLATE_NOOP("Palette", "Swing"));
       stxt->setSwing(true);
-      sp->append(stxt, tr("Swing"));
+      sp->append(stxt, QT_TRANSLATE_NOOP("Palette", "Swing"))->setElementTranslated(true);
 
       stxt = new SystemText(gscore);
-      stxt->setXmlText(tr("System Text"));
-      sp->append(stxt, tr("System text"));
+      stxt->setXmlText(QT_TRANSLATE_NOOP("Palette", "System Text"));
+      sp->append(stxt, QT_TRANSLATE_NOOP("Palette", "System text"))->setElementTranslated(true);
 
       if (!defaultPalettePanel) {
             StaffText* pz = new StaffText(gscore);
-            pz->setXmlText(tr("pizz."));
+            pz->setXmlText(QT_TRANSLATE_NOOP("Palette", "pizz."));
             pz->setChannelName(0, "pizzicato");
-            sp->append(pz, tr("pizz."));
+            sp->append(pz, QT_TRANSLATE_NOOP("Palette", "Pizzicato"))->setElementTranslated(true);
 
             StaffText* ar = new StaffText(gscore);
-            ar->setXmlText(tr("arco"));
+            ar->setXmlText(QT_TRANSLATE_NOOP("Palette", "arco"));
             ar->setChannelName(0, "arco");
-            sp->append(ar, tr("arco"));
+            sp->append(ar, QT_TRANSLATE_NOOP("Palette", "Arco"))->setElementTranslated(true);
 
             StaffText* tm = new StaffText(gscore, Tid::EXPRESSION);
-            tm->setXmlText(tr("tremolo"));
+            tm->setXmlText(QT_TRANSLATE_NOOP("Palette", "tremolo"));
             tm->setChannelName(0, "tremolo");
-            sp->append(tm, tr("tremolo"));
+            sp->append(tm, QT_TRANSLATE_NOOP("Palette", "Tremolo"))->setElementTranslated(true);
 
             StaffText* mu = new StaffText(gscore);
-            mu->setXmlText(tr("mute"));
+            /*: For brass instruments: staff text that prescribes to use mute while playing, see https://en.wikipedia.org/wiki/Mute_(music) */
+            mu->setXmlText(QT_TRANSLATE_NOOP("Palette", "mute"));
             mu->setChannelName(0, "mute");
-            sp->append(mu, tr("mute"));
+            /*: For brass instruments: staff text that prescribes to use mute while playing, see https://en.wikipedia.org/wiki/Mute_(music) */
+            sp->append(mu, QT_TRANSLATE_NOOP("Palette", "Mute"))->setElementTranslated(true);
 
             StaffText* no = new StaffText(gscore);
-            no->setXmlText(tr("open"));
+            /*: For brass instruments: staff text that prescribes to play without mute, see https://en.wikipedia.org/wiki/Mute_(music) */
+            no->setXmlText(QT_TRANSLATE_NOOP("Palette", "open"));
             no->setChannelName(0, "open");
-            sp->append(no, tr("open"));
+            /*: For brass instruments: staff text that prescribes to play without mute, see https://en.wikipedia.org/wiki/Mute_(music) */
+            sp->append(no, QT_TRANSLATE_NOOP("Palette", "Open"))->setElementTranslated(true);
             }
 
       return sp;
@@ -2760,8 +2768,8 @@ PalettePanel* MuseScore::newTimePalettePanel()
             { 7,  8, TimeSigType::NORMAL, "7/8" },
             { 9,  8, TimeSigType::NORMAL, "9/8" },
             { 12, 8, TimeSigType::NORMAL, "12/8" },
-            { 4,  4, TimeSigType::FOUR_FOUR,  tr("4/4 common time") },
-            { 2,  2, TimeSigType::ALLA_BREVE, tr("2/2 alla breve") }
+            { 4,  4, TimeSigType::FOUR_FOUR,  QT_TRANSLATE_NOOP("Palette", "4/4 common time") },
+            { 2,  2, TimeSigType::ALLA_BREVE, QT_TRANSLATE_NOOP("Palette", "2/2 alla breve") }
             };
 
       PalettePanel* sp = new PalettePanel(PalettePanel::Type::TimeSig);

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -2012,6 +2012,9 @@ void MuseScore::retranslate()
 
       Shortcut::retranslate();
       Workspace::retranslate();
+
+      if (paletteWorkspace)
+          paletteWorkspace->retranslate();
       }
       
 //---------------------------------------------------------

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -755,7 +755,7 @@ void PaletteScrollArea::keyPressEvent(QKeyEvent* event)
                   p->setSelected(idx);
                   // set widget name to name of selected element
                   // we could set the description, but some screen readers ignore it
-                  QString name = qApp->translate("Palette", p->cellAt(idx)->name.toUtf8());
+                  QString name = p->cellAt(idx)->translatedName();
                   ScoreAccessibility::makeReadable(name);
                   setAccessibleName(name);
                   QAccessibleEvent aev(this, QAccessible::NameChanged);
@@ -1259,8 +1259,7 @@ bool Palette::event(QEvent* ev)
                   return false;
             if (cellAt(idx) == 0)
                   return false;
-            QToolTip::showText(he->globalPos(),
-               qApp->translate("Palette", cellAt(idx)->name.toUtf8()), this);
+            QToolTip::showText(he->globalPos(), cellAt(idx)->translatedName(), this);
             return false;
             }
       return QWidget::event(ev);

--- a/mscore/palette/palettemodel.cpp
+++ b/mscore/palette/palettemodel.cpp
@@ -251,9 +251,9 @@ QVariant PaletteTreeModel::data(const QModelIndex& index, int role) const
             switch (role) {
                   case Qt::DisplayRole: // TODO don't display cell names in palettes
                   case Qt::ToolTipRole:
-                        return qApp->translate("Palette", cell->name.toUtf8());
+                        return cell->translatedName();
                   case Qt::AccessibleTextRole: {
-                        QString name = qApp->translate("Palette", cell->name.toUtf8());
+                        QString name = cell->translatedName();
                         ScoreAccessibility::makeReadable(name);
                         return name;
                         }

--- a/mscore/palette/palettemodel.cpp
+++ b/mscore/palette/palettemodel.cpp
@@ -780,6 +780,15 @@ void PaletteTreeModel::updateCellsState(const Selection& sel, bool deactivateAll
       }
 
 //---------------------------------------------------------
+//   PaletteTreeModel::retranslate
+//---------------------------------------------------------
+
+void PaletteTreeModel::retranslate()
+      {
+      _paletteTree->retranslate();
+      }
+
+//---------------------------------------------------------
 //   PaletteTreeModel::findPaletteCell
 //---------------------------------------------------------
 

--- a/mscore/palette/palettemodel.h
+++ b/mscore/palette/palettemodel.h
@@ -163,6 +163,7 @@ class PaletteTreeModel : public QAbstractItemModel {
       PaletteCellPtr findCell(const QModelIndex& index);
 
       void updateCellsState(const Selection&, bool deactivateAll);
+      void retranslate();
       };
 
 //---------------------------------------------------------

--- a/mscore/palette/palettetree.cpp
+++ b/mscore/palette/palettetree.cpp
@@ -107,6 +107,43 @@ PaletteCell::PaletteCell(std::unique_ptr<Element> e, const QString& _name, QStri
       }
 
 //---------------------------------------------------------
+//   PaletteCell::translationContext
+//---------------------------------------------------------
+
+const char* PaletteCell::translationContext() const
+      {
+      const ElementType type = element ? element->type() : ElementType::INVALID;
+      switch (type) {
+            case ElementType::ARTICULATION:
+            case ElementType::FERMATA:
+                  return "symUserNames"; // libmscore/sym.cpp, Sym::symUserNames
+            case ElementType::CLEF:
+                  return "clefTable"; // libmscore/clef.cpp, ClefInfo::clefTable[]
+            case ElementType::KEYSIG:
+                  return "MuseScore"; // libmscore/keysig.cpp, keyNames[]
+            case ElementType::MARKER:
+                  return "markerType"; // libmscore/marker.cpp, markerTypeTable[]
+            case ElementType::JUMP:
+                  return "jumpType"; // libmscore/jump.cpp, jumpTypeTable[]
+            case ElementType::TREMOLO:
+                  return "Tremolo"; // libmscore/tremolo.cpp, tremoloName[]
+            case ElementType::BAGPIPE_EMBELLISHMENT:
+                  return "bagpipe"; // libmscore/bagpembell.cpp, BagpipeEmbellishment::BagpipeEmbellishmentList[]
+            case ElementType::TRILL:
+                  return "trillType"; // libmscore/trill.cpp, trillTable[]
+            case ElementType::VIBRATO:
+                  return "vibratoType"; // libmscore/vibrato.cpp, vibratoTable[]
+            case ElementType::CHORDLINE:
+                  return "Ms"; // libmscore/chordline.cpp, scorelineNames[]
+            case ElementType::ICON:
+                  return "action"; // mscore/shortcut.cpp, Shortcut::_sc[]
+            default:
+                  break;
+            }
+      return "Palette";
+      }
+
+//---------------------------------------------------------
 //   PaletteCell::write
 //---------------------------------------------------------
 

--- a/mscore/palette/palettetree.h
+++ b/mscore/palette/palettetree.h
@@ -35,6 +35,7 @@ using PaletteCellConstPtr = std::shared_ptr<const PaletteCell>;
 
 struct PaletteCell {
       std::unique_ptr<Element> element;
+      std::unique_ptr<Element> untranslatedElement;
       QString name;           // used for tool tip
       QString tag;
 
@@ -56,7 +57,10 @@ struct PaletteCell {
       static constexpr const char* mimeDataFormat = "application/musescore/palette/cell";
 
       const char* translationContext() const;
-      QString translatedName() const { return qApp->translate(translationContext(), name.toUtf8()); }
+      QString translatedName() const;
+
+      void retranslate();
+      void setElementTranslated(bool translate);
 
       void write(XmlWriter& xml) const;
       bool read(XmlReader&);
@@ -201,6 +205,8 @@ class PalettePanel {
 
       Type type() const { return _type; }
       void setType(Type t) { _type = t; }
+
+      void retranslate();
       };
 
 //---------------------------------------------------------
@@ -215,6 +221,8 @@ struct PaletteTree {
 
       void insert(int idx, PalettePanel*);
       void append(PalettePanel*);
+
+      void retranslate();
       };
 
 } // namespace Ms

--- a/mscore/palette/palettetree.h
+++ b/mscore/palette/palettetree.h
@@ -55,6 +55,9 @@ struct PaletteCell {
 
       static constexpr const char* mimeDataFormat = "application/musescore/palette/cell";
 
+      const char* translationContext() const;
+      QString translatedName() const { return qApp->translate(translationContext(), name.toUtf8()); }
+
       void write(XmlWriter& xml) const;
       bool read(XmlReader&);
       QByteArray mimeData() const;

--- a/mscore/palette/paletteworkspace.h
+++ b/mscore/palette/paletteworkspace.h
@@ -208,6 +208,7 @@ class PaletteWorkspace : public QObject {
       bool read(XmlReader&);
 
       void updateCellsState(const Selection& sel, bool deactivateAll) { userPalette->updateCellsState(sel, deactivateAll); }
+      void retranslate() { userPalette->retranslate(); masterPalette->retranslate(); defaultPalette->retranslate(); }
       };
 
 } // namespace Ms

--- a/share/workspaces/Advanced.xml
+++ b/share/workspaces/Advanced.xml
@@ -227,7 +227,7 @@
             <accidental>7</accidental>
             </KeySig>
           </Cell>
-        <Cell name="C♭ major / A♭ minor">
+        <Cell name="C♭ major, A♭ minor">
           <staff>1</staff>
           <KeySig>
             <accidental>-7</accidental>
@@ -1518,19 +1518,19 @@
         <mag>0.85</mag>
         <grid>1</grid>
         <moreElements>0</moreElements>
-        <Cell name="Staff text">
+        <Cell name="Staff text" trElement="1">
           <StaffText>
             <text>Staff Text</text>
             </StaffText>
           </Cell>
-        <Cell name="Expression text">
+        <Cell name="Expression text" trElement="1">
           <StaffText>
             <placement>below</placement>
             <style>Expression</style>
             <text>Expression</text>
             </StaffText>
           </Cell>
-        <Cell name="Instrument change">
+        <Cell name="Instrument change" trElement="1">
           <InstrumentChange>
             <Instrument>
               <trackName></trackName>
@@ -1550,52 +1550,47 @@
             <text>B1</text>
             </RehearsalMark>
           </Cell>
-        <Cell name="Swing">
+        <Cell name="Swing" trElement="1">
           <SystemText>
             <swing unit="eighth" ratio= "60"/>
             <style>Tempo</style>
             <text>Swing</text>
             </SystemText>
           </Cell>
-        <Cell name="System text">
+        <Cell name="System text" trElement="1">
           <SystemText>
             <placement>above</placement>
             <text>System Text</text>
             </SystemText>
           </Cell>
-        <Cell name="Pizzicato">
+        <Cell name="Pizzicato" trElement="1">
           <StaffText>
             <channelSwitch voice="0" name="pizzicato"/>
-            <track>0</track>
             <text>pizz.</text>
             </StaffText>
           </Cell>
-        <Cell name="Arco">
+        <Cell name="Arco" trElement="1">
           <StaffText>
             <channelSwitch voice="0" name="arco"/>
-            <track>0</track>
             <text>arco</text>
             </StaffText>
           </Cell>
-        <Cell name="Tremolo">
+        <Cell name="Tremolo" trElement="1">
           <StaffText>
             <channelSwitch voice="0" name="tremolo"/>
-            <track>0</track>
             <style>Expression</style>
             <text>tremolo</text>
             </StaffText>
           </Cell>
-        <Cell name="Mute">
+        <Cell name="Mute" trElement="1">
           <StaffText>
             <channelSwitch voice="0" name="mute"/>
-            <track>0</track>
             <text>mute</text>
             </StaffText>
           </Cell>
-        <Cell name="Open">
+        <Cell name="Open" trElement="1">
           <StaffText>
             <channelSwitch voice="0" name="open"/>
-            <track>0</track>
             <text>open</text>
             </StaffText>
           </Cell>
@@ -1927,145 +1922,145 @@
         <mag>1.5</mag>
         <grid>1</grid>
         <moreElements>0</moreElements>
-        <Cell name="Fingering 0">
+        <Cell name="Fingering &#37;1">
           <Fingering>
             <text>0</text>
             </Fingering>
           </Cell>
-        <Cell name="Fingering 1">
+        <Cell name="Fingering &#37;1">
           <Fingering>
             <text>1</text>
             </Fingering>
           </Cell>
-        <Cell name="Fingering 2">
+        <Cell name="Fingering &#37;1">
           <Fingering>
             <text>2</text>
             </Fingering>
           </Cell>
-        <Cell name="Fingering 3">
+        <Cell name="Fingering &#37;1">
           <Fingering>
             <text>3</text>
             </Fingering>
           </Cell>
-        <Cell name="Fingering 4">
+        <Cell name="Fingering &#37;1">
           <Fingering>
             <text>4</text>
             </Fingering>
           </Cell>
-        <Cell name="Fingering 5">
+        <Cell name="Fingering &#37;1">
           <Fingering>
             <text>5</text>
             </Fingering>
           </Cell>
-        <Cell name="RH Guitar Fingering p">
+        <Cell name="RH Guitar Fingering &#37;1">
           <Fingering>
             <style>RH Guitar Fingering</style>
             <text>p</text>
             </Fingering>
           </Cell>
-        <Cell name="RH Guitar Fingering i">
+        <Cell name="RH Guitar Fingering &#37;1">
           <Fingering>
             <style>RH Guitar Fingering</style>
             <text>i</text>
             </Fingering>
           </Cell>
-        <Cell name="RH Guitar Fingering m">
+        <Cell name="RH Guitar Fingering &#37;1">
           <Fingering>
             <style>RH Guitar Fingering</style>
             <text>m</text>
             </Fingering>
           </Cell>
-        <Cell name="RH Guitar Fingering a">
+        <Cell name="RH Guitar Fingering &#37;1">
           <Fingering>
             <style>RH Guitar Fingering</style>
             <text>a</text>
             </Fingering>
           </Cell>
-        <Cell name="RH Guitar Fingering c">
+        <Cell name="RH Guitar Fingering &#37;1">
           <Fingering>
             <style>RH Guitar Fingering</style>
             <text>c</text>
             </Fingering>
           </Cell>
-        <Cell name="LH Guitar Fingering 0">
+        <Cell name="LH Guitar Fingering &#37;1">
           <Fingering>
             <style>LH Guitar Fingering</style>
             <text>0</text>
             </Fingering>
           </Cell>
-        <Cell name="LH Guitar Fingering 1">
+        <Cell name="LH Guitar Fingering &#37;1">
           <Fingering>
             <style>LH Guitar Fingering</style>
             <text>1</text>
             </Fingering>
           </Cell>
-        <Cell name="LH Guitar Fingering 2">
+        <Cell name="LH Guitar Fingering &#37;1">
           <Fingering>
             <style>LH Guitar Fingering</style>
             <text>2</text>
             </Fingering>
           </Cell>
-        <Cell name="LH Guitar Fingering 3">
+        <Cell name="LH Guitar Fingering &#37;1">
           <Fingering>
             <style>LH Guitar Fingering</style>
             <text>3</text>
             </Fingering>
           </Cell>
-        <Cell name="LH Guitar Fingering 4">
+        <Cell name="LH Guitar Fingering &#37;1">
           <Fingering>
             <style>LH Guitar Fingering</style>
             <text>4</text>
             </Fingering>
           </Cell>
-        <Cell name="LH Guitar Fingering 5">
+        <Cell name="LH Guitar Fingering &#37;1">
           <Fingering>
             <style>LH Guitar Fingering</style>
             <text>5</text>
             </Fingering>
           </Cell>
-        <Cell name="LH Guitar Fingering T">
+        <Cell name="LH Guitar Fingering &#37;1">
           <Fingering>
             <style>LH Guitar Fingering</style>
             <text>T</text>
             </Fingering>
           </Cell>
-        <Cell name="String number 0">
+        <Cell name="String number &#37;1">
           <Fingering>
             <style>String Number</style>
             <text>0</text>
             </Fingering>
           </Cell>
-        <Cell name="String number 1">
+        <Cell name="String number &#37;1">
           <Fingering>
             <style>String Number</style>
             <text>1</text>
             </Fingering>
           </Cell>
-        <Cell name="String number 2">
+        <Cell name="String number &#37;1">
           <Fingering>
             <style>String Number</style>
             <text>2</text>
             </Fingering>
           </Cell>
-        <Cell name="String number 3">
+        <Cell name="String number &#37;1">
           <Fingering>
             <style>String Number</style>
             <text>3</text>
             </Fingering>
           </Cell>
-        <Cell name="String number 4">
+        <Cell name="String number &#37;1">
           <Fingering>
             <style>String Number</style>
             <text>4</text>
             </Fingering>
           </Cell>
-        <Cell name="String number 5">
+        <Cell name="String number &#37;1">
           <Fingering>
             <style>String Number</style>
             <text>5</text>
             </Fingering>
           </Cell>
-        <Cell name="String number 6">
+        <Cell name="String number &#37;1">
           <Fingering>
             <style>String Number</style>
             <text>6</text>

--- a/share/workspaces/Basic.xml
+++ b/share/workspaces/Basic.xml
@@ -87,7 +87,7 @@
             <accidental>7</accidental>
             </KeySig>
           </Cell>
-        <Cell name="C♭ major / A♭ minor">
+        <Cell name="C♭ major, A♭ minor">
           <staff>1</staff>
           <KeySig>
             <accidental>-7</accidental>
@@ -507,19 +507,19 @@
         <mag>0.85</mag>
         <grid>1</grid>
         <moreElements>0</moreElements>
-        <Cell name="Staff text">
+        <Cell name="Staff text" trElement="1">
           <StaffText>
             <text>Staff Text</text>
             </StaffText>
           </Cell>
-        <Cell name="Expression text">
+        <Cell name="Expression text" trElement="1">
           <StaffText>
             <placement>below</placement>
             <style>Expression</style>
             <text>Expression</text>
             </StaffText>
           </Cell>
-        <Cell name="Instrument change">
+        <Cell name="Instrument change" trElement="1">
           <InstrumentChange>
             <Instrument>
               <trackName></trackName>
@@ -539,44 +539,40 @@
             <text>B1</text>
             </RehearsalMark>
           </Cell>
-        <Cell name="Swing">
+        <Cell name="Swing" trElement="1">
           <SystemText>
             <swing unit="eighth" ratio= "60"/>
             <style>Tempo</style>
             <text>Swing</text>
             </SystemText>
           </Cell>
-        <Cell name="System text">
+        <Cell name="System text" trElement="1">
           <SystemText>
             <placement>above</placement>
             <text>System Text</text>
             </SystemText>
           </Cell>
-        <Cell name="Pizzicato">
+        <Cell name="Pizzicato" trElement="1">
           <StaffText>
             <channelSwitch voice="0" name="pizzicato"/>
-            <track>0</track>
             <text>pizz.</text>
             </StaffText>
           </Cell>
-        <Cell name="Arco">
+        <Cell name="Arco" trElement="1">
           <StaffText>
             <channelSwitch voice="0" name="arco"/>
-            <track>0</track>
             <text>arco</text>
             </StaffText>
           </Cell>
-        <Cell name="Mute">
+        <Cell name="Mute" trElement="1">
           <StaffText>
             <channelSwitch voice="0" name="mute"/>
-            <track>0</track>
             <text>mute</text>
             </StaffText>
           </Cell>
-        <Cell name="Open">
+        <Cell name="Open" trElement="1">
           <StaffText>
             <channelSwitch voice="0" name="open"/>
-            <track>0</track>
             <text>open</text>
             </StaffText>
           </Cell>


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/280540

Implements a more consistent approach for defining translation contexts for palette cells so palettes stored in `.workspace` files can also be translated. This includes also an ability to translate text inside text elements (mostly suitable for Text palette).

Merging this would cause a lot of new strings to appear for translations. In order to avoid this a conversion should be done for `.ts` files to move the currently translated string to appropriate contexts. This will be done separately of this PR.