### PR TITLE
fix #296362: screenreader support for RNA

### DIFF
--- a/libmscore/harmony.cpp
+++ b/libmscore/harmony.cpp
@@ -1727,9 +1727,59 @@ QString Harmony::accessibleInfo() const
 
 QString Harmony::screenReaderInfo() const
       {
-      QString rez = Element::accessibleInfo();
-      if (_rootTpc != Tpc::TPC_INVALID)
-            rez = QString("%1 %2").arg(rez).arg(tpc2name(_rootTpc, NoteSpellingType::STANDARD, NoteCaseType::AUTO, true));
+      QString rez = userName();
+
+      switch (_harmonyType) {
+            case HarmonyType::ROMAN: {
+                  QString aux = _textName;
+                  bool hasUpper = aux.contains('I') || aux.contains('V');
+                  bool hasLower = aux.contains('i') || aux.contains('v');
+                  if (hasLower && !hasUpper)
+                        rez = QString("%1 %2").arg(rez).arg(QObject::tr("lower case"));
+                  aux = aux.toLower();
+                  static std::vector<std::pair<QString, QString>> rnaReplacements {
+                        { "vii", "7" },
+                        { "vi", "6" },
+                        { "iv", "4" },
+                        { "v", "5" },
+                        { "iii", "3" },
+                        { "ii", "2" },
+                        { "i", "1" },
+                        };
+                  static std::vector<std::pair<QString, QString>> symbolReplacements {
+                        { "b", "♭" },
+                        { "h", "♮" },
+                        { "#", "♯" },
+                        { "bb", "𝄫" },
+                        { "##", "𝄪" },
+                        // TODO: use SMuFL glyphs and translate
+                        //{ "o", ""},
+                        //{ "0", ""},
+                        //{ "\+", ""},
+                        //{ "\^", ""},
+                        };
+                  for (auto const &r : rnaReplacements)
+                        aux.replace(r.first, r.second);
+                  for (auto const &r : symbolReplacements) {
+                        // only replace when not preceded by backslash
+                        QString s = "(?<!\\\\)" + r.first;
+                        QRegularExpression re(s);
+                        aux.replace(re, r.second);
+                        }
+                  // construct string one character at a time
+                  for (auto c : aux)
+                        rez = QString("%1 %2").arg(rez).arg(c);
+                  }
+                  return rez;
+            case HarmonyType::NASHVILLE:
+                  if (!_function.isEmpty())
+                        rez = QString("%1 %2").arg(rez).arg(_function);
+                  break;
+            case HarmonyType::STANDARD:
+            default:
+                  if (_rootTpc != Tpc::TPC_INVALID)
+                        rez = QString("%1 %2").arg(rez).arg(tpc2name(_rootTpc, NoteSpellingType::STANDARD, NoteCaseType::AUTO, true));
+            }
 
       if (const_cast<Harmony*>(this)->parsedForm() && !hTextName().isEmpty()) {
             QString aux = const_cast<Harmony*>(this)->parsedForm()->handle();
@@ -1737,7 +1787,7 @@ QString Harmony::screenReaderInfo() const
             QString extension = "";
 
             foreach (QString s, aux.split(">", QString::SkipEmptyParts)) {
-                  if(!s.contains("blues"))
+                  if (!s.contains("blues"))
                         s.replace("b", QObject::tr("♭"));
                   extension += s + " ";
                   }

--- a/mscore/scoreaccessibility.cpp
+++ b/mscore/scoreaccessibility.cpp
@@ -301,6 +301,7 @@ void ScoreAccessibility::makeReadable(QString& s)
       {
       static std::vector<std::pair<QString, QString>> unicodeReplacements {
             { "♭", tr(" flat") },
+            { "♮", tr(" natural") },
             { "♯", tr(" sharp") },
             { "𝄫", tr(" double flat") },
             { "𝄪", tr(" double sharp") },


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296362

RNA and Nashville notations are implemented as chord symbols,
because much of the code is common between these,
but it doesn't work to use the regular chord symbol screenreader code.
For Nashville numbers, we need to get the root from the function rather than the rootTpc.
For RNA, we need to perform some rudimentary parsing to turn the Roman numerals into numbers
and substitute the accidentals.

I left a TODO in the comments to handle the diminished, augmented, and similar characters.  These are currently represented by SMuFL symbols and we do have those strings available, but they aren't translated, and it isn't as clear to me how to access this information with the sym data structures.  I'm sure it's possible, but it will require a somewhat different approach from what I have done here.  So for now, the o, 0, and + symbols will read literally.

There is no current way to perform automated tests for screenreader info, but the code works well in my own testing.