### PR TITLE
fix #296127: Can't use CMD+SHIFT+Drag to copy on Mac

### DIFF
--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -210,18 +210,18 @@ void ScoreView::dragEnterEvent(QDragEnterEvent* event)
       const QMimeData* dta = event->mimeData();
 
       if (dta->hasFormat(mimeSymbolListFormat) || dta->hasFormat(mimeStaffListFormat)) {
-            if (event->possibleActions() & Qt::CopyAction) {
+            if (event->possibleActions() & Qt::CopyAction)
                   event->setDropAction(Qt::CopyAction);
+            if (event->dropAction() == Qt::CopyAction)
                   event->accept();
-                  }
             return;
             }
 
       if (dta->hasFormat(mimeSymbolFormat)) {
-            if (event->possibleActions() & Qt::CopyAction) {
+            if (event->possibleActions() & Qt::CopyAction)
                   event->setDropAction(Qt::CopyAction);
+            if (event->dropAction() == Qt::CopyAction)
                   event->accept();
-                  }
 
             QByteArray a = dta->data(mimeSymbolFormat);
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296127.

`ScoreView::dragEnterEvent()` must call `event->accept()` if `event->dropAction() == Qt::CopyAction`, even if for some reason `(event->possibleActions() & Qt::CopyAction)` evaluates to `false`, as is the case on macOS.