### PR TITLE
fix #289908: cannot apply italic or underline to glissando text

### DIFF
--- a/libmscore/glissando.cpp
+++ b/libmscore/glissando.cpp
@@ -637,11 +637,11 @@ bool Glissando::setProperty(Pid propertyId, const QVariant& v)
                   setShowText(v.toBool());
                   break;
             case Pid::GLISSANDO_STYLE:
-                 setGlissandoStyle(GlissandoStyle(v.toInt()));
-                 break;
+                  setGlissandoStyle(GlissandoStyle(v.toInt()));
+                  break;
             case Pid::PLAY:
-                 setPlayGlissando(v.toBool());
-                 break;
+                  setPlayGlissando(v.toBool());
+                  break;
             case Pid::FONT_FACE:
                   setFontFace(v.toString());
                   break;
@@ -649,7 +649,7 @@ bool Glissando::setProperty(Pid propertyId, const QVariant& v)
                   setFontSize(v.toReal());
                   break;
             case Pid::FONT_STYLE:
-                  setFontStyle(FontStyle(v.toBool()));
+                  setFontStyle(FontStyle(v.toInt()));
                   break;
             default:
                   if (!SLine::setProperty(propertyId, v))


### PR DESCRIPTION
Resolves: https://musescore.org/node/289908.

The font style property is being converted from `FontStyle` to `bool` instead of `int`, so bold, italic and underline are all the same.

This commit fixes that.