### PR TITLE
fix #296415: settings in the inspector that are supposed to be greyed out don't appear as such upon the next click on the element

### DIFF
--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -599,7 +599,7 @@ void InspectorFermata::setElement()
       {
       InspectorElementBase::setElement();
       if (!f.playArticulation->isChecked()) {
-            f.label_2->setEnabled(false);
+            f.labelTimeStretch->setEnabled(false);
             f.timeStretch->setEnabled(false);
             f.resetTimeStretch->setEnabled(false);
             }

--- a/mscore/inspector/inspector.cpp
+++ b/mscore/inspector/inspector.cpp
@@ -70,6 +70,8 @@
 #include "libmscore/breath.h"
 #include "libmscore/lyrics.h"
 #include "libmscore/accidental.h"
+#include "libmscore/articulation.h"
+#include "libmscore/fermata.h"
 
 namespace Ms {
 
@@ -560,6 +562,18 @@ InspectorArticulation::InspectorArticulation(QWidget* parent)
       }
 
 //---------------------------------------------------------
+//   setElement
+//---------------------------------------------------------
+
+void InspectorArticulation::setElement()
+      {
+      InspectorElementBase::setElement();
+      if (!ar.playArticulation->isChecked()) {
+            ar.gridWidget->setEnabled(false);
+            }
+      }
+
+//---------------------------------------------------------
 //   InspectorFermata
 //---------------------------------------------------------
 
@@ -575,6 +589,20 @@ InspectorFermata::InspectorFermata(QWidget* parent)
             };
       const std::vector<InspectorPanel> ppList = { { f.title, f.panel } };
       mapSignals(iiList, ppList);
+      }
+
+//---------------------------------------------------------
+//   setElement
+//---------------------------------------------------------
+
+void InspectorFermata::setElement()
+      {
+      InspectorElementBase::setElement();
+      if (!f.playArticulation->isChecked()) {
+            f.label_2->setEnabled(false);
+            f.timeStretch->setEnabled(false);
+            f.resetTimeStretch->setEnabled(false);
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspector.h
+++ b/mscore/inspector/inspector.h
@@ -140,6 +140,7 @@ class InspectorArticulation : public InspectorElementBase {
 
    public:
       InspectorArticulation(QWidget* parent);
+      virtual void setElement() override;
       };
 
 //---------------------------------------------------------
@@ -152,6 +153,7 @@ class InspectorFermata : public InspectorElementBase {
 
    public:
       InspectorFermata(QWidget* parent);
+      virtual void setElement() override;
       };
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspectorAmbitus.cpp
+++ b/mscore/inspector/inspectorAmbitus.cpp
@@ -119,6 +119,17 @@ void InspectorAmbitus::setElement()
 //      InspectorBase::setElement();
       }
 */
+
+void InspectorAmbitus::setElement()
+      {
+      InspectorElementBase::setElement();
+      if (!r.hasLine->isChecked()) {
+            r.label_10->setEnabled(false);
+            r.lineWidth->setEnabled(false);
+            r.resetLineWidth->setEnabled(false);
+            }
+      }
+
 //---------------------------------------------------------
 //   valueChanged
 //---------------------------------------------------------

--- a/mscore/inspector/inspectorAmbitus.cpp
+++ b/mscore/inspector/inspectorAmbitus.cpp
@@ -124,7 +124,7 @@ void InspectorAmbitus::setElement()
       {
       InspectorElementBase::setElement();
       if (!r.hasLine->isChecked()) {
-            r.label_10->setEnabled(false);
+            r.labelLineWidth->setEnabled(false);
             r.lineWidth->setEnabled(false);
             r.resetLineWidth->setEnabled(false);
             }

--- a/mscore/inspector/inspectorAmbitus.h
+++ b/mscore/inspector/inspectorAmbitus.h
@@ -32,6 +32,7 @@ class InspectorAmbitus : public InspectorElementBase {
 
    public:
       InspectorAmbitus(QWidget* parent);
+      virtual void setElement() override;
 
    protected slots:
       void updateRange();

--- a/mscore/inspector/inspectorGlissando.cpp
+++ b/mscore/inspector/inspectorGlissando.cpp
@@ -42,5 +42,21 @@ InspectorGlissando::InspectorGlissando(QWidget* parent)
             };
       mapSignals(iiList, ppList);
       }
+
+//---------------------------------------------------------
+//   setElement
+//---------------------------------------------------------
+
+void InspectorGlissando::setElement()
+      {
+      InspectorElementBase::setElement();
+      if (!g.playGlissando->isChecked()) {
+            g.label_2->setEnabled(false);
+            g.glissandoStyle->setEnabled(false);
+            g.resetGlissandoStyle->setEnabled(false);
+            }
+      if (!g.showText->isChecked())
+            g.textWidget->setVisible(false);
+      }
 }
 

