### PR TITLE
fix #292830: fix copying lyrics to clipboard

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -3997,11 +3997,12 @@ QString Score::extractLyrics()
       for (int track = 0; track < ntracks(); track += VOICES) {
             bool found = false;
             size_t maxLyrics = 1;
+            const RepeatList& rlist = repeatList();
             for (Measure* m = firstMeasure(); m; m = m->nextMeasure()) {
                   m->setPlaybackCount(0);
                   }
             // follow the repeat segments
-            for (const RepeatSegment* rs : repeatList()) {
+            for (const RepeatSegment* rs : rlist) {
                   Fraction startTick  = Fraction::fromTicks(rs->tick);
                   Fraction endTick    = startTick + Fraction::fromTicks(rs->len());
                   for (Measure* m = tick2measure(startTick); m; m = m->nextMeasure()) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/292830

Was broken after 1a6058f9a1245772d695fd5e9068c3139ea15589. Score::extractLyrics() depends on Measure::_playbackCount values which are used internally by RepeatList. A quick way to fix the issue with extracting lyrics (implemented in this commit) is to force repeat list to be computed before resetting playbackCount variables inside extractLyrics().