### PR TITLE
[MU4] Plug-in API: add initial support for Image and Symbol

### DIFF
--- a/libmscore/image.cpp
+++ b/libmscore/image.cpp
@@ -495,6 +495,21 @@ void Image::layout()
       }
 
 //---------------------------------------------------------
+//   id
+//
+//    returns a string identifying the image: either the file name proper,
+//    if _linkPath is not empty, or the _storePath otherwise
+//---------------------------------------------------------
+
+QString Image::id() const
+      {
+      // we cannot use _linkIsValid, as it is set to true only for the
+      // first occurrence of an image and false for any other occurrence
+      QString path = !_linkPath.isEmpty() ? _linkPath : _storePath;
+      return QFileInfo(path).baseName();
+      }
+
+//---------------------------------------------------------
 //   getProperty
 //---------------------------------------------------------
 

--- a/libmscore/image.h
+++ b/libmscore/image.h
@@ -91,6 +91,7 @@ class Image final : public BSymbol {
       Grip initialEditModeGrip() const override { return Grip(1); }
       Grip defaultGrip() const override { return Grip(1); } // TODO
       std::vector<QPointF> gripsPositions(const EditData&) const override;
+      QString id() const;
       };
 
 

--- a/mscore/plugin/api/elements.cpp
+++ b/mscore/plugin/api/elements.cpp
@@ -252,14 +252,18 @@ Element* wrap(Ms::Element* e, Ownership own)
       {
       using Ms::ElementType;
       switch(e->type()) {
-            case ElementType::NOTE:
-                  return wrap<Note>(toNote(e), own);
             case ElementType::CHORD:
                   return wrap<Chord>(toChord(e), own);
-            case ElementType::SEGMENT:
-                  return wrap<Segment>(toSegment(e), own);
+            case ElementType::IMAGE:
+                  return wrap<Image>(toImage(e), own);
             case ElementType::MEASURE:
                   return wrap<Measure>(toMeasure(e), own);
+            case ElementType::NOTE:
+                  return wrap<Note>(toNote(e), own);
+            case ElementType::SEGMENT:
+                  return wrap<Segment>(toSegment(e), own);
+            case ElementType::SYMBOL:
+                  return wrap<Symbol>(toSymbol(e), own);
             default:
                   break;
             }

--- a/mscore/plugin/api/elements.h
+++ b/mscore/plugin/api/elements.h
@@ -14,19 +14,21 @@
 #define __PLUGIN_API_ELEMENTS_H__
 
 #include "scoreelement.h"
+#include "libmscore/accidental.h"
 #include "libmscore/element.h"
 #include "libmscore/chord.h"
+#include "libmscore/image.h"
 #include "libmscore/lyrics.h"
 #include "libmscore/measure.h"
+#include "libmscore/musescoreCore.h"
 #include "libmscore/note.h"
 #include "libmscore/notedot.h"
-#include "libmscore/segment.h"
-#include "libmscore/accidental.h"
-#include "libmscore/musescoreCore.h"
 #include "libmscore/score.h"
+#include "libmscore/segment.h"
+#include "libmscore/symbol.h"
+#include "libmscore/types.h"
 #include "libmscore/undo.h"
 #include "playevent.h"
-#include "libmscore/types.h"
 
 namespace Ms {
 namespace PluginAPI {
@@ -662,6 +664,72 @@ class Measure : public Element {
       Measure* nextMeasure() { return wrap<Measure>(measure()->nextMeasure(), Ownership::SCORE); }
 
       QQmlListProperty<Element> elements() { return wrapContainerProperty<Element>(this, measure()->el()); }
+      /// \endcond
+      };
+
+//---------------------------------------------------------
+//   BSymbol
+//    BSymbol wrapper
+//---------------------------------------------------------
+
+class BSymbol : public Element {
+      /// \since MuseScore 3.3.1
+      Q_OBJECT
+      Q_PROPERTY(QQmlListProperty<Ms::PluginAPI::Element>  elements          READ elements)
+
+   public:
+      /// \cond MS_INTERNAL
+      BSymbol(Ms::BSymbol* o = nullptr, Ownership own = Ownership::PLUGIN)
+         : Element(o, own) {}
+
+      Ms::BSymbol* bsymbol() { return toBSymbol(e); }
+      const Ms::BSymbol* bsymbol() const { return toBSymbol(e); }
+
+      QQmlListProperty<Element> elements() { return wrapContainerProperty<Element>(this, bsymbol()->leafs());   }
+      /// \endcond
+      };
+
+//---------------------------------------------------------
+//   Image
+//    Image wrapper
+//---------------------------------------------------------
+
+class Image : public BSymbol {
+      /// \since MuseScore 3.3.1
+      Q_OBJECT
+      Q_PROPERTY(QString id   READ id)
+
+   public:
+      /// \cond MS_INTERNAL
+      Image(Ms::Image* o = nullptr, Ownership own = Ownership::PLUGIN)
+         : BSymbol(o, own) {}
+
+      Ms::Image* image()             { return toImage(e); }
+      const Ms::Image* image() const { return toImage(e); }
+
+      QString id() const             { return image()->id(); }
+      /// \endcond
+      };
+
+//---------------------------------------------------------
+//   Symbol
+//    Symbol wrapper
+//---------------------------------------------------------
+
+class Symbol : public BSymbol {
+      /// \since MuseScore 3.3.1
+      Q_OBJECT
+      Q_PROPERTY(QString id  READ id)
+
+   public:
+      /// \cond MS_INTERNAL
+      Symbol(Ms::Symbol* o = nullptr, Ownership own = Ownership::PLUGIN)
+         : BSymbol(o, own) {}
+
+      Ms::Symbol* symbol()             { return toSymbol(e); }
+      const Ms::Symbol* symbol() const { return toSymbol(e); }
+
+      QString id() const               { return symbol()->symName(); }
       /// \endcond
       };
 


### PR DESCRIPTION
Adding images and symbols to notes (or other elements) is not rarely required to implement score elements for special purposes or applications, not yet supported and/or unlikely to be supported in the near future as too specialised.

As specialised needs are an obvious field for plug-ins, it is useful they can manage images and symbols.

This PR adds initial support for the `PluginAPI::Image` and `PluginAPI::Symbol` classes (through a common parent class `BSymbol`). Only one property is currently implemented, namely `id`, through which a plug-in can identify the image/symbol and act accordingly.

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why are those changes really necessary as improvements?"
