### PR TITLE
Redesign note input workflow based on Tantacrul's suggestions

### DIFF
--- a/libmscore/accidental.cpp
+++ b/libmscore/accidental.cpp
@@ -234,6 +234,14 @@ const char* Accidental::subtype2name(AccidentalType st)
       }
 
 //---------------------------------------------------------
+//   subtype2symbol
+//---------------------------------------------------------
+
+SymId Accidental::subtype2symbol(AccidentalType st)
+      {
+      return accList[int(st)].sym;
+      }
+//---------------------------------------------------------
 //   name2subtype
 //---------------------------------------------------------
 

--- a/libmscore/accidental.h
+++ b/libmscore/accidental.h
@@ -114,6 +114,7 @@ class Accidental final : public Element {
       virtual QString propertyUserValue(Pid) const override;
 
       static AccidentalVal subtype2value(AccidentalType);             // return effective pitch offset
+      static SymId subtype2symbol(AccidentalType);
       static const char* subtype2name(AccidentalType);
       static AccidentalType value2subtype(AccidentalVal);
       static AccidentalType name2subtype(const QString&);

--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -604,7 +604,7 @@ void Score::createCRSequence(const Fraction& f, ChordRest* cr, const Fraction& t
 //    return segment of last created note/rest
 //---------------------------------------------------------
 
-Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction sd, Direction stemDirection, bool rhythmic)
+Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction sd, Direction stemDirection, bool forceAccidental, bool rhythmic)
       {
       Q_ASSERT(segment->segmentType() == SegmentType::ChordRest);
 
@@ -661,6 +661,15 @@ Segment* Score::setNoteRest(Segment* segment, int track, NoteVal nval, Fraction 
                         chord->setStemDirection(stemDirection);
                         chord->add(note);
                         note->setNval(nval, tick);
+                        if (forceAccidental) {
+                              int tpc = styleB(Sid::concertPitch) ? nval.tpc2 : nval.tpc1;
+                              AccidentalVal alter = tpc2alter(tpc);
+                              AccidentalType at = Accidental::value2subtype(alter);
+                              Accidental* a = new Accidental(this);
+                              a->setAccidentalType(at);
+                              a->setRole(AccidentalRole::USER);
+                              note->add(a);
+                              }
                         ncr = chord;
                         if (i+1 < n) {
                               tie = new Tie(this);
@@ -1569,6 +1578,29 @@ void Score::addArticulation(SymId attr)
             }
       }
 
+//---------------------------------------------------------
+//   toggleAccidental
+//---------------------------------------------------------
+
+void Score::toggleAccidental(AccidentalType at, const EditData& ed)
+      {
+      if (_is.accidentalType() == at)
+            at = AccidentalType::NONE;
+      if (noteEntryMode()) {
+            _is.setAccidentalType(at);
+            _is.setRest(false);
+            }
+      else {
+            if (selection().isNone()) {
+                  ed.view->startNoteEntryMode();
+                  _is.setAccidentalType(at);
+                  _is.setDuration(TDuration::DurationType::V_QUARTER);
+                  _is.setRest(false);
+                  }
+            else
+                  changeAccidental(at);
+            }
+      }
 //---------------------------------------------------------
 //   changeAccidental
 ///   Change accidental to subtype \a idx for all selected
@@ -3155,39 +3187,39 @@ void Score::cmdPitchDownOctave()
 //   cmdPadNoteInclreaseTAB
 //---------------------------------------------------------
 
-void Score::cmdPadNoteIncreaseTAB()
+void Score::cmdPadNoteIncreaseTAB(const EditData& ed)
       {
       switch (_is.duration().type() ) {
 // cycle back from longest to shortest?
 //          case TDuration::V_LONG:
-//                padToggle(Pad::NOTE128);
+//                padToggle(Pad::NOTE128, ed);
 //                break;
             case TDuration::DurationType::V_BREVE:
-                  padToggle(Pad::NOTE00);
+                  padToggle(Pad::NOTE00, ed);
                   break;
             case TDuration::DurationType::V_WHOLE:
-                  padToggle(Pad::NOTE0);
+                  padToggle(Pad::NOTE0, ed);
                   break;
             case TDuration::DurationType::V_HALF:
-                  padToggle(Pad::NOTE1);
+                  padToggle(Pad::NOTE1, ed);
                   break;
             case TDuration::DurationType::V_QUARTER:
-                  padToggle(Pad::NOTE2);
+                  padToggle(Pad::NOTE2, ed);
                   break;
             case TDuration::DurationType::V_EIGHTH:
-                  padToggle(Pad::NOTE4);
+                  padToggle(Pad::NOTE4, ed);
                   break;
             case TDuration::DurationType::V_16TH:
-                  padToggle(Pad::NOTE8);
+                  padToggle(Pad::NOTE8, ed);
                   break;
             case TDuration::DurationType::V_32ND:
-                  padToggle(Pad::NOTE16);
+                  padToggle(Pad::NOTE16, ed);
                   break;
             case TDuration::DurationType::V_64TH:
-                  padToggle(Pad::NOTE32);
+                  padToggle(Pad::NOTE32, ed);
                   break;
             case TDuration::DurationType::V_128TH:
-                  padToggle(Pad::NOTE64);
+                  padToggle(Pad::NOTE64, ed);
                   break;
             default:
                   break;
@@ -3198,39 +3230,39 @@ void Score::cmdPadNoteIncreaseTAB()
 //   cmdPadNoteDecreaseTAB
 //---------------------------------------------------------
 
-void Score::cmdPadNoteDecreaseTAB()
+void Score::cmdPadNoteDecreaseTAB(const EditData& ed)
       {
       switch (_is.duration().type() ) {
             case TDuration::DurationType::V_LONG:
-                  padToggle(Pad::NOTE0);
+                  padToggle(Pad::NOTE0, ed);
                   break;
             case TDuration::DurationType::V_BREVE:
-                  padToggle(Pad::NOTE1);
+                  padToggle(Pad::NOTE1, ed);
                   break;
             case TDuration::DurationType::V_WHOLE:
-                  padToggle(Pad::NOTE2);
+                  padToggle(Pad::NOTE2, ed);
                   break;
             case TDuration::DurationType::V_HALF:
-                  padToggle(Pad::NOTE4);
+                  padToggle(Pad::NOTE4, ed);
                   break;
             case TDuration::DurationType::V_QUARTER:
-                  padToggle(Pad::NOTE8);
+                  padToggle(Pad::NOTE8, ed);
                   break;
             case TDuration::DurationType::V_EIGHTH:
-                  padToggle(Pad::NOTE16);
+                  padToggle(Pad::NOTE16, ed);
                   break;
             case TDuration::DurationType::V_16TH:
-                  padToggle(Pad::NOTE32);
+                  padToggle(Pad::NOTE32, ed);
                   break;
             case TDuration::DurationType::V_32ND:
-                  padToggle(Pad::NOTE64);
+                  padToggle(Pad::NOTE64, ed);
                   break;
             case TDuration::DurationType::V_64TH:
-                  padToggle(Pad::NOTE128);
+                  padToggle(Pad::NOTE128, ed);
                   break;
 // cycle back from shortest to longest?
 //          case TDuration::DurationType::V_128TH:
-//                padToggle(Pad::NOTE00);
+//                padToggle(Pad::NOTE00, ed);
 //                break;
             default:
                   break;
@@ -3497,7 +3529,9 @@ void Score::cmdAddPitch(int step, bool addFlag, bool insert)
                   NoteVal nval = noteValForPosition(pos, error);
                   if (error)
                         return;
-                  addNote(chord, nval);
+                  bool forceAccidental = _is.accidentalType() != AccidentalType::NONE;
+                  addNote(chord, nval, forceAccidental);
+                  _is.setAccidentalType(AccidentalType::NONE);
                   return;
                   }
             }
@@ -3669,26 +3703,26 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "add-down-bow",               [this]{ addArticulation(SymId::stringsDownBow);                     }},
             { "add-8va",                    [this]{ cmdAddOttava(OttavaType::OTTAVA_8VA);                       }},
             { "add-8vb",                    [this]{ cmdAddOttava(OttavaType::OTTAVA_8VB);                       }},
-            { "note-longa",                 [this]{ padToggle(Pad::NOTE00);                                     }},
-            { "note-longa-TAB",             [this]{ padToggle(Pad::NOTE00);                                     }},
-            { "note-breve",                 [this]{ padToggle(Pad::NOTE0);                                      }},
-            { "note-breve-TAB",             [this]{ padToggle(Pad::NOTE0);                                      }},
-            { "pad-note-1",                 [this]{ padToggle(Pad::NOTE1);                                      }},
-            { "pad-note-1-TAB",             [this]{ padToggle(Pad::NOTE1);                                      }},
-            { "pad-note-2",                 [this]{ padToggle(Pad::NOTE2);                                      }},
-            { "pad-note-2-TAB",             [this]{ padToggle(Pad::NOTE2);                                      }},
-            { "pad-note-4",                 [this]{ padToggle(Pad::NOTE4);                                      }},
-            { "pad-note-4-TAB",             [this]{ padToggle(Pad::NOTE4);                                      }},
-            { "pad-note-8",                 [this]{ padToggle(Pad::NOTE8);                                      }},
-            { "pad-note-8-TAB",             [this]{ padToggle(Pad::NOTE8);                                      }},
-            { "pad-note-16",                [this]{ padToggle(Pad::NOTE16);                                     }},
-            { "pad-note-16-TAB",            [this]{ padToggle(Pad::NOTE16);                                     }},
-            { "pad-note-32",                [this]{ padToggle(Pad::NOTE32);                                     }},
-            { "pad-note-32-TAB",            [this]{ padToggle(Pad::NOTE32);                                     }},
-            { "pad-note-64",                [this]{ padToggle(Pad::NOTE64);                                     }},
-            { "pad-note-64-TAB",            [this]{ padToggle(Pad::NOTE64);                                     }},
-            { "pad-note-128",               [this]{ padToggle(Pad::NOTE128);                                    }},
-            { "pad-note-128-TAB",           [this]{ padToggle(Pad::NOTE128);                                    }},
+            { "note-longa",                 [this,ed]{ padToggle(Pad::NOTE00, ed);                              }},
+            { "note-longa-TAB",             [this,ed]{ padToggle(Pad::NOTE00, ed);                              }},
+            { "note-breve",                 [this,ed]{ padToggle(Pad::NOTE0, ed);                               }},
+            { "note-breve-TAB",             [this,ed]{ padToggle(Pad::NOTE0, ed);                               }},
+            { "pad-note-1",                 [this,ed]{ padToggle(Pad::NOTE1, ed);                               }},
+            { "pad-note-1-TAB",             [this,ed]{ padToggle(Pad::NOTE1, ed);                               }},
+            { "pad-note-2",                 [this,ed]{ padToggle(Pad::NOTE2, ed);                               }},
+            { "pad-note-2-TAB",             [this,ed]{ padToggle(Pad::NOTE2, ed);                               }},
+            { "pad-note-4",                 [this,ed]{ padToggle(Pad::NOTE4, ed);                               }},
+            { "pad-note-4-TAB",             [this,ed]{ padToggle(Pad::NOTE4, ed);                               }},
+            { "pad-note-8",                 [this,ed]{ padToggle(Pad::NOTE8, ed);                               }},
+            { "pad-note-8-TAB",             [this,ed]{ padToggle(Pad::NOTE8, ed);                               }},
+            { "pad-note-16",                [this,ed]{ padToggle(Pad::NOTE16, ed);                              }},
+            { "pad-note-16-TAB",            [this,ed]{ padToggle(Pad::NOTE16, ed);                              }},
+            { "pad-note-32",                [this,ed]{ padToggle(Pad::NOTE32, ed);                              }},
+            { "pad-note-32-TAB",            [this,ed]{ padToggle(Pad::NOTE32, ed);                              }},
+            { "pad-note-64",                [this,ed]{ padToggle(Pad::NOTE64, ed);                              }},
+            { "pad-note-64-TAB",            [this,ed]{ padToggle(Pad::NOTE64, ed);                              }},
+            { "pad-note-128",               [this,ed]{ padToggle(Pad::NOTE128, ed);                             }},
+            { "pad-note-128-TAB",           [this,ed]{ padToggle(Pad::NOTE128, ed);                             }},
             { "reset-style",                [this]{ cmdResetStyle();                                            }},
             { "reset-beammode",             [this]{ cmdResetBeamMode();                                         }},
             { "reset-groupings",            [this]{ cmdResetNoteAndRestGroupings();                             }},
@@ -3700,21 +3734,21 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "voice-x23",                  [this]{ cmdExchangeVoice(1, 2);                                     }},
             { "voice-x24",                  [this]{ cmdExchangeVoice(1, 3);                                     }},
             { "voice-x34",                  [this]{ cmdExchangeVoice(2, 3);                                     }},
-            { "pad-rest",                   [this]{ padToggle(Pad::REST);                                       }},
-            { "pad-dot",                    [this]{ padToggle(Pad::DOT);                                        }},
-            { "pad-dotdot",                 [this]{ padToggle(Pad::DOTDOT);                                     }},
-            { "pad-dot3",                   [this]{ padToggle(Pad::DOT3);                                       }},
-            { "pad-dot4",                   [this]{ padToggle(Pad::DOT4);                                       }},
+            { "pad-rest",                   [this,ed]{ padToggle(Pad::REST, ed);                                }},
+            { "pad-dot",                    [this,ed]{ padToggle(Pad::DOT, ed);                                 }},
+            { "pad-dotdot",                 [this,ed]{ padToggle(Pad::DOTDOT, ed);                              }},
+            { "pad-dot3",                   [this,ed]{ padToggle(Pad::DOT3, ed);                                }},
+            { "pad-dot4",                   [this,ed]{ padToggle(Pad::DOT4, ed);                                }},
             { "beam-start",                 [this]{ cmdSetBeamMode(Beam::Mode::BEGIN);                          }},
             { "beam-mid",                   [this]{ cmdSetBeamMode(Beam::Mode::MID);                            }},
             { "no-beam",                    [this]{ cmdSetBeamMode(Beam::Mode::NONE);                           }},
             { "beam32",                     [this]{ cmdSetBeamMode(Beam::Mode::BEGIN32);                        }},
             { "beam64",                     [this]{ cmdSetBeamMode(Beam::Mode::BEGIN64);                        }},
-            { "sharp2",                     [this]{ changeAccidental(AccidentalType::SHARP2);                   }},
-            { "sharp",                      [this]{ changeAccidental(AccidentalType::SHARP);                    }},
-            { "nat",                        [this]{ changeAccidental(AccidentalType::NATURAL);                  }},
-            { "flat",                       [this]{ changeAccidental(AccidentalType::FLAT);                     }},
-            { "flat2",                      [this]{ changeAccidental(AccidentalType::FLAT2);                    }},
+            { "sharp2",                     [this,ed]{ toggleAccidental(AccidentalType::SHARP2, ed);            }},
+            { "sharp",                      [this,ed]{ toggleAccidental(AccidentalType::SHARP, ed);             }},
+            { "nat",                        [this,ed]{ toggleAccidental(AccidentalType::NATURAL, ed);           }},
+            { "flat",                       [this,ed]{ toggleAccidental(AccidentalType::FLAT, ed);              }},
+            { "flat2",                      [this,ed]{ toggleAccidental(AccidentalType::FLAT2, ed);             }},
             { "flip",                       [this]{ cmdFlip();                                                  }},
             { "stretch+",                   [this]{ cmdAddStretch(0.1);                                         }},
             { "stretch-",                   [this]{ cmdAddStretch(-0.1);                                        }},
@@ -3748,10 +3782,10 @@ void Score::cmd(const QAction* a, EditData& ed)
             { "time-delete",                [this]{ cmdTimeDelete();                                            }},
             { "pitch-up-octave",            [this]{ cmdPitchUpOctave();                                         }},
             { "pitch-down-octave",          [this]{ cmdPitchDownOctave();                                       }},
-            { "pad-note-increase",          [this]{ cmdPadNoteIncreaseTAB();                                    }},
-            { "pad-note-decrease",          [this]{ cmdPadNoteDecreaseTAB();                                    }},
-            { "pad-note-increase-TAB",      [this]{ cmdPadNoteIncreaseTAB();                                    }},
-            { "pad-note-decrease-TAB",      [this]{ cmdPadNoteDecreaseTAB();                                    }},
+            { "pad-note-increase",          [this,ed]{ cmdPadNoteIncreaseTAB(ed);                               }},
+            { "pad-note-decrease",          [this,ed]{ cmdPadNoteDecreaseTAB(ed);                               }},
+            { "pad-note-increase-TAB",      [this,ed]{ cmdPadNoteIncreaseTAB(ed);                               }},
+            { "pad-note-decrease-TAB",      [this,ed]{ cmdPadNoteDecreaseTAB(ed);                               }},
             { "toggle-mmrest",              [this]{ cmdToggleMmrest();                                          }},
             { "toggle-hide-empty",          [this]{ cmdToggleHideEmpty();                                       }},
             { "set-visible",                [this]{ cmdSetVisible();                                            }},

--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -368,13 +368,23 @@ Rest* Score::setRest(const Fraction& _tick, int track, const Fraction& _l, bool 
 //   addNote from NoteVal
 //---------------------------------------------------------
 
-Note* Score::addNote(Chord* chord, NoteVal& noteVal)
+Note* Score::addNote(Chord* chord, NoteVal& noteVal, bool forceAccidental)
       {
       Note* note = new Note(this);
       note->setParent(chord);
       note->setTrack(chord->track());
       note->setNval(noteVal);
       undoAddElement(note);
+      if (forceAccidental) {
+            int tpc = styleB(Sid::concertPitch) ? noteVal.tpc2 : noteVal.tpc1;
+            AccidentalVal alter = tpc2alter(tpc);
+            AccidentalType at = Accidental::value2subtype(alter);
+            Accidental* a = new Accidental(this);
+            a->setAccidentalType(at);
+            a->setRole(AccidentalRole::USER);
+            a->setParent(note);
+            undoAddElement(a);
+            }
       setPlayNote(true);
       setPlayChord(true);
       select(note, SelectType::SINGLE, 0);
@@ -1045,7 +1055,7 @@ void Score::regroupNotesAndRests(const Fraction& startTick, const Fraction& endT
                               lastRest = cr;
                               }
                         Fraction restTicks = lastRest->tick() + lastRest->ticks() - curr->tick();
-                        seg = setNoteRest(seg, curr->track(), NoteVal(), restTicks, Direction::AUTO, true);
+                        seg = setNoteRest(seg, curr->track(), NoteVal(), restTicks, Direction::AUTO, false, true);
                         }
                   else if (curr->isChord()) {
                         // combine tied chords

--- a/libmscore/input.h
+++ b/libmscore/input.h
@@ -25,6 +25,7 @@ class ChordRest;
 class Drumset;
 class Segment;
 class Score;
+class Selection;
 
 //---------------------------------------------------------
 //   NoteEntryMethod
@@ -51,6 +52,7 @@ class InputState {
       Beam::Mode _beamMode       { Beam::Mode::AUTO };
       bool _noteEntryMode      { false };
       NoteEntryMethod _noteEntryMethod { NoteEntryMethod::STEPTIME };
+      AccidentalType _accidentalType { AccidentalType::NONE };
       Slur* _slur              { 0     };
       bool _insertMode         { false };
 
@@ -63,7 +65,7 @@ class InputState {
 
       void setDuration(const TDuration& d) { _duration = d;          }
       TDuration duration() const           { return _duration;       }
-      void setDots(int n)                  { _duration.setDots(n);   }
+      void setDots(int n);
       Fraction ticks() const               { return _duration.ticks(); }
 
       Segment* segment() const            { return _segment;        }
@@ -103,13 +105,16 @@ class InputState {
       void setNoteEntryMethod(NoteEntryMethod m)            { _noteEntryMethod = m; }
       bool usingNoteEntryMethod(NoteEntryMethod m) const    { return m == noteEntryMethod(); }
 
+      AccidentalType accidentalType() const                 { return _accidentalType; }
+      void setAccidentalType(AccidentalType val)            { _accidentalType = val;  }
+
       Slur* slur() const                  { return _slur; }
       void setSlur(Slur* s)               { _slur = s; }
 
       bool insertMode() const             { return _insertMode; }
       void setInsertMode(bool val)        { _insertMode = val; }
 
-      void update(Element* e);
+      void update(Selection& selection);
       void moveInputPos(Element* e);
       void moveToNextInputPos();
       bool endOfScore() const;

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -461,7 +461,7 @@ class Score : public QObject, public ScoreElement {
       ChordRest* nextTrack(ChordRest* cr);
       ChordRest* prevTrack(ChordRest* cr);
 
-      void padToggle(Pad n);
+      void padToggle(Pad n, const EditData& ed);
       void addTempo();
       void addMetronome();
 
@@ -523,8 +523,8 @@ class Score : public QObject, public ScoreElement {
       void cmdPitchDown();
       void cmdPitchUpOctave();
       void cmdPitchDownOctave();
-      void cmdPadNoteIncreaseTAB();
-      void cmdPadNoteDecreaseTAB();
+      void cmdPadNoteIncreaseTAB(const EditData& ed);
+      void cmdPadNoteDecreaseTAB(const EditData& ed);
       void cmdToggleMmrest();
       void cmdToggleHideEmpty();
       void cmdSetVisible();
@@ -643,7 +643,7 @@ class Score : public QObject, public ScoreElement {
 
       Note* setGraceNote(Chord*,  int pitch, NoteType type, int len);
 
-      Segment* setNoteRest(Segment*, int track, NoteVal nval, Fraction, Direction stemDirection = Direction::AUTO, bool rhythmic = false);
+      Segment* setNoteRest(Segment*, int track, NoteVal nval, Fraction, Direction stemDirection = Direction::AUTO, bool forceAccidental = false, bool rhythmic = false);
       void changeCRlen(ChordRest* cr, const TDuration&);
       void changeCRlen(ChordRest* cr, const Fraction&, bool fillWithRest=true);
       void createCRSequence(const Fraction& f, ChordRest* cr, const Fraction& tick);
@@ -666,6 +666,7 @@ class Score : public QObject, public ScoreElement {
       // undo/redo ops
       void addArticulation(SymId);
       bool addArticulation(Element*, Articulation* atr);
+      void toggleAccidental(AccidentalType, const EditData& ed);
       void changeAccidental(AccidentalType);
       void changeAccidental(Note* oNote, Ms::AccidentalType);
 
@@ -676,7 +677,7 @@ class Score : public QObject, public ScoreElement {
       void addPitch(int pitch, bool addFlag, bool insert);
       Note* addTiedMidiPitch(int pitch, bool addFlag, Chord* prevChord);
       Note* addMidiPitch(int pitch, bool addFlag);
-      Note* addNote(Chord*, NoteVal& noteVal);
+      Note* addNote(Chord*, NoteVal& noteVal, bool forceAccidental = false);
 
       NoteVal noteValForPosition(Position pos, bool &error);
 

--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -681,8 +681,6 @@ void Selection::updateState()
             if (e->track() >= 0)
                   _currentTrack = e->track();
             }
-      if (!_score->noteEntryMode())
-             _score->inputState().update(e);
       }
 
 //---------------------------------------------------------

--- a/libmscore/shadownote.cpp
+++ b/libmscore/shadownote.cpp
@@ -16,6 +16,7 @@
 #include "sym.h"
 #include "rest.h"
 #include "mscore.h"
+#include "accidental.h"
 
 namespace Ms {
 
@@ -114,6 +115,15 @@ void ShadowNote::draw(QPainter* painter) const
       QPen pen(MScore::selectColor[_voice].lighter(SHADOW_NOTE_LIGHT), lw, Qt::SolidLine, Qt::RoundCap);
       painter->setPen(pen);
 
+      // draw the accidental
+      SymId acc = Accidental::subtype2symbol(score()->inputState().accidentalType());
+      if (acc != SymId::noSym) {
+            QPointF posAcc;
+            posAcc.rx() -= symWidth(acc) + score()->styleP(Sid::accidentalNoteDistance) * mag();
+            drawSymbol(acc, painter, posAcc);
+            }
+
+      // draw the notehead
       drawSymbol(_notehead, painter);
 
       // draw the dots

--- a/mscore/events.cpp
+++ b/mscore/events.cpp
@@ -284,8 +284,7 @@ void ScoreView::mouseReleaseEvent(QMouseEvent* mouseEvent)
                   if (editData.startMove == editData.pos && clickOffElement) {
                         _score->deselectAll();
                         _score->update();
-                        mscore->updateInspector();
-                        ScoreAccessibility::instance()->updateAccessibilityInfo();
+                        mscore->endCmd();
                         }
             case ViewState::EDIT:
             case ViewState::NOTE_ENTRY:

--- a/mscore/keyb.cpp
+++ b/mscore/keyb.cpp
@@ -87,6 +87,8 @@ void MuseScore::updateInputState(Score* score)
                         break;
                   }
             }
+      else
+            is.update(score->selection());
 
       getAction("pad-rest")->setChecked(is.rest());
       getAction("pad-dot")->setChecked(is.duration().dots() == 1);
@@ -129,6 +131,12 @@ void MuseScore::updateInputState(Score* score)
       getAction("pad-note-32")->setChecked(is.duration() == TDuration::DurationType::V_32ND);
       getAction("pad-note-64")->setChecked(is.duration() == TDuration::DurationType::V_64TH);
       getAction("pad-note-128")->setChecked(is.duration() == TDuration::DurationType::V_128TH);
+
+      getAction("sharp2")->setChecked(is.accidentalType() == AccidentalType::SHARP2);
+      getAction("sharp")->setChecked(is.accidentalType() == AccidentalType::SHARP);
+      getAction("nat")->setChecked(is.accidentalType() == AccidentalType::NATURAL);
+      getAction("flat")->setChecked(is.accidentalType() == AccidentalType::FLAT);
+      getAction("flat2")->setChecked(is.accidentalType() == AccidentalType::FLAT2);
 
       // uncheck all voices if multi-selection
       int voice = score->selection().isSingle() ? is.voice() : -1;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -1787,8 +1787,14 @@ void ScoreView::cmd(const char* s)
       if (cmd == "escape")
             escapeCmd();
       else if (cmd == "note-input") {
-            if (state == ViewState::NORMAL)
+            if (state == ViewState::NORMAL) {
                   changeState(ViewState::NOTE_ENTRY);
+                  TDuration td = _score->inputState().duration();
+                  if (!td.isValid() || td.isZero() || td.isMeasure())
+                        _score->inputState().setDuration(TDuration::DurationType::V_QUARTER);
+                  _score->inputState().setAccidentalType(AccidentalType::NONE);
+                  _score->inputState().setRest(false);
+                  }
             else if (state == ViewState::NOTE_ENTRY)
                   changeState(ViewState::NORMAL);
             }
@@ -2674,7 +2680,6 @@ void ScoreView::startNoteEntry()
             is.setDuration(TDuration(TDuration::DurationType::V_QUARTER));
 
       _score->select(el, SelectType::SINGLE, 0);
-      is.update(el);
       is.setRest(false);
       is.setNoteEntryMode(true);
       adjustCanvasPosition(el, false);

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -1574,7 +1574,8 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Note input: Double ♯"),
          QT_TRANSLATE_NOOP("action","Double ♯"),
          Icons::sharpsharp_ICON,
-         Qt::WindowShortcut
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CHECKABLE
          },
       {
          MsWidget::SCORE_TAB,
@@ -1584,7 +1585,8 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Note input: ♯"),
          QT_TRANSLATE_NOOP("action","♯"),
          Icons::sharp_ICON,
-         Qt::WindowShortcut
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CHECKABLE
          },
       {
          MsWidget::SCORE_TAB,
@@ -1594,7 +1596,8 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Note input: ♮"),
          QT_TRANSLATE_NOOP("action","♮"),
          Icons::natural_ICON,
-         Qt::WindowShortcut
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CHECKABLE
          },
       {
          MsWidget::SCORE_TAB,
@@ -1604,7 +1607,8 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Note input: ♭"),
          QT_TRANSLATE_NOOP("action","♭"),
          Icons::flat_ICON,
-         Qt::WindowShortcut
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CHECKABLE
          },
       {
          MsWidget::SCORE_TAB,
@@ -1614,7 +1618,8 @@ Shortcut Shortcut::_sc[] = {
          QT_TRANSLATE_NOOP("action","Note input: Double ♭"),
          QT_TRANSLATE_NOOP("action","Double ♭"),
          Icons::flatflat_ICON,
-         Qt::WindowShortcut
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CHECKABLE
          },
       {
          MsWidget::SCORE_TAB,


### PR DESCRIPTION
See https://musescore.org/en/noteinput_redesign.

This implements most of the changes Tantacrul suggested in his document, except for the part on Tuplets.