### PR TITLE
fix #292343: measure numbers restart from 1 after section break even if the corresponding property got disabled

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2249,7 +2249,7 @@ int LayoutContext::adjustMeasureNo(MeasureBase* m)
       m->setNo(measureNo);
       if (!m->irregular())          // don’t count measure
             ++measureNo;
-      if (m->sectionBreak())
+      if (m->sectionBreakElement() && m->sectionBreakElement()->startWithMeasureOne())
             measureNo = 0;
       return measureNo;
       }
@@ -4429,7 +4429,8 @@ void Score::doLayoutRange(const Fraction& st, const Fraction& et)
                   lc.tick      = Fraction(0,1);
                   }
             else {
-                  if (lc.nextMeasure->prevMeasure()->sectionBreak())
+                  LayoutBreak* sectionBreak = lc.nextMeasure->prevMeasure()->sectionBreakElement();
+                  if (sectionBreak && sectionBreak->startWithMeasureOne())
                         lc.measureNo = 0;
                   else
                         lc.measureNo = lc.nextMeasure->prevMeasure()->no() + 1; // will be adjusted later with respect


### PR DESCRIPTION
Resolves: https://musescore.org/node/292343.

Some calls of `sectionBreak()` should be changed to `sectionBreakElement()` so the property can be accessed by `sectionBreakElement()->startWithMeasureOne()`.