### PR TITLE
fix #281866: fix inability to correctly set loop markers in parts

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -256,9 +256,6 @@ Score::Score()
 
       _scoreFont = ScoreFont::fontFactory("emmentaler");
 
-      _pos[int(POS::CURRENT)] = Fraction(0,1);
-      _pos[int(POS::LEFT)]    = Fraction(0,1);
-      _pos[int(POS::RIGHT)]   = Fraction(0,1);
       _fileDivision           = MScore::division;
       _style  = MScore::defaultStyle();
 //      accInfo = tr("No selection");     // ??
@@ -3761,7 +3758,7 @@ void Score::removeUnmanagedSpanner(Spanner* s)
 //   setPos
 //---------------------------------------------------------
 
-void Score::setPos(POS pos, Fraction tick)
+void MasterScore::setPos(POS pos, Fraction tick)
       {
       if (tick < Fraction(0,1))
             tick = Fraction(0,1);
@@ -3771,7 +3768,8 @@ void Score::setPos(POS pos, Fraction tick)
       // even though tick position might not have changed, layout might have
       // so we should update cursor here
       // however, we must be careful not to call setPos() again while handling posChanged, or recursion results
-      emit posChanged(pos, unsigned(tick.ticks()));
+      for (Score* s : scoreList())
+            emit s->posChanged(pos, unsigned(tick.ticks()));
       }
 
 //---------------------------------------------------------
@@ -4454,6 +4452,10 @@ MasterScore::MasterScore()
       _repeatList  = new RepeatList(this);
       _revisions   = new Revisions;
       setMasterScore(this);
+
+      _pos[int(POS::CURRENT)] = Fraction(0,1);
+      _pos[int(POS::LEFT)]    = Fraction(0,1);
+      _pos[int(POS::RIGHT)]   = Fraction(0,1);
 
 #if defined(Q_OS_WIN)
       metaTags().insert("platform", "Microsoft Windows");

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -434,8 +434,6 @@ class Score : public QObject, public ScoreElement {
       bool _defaultsRead        { false };      ///< defaults were read at MusicXML import, allow export of defaults in convertermode
       bool _isPalette           { false };
 
-      Fraction _pos[3];                    ///< 0 - current, 1 - left loop, 2 - right loop
-
       int _mscVersion { MSCVERSION };   ///< version of current loading *.msc file
 
       QMap<QString, QString> _metaTags;
@@ -851,8 +849,8 @@ class Score : public QObject, public ScoreElement {
       void setLoopInTick(const Fraction& tick)      { setPos(POS::LEFT, tick);    }
       void setLoopOutTick(const Fraction& tick)     { setPos(POS::RIGHT, tick);   }
 
-      Fraction pos(POS pos) const                   {  return _pos[int(pos)]; }
-      void setPos(POS pos, Fraction tick);
+      inline Fraction pos(POS pos) const;
+      inline void setPos(POS pos, Fraction tick);
 
       bool noteEntryMode() const                   { return inputState().noteEntryMode(); }
       void setNoteEntryMode(bool val)              { inputState().setNoteEntryMode(val); }
@@ -1211,6 +1209,8 @@ class MasterScore : public Score {
       Omr* _omr               { 0 };
       bool _showOmr           { false };
 
+      Fraction _pos[3];                    ///< 0 - current, 1 - left loop, 2 - right loop
+
       int _midiPortCount      { 0 };                  // A count of JACK/ALSA midi out ports
       QQueue<MidiInputEvent> _midiInputQueue;         // MIDI events that have yet to be processed
       std::list<MidiInputEvent> _activeMidiPitches;   // MIDI keys currently being held down
@@ -1319,6 +1319,10 @@ class MasterScore : public Score {
       void updateExpressive(Synthesizer* synth, bool expressive, bool force = false);
       void setSoloMute();
 
+      using Score::pos;
+      Fraction pos(POS pos) const { return _pos[int(pos)]; }
+      void setPos(POS pos, Fraction tick);
+
       void addExcerpt(Excerpt*);
       void removeExcerpt(Excerpt*);
       void deleteExcerpt(Excerpt*);
@@ -1379,6 +1383,9 @@ inline void Score::addLayoutFlags(LayoutFlags f)       { _masterScore->addLayout
 inline void Score::setInstrumentsChanged(bool v)       { _masterScore->setInstrumentsChanged(v); }
 inline Movements* Score::movements()                   { return _masterScore->movements();       }
 inline const Movements* Score::movements() const       { return _masterScore->movements();       }
+
+inline Fraction Score::pos(POS pos) const              { return _masterScore->pos(pos);          }
+inline void Score::setPos(POS pos, Fraction tick)      { _masterScore->setPos(pos, tick);        }
 
 extern MasterScore* gscore;
 

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -6333,8 +6333,7 @@ void MuseScore::cmd(QAction* a, const QString& cmd)
             addTempo();
       else if (cmd == "loop") {
             if (loop()) {
-                  if (cs->selection().isRange())
-                        seq->setLoopSelection();
+                  seq->setLoopSelection();
                   }
             }
       else if (cmd == "loop-in") {

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4590,10 +4590,11 @@ Element* ScoreView::elementNear(QPointF p)
 
 void ScoreView::posChanged(POS pos, unsigned tick)
       {
-      if (this != mscore->currentScoreView() && !_moveWhenInactive)
-            return;
       switch (pos) {
             case POS::CURRENT:
+                  // draw playback cursor only in the currently active view
+                  if (this != mscore->currentScoreView() && !_moveWhenInactive)
+                        return;
                   if (noteEntryMode())
                         moveCursor();     // update input cursor position
                   else

--- a/mscore/seq.cpp
+++ b/mscore/seq.cpp
@@ -1141,8 +1141,7 @@ int Seq::getPlayStartUtick()
       {
       if ((mscore->loop())) {
             if (preferences.getBool(PREF_APP_PLAYBACK_LOOPTOSELECTIONONPLAY)) {
-                  if (cs->selection().isRange())
-                        setLoopSelection();
+                  setLoopSelection();
                   }
             return cs->repeatList().tick2utick(cs->loopInTick().ticks());
             }
@@ -1710,8 +1709,13 @@ void Seq::setPos(POS, unsigned t)
 
 void Seq::setLoopSelection()
       {
-      cs->setLoopInTick(cs->selection().tickStart());
-      cs->setLoopOutTick(cs->selection().tickEnd());
+      const Score* score = mscore->currentScore();
+      Q_ASSERT(!score || score->masterScore() == cs);
+
+      if (score && score->selection().isRange()) {
+            cs->setLoopInTick(score->selection().tickStart());
+            cs->setLoopOutTick(score->selection().tickEnd());
+            }
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/281866.

As playback is currently always performed for MasterScore, it would be logical to store the information about positions of playback cursor and loop markers in MasterScore rather than individual excerpt scores. This commit implements this approach and fixes the issue with inability to set loop markers from parts. Strictly speaking, only changing `Seq::setLoopSelection` is absolutely necessary to fix the issue, the approach with moving `_pos` to `MasterScore` allows to naturally avoid incorrect visual feedback due to markers positions information being not synchronized across scores and ScoreViews.