### PR TITLE
fix #295944: Tuplet dialog does not default to style settings, and creates tuplets with bad property flags

### DIFF
--- a/mscore/tupletdialog.cpp
+++ b/mscore/tupletdialog.cpp
@@ -50,6 +50,23 @@ TupletDialog::TupletDialog(QWidget* parent)
       }
 
 //---------------------------------------------------------
+//   defaultToStyleSettings
+//---------------------------------------------------------
+
+void TupletDialog::defaultToStyleSettings(Score* score)
+      {
+      TupletNumberType nt = TupletNumberType(score->styleI(Sid::tupletNumberType));
+      number->setChecked(nt == TupletNumberType::SHOW_NUMBER);
+      relation->setChecked(nt == TupletNumberType::SHOW_RELATION);
+      noNumber->setChecked(nt == TupletNumberType::NO_TEXT);
+
+      TupletBracketType bt = TupletBracketType(score->styleI(Sid::tupletBracketType));
+      autoBracket->setChecked(bt == TupletBracketType::AUTO_BRACKET);
+      bracket->setChecked(bt == TupletBracketType::SHOW_BRACKET);
+      noBracket->setChecked(bt == TupletBracketType::SHOW_NO_BRACKET);
+      }
+
+//---------------------------------------------------------
 //   setupTuplet
 //---------------------------------------------------------
 
@@ -68,6 +85,16 @@ void TupletDialog::setupTuplet(Tuplet* tuplet)
             tuplet->setBracketType(TupletBracketType::SHOW_BRACKET);
       else if (noBracket->isChecked())
             tuplet->setBracketType(TupletBracketType::SHOW_NO_BRACKET);
+
+      if (tuplet->numberType() == TupletNumberType(tuplet->score()->styleI(Sid::tupletNumberType)))
+            tuplet->setPropertyFlags(Pid::NUMBER_TYPE, PropertyFlags::STYLED);
+      else
+            tuplet->setPropertyFlags(Pid::NUMBER_TYPE, PropertyFlags::UNSTYLED);
+
+      if (tuplet->bracketType() == TupletBracketType(tuplet->score()->styleI(Sid::tupletBracketType)))
+            tuplet->setPropertyFlags(Pid::BRACKET_TYPE, PropertyFlags::STYLED);
+      else
+            tuplet->setPropertyFlags(Pid::BRACKET_TYPE, PropertyFlags::UNSTYLED);
       }
 
 //---------------------------------------------------------
@@ -98,6 +125,7 @@ Tuplet* MuseScore::tupletDialog()
             return 0;
 
       TupletDialog td;
+      td.defaultToStyleSettings(cs);
       if (!td.exec())
             return 0;
 

--- a/mscore/tupletdialog.h
+++ b/mscore/tupletdialog.h
@@ -35,6 +35,7 @@ class TupletDialog : public QDialog, Ui::TupletDialog {
       virtual void hideEvent(QHideEvent*);
    public:
       TupletDialog(QWidget* parent = 0);
+      void defaultToStyleSettings(Score* score);
       void setupTuplet(Tuplet* tuplet);
       int getNormalNotes() const { return normalNotes->value(); }
       };


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/295944.

This PR implements a feature request and fixes a bug. 

The bug is that tuplets created with the tuplet dialog have their property flags for Pid::NUMBER_TYPE and Pid::BRACKET_TYPE set incorrectly, so that when the score is saved, these properties will not be written, even if they differ from the default values.

The feature request is to have the tuplet dialog open up with the current style settings for Sid::tupletNumberType and Sid::tupletBracketType selected by default.