### PR TITLE
add palette search shortcut

### DIFF
--- a/mscore/data/shortcuts-Mac.xml
+++ b/mscore/data/shortcuts-Mac.xml
@@ -273,6 +273,18 @@
     <seq>Ctrl+Alt+Shift+Left</seq>
     </SC>
   <SC>
+    <key>next-element</key>
+    <seq>Alt+Right</seq>
+    </SC>
+  <SC>
+    <key>prev-element</key>
+    <seq>Alt+Left</seq>
+    </SC>
+  <SC>
+    <key>palette-search</key>
+    <seq>Ctrl+F9</seq>
+    </SC>
+  <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
     </SC>

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -281,6 +281,10 @@
     <seq>Alt+Left</seq>
     </SC>
   <SC>
+    <key>palette-search</key>
+    <seq>Ctrl+F9</seq>
+    </SC>
+  <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
     </SC>

--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -283,6 +283,18 @@
     <seq>Ctrl+Alt+Shift+Left</seq>
     </SC>
   <SC>
+    <key>next-element</key>
+    <seq>Alt+Right</seq>
+    </SC>
+  <SC>
+    <key>prev-element</key>
+    <seq>Alt+Left</seq>
+    </SC>
+  <SC>
+    <key>palette-search</key>
+    <seq>Ctrl+F9</seq>
+    </SC>
+  <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
     </SC>


### PR DESCRIPTION
It is possible already for users to define a shortcut for the palette search command, but this process is not easily discoverable and awkward (although possible) to operate for blind users.  Accessibility is aided if a default shortcut is provided, so this PR adds Ctrl+Alt+P