### PR TITLE
fix #294542: Allow setting notehead scheme on a note-by-note basis in the Inspector

### DIFF
--- a/libmscore/mscore.h
+++ b/libmscore/mscore.h
@@ -179,19 +179,6 @@ enum class StaffGroup : char {
       };
 const int STAFF_GROUP_MAX = int(StaffGroup::TAB) + 1;      // out of enum to avoid compiler complains about not handled switch cases
 
-enum class NoteHeadScheme : char {
-      HEAD_NORMAL = 0,
-      HEAD_PITCHNAME,
-      HEAD_PITCHNAME_GERMAN,
-      HEAD_SOLFEGE,
-      HEAD_SOLFEGE_FIXED,
-      HEAD_SHAPE_NOTE_4,
-      HEAD_SHAPE_NOTE_7_AIKIN,
-      HEAD_SHAPE_NOTE_7_FUNK,
-      HEAD_SHAPE_NOTE_7_WALKER,
-      HEAD_SCHEMES
-      };
-
 //---------------------------------------------------------
 //   BarLineType
 //---------------------------------------------------------

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -215,6 +215,20 @@ struct NoteHeadName {
    const char* username;
 };
 
+// same order as NoteHead::Scheme
+static NoteHeadName noteHeadSchemeNames[] = {
+      {"auto",                QT_TRANSLATE_NOOP("noteheadschemes", "Auto") },
+      {"normal",              QT_TRANSLATE_NOOP("noteheadschemes", "Normal") },
+      {"name-pitch",          QT_TRANSLATE_NOOP("noteheadschemes", "Pitch Names") },
+      {"name-pitch-german",   QT_TRANSLATE_NOOP("noteheadschemes", "German Pitch Names") },
+      {"solfege-movable",     QT_TRANSLATE_NOOP("noteheadschemes", "Solf\u00e8ge Movable Do") }, // &egrave;
+      {"solfege-fixed",       QT_TRANSLATE_NOOP("noteheadschemes", "Solf\u00e8ge Fixed Do") },   // &egrave;
+      {"shape-4",             QT_TRANSLATE_NOOP("noteheadschemes", "4-shape (Walker)") },
+      {"shape-7-aikin",       QT_TRANSLATE_NOOP("noteheadschemes", "7-shape (Aikin)") },
+      {"shape-7-funk",        QT_TRANSLATE_NOOP("noteheadschemes", "7-shape (Funk)") },
+      {"shape-7-walker",      QT_TRANSLATE_NOOP("noteheadschemes", "7-shape (Walker)") }
+      };
+
 // same order as NoteHead::Group
 static NoteHeadName noteHeadGroupNames[] = {
       {"normal",         QT_TRANSLATE_NOOP("noteheadnames", "Normal") },
@@ -299,6 +313,15 @@ static NoteHeadName noteHeadTypeNames[] = {
       };
 
 //---------------------------------------------------------
+//   scheme2userName
+//---------------------------------------------------------
+
+QString NoteHead::scheme2userName(NoteHead::Scheme scheme)
+      {
+      return qApp->translate("noteheadschemes", noteHeadSchemeNames[int(scheme) + 1].username);
+      }
+
+//---------------------------------------------------------
 //   group2userName
 //---------------------------------------------------------
 
@@ -314,6 +337,15 @@ QString NoteHead::group2userName(NoteHead::Group group)
 QString NoteHead::type2userName(NoteHead::Type type)
       {
       return qApp->translate("noteheadnames", noteHeadTypeNames[int(type) + 1].username);
+      }
+
+//---------------------------------------------------------
+//   scheme2name
+//---------------------------------------------------------
+
+QString NoteHead::scheme2name(NoteHead::Scheme scheme)
+      {
+      return noteHeadSchemeNames[int(scheme) + 1].name;
       }
 
 //---------------------------------------------------------
@@ -335,10 +367,23 @@ QString NoteHead::type2name(NoteHead::Type type)
       }
 
 //---------------------------------------------------------
+//   name2scheme
+//---------------------------------------------------------
+
+NoteHead::Scheme NoteHead::name2scheme(const QString& s)
+      {
+      for (int i = 0; i <= int(NoteHead::Scheme::HEAD_SCHEMES); ++i) {
+            if (noteHeadSchemeNames[i].name == s)
+                  return NoteHead::Scheme(i - 1);
+            }
+      return NoteHead::Scheme::HEAD_NORMAL;
+      }
+
+//---------------------------------------------------------
 //   name2group
 //---------------------------------------------------------
 
