### PR TITLE
fix #294728: min distance not saved for lines unless offset changed too

### DIFF
--- a/libmscore/line.cpp
+++ b/libmscore/line.cpp
@@ -986,6 +986,7 @@ void SLine::writeProperties(XmlWriter& xml) const
       bool modified = false;
       for (const SpannerSegment* seg : spannerSegments()) {
             if (!seg->autoplace() || !seg->visible() ||
+               (seg->propertyFlags(Pid::MIN_DISTANCE) == PropertyFlags::UNSTYLED || seg->getProperty(Pid::MIN_DISTANCE) != seg->propertyDefault(Pid::MIN_DISTANCE)) ||
                (!seg->isStyled(Pid::OFFSET) && (!seg->offset().isNull() || !seg->userOff2().isNull()))) {
                   modified = true;
                   break;

--- a/mtest/libmscore/spanners/linecolor01-ref.mscx
+++ b/mtest/libmscore/spanners/linecolor01-ref.mscx
@@ -99,6 +99,13 @@
               <beginHookType>1</beginHookType>
               <color r="255" g="0" b="0" a="255"/>
               <color r="255" g="0" b="0" a="255"/>
+              <Segment>
+                <subtype>0</subtype>
+                <offset x="0" y="4"/>
+                <off2 x="0" y="0"/>
+                <minDistance>0</minDistance>
+                <color r="255" g="0" b="0" a="255"/>
+                </Segment>
               </Pedal>
             <next>
               <location>

--- a/mtest/libmscore/spanners/tst_spanners.cpp
+++ b/mtest/libmscore/spanners/tst_spanners.cpp
@@ -53,7 +53,7 @@ class TestSpanners : public QObject, public MTest
       void spanners12();            // remove a measure containing the middle portion of a LyricsLine and undo
 //      void spanners13();            // drop a line break at the middle of a LyricsLine and check LyricsLineSegments
       void spanners14();            // creating part from an existing grand staff containing a cross staff glissando
-      void spanners15();            // change the color of a line and save it
+      void spanners15();            // change the color & min distance of a line and save it
       };
 
 //---------------------------------------------------------
@@ -176,7 +176,7 @@ void TestSpanners::spanners02()
       MasterScore* score = readScore(DIR + "glissando-crossstaff01.mscx");
       QVERIFY(score);
 
-      QVERIFY(saveCompareScore(score, "glissando-crsossstaff01.mscx", DIR + "glissando-crossstaff01-ref.mscx"));
+      QVERIFY(saveCompareScore(score, "glissando-crossstaff01.mscx", DIR + "glissando-crossstaff01-ref.mscx"));
       delete score;
       }
 
@@ -637,6 +637,10 @@ void TestSpanners::spanners15()
             Spanner* spanner = (*it).second;
             SLine* sl = static_cast<SLine*>(spanner);
             sl->setProperty(Pid::COLOR, QVariant::fromValue(QColor(255, 0, 0, 255)));
+            for (auto ss : sl->spannerSegments()) {
+                  ss->setProperty(Pid::MIN_DISTANCE, 0.0);
+                  ss->setPropertyFlags(Pid::MIN_DISTANCE, PropertyFlags::UNSTYLED);
+                  }
             }
 
       QVERIFY(saveCompareScore(score, "linecolor01.mscx", DIR + "linecolor01-ref.mscx"));


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/294728

If you move a line into the skyline (e.g, overlapping other elements),
we reduce the min distance automatically and save the result correctly.
But if you reduce the min distance manually via the Inspector
but don't change the offset, then save, the min distance is not written.
That is because we check if the line has been modified before writing these properties.
But we were only checking offset and offset2, not min distance.
This change adds that check.

Quick mtest added, not built locally so we'll see if it works.