### PR TITLE
fix #295957 Pedal continueText not saved

### DIFF
--- a/libmscore/pedal.cpp
+++ b/libmscore/pedal.cpp
@@ -84,6 +84,7 @@ Pedal::Pedal(Score* s)
       initElementStyle(&pedalStyle);
       setLineVisible(true);
       resetProperty(Pid::BEGIN_TEXT);
+      resetProperty(Pid::CONTINUE_TEXT);
       resetProperty(Pid::END_TEXT);
 
       resetProperty(Pid::LINE_WIDTH);
@@ -123,6 +124,7 @@ void Pedal::write(XmlWriter& xml) const
       for (auto i : {
          Pid::END_HOOK_TYPE,
          Pid::BEGIN_TEXT,
+         Pid::CONTINUE_TEXT,
          Pid::END_TEXT,
          Pid::LINE_VISIBLE,
          Pid::BEGIN_HOOK_TYPE

--- a/mtest/testscript/scripts/palette_lines_1.mscx
+++ b/mtest/testscript/scripts/palette_lines_1.mscx
@@ -355,6 +355,7 @@
           <Spanner type="Pedal">
             <Pedal>
               <beginText>&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;</beginText>
+              <continueText>(&lt;sym&gt;keyboardPedalPed&lt;/sym&gt;)</continueText>
               <endText>&lt;sym&gt;keyboardPedalUp&lt;/sym&gt;</endText>
               <lineVisible>0</lineVisible>
               </Pedal>


### PR DESCRIPTION
Resolves: *(https://musescore.org/en/node/295957)*

Save the continue texts for pedal lines.
I had to change the mtest/testscript/scripts/palette_lines_1.mscx file because the old version would not save the continueText field for the pedal and therefore the test failed.

Side note: MuseScore v3.2.3 and later have pedal lines in the palettes with no continue text. However, all pedal lines starting with the "Ped."-Symbol in v2 had them and they are also still hardcoded defaults in mscore/menu.cpp:
https://github.com/musescore/MuseScore/blob/3b4f620cc13c96e497a34de760875a2742de1391/mscore/menus.cpp#L1415

So I think this might also be due to the fact, that continueText was not saved.