### PR TITLE
Fix clang warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ if (NOT MSVC)
 endif (NOT MSVC)
 
 if (APPLE)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -stdlib=libc++ -Wno-inconsistent-missing-override")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -stdlib=libc++ -Wno-inconsistent-missing-override -Wno-deprecated-register")
    # This is necessary for genManual to be executed during the build phase,
    # it needs to be able to get the Qt libs.
    # TODO: is it still needed? genManual is removed.

--- a/libmscore/beam.cpp
+++ b/libmscore/beam.cpp
@@ -2056,7 +2056,6 @@ void Beam::write(XmlWriter& xml) const
 
 void Beam::read(XmlReader& e)
       {
-      QPointF p1, p2;
       qreal _spatium = spatium();
       if (score()->mscVersion() < 301)
             _id = e.intAttribute("id");

--- a/libmscore/bend.cpp
+++ b/libmscore/bend.cpp
@@ -148,7 +148,6 @@ void Bend::layout()
 
                   int idx = (_points[pt+1].pitch + 12)/25;
                   const char* l = label[idx];
-                  QRectF r;
                   bb |= fm.boundingRect(QRectF(x2, y2, 0, 0),
                      Qt::AlignHCenter | Qt::AlignBottom | Qt::TextDontClip, QString(l));
                   }

