### PR TITLE
fix #292079: prevent crash when adding grace notes to a selected measure

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2498,7 +2498,8 @@ void Score::cmdInsertClef(Clef* clef, ChordRest* cr)
 
 void Score::cmdAddGrace (NoteType graceType, int duration)
       {
-      for (Element* e : selection().elements()) {
+      const QList<Element*> copyOfElements = selection().elements();
+      for (Element* e : copyOfElements) {
             if (e->type() == ElementType::NOTE) {
                   Note* n = toNote(e);
                   setGraceNote(n->chord(), n->pitch(), graceType, duration);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/292079

Copy selected elements and iterate over the copied list since the
original list might be changed during the execution of the loop.
