### PR TITLE
fix #292606: image attached to a measure doesn't show

### DIFF
--- a/libmscore/measure.cpp
+++ b/libmscore/measure.cpp
@@ -1970,6 +1970,16 @@ void Measure::read(XmlReader& e, int staffIdx)
                   e.setTick(tick());
                   readVoice(e, staffIdx, irregular);
                   }
+            else if (tag == "Image") {
+                  if (MScore::noImages)
+                        e.skipCurrentElement();
+                  else {
+                        Element* el = Element::name2Element(tag, score());
+                        el->setTrack(staffIdx * VOICES);
+                        el->read(e);
+                        add(el);
+                        }
+                  }
             else if (tag == "Marker" || tag == "Jump") {
                   Element* el = Element::name2Element(tag, score());
                   el->setTrack(e.track());
@@ -2321,6 +2331,9 @@ void Measure::readVoice(XmlReader& e, int staffIdx, bool irregular)
                   fermata->setPlacement(fermata->track() & 1 ? Placement::BELOW : Placement::ABOVE);
                   fermata->read(e);
                   }
+            // There could be an Image here if the score was saved with an earlier version of MuseScore 3.
+            // This image would not have been visible upon reload. Let's read it in and add it directly
+            // to the measure so that it can be displayed.
             else if (tag == "Image") {
                   if (MScore::noImages)
                         e.skipCurrentElement();
@@ -2328,8 +2341,7 @@ void Measure::readVoice(XmlReader& e, int staffIdx, bool irregular)
                         Element* el = Element::name2Element(tag, score());
                         el->setTrack(e.track());
                         el->read(e);
-                        segment = getSegment(SegmentType::ChordRest, e.tick());
-                        segment->add(el);
+                        add(el);
                         }
                   }
             //----------------------------------------------------

--- a/libmscore/read114.cpp
+++ b/libmscore/read114.cpp
@@ -2043,8 +2043,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                         Element* el = Element::name2Element(tag, m->score());
                         el->setTrack(e.track());
                         el->read(e);
-                        segment = m->getSegment(SegmentType::ChordRest, e.tick());
-                        segment->add(el);
+                        m->add(el);
                         }
                   }
             else if (tag == "stretch") {

--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -3254,8 +3254,7 @@ static void readMeasure(Measure* m, int staffIdx, XmlReader& e)
                         Element* el = Element::name2Element(tag, score);
                         el->setTrack(e.track());
                         el->read(e);
-                        segment = m->getSegment(SegmentType::ChordRest, e.tick());
-                        segment->add(el);
+                        m->add(el);
                         }
                   }
             //----------------------------------------------------

--- a/mscore/dragdrop.cpp
+++ b/mscore/dragdrop.cpp
@@ -482,7 +482,13 @@ void ScoreView::dropEvent(QDropEvent* event)
                               el = _score->pos2measure(pos, &staffIdx, 0, &seg, &offset);
                               if (el && el->isMeasure()) {
                                     editData.dropElement->setTrack(staffIdx * VOICES);
-                                    editData.dropElement->setParent(seg);
+                                    if (editData.dropElement->isImage()) {
+                                          editData.dropElement->setParent(el);
+                                          offset = pos - el->canvasPos();
+                                          }
+                                    else {
+                                          editData.dropElement->setParent(seg);
+                                          }
                                     if (applyUserOffset)
                                           editData.dropElement->setOffset(offset);
                                     score()->undoAddElement(editData.dropElement);


### PR DESCRIPTION
Note: When I first created this PR, my solution was simply to be sure to call an image's layout() function when adding it to a segment, since Score::layoutSystemElements() currently does not layout images that are children of segments. But even though the image was then visible, there were problems with trying to reposition it. This PR now takes a completely different approach.

Resolves: https://musescore.org/en/node/292606.

Images added to a measure now belong to the measure itself, rather than to one of the measure's segments. This not only allows the image to be visible, but it also solve problems related to the positioning of the image.