### PR TITLE
fix #297008 : note_input_mode_selection

### DIFF
--- a/libmscore/score.cpp
+++ b/libmscore/score.cpp
@@ -2903,8 +2903,13 @@ void Score::padToggle(Pad n, const EditData& ed)
                         cr = m->findChordRest(m->tick(), 0);
                   }
 
-            if (cr)
+            if (cr) {
                   crs.push_back(cr);
+                  }
+            else {
+                  ed.view->startNoteEntryMode();
+                  deselect(e);
+                  }
             }
       else if (selection().isNone() && n != Pad::REST) {
             TDuration td = _is.duration();


### PR DESCRIPTION
Repeated behavior of transition to note input mode accordingly to cases when no items selected

Turn on note input mode by toggling pad even if user selection is on the text element for example