### PR TITLE
Rework workspaces editing workflow

### DIFF
--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5445,6 +5445,9 @@ PaletteWorkspace* MuseScore::getPaletteWorkspace()
             paletteWorkspace = new PaletteWorkspace(emptyModel, masterPaletteModel, /* parent */ this);
             emptyModel->setParent(paletteWorkspace);
             masterPaletteModel->setParent(paletteWorkspace);
+
+            if (Workspace::currentWorkspace)
+                  connect(paletteWorkspace, &PaletteWorkspace::userPaletteChanged, Workspace::currentWorkspace, QOverload<>::of(&Workspace::setDirty), Qt::UniqueConnection);
             }
 
       return paletteWorkspace;

--- a/mscore/palette/palettemodel.cpp
+++ b/mscore/palette/palettemodel.cpp
@@ -66,6 +66,32 @@ void PaletteTreeModel::onDataChanged(const QModelIndex& topLeft, const QModelInd
       }
 
 //---------------------------------------------------------
+//   PaletteTreeModel::setTreeChanged
+//---------------------------------------------------------
+
+void PaletteTreeModel::setTreeChanged()
+      {
+      _treeChanged = true;
+      if (!_treeChangedSignalBlocked)
+            emit treeChanged();
+      }
+
+//---------------------------------------------------------
+//   PaletteTreeModel::blockTreeChanged
+//---------------------------------------------------------
+
+bool PaletteTreeModel::blockTreeChanged(bool block)
+      {
+      const bool wasBlocked = _treeChangedSignalBlocked;
+      _treeChangedSignalBlocked = block;
+
+      if (wasBlocked && !block && _treeChanged)
+            emit treeChanged();
+
+      return wasBlocked;
+      }
+
+//---------------------------------------------------------
 //   PaletteTreeModel::iptrToPalettePanel
 //---------------------------------------------------------
 

