### PR TITLE
Upload latest vtest metadata to vtest.musescore.org

### DIFF
--- a/build/travis/job1_Tests/environment.sh
+++ b/build/travis/job1_Tests/environment.sh
@@ -33,7 +33,7 @@ export PATH="$PATH:$HOME/bin:$HOME/software/bin"
 
 # Prepare for post-install upload of artifacts to S3
 export TRAVIS_SHORT_COMMIT="$(echo $TRAVIS_COMMIT | cut -c 1-8)"
-export ARTIFACTS_TARGET_PATHS="$TRAVIS_SHORT_COMMIT"
+export ARTIFACTS_TARGET_PATHS="$TRAVIS_SHORT_COMMIT:latest"
 export ARTIFACTS_PERMISSIONS=public-read
 export TRAVIS_BUILD_DIR=vtest/html
 #compatibility between ruby travis artifact and GO one

--- a/build/travis/job1_Tests/run_tests.sh
+++ b/build/travis/job1_Tests/run_tests.sh
@@ -37,7 +37,7 @@ rm -f /tmp/$$ # Cleanup
 
 #pwd == build.debug/mtest
 cd ../../vtest
-VTEST_BROWSER=ls xvfb-run ./gen
+VTEST_BROWSER=ls VTEST_GEN_METADATA=1 xvfb-run ./gen
 cd -
 
 #make reporthtml

--- a/vtest/gen
+++ b/vtest/gen
@@ -105,6 +105,16 @@ echo "{}]" >> $JSON_FILE
 echo "Generate PNG files"
 $MSCORE -j $JSON_FILE -r $DPI >LOG 2>&1
 
+if [ "$VTEST_GEN_METADATA" = "1" ]
+then
+    git branch --sort=-committerdate --format="%(refname:short) %(objectname:short)" > branches.list
+    rm -f tests.list
+    for F in $SRC
+    do
+        echo "$F" >> tests.list
+    done
+fi
+
 echo "Compare PNG files and references"
 for src in $SRC; do
       if test -f $src-1.png; then


### PR DESCRIPTION
That would allow http://vtest.musescore.org/compare.html to always use actual data regarding existing tests and MuseScore versions.

I don't know how to test this before merging though as these changes should probably change anything only for branches from the main MuseScore repository so pull requests won't upload anything.