### PR TITLE
proposed fix for basic workspace being marked edited after editing advanced

### DIFF
--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -214,9 +214,8 @@ void MuseScore::changeWorkspace(Workspace* p, bool first)
                   disconnect(getPaletteWorkspace(), &PaletteWorkspace::userPaletteChanged, WorkspacesManager::currentWorkspace(), QOverload<>::of(&Workspace::setDirty));
             }
 
-
-      p->read();
       WorkspacesManager::setCurrentWorkspace(p);
+      p->read();
       if (!first) {
             updateIcons();
             preferencesChanged(true);


### PR DESCRIPTION
If you start MuseScore for first time or after factory reset,
and in the startup wizard you choose Advannced workspace,
you end up in situation where the Basic workspace is also connected to signals.
This seems to be because in the process of reading the Advanced palette,
we start setting up signals, but this happens before we've set it as current.
So a default workspace is create and set up during the read.

Without knowing that much about signals in general,
or about how this code is strucutred, I see a couple of possible fixes.
This implements the one that seems safer to me:
just assigning the workspace to be current *before* reading it.
Maybe it's not safe, but it doesn't involve fiddling with signals.
The other solution I tried is to move the code that disconnects the signal
outside the "if (!first)" a few lines above in this same function.
It's weird, because as far as I know, the signal isn't actually connected then;
it's the read that connects it.
But, doing the disconnect ends up triggerng and connection first (!),
as part of the getPaletteWorkspace() call.
Which seems hacky, but it does seem to work.
Calling the disconnect function forces it to be connected,
so the disconnect succeeds.

Either approach works as far as I can tell.
Probably others would too.
So feel free to use this or not.