### PR TITLE
fix #296065: Toolbar accidentals don't respect changes to previous notes

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -2908,7 +2908,7 @@ void Score::cmdSlashFill()
                         p.line = line;
                         p.fret = FRET_NONE;
                         _is.setRest(false);     // needed for tab
-                        nv = noteValForPosition(p, error);
+                        nv = noteValForPosition(p, AccidentalType::NONE, error);
                         }
                   if (error)
                         continue;
@@ -3526,10 +3526,14 @@ void Score::cmdAddPitch(int step, bool addFlag, bool insert)
                   ClefType clef = staff(pos.staffIdx)->clef(seg->tick());
                   pos.line      = relStep(step, clef);
                   bool error;
-                  NoteVal nval = noteValForPosition(pos, error);
+                  NoteVal nval = noteValForPosition(pos, _is.accidentalType(), error);
                   if (error)
                         return;
-                  bool forceAccidental = _is.accidentalType() != AccidentalType::NONE;
+                  bool forceAccidental = false;
+                  if (_is.accidentalType() != AccidentalType::NONE) {
+                        NoteVal nval2 = noteValForPosition(pos, AccidentalType::NONE, error);
+                        forceAccidental = (nval.pitch == nval2.pitch);
+                        }
                   addNote(chord, nval, forceAccidental);
                   _is.setAccidentalType(AccidentalType::NONE);
                   return;

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -33,7 +33,7 @@ namespace Ms {
 //   noteValForPosition
 //---------------------------------------------------------
 
-NoteVal Score::noteValForPosition(Position pos, bool &error)
+NoteVal Score::noteValForPosition(Position pos, AccidentalType at, bool &error)
       {
       error           = false;
       Segment* s      = pos.segment;
@@ -93,7 +93,6 @@ NoteVal Score::noteValForPosition(Position pos, bool &error)
                   }
 
             case StaffGroup::STANDARD: {
-                  AccidentalType at = _is.accidentalType();
                   AccidentalVal acci = (at == AccidentalType::NONE ? s->measure()->findAccidental(s, staffIdx, line, error) : Accidental::subtype2value(at));
                   if (error)
                         return nval;
@@ -318,7 +317,7 @@ void Score::putNote(const Position& p, bool replace)
 
       Direction stemDirection = Direction::AUTO;
       bool error;
-      NoteVal nval = noteValForPosition(p, error);
+      NoteVal nval = noteValForPosition(p, _is.accidentalType(), error);
       if (error)
             return;
 
@@ -388,7 +387,11 @@ void Score::putNote(const Position& p, bool replace)
                   addToChord = true;            // if no special case, add note to chord
                   }
             }
-      bool forceAccidental = _is.accidentalType() != AccidentalType::NONE;
+      bool forceAccidental = false;
+      if (_is.accidentalType() != AccidentalType::NONE) {
+            NoteVal nval2 = noteValForPosition(p, AccidentalType::NONE, error);
+            forceAccidental = (nval.pitch == nval2.pitch);
+            }
       if (addToChord && cr->isChord()) {
             // if adding, add!
             addNote(toChord(cr), nval, forceAccidental);

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -679,7 +679,7 @@ class Score : public QObject, public ScoreElement {
       Note* addMidiPitch(int pitch, bool addFlag);
       Note* addNote(Chord*, NoteVal& noteVal, bool forceAccidental = false);
 
-      NoteVal noteValForPosition(Position pos, bool &error);
+      NoteVal noteValForPosition(Position pos, AccidentalType at, bool &error);
 
       void deleteItem(Element*);
       void deleteMeasures(MeasureBase* firstMeasure, MeasureBase* lastMeasure);


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296065.

Only add a *forced* accidental if there is an accidental selected in the toolbar and the note value is the same as it would be without an accidental.