### PR TITLE
Fix automatic viewport changes in scores with parts

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -4636,12 +4636,15 @@ void MasterScore::setLayoutAll(int staff, const Element* e)
       _cmdState.setTick(Fraction(0,1));
       _cmdState.setTick(measures()->last() ? measures()->last()->endTick() : Fraction(0,1));
 
-      const int startStaff = staff == -1 ? 0 : staff;
-      const int endStaff = staff == -1 ? (nstaves() - 1) : staff;
-      _cmdState.setStaff(startStaff);
-      _cmdState.setStaff(endStaff);
+      if (e && e->score() == this) {
+            // TODO: map staff number properly
+            const int startStaff = staff == -1 ? 0 : staff;
+            const int endStaff = staff == -1 ? (nstaves() - 1) : staff;
+            _cmdState.setStaff(startStaff);
+            _cmdState.setStaff(endStaff);
 
-      _cmdState.setElement(e);
+            _cmdState.setElement(e);
+            }
       }
 
 //---------------------------------------------------------
@@ -4653,9 +4656,11 @@ void MasterScore::setLayout(const Fraction& t, int staff, const Element* e)
       if (t >= Fraction(0,1))
             _cmdState.setTick(t);
 
-      // TODO: handle staff == -1
-      _cmdState.setStaff(staff);
-      _cmdState.setElement(e);
+      if (e && e->score() == this) {
+            // TODO: map staff number properly
+            _cmdState.setStaff(staff);
+            _cmdState.setElement(e);
+            }
       }
 
 void MasterScore::setLayout(const Fraction& tick1, const Fraction& tick2, int staff1, int staff2, const Element* e)
@@ -4665,11 +4670,13 @@ void MasterScore::setLayout(const Fraction& tick1, const Fraction& tick2, int st
       if (tick2 >= Fraction(0,1))
             _cmdState.setTick(tick2);
 
-      // TODO: handle staff == -1
-      _cmdState.setStaff(staff1);
-      _cmdState.setStaff(staff2);
+      if (e && e->score() == this) {
+            // TODO: map staff number properly
+            _cmdState.setStaff(staff1);
+            _cmdState.setStaff(staff2);
 
-      _cmdState.setElement(e);
+            _cmdState.setElement(e);
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -4803,6 +4803,25 @@ bool ScoreView::fotoMode() const
       return false;
       }
 
+//---------------------------------------------------------
+//   visibleElementInScore
+//---------------------------------------------------------
+
+static const Element* visibleElementInScore(const Element* orig, const Score* s)
+      {
+      if (!orig)
+            return nullptr;
+      if (orig->score() == s && orig->bbox().isValid())
+            return orig;
+
+      for (const ScoreElement* se : orig->linkList()) {
+            const Element* e = toElement(se);
+            if (e->score() == s && e->bbox().isValid()) // bbox check to ensure the element is indeed visible
+                  return e;
+            }
+
+      return nullptr;
+      }
 
 //---------------------------------------------------------
 //   needViewportMove
@@ -4822,7 +4841,7 @@ static bool needViewportMove(Score* cs, ScoreView* cv)
 
       const QRectF viewport = cv->canvasViewport(); // TODO: margins for intersection check?
 
-      const Element* editElement = state.element();
+      const Element* editElement = visibleElementInScore(state.element(), cs);
       if (editElement && editElement->bbox().isValid() && !editElement->isSpanner())
             return !viewport.intersects(editElement->canvasBoundingRect());
 
@@ -4834,8 +4853,9 @@ static bool needViewportMove(Score* cs, ScoreView* cv)
       Measure* mEnd = cs->tick2measureMM(state.endTick());
       mEnd = mEnd ? mEnd->nextMeasureMM() : nullptr;
 
-      const int startStaff = state.startStaff() == -1 ? 0 : state.startStaff();
-      const int endStaff = state.endStaff() == -1 ? (cs->nstaves() - 1) : state.endStaff();
+      const bool isExcerpt = !cs->isMaster();
+      const int startStaff = (isExcerpt || state.startStaff() == -1) ? 0 : state.startStaff();
+      const int endStaff = (isExcerpt || state.endStaff() == -1) ? (cs->nstaves() - 1) : state.endStaff();
 
       for (Measure* m = mStart; m && m != mEnd; m = m->nextMeasureMM()) {
             for (int st = startStaff; st <= endStaff; ++st) {
@@ -4874,7 +4894,8 @@ void ScoreView::moveViewportToLastEdit()
             return;
 
       const CmdState& state = s->cmdState();
-      const Element* editElement = state.element();
+      const Element* editElement = visibleElementInScore(state.element(), s);
+
       const MeasureBase* mb = nullptr;
       if (editElement)
             mb = editElement->findMeasureBase();
@@ -4883,7 +4904,7 @@ void ScoreView::moveViewportToLastEdit()
 
       const Element* viewportElement = (editElement && editElement->bbox().isValid() && !mb->isMeasure()) ? editElement : mb;
 
-      const int staff = state.startStaff(); // TODO: choose the closest staff to the current viewport?
+      const int staff = s->isMaster() ? state.startStaff() : -1; // TODO: choose the closest staff to the current viewport?
       adjustCanvasPosition(viewportElement, /* playback */ false, staff);
       }
 }


### PR DESCRIPTION
Fixes issues with automatic viewport change (#5422) in scores with parts. This fix could be largely improved though by proper mapping of staff numbers between master score and parts.