--- a/mscore/palette/palettemodel.h
+++ b/mscore/palette/palettemodel.h
@@ -105,6 +105,7 @@ class PaletteTreeModel : public QAbstractItemModel {
    private:
       std::unique_ptr<PaletteTree> _paletteTree;
       bool _treeChanged = false;
+      bool _treeChangedSignalBlocked = false;
 
       std::vector<std::unique_ptr<PalettePanel>>& palettes() { return _paletteTree->palettes; }
       const std::vector<std::unique_ptr<PalettePanel>>& palettes() const { return _paletteTree->palettes; }
@@ -117,13 +118,18 @@ class PaletteTreeModel : public QAbstractItemModel {
       
    public slots:
       void itemDataChanged(const QModelIndex& idx);
-      void setTreeChanged() { _treeChanged = true; }
+      void setTreeChanged();
       void setTreeUnchanged() { _treeChanged = false; }
+
+   signals:
+      void treeChanged();
 
    public:
       explicit PaletteTreeModel(std::unique_ptr<PaletteTree> tree, QObject* parent = nullptr);
       explicit PaletteTreeModel(PaletteTree* tree, QObject* parent = nullptr)
          : PaletteTreeModel(std::unique_ptr<PaletteTree>(tree), parent) {}
+
+      bool blockTreeChanged(bool block);
 
       void setPaletteTree(std::unique_ptr<PaletteTree> tree);
       const PaletteTree* paletteTree() const { return _paletteTree.get(); }

--- a/mscore/palette/paletteworkspace.h
+++ b/mscore/palette/paletteworkspace.h
@@ -185,6 +185,9 @@ class PaletteWorkspace : public QObject {
             PaletteIndexRole
             };
 
+   signals:
+      void userPaletteChanged();
+
    public:
       explicit PaletteWorkspace(PaletteTreeModel* user, PaletteTreeModel* master = nullptr, QObject* parent = nullptr);
 

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -46,12 +46,55 @@ static const std::vector<QString> defaultWorkspaces {
       QT_TRANSLATE_NOOP("Ms::Workspace", "Advanced"),
       };
 
+static const std::vector<QString> defaultEditedWorkpaces {
+      QT_TRANSLATE_NOOP("Ms::Workspace", "Basic edited"),
+      QT_TRANSLATE_NOOP("Ms::Workspace", "Advanced edited"),
+      };
+
+//---------------------------------------------------------
+//   editedWorkspaceName
+//---------------------------------------------------------
+
+static QString editedWorkspaceTranslatableName(const QString& oldWorkspaceTranslatableName)
+      {
+      if (oldWorkspaceTranslatableName.isEmpty())
+            return QString();
+
+      const auto it = std::find(defaultWorkspaces.begin(), defaultWorkspaces.end(), oldWorkspaceTranslatableName);
+
+      if (it != defaultWorkspaces.end()) {
+            const int idx = it - defaultWorkspaces.begin();
+            if (idx < int(defaultEditedWorkpaces.size()))
+                  return defaultEditedWorkpaces[idx];
+            }
+
+      return QString();
+      }
+
+//---------------------------------------------------------
+//   editedWorkspaceName
+//---------------------------------------------------------
+
+static QString defaultWorkspaceTranslatableName(const QString& editedWorkspaceName)
+      {
+      const auto it = std::find(defaultEditedWorkpaces.begin(), defaultEditedWorkpaces.end(), editedWorkspaceName);
+
+      if (it != defaultEditedWorkpaces.end()) {
+            const int idx = it - defaultEditedWorkpaces.begin();
+            if (idx < int(defaultWorkspaces.size()))
+                  return defaultWorkspaces[idx];
+            }
+
+      return QString();
+      }
+
 //---------------------------------------------------------
 //   undoWorkspace
 //---------------------------------------------------------
 
 void MuseScore::undoWorkspace()
       {
+      // TODO: make a separate session start backup?
       Workspace::currentWorkspace->read();
       Workspace::currentWorkspace->setDirty(false);
       }
@@ -172,8 +215,12 @@ void MuseScore::changeWorkspace(const QString& name)
 
 void MuseScore::changeWorkspace(Workspace* p, bool first)
       {
-      if (!first)
+      if (!first) {
             Workspace::currentWorkspace->save();
+            if (Workspace::currentWorkspace)
+                  disconnect(getPaletteWorkspace(), &PaletteWorkspace::userPaletteChanged, Workspace::currentWorkspace, QOverload<>::of(&Workspace::setDirty));
+            }
+
 
       p->read();
       Workspace::currentWorkspace = p;
@@ -181,6 +228,8 @@ void MuseScore::changeWorkspace(Workspace* p, bool first)
             updateIcons();
             preferencesChanged(true);
             }
+
+      connect(getPaletteWorkspace(), &PaletteWorkspace::userPaletteChanged, Workspace::currentWorkspace, QOverload<>::of(&Workspace::setDirty), Qt::UniqueConnection);
 
       preferences.setPreference(PREF_APP_WORKSPACE, p->name());
       emit mscore->workspacesChanged();
@@ -248,6 +297,10 @@ Workspace::Workspace()
       saveComponents = false;
       saveToolbars = false;
       saveMenuBar = false;
+
+      _saveTimer.setInterval(0);
+      _saveTimer.setSingleShot(true);
+      connect(&_saveTimer, &QTimer::timeout, this, &Workspace::ensureWorkspaceSaved);
       }
 
 //---------------------------------------------------------
@@ -976,6 +1029,50 @@ void Workspace::readGlobalGUIState()
       }
 
 //---------------------------------------------------------
+//   ensureWorkspaceSaved
+//---------------------------------------------------------
+
+void Workspace::ensureWorkspaceSaved()
+      {
+      if (!_dirty)
+            return;
+
+      if (_readOnly) {
+            setTranslatableName(editedWorkspaceTranslatableName(translatableName()));
+
+            if (translatableName().isEmpty()) {
+                  /*: Name of the edited read-only workspace, %1 is replaced with the old workspace name */
+                  setName(tr("%1 edited").arg(name()));
+                  }
+            else
+                  setName(tr(translatableName().toUtf8()));
+
+            _path = Workspace::makeUserWorkspacePath(translatableName().isEmpty() ? name() : translatableName());
+
+            write();
+
+            const QFileInfo fi(_path);
+            _readOnly = !fi.isWritable();
+            Q_ASSERT(!_readOnly);
+
+            preferences.setPreference(PREF_APP_WORKSPACE, name());
+            emit mscore->workspacesChanged();
+            }
+      else
+            write();
+      }
+
+//---------------------------------------------------------
+//   setDirty
+//---------------------------------------------------------
+
+void Workspace::setDirty(bool val)
+      {
+      _dirty = val;
+      _saveTimer.start();
+      }
+
+//---------------------------------------------------------
 //   save
 //---------------------------------------------------------
 
