### PR TITLE
fix #296915: honor slur properties when adding slur from a palette

### DIFF
--- a/libmscore/mscoreview.h
+++ b/libmscore/mscoreview.h
@@ -17,6 +17,7 @@ namespace Ms {
 
 class Element;
 class Score;
+class Slur;
 class Note;
 class Page;
 class ChordRest;
@@ -57,7 +58,7 @@ class MuseScoreView {
       virtual void setCursor(const QCursor&) {};
       virtual int gripCount() const { return 0; }
       virtual void setDropRectangle(const QRectF&) {};
-      virtual void cmdAddSlur(ChordRest*, ChordRest*) {};
+      virtual void cmdAddSlur(ChordRest*, ChordRest*, const Slur* /* slurTemplate */) {};
       virtual void startEdit() {};
       virtual void startEditMode(Element*) {};
       virtual void startEdit(Element*, Grip /*startGrip*/) {};

--- a/libmscore/note.cpp
+++ b/libmscore/note.cpp
@@ -1671,7 +1671,7 @@ Element* Note::drop(EditData& data)
                   return 0;
 
             case ElementType::SLUR:
-                  data.view->cmdAddSlur(chord(), nullptr);
+                  data.view->cmdAddSlur(chord(), nullptr, toSlur(e));
                   delete e;
                   return 0;
 

--- a/mscore/palette.cpp
+++ b/mscore/palette.cpp
@@ -530,7 +530,7 @@ void Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                   score->cmdToggleLayoutBreak(breakElement->layoutBreakType());
                   }
             else if (element->isSlur() && addSingle) {
-                  viewer->addSlur();
+                  viewer->addSlur(toSlur(element));
                   }
             else if (element->isSLine() && !element->isGlissando() && addSingle) {
                   Segment* startSegment = cr1->segment();
@@ -682,7 +682,7 @@ void Palette::applyPaletteElement(Element* element, Qt::KeyboardModifiers modifi
                         }
                   }
             else if (element->isSlur()) {
-                  viewer->addSlur();
+                  viewer->addSlur(toSlur(element));
                   }
             else if (element->isSLine() && element->type() != ElementType::GLISSANDO) {
                   Segment* startSegment = sel.startSegment();

--- a/mscore/scoreview.cpp
+++ b/mscore/scoreview.cpp
@@ -3437,7 +3437,7 @@ void ScoreView::startUndoRedo(bool undo)
 //    command invoked, or icon double clicked
 //---------------------------------------------------------
 
-void ScoreView::addSlur()
+void ScoreView::addSlur(const Slur* slurTemplate)
       {
       InputState& is = _score->inputState();
       if (noteEntryMode() && is.slur()) {
@@ -3472,7 +3472,7 @@ void ScoreView::addSlur()
                               cr2 = cr;
                         }
                   if (cr1 && (cr1 != cr2))
-                        cmdAddSlur(cr1, cr2);
+                        cmdAddSlur(cr1, cr2, slurTemplate);
                   }
             }
       else {
@@ -3492,7 +3492,7 @@ void ScoreView::addSlur()
             if (cr1 == cr2)
                   cr2 = 0;
             if (cr1)
-                  cmdAddSlur(cr1, cr2);
+                  cmdAddSlur(cr1, cr2, slurTemplate);
             }
       }
 
@@ -3500,7 +3500,7 @@ void ScoreView::addSlur()
 //   cmdAddSlur
 //---------------------------------------------------------
 
-void ScoreView::cmdAddSlur(ChordRest* cr1, ChordRest* cr2)
+void ScoreView::cmdAddSlur(ChordRest* cr1, ChordRest* cr2, const Slur* slurTemplate)
       {
       bool startEditMode = false;
       if (cr2 == 0) {
@@ -3512,7 +3512,8 @@ void ScoreView::cmdAddSlur(ChordRest* cr1, ChordRest* cr2)
 
       _score->startCmd();
 
-      Slur* slur = new Slur(cr1->score());
+      Slur* slur = slurTemplate ? slurTemplate->clone() : new Slur(cr1->score());
+      slur->setScore(cr1->score());
       slur->setTick(cr1->tick());
       slur->setTick2(cr2->tick());
       slur->setTrack(cr1->track());

--- a/mscore/scoreview.h
+++ b/mscore/scoreview.h
@@ -330,8 +330,8 @@ class ScoreView : public QWidget, public MuseScoreView {
       void doDragEdit(QMouseEvent* ev);
       bool testElementDragTransition(QMouseEvent* ev);
       bool fotoEditElementDragTransition(QMouseEvent* ev);
-      void addSlur();
-      virtual void cmdAddSlur(ChordRest*, ChordRest*) override;
+      void addSlur(const Slur* slurTemplate = nullptr);
+      void cmdAddSlur(ChordRest*, ChordRest*, const Slur*) override;
       virtual void cmdAddHairpin(HairpinType);
       void cmdAddNoteLine();
 


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296915
