### PR TITLE
fix remaining bugs with workspaces

### DIFF
--- a/mscore/musescore.h
+++ b/mscore/musescore.h
@@ -568,7 +568,7 @@ class MuseScore : public QMainWindow, public MuseScoreCore {
       void oscAction();
 #endif
       void deleteWorkspace();
-      void undoWorkspace();
+      void resetWorkspace();
       void showWorkspaceMenu();
       void switchLayer(const QString&);
       void switchPlayMode(int);

--- a/mscore/workspace.cpp
+++ b/mscore/workspace.cpp
@@ -220,12 +220,11 @@ void MuseScore::changeWorkspace(const QString& name)
 
 void MuseScore::changeWorkspace(Workspace* p, bool first)
       {
-      if (!first) {
+      if (!first)
             WorkspacesManager::currentWorkspace()->save();
-            if (WorkspacesManager::currentWorkspace())
-                  disconnect(getPaletteWorkspace(), &PaletteWorkspace::userPaletteChanged, WorkspacesManager::currentWorkspace(), QOverload<>::of(&Workspace::setDirty));
-            }
 
+      if (WorkspacesManager::currentWorkspace())
+            disconnect(getPaletteWorkspace(), &PaletteWorkspace::userPaletteChanged, WorkspacesManager::currentWorkspace(), QOverload<>::of(&Workspace::setDirty));
 
       p->read();
       WorkspacesManager::setCurrentWorkspace(p);
@@ -1195,22 +1194,6 @@ void WorkspacesManager::initWorkspaces()
       for (Workspace* old : oldWorkspaces)
             m_workspaces.removeOne(old);
 
-      // Delete default workspaces if there are corresponding user-edited ones
-      m_visibleWorkspaces = m_workspaces;
-      for (Workspace* ew : editedWorkpaces) {
-            const QString uneditedName = defaultWorkspaceTranslatableName(ew->translatableName());
-            if (uneditedName.isEmpty())
-                  continue;
-
-            for (auto it = m_visibleWorkspaces.begin(); it != m_visibleWorkspaces.end(); ++it) {
-                  Workspace* w = *it;
-                  if (w->translatableName() == uneditedName) {
-                        m_visibleWorkspaces.erase(it);
-                        break;
-                        }
-                  }
-            }
-
       if (m_workspaces.empty())
             qFatal("No workspaces found");
 
@@ -1227,7 +1210,25 @@ void WorkspacesManager::initWorkspaces()
                   break;
                   }
             }
+      
       retranslate(m_workspaces);
+      
+      // Delete default workspaces if there are corresponding user-edited ones
+      m_visibleWorkspaces = m_workspaces;
+      for (Workspace* ew : editedWorkpaces) {
+            const QString uneditedName = defaultWorkspaceTranslatableName(ew->translatableName());
+            if (uneditedName.isEmpty())
+                  continue;
+
+            for (auto it = m_visibleWorkspaces.begin(); it != m_visibleWorkspaces.end(); ++it) {
+                  Workspace* w = *it;
+                  if (w->translatableName() == uneditedName) {
+                        m_visibleWorkspaces.erase(it);
+                        break;
+                        }
+                  }
+            }
+      
       isWorkspacesListDirty = false;
       }
 
@@ -1285,6 +1286,7 @@ Workspace* WorkspacesManager::createNewWorkspace(const QString& name)
       w->setSourceWorkspaceName(WorkspacesManager::currentWorkspace()->sourceWorkspace()->translatableName());
 
       m_workspaces.append(w);
