### PR TITLE
Fix a crash on reading a workspace with non-existing preferences

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -227,7 +227,7 @@ QVariant Preferences::defaultValue(const QString key) const
       {
       checkIfKeyExists(key);
       Preference* pref = _allPreferences.value(key);
-      return pref->defaultValue();
+      return pref ? pref->defaultValue() : QVariant();
       }
 
 QSettings* Preferences::settings() const


### PR DESCRIPTION
This should prevent issues like [#295238](https://musescore.org/en/node/295238) from happening in future in case new settings get introduced to MuseScore.