### PR TITLE
fix #229246: staff incorrectly numbered in "Instruments" dialog

### DIFF
--- a/mscore/instrwidget.cpp
+++ b/mscore/instrwidget.cpp
@@ -485,6 +485,25 @@ void InstrumentsWidget::genPartList(Score* cs)
       }
 
 //---------------------------------------------------------
+//   updatePartIdx
+//---------------------------------------------------------
+
+void InstrumentsWidget::updatePartIdx()
+      {
+      for (int i = 0; i < partiturList->topLevelItemCount(); ++i) {
+            PartListItem* tli = static_cast<PartListItem*>(partiturList->topLevelItem(i));
+            int partIdx = -1;
+            for (int j = 0; j < tli->childCount(); ++j) {
+                  StaffListItem* sli = static_cast<StaffListItem*>(tli->child(j));
+                  if (!sli->isHidden()) {
+                        partIdx++;
+                        sli->setPartIdx(partIdx);
+                        }
+                  }
+            }
+      }
+
+//---------------------------------------------------------
 //   on_instrumentList_itemSelectionChanged
 //---------------------------------------------------------
 
@@ -638,6 +657,7 @@ void InstrumentsWidget::on_removeButton_clicked()
                   }
             static_cast<PartListItem*>(parent)->updateClefs();
             partiturList->setCurrentItem(parent);
+            updatePartIdx();
             }
       else {
             if (partiturList->topLevelItemCount() == 1) {
@@ -763,6 +783,7 @@ void InstrumentsWidget::on_upButton_clicked()
                         }
                   }
             }
+      updatePartIdx();
       }
 
 //---------------------------------------------------------
@@ -854,6 +875,7 @@ void InstrumentsWidget::on_downButton_clicked()
                         }
                   }
             }
+      updatePartIdx();
       }
 
 //---------------------------------------------------------
@@ -893,6 +915,7 @@ StaffListItem* InstrumentsWidget::on_addStaffButton_clicked()
       partiturList->clearSelection();           // should not be necessary
       partiturList->setCurrentItem(nsli);
       pli->updateClefs();
+      updatePartIdx();
       return nsli;
       }
 

--- a/mscore/instrwidget.h
+++ b/mscore/instrwidget.h
@@ -152,6 +152,7 @@ class InstrumentsWidget : public QWidget, public Ui::InstrumentsWidget {
    public:
       InstrumentsWidget(QWidget* parent = 0);
       void genPartList(Score*);
+      void updatePartIdx();
       void init();
       void createInstruments(Score*);
       QTreeWidget* getPartiturList();


### PR DESCRIPTION
Resolves: https://musescore.org/node/229246.

Staff numbers are only updated (actually re-created by `genPartList()`) upon next opening of the dialog, not instantly when staffs are changed. A new function `updatePartIdx()` does what's needed to be done.