### PR TITLE
fix #296171: fix triggerLayoutAll() for spanners

### DIFF
--- a/libmscore/element.h
+++ b/libmscore/element.h
@@ -462,7 +462,7 @@ class Element : public ScoreElement {
             }
 
       virtual void triggerLayout() const;
-      void triggerLayoutAll() const;
+      virtual void triggerLayoutAll() const;
       virtual void drawEditMode(QPainter*, EditData&);
 
       void autoplaceSegmentElement(bool above, bool add);        // helper functions

--- a/libmscore/spanner.cpp
+++ b/libmscore/spanner.cpp
@@ -1033,8 +1033,19 @@ void Spanner::setTicks(const Fraction& f)
 
 void Spanner::triggerLayout() const
       {
+      // Spanners do not have parent even when added to a score, so can't check parent here
       const int tr2 = track2() == -1 ? track() : track2();
       score()->setLayout(_tick, _tick + _ticks, staffIdx(), track2staff(tr2), this);
+      }
+
+void Spanner::triggerLayoutAll() const
+      {
+      // Spanners do not have parent even when added to a score, so can't check parent here
+      score()->setLayoutAll(staffIdx(), this);
+
+      const int tr2 = track2();
+      if (tr2 != -1 && tr2 != track())
+            score()->setLayoutAll(track2staff(tr2), this);
       }
 
 //---------------------------------------------------------

--- a/libmscore/spanner.h
+++ b/libmscore/spanner.h
@@ -217,6 +217,7 @@ class Spanner : public Element {
       virtual void layoutSystemsDone();
 
       virtual void triggerLayout() const override;
+      virtual void triggerLayoutAll() const override;
       virtual void add(Element*) override;
       virtual void remove(Element*) override;
       virtual void scanElements(void* data, void (*func)(void*, Element*), bool all=true) override;

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4823,7 +4823,7 @@ static bool needViewportMove(Score* cs, ScoreView* cv)
       const QRectF viewport = cv->canvasViewport(); // TODO: margins for intersection check?
 
       const Element* editElement = state.element();
-      if (editElement && editElement->bbox().isValid())
+      if (editElement && editElement->bbox().isValid() && !editElement->isSpanner())
             return !viewport.intersects(editElement->canvasBoundingRect());
 
       if (state.startTick().isZero() && state.endTick() == cs->endTick())


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296171 (a regression from #5422)

Fixup for 99c7b0d74675df6880af6647b027ac34e53b8569

triggerLayout() and triggerLayoutAll() implementations in Element have an optimization that allows to avoid triggering layout for elements not yet added to a score by checking the element's parent. This optimization is not suitable for spanners since they don't have a parent even when added to a score. This commit adds a missing implementation of Spanner::triggerLayoutAll() that takes this into account.