--- a/libmscore/box.h
+++ b/libmscore/box.h
@@ -42,7 +42,6 @@ class Box : public MeasureBase {
       qreal _topMargin              { 0.0   };
       qreal _bottomMargin           { 0.0   };
       bool editMode                 { false };
-      qreal dragX;                        // used during drag of hbox
 
    public:
       Box(Score*);

--- a/libmscore/bracketItem.h
+++ b/libmscore/bracketItem.h
@@ -26,7 +26,6 @@ class BracketItem final : public ScoreElement {
       BracketType _bracketType { BracketType::NO_BRACKET };
       int _column              { 0     };
       int  _bracketSpan        { 0     };
-      bool _selected           { false };
       Staff* _staff            { 0     };
 
    public:

--- a/libmscore/input.h
+++ b/libmscore/input.h
@@ -39,7 +39,6 @@ enum class NoteEntryMethod : char {
 //---------------------------------------------------------
 
 class InputState {
-      Score*      _score;
       TDuration   _duration    { TDuration::DurationType::V_INVALID };  // currently duration
       int         _drumNote    { -1 };
       int         _track       { 0 };
@@ -58,8 +57,6 @@ class InputState {
       Segment* nextInputPos() const;
 
    public:
-      InputState(Score* s) : _score(s) {}
-
       ChordRest* cr() const;
 
       Fraction tick() const;

--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -244,7 +244,7 @@ void MeasureBaseList::change(MeasureBase* ob, MeasureBase* nb)
 //---------------------------------------------------------
 
 Score::Score()
-   : ScoreElement(this), _is(this), _selection(this), _selectionFilter(this)
+   : ScoreElement(this), _selection(this), _selectionFilter(this)
       {
       Score::validScores.insert(this);
       _masterScore = 0;

--- a/libmscore/undo.cpp
+++ b/libmscore/undo.cpp
@@ -413,7 +413,7 @@ Element* UndoMacro::selectedElement(const Selection& sel)
       }
 
 UndoMacro::UndoMacro(Score* s)
-   : undoInputState(s->inputState()), redoInputState(s),
+   : undoInputState(s->inputState()),
    undoSelectedElement(selectedElement(s->selection())), score(s)
       {
       }

--- a/mscore/importptb.h
+++ b/mscore/importptb.h
@@ -70,9 +70,11 @@ class PowerTab {
                   virtual Type type() {
                         return Empty;
                         };
+                  
+                  virtual ~ptComponent() {}
                   };
 
-            struct stRhytmSlash : public ptComponent {
+            struct stRhytmSlash final : public ptComponent {
                   int position {0};
                   int duration {0};
                   bool triplet{ false };
@@ -82,39 +84,39 @@ class PowerTab {
                   bool is_rest{ false };
                   };
 
-            struct ptGuitarIn : public ptComponent {
+            struct ptGuitarIn final : public ptComponent {
                   int rhytmSlash{ true };
                   int staff{ 0 };
                   int trackinfo{ 0 };
                   int section{ 0 };
                   int position{ 0 };
-                  Type type() {
+                  Type type() override {
                         return GuitarIn;
                         }
                   };
 
-            struct ptSymbol : public ptComponent {
+            struct ptSymbol final : public ptComponent {
                   int value{ 0 };
                   ptSymbol(int val) : value(val) {}
-                  Type type() {
+                  Type type() override {
                         return Symbol;
                         }
                   };
 
-            struct ptBar : public ptComponent {
+            struct ptBar final : public ptComponent {
                   int         measureNo{ 0 };
                   int         repeatClose{ 0 };
                   bool  repeatStart{ false };
 
                   int         numerator{ 0 };
                   int         denominator{ 0 };
-                  Type type() {
+                  Type type() override {
                         return Bar;
                         }
                   };
             std::vector<ptBar*> bars;
 
-            struct ptNote : public ptComponent {
+            struct ptNote final : public ptComponent {
                   int               value{ 0 };
                   int               str{ 0 };
                   int               bend{0};
@@ -122,12 +124,12 @@ class PowerTab {
                   bool        dead{ false };
                   bool        hammer{ false };
                   int               slide{ 0 };
-                  Type type() {
+                  Type type() override {
                         return Note;
                         }
                   };
 
-            struct ptChord : public ptComponent {
+            struct ptChord final : public ptComponent {
                   int key;
                   int formula;
                   int modification;
@@ -136,7 +138,7 @@ class PowerTab {
                   std::vector<int> frets;
                   };
 
-            struct ptChordText : public ptComponent {
+            struct ptChordText final : public ptComponent {
                   int position;
                   int key;
                   int formula;
@@ -144,7 +146,7 @@ class PowerTab {
                   int extra;
                   };
 
-            struct ptBeat : public ptComponent {
+            struct ptBeat final : public ptComponent {
                   int                           position{ 0 };
                   int                           staff{ 0 };
                   int                           voice{ 0 };
@@ -166,12 +168,12 @@ class PowerTab {
                   std::vector<ptNote> notes;
 
                   ptBeat(int _staff, int _voice) : staff(_staff), voice(_voice) {}
-                  Type type() {
+                  Type type() override {
                         return Beat;
                         }
                   };
 
-            struct ptDirection : public ptComponent {
+            struct ptDirection final : public ptComponent {
                   enum Direction {
                         DIRECTION_CODA = 0,
                         DIRECTION_DOUBLE_CODA = 1,
@@ -207,7 +209,7 @@ class PowerTab {
 
                   ptDirection(int dir, int sym, int rep) : direction((Direction)dir),
                         activeSymbol((ActiveSym)sym), repeat(rep) {}
-                  Type type() {
+                  Type type() override {
                         return TDirection;
                         }
                   };

--- a/mscore/plugin/qmliconview.cpp
+++ b/mscore/plugin/qmliconview.cpp
@@ -44,7 +44,7 @@ void QmlIconView::paint(QPainter* p)
 void QmlIconView::setIcon(QVariant v)
       {
       if (v.canConvert<QIcon>())
-            _icon = std::move(v.value<QIcon>());
+            _icon = v.value<QIcon>();
       else if (v.canConvert<QColor>()) {
             _color = v.value<QColor>();
             _icon = QIcon();

--- a/mscore/plugin/qmlpluginengine.cpp
+++ b/mscore/plugin/qmlpluginengine.cpp
@@ -26,7 +26,9 @@
 
 namespace Ms {
 
+#ifndef TESTROOT
 static constexpr int maxCmdCount = 10; // recursion prevention
+#endif
 
 //---------------------------------------------------------
 //   QmlPluginEngine

--- a/mscore/sparkle/autoUpdater.h
+++ b/mscore/sparkle/autoUpdater.h
@@ -20,6 +20,7 @@ namespace Ms
             virtual void checkUpdates() {}
             virtual void checkForUpdatesNow() {}
             virtual void cleanup() {}
+            virtual ~GeneralAutoUpdater() {}
       };
 
 } //Ms

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -632,7 +632,7 @@ std::unique_ptr<PaletteTree> Workspace::getPaletteTree() const
                         e.skipCurrentElement();
                   }
             });
-      return std::move(paletteTree);
+      return paletteTree;
       }
 
 void Workspace::read(XmlReader& e)


### PR DESCRIPTION
But the ones related to deprecations in third-party libs

* Remove unused variables
* Prevent calling non-virtual destructors
* Prevent the warning "Moving a temporary object prevents copy elision" by removing std::move call