-NoteHead::Group NoteHead::name2group(QString s)
+NoteHead::Group NoteHead::name2group(const QString& s)
       {
       for (int i = 0; i < int(NoteHead::Group::HEAD_GROUPS); ++i) {
             if (noteHeadGroupNames[i].name == s)
@@ -351,7 +396,7 @@ NoteHead::Group NoteHead::name2group(QString s)
 //   name2type
 //---------------------------------------------------------
 
-NoteHead::Type NoteHead::name2type(QString s)
+NoteHead::Type NoteHead::name2type(const QString& s)
       {
       for (int i = 0; i <= int(NoteHead::Type::HEAD_TYPES); ++i) {
             if (noteHeadTypeNames[i].name == s)
@@ -369,17 +414,17 @@ SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t)
       return noteHeads[direction][int(group)][int(t)];
       }
 
-SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, int tpc, Key key, NoteHeadScheme scheme)
+SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, int tpc, Key key, NoteHead::Scheme scheme)
       {
       // shortcut
-      if (scheme == NoteHeadScheme::HEAD_NORMAL)
+      if (scheme == NoteHead::Scheme::HEAD_NORMAL)
             return noteHeads[direction][int(group)][int(t)];
       // other schemes
-      if (scheme == NoteHeadScheme::HEAD_PITCHNAME || scheme == NoteHeadScheme::HEAD_PITCHNAME_GERMAN) {
+      if (scheme == NoteHead::Scheme::HEAD_PITCHNAME || scheme == NoteHead::Scheme::HEAD_PITCHNAME_GERMAN) {
             if (tpc == Tpc::TPC_A)
                   group = NoteHead::Group::HEAD_A;
             else if (tpc == Tpc::TPC_B) {
-                  if (scheme == NoteHeadScheme::HEAD_PITCHNAME_GERMAN)
+                  if (scheme == NoteHead::Scheme::HEAD_PITCHNAME_GERMAN)
                         group = NoteHead::Group::HEAD_H;
                   else
                         group = NoteHead::Group::HEAD_B;
@@ -397,7 +442,7 @@ SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, int
             else if (tpc == Tpc::TPC_A_S)
                   group = NoteHead::Group::HEAD_A_SHARP;
             else if (tpc == Tpc::TPC_B_S)
-                  if (scheme == NoteHeadScheme::HEAD_PITCHNAME_GERMAN)
+                  if (scheme == NoteHead::Scheme::HEAD_PITCHNAME_GERMAN)
                         group = NoteHead::Group::HEAD_H_SHARP;
                   else
                         group = NoteHead::Group::HEAD_B_SHARP;
@@ -414,7 +459,7 @@ SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, int
             else if (tpc == Tpc::TPC_A_B)
                   group = NoteHead::Group::HEAD_A_FLAT;
             else if (tpc == Tpc::TPC_B_B)
-                  if (scheme == NoteHeadScheme::HEAD_PITCHNAME_GERMAN)
+                  if (scheme == NoteHead::Scheme::HEAD_PITCHNAME_GERMAN)
                         group = NoteHead::Group::HEAD_B;
                   else
                         group = NoteHead::Group::HEAD_B_FLAT;
@@ -429,7 +474,7 @@ SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, int
             else if (tpc == Tpc::TPC_G_B)
                   group = NoteHead::Group::HEAD_G_FLAT;
             }
-      else if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_4) {
+      else if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_4) {
             int degree = tpc2degree(tpc, key);
             switch (degree) {
                   case 0:
@@ -445,25 +490,25 @@ SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, int
                         group = NoteHead::Group::HEAD_MI; break;
                   }
             }
-      else if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_AIKIN
-         || scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_FUNK
-         || scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_WALKER) {
+      else if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_AIKIN
+         || scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_FUNK
+         || scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_WALKER) {
             int degree = tpc2degree(tpc, key);
             switch (degree) {
                   case 0:
-                        if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_AIKIN)
+                        if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_AIKIN)
                               group = NoteHead::Group::HEAD_DO;
-                        else if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_FUNK)
+                        else if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_FUNK)
                               group = NoteHead::Group::HEAD_DO_FUNK;
-                        else if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_WALKER)
+                        else if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_WALKER)
                               group = NoteHead::Group::HEAD_DO_WALKER;
                         break;
                   case 1:
-                        if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_AIKIN)
+                        if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_AIKIN)
                               group = NoteHead::Group::HEAD_RE;
-                        else if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_FUNK)
+                        else if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_FUNK)
                               group = NoteHead::Group::HEAD_RE_FUNK;
-                        else if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_WALKER)
+                        else if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_WALKER)
                               group = NoteHead::Group::HEAD_RE_WALKER;
                         break;
                   case 2:
@@ -475,16 +520,16 @@ SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, int
                   case 5:
                         group = NoteHead::Group::HEAD_LA; break;
                   case 6:
-                        if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_AIKIN)
+                        if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_AIKIN)
                               group = NoteHead::Group::HEAD_TI;
-                        else if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_FUNK)
+                        else if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_FUNK)
                               group = NoteHead::Group::HEAD_TI_FUNK;
-                        else if (scheme == NoteHeadScheme::HEAD_SHAPE_NOTE_7_WALKER)
+                        else if (scheme == NoteHead::Scheme::HEAD_SHAPE_NOTE_7_WALKER)
                               group = NoteHead::Group::HEAD_TI_WALKER;
                         break;
                   }
             }
