### PR TITLE
fix #296298: Inspector: segment "Leading Space" input field topped at 10sp

### DIFF
--- a/mscore/inspector/inspector_segment.ui
+++ b/mscore/inspector/inspector_segment.ui
@@ -120,7 +120,7 @@
          <double>-10.000000000000000</double>
         </property>
         <property name="maximum">
-         <double>10.000000000000000</double>
+         <double>50.000000000000000</double>
         </property>
         <property name="singleStep">
          <double>0.100000000000000</double>


### PR DESCRIPTION
fixes https://musescore.org/en/node/296298