### PR TITLE
fix #293429: tuplet property saving

### DIFF
--- a/libmscore/tuplet.cpp
+++ b/libmscore/tuplet.cpp
@@ -755,10 +755,6 @@ void Tuplet::write(XmlWriter& xml) const
       xml.stag(this);
       Element::writeProperties(xml);
 
-      writeProperty(xml, Pid::DIRECTION);
-      writeProperty(xml, Pid::NUMBER_TYPE);
-      writeProperty(xml, Pid::BRACKET_TYPE);
-      writeProperty(xml, Pid::LINE_WIDTH);
       writeProperty(xml, Pid::NORMAL_NOTES);
       writeProperty(xml, Pid::ACTUAL_NOTES);
       writeProperty(xml, Pid::P1);
@@ -773,6 +769,9 @@ void Tuplet::write(XmlWriter& xml) const
             _number->writeProperties(xml);
             xml.etag();
             }
+
+      writeStyledProperties(xml);
+
       xml.etag();
       }
 
@@ -803,6 +802,24 @@ bool Tuplet::readProperties(XmlReader& e)
 
       if (readStyledProperty(e, tag))
             ;
+      else if (tag == "bold") { //important that these properties are read after number is created
+            bool val = e.readInt();
+            _number->setBold(val);
+            if (isStyled(Pid::FONT_STYLE))
+                  setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
+            }
+      else if (tag == "italic") {
+            bool val = e.readInt();
+            _number->setItalic(val);
+            if (isStyled(Pid::FONT_STYLE))
+                  setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
+            }
+      else if (tag == "underline") {
+            bool val = e.readInt();
+            _number->setUnderline(val);
+            if (isStyled(Pid::FONT_STYLE))
+                  setPropertyFlags(Pid::FONT_STYLE, PropertyFlags::UNSTYLED);
+            }
       else if (tag == "normalNotes")
             _ratio.setDenominator(e.readInt());
       else if (tag == "actualNotes")

--- a/mtest/guitarpro/tuplets.gpx-ref.mscx
+++ b/mtest/guitarpro/tuplets.gpx-ref.mscx
@@ -279,7 +279,6 @@
         <voice>
           <Tuplet>
             <linkedMain/>
-            <numberType>1</numberType>
             <normalNotes>8</normalNotes>
             <actualNotes>15</actualNotes>
             <baseNote>16th</baseNote>
@@ -287,6 +286,7 @@
               <style>Tuplet</style>
               <text>15:8</text>
               </Number>
+            <numberType>1</numberType>
             </Tuplet>
           <Beam>
             <l1>19</l1>
@@ -858,7 +858,6 @@
             <Tuplet>
               <linked>
                 </linked>
-              <numberType>1</numberType>
               <normalNotes>8</normalNotes>
               <actualNotes>15</actualNotes>
               <baseNote>16th</baseNote>
@@ -866,6 +865,7 @@
                 <style>Tuplet</style>
                 <text>15:8</text>
                 </Number>
+              <numberType>1</numberType>
               </Tuplet>
             <Beam>
               <l1>19</l1>
@@ -1337,7 +1337,6 @@
             <Tuplet>
               <linked>
                 </linked>
-              <numberType>1</numberType>
               <normalNotes>8</normalNotes>
               <actualNotes>15</actualNotes>
               <baseNote>16th</baseNote>
@@ -1345,6 +1344,7 @@
                 <style>Tuplet</style>
                 <text>15:8</text>
                 </Number>
+              <numberType>1</numberType>
               </Tuplet>
             <Beam>
               <l1>46</l1>

--- a/mtest/libmscore/compat114/tuplets-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets-ref.mscx
@@ -329,13 +329,13 @@
       <Measure>
         <voice>
           <Tuplet>
-            <direction>up</direction>
             <normalNotes>8</normalNotes>
             <actualNotes>9</actualNotes>
             <baseNote>16th</baseNote>
             <Number>
               <text>9</text>
               </Number>
+            <direction>up</direction>
             </Tuplet>
           <Beam>
             <l1>31</l1>

--- a/mtest/libmscore/compat114/tuplets_1-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_1-ref.mscx
@@ -110,14 +110,14 @@
               </Number>
             </Tuplet>
           <Tuplet>