--- a/mscore/inspector/inspectorGlissando.cpp
+++ b/mscore/inspector/inspectorGlissando.cpp
@@ -51,7 +51,7 @@ void InspectorGlissando::setElement()
       {
       InspectorElementBase::setElement();
       if (!g.playGlissando->isChecked()) {
-            g.label_2->setEnabled(false);
+            g.labelGlissandoStyle->setEnabled(false);
             g.glissandoStyle->setEnabled(false);
             g.resetGlissandoStyle->setEnabled(false);
             }

--- a/mscore/inspector/inspectorGlissando.h
+++ b/mscore/inspector/inspectorGlissando.h
@@ -30,6 +30,7 @@ class InspectorGlissando : public InspectorElementBase {
 
    public:
       InspectorGlissando(QWidget* parent);
+      virtual void setElement() override;
       };
 
 

--- a/mscore/inspector/inspectorHairpin.cpp
+++ b/mscore/inspector/inspectorHairpin.cpp
@@ -97,6 +97,11 @@ void InspectorHairpin::setElement()
       {
       InspectorTextLineBase::setElement();
       updateLineType();
+      if (!h.singleNoteDynamics->isChecked()) {
+            h.label_7->setEnabled(false);
+            h.veloChangeMethod->setEnabled(false);
+            h.resetVeloChangeMethod->setEnabled(false);
+            }
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspectorHairpin.cpp
+++ b/mscore/inspector/inspectorHairpin.cpp
@@ -98,7 +98,7 @@ void InspectorHairpin::setElement()
       InspectorTextLineBase::setElement();
       updateLineType();
       if (!h.singleNoteDynamics->isChecked()) {
-            h.label_7->setEnabled(false);
+            h.labelVeloChangeMethod->setEnabled(false);
             h.veloChangeMethod->setEnabled(false);
             h.resetVeloChangeMethod->setEnabled(false);
             }

--- a/mscore/inspector/inspectorNote.cpp
+++ b/mscore/inspector/inspectorNote.cpp
@@ -142,6 +142,11 @@ void InspectorNote::setElement()
       bool nograce = !note->chord()->isGrace();
       s.leadingSpace->setEnabled(nograce);
       s.resetLeadingSpace->setEnabled(nograce && s.leadingSpace->value());
+
+      if (!n.fixed->isChecked())
+            n.fixedLine->setEnabled(false);
+      if (!n.play->isChecked())
+            n.playWidget->setVisible(false);
       }
 
 //---------------------------------------------------------

--- a/mscore/inspector/inspectorTextLineBase.cpp
+++ b/mscore/inspector/inspectorTextLineBase.cpp
@@ -70,9 +70,9 @@ InspectorTextLineBase::InspectorTextLineBase(QWidget* parent)
             { Pid::BEGIN_FONT_SIZE,         0, tl.beginFontSize,         tl.resetBeginFontSize         },
             { Pid::BEGIN_FONT_STYLE,        0, tl.beginFontStyle,        tl.resetBeginFontStyle        },
             { Pid::BEGIN_TEXT_OFFSET,       0, tl.beginTextOffset,       tl.resetBeginTextOffset       },
-
             { Pid::BEGIN_HOOK_TYPE,         0, tl.beginHookType,         tl.resetBeginHookType         },
             { Pid::BEGIN_HOOK_HEIGHT,       0, tl.beginHookHeight,       tl.resetBeginHookHeight       },
+
             { Pid::CONTINUE_TEXT,           0, tl.continueText,          tl.resetContinueText          },
             { Pid::CONTINUE_TEXT_PLACE,     0, tl.continueTextPlacement, tl.resetContinueTextPlacement },
             { Pid::CONTINUE_TEXT_ALIGN,     0, tl.continueTextAlign,     tl.resetContinueTextAlign     },

--- a/mscore/inspector/inspectorTrill.cpp
+++ b/mscore/inspector/inspectorTrill.cpp
@@ -39,5 +39,18 @@ InspectorTrill::InspectorTrill(QWidget* parent)
       mapSignals(iiList, ppList);
       }
 
