### PR TITLE
fix #294873: AUTO sharp/flat change to natural-sharp/natural-flat if there's double-sharp/double-flat before

### DIFF
--- a/libmscore/accidental.h
+++ b/libmscore/accidental.h
@@ -117,7 +117,7 @@ class Accidental final : public Element {
       static const char* subtype2name(AccidentalType);
       static AccidentalType value2subtype(AccidentalVal);
       static AccidentalType name2subtype(const QString&);
-      static bool isMicrotonal(AccidentalType t)  { return t > AccidentalType::FLAT2; }
+      static bool isMicrotonal(AccidentalType t)  { return t > AccidentalType::SHARP_SHARP; }
 
       QString accessibleInfo() const override;
       };

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -1673,25 +1673,31 @@ void Score::changeAccidental(Note* note, AccidentalType accidental)
 
       int tpc = step2tpc(step, acc);
 
+      bool isUnusual = false;
       bool forceRemove = false;
       bool forceAdd = false;
+
+      if (accidental == AccidentalType::NATURAL_SHARP
+            || accidental == AccidentalType::NATURAL_FLAT
+            || accidental == AccidentalType::SHARP_SHARP)
+            isUnusual = true;
 
       // delete accidental
       // both for this note and for any linked notes
       if (accidental == AccidentalType::NONE)
             forceRemove = true;
 
-      // precautionary or microtonal accidental
+      // precautionary or microtonal or unusual
       // either way, we display it unconditionally
       // both for this note and for any linked notes
-      else if (acc == acc2 || pitch == note->pitch() || Accidental::isMicrotonal(accidental))
+      else if (acc == acc2 || pitch == note->pitch() || Accidental::isMicrotonal(accidental) || isUnusual)
             forceAdd = true;
 
       for (ScoreElement* se : note->linkList()) {
             Note* ln = toNote(se);
             if (ln->concertPitch() != note->concertPitch())
                   continue;
-            Score* lns    = ln->score();
+            Score* lns = ln->score();
             Accidental* a = ln->accidental();
             if (forceRemove) {
                   if (a)


### PR DESCRIPTION
Resolves: https://musescore.org/node/294873.

This fix is based on the following logic:
- If the user put sharp/flat at one note, and put double-sharp/double-flat at a note before it, that sharp/flat automatically changes to natural-sharp/natural-flat. If the double-sharp/double-flat no longer exists, that natural-sharp/natural-flat reverts to sharp/flat;
- If a natural-sharp/natural-flat is changed to regular sharp/flat by the user, that sharp/flat won't get changed later;
- If the accidental should normally be sharp/flat but the user put natural-sharp/natural-flat intendedly, then that natural-sharp/natural-flat won't get changed later;
- If a note has regular sharp/flat (natural-sharp/natural-flat are not affected) but a note in front of it is added natural-sharp/natural-flat, that sharp/flat is removed.

The most probable cause of #279179 and #293984 is isMicrotonal(), which treats natural-sharp/natural-flat/sharp-sharp wrongly as microtonal. PR #5341 fixes these two, but it still treats those three as microtonal. In order to implement #294873 this has to be changed.