### PR TITLE
fix #294677: screenreader does not read consecutive frames

### DIFF
--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -166,6 +166,8 @@ void ScoreAccessibility::currentInfoChanged()
             QString rez = e->accessibleInfo();
             if (!barsAndBeats.isEmpty())
                   rez += "; " + barsAndBeats;
+            else
+                  oldScreenReaderInfo.clear();  // force regeneration for elements with no barbeat info - see below
 
             QString staff = "";
             QString optimizedStaff = "";
@@ -188,14 +190,21 @@ void ScoreAccessibility::currentInfoChanged()
 
             statusBarLabel->setText(rez);
             QString screenReaderRez;
-            if (rez != oldStatus) {
+            if (rez != oldStatus || oldScreenReaderInfo.isEmpty()) {
+                  // status has changed since last call, or there is no existing screenreader info
+                  //
+                  // build new screenreader info
                   screenReaderRez = QString("%1%2 %3 %4").arg(e->screenReaderInfo()).arg(optimizedBarsAndBeats).arg(optimizedStaff).arg(e->accessibleExtraInfo());
                   makeReadable(screenReaderRez);
                   }
             else {
-                  // if status has not changed, we may have over-optimized screenreader info
-                  // this happens if this function is called twice within same command
-                  // so let the previous screenreader info stand
+                  // status has not changed since last call, and there is existing screenreader info
+                  //
+                  // if this function is called twice within the same command,
+                  // then status does not change between calls,
+                  // but the second call may result in too much information being optimized away for screenreader
+                  // so in these cases, let the previous screenreader info stand
+                  // (this is relevant only for elements with bar and beat info)
                   screenReaderRez = oldScreenReaderInfo;
                   }
             score->setAccessibleInfo(screenReaderRez);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/294677

The screenreader info code tries to optimize during navigation and not read info that has not changed.
Unfortunately this is a little too effective,
we end up optimizing away information about consecutive frames.
This commit fixes this by limiting the optimization to elements with bar and beat info,
which is what we are trying to optimize.
So frames and any other elements whose status bar info does not change from element to element
will no longer be optimized.
The code accomplishes this by clearing the oldcAcessibilityInfo for elements with no barsAndBeats info,
then checking for empty oldAccessibilityInfo before reusing it.
This lso has the benefit of forcing a rebuild of the accessibility info
if it ever accidentally gets cleared for any other reason.

There is not currently a way to create automated tests for screenreader behavior.