+//---------------------------------------------------------
+//   setElement
+//---------------------------------------------------------
+
+void InspectorTrill::setElement()
+      {
+      InspectorElementBase::setElement();
+      if (!t.playArticulation->isChecked()) {
+            t.label_3->setEnabled(false);
+            t.ornamentStyle->setEnabled(false);
+            t.resetOrnamentStyle->setEnabled(false);
+            }
+      }
 }
 

--- a/mscore/inspector/inspectorTrill.cpp
+++ b/mscore/inspector/inspectorTrill.cpp
@@ -47,7 +47,7 @@ void InspectorTrill::setElement()
       {
       InspectorElementBase::setElement();
       if (!t.playArticulation->isChecked()) {
-            t.label_3->setEnabled(false);
+            t.labelOrnamentStyle->setEnabled(false);
             t.ornamentStyle->setEnabled(false);
             t.resetOrnamentStyle->setEnabled(false);
             }

--- a/mscore/inspector/inspectorTrill.h
+++ b/mscore/inspector/inspectorTrill.h
@@ -31,6 +31,7 @@ class InspectorTrill : public InspectorElementBase {
 
    public:
       InspectorTrill(QWidget* parent);
+      virtual void setElement() override;
       };
 
 

--- a/mscore/inspector/inspector_ambitus.ui
+++ b/mscore/inspector/inspector_ambitus.ui
@@ -227,7 +227,7 @@
        </widget>
       </item>
       <item row="4" column="0">
-       <widget class="QLabel" name="label_10">
+       <widget class="QLabel" name="labelLineWidth">
         <property name="text">
          <string>Line thickness:</string>
         </property>

--- a/mscore/inspector/inspector_fermata.ui
+++ b/mscore/inspector/inspector_fermata.ui
@@ -119,7 +119,7 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="label_2">
+       <widget class="QLabel" name="labelTimeStretch">
         <property name="text">
          <string>Time stretch:</string>
         </property>

--- a/mscore/inspector/inspector_glissando.ui
+++ b/mscore/inspector/inspector_glissando.ui
@@ -97,7 +97,7 @@
        </widget>
       </item>
       <item row="9" column="0">
-       <widget class="QLabel" name="label_2">
+       <widget class="QLabel" name="labelGlissandoStyle">
         <property name="text">
          <string>Play style:</string>
         </property>

--- a/mscore/inspector/inspector_hairpin.ui
+++ b/mscore/inspector/inspector_hairpin.ui
@@ -292,12 +292,15 @@
        </widget>
       </item>
       <item row="11" column="0">
-       <widget class="QLabel" name="label_7">
+       <widget class="QLabel" name="labelVeloChangeMethod">
         <property name="text">
          <string>Dynamics method:</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>veloChangeMethod</cstring>
         </property>
        </widget>
       </item>

--- a/mscore/inspector/inspector_trill.ui
+++ b/mscore/inspector/inspector_trill.ui
@@ -228,7 +228,7 @@
        </widget>
       </item>
       <item row="3" column="0">
-       <widget class="QLabel" name="label_3">
+       <widget class="QLabel" name="labelOrnamentStyle">
         <property name="text">
          <string>Ornament style:</string>
         </property>


### PR DESCRIPTION
Resolves: https://musescore.org/node/296415.

The inspector is not updated properly upon the next click, which can be solved by adding a few lines in `setElement()` stating that those which are supposed to be greyed out (or invisible) have their `enabled` (or `visible`) set to `false`.

Co-Authored-By: mattmcclinch <mattmcclinch@users.noreply.github.com>