-            <numberType>1</numberType>
-            <bracketType>1</bracketType>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
             <Number>
               <text>3:2</text>
               </Number>
+            <numberType>1</numberType>
+            <bracketType>1</bracketType>
             </Tuplet>
           <Chord>
             <durationType>eighth</durationType>
@@ -159,14 +159,14 @@
             <fractions>-1/960</fractions>
             </location>
           <Tuplet>
-            <numberType>1</numberType>
-            <bracketType>1</bracketType>
             <normalNotes>4</normalNotes>
             <actualNotes>6</actualNotes>
             <baseNote>32nd</baseNote>
             <Number>
               <text>6:4</text>
               </Number>
+            <numberType>1</numberType>
+            <bracketType>1</bracketType>
             </Tuplet>
           <Beam>
             <l1>15</l1>

--- a/mtest/libmscore/compat114/tuplets_2-ref.mscx
+++ b/mtest/libmscore/compat114/tuplets_2-ref.mscx
@@ -110,14 +110,14 @@
               </Number>
             </Tuplet>
           <Tuplet>
-            <numberType>1</numberType>
-            <bracketType>1</bracketType>
             <normalNotes>2</normalNotes>
             <actualNotes>3</actualNotes>
             <baseNote>eighth</baseNote>
             <Number>
               <text>3:2</text>
               </Number>
+            <numberType>1</numberType>
+            <bracketType>1</bracketType>
             </Tuplet>
           <Chord>
             <durationType>eighth</durationType>
@@ -159,14 +159,14 @@
             <fractions>-1/960</fractions>
             </location>
           <Tuplet>
-            <numberType>1</numberType>
-            <bracketType>1</bracketType>
             <normalNotes>4</normalNotes>
             <actualNotes>6</actualNotes>
             <baseNote>32nd</baseNote>
             <Number>
               <text>6:4</text>
               </Number>
+            <numberType>1</numberType>
+            <bracketType>1</bracketType>
             </Tuplet>
           <Beam>
             <l1>15</l1>

--- a/mtest/libmscore/compat206/tuplets-ref.mscx
+++ b/mtest/libmscore/compat206/tuplets-ref.mscx
@@ -137,13 +137,13 @@
             <sigD>4</sigD>
             </TimeSig>
           <Tuplet>
-            <numberType>1</numberType>
             <normalNotes>4</normalNotes>
             <actualNotes>6</actualNotes>
             <baseNote>16th</baseNote>
             <Number>
               <text>6:4</text>
               </Number>
+            <numberType>1</numberType>
             </Tuplet>
           <Beam>
             <l1>24</l1>
@@ -203,13 +203,13 @@
       <Measure>
         <voice>
           <Tuplet>
-            <numberType>1</numberType>
             <normalNotes>8</normalNotes>
             <actualNotes>10</actualNotes>
             <baseNote>eighth</baseNote>
             <Number>
               <text>10:8</text>
               </Number>
+            <numberType>1</numberType>
             </Tuplet>
           <Beam>
             <l1>20</l1>
@@ -369,13 +369,13 @@
           </LayoutBreak>
         <voice>
           <Tuplet>
-            <direction>up</direction>
             <normalNotes>8</normalNotes>
             <actualNotes>9</actualNotes>
             <baseNote>16th</baseNote>
             <Number>
               <text>9</text>
               </Number>
+            <direction>up</direction>
             </Tuplet>
           <Beam>
             <l1>31</l1>
@@ -497,13 +497,13 @@
       <Measure>
         <voice>
           <Tuplet>
-            <direction>up</direction>
             <normalNotes>6</normalNotes>
             <actualNotes>11</actualNotes>
             <baseNote>eighth</baseNote>
             <Number>
               <text>11</text>
               </Number>
+            <direction>up</direction>
             </Tuplet>
           <Beam>
             <l1>25</l1>
@@ -517,13 +517,13 @@
               </Note>
             </Chord>
           <Tuplet>
-            <direction>up</direction>
             <normalNotes>2</normalNotes>
             <actualNotes>2</actualNotes>
             <baseNote>16th</baseNote>
             <Number>
               <text>2</text>
               </Number>
