### PR TITLE
add B-flat Trumpet to Orchestra genre, delete Piccolo Trumpet in B-flat from Orchestra and Concert Band genres

### DIFF
--- a/share/instruments/instruments.xml
+++ b/share/instruments/instruments.xml
@@ -3287,8 +3287,6 @@
                   <Channel name="mute">
                         <program value="59"/> <!--Muted Trumpet-->
                   </Channel>
-                  <genre>orchestra</genre>
-                  <genre>concertband</genre>
             </Instrument>
             <Instrument id="a-piccolo-trumpet">
                   <longName>Piccolo Trumpet in A</longName>
@@ -3417,6 +3415,7 @@
                   <genre>common</genre>
                   <genre>jazz</genre>
                   <genre>popular</genre>
+                  <genre>orchestra</genre>
                   <genre>concertband</genre>
                   <genre>marching</genre>
             </Instrument>


### PR DESCRIPTION
Since B-flat Trumpet is the most common type and it's used often in orchestras (come on, it's in the Symphony Orchestra template), it should be in the Orchestra genre, instead of Piccolo Trumpet in B-flat, which is rarely used in an orchestra or concert band.