### PR TITLE
fix #276511: Entering notes with mouse fails in Italian TAB

### DIFF
--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -68,6 +68,7 @@ NoteVal Score::noteValForPosition(Position pos, bool &error)
                         return nval;
                         }
                   stringData = instr->stringData();
+                  line = st->staffType(tick)->visualStringToPhys(line);
                   if (line < 0 || line >= stringData->strings()) {
                         error = true;
                         return nval;

--- a/libmscore/stafftype.cpp
+++ b/libmscore/stafftype.cpp
@@ -901,7 +901,7 @@ void TabDurationSymbol::layout()
       qreal xpos, ypos;             // position coords
 
       _beamGrid = TabBeamGrid::NONE;
-      Chord* chord = toChord(parent());
+      Chord* chord = parent() && parent()->isChord() ? toChord(parent()) : nullptr;
       // if no chord (shouldn't happens...) or not a special beam mode, layout regular symbol
       if (!chord || !chord->isChord() ||
             (chord->beamMode() != Beam::Mode::BEGIN && chord->beamMode() != Beam::Mode::MID &&


### PR DESCRIPTION
Resolves: https://musescore.org/node/276511

When entering notes with the mouse onto a TAB staff, a translation must be made from the visual line to the physical string, in case the staff's upsideDown flag is set.

Also, when casting a TabDurationSymbol's parent to a Chord, we must first make sure that the TabDurationSymbol's parent is in fact a Chord.