@@ -986,15 +1083,9 @@ void Workspace::save()
       if (!saveToolbars)
             writeGlobalToolBar();
 
-      if (_readOnly) {
-            PaletteWorkspace* pw = mscore->getPaletteWorkspace();
-            if (pw->paletteChanged()) { // TODO: use Workspace::dirty instead
-                  const QString customizedWorkspaceName(name() + "__edited"); // TODO: ?
-                  Workspace::currentWorkspace = createNewWorkspace(customizedWorkspaceName);
-                  mscore->changeWorkspace(customizedWorkspaceName); // HACK: just to get that name reflected in preferences...
-                  }
+      if (_readOnly)
             return;
-            }
+
       write();
       }
 
@@ -1033,13 +1124,17 @@ QList<Workspace*>& Workspace::workspaces()
       {
       if (!workspacesRead) {
             QList<Workspace*> oldWorkspaces(_workspaces);
+            QList<Workspace*> editedWorkpaces;
             
             for (const QString& path : findWorkspaceFiles()) {
                   Workspace* p = 0;
                   QFileInfo fi(path);
                   QString name(fi.completeBaseName());
 
-                  const bool translate = std::find(defaultWorkspaces.begin(), defaultWorkspaces.end(), name) != defaultWorkspaces.end();
+                  const bool isDefault = std::find(defaultWorkspaces.begin(), defaultWorkspaces.end(), name) != defaultWorkspaces.end();
+                  const bool isEditedDefault = std::find(defaultEditedWorkpaces.begin(), defaultEditedWorkpaces.end(), name) != defaultEditedWorkpaces.end();
+
+                  const bool translate = isDefault || isEditedDefault;
 
                   for (Workspace* w : _workspaces) {
                         if (w->name() == name || (translate && w->translatableName() == name)) {
@@ -1062,10 +1157,29 @@ QList<Workspace*>& Workspace::workspaces()
                         p->setTranslatableName(name);
 
                   p->setReadOnly(!fi.isWritable());
+
+                  if (isEditedDefault)
+                        editedWorkpaces.push_back(p);
                   }
 
             for (Workspace* old : oldWorkspaces)
                   _workspaces.removeOne(old);
+
+            // Delete default workspaces if there are corresponding user-edited ones
+            for (Workspace* ew : editedWorkpaces) {
+                  const QString uneditedName = defaultWorkspaceTranslatableName(ew->translatableName());
+                  if (uneditedName.isEmpty())
+                        continue;
+
+                  for (auto it = _workspaces.begin(); it != _workspaces.end(); ++it) {
+                        Workspace* w = *it;
+                        if (w->translatableName() == uneditedName) {
+                              _workspaces.erase(it);
+                              delete w;
+                              break;
+                              }
+                        }
+                  }
 
             if (_workspaces.empty())
                   qFatal("No workspaces found");
@@ -1077,7 +1191,8 @@ QList<Workspace*>& Workspace::workspaces()
 
             // hack
             for (int i = 0; i < _workspaces.size(); i++) {
-                  if (_workspaces[i]->translatableName() == defaultWorkspaces[0]) {
+                  const QString& trName = _workspaces[i]->translatableName();
+                  if (trName == defaultWorkspaces[0] || trName == defaultEditedWorkpaces[0]) {
                         _workspaces.move(i, 0);
                         break;
                         }

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -56,6 +56,8 @@ class Workspace : public QObject {
       bool _dirty;
       bool _readOnly;
 
+      QTimer _saveTimer;
+
       bool saveComponents;
       bool saveToolbars;
       bool saveMenuBar;
@@ -67,8 +69,12 @@ class Workspace : public QObject {
       static QString makeUserWorkspacePath(const QString& name);
       static void readWorkspaceFile(const QString& path, std::function<void(XmlReader&)> readWorkspace);
 
+   private slots:
+      void ensureWorkspaceSaved();
+
    public slots:
-      void setDirty(bool val = true) { _dirty = val;    }
+      void setDirty(bool val);
+      void setDirty() { setDirty(true); }
 
    public:
       Workspace();


### PR DESCRIPTION
 - Workspaces are saved automatically after each change (prevents
   possible data loss after MuseScore crashes);
 - Read-only workspaces are automatically saved to different location
   with "edited" suffix;
 - Edited versions of Basic and Advanced workspace hide the default
   ones.