### PR TITLE
fix #296271: Crash by undoing/redoing in main score a copy-paste made in the parts

### DIFF
--- a/libmscore/select.cpp
+++ b/libmscore/select.cpp
@@ -83,7 +83,7 @@ Fraction Selection::tickStart() const
       {
       switch (_state) {
             case SelState::RANGE:
-                  return _startSegment->tick();
+                  return _startSegment ? _startSegment->tick() : Fraction(-1,1);
             case SelState::LIST: {
                   ChordRest* cr = firstChordRest();
                   return (cr) ? cr->tick() : Fraction(-1,1);


### PR DESCRIPTION
fixes https://musescore.org/en/node/296271