### PR TITLE
Reload sources for QmlDockWidgets if errors occur the first time.

### DIFF
--- a/mscore/qmldockwidget.cpp
+++ b/mscore/qmldockwidget.cpp
@@ -247,6 +247,13 @@ void QmlDockWidget::setSource(const QUrl& url)
       setupStyle();
 
       view->setSource(url);
+      // In some cases, setSource() will result in errors the first time the sources are loaded.
+      // If this happens, reload the sources from the same URL.
+      // For some reason, it seems to work the second time.
+      if (view->status() == QQuickView::Error) {
+            engine->clearComponentCache();
+            view->setSource(url);
+            }
       view->setResizeMode(QQuickView::SizeRootObjectToView);
       }
 


### PR DESCRIPTION
This resolves the issue of empty palettes on macOS self-builds.

See https://musescore.org/en/node/296712.