+            <direction>up</direction>
             </Tuplet>
           <Chord>
             <durationType>16th</durationType>

--- a/mtest/libmscore/tuplet/save-load.mscx
+++ b/mtest/libmscore/tuplet/save-load.mscx
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle"></metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>150</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="sforzatoStaccato">
+          <velocity>150</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoStaccato">
+          <velocity>120</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="marcatoTenuto">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <Measure>
+        <voice>
+          <TimeSig>
+            <sigN>4</sigN>
+            <sigD>4</sigD>
+            </TimeSig>
+          <Tuplet>
+            <normalNotes>2</normalNotes>
+            <actualNotes>3</actualNotes>
+            <baseNote>eighth</baseNote>
+            <Number>
+              <style>Tuplet</style>
+              <text>3</text>
+              </Number>
+            <size>4</size>
+            </Tuplet>
+          <Beam>
+            <l1>19</l1>
+            <l2>19</l2>
+            </Beam>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <endTuplet/>
+          <Tuplet>
+            <normalNotes>2</normalNotes>
+            <actualNotes>3</actualNotes>
+            <baseNote>eighth</baseNote>
+            <Number>
+              <style>Tuplet</style>
+              <text>3</text>
+              </Number>
+            <size>12</size>
+            <bold>1</bold>
+            <underline>1</underline>
+            </Tuplet>
+          <Beam>
+            <l1>19</l1>
+            <l2>19</l2>
+            </Beam>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <endTuplet/>
+          <Tuplet>
+            <normalNotes>2</normalNotes>
+            <actualNotes>3</actualNotes>
+            <baseNote>eighth</baseNote>
+            <Number>
+              <style>Tuplet</style>
+              <text>3</text>
+              </Number>
+            <bracketType>1</bracketType>
+            <lineWidth>0.6</lineWidth>
+            <size>11</size>
+            </Tuplet>
+          <Beam>
+            <l1>19</l1>
+            <l2>19</l2>
+            </Beam>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <endTuplet/>
+          <Tuplet>
+            <normalNotes>2</normalNotes>
+            <actualNotes>3</actualNotes>
+            <baseNote>eighth</baseNote>
+            <Number>
+              <style>Tuplet</style>
+              <text>3:2</text>
+              </Number>
+            <numberType>1</numberType>
+            <bracketType>1</bracketType>
+            <family>EB Garamond SC</family>
+            <size>15</size>
+            </Tuplet>
+          <Beam>
+            <l1>19</l1>
+            <l2>19</l2>
+            </Beam>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>eighth</durationType>
+            <Note>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <endTuplet/>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/libmscore/tuplet/tst_tuplet.cpp
+++ b/mtest/libmscore/tuplet/tst_tuplet.cpp
@@ -42,6 +42,7 @@ class TestTuplet : public QObject, public MTest
       void split2() { split("split2.mscx",   "split2-ref.mscx");  }
       void split3() { split("split3.mscx",   "split3-ref.mscx");  }
       void split4() { split("split4.mscx",   "split4-ref.mscx");  }
+      void saveLoad();
       void addStaff();
       };
 
@@ -176,6 +177,19 @@ void TestTuplet::addStaff()
       score->undoInsertStaff(newStaff, 0, true);
 
       QVERIFY(saveCompareScore(score, "nestedTuplets_addStaff.mscx", DIR + "nestedTuplets_addStaff-ref.mscx"));
+      delete score;
+      }
+
+//-----------------------------------------
+//    saveLoad
+//     checks that properties persist after loading and saving
+//-----------------------------------------
+void TestTuplet::saveLoad()
+      {
+      MasterScore* score = readScore(DIR + "save-load.mscx");
+      QVERIFY(score);
+      //simply load and save
+      QVERIFY(saveCompareScore(score, "save-load.mscx", DIR + "save-load.mscx"));
       delete score;
       }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293429

Previously tuplets never saved the font properties. Now they are written after the number property is written which it must be since the font properties are passed over to `_number` on read. I also added a save and load test which just literally loads a score and then saves it and compares it to the score that was loaded. 