### PR TITLE
fix #295881: fix a crash on undoing adding an instrument in continuous view

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -1781,11 +1781,7 @@ System* Score::getNextSystem(LayoutContext& lc)
       _systems.append(system);
       if (!isVBox) {
             int nstaves = Score::nstaves();
-            for (int i = system->staves()->size(); i < nstaves; ++i)
-                  system->insertStaff(i);
-            int dn = system->staves()->size() - nstaves;
-            for (int i = 0; i < dn; ++i)
-                  system->removeStaff(system->staves()->size()-1);
+            system->adjustStavesNumber(nstaves);
             }
       return system;
       }

--- a/libmscore/layoutlinear.cpp
+++ b/libmscore/layoutlinear.cpp
@@ -75,8 +75,7 @@ void Score::resetSystems(bool layoutAll, LayoutContext& lc)
             System* system = new System(this);
             _systems.push_back(system);
             page->appendSystem(system);
-            for (int i = 0; i < nstaves(); ++i)
-                  system->insertStaff(i);
+            system->adjustStavesNumber(nstaves());
             }
       else {
             if (pages().isEmpty())
@@ -84,6 +83,7 @@ void Score::resetSystems(bool layoutAll, LayoutContext& lc)
             page = pages().front();
             System* system = systems().front();
             system->clear();
+            system->adjustStavesNumber(nstaves());
             }
       lc.page = page;
       }

--- a/libmscore/system.cpp
+++ b/libmscore/system.cpp
@@ -180,6 +180,19 @@ void System::removeStaff(int idx)
       }
 
 //---------------------------------------------------------
+//   adjustStavesNumber
+//---------------------------------------------------------
+
+void System::adjustStavesNumber(int nstaves)
+      {
+      for (int i = _staves.size(); i < nstaves; ++i)
+            insertStaff(i);
+      const int dn = _staves.size() - nstaves;
+      for (int i = 0; i < dn; ++i)
+            removeStaff(_staves.size() - 1);
+      }
+
+//---------------------------------------------------------
 //   layoutSystem
 ///   Layout the System
 //---------------------------------------------------------

--- a/libmscore/system.h
+++ b/libmscore/system.h
@@ -134,6 +134,7 @@ public:
 
       SysStaff* insertStaff(int);
       void removeStaff(int);
+      void adjustStavesNumber(int);
 
       int y2staff(qreal y) const;
       void setInstrumentNames(bool longName, Fraction tick = {0,1});


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/295881