### PR TITLE
fix #285040 crash when changing a triplet's rest's duration

### DIFF
--- a/libmscore/edit.cpp
+++ b/libmscore/edit.cpp
@@ -4801,8 +4801,11 @@ void Score::undoAddCR(ChordRest* cr, Measure* measure, const Fraction& tick)
                                     if (nt == 0)
                                           qWarning("linked tuplet not found");
                                     }
-                              newcr->setTuplet(nt);
-                              nt->setParent(newcr->measure());
+
+                              if (nt) {
+                                    newcr->setTuplet(nt);
+                                    nt->setParent(newcr->measure());
+                                    }
                               }
                         }
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/285040

Prevents a null pointer dereference and subsequent app crash.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
