### PR TITLE
fix #279179, fix #293984: Natural-sharp/natural-flat not recognized as same accidental as sharp/flat

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2150,7 +2150,8 @@ void Note::updateAccidental(AccidentalState* as)
             // ultimetely, they should probably get their own state
             // for now, at least change state to natural, so subsequent notes playback as might be expected
             // this is an incompatible change, but better to break it for 2.0 than wait until later
-            as->setAccidentalVal(relLine, AccidentalVal::NATURAL, _tieBack != 0 && _accidental == 0);
+            AccidentalVal accVal = Accidental::subtype2value(_accidental->accidentalType());
+            as->setAccidentalVal(relLine, accVal, _tieBack != 0 && _accidental == 0);
             }
 
       updateRelLine(relLine, true);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/279179.
Also resolves: https://musescore.org/en/node/293984, which is really the same issue.

NATURAL_SHARP and NATURAL_FLAT are handled in the same way as microtonal accidentals, but unlike microtonal accidentals, NATURAL_SHARP and NATURAL_FLAT affect the playback pitch of the note. Therefore, when these accidentals are encountered, it is incorrect to set the accidental state to NATURAL. Instead, it must be set to the AccidentalValue that corresponds to the accidental's subtype.

This PR is offered as a solution to the natural-sharp/natural-flat issue that does not involve automatically adding and removing natural-sharps and natural-flats. This PR does not conflict with #5337, but that PR has a different goal. The goal of this PR is simply to correct the accidental state that is set when natural-sharps and natural-flats are encountered. Thus, it may actually have a chance at being included in MuseScore 3.3.