### PR TITLE
fix #295107: hang or crash on fingering mode after last note

### DIFF
--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -2874,6 +2874,8 @@ Element* Note::nextInEl(Element* e)
       if (e == _el.back())
             return nullptr;
       auto i = std::find(_el.begin(), _el.end(), e);
+      if (i == _el.end())
+            return nullptr;
       return *(i+1);
       }
 
@@ -2887,6 +2889,8 @@ Element* Note::prevInEl(Element* e)
       if (e == _el.front())
             return nullptr;
       auto i = std::find(_el.begin(), _el.end(), e);
+      if (i == _el.end())
+            return nullptr;
       return *(i-1);
       }
 

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -743,6 +743,11 @@ void ScoreView::keyPressEvent(QKeyEvent* ev)
 
       if (!( (editData.modifiers & Qt::ShiftModifier) && (editData.key == Qt::Key_Backtab) )) {
             if (editData.element->edit(editData)) {
+                  if (state != ViewState::EDIT) {
+                        // textTab or other function may have terminated edit mode
+                        mscore->endCmd();
+                        return;
+                        }
                   if (editData.element->isTextBase())
                         mscore->textTools()->updateTools(editData);
                   else

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -2432,7 +2432,7 @@ void ScoreView::textTab(bool back)
       changeState(ViewState::NORMAL);
 
       // find new note to add text to
-      bool here = false;      // prevent infinite loop
+      bool here = false;      // prevent infinite loop (relevant if navigation is allowed to wrap around end of score)
       while (el) {
             if (el->isNote()) {
                   Note* n = toNote(el);
@@ -2455,12 +2455,18 @@ void ScoreView::textTab(bool back)
                   }
             // get prev/next note
             score()->select(el);
-            el = back ? score()->prevElement() : score()->nextElement();
+            Element* el2 = back ? score()->prevElement() : score()->nextElement();
+            // start/end of score reached
+            if (el2 == el)
+                  break;
+            el = el2;
             }
       if (!el || !el->isNote()) {
-            // nothing found, re-select original element and give up
-            score()->select(oe);
-            changeState(ViewState::EDIT);
+            // nothing found, exit cleanly
+            if (op->selectable())
+                  score()->select(op);
+            else
+                  score()->deselectAll();
             return;
             }
       Note* nn = toNote(el);
@@ -2499,7 +2505,6 @@ void ScoreView::textTab(bool back)
       if (el) {
             // edit existing text
             score()->select(el);
-            mscore->updateInspector();    // needed for Space with fingering
             startEditMode(el);
             }
       else {

--- a/mtest/testscript/scripts/#295107-last-finger-crash.mscx
+++ b/mtest/testscript/scripts/#295107-last-finger-crash.mscx
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<museScore version="3.01">
+  <Score>
+    <LayerTag id="0" tag="default"></LayerTag>
+    <currentLayer>0</currentLayer>
+    <Division>480</Division>
+    <Style>
+      <pageWidth>8.27</pageWidth>
+      <pageHeight>11.69</pageHeight>
+      <pagePrintableWidth>7.4826</pagePrintableWidth>
+      <lastSystemFillLimit>0</lastSystemFillLimit>
+      <Spatium>1.76389</Spatium>
+      </Style>
+    <showInvisible>1</showInvisible>
+    <showUnprintable>1</showUnprintable>
+    <showFrames>1</showFrames>
+    <showMargins>0</showMargins>
+    <metaTag name="arranger"></metaTag>
+    <metaTag name="composer"></metaTag>
+    <metaTag name="copyright"></metaTag>
+    <metaTag name="creationDate">2018-11-12</metaTag>
+    <metaTag name="lyricist"></metaTag>
+    <metaTag name="movementNumber"></metaTag>
+    <metaTag name="movementTitle"></metaTag>
+    <metaTag name="platform">Linux</metaTag>
+    <metaTag name="poet"></metaTag>
+    <metaTag name="source"></metaTag>
+    <metaTag name="translator"></metaTag>
+    <metaTag name="workNumber"></metaTag>
+    <metaTag name="workTitle">Treble</metaTag>
+    <Part>
+      <Staff id="1">
+        <StaffType group="pitched">
+          <name>stdNormal</name>
+          </StaffType>
+        </Staff>
+      <trackName>Piano</trackName>
+      <Instrument>
+        <longName>Piano</longName>
+        <shortName>Pno.</shortName>
+        <trackName>Piano</trackName>
+        <minPitchP>21</minPitchP>
+        <maxPitchP>108</maxPitchP>
+        <minPitchA>21</minPitchA>
+        <maxPitchA>108</maxPitchA>
+        <instrumentId>keyboard.piano</instrumentId>
+        <Articulation>
+          <velocity>100</velocity>
+          <gateTime>95</gateTime>
+          </Articulation>
+        <Articulation name="staccatissimo">
+          <velocity>100</velocity>
+          <gateTime>33</gateTime>
+          </Articulation>
+        <Articulation name="staccato">
+          <velocity>100</velocity>
+          <gateTime>50</gateTime>
+          </Articulation>
+        <Articulation name="portato">
+          <velocity>100</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="tenuto">
+          <velocity>100</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Articulation name="marcato">
+          <velocity>120</velocity>
+          <gateTime>67</gateTime>
+          </Articulation>
+        <Articulation name="sforzato">
+          <velocity>120</velocity>
+          <gateTime>100</gateTime>
+          </Articulation>
+        <Channel>
+          <program value="0"/>
+          </Channel>
+        </Instrument>
+      </Part>
+    <Staff id="1">
+      <VBox>
+        <height>10</height>
+        <Text>
+          <style>Title</style>
+          <text>Treble</text>
+          </Text>
+        </VBox>
+      <Measure>
+        <voice>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <Fingering>
+                <style>String Number</style>
+                <text>3</text>
+                </Fingering>
+              <pitch>72</pitch>
+              <tpc>14</tpc>
+              </Note>
+            </Chord>
+          <Chord>
+            <durationType>half</durationType>
+            <Note>
+              <pitch>71</pitch>
+              <tpc>19</tpc>
+              </Note>
+            </Chord>
+          </voice>
+        </Measure>
+      </Staff>
+    </Score>
+  </museScore>

--- a/mtest/testscript/scripts/#295107-last-finger-crash.script
+++ b/mtest/testscript/scripts/#295107-last-finger-crash.script
@@ -1,0 +1,16 @@
+init init/Treble.mscx
+cmd select-all
+cmd time-delete
+cmd append-measure
+cmd note-input
+cmd pad-note-2
+cmd note-c
+cmd note-c
+cmd escape
+cmd prev-chord
+palette Fingering style String&#032Number text 3
+cmd edit-element
+cmd next-element
+cmd next-element
+cmd pitch-down
+test score #295107-last-finger-crash.mscx


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/295107

The issue is a crash or hang on navigation while in text edit mode (aka "fingering mode") after the last note of a score.  Results differ according to whether you actually enter text onto that note or not, whether it was a fingering or a different type of text (segment attached), and for fingering, whether you press Space or Alt+Right to navigate.  All of these presented slightly different different aspects of the problem and needed to be dealt with slightly differently.

There turned out to be several aspects to this.
In 3.2.3, we could get a hang if there was literally only one note,
as the navigation would loop back around and we didn't always catch it.
For 3.3 I eliminated the looping back around on navigation,
but neglected to add a check for start/end of score in "fingering mode".
This adds that check (in ScoreView::textTab(), the test for el2 == el).
But further testing revealed further checks we need to make to be safe.
The checks that the current element is actually a child of the note
in Note::nextInEl() and Note::prevInEl() prevents a crash
if one navigates before the fingering has been added to its parent
or after it has been removed (which happens with empty fingering elements).
For consistency with how chord symbols work, and to circumvent other future problems,
I elected to have Space *exit* "fingering mode" after reaching the end of the score.
This required making a reasonable selection (the "exit cleanly" code in textTab)
but also calling mscore->endCmd() and returning immediately in events.cpp in that case.
This had the side benefit of allowing me to remove the updateInspector() call
in textTab(), as it is covered by the endCmd() call.
I should note there are other code paths in, for example, the harmony tab functions,
that can leave an empty / deleted element still selected
when hitting space upon reaching the last note of a score.
But I could not cause an actual problem to occur and chose to not deal with that here.

Script test added to cover the basic issue here.
