### PR TITLE
fix #295106: crash on next element

### DIFF
--- a/libmscore/bsymbol.cpp
+++ b/libmscore/bsymbol.cpp
@@ -92,6 +92,7 @@ void BSymbol::add(Element* e)
       {
       if (e->isSymbol() || e->isImage()) {
             e->setParent(this);
+            e->setTrack(track());
             _leafs.append(e);
             toBSymbol(e)->setZ(z() - 1);    // draw on top of parent
             }

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4479,6 +4479,12 @@ void Score::undoAddElement(Element* element)
                                           }
                                     }
                               }
+                        else if (ne->isFretDiagram()) {
+                              // update track of child harmony
+                              FretDiagram* fd = toFretDiagram(ne);
+                              if (fd->harmony())
+                                    fd->harmony()->setTrack(ntrack);
+                              }
 
                         undo(new AddElement(ne));
                         // transpose harmony if necessary

--- a/libmscore/navigate.cpp
+++ b/libmscore/navigate.cpp
@@ -537,6 +537,7 @@ Element* Score::nextElement()
       while (e) {
             switch (e->type()) {
                   case ElementType::NOTE:
+                  case ElementType::REST:
                   case ElementType::CHORD: {
                         Element* next = e->nextElement();
                         if (next)

--- a/libmscore/segment.cpp
+++ b/libmscore/segment.cpp
@@ -1506,7 +1506,9 @@ Element* Segment::nextElement(int activeStaff)
             case ElementType::STAFF_STATE:
             case ElementType::INSTRUMENT_CHANGE:
             case ElementType::STICKING: {
-                  Element* next = nextAnnotation(e);
+                  Element* next = nullptr;
+                  if (e->parent() == this)
+                        next = nextAnnotation(e);
                   if (next)
                         return next;
                   else {
@@ -1624,7 +1626,9 @@ Element* Segment::prevElement(int activeStaff)
             case ElementType::STAFF_STATE:
             case ElementType::INSTRUMENT_CHANGE:
             case ElementType::STICKING: {
-                  Element* prev = prevAnnotation(e);
+                  Element* prev = nullptr;
+                  if (e->parent() == this)
+                        prev = prevAnnotation(e);
                   if (prev)
                         return prev;
                   if (notChordRestType(this)) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/295106

There are a number of cases where next element ended up hitting unexpected code paths.
Mostly these involve cases of elements being attached somewhere pther than expected:
symbols attached to rests or to other symbols rather than to notes,
chord symbols attached to fret diagrams.
This change addresses these cases in a few different ways:
1) for symbols to attached to other symbols, or chord symbols attached to fret diagrams,
srt the track correctly (it was -1, causing the  the code to not be able to find a next element).
2) for symbols attached to rests, be sure to handle that case in Score::nextElement(),
and also make sure that Segment::nextElement() and Segment::prevElement()
don't assume these elements actually have the segment as parent,
but instead check for that and move on if not.

I did try to add a script test but ran into a couple of problems: the Symbols palette isn't visible to the script framework, and there is no way to select a symbol attached to a rest other than by clicking,
which also can't be captured in a script test.  Really, though, that in itself is another issue that needs fixing: navigation skips symbols attached to rests, or to other symbols.  The good news, that means most people won't hit this bug, since navigation won't reach the elements that would cause a crash.
You have to explicitly click the element then hit Alt+Right (or Left) to see the problem.

Fixing the navigation so these symbols can be reached is certainly possible but more work, and I did want to at least fix the crash for 3.3 if possible.