### PR TITLE
Fixes and improvements for workspaces

### DIFF
--- a/mscore/palette/paletteworkspace.h
+++ b/mscore/palette/paletteworkspace.h
@@ -208,6 +208,7 @@ class PaletteWorkspace : public QObject {
       bool paletteChanged() const { return userPalette->paletteTreeChanged(); }
 
       void setUserPaletteTree(std::unique_ptr<PaletteTree> tree);
+      void setDefaultPaletteTree(std::unique_ptr<PaletteTree> tree);
       void write(XmlWriter&) const;
       bool read(XmlReader&);
 

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -251,19 +251,31 @@ Workspace::Workspace()
       }
 
 //---------------------------------------------------------
+//   makeUserWorkspacePath
+///   Returns path for the workspace with the given \p name
+///   creating all the necessary directories.
+//---------------------------------------------------------
+
+QString Workspace::makeUserWorkspacePath(const QString& name)
+      {
+      const QString ext(".workspace");
+      QDir dir;
+      dir.mkpath(dataPath);
+      QString path(dataPath + "/workspaces");
+      dir.mkpath(path);
+      path += "/" + name + ext;
+      return path;
+      }
+
+//---------------------------------------------------------
 //   write
 //---------------------------------------------------------
 
 void Workspace::write()
       {
-      if (_path.isEmpty()) {
-            QString ext(".workspace");
-            QDir dir;
-            dir.mkpath(dataPath);
-            _path = dataPath + "/workspaces";
-            dir.mkpath(_path);
-            _path += "/" + _name + ext;
-            }
+      if (_path.isEmpty())
+            _path = Workspace::makeUserWorkspacePath(_name);
+
       MQZipWriter f(_path);
       f.setCreationPermissions(
          QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner
@@ -1208,10 +1220,14 @@ QString Workspace::findStringFromMenu(QMenu* menu)
 
 void Workspace::rename(const QString& s)
       {
-      QFile file (_path);
-      file.remove();
+      const QString newPath = Workspace::makeUserWorkspacePath(s);
+
+      QFile file(_path);
+      if (file.exists())
+            file.rename(newPath);
+
       setName(s);
-      _path = "";
+      _path = newPath;
       save();
       }
 }

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -34,9 +34,6 @@ class XmlWriter;
 class Workspace : public QObject {
       Q_OBJECT
 
-      static const char* advancedWorkspaceTranslatableName;
-      static const char* basicWorkspaceTranslatableName;
-
       static QList<Workspace*> _workspaces;
       static QList<QPair<QAction*, QString>> actionToStringList;
       static QList<QPair<QMenu*, QString>> menuToStringList;

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -62,6 +62,8 @@ class Workspace : public QObject {
       void readGlobalMenuBar();
       void readGlobalGUIState();
 
+      static QString makeUserWorkspacePath(const QString& name);
+
    public slots:
       void setDirty(bool val = true) { _dirty = val;    }
 

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -24,6 +24,7 @@
 
 namespace Ms {
 
+class PaletteTree;
 class XmlReader;
 class XmlWriter;
 
@@ -50,6 +51,7 @@ class Workspace : public QObject {
 
       QString _name;
       QString _translatableName;
+      QString _sourceWorkspaceName;
       QString _path;
       bool _dirty;
       bool _readOnly;
@@ -63,6 +65,7 @@ class Workspace : public QObject {
       void readGlobalGUIState();
 
       static QString makeUserWorkspacePath(const QString& name);
+      static void readWorkspaceFile(const QString& path, std::function<void(XmlReader&)> readWorkspace);
 
    public slots:
       void setDirty(bool val = true) { _dirty = val;    }
@@ -94,6 +97,10 @@ class Workspace : public QObject {
       static Workspace* createNewWorkspace(const QString& name);
       static bool workspacesRead;
       static QList<Workspace*>& refreshWorkspaces();
+
+      const Workspace* sourceWorkspace() const;
+
+      std::unique_ptr<PaletteTree> getPaletteTree() const;
 
       static void addActionAndString(QAction* action, QString string);
       static void addRemainingFromMenuBar(QMenuBar* mb);


### PR DESCRIPTION
- Fixes workspace loss happening after renaming a workspace;
- Rewrite `Workspace::rename()` function to be more cautions against a possible data loss;
- Make it possible for "Reset Palette" action to reset a palette to a state stored in `.workspace` file.