### PR TITLE
fix #296960: Percent sign cannot be entered into text.

### DIFF
--- a/libmscore/xmlwriter.cpp
+++ b/libmscore/xmlwriter.cpp
@@ -334,8 +334,6 @@ QString XmlWriter::xmlString(ushort c)
                   return QLatin1String("&amp;");
             case '\"':
                   return QLatin1String("&quot;");
-            case '%':
-                  return QLatin1String("&#37;");
             default:
                   // ignore invalid characters in xml 1.0
                   if ((c < 0x20 && c != 0x09 && c != 0x0A && c != 0x0D))

--- a/mscore/palette/palettetree.cpp
+++ b/mscore/palette/palettetree.cpp
@@ -212,11 +212,11 @@ void PaletteCell::write(XmlWriter& xml) const
       // using attributes for `custom` and `visible`
       // properties instead of nested tags for pre-3.3
       // version compatibility
-      xml.stag(QString("Cell%1%2%3%4")
-         .arg(!name.isEmpty() ? QString(" name=\"%1\"").arg(XmlWriter::xmlString(name)) : "")
-         .arg(custom ? " custom=\"1\"" : "")
-         .arg(!visible ? " visible=\"0\"" : "")
-         .arg(untranslatedElement ? " trElement=\"1\"" : "")
+      xml.stag(QString("Cell")
+         + (!name.isEmpty() ? " name=\"" + XmlWriter::xmlString(name) + "\"" : "")
+         + (custom ? " custom=\"1\"" : "")
+         + (!visible ? " visible=\"0\"" : "")
+         + (untranslatedElement ? " trElement=\"1\"" : "")
          );
 
       if (drawStaff)


### PR DESCRIPTION
Resolves: https://musescore.org/en/node/296960.

As I understand it, the only reason for escaping the % character was for the sake of one xml.stag() call in PaletteCell::write(). By changing the way this XML tag is constructed, we can get away with not escaping the % character at all.