+      m_visibleWorkspaces.append(w);
       return w;
       }
 

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -91,8 +91,10 @@ class Workspace : public QObject {
       void read();
       bool readOnly() const          { return _readOnly;  }
       void setReadOnly(bool val)     { _readOnly = val;   }
+      void reset();
 
       const Workspace* sourceWorkspace() const;
+      void setSourceWorkspaceName(const QString& sourceWorkspaceName) { _sourceWorkspaceName = sourceWorkspaceName; }
 
       std::unique_ptr<PaletteTree> getPaletteTree() const;
 
@@ -142,10 +144,7 @@ class WorkspacesManager {
             return nullptr;
             }
       
-      static void remove(const QString& name) {
-            m_workspaces.removeOne(findByName(name));
-            }
-      
+      static void remove(Workspace* workspace);
       static const QList<Workspace*>& workspaces() {
             if (isWorkspacesListDirty || m_workspaces.isEmpty())
                   initWorkspaces();
@@ -156,13 +155,19 @@ class WorkspacesManager {
             if (isWorkspacesListDirty || m_visibleWorkspaces.isEmpty())
                   initWorkspaces();
             return m_visibleWorkspaces;
-      }
+            }
       
       //replace with `const Workspace*` in future
       static Workspace* currentWorkspace() { return m_currentWorkspace; }
       static void setCurrentWorkspace(Workspace* currWorkspace) { m_currentWorkspace = currWorkspace; }
       
       static void initCurrentWorkspace();
+      static bool isDefaultWorkspace(Workspace* workspace);
+      static bool isDefaultEditedWorkspace(Workspace* workspace);
+      
+   public:
+      static std::vector<QString> defaultWorkspaces;
+      static std::vector<QString> defaultEditedWorkspaces;
       
    private:
       static QList<Workspace*> m_workspaces;

--- a/mscore/workspace.h
+++ b/mscore/workspace.h
@@ -95,6 +95,7 @@ class Workspace : public QObject {
 
       const Workspace* sourceWorkspace() const;
       void setSourceWorkspaceName(const QString& sourceWorkspaceName) { _sourceWorkspaceName = sourceWorkspaceName; }
+      QString sourceWorkspaceName() { return _sourceWorkspaceName; }
 
       std::unique_ptr<PaletteTree> getPaletteTree() const;
 
@@ -164,6 +165,7 @@ class WorkspacesManager {
       static void initCurrentWorkspace();
       static bool isDefaultWorkspace(Workspace* workspace);
       static bool isDefaultEditedWorkspace(Workspace* workspace);
+      static QString defaultWorkspaceTranslatableName(const QString& editedWorkspaceName);
       
    public:
       static std::vector<QString> defaultWorkspaces;

--- a/mscore/workspacedialog.cpp
+++ b/mscore/workspacedialog.cpp
@@ -125,22 +125,29 @@ void WorkspaceDialog::accepted()
                   break;
             }
 
+      Workspace* newWorkspace = editMode ? WorkspacesManager::currentWorkspace() : WorkspacesManager::createNewWorkspace(s);
       if (!editMode) {
+            //save current workspace
             if (WorkspacesManager::currentWorkspace()->dirty())
                   WorkspacesManager::currentWorkspace()->save();
-            WorkspacesManager::setCurrentWorkspace(WorkspacesManager::createNewWorkspace(s));
-            preferences.updateLocalPreferences();
             }
 
-      WorkspacesManager::currentWorkspace()->setSaveComponents(componentsCheck->isChecked());
-      WorkspacesManager::currentWorkspace()->setSaveToolbars(toolbarsCheck->isChecked());
-      WorkspacesManager::currentWorkspace()->setSaveMenuBar(menubarCheck->isChecked());
+      //update workspace properties with the dialog values
+      newWorkspace->setSaveComponents(componentsCheck->isChecked());
+      newWorkspace->setSaveToolbars(toolbarsCheck->isChecked());
+      newWorkspace->setSaveMenuBar(menubarCheck->isChecked());
       preferences.setUseLocalPreferences(prefsCheck->isChecked());
-      WorkspacesManager::currentWorkspace()->save();
+      
+      //save newly created/edited workspace
+      newWorkspace->save();
 
-      if (editMode && WorkspacesManager::currentWorkspace()->name() != s)
-            WorkspacesManager::currentWorkspace()->rename(s);
+      //rename if we edit name of the existing workspace
+      if (editMode && newWorkspace->name() != s)
+            newWorkspace->rename(s);
 
+      mscore->changeWorkspace(newWorkspace);
+      
+      preferences.updateLocalPreferences();
       preferences.setPreference(PREF_APP_WORKSPACE, WorkspacesManager::currentWorkspace()->name());
       emit mscore->workspacesChanged();
       close();

--- a/mscore/workspacedialog.cpp
+++ b/mscore/workspacedialog.cpp
@@ -145,9 +145,11 @@ void WorkspaceDialog::accepted()
       if (editMode && newWorkspace->name() != s)
             newWorkspace->rename(s);
 
-      mscore->changeWorkspace(newWorkspace);
-      
-      preferences.updateLocalPreferences();
+      if (!editMode) {
+            mscore->changeWorkspace(newWorkspace);
+            preferences.updateLocalPreferences();
+            }
+            
       preferences.setPreference(PREF_APP_WORKSPACE, WorkspacesManager::currentWorkspace()->name());
       emit mscore->workspacesChanged();
       close();


### PR DESCRIPTION
- Rename "Undo Changes" to "Reset workspace". The operation reverts all the changes made in current workspace to the state of the `source` workspace. Newly created custom workspaces inherits `source` tag from the workspace they have been created from
- Resetting "Basic/Advanced edited" is performed by deleting the edited workspace and restoring Basic/Advanced one in the workspaces lists (the menu and the combobox)
- Correctly set `_sourceWorkspaceName` for newly created workspaces
- Move `defaultWorkspaces` and `defaultEditedWorkspaces` to reuse them outside the workspace.cpp file
- Fix logic on creating new workspaces to prevent changing current workspace (use `changeWorkspace` method)
- Complete `remove` method
- Fix typo in `defaultEditedWorkspaces` variable

@MarcSabatella @dmitrio95 review and testing are welcome.