### PR TITLE
[Backup File] fix #295701: able to open backup files as an import

### DIFF
--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -891,7 +891,7 @@ Score::FileError MasterScore::loadMsc(QString name, QIODevice* io, bool ignoreVe
       ScoreLoad sl;
       fileInfo()->setFile(name);
 
-      if (name.endsWith(".mscz"))
+      if (name.endsWith(".mscz") || name.endsWith(".mscz,"))
             return loadCompressedMsc(io, ignoreVersionError);
       else {
             XmlReader r(io);


### PR DESCRIPTION
Resolves: https://musescore.org/node/295701.

A new function `importBackup` handles the main process. Also, a few improvements are made to make sure the backup file "`.name.mscz,/mscx,`" is saved (saved as/saved as copy) correctly as "`name.mscz/mscx`".