### PR TITLE
fix #293301: add get-location command to read current location

### DIFF
--- a/mscore/data/shortcuts-Mac.xml
+++ b/mscore/data/shortcuts-Mac.xml
@@ -285,6 +285,10 @@
     <seq>Ctrl+F9</seq>
     </SC>
   <SC>
+    <key>get-location</key>
+    <seq>Shift+L</seq>
+    </SC>
+  <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
     </SC>

--- a/mscore/data/shortcuts.xml
+++ b/mscore/data/shortcuts.xml
@@ -285,6 +285,10 @@
     <seq>Ctrl+F9</seq>
     </SC>
   <SC>
+    <key>get-location</key>
+    <seq>Shift+L</seq>
+    </SC>
+  <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
     </SC>

--- a/mscore/data/shortcuts_AZERTY.xml
+++ b/mscore/data/shortcuts_AZERTY.xml
@@ -295,6 +295,10 @@
     <seq>Ctrl+F9</seq>
     </SC>
   <SC>
+    <key>get-location</key>
+    <seq>Shift+L</seq>
+    </SC>
+  <SC>
     <key>move-up</key>
     <seq>Ctrl+Shift+Up</seq>
     </SC>

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -110,6 +110,8 @@ void ScoreAccessibility::clearAccessibilityInfo()
       MuseScoreView* view = static_cast<MuseScore*>(mainWindow)->currentScoreView();
       if (view)
             view->score()->setAccessibleInfo(tr("No selection"));
+      _oldBar = -1;
+      _oldStaff = -1;
       }
 
 void ScoreAccessibility::currentInfoChanged()

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -23,6 +23,7 @@
 #include "musescore.h"
 #include "navigator.h"
 #include "preferences.h"
+#include "scoreaccessibility.h"
 #include "scoretab.h"
 #include "seq.h"
 #include "splitstaff.h"
@@ -2143,6 +2144,25 @@ void ScoreView::cmd(const char* s)
             }
       else if (cmd == "last-element") {
             cmdGotoElement(score()->lastElement(false));
+            }
+      else if (cmd == "get-location") {
+            // get current selection
+            Element* e = score()->selection().element();
+            if (!e) {
+                  // no current selection - restore lost selection
+                  e = score()->selection().currentCR();
+                  if (e && e->isChord())
+                        e = toChord(e)->upNote();
+                  }
+            if (!e) {
+                  // no current or last selection - fall back to first element
+                  e = score()->firstElement(false);
+                  }
+            // TODO: find & read current key & time signatures
+            if (e) {
+                  ScoreAccessibility::instance()->clearAccessibilityInfo();
+                  cmdGotoElement(e);
+                  }
             }
       else if (cmd == "rest" || cmd == "rest-TAB")
             cmdEnterRest();

--- a/mscore/shortcut.cpp
+++ b/mscore/shortcut.cpp
@@ -918,6 +918,17 @@ Shortcut Shortcut::_sc[] = {
          ShortcutFlags::A_CMD
          },
       {
+         MsWidget::SCORE_TAB,
+         STATE_NORMAL | STATE_TEXT_EDIT | STATE_HARMONY_FIGBASS_EDIT,
+         "get-location",
+         QT_TRANSLATE_NOOP("action","Get Location"),
+         QT_TRANSLATE_NOOP("action","Accessibility: Get location"),
+         0,
+         Icons::Invalid_ICON,
+         Qt::WindowShortcut,
+         ShortcutFlags::A_CMD
+         },
+      {
          MsWidget::MAIN_WINDOW,
          STATE_NORMAL | STATE_NOTE_ENTRY,
          "palette-search",


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/293301

We have optimized the screenreader feedback when navigating
to only mention measure and staff if it has changed.
Blind users can easily lose track of where they are, however,
so this adds a new command "Get Location" that forces a full read.
It also re-establishes a lost selection (the last-selected note or rest),
which can also be useful for sighted users,
although Alt+Left/Right already re-established the location before beginning navigation.

Eventually I would like the new "Get Location" command
to read the current key and time signature.
Right now, though, it is is not straightforward to force the screenreader to do this,
I left it as a TODO in the code.