### PR TITLE
fix #296154: Accessibility: Make palette tree a single Tab object

### DIFF
--- a/mscore/qml/palettes/Palette.qml
+++ b/mscore/qml/palettes/Palette.qml
@@ -33,7 +33,6 @@ GridView {
     interactive: height < contentHeight // TODO: check if it helps on Mac
 
     keyNavigationEnabled: true
-    activeFocusOnTab: true
 
     property size cellSize
     property bool drawGrid: false
@@ -104,6 +103,7 @@ GridView {
     StyledButton {
         id: moreButton
         visible: showMoreButton
+        activeFocusOnTab: parent.currentItem === paletteTree.currentTreeItem
 
         background: Rectangle {
             color: moreButton.down ? globalStyle.button : mscore.paletteBackground
@@ -346,6 +346,11 @@ GridView {
             property var modelIndex: paletteView.model.modelIndex(index)
             property var parentModelIndex: paletteView.paletteRootIndex
 
+            onActiveFocusChanged: {
+                if (activeFocus)
+                    paletteTree.currentTreeItem = this;
+            }
+
             opacity: enabled ? 1.0 : 0.3
 
             readonly property bool dragged: Drag.active && !dragDropReorderTimer.running
@@ -360,7 +365,7 @@ GridView {
             width: paletteView.cellWidth
             height: paletteView.cellHeight
 
-            activeFocusOnTab: true
+            activeFocusOnTab: this === paletteTree.currentTreeItem
 
             contentItem: QmlIconView {
                 id: icon

--- a/mscore/qml/palettes/PalettesWidgetHeader.qml
+++ b/mscore/qml/palettes/PalettesWidgetHeader.qml
@@ -60,6 +60,7 @@ Item {
             border.color: "#aeaeae"
         }
 
+        KeyNavigation.tab: paletteTree.currentTreeItem
         KeyNavigation.up: paletteTree
         KeyNavigation.down: paletteTree
         Keys.onDownPressed: paletteTree.focusFirstItem();

--- a/mscore/qml/palettes/TreePaletteHeader.qml
+++ b/mscore/qml/palettes/TreePaletteHeader.qml
@@ -51,6 +51,7 @@ Item {
         z: 1000
         width: height
         visible: !paletteHeader.unresolved // TODO: make a separate palette placeholder component
+        activeFocusOnTab: false // same focus object as parent palette
         text: paletteHeader.expanded ? qsTr("Collapse") : qsTr("Expand")
 
         padding: 0
@@ -116,13 +117,15 @@ Item {
         height: parent.height
         anchors.right: parent.right
 
+        activeFocusOnTab: parent.parent.parent === paletteTree.currentTreeItem
+
         padding: 4
 
         contentItem: StyledIcon {
             source: "icons/more.png"
         }
 
-        Accessible.name: qsTr("Palette menu")
+        text: qsTr("Palette menu") // used by screen readers (they ignore Accessible.name for buttons)
 
         onClicked: {
             paletteHeaderMenu.x = paletteHeaderMenuButton.x + paletteHeaderMenuButton.width - paletteHeaderMenu.width;


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296154

Reduces the number of tabbable objects in the palette widget area, which speeds up navigation considerably.

Makes the palettes behave more like a traditional treeview. Navigation within the tree is done with the arrow keys, which means that Tab and Shift+Tab are always available to navigate away from the tree.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
