### PR TITLE
fix #295895: language list in Resource Manager sorted by size is sorted in the style of string rather than that of number

### DIFF
--- a/mscore/resourceManager.h
+++ b/mscore/resourceManager.h
@@ -46,5 +46,28 @@ private slots:
     void uninstallExtension();
    };
 
+class ExtensionFileSize : public QTableWidgetItem
+   {
+      int _size;
+
+   public:
+      ExtensionFileSize(const int i);
+      int getSize() const { return _size; }
+      bool operator<(const QTableWidgetItem& nextItem) const;
+      static int int2size(QChar sizeType, int i);
+
+   };
+
+class LanguageFileSize : public QTableWidgetItem
+   {
+      double _size;
+
+   public:
+      LanguageFileSize(const double d);
+      double getSize() const { return _size; }
+      bool operator<(const QTableWidgetItem& nextItem) const;
+
+   };
+
 }
 #endif // RESOURCE_H

--- a/mscore/stringutils.cpp
+++ b/mscore/stringutils.cpp
@@ -102,17 +102,17 @@ QString stringutils::removeDiacritics(const QString& pre)
 QString stringutils::convertFileSizeToHumanReadable(const qlonglong& bytes)
       {
       QString number;
-      if (bytes < 0x400) {//If less than 1 KB, report in B
+      if (bytes < 0x400) { // If less than 1 KB, report in B
             number = QLocale::system().toString(bytes);
             number.append(" B");
             return number;
             }
       else {
-            if (bytes >= 0x400 && bytes < 0x100000) { //If less than 1 MB, report in KB, unless rounded result is 1024 KB, then report in MB
+            if (bytes >= 0x400 && bytes < 0x100000) { // If less than 1 MB, report in KB, unless rounded result is 1024 KB, then report in MB
                   qlonglong result = (bytes + (0x400 / 2)) / 0x400;
-                  if(result < 0x400) {
+                  if (result < 0x400) {
                         number = QLocale::system().toString(result);
-                        number.append(" kB");
+                        number.append(" KB");
                         return number;
                         }
                   else {
@@ -123,7 +123,7 @@ QString stringutils::convertFileSizeToHumanReadable(const qlonglong& bytes)
                         }
                   }
             else {
-                  if (bytes >= 0x100000 && bytes < 0x40000000) { //If less than 1 GB, report in MB, unless rounded result is 1024 MB, then report in GB
+                  if (bytes >= 0x100000 && bytes < 0x40000000) { // If less than 1 GB, report in MB, unless rounded result is 1024 MB, then report in GB
                         qlonglong result = (bytes + (0x100000 / 2)) / 0x100000;
                         if (result < 0x100000) {
                               number = QLocale::system().toString(result);
@@ -138,7 +138,7 @@ QString stringutils::convertFileSizeToHumanReadable(const qlonglong& bytes)
                               }
                         }
                   else {
-                        if (bytes >= 0x40000000 && bytes < 0x10000000000) { //If less than 1 TB, report in GB, unless rounded result is 1024 GB, then report in TB
+                        if (bytes >= 0x40000000 && bytes < 0x10000000000) { // If less than 1 TB, report in GB, unless rounded result is 1024 GB, then report in TB
                               qlonglong result = (bytes + (0x40000000 / 2)) / 0x40000000;
                               if (result < 0x40000000) {
                                     number = QLocale::system().toString(result);
@@ -153,7 +153,7 @@ QString stringutils::convertFileSizeToHumanReadable(const qlonglong& bytes)
                                     }
                             }
                         else {
-                              qlonglong result = (bytes + (0x10000000000 / 2)) / 0x10000000000; //If more than 1 TB, report in TB
+                              qlonglong result = (bytes + (0x10000000000 / 2)) / 0x10000000000; // If more than 1 TB, report in TB
                               number = QLocale::system().toString(result);
                               number.append(" TB");
                               return number;


### PR DESCRIPTION
Resolves: https://musescore.org/node/295895.

Follows the idea of https://stackoverflow.com/questions/7848683/how-to-sort-data-in-qtablewidget.
Two new classes `ExtensionFileSize` and `LanguageFileSize` are setup to overload the `<` operator in order to achieve the correct sorting.