### PR TITLE
Accessibility: Note input toolbutton

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -572,10 +572,10 @@ void MuseScore::populateNoteInputMenu()
                         connect(noteEntryMethods, SIGNAL(triggered(QAction*)), this, SLOT(cmd(QAction*)));
 
                         w = new ToolButtonMenu(tr("Note Entry Methods"),
-                           ToolButtonMenu::TYPES::ICON_CHANGED,
                            getAction("note-input"),
                            noteEntryMethods,
-                           this);
+                           this,
+                           false);
                         w->setObjectName("note-entry-methods");
                         }
                   else if (strncmp(s, "voice-", 6) == 0) {

--- a/mscore/toolbuttonmenu.cpp
+++ b/mscore/toolbuttonmenu.cpp
@@ -13,24 +13,25 @@
 
 namespace Ms {
 
-ToolButtonMenu::ToolButtonMenu(QString str,
-                     TYPES type,
+ToolButtonMenu::ToolButtonMenu(QString name,
                      QAction* defaultAction,
                      QActionGroup* alternativeActions,
-                     QWidget* parent) : AccessibleToolButton(parent, defaultAction)
+                     QWidget* parent,
+                     bool swapAction)
+      : AccessibleToolButton(parent, defaultAction)
       {
-      // if, and only if, type is ACTION_SWAPPED then the default action is also an alternative action.
-      Q_ASSERT((type == TYPES::ACTION_SWAPPED) == alternativeActions->actions().contains(defaultAction));
+      // does the default action count as one of the alternative actions?
+      Q_ASSERT(swapAction == alternativeActions->actions().contains(defaultAction));
 
-      _type = type;
+      _swapAction = swapAction;
       _alternativeActions = alternativeActions;
 
-      setMenu(new QMenu(str, this));
+      setMenu(new QMenu(name, this));
       menu()->setToolTipsVisible(true);
 
       setPopupMode(QToolButton::MenuButtonPopup);
 
-      if (_type != TYPES::ACTION_SWAPPED) {
+      if (!swapAction) {
             addAction(defaultAction);
             addSeparator();
             }
@@ -45,11 +46,11 @@ ToolButtonMenu::ToolButtonMenu(QString str,
 
       connect(_alternativeActions, SIGNAL(triggered(QAction*)), this, SLOT(handleAlternativeAction(QAction*)));
 
-      if (_type != TYPES::ACTION_SWAPPED) {
+      if (!swapAction) {
+            // select first alternative action and use its icon for the default action
             QAction* a = _alternativeActions->actions().first();
             a->setChecked(true);
-            if (_type == TYPES::ICON_CHANGED)
-                  changeIcon(a);
+            switchIcon(a);
             }
       }
 
@@ -57,16 +58,10 @@ void ToolButtonMenu::handleAlternativeAction(QAction* a)
       {
       Q_ASSERT(_alternativeActions->actions().contains(a));
 
-      switch (_type) {
-            case TYPES::FIXED:
-                  break;
-            case TYPES::ICON_CHANGED:
-                  changeIcon(a);
-                  break;
-            case TYPES::ACTION_SWAPPED:
-                  setDefaultAction(a);
-                  break;
-            }
+      if (_swapAction)
+            setDefaultAction(a);
+      else
+            switchIcon(a);
 
       QAction* def = defaultAction();
 

--- a/mscore/toolbuttonmenu.cpp
+++ b/mscore/toolbuttonmenu.cpp
@@ -69,4 +69,19 @@ void ToolButtonMenu::handleAlternativeAction(QAction* a)
             def->trigger();
       }
 
+void ToolButtonMenu::keyPressEvent(QKeyEvent* event)
+      {
+      switch(event->key()) {
+            case Qt::Key_Enter:
+            case Qt::Key_Return:
+            case Qt::Key_Space:
+                  menu()->exec(this->mapToGlobal(QPoint(0, size().height())));
+                  menu()->setFocus();
+                  menu()->setActiveAction(defaultAction());
+                  break;
+            default:
+                  AccessibleToolButton::keyPressEvent(event);
+            }
+      }
+
 } // namespace Ms

--- a/mscore/toolbuttonmenu.h
+++ b/mscore/toolbuttonmenu.h
@@ -20,44 +20,43 @@ namespace Ms {
 //   ToolButtonMenu
 //   ==============
 //   This creates a button with an arrow next to it. Clicking the button triggers the default
-//   action, while pressing the arrow brings up a menu of alternative actions and/or other
-//   actions. Selecting an alternative action has some effect on the default action's icon
-//   and/or its behavior. Other actions have no effect on the default action.
+//   action, while pressing the arrow brings up a menu of alternative actions. Selecting an
+//   alternative action triggers it and also has some effect on the default action.
+//
+//   The menu may contain:
+//      - Any number of alternative actions in addition to the default action.
+//      - Other actions that do not affect the default action.
+//         - These are not considered "alternative actions" for our purposes.
+//
+//   The effect of selecting an alternative action is determined by the swapAction boolean.
+//      TRUE: The selected action replaces the default action (it becomes the new default).
+//      FALSE: The default action remains unchanged, but its icon is updated to match the
+//         icon of the selected alternative action.
 //---------------------------------------------------------
 
 class ToolButtonMenu : public AccessibleToolButton { // : public QToolButton {
       Q_OBJECT
 
-   public:
-      enum class TYPES {
-            // What happens to the default action if an alternative (non-default) action is triggered?
-            FIXED, // default action is also triggered but is otherwise unchanged.
-            ICON_CHANGED, // default action is triggered and its icon is modified and/or set to that of the triggering action.
-            ACTION_SWAPPED // default action is not triggered. Triggering action (and its icon) become the new default.
-            };
-
    private:
-      TYPES _type;
       QActionGroup* _alternativeActions;
+      bool _swapAction;
 
    public:
       ToolButtonMenu(QString str,
-                     TYPES type,
                      QAction* defaultAction,
                      QActionGroup* alternativeActions,
-                     QWidget* parent);
+                     QWidget* parent = nullptr,
+                     bool swapAction = true);
       void addAction(QAction* a) { menu()->addAction(a); }
       void addSeparator() { menu()->addSeparator(); }
       void addActions(QList<QAction*> actions) { for (QAction* a : actions) addAction(a); }
 
    private:
       void switchIcon(QAction* a) {
-            Q_ASSERT(_type == TYPES::ICON_CHANGED && _alternativeActions->actions().contains(a));
+            Q_ASSERT(!_swapAction);
+            Q_ASSERT(_alternativeActions->actions().contains(a));
             defaultAction()->setIcon(a->icon());
             }
-
-   protected:
-      virtual void changeIcon(QAction* a) { switchIcon(a); }
 
    private slots:
       void handleAlternativeAction(QAction* a);

--- a/mscore/toolbuttonmenu.h
+++ b/mscore/toolbuttonmenu.h
@@ -61,6 +61,9 @@ class ToolButtonMenu : public AccessibleToolButton { // : public QToolButton {
    private slots:
       void handleAlternativeAction(QAction* a);
 
+   protected:
+      void keyPressEvent(QKeyEvent* event) override;
+
       };
 
 } // namespace Ms


### PR DESCRIPTION
This PR makes the note input toolbar's dropdown menu of note input modes (real-time, step-time, repitch, etc.) accessible to keyboard users. Previously the main note input button was accessible but the dropdown menu next to it was not.

To test, press the Tab key until the Note Input button has focus, then press Enter, Return, or Space to open the menu. The menu opens on the default option, so pressing Enter a second time is equivalent to a sighted person clicking the main note input button once.

An alternative method would be to set the toolbutton's menu popup mode to [QToolButton::InstantPopup](https://doc.qt.io/qt-5/qtoolbutton.html#ToolButtonPopupMode-enum). This is simpler, but it would mean that sighted users would need to click twice too.