### PR TITLE
Default to native file dialogues (needed to fix directory bookmarks) also on Linux

### DIFF
--- a/mscore/preferences.cpp
+++ b/mscore/preferences.cpp
@@ -48,13 +48,6 @@ void Preferences::init(bool storeInMemoryOnly)
       bool checkExtensionsUpdateStartup = false;
 #endif
 
-#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
-      // use system native file dialogs
-      // Qt file dialog is very slow on Windows and Mac
-      bool nativeDialogs           = true;
-#else
-      bool nativeDialogs           = false;    // don't use system native file dialogs
-#endif
       bool defaultUsePortAudio = false;
       bool defaultUsePulseAudio = false;
       bool defaultUseJackAudio = false;
@@ -174,7 +167,7 @@ void Preferences::init(bool storeInMemoryOnly)
             {PREF_UI_APP_RASTER_HORIZONTAL,                        new IntPreference(2)},
             {PREF_UI_APP_RASTER_VERTICAL,                          new IntPreference(2)},
             {PREF_UI_APP_SHOWSTATUSBAR,                            new BoolPreference(true)},
-            {PREF_UI_APP_USENATIVEDIALOGS,                         new BoolPreference(nativeDialogs)},
+            {PREF_UI_APP_USENATIVEDIALOGS,                         new BoolPreference(true)},
             {PREF_UI_PIANO_HIGHLIGHTCOLOR,                         new ColorPreference(QColor("#1259d0"))},
             {PREF_UI_SCORE_NOTE_DROPCOLOR,                         new ColorPreference(QColor("#1778db"))},
             {PREF_UI_SCORE_DEFAULTCOLOR,                           new ColorPreference(QColor("#000000"))},


### PR DESCRIPTION
Resolves: https://musescore.org/en/comment/956706#comment-956706

We already use them by default on the other platforms (Mac OSX and Windows), and not using them causes directory bookmark hassles, perhaps due to a bug in Qt, so better be consistent. (We still offer the nōn-native dialogues and will need to eventually fix them, but this will help users.) There’s some discussion and links in the issue.

- [✓] I signed [CLA](https://musescore.org/en/cla)
- [✓] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [ ] I made sure the code compiles on my machine
- [✓] I made sure there are no unnecessary changes in the code
- [✓] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [✓] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [✓] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
