### PR TITLE
Accessibility: Improve speech for chordrests with spanners

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -1172,20 +1172,20 @@ QString ChordRest::accessibleExtraInfo() const
                       s->type() == ElementType::TIE    ) //ties are added in notes
                         continue;
 
-                  Segment* seg = 0;
                   if (s->type() == ElementType::SLUR) {
                         if (s->tick() == tick() && s->track() == track())
                               rez = QObject::tr("%1 Start of %2").arg(rez).arg(s->screenReaderInfo());
                         if (s->tick2() == tick() && s->track2() == track())
                               rez = QObject::tr("%1 End of %2").arg(rez).arg(s->screenReaderInfo());
                         }
-                  else  {
-                        if (s->tick() == tick() && s->staffIdx() == staffIdx())
+                  else if (s->staffIdx() == staffIdx()) {
+                        bool start = s->tick()  == tick();
+                        bool end   = s->tick2() == tick() + ticks();
+                        if (start && end)
+                              rez = QObject::tr("%1 Start and end of %2").arg(rez).arg(s->screenReaderInfo());
+                        else if (start)
                               rez = QObject::tr("%1 Start of %2").arg(rez).arg(s->screenReaderInfo());
-                        seg = segment()->next1MM(SegmentType::ChordRest);
-                        if (!seg)
-                              continue;
-                        if (s->tick2() == seg->tick() && s->staffIdx() == staffIdx())
+                        else if (end)
                               rez = QObject::tr("%1 End of %2").arg(rez).arg(s->screenReaderInfo());
                         }
                   }


### PR DESCRIPTION
Resolves https://musescore.org/en/node/296176

- Optimize speech output when line starts and ends on same note
- fix [#296176](https://musescore.org/en/node/296176): Line endings not spoken for overlapping chordrests