### PR TITLE
Adapt test scripts framework to redesigned palettes

### DIFF
--- a/mscore/menus.cpp
+++ b/mscore/menus.cpp
@@ -87,6 +87,7 @@
 
 #include "palette/palettetree.h"
 #include "palette/palettewidget.h"
+#include "palette/paletteworkspace.h"
 #include "qml/msqmlengine.h"
 
 namespace Ms {
@@ -2877,33 +2878,35 @@ PalettePanel* MuseScore::newFretboardDiagramPalettePanel()
 
 void MuseScore::setDefaultPalette()
       {
-      mscore->getPaletteBox();
-      paletteBox->clear();
-      paletteBox->addPalette(newClefsPalette(true));
-      paletteBox->addPalette(newKeySigPalette());
-      paletteBox->addPalette(newTimePalette());
-      paletteBox->addPalette(newBracketsPalette());
-      paletteBox->addPalette(newAccidentalsPalette(true));
-      paletteBox->addPalette(newArticulationsPalette());
-      paletteBox->addPalette(newOrnamentsPalette());
-      paletteBox->addPalette(newBreathPalette());
-      paletteBox->addPalette(newGraceNotePalette());
-      paletteBox->addPalette(newNoteHeadsPalette());
-      paletteBox->addPalette(newLinesPalette());
-      paletteBox->addPalette(newBarLinePalette());
-      paletteBox->addPalette(newArpeggioPalette());
-      paletteBox->addPalette(newTremoloPalette());
-      paletteBox->addPalette(newTextPalette(true));
-      paletteBox->addPalette(newTempoPalette(true));
-      paletteBox->addPalette(newDynamicsPalette(true));
-      paletteBox->addPalette(newFingeringPalette());
-      paletteBox->addPalette(newRepeatsPalette());
-      paletteBox->addPalette(newFretboardDiagramPalette());
-      paletteBox->addPalette(newAccordionPalette());
-      paletteBox->addPalette(newBagpipeEmbellishmentPalette());
-      paletteBox->addPalette(newBreaksPalette());
-      paletteBox->addPalette(newFramePalette());
-      paletteBox->addPalette(newBeamPalette());
+      std::unique_ptr<PaletteTree> defaultPalette(new PaletteTree);
+
+      defaultPalette->append(newClefsPalettePanel(true));
+      defaultPalette->append(newKeySigPalettePanel());
+      defaultPalette->append(newTimePalettePanel());
+      defaultPalette->append(newBracketsPalettePanel());
+      defaultPalette->append(newAccidentalsPalettePanel(true));
+      defaultPalette->append(newArticulationsPalettePanel());
+      defaultPalette->append(newOrnamentsPalettePanel());
+      defaultPalette->append(newBreathPalettePanel());
+      defaultPalette->append(newGraceNotePalettePanel());
+      defaultPalette->append(newNoteHeadsPalettePanel());
+      defaultPalette->append(newLinesPalettePanel());
+      defaultPalette->append(newBarLinePalettePanel());
+      defaultPalette->append(newArpeggioPalettePanel());
+      defaultPalette->append(newTremoloPalettePanel());
+      defaultPalette->append(newTextPalettePanel(true));
+      defaultPalette->append(newTempoPalettePanel(true));
+      defaultPalette->append(newDynamicsPalettePanel(true));
+      defaultPalette->append(newFingeringPalettePanel());
+      defaultPalette->append(newRepeatsPalettePanel());
+      defaultPalette->append(newFretboardDiagramPalettePanel());
+      defaultPalette->append(newAccordionPalettePanel());
+      defaultPalette->append(newBagpipeEmbellishmentPalettePanel());
+      defaultPalette->append(newBreaksPalettePanel());
+      defaultPalette->append(newFramePalettePanel());
+      defaultPalette->append(newBeamPalettePanel());
+
+      mscore->getPaletteWorkspace()->setUserPaletteTree(std::move(defaultPalette));
       }
 
 //---------------------------------------------------------

--- a/mscore/palette/paletteworkspace.cpp
+++ b/mscore/palette/paletteworkspace.cpp
@@ -736,6 +736,18 @@ bool PaletteWorkspace::resetPalette(const QModelIndex& index)
       }
 
 //---------------------------------------------------------
+//   PaletteWorkspace::setUserPaletteTree
+//---------------------------------------------------------
+
+void PaletteWorkspace::setUserPaletteTree(std::unique_ptr<PaletteTree> tree)
+      {
+      if (userPalette)
+            userPalette->setPaletteTree(std::move(tree));
+      else
+            userPalette = new PaletteTreeModel(std::move(tree), /* parent */ this);
+      }
+
+//---------------------------------------------------------
 //   PaletteWorkspace::write
 //---------------------------------------------------------
 
@@ -757,10 +769,7 @@ bool PaletteWorkspace::read(XmlReader& e)
       if (!tree->read(e))
             return false;
 
-      if (userPalette)
-            userPalette->setPaletteTree(std::move(tree));
-      else
-            userPalette = new PaletteTreeModel(std::move(tree), /* parent */ this);
+      setUserPaletteTree(std::move(tree));
 
       return true;
       }

