### PR TITLE
Fix #296345 : "Offset" suffix for text style fixed to "sp"

### DIFF
--- a/mscore/editstyle.cpp
+++ b/mscore/editstyle.cpp
@@ -1424,9 +1424,12 @@ void EditStyle::textStyleChanged(int row)
                         resetTextStyleOffset->setEnabled(cs->styleV(a.sid) != MScore::defaultStyle().value(a.sid));
                         break;
 
-                  case Pid::SIZE_SPATIUM_DEPENDENT:
-                        textStyleSpatiumDependent->setChecked(cs->styleV(a.sid).toBool());
-                        resetTextStyleSpatiumDependent->setEnabled(cs->styleV(a.sid) != MScore::defaultStyle().value(a.sid));
+                  case Pid::SIZE_SPATIUM_DEPENDENT: {
+                        QVariant val = cs->styleV(a.sid);
+                        textStyleSpatiumDependent->setChecked(val.toBool());
+                        resetTextStyleSpatiumDependent->setEnabled(val != MScore::defaultStyle().value(a.sid));
+                        textStyleOffset->setSuffix(val.toBool() ? tr("sp") : tr("mm"));
+                        }
                         break;
 
                   case Pid::FRAME_TYPE:


### PR DESCRIPTION
Resolves: [#296345](https://musescore.org/en/node/296345)

In the Edit Text Style dlg box, the suffixes of "Offset" values are always "sp", but when "Follow staff size" is unchecked, the values are considered "mm". This PR makes the "Offset" suffixes to correspond to the actual meaning of the values.

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
