### PR TITLE
Fix #282893 : Fig.Bass duration lines exceedingly thin

### DIFF
--- a/libmscore/figuredbass.cpp
+++ b/libmscore/figuredbass.cpp
@@ -1247,7 +1247,7 @@ void FiguredBass::draw(QPainter* painter) const
       if (!score()->printing() && score()->showUnprintable()) {
             for (qreal len : _lineLengths) {
                   if (len > 0) {
-                        painter->setPen(QPen(Qt::lightGray, 1));
+                        painter->setPen(QPen(Qt::lightGray, 3));
                         painter->drawLine(0.0, -2, len, -2);      // -2: 2 rast. un. above digits
                         }
                   }


### PR DESCRIPTION
Resolves: *(https://musescore.org/en/node/282893)*

It seems there has been some change of unit. I simply increased the pen width.

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
