### PR TITLE
fixes the portaudio dependency for MinGW64 builds, no renaming is required

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -133,13 +133,9 @@ if (MINGW)
             ${DEPENDENCIES_DIR}/libssl-1_1-x64.dll
             DESTINATION bin)
       endif (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.12.4")
-      install( FILES
-         ${DEPENDENCIES_DIR}/portaudio.dll RENAME libportaudio-x86_64-w64-mingw32.static.dll
-         DESTINATION bin)
    else (BUILD_64)
       install( FILES
          ${MINGW_ROOT}/bin/libgcc_s_dw2-1.dll
-         ${DEPENDENCIES_DIR}/portaudio.dll
          DESTINATION bin)
       if (Qt5Widgets_VERSION VERSION_GREATER_EQUAL "5.12.4")
          install( FILES
@@ -156,6 +152,7 @@ if (MINGW)
       ${DEPENDENCIES_DIR}/libsndfile-1.dll
       ${DEPENDENCIES_DIR}/libvorbis.dll
       ${DEPENDENCIES_DIR}/libvorbisfile.dll
+	  ${DEPENDENCIES_DIR}/portaudio.dll
       ${QT_INSTALL_BINS}/libEGL.dll
       ${QT_INSTALL_BINS}/libGLESv2.dll
       ${QT_INSTALL_BINS}/opengl32sw.dll


### PR DESCRIPTION
Resolves: Running/Debugging MinGW64 builds from QtCreator/cmd.exe instantly crashed due to not found portaudio.dll dependency

Talked this through with @Jojo-Schmitz on Telegram. We can't discover why the rename of the file happens; but doing so results in MuseScore3.exe crashing when ran from the install directory from within QtCreator and from cmd.exe. This also prevents debugging.

Weird side fact: when launching the same executable from within Windows Explorer, this crash doesn't happen. It is likely that the explorer shell has additional PATHs loaded leading to finding a (different) portaudio.dll on my system.

- [x] I signed [CLA](https://musescore.org/en/cla)
- [x] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [x] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [N/A] I created the test (mtest, vtest, script test) to verify the changes I made
