### PR TITLE
Fix #295224: end-start-repeat crashes in timeline

### DIFF
--- a/mscore/timeline.cpp
+++ b/mscore/timeline.cpp
@@ -1232,7 +1232,7 @@ void Timeline::barline_meta(Segment* seg, int* stagger, int pos)
                         repeat_text = QString("End repeat");
                         break;
                   case BarLineType::END_START_REPEAT:
-                        repeat_text = QString("End-start repeat");
+                        // actually an end repeat followed by a start repeat, so nothing needs to be done here
                         break;
                   case BarLineType::DOUBLE:
                         repeat_text = QString("Double barline");


### PR DESCRIPTION
thanks to @mattmcclinch for finding the culprit line of code