--- a/mscore/palette/paletteworkspace.h
+++ b/mscore/palette/paletteworkspace.h
@@ -204,6 +204,7 @@ class PaletteWorkspace : public QObject {
 
       bool paletteChanged() const { return userPalette->paletteTreeChanged(); }
 
+      void setUserPaletteTree(std::unique_ptr<PaletteTree> tree);
       void write(XmlWriter&) const;
       bool read(XmlReader&);
 

--- a/mscore/script/scriptentry.cpp
+++ b/mscore/script/scriptentry.cpp
@@ -16,6 +16,7 @@
 #include "inspector/inspector.h"
 #include "palette.h"
 #include "palettebox.h"
+#include "palette/paletteworkspace.h"
 #include "scoretab.h"
 #include "script.h"
 #include "testscript.h"
@@ -152,16 +153,6 @@ static Pid deserializePropertyId(ElementType type, const QString& name)
       }
 
 //---------------------------------------------------------
-//   PaletteCellInfo
-//---------------------------------------------------------
-
-struct PaletteCellInfo {
-      Palette* palette;
-      int idx;
-      const Element* e;
-      };
-
-//---------------------------------------------------------
 //   PaletteElementScriptEntry::_pids
 //    List of PIDs used to distinguish palette elements,
 //    sorted by their priority (PIDs from the beginning of
@@ -213,21 +204,25 @@ const std::initializer_list<Pid> PaletteElementScriptEntry::_pids {
 //   PaletteElementScriptEntry::paletteElements
 //---------------------------------------------------------
 
-static std::vector<PaletteCellInfo> getPaletteCells(ElementType elType, ScriptContext& ctx)
+static std::vector<Element*> getPaletteElements(ElementType elType, ScriptContext& ctx)
       {
-      std::vector<PaletteCellInfo> cells;
-      const PaletteBox* box = ctx.mscore()->getPaletteBox();
-      if (!box)
-            return cells;
-      for (Palette* p : box->palettes()) {
-            const int n = p->size();
+      std::vector<Element*> elements;
+
+      PaletteWorkspace* pw = ctx.mscore()->getPaletteWorkspace();
+      if (!pw)
+          return elements;
+
+      const PaletteTree* tree = pw->userPaletteModel()->paletteTree();
+
+      for (auto& p : tree->palettes) {
+            const int n = p->ncells();
             for (int i = 0; i < n; ++i) {
-                  const Element* e = p->element(i);
+                  Element* e = p->cell(i)->element.get();
                   if (e && e->type() == elType)
-                        cells.push_back({ p, i, e });
+                        elements.push_back(e);
                   }
             }
-      return cells;
+      return elements;
       }
 
 //---------------------------------------------------------
@@ -236,13 +231,13 @@ static std::vector<PaletteCellInfo> getPaletteCells(ElementType elType, ScriptCo
 
 bool PaletteElementScriptEntry::execute(ScriptContext& ctx) const
       {
-      const auto cells(getPaletteCells(_type, ctx));
+      const auto elements(getPaletteElements(_type, ctx));
 
-      for (const PaletteCellInfo& c : cells) {
+      for (Element* e : elements) {
             bool match = true;
             for (const auto& p : _props) {
                   const Pid pid = p.first;
-                  const QVariant pVal = c.e->getProperty(pid);
+                  const QVariant pVal = e->getProperty(pid);
                   if (serializePropertyValue(pid, pVal) != p.second) {
                         match = false;
                         break;
@@ -250,8 +245,7 @@ bool PaletteElementScriptEntry::execute(ScriptContext& ctx) const
                   }
 
             if (match) {
-                  c.palette->setCurrentIdx(c.idx);
-                  c.palette->applyPaletteElement();
+                  Palette::applyPaletteElement(e);
                   return true;
                   }
             }
@@ -267,24 +261,25 @@ std::unique_ptr<ScriptEntry> PaletteElementScriptEntry::fromContext(const Elemen
       {
       const ElementType type = e->type();
       std::vector<std::pair<Pid, QString>> props;
-      auto cells(getPaletteCells(type, ctx));
+      auto paletteElements(getPaletteElements(type, ctx));
 
-      if (cells.empty())
+      if (paletteElements.empty())
             return nullptr;
 
-      if (cells.size() > 1) {
+      if (paletteElements.size() > 1) {
             for (Pid pid : PaletteElementScriptEntry::_pids) {
                   const QVariant val = e->getProperty(pid);
                   bool sameValue = false;
                   if (!val.isValid())
                         continue;
-                  for (PaletteCellInfo& c : cells) {
-                        if (c.e == e || !c.e)
+                  for (auto i = paletteElements.begin(); i != paletteElements.end(); ++i) {
+                        const Element* pe = *i;
+                        if (pe == e || !pe)
                               continue;
-                        if (c.e->getProperty(pid) == val)
+                        if (pe->getProperty(pid) == val)
                               sameValue = true;
                         else
-                              c.e = nullptr; // excude it from further comparisons
+                              (*i) = nullptr; // exclude it from further comparisons
                         }
 
                   props.emplace_back(pid, serializePropertyValue(pid, val));


### PR DESCRIPTION
This PR adapts script tests framework code to the recent changes regarding palettes. With this PR test script recorder works with QML palettes and tests are replayed not using the code that belongs to old palettes widget exclusively. View components of palettes widget do not belong to the scope of this test framework (they wasn't really covered before this PR too), and it is not necessary now to instantiate palettes view components to run test scripts.