### PR TITLE
Ensure a valid duration in the input state when entering a rest.

### DIFF
--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3345,9 +3345,11 @@ void ScoreView::adjustCanvasPosition(const Element* el, bool playBack, int staff
 
 void ScoreView::cmdEnterRest()
       {
-      const InputState& is = _score->inputState();
+      InputState& is = _score->inputState();
       if (is.track() == -1 || is.segment() == 0)          // invalid state
             return;
+      if (!is.duration().isValid() || is.duration().isZero() || is.duration().isMeasure())
+            is.setDuration(TDuration::DurationType::V_QUARTER);
       cmdEnterRest(is.duration());
       }
 


### PR DESCRIPTION
This adds a check for valid duration in ScoreView::cmdEnterRest() that was never strictly necessary before #5376 was merged. But now it is possible that the input state's duration may be invalid or equal to V_MEASURE, even if the check for invalid state does not cause the function to return early. If this is the case, we must set a valid duration at this time. Otherwise, this will result in an assertion failure in Score::makeGap().