### PR TITLE
fix #296363: Accidental shortcuts do not work in Re-Pitch mode

### DIFF
--- a/libmscore/cmd.cpp
+++ b/libmscore/cmd.cpp
@@ -3606,6 +3606,7 @@ void Score::cmdAddPitch(int step, bool addFlag, bool insert)
             else
                   putNote(pos, !addFlag);
             }
+      _is.setAccidentalType(AccidentalType::NONE);
       }
 
 //---------------------------------------------------------

--- a/libmscore/noteentry.cpp
+++ b/libmscore/noteentry.cpp
@@ -423,7 +423,8 @@ void Score::repitchNote(const Position& p, bool replace)
 
       NoteVal nval;
       bool error = false;
-      AccidentalVal acci = s->measure()->findAccidental(s, p.staffIdx, p.line, error);
+      AccidentalType at = _is.accidentalType();
+      AccidentalVal acci = (at == AccidentalType::NONE ? s->measure()->findAccidental(s, p.staffIdx, p.line, error) : Accidental::subtype2value(at));
       if (error)
             return;
       int step   = absStep(p.line, clef);
@@ -503,6 +504,21 @@ void Score::repitchNote(const Position& p, bool replace)
       }
       // add new note to chord
       undoAddElement(note);
+      bool forceAccidental = false;
+      if (_is.accidentalType() != AccidentalType::NONE) {
+            NoteVal nval2 = noteValForPosition(p, AccidentalType::NONE, error);
+            forceAccidental = (nval.pitch == nval2.pitch);
+            }
+      if (forceAccidental) {
+            int tpc = styleB(Sid::concertPitch) ? nval.tpc2 : nval.tpc1;
+            AccidentalVal alter = tpc2alter(tpc);
+            at = Accidental::value2subtype(alter);
+            Accidental* a = new Accidental(this);
+            a->setAccidentalType(at);
+            a->setRole(AccidentalRole::USER);
+            a->setParent(note);
+            undoAddElement(a);
+            }
       setPlayNote(true);
       setPlayChord(true);
       // recreate tie forward if there is a note to tie to


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296363.