### PR TITLE
fix #295792: fix a crash on changing duration of multiple notes in some situations

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2908,7 +2908,9 @@ void Score::padToggle(Pad n)
             if (canAdjustLength) {
                   // Change length from last to first chord/rest
                   std::sort(crs.begin(), crs.end(), [](const ChordRest* cr1, const ChordRest* cr2) {
-                        return cr2->track() < cr1->track() || cr2->isBefore(cr1);
+                        if (cr2->track() == cr1->track())
+                              return cr2->isBefore(cr1);
+                        return cr2->track() < cr1->track();
                         });
                   }
             else


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/295792

When implementing changing duration of multiple notes in #4932 I have apparently incorrectly defined the comparison function for `std::sort` algorithm applied to the list of chords which lengths should be changed. This PR corrects this function and thus avoids crashing `std::sort` algorithm.