### PR TITLE
fix #295153: minimum distance property for all kinds of fermata is not saved

### DIFF
--- a/libmscore/fermata.cpp
+++ b/libmscore/fermata.cpp
@@ -79,7 +79,7 @@ bool Fermata::readProperties(XmlReader& e)
             SymId id = Sym::name2id(s);
             setSymId(id);
             }
-      else if ( tag == "play")
+      else if (tag == "play")
             setPlay(e.readBool());
       else if (tag == "timeStretch")
             _timeStretch = e.readDouble();
@@ -110,6 +110,7 @@ void Fermata::write(XmlWriter& xml) const
       xml.tag("subtype", Sym::id2name(_symId));
       writeProperty(xml, Pid::TIME_STRETCH);
       writeProperty(xml, Pid::PLAY);
+      writeProperty(xml, Pid::MIN_DISTANCE);
       if (!isStyled(Pid::OFFSET))
             writeProperty(xml, Pid::OFFSET);
       Element::writeProperties(xml);


### PR DESCRIPTION
Resolves: https://musescore.org/node/295153.

Fermata uses a different cpp file than other articulations, so it is possible that this part of property read-and-writing was simply forgotten.