### PR TITLE
fix #296329: Instrument change should be able to apply to multimeasure rest

### DIFF
--- a/libmscore/layout.cpp
+++ b/libmscore/layout.cpp
@@ -2058,7 +2058,7 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
             // clone elements from underlying measure to mmr
             for (Element* e : cs->annotations()) {
                   // look at elements in underlying measure
-                  if (!(e->isRehearsalMark() || e->isTempoText() || e->isHarmony() || e->isStaffText() || e->isSystemText()))
+                  if (!(e->isRehearsalMark() || e->isTempoText() || e->isHarmony() || e->isStaffText() || e->isSystemText() || e->isInstrumentChange()))
                         continue;
                   // try to find a match in mmr
                   bool found = false;
@@ -2080,7 +2080,7 @@ void Score::createMMRest(Measure* m, Measure* lm, const Fraction& len)
             // this should not happen since the elements are linked?
             for (Element* e : s->annotations()) {
                   // look at elements in mmr
-                  if (!(e->isRehearsalMark() || e->isTempoText() || e->isHarmony() || e->isStaffText() || e->isSystemText()))
+                  if (!(e->isRehearsalMark() || e->isTempoText() || e->isHarmony() || e->isStaffText() || e->isSystemText() || e->isInstrumentChange()))
                         continue;
                   // try to find a match in underlying measure
                   bool found = false;
@@ -2114,7 +2114,7 @@ static bool validMMRestMeasure(Measure* m)
       int n = 0;
       for (Segment* s = m->first(); s; s = s->next()) {
             for (Element* e : s->annotations()) {
-                  if (!(e->isRehearsalMark() || e->isTempoText() || e->isHarmony() || e->isStaffText() || e->isSystemText()))
+                  if (!(e->isRehearsalMark() || e->isTempoText() || e->isHarmony() || e->isStaffText() || e->isSystemText() || e->isInstrumentChange()))
                         return false;
                   }
             if (s->isChordRestType()) {
@@ -2200,7 +2200,7 @@ static bool breakMultiMeasureRest(Measure* m)
                         continue;
                   if (e->isRehearsalMark() ||
                       e->isTempoText() ||
-                      ((e->isHarmony() || e->isStaffText() || e->isSystemText()) && (e->systemFlag() || m->score()->staff(e->staffIdx())->show())))
+                      ((e->isHarmony() || e->isStaffText() || e->isSystemText() || e->isInstrumentChange()) && (e->systemFlag() || m->score()->staff(e->staffIdx())->show())))
                         return true;
                   }
             for (int staffIdx = 0; staffIdx < m->score()->nstaves(); ++staffIdx) {


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296329.

Before:
<img width="987" alt="before" src="https://user-images.githubusercontent.com/35512972/67953799-31da5780-fbc6-11e9-8896-e984110a0545.png">
After:
<img width="994" alt="after" src="https://user-images.githubusercontent.com/35512972/67953829-3e5eb000-fbc6-11e9-84a3-e55d66c3230b.png">