-      else if (scheme == NoteHeadScheme::HEAD_SOLFEGE) {
+      else if (scheme == NoteHead::Scheme::HEAD_SOLFEGE) {
             int degree = tpc2degree(tpc, key);
             switch (degree) {
                   case 0:
@@ -503,7 +548,7 @@ SymId Note::noteHead(int direction, NoteHead::Group group, NoteHead::Type t, int
                         group = NoteHead::Group::HEAD_TI_NAME; break;
                   }
             }
-      else if (scheme == NoteHeadScheme::HEAD_SOLFEGE_FIXED) {
+      else if (scheme == NoteHead::Scheme::HEAD_SOLFEGE_FIXED) {
             QString stepName = tpc2stepName(tpc);
             if (stepName == "C")
                   group = NoteHead::Group::HEAD_DO_NAME;
@@ -582,6 +627,7 @@ Note::Note(const Note& n, bool link)
       _tuning            = n._tuning;
       _veloType          = n._veloType;
       _veloOffset        = n._veloOffset;
+      _headScheme        = n._headScheme;
       _headGroup         = n._headGroup;
       _headType          = n._headType;
       _mirror            = n._mirror;
@@ -822,14 +868,17 @@ SymId Note::noteHead() const
             }
 
       Key key = Key::C;
-      NoteHeadScheme scheme = NoteHeadScheme::HEAD_NORMAL;
+      NoteHead::Scheme scheme = _headScheme;
       if (st) {
             Fraction tick = chord()->tick();
             if (tick >= Fraction(0,1)) {
                   key    = st->key(tick);
-                  scheme = st->staffTypeForElement(chord())->noteHeadScheme();
+                  if (scheme == NoteHead::Scheme::HEAD_AUTO)
+                        scheme = st->staffTypeForElement(chord())->noteHeadScheme();
                   }
             }
+      if (scheme == NoteHead::Scheme::HEAD_AUTO)
+            scheme = NoteHead::Scheme::HEAD_NORMAL;
       SymId t = noteHead(up, _headGroup, ht, tpc(), key, scheme);
       if (t == SymId::noSym) {
             qDebug("invalid notehead %d/%d", int(_headGroup), int(ht));
@@ -1093,8 +1142,11 @@ bool Note::isNoteName() const
       {
       if (chord() && chord()->staff()) {
             const Staff* st = staff();
-            NoteHeadScheme s = st->staffTypeForElement(this)->noteHeadScheme();
-            return s == NoteHeadScheme::HEAD_PITCHNAME || s == NoteHeadScheme::HEAD_PITCHNAME_GERMAN || s == NoteHeadScheme::HEAD_SOLFEGE || s == NoteHeadScheme::HEAD_SOLFEGE_FIXED;
+            NoteHead::Scheme s = _headScheme;
+            if (s == NoteHead::Scheme::HEAD_AUTO)
+                  s = st->staffTypeForElement(this)->noteHeadScheme();
+            return s == NoteHead::Scheme::HEAD_PITCHNAME || s == NoteHead::Scheme::HEAD_PITCHNAME_GERMAN || s == NoteHead::Scheme::HEAD_SOLFEGE || s == NoteHead::Scheme::HEAD_SOLFEGE_FIXED;
+
             }
       return false;
       }
@@ -1209,7 +1261,7 @@ void Note::write(XmlWriter& xml) const
             xml.etag();
             }
       for (Pid id : { Pid::PITCH, Pid::TPC1, Pid::TPC2, Pid::SMALL, Pid::MIRROR_HEAD, Pid::DOT_POSITION,
-         Pid::HEAD_GROUP, Pid::VELO_OFFSET, Pid::PLAY, Pid::TUNING, Pid::FRET, Pid::STRING,
+         Pid::HEAD_SCHEME, Pid::HEAD_GROUP, Pid::VELO_OFFSET, Pid::PLAY, Pid::TUNING, Pid::FRET, Pid::STRING,
          Pid::GHOST, Pid::HEAD_TYPE, Pid::VELO_TYPE, Pid::FIXED, Pid::FIXED_LINE
             }) {
             writeProperty(xml, id);
@@ -1339,6 +1391,8 @@ bool Note::readProperties(XmlReader& e)
             setFixed(e.readBool());
       else if (tag == "fixedLine")
             setFixedLine(e.readInt());
+      else if (tag == "headScheme")
+            readProperty(e, Pid::HEAD_SCHEME);
       else if (tag == "head")
             readProperty(e, Pid::HEAD_GROUP);
       else if (tag == "velocity")
@@ -2253,6 +2307,18 @@ void Note::setString(int val)
       }
 
 //---------------------------------------------------------
+//   setHeadScheme
+//---------------------------------------------------------
+
+void Note::setHeadScheme(NoteHead::Scheme val)
+      {
+      IF_ASSERT_FAILED(int(val) >= -1 && int(val) < int(NoteHead::Scheme::HEAD_SCHEMES)) {
+            val = NoteHead::Scheme::HEAD_AUTO;
+            }
+      _headScheme = val;
+      }
+
+//---------------------------------------------------------
 //   setHeadGroup
 //---------------------------------------------------------
 
@@ -2654,6 +2720,8 @@ QVariant Note::getProperty(Pid propertyId) const
                   return int(userMirror());
             case Pid::DOT_POSITION:
                   return QVariant::fromValue<Direction>(userDotPosition());
+            case Pid::HEAD_SCHEME:
+                  return int(headScheme());
             case Pid::HEAD_GROUP:
                   return int(headGroup());
             case Pid::VELO_OFFSET:
@@ -2715,6 +2783,9 @@ bool Note::setProperty(Pid propertyId, const QVariant& v)
                   setUserDotPosition(v.value<Direction>());
                   triggerLayout();
                   return true;
+            case Pid::HEAD_SCHEME:
+                  setHeadScheme(NoteHead::Scheme(v.toInt()));
+                  break;
             case Pid::HEAD_GROUP:
                   setHeadGroup(NoteHead::Group(v.toInt()));
                   break;
@@ -2791,6 +2862,8 @@ QVariant Note::propertyDefault(Pid propertyId) const
                   return int(MScore::DirectionH::AUTO);
             case Pid::DOT_POSITION:
                   return QVariant::fromValue<Direction>(Direction::AUTO);
+            case Pid::HEAD_SCHEME:
+                  return int(NoteHead::Scheme::HEAD_AUTO);
             case Pid::HEAD_GROUP:
                   return int(NoteHead::Group::HEAD_NORMAL);
             case Pid::VELO_OFFSET:

--- a/libmscore/note.h
+++ b/libmscore/note.h
@@ -53,6 +53,23 @@ static const int MAX_DOTS = 4;
 class NoteHead final : public Symbol {
       Q_GADGET
    public:
+      // keep in sync with noteHeadSchemeNames array in note.cpp
+      enum class Scheme : signed char {
+            ///.\{
+            HEAD_AUTO = -1,
+            HEAD_NORMAL,
+            HEAD_PITCHNAME,
+            HEAD_PITCHNAME_GERMAN,
+            HEAD_SOLFEGE,
+            HEAD_SOLFEGE_FIXED,
+            HEAD_SHAPE_NOTE_4,
+            HEAD_SHAPE_NOTE_7_AIKIN,
+            HEAD_SHAPE_NOTE_7_FUNK,
+            HEAD_SHAPE_NOTE_7_WALKER,
+            HEAD_SCHEMES
+            ///\}
+            };
+      // keep in sync with noteHeadGroupNames array in note.cpp
       enum class Group : signed char {
             ///.\{
             HEAD_NORMAL = 0,
@@ -126,6 +143,7 @@ class NoteHead final : public Symbol {
             HEAD_INVALID = -1
             ///\}
             };
+      // keep in sync with noteHeadTypeNames array in note.cpp
       enum class Type : signed char {
             ///.\{
             HEAD_AUTO    = -1,
@@ -137,6 +155,7 @@ class NoteHead final : public Symbol {
             ///\}
             };
 
+      Q_ENUM(Scheme);
       Q_ENUM(Group);
       Q_ENUM(Type);
 
@@ -147,12 +166,15 @@ class NoteHead final : public Symbol {
 
       Group headGroup() const;
 
+      static QString scheme2userName(Scheme scheme);
       static QString group2userName(Group group);
       static QString type2userName(Type type);
+      static QString scheme2name(Scheme scheme);
       static QString group2name(Group group);
       static QString type2name(Type type);
-      static Group name2group(QString s);
-      static Type name2type(QString s);
+      static Scheme name2scheme(const QString& s);
+      static Group name2group(const QString& s);
+      static Type name2type(const QString& s);
       };
 
 //---------------------------------------------------------
@@ -186,8 +208,9 @@ static const int INVALID_LINE = -10000;
 //   @P elements         array[Element]   list of elements attached to notehead
 //   @P fret             int              fret number in tablature
 //   @P ghost            bool             ghost note (guitar: death note)
-//   @P headGroup        enum (NoteHead.HEAD_NORMAL, .HEAD_BREVIS_ALT, .HEAD_CROSS, .HEAD_DIAMOND, .HEAD_DO, .HEAD_FA, .HEAD_LA, .HEAD_MI, .HEAD_RE, .HEAD_SLASH, .HEAD_SOL, .HEAD_TI, .HEAD_XCIRCLE, .HEAD_TRIANGLE)
-//   @P headType         enum (NoteHead.HEAD_AUTO, .HEAD_BREVIS, .HEAD_HALF, .HEAD_QUARTER, .HEAD_WHOLE)
+//   @P headScheme       enum (NoteHeadScheme.HEAD_AUTO, .HEAD_NORMAL, .HEAD_PITCHNAME, .HEAD_PITCHNAME_GERMAN, .HEAD_SHAPE_NOTE_4, .HEAD_SHAPE_NOTE_7_AIKIN, .HEAD_SHAPE_NOTE_7_FUNK, .HEAD_SHAPE_NOTE_7_WALKER, .HEAD_SOLFEGE, .HEAD_SOLFEGE_FIXED)
+//   @P headGroup        enum (NoteHeadGroup.HEAD_NORMAL, .HEAD_BREVIS_ALT, .HEAD_CROSS, .HEAD_DIAMOND, .HEAD_DO, .HEAD_FA, .HEAD_LA, .HEAD_MI, .HEAD_RE, .HEAD_SLASH, .HEAD_SOL, .HEAD_TI, .HEAD_XCIRCLE, .HEAD_TRIANGLE)
+//   @P headType         enum (NoteHeadType.HEAD_AUTO, .HEAD_BREVIS, .HEAD_HALF, .HEAD_QUARTER, .HEAD_WHOLE)
 //   @P hidden           bool             hidden, not played note (read only)
 //   @P line             int              notehead position (read only)
 //   @P mirror           bool             mirror notehead on x axis (read only)
@@ -234,6 +257,7 @@ class Note final : public Element {
       MScore::DirectionH _userMirror { MScore::DirectionH::AUTO };      ///< user override of mirror
       Direction _userDotPosition     { Direction::AUTO };               ///< user override of dot position
 
+      NoteHead::Scheme _headScheme { NoteHead::Scheme::HEAD_AUTO };
       NoteHead::Group _headGroup { NoteHead::Group::HEAD_NORMAL };
       NoteHead::Type  _headType  { NoteHead::Type::HEAD_AUTO    };
 
@@ -319,8 +343,10 @@ class Note final : public Element {
       qreal bboxRightPos() const;
       qreal headBodyWidth() const;
 
+      NoteHead::Scheme headScheme() const { return _headScheme; }
       NoteHead::Group headGroup() const   { return _headGroup; }
       NoteHead::Type headType() const     { return _headType;  }
+      void setHeadScheme(NoteHead::Scheme val);
       void setHeadGroup(NoteHead::Group val);
       void setHeadType(NoteHead::Type t);
 
@@ -478,7 +504,7 @@ class Note final : public Element {
 
       void addParentheses();
 
-      static SymId noteHead(int direction, NoteHead::Group, NoteHead::Type, int tpc, Key key, NoteHeadScheme scheme);
+      static SymId noteHead(int direction, NoteHead::Group, NoteHead::Type, int tpc, Key key, NoteHead::Scheme scheme);
       static SymId noteHead(int direction, NoteHead::Group, NoteHead::Type);
       NoteVal noteVal() const;
 

--- a/libmscore/property.cpp
+++ b/libmscore/property.cpp
@@ -253,7 +253,7 @@ static constexpr PropertyMetaData propertyList[] = {
       { Pid::STAFF_SHOW_LEDGERLINES,  false, "",                      P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "showing ledgerlines") },
       { Pid::STAFF_STEMLESS,          false, "",                      P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "stemless")         },
 
-      { Pid::STAFF_NOTEHEAD_SCHEME,   false, "",                      P_TYPE::INT,                 DUMMY_QT_TRANSLATE_NOOP("propertyName", "notehead scheme")  },
+      { Pid::HEAD_SCHEME,             false, "headScheme",            P_TYPE::HEAD_SCHEME,         DUMMY_QT_TRANSLATE_NOOP("propertyName", "notehead scheme")  },
       { Pid::STAFF_GEN_CLEF,          false, "",                      P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "generating clefs") },
       { Pid::STAFF_GEN_TIMESIG,       false, "",                      P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "generating time signature") },
       { Pid::STAFF_GEN_KEYSIG,        false, "",                      P_TYPE::BOOL,                DUMMY_QT_TRANSLATE_NOOP("propertyName", "generating key signature")  },
@@ -532,6 +532,8 @@ QVariant propertyFromString(Pid id, QString value)
                   return QVariant();
             case P_TYPE::SYMID:
                   return QVariant::fromValue(Sym::name2id(value));
+            case P_TYPE::HEAD_SCHEME:
+                  return QVariant::fromValue(NoteHead::name2scheme(value));
             case P_TYPE::HEAD_GROUP:
                   return QVariant::fromValue(NoteHead::name2group(value));
             case P_TYPE::HEAD_TYPE:
@@ -621,6 +623,7 @@ QVariant readProperty(Pid id, XmlReader& e)
             case P_TYPE::TEXT_PLACE:
             case P_TYPE::BARLINE_TYPE:
             case P_TYPE::SYMID:
+            case P_TYPE::HEAD_SCHEME:
             case P_TYPE::HEAD_GROUP:
             case P_TYPE::HEAD_TYPE:
             case P_TYPE::SUB_STYLE:
@@ -788,6 +791,8 @@ QString propertyToString(Pid id, QVariant value, bool mscx)
                   return Sym::id2name(SymId(value.toInt()));
             case P_TYPE::BARLINE_TYPE:
                   return BarLine::barLineTypeName(BarLineType(value.toInt()));
+            case P_TYPE::HEAD_SCHEME:
+                  return NoteHead::scheme2name(NoteHead::Scheme(value.toInt()));
             case P_TYPE::HEAD_GROUP:
                   return NoteHead::group2name(NoteHead::Group(value.toInt()));
             case P_TYPE::HEAD_TYPE:

--- a/libmscore/property.h
+++ b/libmscore/property.h
@@ -263,7 +263,7 @@ enum class Pid {
       STAFF_SHOW_LEDGERLINES,
       STAFF_STEMLESS,
 
-      STAFF_NOTEHEAD_SCHEME,
+      HEAD_SCHEME,
       STAFF_GEN_CLEF,
       STAFF_GEN_TIMESIG,
       STAFF_GEN_KEYSIG,
@@ -400,6 +400,7 @@ enum class P_TYPE : char {
       KEYMODE,          // enum class KeyMode
 
       PATH,             // QPainterPath
+      HEAD_SCHEME,      // enum class NoteHead::Scheme
       };
 
 extern QVariant readProperty(Pid type, XmlReader& e);

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -221,7 +221,7 @@ void StaffType::write(XmlWriter& xml) const
       if (!_genTimesig)
             xml.tag("timesig", _genTimesig);
       if (_group == StaffGroup::STANDARD) {
-            xml.tag("noteheadScheme", StaffType::scheme2name(_noteHeadScheme), StaffType::scheme2name(NoteHeadScheme::HEAD_NORMAL));
+            xml.tag("noteheadScheme", NoteHead::scheme2name(_noteHeadScheme), NoteHead::scheme2name(NoteHead::Scheme::HEAD_NORMAL));
             }
       if (_group == StaffGroup::STANDARD || _group == StaffGroup::PERCUSSION) {
             if (!_genKeysig)
@@ -305,7 +305,7 @@ void StaffType::read(XmlReader& e)
             else if (tag == "timesig")
                   setGenTimesig(e.readInt());
             else if (tag == "noteheadScheme")
-                  setNoteHeadScheme(StaffType::name2scheme(e.readElementText()));
+                  setNoteHeadScheme(NoteHead::name2scheme(e.readElementText()));
             else if (tag == "keysig")
                   _genKeysig = e.readInt();
             else if (tag == "ledgerlines")
@@ -1314,46 +1314,6 @@ const StaffType* StaffType::getDefaultPreset(StaffGroup grp)
       {
       int _idx = _defaultPreset[int(grp)];
       return &_presets[_idx];
-      }
-
-//---------------------------------------------------------
-//   NoteHeadScheme utils
-//---------------------------------------------------------
-
-struct NoteHeadSchemeName {
-      const char* name;
-      const char* username;
-      };
-
-static NoteHeadSchemeName noteHeadSchemeNames[] = {
-      {"normal",              QT_TRANSLATE_NOOP("noteheadschemes", "Normal") },
-      {"name-pitch",          QT_TRANSLATE_NOOP("noteheadschemes", "Pitch Names") },
-      {"name-pitch-german",   QT_TRANSLATE_NOOP("noteheadschemes", "German Pitch Names") },
-      {"solfege-movable",     QT_TRANSLATE_NOOP("noteheadschemes", "Solf\u00e8ge Movable Do") }, // &egrave;
-      {"solfege-fixed",       QT_TRANSLATE_NOOP("noteheadschemes", "Solf\u00e8ge Fixed Do") },   // &egrave;
-      {"shape-4",             QT_TRANSLATE_NOOP("noteheadschemes", "4-shape (Walker)") },
-      {"shape-7-aikin",       QT_TRANSLATE_NOOP("noteheadschemes", "7-shape (Aikin)") },
-      {"shape-7-funk",        QT_TRANSLATE_NOOP("noteheadschemes", "7-shape (Funk)") },
-      {"shape-7-walker",      QT_TRANSLATE_NOOP("noteheadschemes", "7-shape (Walker)") }
-      };
-
-QString StaffType::scheme2userName(NoteHeadScheme ns)
-      {
-      return qApp->translate("noteheadschemes", noteHeadSchemeNames[int(ns)].username);
-      }
-
-QString StaffType::scheme2name(NoteHeadScheme ns)
-      {
-      return noteHeadSchemeNames[int(ns)].name;
-      }
-
-NoteHeadScheme StaffType::name2scheme(QString name)
-      {
-      for (int i = 0; i < int(NoteHeadScheme::HEAD_SCHEMES); ++i) {
-            if (noteHeadSchemeNames[i].name == name)
-                  return NoteHeadScheme(i);
-            }
-      return NoteHeadScheme::HEAD_NORMAL;
       }
 
 //---------------------------------------------------------

--- a/libmscore/stafftype.h
+++ b/libmscore/stafftype.h
@@ -17,6 +17,7 @@
 #include "spatium.h"
 #include "mscore.h"
 #include "durationtype.h"
+#include "note.h"
 
 namespace Ms {
 
@@ -194,7 +195,7 @@ class StaffType {
       bool _genKeysig       = true;       // create key signature at beginning of system
 
       // Standard: configurable properties
-      NoteHeadScheme _noteHeadScheme = NoteHeadScheme::HEAD_NORMAL;
+      NoteHead::Scheme _noteHeadScheme = NoteHead::Scheme::HEAD_NORMAL;
 
       // TAB: configurable properties
       qreal _durationFontSize = 15.0;     // the size (in points) for the duration symbol font
@@ -316,8 +317,8 @@ class StaffType {
       bool genKeysig() const                   { return _genKeysig;         }
       void setShowLedgerLines(bool val)        { _showLedgerLines = val;    }
       bool showLedgerLines() const             { return _showLedgerLines;   }
-      void setNoteHeadScheme(NoteHeadScheme s) { _noteHeadScheme = s;       }
-      NoteHeadScheme noteHeadScheme() const    { return _noteHeadScheme;    }
+      void setNoteHeadScheme(NoteHead::Scheme s) { _noteHeadScheme = s;     }
+      NoteHead::Scheme noteHeadScheme() const    { return _noteHeadScheme;  }
 
       QString fretString(int fret, int string, bool ghost) const;   // returns a string with the text for fret
       QString durationString(TDuration::DurationType type, int dots) const;
@@ -400,9 +401,6 @@ class StaffType {
 
       static void initStaffTypes();
       static const std::vector<StaffType>& presets() { return _presets; }
-      static QString scheme2userName(NoteHeadScheme ns);
-      static QString scheme2name(NoteHeadScheme ns);
-      static NoteHeadScheme name2scheme(QString name);
       };
 
 //---------------------------------------------------------

--- a/libmscore/stafftypechange.cpp
+++ b/libmscore/stafftypechange.cpp
@@ -132,7 +132,7 @@ QVariant StaffTypeChange::getProperty(Pid propertyId) const
                   return _staffType->showLedgerLines();
             case Pid::STAFF_STEMLESS:
                   return _staffType->stemless();
-            case Pid::STAFF_NOTEHEAD_SCHEME:
+            case Pid::HEAD_SCHEME:
                   return int(_staffType->noteHeadScheme());
             case Pid::STAFF_GEN_CLEF:
                   return _staffType->genClef();
@@ -176,8 +176,8 @@ bool StaffTypeChange::setProperty(Pid propertyId, const QVariant& v)
             case Pid::STAFF_STEMLESS:
                   _staffType->setStemless(v.toBool());
                   break;
-            case Pid::STAFF_NOTEHEAD_SCHEME:
-                  _staffType->setNoteHeadScheme(NoteHeadScheme(v.toInt()));
+            case Pid::HEAD_SCHEME:
+                  _staffType->setNoteHeadScheme(NoteHead::Scheme(v.toInt()));
                   break;
             case Pid::STAFF_GEN_CLEF:
                   _staffType->setGenClef(v.toBool());
@@ -236,8 +236,8 @@ QVariant StaffTypeChange::propertyDefault(Pid id) const
                   return true;
             case Pid::STAFF_STEMLESS:
                   return false;
-            case Pid::STAFF_NOTEHEAD_SCHEME:
-                  return int(NoteHeadScheme::HEAD_NORMAL);
+            case Pid::HEAD_SCHEME:
+                  return int(NoteHead::Scheme::HEAD_NORMAL);
             case Pid::STAFF_GEN_CLEF:
                   return true;
             case Pid::STAFF_GEN_TIMESIG:

--- a/mscore/editstafftype.cpp
+++ b/mscore/editstafftype.cpp
@@ -34,16 +34,16 @@ const char* g_groupNames[STAFF_GROUP_MAX] = {
 //   noteHeadSchemes
 //---------------------------------------------------------
 
-NoteHeadScheme noteHeadSchemes[] = {
-      NoteHeadScheme::HEAD_NORMAL,
-      NoteHeadScheme::HEAD_PITCHNAME,
-      NoteHeadScheme::HEAD_PITCHNAME_GERMAN,
-      NoteHeadScheme::HEAD_SOLFEGE,
-      NoteHeadScheme::HEAD_SOLFEGE_FIXED,
-      NoteHeadScheme::HEAD_SHAPE_NOTE_4,
-      NoteHeadScheme::HEAD_SHAPE_NOTE_7_AIKIN,
-      NoteHeadScheme::HEAD_SHAPE_NOTE_7_FUNK,
-      NoteHeadScheme::HEAD_SHAPE_NOTE_7_WALKER
+NoteHead::Scheme noteHeadSchemes[] = {
+      NoteHead::Scheme::HEAD_NORMAL,
+      NoteHead::Scheme::HEAD_PITCHNAME,
+      NoteHead::Scheme::HEAD_PITCHNAME_GERMAN,
+      NoteHead::Scheme::HEAD_SOLFEGE,
+      NoteHead::Scheme::HEAD_SOLFEGE_FIXED,
+      NoteHead::Scheme::HEAD_SHAPE_NOTE_4,
+      NoteHead::Scheme::HEAD_SHAPE_NOTE_7_AIKIN,
+      NoteHead::Scheme::HEAD_SHAPE_NOTE_7_FUNK,
+      NoteHead::Scheme::HEAD_SHAPE_NOTE_7_WALKER
       };
 
 //---------------------------------------------------------
@@ -89,7 +89,7 @@ EditStaffType::EditStaffType(QWidget* parent, Staff* st)
       durFontName->setCurrentIndex(0);
 
       for (auto i : noteHeadSchemes)
-            noteHeadScheme->addItem(StaffType::scheme2userName(i), StaffType::scheme2name(i));
+            noteHeadScheme->addItem(NoteHead::scheme2userName(i), NoteHead::scheme2name(i));
 
       // load a sample standard score in preview
       MasterScore* sc = new MasterScore(MScore::defaultStyle());
@@ -383,7 +383,7 @@ void EditStaffType::setFromDlg()
             staffType.setGenKeysig(genKeysigPitched->isChecked());
             staffType.setShowLedgerLines(showLedgerLinesPitched->isChecked());
             staffType.setStemless(stemlessPitched->isChecked());
-            staffType.setNoteHeadScheme(StaffType::name2scheme(noteHeadScheme->currentData().toString()));
+            staffType.setNoteHeadScheme(NoteHead::name2scheme(noteHeadScheme->currentData().toString()));
             }
       if (staffType.group() == StaffGroup::PERCUSSION) {
             staffType.setGenKeysig(genKeysigPercussion->isChecked());

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -497,7 +497,7 @@ InspectorStaffTypeChange::InspectorStaffTypeChange(QWidget* parent)
             { Pid::STAFF_SHOW_BARLINES,    0, sl.showBarlines,    sl.resetShowBarlines    },
             { Pid::STAFF_SHOW_LEDGERLINES, 0, sl.showLedgerlines, sl.resetShowLedgerlines },
             { Pid::STAFF_STEMLESS,         0, sl.stemless,        sl.resetStemless        },
-            { Pid::STAFF_NOTEHEAD_SCHEME,  0, sl.noteheadScheme,  sl.resetNoteheadScheme  },
+            { Pid::HEAD_SCHEME,            0, sl.noteheadScheme,  sl.resetNoteheadScheme  },
             { Pid::STAFF_GEN_CLEF,         0, sl.genClefs,        sl.resetGenClefs        },
             { Pid::STAFF_GEN_TIMESIG,      0, sl.genTimesig,      sl.resetGenTimesig      },
             { Pid::STAFF_GEN_KEYSIG,       0, sl.genKeysig,       sl.resetGenKeysig       },
@@ -505,16 +505,16 @@ InspectorStaffTypeChange::InspectorStaffTypeChange(QWidget* parent)
       pList = { { sl.title, sl.panel } };
 
       sl.noteheadScheme->clear();
-      for (auto i : { NoteHeadScheme::HEAD_NORMAL,
-         NoteHeadScheme::HEAD_PITCHNAME,
-         NoteHeadScheme::HEAD_PITCHNAME_GERMAN,
-         NoteHeadScheme::HEAD_SOLFEGE,
-         NoteHeadScheme::HEAD_SOLFEGE_FIXED,
-         NoteHeadScheme::HEAD_SHAPE_NOTE_4,
-         NoteHeadScheme::HEAD_SHAPE_NOTE_7_AIKIN,
-         NoteHeadScheme::HEAD_SHAPE_NOTE_7_FUNK,
-         NoteHeadScheme::HEAD_SHAPE_NOTE_7_WALKER} ) {
-            sl.noteheadScheme->addItem(StaffType::scheme2userName(i), int(i));
+      for (auto i : { NoteHead::Scheme::HEAD_NORMAL,
+         NoteHead::Scheme::HEAD_PITCHNAME,
+         NoteHead::Scheme::HEAD_PITCHNAME_GERMAN,
+         NoteHead::Scheme::HEAD_SOLFEGE,
+         NoteHead::Scheme::HEAD_SOLFEGE_FIXED,
+         NoteHead::Scheme::HEAD_SHAPE_NOTE_4,
+         NoteHead::Scheme::HEAD_SHAPE_NOTE_7_AIKIN,
+         NoteHead::Scheme::HEAD_SHAPE_NOTE_7_FUNK,
+         NoteHead::Scheme::HEAD_SHAPE_NOTE_7_WALKER} ) {
+            sl.noteheadScheme->addItem(NoteHead::scheme2userName(i), int(i));
             }
       mapSignals();
       }

--- a/mscore/inspector/inspectorNote.h
+++ b/mscore/inspector/inspectorNote.h
@@ -35,6 +35,7 @@ class InspectorNote : public InspectorElementBase {
       void block(bool);
 
    private slots:
+      void noteHeadSchemeChanged(int val);
       void dot1Clicked();
       void dot2Clicked();
       void dot3Clicked();

--- a/mscore/inspector/inspector_note.ui
+++ b/mscore/inspector/inspector_note.ui
@@ -76,7 +76,7 @@
       <property name="spacing">
        <number>3</number>
       </property>
-      <item row="10" column="2">
+      <item row="11" column="2">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -96,7 +96,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="3">
+      <item row="2" column="3">
        <widget class="Ms::ResetButton" name="resetNoteHeadGroup" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -109,7 +109,7 @@
         </property>
        </widget>
       </item>
-      <item row="12" column="0" colspan="4">
+      <item row="13" column="0" colspan="4">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QToolButton" name="dot1">
@@ -168,7 +168,7 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="3">
+      <item row="3" column="3">
        <widget class="Ms::ResetButton" name="resetNoteHeadType" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -181,7 +181,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="2">
+      <item row="4" column="2">
        <widget class="QComboBox" name="mirrorHead">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -209,7 +209,7 @@
         </item>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Mirror head:</string>
@@ -222,7 +222,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="3">
+      <item row="6" column="3">
        <widget class="Ms::ResetButton" name="resetPlay" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -235,7 +235,7 @@
         </property>
        </widget>
       </item>
-      <item row="11" column="0" colspan="4">
+      <item row="12" column="0" colspan="4">
        <widget class="QLabel" name="label_2">
         <property name="font">
          <font>
@@ -251,7 +251,7 @@
         </property>
        </widget>
       </item>
-      <item row="13" column="0" colspan="4">
+      <item row="14" column="0" colspan="4">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QToolButton" name="stem">
@@ -307,7 +307,7 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
          <string>Head type:</string>
@@ -333,7 +333,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0" colspan="3">
+      <item row="6" column="0" colspan="3">
        <widget class="QCheckBox" name="play">
         <property name="focusPolicy">
          <enum>Qt::TabFocus</enum>
@@ -343,7 +343,46 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_headScheme">
+        <property name="text">
+         <string>Head scheme:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>noteHeadScheme</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="2">
+       <widget class="QComboBox" name="noteHeadScheme">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Head scheme</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="Ms::ResetButton" name="resetNoteHeadScheme" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="accessibleName">
+         <string>Reset 'Head scheme' value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
        <widget class="QComboBox" name="noteHeadGroup">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -359,7 +398,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
+      <item row="4" column="3">
        <widget class="Ms::ResetButton" name="resetMirrorHead" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -372,7 +411,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
+      <item row="3" column="2">
        <widget class="QComboBox" name="noteHeadType">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -385,7 +424,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>Head group:</string>
@@ -398,7 +437,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0" colspan="4">
+      <item row="7" column="0" colspan="4">
        <widget class="QWidget" name="playWidget" native="true">
         <layout class="QGridLayout" name="gridLayout_2">
          <property name="leftMargin">
@@ -576,7 +615,7 @@
         </layout>
        </widget>
       </item>
-      <item row="4" column="0" colspan="3">
+      <item row="5" column="0" colspan="3">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <property name="spacing">
          <number>3</number>
@@ -631,7 +670,7 @@
         </item>
        </layout>
       </item>
-      <item row="4" column="3">
+      <item row="5" column="3">
        <widget class="Ms::ResetButton" name="resetFixedLine" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -660,6 +699,7 @@
  <tabstops>
   <tabstop>title</tabstop>
   <tabstop>small</tabstop>
+  <tabstop>noteHeadScheme</tabstop>
   <tabstop>noteHeadGroup</tabstop>
   <tabstop>noteHeadType</tabstop>
   <tabstop>mirrorHead</tabstop>

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -142,6 +142,8 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( fixedLine,               FIXED_LINE                )
       /** Notehead type, one of PluginAPI::PluginAPI::NoteHeadType values */
       API_PROPERTY( headType,                HEAD_TYPE                 )
+      /** Notehead scheme, one of PluginAPI::PluginAPI::NoteHeadScheme values */
+      API_PROPERTY( headScheme,              HEAD_SCHEME               )
       /** Notehead group, one of PluginAPI::PluginAPI::NoteHeadGroup values */
       API_PROPERTY( headGroup,               HEAD_GROUP                )
       API_PROPERTY( articulationAnchor,      ARTICULATION_ANCHOR       )
@@ -306,7 +308,6 @@ class Element : public Ms::PluginAPI::ScoreElement {
       API_PROPERTY( staffShowBarlines,       STAFF_SHOW_BARLINES       )
       API_PROPERTY( staffShowLedgerlines,    STAFF_SHOW_LEDGERLINES    )
       API_PROPERTY( staffStemless,           STAFF_STEMLESS            )
-      API_PROPERTY( staffNoteheadScheme,     STAFF_NOTEHEAD_SCHEME     )
       API_PROPERTY( staffGenClef,            STAFF_GEN_CLEF            )
       API_PROPERTY( staffGenTimesig,         STAFF_GEN_TIMESIG         )
       API_PROPERTY( staffGenKeysig,          STAFF_GEN_KEYSIG          )

--- a/mscore/plugin/api/qmlpluginapi.cpp
+++ b/mscore/plugin/api/qmlpluginapi.cpp
@@ -46,6 +46,7 @@ Enum* PluginAPI::alignEnum;
 Enum* PluginAPI::noteTypeEnum;
 Enum* PluginAPI::playEventTypeEnum;
 Enum* PluginAPI::noteHeadTypeEnum;
+Enum* PluginAPI::noteHeadSchemeEnum;
 Enum* PluginAPI::noteHeadGroupEnum;
 Enum* PluginAPI::noteValueTypeEnum;
 Enum* PluginAPI::segmentTypeEnum;
@@ -76,6 +77,7 @@ void PluginAPI::initEnums() {
       PluginAPI::noteTypeEnum = wrapEnum<Ms::NoteType>();
       PluginAPI::playEventTypeEnum = wrapEnum<Ms::PlayEventType>();
       PluginAPI::noteHeadTypeEnum = wrapEnum<Ms::NoteHead::Type>();
+      PluginAPI::noteHeadSchemeEnum = wrapEnum<Ms::NoteHead::Scheme>();
       PluginAPI::noteHeadGroupEnum = wrapEnum<Ms::NoteHead::Group>();
       PluginAPI::noteValueTypeEnum = wrapEnum<Ms::Note::ValueType>();
       PluginAPI::segmentTypeEnum = wrapEnum<Ms::SegmentType>();

--- a/mscore/plugin/api/qmlpluginapi.h
+++ b/mscore/plugin/api/qmlpluginapi.h
@@ -138,6 +138,8 @@ class PluginAPI : public Ms::QmlPlugin {
       /// \note In MuseScore 2.X this enumeration was available in
       /// NoteHead class (e.g. NoteHead.HEAD_QUARTER).
       DECLARE_API_ENUM( NoteHeadType,     noteHeadTypeEnum        )
+      /// Contains Ms::NoteHead::Scheme enumeration values
+      DECLARE_API_ENUM( NoteHeadScheme,   noteHeadSchemeEnum      )
       /// Contains Ms::NoteHead::Group enumeration values
       /// \note In MuseScore 2.X this enumeration was available in
       /// NoteHead class (e.g. NoteHead.HEAD_TRIANGLE).


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/294542.

Up until now, notehead scheme has only been a StaffType property. If a Note is going to have its own notehead scheme, it seems fitting to do a bit of reorganization. Here is a summary of the changes made:

- Moved enum class NoteHeadScheme to NoteHead::Scheme, alongside NoteHead::Group and NoteHead::Type.
- Added HEAD_AUTO as a possible value for NoteHead::Scheme.
- Moved scheme2userName(), scheme2name(), and name2scheme() from class StaffType to class NoteHead.
- Renamed Pid::STAFF_NOTEHEAD_SCHEME to Pid::HEAD_SCHEME. This change is reflected in the Plugin API, with Element property staffNoteheadScheme being renamed to headScheme. This should not break too many existing plugins, because the NoteHeadScheme enum values have never been exposed until now. Speaking of which, 
- Exposed the NoteHead::Scheme enum values to the Plugin API as NoteHeadScheme.HEAD_AUTO, etc. And finally, (and the main point of all of this):
- Added a property of type NoteHead::Scheme to class Note, and exposed it via the Inspector. If set to HEAD_AUTO (the default), the StaffType’s noteHeadScheme will be used. Otherwise, this will override the StaffType’s noteHeadScheme.
