### PR TITLE
Fix #293998 : Fig. Bass continuation lines disappearing

### DIFF
--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -1080,7 +1080,7 @@ void FiguredBass::read(XmlReader& e)
       while (e.readNextStartElement()) {
             const QStringRef& tag(e.name());
             if (tag == "ticks")
-                  setTicks(Fraction::fromTicks(e.readInt()));
+                  setTicks(e.readFraction());
             else if (tag == "onNote")
                   setOnNote(e.readInt() != 0l);
             else if (tag == "FiguredBassItem") {


### PR DESCRIPTION
Resolves: *(https://musescore.org/en/node/293998)*

The issue was a consequence of the switch to fractions in 3.1: the ticks of a Fig. Bass element were written in the file as fraction but read back as an `int`, which in most cases resulted in a 0-duration element.

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
