### PR TITLE
fix #284481: automatic placement of single rests in multiple voice areas, follow-up for PR #5127

### DIFF
--- a/libmscore/rest.cpp
+++ b/libmscore/rest.cpp
@@ -488,8 +488,13 @@ int Rest::computeLineOffset(int lines)
                         offsetVoices = false;
                         }
                   }
-            else if (measure()->isOnlyDeletedRests(track() + 1, tick(), tick() + globalTicks()))
+            else {
                   offsetVoices = false;
+                  for (int i = 1; i < VOICES; ++i) {
+                        if (!measure()->isOnlyDeletedRests(track() + i, tick(), tick() + globalTicks()))
+                              offsetVoices = true;
+                        }
+                  }
             }
 #if 0
       if (offsetVoices && staff()->mergeMatchingRests()) {


### PR DESCRIPTION
PR #5127 only deals with "the next track" (`track() + 1`), which is the second track, but the check is needed for all three other tracks.