### PR TITLE
fix #52151: "Auto" beam setting for *Rests* should not beam

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2348,8 +2348,10 @@ void Score::createBeams(Measure* measure)
                               chord->crossMeasureSetup(crossMeasure);
                         }
 
-                  // get defaults from time signature properties
-                  bm = Groups::endBeam(cr, prev);
+                  if (cr->isRest() && cr->beamMode() == Beam::Mode::AUTO)
+                        bm = Beam::Mode::NONE;           // do not beam rests set to Beam::Mode::AUTO
+                  else
+                        bm = Groups::endBeam(cr, prev);  // get defaults from time signature properties
 
                   // perform additional context-dependent checks
                   if (bm == Beam::Mode::AUTO) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/52151.

This PR is offered as an alternative to #5322.

This approach still makes it possible to set `AUTO` beam mode from the user interface, but changes how `AUTO` beam mode is interpreted for rests.