### PR TITLE
add missing shortcuts of Mac and AZERTY keyboards

### DIFF
--- a/mscore/data/shortcuts-Mac.xml
+++ b/mscore/data/shortcuts-Mac.xml
@@ -53,6 +53,14 @@
     <seq>Ctrl+V</seq>
     </SC>
   <SC>
+    <key>paste-half</key>
+    <seq>Ctrl+Shift+Q</seq>
+    </SC>
+  <SC>
+    <key>paste-double</key>
+    <seq>Ctrl+Shift+W</seq>
+    </SC>
+  <SC>
     <key>swap</key>
     <seq>Ctrl+Shift+X</seq>
     </SC>
@@ -159,6 +167,10 @@
   <SC>
     <key>chord-g</key>
     <seq>Shift+G</seq>
+    </SC>
+  <SC>
+    <key>chord-tie</key>
+    <seq>Alt++</seq>
     </SC>
   <SC>
     <key>insert-a</key>
@@ -353,12 +365,20 @@
     <seq>Shift+Down</seq>
     </SC>
   <SC>
-    <key>page-prev</key>
+    <key>scr-prev</key>
     <seq>PgUp</seq>
     </SC>
   <SC>
-    <key>page-next</key>
+    <key>scr-next</key>
     <seq>PgDown</seq>
+    </SC>
+  <SC>
+    <key>page-prev</key>
+    <seq>Ctrl+PgUp</seq>
+    </SC>
+  <SC>
+    <key>page-next</key>
+    <seq>Ctrl+PgDown</seq>
     </SC>
   <SC>
     <key>page-top</key>
@@ -993,5 +1013,9 @@
   <SC>
     <key>toggle-insert-mode</key>
     <seq>Ctrl+I</seq>
+    </SC>
+  <SC>
+    <key>toggle-autoplace</key>
+    <seq>=</seq>
     </SC>
   </Shortcuts>

--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -53,6 +53,14 @@
     <seq>Ctrl+V</seq>
     </SC>
   <SC>
+    <key>paste-half</key>
+    <seq>Ctrl+Shift+Q</seq>
+    </SC>
+  <SC>
+    <key>paste-double</key>
+    <seq>Ctrl+Shift+W</seq>
+    </SC>
+  <SC>
     <key>swap</key>
     <seq>Ctrl+Shift+X</seq>
     </SC>
@@ -168,6 +176,10 @@
   <SC>
     <key>chord-g</key>
     <seq>Shift+G</seq>
+    </SC>
+  <SC>
+    <key>chord-tie</key>
+    <seq>Alt++</seq>
     </SC>
   <SC>
     <key>insert-a</key>
@@ -1037,5 +1049,9 @@
   <SC>
     <key>toggle-insert-mode</key>
     <seq>Ctrl+I</seq>
+    </SC>
+  <SC>
+    <key>toggle-autoplace</key>
+    <seq>=</seq>
     </SC>
   </Shortcuts>


### PR DESCRIPTION
See #5402.  I was not aware of the Mac and AZERTY shortcut files, and had added several commands over the past year without updating these files.  A check of the GitHub history turned up a few other  commands that also were missing Mac and/or AZERTY shortcuts.  I added the ones relevant to #5402 in that PR, and added the rest here.

I have no way of testing this, but I don't anticipate problems.  I know numebr keys work dffierently on AZERTY but none are used here.  I know Mac keyboards often (always?) lack PgUp/PgDn keys, but as far as I know they these functions can be triggered by Fn+Up/Down.  And in any case, even if some particular keyboard does not generate this keycode, we should be no worse off with this change than without.

I don't know a way to add tests for this.