### PR TITLE
Fix #296610 : import from 2.x may create useless "Fig. bass" user text style

### DIFF
--- a/libmscore/read206.cpp
+++ b/libmscore/read206.cpp
@@ -609,7 +609,8 @@ void readTextStyle206(MStyle* style, XmlReader& e, std::map<QString, std::map<Si
             { "Header",                  Tid::HEADER },
             { "Footer",                  Tid::FOOTER },
             { "Instrument Change",       Tid::INSTRUMENT_CHANGE },
-            { "Figured Bass",            Tid::TEXT_STYLES },            // invalid
+            { "Repeat Text",             Tid::IGNORED_STYLES, },     // Repeat Text style no longer exists
+            { "Figured Bass",            Tid::IGNORED_STYLES, },     // F.B. data are in style properties
             { "Volta",                   Tid::VOLTA },
             };
       Tid ss = Tid::TEXT_STYLES;
@@ -619,6 +620,9 @@ void readTextStyle206(MStyle* style, XmlReader& e, std::map<QString, std::map<Si
                   break;
                   }
             }
+
+      if (ss == Tid::IGNORED_STYLES)
+            return;
 
       bool isExcessStyle = false;
       if (ss == Tid::TEXT_STYLES) {

--- a/libmscore/types.h
+++ b/libmscore/types.h
@@ -420,7 +420,9 @@ enum class Tid {
       USER4,
       USER5,
       USER6,
-      TEXT_STYLES
+      // special, no-contents, styles used while importing older scores
+      TEXT_STYLES,           // used for user-defined styles
+      IGNORED_STYLES         // used for styles no longer relevant (mainly Figured bass text style)
       ///.\}
       };
 


### PR DESCRIPTION
See the [original issue](https://musescore.org/en/node/296610) for details and why this text style is superfluous.

The fix simply ignores the "Figured bass" text style while importing from 2.x; possibly customised F.b. parameters are in any case loaded form the relevant tags of the main <Style> section.

- [X] I signed [CLA](https://musescore.org/en/cla)
- [X] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [X] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
