### PR TITLE
Add the bbox property to PluginAPI::Element

### DIFF
--- a/mscore/plugin/api/elements.cpp
+++ b/mscore/plugin/api/elements.cpp
@@ -42,6 +42,18 @@ void Element::setOffsetY(qreal offY)
       }
 
 //---------------------------------------------------------
+//   Element::bbox
+//   return the element bbox in spatium units, rather than in raster units as stored internally
+//---------------------------------------------------------
+
+QRectF Element::bbox() const
+      {
+      QRectF bbox       = element()->bbox();
+      qreal  spatium    = element()->spatium();
+      return QRectF(bbox.x() / spatium, bbox.y() / spatium, bbox.width() / spatium, bbox.height() / spatium);
+      }
+
+//---------------------------------------------------------
 //   Segment::elementAt
 //---------------------------------------------------------
 

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -98,7 +98,7 @@ class Element : public Ms::PluginAPI::ScoreElement {
        * element. You can use this value to accurately position other elements 
        * related to the same parent.
        *
-       * This value is in spatium units for compatiblity with Element.offsetX.
+       * This value is in spatium units for compatibility with Element.offsetX.
        * \since MuseScore 3.3
        */
       Q_PROPERTY(qreal posX READ posX)
@@ -110,10 +110,18 @@ class Element : public Ms::PluginAPI::ScoreElement {
        * element. You can use this value to accurately position other elements 
        * related to the same parent.
        *
-       * This value is in spatium units for compatiblity with Element.offsetY.
+       * This value is in spatium units for compatibility with Element.offsetY.
        * \since MuseScore 3.3
        */
       Q_PROPERTY(qreal posY READ posY)
+
+      /**
+       * Bounding box of this element.
+       *
+       * This value is in spatium units for compatibility with other Element positioning properties.
+       * \since MuseScore 3.3.1
+       */
+      Q_PROPERTY(QRectF bbox READ bbox)
 
       API_PROPERTY( subtype,                 SUBTYPE                   )
       API_PROPERTY_READ_ONLY_T( bool, selected, SELECTED               )
@@ -356,6 +364,8 @@ class Element : public Ms::PluginAPI::ScoreElement {
       qreal posY() const { return element()->pos().y() / element()->spatium(); }
 
       Ms::PluginAPI::Element* parent() const { return wrap(element()->parent()); }
+
+      QRectF bbox() const;
 
    public:
       /// \cond MS_INTERNAL


### PR DESCRIPTION
Adding the `bbox` read-only property to plug-in `Element` class allows to precisely place an element of variable dimensions (like an accidental or an image) relatively to its parent according to specific in-between blank distance (for which the size of the elements are needed) rather than origin-to-origin distances.

Use cases for which plug-ins could be effectively used include:

- editorial accidentals, which are placed above the note head at a fixed distance from the note head or from the stave, whichever is near
- images for currently unsupported ornaments / articulations
- in general, special placements for which the general auto-placement cannot be expected to support.

- [X ] I signed [CLA](https://musescore.org/en/cla)
- [X ] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [X ] I made sure the code compiles on my machine
- [X ] I made sure there are no unnecessary changes in the code
- [X ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X ] I made sure the commit message(s) contain a description and answer the question  "Why are those changes really necessary as improvements?"
