### PR TITLE
fix #295531: unable to enter successive sticking elements

### DIFF
--- a/libmscore/sticking.cpp
+++ b/libmscore/sticking.cpp
@@ -78,6 +78,20 @@ void Sticking::layout()
       }
 
 //---------------------------------------------------------
+//   propertyDefault
+//---------------------------------------------------------
+
+QVariant Sticking::propertyDefault(Pid id) const
+      {
+      switch(id) {
+            case Pid::SUB_STYLE:
+                  return int(Tid::STICKING);
+            default:
+                  return TextBase::propertyDefault(id);
+            }
+      }
+
+//---------------------------------------------------------
 //   getPropertyStyle
 //---------------------------------------------------------
 

--- a/libmscore/sticking.h
+++ b/libmscore/sticking.h
@@ -31,6 +31,7 @@ namespace Ms {
 
 class Sticking final : public TextBase {
       virtual Sid getPropertyStyle(Pid) const override;
+      virtual QVariant propertyDefault(Pid id) const override;
 
    public:
       Sticking(Score*);

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4048,6 +4048,8 @@ void ScoreView::cmdAddText(Tid tid, Tid customTid)
 
       TextBase* s = 0;
       _score->startCmd();
+      if (tid == Tid::STAFF && customTid == Tid::EXPRESSION)
+            tid = customTid;  // expression is not first class element, but treat as such
       switch (tid) {
             case Tid::TITLE:
             case Tid::SUBTITLE:


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/295531

In an earlier fix for a crash entering fingering with custom text style,
I introduced a change to how the textTab() function ("fingering mode") works,
so instead of creating a new text element with the same text style as the previous element
(which could conceivably be a user style),
we create one with the same text style as the *default* text style for that element,
and then change the text style later if needed.
This fails for sticking because it had no default text style.
So this change simply adds one, by overriding Sticking::propertyDefault().

The same previous bug fix also broke expression text a little,
because this is actually a staff text, and this process of first creating an element
with the default text style and then changing it ends up missing the placement property.
So you get an object with expression text style but palcement above.
I fix that by special-casing this combination - one of the few places
where we create a pseudo element type that is really just a different text style.
We formerly did this for system text, but it's a first class element now.
Also, RNA is just a different text style on chord symbol,
but that goes through a totally different code path, which works correctly already.

No obvious way to create an automated test for this, since it involves what happens while typing text.