### PR TITLE
fix #283319: Time Signature disappears

### DIFF
--- a/libmscore/style.cpp
+++ b/libmscore/style.cpp
@@ -2415,7 +2415,7 @@ bool MStyle::readProperties(XmlReader& e)
                         e.readElementText();
                         }
                   else if (!strcmp("QSizeF", type)) {
-                        qreal x = e.intAttribute("w", 0);
+                        qreal x = e.doubleAttribute("w", 0.0);
                         qreal y = e.doubleAttribute("h", 0.0);
                         set(idx, QSizeF(x, y));
                         e.readElementText();


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/283319.

There is a mistake in MStyle::readProperties() when reading a property of type QSizeF. The "w" attribute has been written as a double, but it is attempting to read it as an integer. This fails, so x is set to 0, which means that an object of that size has zero width, and is therefore invisible.