### PR TITLE
fix #295443: "Toggle 'MIDI Input'" should reflect the setting of Edit > Prefecences > Score > Enable MIDI input on start of MuseScore

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -434,7 +434,7 @@ void MuseScore::preferencesChanged(bool fromWorkspace)
       setPlayRepeats(MScore::playRepeats);
       getAction("pan")->setChecked(MScore::panPlayback);
       getAction("follow")->setChecked(preferences.getBool(PREF_APP_PLAYBACK_FOLLOWSONG));
-      getAction("midi-on")->setEnabled(preferences.getBool(PREF_IO_MIDI_ENABLEINPUT));
+      getAction("midi-on")->setChecked(preferences.getBool(PREF_IO_MIDI_ENABLEINPUT));
       getAction("toggle-statusbar")->setChecked(preferences.getBool(PREF_UI_APP_SHOWSTATUSBAR));
       getAction("show-tours")->setChecked(preferences.getBool(PREF_UI_APP_STARTUP_SHOWTOURS));
       _statusBar->setVisible(preferences.getBool(PREF_UI_APP_SHOWSTATUSBAR));


### PR DESCRIPTION
reflect the setting of Edit > Prefecences > Score > Enable MIDI input on start of MuseScore.

Fixes https://musescore.org/en/node/295443

Whether that Icon (and preference setting) is enabled or not should rather depend on whether there is a MIDI device detected, but fixing this is for another day ;-)